### PR TITLE
Implement Phase 3 admin seeding and session endpoints with tests

### DIFF
--- a/server/api/alert_api_test.go
+++ b/server/api/alert_api_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/fleetdm/edr/server/authn"
 	"github.com/fleetdm/edr/server/graph"
 	"github.com/fleetdm/edr/server/store"
 )
@@ -151,4 +152,35 @@ func TestUpdateAlertStatusAPI(t *testing.T) {
 		mux.ServeHTTP(w, req)
 		assert.Equal(t, http.StatusNotFound, w.Code)
 	})
+}
+
+// TestUpdateAlertStatus_CapturesUserID locks in the Phase 3 audit contract: when the
+// request context carries an authenticated user id (pinned by authn.Session), the
+// updated_by column is set on the row. Without a session on ctx, updated_by stays
+// NULL — this is the path admin-less direct calls (e.g. internal backfills) take.
+func TestUpdateAlertStatus_CapturesUserID(t *testing.T) {
+	mux, s := setupAlertTestHandler(t)
+	ctx := t.Context()
+
+	procID, err := s.InsertProcess(ctx, store.Process{HostID: "host-a", PID: 100, PPID: 1, Path: "/bin/sh", ForkTimeNs: 1000})
+	require.NoError(t, err)
+	alertID, _, err := s.InsertAlert(ctx, store.Alert{
+		HostID: "host-a", RuleID: "r1", Severity: "high", Title: "Test", ProcessID: procID,
+	}, nil)
+	require.NoError(t, err)
+
+	body := `{"status":"resolved"}`
+	req := httptest.NewRequestWithContext(t.Context(), "PUT",
+		fmt.Sprintf("/api/v1/alerts/%d", alertID), strings.NewReader(body))
+	req = req.WithContext(authn.WithUserIDForTest(req.Context(), 42))
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	require.Equal(t, http.StatusNoContent, w.Code)
+
+	// Verify the updated_by column directly — Alert type doesn't expose it (SOC-only).
+	var updatedBy *int64
+	err = s.DB().GetContext(ctx, &updatedBy, "SELECT updated_by FROM alerts WHERE id = ?", alertID)
+	require.NoError(t, err)
+	require.NotNil(t, updatedBy)
+	assert.Equal(t, int64(42), *updatedBy)
 }

--- a/server/api/alert_api_test.go
+++ b/server/api/alert_api_test.go
@@ -162,6 +162,14 @@ func TestUpdateAlertStatus_CapturesUserID(t *testing.T) {
 	mux, s := setupAlertTestHandler(t)
 	ctx := t.Context()
 
+	// Phase 3 added an FK alerts.updated_by → users(id) ON DELETE SET NULL, so the
+	// user we reference via WithUserIDForTest must exist in the users table.
+	_, err := s.DB().ExecContext(ctx, `
+		INSERT INTO users (id, email, password_hash, password_salt)
+		VALUES (?, ?, ?, ?)
+	`, 42, "seed@test", []byte("hash"), []byte("salt"))
+	require.NoError(t, err)
+
 	procID, err := s.InsertProcess(ctx, store.Process{HostID: "host-a", PID: 100, PPID: 1, Path: "/bin/sh", ForkTimeNs: 1000})
 	require.NoError(t, err)
 	alertID, _, err := s.InsertAlert(ctx, store.Alert{

--- a/server/api/api.go
+++ b/server/api/api.go
@@ -205,7 +205,12 @@ func (h *Handler) handleUpdateAlertStatus(w http.ResponseWriter, r *http.Request
 	}
 
 	ctx := r.Context()
-	if err := h.store.UpdateAlertStatus(ctx, id, body.Status); err != nil {
+	// Phase 3: record the authenticated user id on the row so SOC forensics can tell
+	// who resolved what. When the handler is invoked outside the session middleware
+	// stack (e.g. direct test harness), UserIDFromContext returns false and we pass 0,
+	// which UpdateAlertStatus treats as "leave updated_by alone".
+	userID, _ := authn.UserIDFromContext(ctx)
+	if err := h.store.UpdateAlertStatus(ctx, id, body.Status, userID); err != nil {
 		if errors.Is(err, errNotFound) {
 			http.Error(w, "not found", http.StatusNotFound)
 			return
@@ -213,6 +218,15 @@ func (h *Handler) handleUpdateAlertStatus(w http.ResponseWriter, r *http.Request
 		h.logger.ErrorContext(ctx, "update alert status", "id", id, "err", err)
 		http.Error(w, "internal error", http.StatusInternalServerError)
 		return
+	}
+
+	if userID > 0 {
+		h.logger.InfoContext(ctx, "alert status updated",
+			"edr.admin.action", "alert_update",
+			"edr.alert.id", id,
+			"edr.alert.status", body.Status,
+			"edr.user.id", userID,
+		)
 	}
 
 	w.WriteHeader(http.StatusNoContent)

--- a/server/authn/authn.go
+++ b/server/authn/authn.go
@@ -1,22 +1,30 @@
-// Package authn ties the HTTP Authorization header to the identity established at enroll
-// time. Two middlewares live here:
+// Package authn ties HTTP credentials to identities. Three middlewares live here:
 //
 //   - HostToken wraps ingest + command-poll routes. It resolves the bearer token to a
 //     host_id via the enrollment store, pins the host_id on the request context, and
 //     attaches `edr.host_id` to the active OTel span.
 //
-//   - AdminToken wraps UI + admin routes. It compares the bearer token against the
-//     single-value EDR_ADMIN_TOKEN (stopgap until Phase 3 replaces with sessions).
+//   - Session wraps UI + admin routes. It extracts the `edr_session` cookie, looks up
+//     the row in the sessions table, and pins user_id + session_id + csrf_token onto
+//     the request context. Phase 3 replaces the Phase 1 `AdminToken` stopgap.
+//
+//   - CSRF wraps the same UI + admin routes as Session (applied on the outside of
+//     Session so it can read the per-session CSRF token off the context). It compares
+//     the `X-CSRF-Token` header against the stored value on unsafe methods (POST, PUT,
+//     DELETE, PATCH) via subtle.ConstantTimeCompare; safe methods (GET, HEAD, OPTIONS)
+//     pass through.
 //
 // Authentication failures return 401 + JSON body + `WWW-Authenticate: Bearer`. Verifier
 // outages (DB down, unexpected errors) return 503 without WWW-Authenticate so an agent
 // cannot misinterpret infrastructure failure as token revocation and burn its re-enroll
-// throttle. All outcomes emit structured audit logs + span attributes for SigNoz.
+// throttle. CSRF failures return 403. All outcomes emit structured audit logs + span
+// attributes for SigNoz.
 package authn
 
 import (
 	"context"
 	"crypto/subtle"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"log/slog"
@@ -27,14 +35,45 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/fleetdm/edr/server/enrollment"
+	"github.com/fleetdm/edr/server/sessions"
 )
+
+// Shared base64url encoders. `rawURLEncoding` (no padding) is what we emit for session
+// ids + CSRF tokens on the wire; `urlEncoding` (with padding) is accepted as a fallback
+// when decoding so padding-normalising middleboxes don't lock users out.
+var (
+	rawURLEncoding = base64.RawURLEncoding
+	urlEncoding    = base64.URLEncoding
+)
+
+// EncodeSessionID serialises the raw session id bytes into the on-wire cookie value.
+// Exported so the session handler package can set Set-Cookie with the same encoding
+// the Session middleware expects.
+func EncodeSessionID(raw []byte) string { return rawURLEncoding.EncodeToString(raw) }
+
+// DecodeSessionIDForTest is the reverse. Exported for downstream test packages that
+// need to look up a session by cookie value via the sessions store directly. Production
+// code should go through the Session middleware.
+func DecodeSessionIDForTest(cookieValue string) ([]byte, error) {
+	return decodeSessionCookie(cookieValue)
+}
 
 // ctxKey is an unexported context key type so callers have to go through HostIDFromContext.
 type ctxKey int
 
 const (
 	ctxKeyHostID ctxKey = iota + 1
+	ctxKeyUserID
+	ctxKeySession
 )
+
+// SessionCookieName is the HTTP cookie name the UI uses for the session id. Exported so
+// the session handler package (which sets + clears the cookie) stays consistent with
+// this package's middleware (which reads it).
+const SessionCookieName = "edr_session"
+
+// CSRFHeaderName is the HTTP header the UI sends the per-session CSRF token in.
+const CSRFHeaderName = "X-CSRF-Token"
 
 // HostIDFromContext returns the host_id pinned by the HostToken middleware. The second
 // return value is false when the context was not wrapped (e.g. the caller bypassed middleware).
@@ -90,12 +129,42 @@ func HostToken(store *enrollment.Store, logger *slog.Logger) func(http.Handler) 
 	}
 }
 
-// AdminToken returns a middleware that gates UI + admin routes behind a shared admin token.
-// Phase 3 replaces this with session cookies + a proper user table; until then the admin
-// token is the stopgap.
-func AdminToken(adminToken string, logger *slog.Logger) func(http.Handler) http.Handler {
-	if adminToken == "" {
-		panic("authn.AdminToken: adminToken must not be empty")
+// UserIDFromContext returns the user id pinned by the Session middleware. Second return
+// is false when the context was not wrapped.
+func UserIDFromContext(ctx context.Context) (int64, bool) {
+	v := ctx.Value(ctxKeyUserID)
+	n, ok := v.(int64)
+	return n, ok && n > 0
+}
+
+// SessionFromContext returns the full session pinned by the Session middleware. Callers
+// that only need the user id should use UserIDFromContext; those that also need the
+// CSRF token (e.g. an endpoint that re-renders the login page) can read it from here.
+func SessionFromContext(ctx context.Context) (*sessions.Session, bool) {
+	v := ctx.Value(ctxKeySession)
+	s, ok := v.(*sessions.Session)
+	return s, ok && s != nil
+}
+
+// WithUserIDForTest pins a user id on the ctx. Exported so handler tests can bypass the
+// Session middleware. Production code must not call this.
+func WithUserIDForTest(ctx context.Context, userID int64) context.Context {
+	return context.WithValue(ctx, ctxKeyUserID, userID)
+}
+
+// WithSessionForTest pins a full session on the ctx. Same test-only caveat as
+// WithUserIDForTest.
+func WithSessionForTest(ctx context.Context, s *sessions.Session) context.Context {
+	return context.WithValue(ctx, ctxKeySession, s)
+}
+
+// Session returns a middleware that validates the `edr_session` cookie against the
+// sessions store. On success the request context carries user_id + the full session
+// (for downstream CSRF + handlers that log the actor). On failure it returns 401 with
+// a typed reason that the UI's 401 handler maps to "redirect to login".
+func Session(store *sessions.Store, logger *slog.Logger) func(http.Handler) http.Handler {
+	if store == nil {
+		panic("authn.Session: store must not be nil")
 	}
 	if logger == nil {
 		logger = slog.Default()
@@ -103,18 +172,101 @@ func AdminToken(adminToken string, logger *slog.Logger) func(http.Handler) http.
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			ctx := r.Context()
-			token, ok := extractBearer(r)
-			if !ok {
-				fail(ctx, w, logger, "missing_bearer")
+			cookie, err := r.Cookie(SessionCookieName)
+			if err != nil || cookie.Value == "" {
+				fail(ctx, w, logger, "missing_session")
 				return
 			}
-			if subtle.ConstantTimeCompare([]byte(token), []byte(adminToken)) != 1 {
-				fail(ctx, w, logger, "invalid_token")
+			raw, err := decodeSessionCookie(cookie.Value)
+			if err != nil {
+				fail(ctx, w, logger, "invalid_session")
+				return
+			}
+			sess, err := store.Get(ctx, raw)
+			switch {
+			case errors.Is(err, sessions.ErrNotFound):
+				// Covers both "cookie points at a deleted row" (logout happened elsewhere)
+				// and "cookie points at an expired row". The UI collapses these to the
+				// same "redirect to login" behaviour.
+				fail(ctx, w, logger, "invalid_session")
+				return
+			case err != nil:
+				logger.ErrorContext(ctx, "session lookup", "err", err)
+				failStatus(ctx, w, logger, http.StatusServiceUnavailable, "session_store_unavailable")
+				return
+			}
+			trace.SpanFromContext(ctx).SetAttributes(
+				attribute.Int64("edr.user.id", sess.UserID),
+				attribute.String("edr.auth.result", "ok"),
+			)
+			ctx = context.WithValue(ctx, ctxKeyUserID, sess.UserID)
+			ctx = context.WithValue(ctx, ctxKeySession, sess)
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}
+
+// CSRF returns a middleware that enforces per-session CSRF tokens on unsafe methods.
+// Wire it on the OUTSIDE of Session so the session is already pinned on ctx by the
+// time CSRF reads it:
+//
+//	mux.Handle("PUT /api/v1/alerts/{id}", CSRF(logger)(Session(store, logger)(h)))
+//
+// Safe methods (GET/HEAD/OPTIONS) pass through without any CSRF check. Callers that
+// expose a non-idempotent GET would be making a mistake regardless of auth.
+func CSRF(logger *slog.Logger) func(http.Handler) http.Handler {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if isSafeMethod(r.Method) {
+				next.ServeHTTP(w, r)
+				return
+			}
+			ctx := r.Context()
+			sess, ok := SessionFromContext(ctx)
+			if !ok {
+				// Middleware mis-wiring: CSRF without Session. Fail loud rather than
+				// silently let the request through. 500 rather than 401 because the
+				// problem is server-side, not the caller's credentials.
+				logger.ErrorContext(ctx, "CSRF middleware invoked without Session on ctx")
+				failStatus(ctx, w, logger, http.StatusInternalServerError, "csrf_misconfigured")
+				return
+			}
+			presented := r.Header.Get(CSRFHeaderName)
+			if presented == "" {
+				failStatus(ctx, w, logger, http.StatusForbidden, "csrf_missing")
+				return
+			}
+			got, err := decodeSessionCookie(presented)
+			if err != nil || subtle.ConstantTimeCompare(got, sess.CSRFToken) != 1 {
+				failStatus(ctx, w, logger, http.StatusForbidden, "csrf_mismatch")
 				return
 			}
 			next.ServeHTTP(w, r)
 		})
 	}
+}
+
+func isSafeMethod(m string) bool {
+	switch m {
+	case http.MethodGet, http.MethodHead, http.MethodOptions:
+		return true
+	}
+	return false
+}
+
+// decodeSessionCookie is the shared base64url decoder for session ids + CSRF tokens. We
+// accept both padded and raw-unpadded encodings because middlebox URL rewriters
+// occasionally strip trailing `=` and we'd rather accept the slight ambiguity than lock
+// customers out. Production UI always emits the raw-unpadded form.
+func decodeSessionCookie(s string) ([]byte, error) {
+	// Try raw-unpadded first (the form we emit).
+	if b, err := rawURLEncoding.DecodeString(s); err == nil {
+		return b, nil
+	}
+	return urlEncoding.DecodeString(s)
 }
 
 // extractBearer returns the token portion of an "Authorization: Bearer <token>" header.

--- a/server/authn/authn.go
+++ b/server/authn/authn.go
@@ -8,11 +8,14 @@
 //     the row in the sessions table, and pins user_id + session_id + csrf_token onto
 //     the request context. Phase 3 replaces the Phase 1 `AdminToken` stopgap.
 //
-//   - CSRF wraps the same UI + admin routes as Session (applied on the outside of
-//     Session so it can read the per-session CSRF token off the context). It compares
-//     the `X-CSRF-Token` header against the stored value on unsafe methods (POST, PUT,
-//     DELETE, PATCH) via subtle.ConstantTimeCompare; safe methods (GET, HEAD, OPTIONS)
-//     pass through.
+//   - CSRF wraps the same UI + admin routes as Session and runs AFTER Session has
+//     pinned the per-session CSRF token onto the context (i.e. Session is the outer
+//     middleware; CSRF is applied to the inner handler). In Go's convention
+//     `outer(inner(h))` runs the outer on the way in, so the correct composition is
+//     `Session(CSRF(h))`. Reversing them yields csrf_misconfigured 500s on every
+//     unsafe method. The middleware compares the `X-CSRF-Token` header against the
+//     stored value on unsafe methods (POST, PUT, DELETE, PATCH) via
+//     subtle.ConstantTimeCompare; safe methods (GET, HEAD, OPTIONS) pass through.
 //
 // Authentication failures return 401 + JSON body + `WWW-Authenticate: Bearer`. Verifier
 // outages (DB down, unexpected errors) return 503 without WWW-Authenticate so an agent
@@ -207,10 +210,10 @@ func Session(store *sessions.Store, logger *slog.Logger) func(http.Handler) http
 }
 
 // CSRF returns a middleware that enforces per-session CSRF tokens on unsafe methods.
-// Wire it on the OUTSIDE of Session so the session is already pinned on ctx by the
-// time CSRF reads it:
+// Wire it INSIDE Session so Session runs first (outer middleware runs on the way in)
+// and pins the session on ctx before CSRF reads it:
 //
-//	mux.Handle("PUT /api/v1/alerts/{id}", CSRF(logger)(Session(store, logger)(h)))
+//	mux.Handle("PUT /api/v1/alerts/{id}", Session(store, logger)(CSRF(logger)(h)))
 //
 // Safe methods (GET/HEAD/OPTIONS) pass through without any CSRF check. Callers that
 // expose a non-idempotent GET would be making a mistake regardless of auth.

--- a/server/authn/authn_test.go
+++ b/server/authn/authn_test.go
@@ -15,10 +15,7 @@ import (
 	"github.com/fleetdm/edr/server/store"
 )
 
-const (
-	testAdminToken = "test-admin-token"
-	testUUID       = "93DFC6F5-763D-5075-B305-8AC145D12F96"
-)
+const testUUID = "93DFC6F5-763D-5075-B305-8AC145D12F96"
 
 // enrolledHost constructs a store with a single enrolled host and returns its token.
 func enrolledHost(t *testing.T) (*enrollment.Store, string) {
@@ -146,51 +143,10 @@ func TestHostToken_RevokedToken(t *testing.T) {
 	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
 }
 
-func TestAdminToken_HappyPath(t *testing.T) {
-	mw := AdminToken(testAdminToken, slog.Default())
-	mux := http.NewServeMux()
-	mux.Handle("GET /admin", mw(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	})))
-	srv := httptest.NewServer(mux)
-	t.Cleanup(srv.Close)
-
-	t.Run("valid admin token", func(t *testing.T) {
-		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+"/admin", nil)
-		require.NoError(t, err)
-		req.Header.Set("Authorization", "Bearer "+testAdminToken)
-		resp, err := srv.Client().Do(req)
-		require.NoError(t, err)
-		defer resp.Body.Close()
-		assert.Equal(t, http.StatusOK, resp.StatusCode)
-	})
-
-	t.Run("wrong admin token", func(t *testing.T) {
-		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+"/admin", nil)
-		require.NoError(t, err)
-		req.Header.Set("Authorization", "Bearer nope")
-		resp, err := srv.Client().Do(req)
-		require.NoError(t, err)
-		defer resp.Body.Close()
-		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
-	})
-
-	t.Run("wrong scheme", func(t *testing.T) {
-		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+"/admin", nil)
-		require.NoError(t, err)
-		req.Header.Set("Authorization", "Token "+testAdminToken)
-		resp, err := srv.Client().Do(req)
-		require.NoError(t, err)
-		defer resp.Body.Close()
-		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
-	})
-}
-
-func TestAdminToken_PanicsOnEmptyToken(t *testing.T) {
-	assert.PanicsWithValue(t, "authn.AdminToken: adminToken must not be empty", func() {
-		_ = AdminToken("", slog.Default())
-	})
-}
+// The Phase 1 AdminToken tests used to live here; Phase 3 replaces AdminToken with
+// Session + CSRF. Session middleware coverage lives in session_test.go (full happy
+// path + CSRF + expiry). The smoke tests below are kept to lock in the basics so the
+// shared fail/failStatus path keeps working as we refactor.
 
 func TestHostIDFromContext_Nil(t *testing.T) {
 	_, ok := HostIDFromContext(t.Context())

--- a/server/authn/session_test.go
+++ b/server/authn/session_test.go
@@ -1,0 +1,187 @@
+package authn
+
+import (
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fleetdm/edr/server/sessions"
+	"github.com/fleetdm/edr/server/store"
+)
+
+// newSessionsStore returns a ready-to-use sessions.Store backed by a fresh test DB.
+func newSessionsStore(t *testing.T) *sessions.Store {
+	t.Helper()
+	return sessions.New(store.OpenTestStore(t).DB(), sessions.Options{})
+}
+
+// sealedBody is a tiny handler that writes "ok" once the middleware lets it through.
+// Tests use it to distinguish "middleware let me through" (body == "ok") from
+// "middleware short-circuited with an error" (status != 200 and body is JSON).
+var sealedBody = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	_, _ = io.WriteString(w, "ok")
+})
+
+func TestSession_MissingCookieReturns401(t *testing.T) {
+	st := newSessionsStore(t)
+	mw := Session(st, slog.Default())
+	srv := httptest.NewServer(mw(sealedBody))
+	t.Cleanup(srv.Close)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+"/", nil)
+	require.NoError(t, err)
+	resp, err := srv.Client().Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+}
+
+func TestSession_UnknownCookieReturns401(t *testing.T) {
+	st := newSessionsStore(t)
+	mw := Session(st, slog.Default())
+	srv := httptest.NewServer(mw(sealedBody))
+	t.Cleanup(srv.Close)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+"/", nil)
+	require.NoError(t, err)
+	// 32 zero bytes, base64url — never matches a real session.
+	req.AddCookie(&http.Cookie{Name: SessionCookieName, Value: EncodeSessionID(make([]byte, sessions.IDLen))})
+	resp, err := srv.Client().Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+}
+
+func TestSession_MalformedCookieReturns401(t *testing.T) {
+	st := newSessionsStore(t)
+	mw := Session(st, slog.Default())
+	srv := httptest.NewServer(mw(sealedBody))
+	t.Cleanup(srv.Close)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+"/", nil)
+	require.NoError(t, err)
+	req.AddCookie(&http.Cookie{Name: SessionCookieName, Value: "not-base64-@#$%"})
+	resp, err := srv.Client().Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+}
+
+func TestSession_ValidCookieLetsHandlerRun(t *testing.T) {
+	st := newSessionsStore(t)
+	sess, err := st.Create(t.Context(), 42)
+	require.NoError(t, err)
+
+	mw := Session(st, slog.Default())
+	var sawUserID int64
+	var sawSession *sessions.Session
+	srv := httptest.NewServer(mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		uid, _ := UserIDFromContext(r.Context())
+		sawUserID = uid
+		s, _ := SessionFromContext(r.Context())
+		sawSession = s
+		w.WriteHeader(http.StatusOK)
+	})))
+	t.Cleanup(srv.Close)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+"/", nil)
+	require.NoError(t, err)
+	req.AddCookie(&http.Cookie{Name: SessionCookieName, Value: EncodeSessionID(sess.ID)})
+	resp, err := srv.Client().Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, int64(42), sawUserID)
+	require.NotNil(t, sawSession)
+	assert.Equal(t, sess.CSRFToken, sawSession.CSRFToken)
+}
+
+// TestCSRF_SafeMethodPassesThrough — a GET never needs a CSRF header even if one of
+// the authenticated admin surfaces ever ends up behind the CSRF middleware.
+func TestCSRF_SafeMethodPassesThrough(t *testing.T) {
+	mw := CSRF(slog.Default())
+	srv := httptest.NewServer(mw(sealedBody))
+	t.Cleanup(srv.Close)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+"/", nil)
+	require.NoError(t, err)
+	resp, err := srv.Client().Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+// TestCSRF_MisconfiguredReturns500 — CSRF outside Session (no session on ctx for an
+// unsafe method) is a programming error; we surface it as 500 not 401 so the ops team
+// pages on server misconfiguration rather than assuming a bad token.
+func TestCSRF_MisconfiguredReturns500(t *testing.T) {
+	mw := CSRF(slog.Default())
+	srv := httptest.NewServer(mw(sealedBody))
+	t.Cleanup(srv.Close)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, srv.URL+"/", nil)
+	require.NoError(t, err)
+	resp, err := srv.Client().Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+}
+
+// TestCSRF_Stack happy path + the two failure modes with a real Session pinned.
+func TestCSRF_Stack(t *testing.T) {
+	st := newSessionsStore(t)
+	sess, err := st.Create(t.Context(), 7)
+	require.NoError(t, err)
+
+	csrf := EncodeSessionID(sess.CSRFToken)
+
+	// Middleware order: outer CSRF, inner Session. At request time, Session runs first
+	// (wraps the request on the way in), CSRF checks afterwards — but they share ctx
+	// only because CSRF invokes `next` which is Session(sealedBody). So we actually
+	// want Session(CSRF(sealedBody)) — Session runs first, CSRF sees ctx it populated.
+	mw := Session(st, slog.Default())(CSRF(slog.Default())(sealedBody))
+	srv := httptest.NewServer(mw)
+	t.Cleanup(srv.Close)
+
+	makeReq := func(t *testing.T, method string) *http.Request {
+		t.Helper()
+		req, err := http.NewRequestWithContext(t.Context(), method, srv.URL+"/", nil)
+		require.NoError(t, err)
+		req.AddCookie(&http.Cookie{Name: SessionCookieName, Value: EncodeSessionID(sess.ID)})
+		return req
+	}
+
+	t.Run("unsafe method missing header → 403", func(t *testing.T) {
+		resp, err := srv.Client().Do(makeReq(t, http.MethodPost))
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+	})
+
+	t.Run("unsafe method wrong header → 403", func(t *testing.T) {
+		req := makeReq(t, http.MethodPost)
+		req.Header.Set(CSRFHeaderName, EncodeSessionID(make([]byte, sessions.IDLen)))
+		resp, err := srv.Client().Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+	})
+
+	t.Run("unsafe method correct header → 200", func(t *testing.T) {
+		req := makeReq(t, http.MethodPost)
+		req.Header.Set(CSRFHeaderName, csrf)
+		resp, err := srv.Client().Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+}
+
+func TestSession_PanicsOnNilStore(t *testing.T) {
+	assert.Panics(t, func() { _ = Session(nil, slog.Default()) })
+}

--- a/server/authn/session_test.go
+++ b/server/authn/session_test.go
@@ -15,9 +15,38 @@ import (
 )
 
 // newSessionsStore returns a ready-to-use sessions.Store backed by a fresh test DB.
+// A stub users row (id=42, and anything else tests reference) is inserted first so the
+// Phase 3 FK sessions.user_id → users(id) constraint doesn't reject the insert.
 func newSessionsStore(t *testing.T) *sessions.Store {
 	t.Helper()
-	return sessions.New(store.OpenTestStore(t).DB(), sessions.Options{})
+	s := store.OpenTestStore(t)
+	for _, uid := range []int64{1, 7, 42} {
+		_, err := s.DB().ExecContext(t.Context(),
+			`INSERT INTO users (id, email, password_hash, password_salt) VALUES (?, ?, ?, ?)`,
+			uid, "authn-stub@test", []byte("stub-hash"), []byte("stub-salt"))
+		if err != nil {
+			// Email is UNIQUE so the 2nd+ inserts with the same email fail. Use unique.
+			_, err2 := s.DB().ExecContext(t.Context(),
+				`INSERT INTO users (id, email, password_hash, password_salt) VALUES (?, ?, ?, ?)`,
+				uid, "authn-stub-"+fmtInt(uid)+"@test", []byte("stub-hash"), []byte("stub-salt"))
+			if err2 != nil {
+				t.Fatalf("seed stub user %d: %v / %v", uid, err, err2)
+			}
+		}
+	}
+	return sessions.New(s.DB(), sessions.Options{})
+}
+
+func fmtInt(i int64) string {
+	if i == 0 {
+		return "0"
+	}
+	var out []byte
+	for i > 0 {
+		out = append([]byte{byte('0' + i%10)}, out...)
+		i /= 10
+	}
+	return string(out)
 }
 
 // sealedBody is a tiny handler that writes "ok" once the middleware lets it through.

--- a/server/cmd/fleet-edr-server/main.go
+++ b/server/cmd/fleet-edr-server/main.go
@@ -3,7 +3,7 @@
 // by a separate fleet-edr-ingest instance.
 //
 // Configuration is loaded from environment variables; see server/config for the full list.
-// Start it with EDR_DSN, EDR_ENROLL_SECRET, EDR_ADMIN_TOKEN, TLS cert files (or
+// Start it with EDR_DSN, EDR_ENROLL_SECRET, TLS cert files (or
 // EDR_ALLOW_INSECURE_HTTP=1 for dev), and optionally the OTEL_* vars that route traces and
 // logs to a collector (SigNoz, Tempo, Datadog, ...).
 package main
@@ -35,8 +35,12 @@ import (
 	"github.com/fleetdm/edr/server/observability"
 	"github.com/fleetdm/edr/server/policy"
 	"github.com/fleetdm/edr/server/processor"
+	"github.com/fleetdm/edr/server/seed"
+	"github.com/fleetdm/edr/server/session"
+	"github.com/fleetdm/edr/server/sessions"
 	"github.com/fleetdm/edr/server/store"
 	"github.com/fleetdm/edr/server/ui"
+	"github.com/fleetdm/edr/server/users"
 )
 
 // Build info injected via -ldflags at build time.
@@ -126,6 +130,17 @@ func run() error {
 
 	enrollStore := enrollment.NewStore(s.DB())
 	policyStore := policy.New(s.DB())
+	userStore := users.New(s.DB())
+	sessionStore := sessions.New(s.DB(), sessions.Options{})
+
+	// Phase 3: seed the first admin before we bind the HTTP listener. If the operator
+	// is watching, they capture the printed password at boot; if they miss it they can
+	// restart and re-seed by deleting the admin row. Never fatal — a seed failure is
+	// logged but the server still boots (operator can run migrations by hand).
+	if _, _, err := seed.Admin(ctx, userStore, logger, os.Stderr); err != nil {
+		logger.ErrorContext(ctx, "admin seed failed", "err", err)
+	}
+
 	enrollHandler := enrollment.NewHandler(enrollStore, enrollment.Options{
 		EnrollSecret:  cfg.EnrollSecret,
 		RatePerMinute: cfg.EnrollRatePerMin,
@@ -134,22 +149,32 @@ func run() error {
 		CommandStore:  s,
 	})
 	adminHandler := admin.New(enrollStore, policyStore, s, logger)
+	sessionHandler := session.New(userStore, sessionStore, session.Options{
+		RatePerMinute: cfg.LoginRatePerMin,
+		CookieSecure:  cfg.TLSEnabled(),
+		Logger:        logger,
+	})
 
 	// Build the mux as a composition of three authorization domains:
-	//   - public:  /livez, /readyz, /health, POST /api/v1/enroll
+	//   - public:  /livez, /readyz, /health, POST /api/v1/enroll, POST /api/v1/session
 	//   - host:    POST /api/v1/events, GET /api/v1/commands, PUT /api/v1/commands/{id}
 	//             (wrapped in authn.HostToken — the agent polls for + reports on its own commands)
-	//   - admin:   everything under /api/v1/{hosts,alerts,admin}, POST /api/v1/commands,
-	//             GET /api/v1/commands/{id}, and /ui/* (wrapped in authn.AdminToken)
+	//   - session: everything under /api/v1/{hosts,alerts,admin}, POST /api/v1/commands,
+	//             GET /api/v1/commands/{id}, GET/DELETE /api/v1/session (wrapped in
+	//             authn.Session; unsafe methods additionally gated by authn.CSRF)
 	//
 	// Middleware is applied per-handler at registration time so a single mux serves the whole
 	// surface and we don't have to route through multiple servers.
 	hostTokenMW := authn.HostToken(enrollStore, logger)
-	adminTokenMW := authn.AdminToken(cfg.AdminToken, logger)
+	sessionMW := authn.Session(sessionStore, logger)
+	csrfMW := authn.CSRF(logger)
 
 	mux := http.NewServeMux()
 	ingestHandler.RegisterHealthRoutes(mux)
 	enrollHandler.RegisterRoutes(mux)
+	// POST /api/v1/session is public — there is no session yet. The session handler
+	// does its own rate-limit + audit log so we don't need to wrap it.
+	sessionHandler.RegisterPublicRoutes(mux)
 
 	// Host-token protected agent endpoints. We wrap a dedicated sub-mux so the api.Handler
 	// routes (GET/PUT commands) share scoping logic with the ingest handler.
@@ -166,24 +191,54 @@ func run() error {
 		mux.Handle(p, hostProtected)
 	}
 
-	// Admin-token protected admin APIs. api.Handler.RegisterRoutes registers onto a dedicated
-	// sub-mux so we can wrap that whole sub-mux in the admin middleware. GET /commands and
+	// Session-protected admin APIs. api.Handler.RegisterRoutes registers onto a dedicated
+	// sub-mux so we can wrap that whole sub-mux in the session middleware. GET /commands and
 	// PUT /commands/{id} are deliberately host-token-only — those paths are the agent-facing
-	// command protocol. Admin UI command management (POST, GET /{id}) goes here.
+	// command protocol. Admin UI command management (POST, GET /{id}) goes here. The
+	// session + CSRF middleware pair lives here: Session first (reads cookie, pins user
+	// + session on ctx), CSRF second (reads session off ctx, validates X-CSRF-Token on
+	// unsafe methods). GET + DELETE /api/v1/session live under the same stack; login POST
+	// is public (above).
 	apiMux := http.NewServeMux()
 	apiHandler.RegisterRoutes(apiMux)
 	adminHandler.RegisterRoutes(apiMux)
-	adminProtected := adminTokenMW(apiMux)
+	sessionHandler.RegisterAuthedRoutes(apiMux)
+	sessionProtected := sessionMW(csrfMW(apiMux))
 	for _, p := range []string{
 		"GET /api/v1/hosts", "GET /api/v1/hosts/{host_id}/tree", "GET /api/v1/hosts/{host_id}/processes/{pid}",
 		"GET /api/v1/alerts", "GET /api/v1/alerts/{id}", "PUT /api/v1/alerts/{id}",
 		"GET /api/v1/commands/{id}", "POST /api/v1/commands",
 		"GET /api/v1/admin/enrollments", "POST /api/v1/admin/enrollments/{host_id}/revoke",
 		"GET /api/v1/admin/policy", "PUT /api/v1/admin/policy",
+		"GET /api/v1/session", "DELETE /api/v1/session",
 	} {
-		mux.Handle(p, adminProtected)
+		mux.Handle(p, sessionProtected)
 	}
 	registerUIRoutes(mux, logger)
+
+	// Phase 3: periodic cleanup of expired session rows. Every 5 minutes; the exact
+	// interval doesn't matter much — 12h-TTL rows that linger for a few extra minutes
+	// are harmless because Session middleware already rejects expired rows via the
+	// `expires_at > NOW()` filter.
+	go func() {
+		t := time.NewTicker(5 * time.Minute)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+				n, err := sessionStore.CleanupExpired(ctx)
+				if err != nil {
+					logger.WarnContext(ctx, "session cleanup", "err", err)
+					continue
+				}
+				if n > 0 {
+					logger.InfoContext(ctx, "session cleanup removed rows", "count", n)
+				}
+			}
+		}
+	}()
 
 	// Start the background event processor.
 	go func() {
@@ -288,10 +343,12 @@ func run() error {
 }
 
 // registerUIRoutes serves the embedded React UI at /ui/ and redirects / to /ui/. The bundle
-// itself is intentionally unauthenticated: the React app's login screen is what collects the
-// admin token and stores it in sessionStorage, from which every subsequent API call reads it
-// into an `Authorization: Bearer` header. Gating /ui/ behind AdminToken would make the login
-// page unreachable (chicken/egg). The privileged surface is /api/v1/*, which IS gated.
+// itself is intentionally unauthenticated: the React app's Login screen is what collects the
+// email + password via POST /api/v1/session. The server replies with a HttpOnly session
+// cookie and a CSRF token the JS stores in memory. Every subsequent state-changing call
+// carries both the cookie (automatic, HttpOnly) and an X-CSRF-Token header. Gating /ui/
+// itself behind the Session middleware would make the login page unreachable (chicken/egg).
+// The privileged surface is /api/v1/*, which IS session-gated.
 // Phase 3 replaces this with a server-rendered login endpoint + session cookies.
 func registerUIRoutes(mux *http.ServeMux, logger *slog.Logger) {
 	uiDist, err := fs.Sub(ui.DistFS, "dist")

--- a/server/cmd/fleet-edr-server/main.go
+++ b/server/cmd/fleet-edr-server/main.go
@@ -210,7 +210,7 @@ func run() error {
 		"GET /api/v1/commands/{id}", "POST /api/v1/commands",
 		"GET /api/v1/admin/enrollments", "POST /api/v1/admin/enrollments/{host_id}/revoke",
 		"GET /api/v1/admin/policy", "PUT /api/v1/admin/policy",
-		"GET /api/v1/session", "DELETE /api/v1/session",
+		"GET /api/v1/session",
 	} {
 		mux.Handle(p, sessionProtected)
 	}
@@ -349,7 +349,6 @@ func run() error {
 // carries both the cookie (automatic, HttpOnly) and an X-CSRF-Token header. Gating /ui/
 // itself behind the Session middleware would make the login page unreachable (chicken/egg).
 // The privileged surface is /api/v1/*, which IS session-gated.
-// Phase 3 replaces this with a server-rendered login endpoint + session cookies.
 func registerUIRoutes(mux *http.ServeMux, logger *slog.Logger) {
 	uiDist, err := fs.Sub(ui.DistFS, "dist")
 	if err != nil {

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -18,12 +18,12 @@ type Config struct {
 	DSN               string
 	ListenAddr        string
 	EnrollSecret      string
-	AdminToken        string
 	TLSCertFile       string
 	TLSKeyFile        string
 	AllowInsecureHTTP bool
 	AllowTLS12        bool
 	EnrollRatePerMin  int
+	LoginRatePerMin   int
 	LogLevel          string
 	LogFormat         string
 	ProcessInterval   time.Duration
@@ -49,6 +49,7 @@ func defaults() Config {
 		ProcessInterval:  500 * time.Millisecond,
 		ProcessBatch:     500,
 		EnrollRatePerMin: 30,
+		LoginRatePerMin:  6,
 	}
 }
 
@@ -66,7 +67,9 @@ func loadFrom(getenv func(string) string) (*Config, error) {
 	requireStr(&c.DSN, "EDR_DSN", getenv, &errs, true)
 	optionalStr(&c.ListenAddr, "EDR_LISTEN_ADDR", getenv)
 	requireStr(&c.EnrollSecret, "EDR_ENROLL_SECRET", getenv, &errs, true)
-	requireStr(&c.AdminToken, "EDR_ADMIN_TOKEN", getenv, &errs, true)
+	// Phase 3 removed EDR_ADMIN_TOKEN. UI + admin surfaces now authenticate via the
+	// session cookie minted by POST /api/v1/session. The first-boot seeder prints the
+	// admin password once so the operator can log in.
 	optionalStr(&c.TLSCertFile, "EDR_TLS_CERT_FILE", getenv)
 	optionalStr(&c.TLSKeyFile, "EDR_TLS_KEY_FILE", getenv)
 

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -100,6 +100,18 @@ func loadFrom(getenv func(string) string) (*Config, error) {
 		}
 	}
 
+	if v := getenv("EDR_LOGIN_RATE_PER_MIN"); v != "" {
+		n, err := strconv.Atoi(v)
+		switch {
+		case err != nil:
+			errs = append(errs, fmt.Errorf("EDR_LOGIN_RATE_PER_MIN=%q: %w", v, err))
+		case n <= 0:
+			errs = append(errs, fmt.Errorf("EDR_LOGIN_RATE_PER_MIN=%d must be positive", n))
+		default:
+			c.LoginRatePerMin = n
+		}
+	}
+
 	if v := getenv("EDR_LAUNCHAGENT_ALLOWLIST"); v != "" {
 		c.LaunchAgentAllowlist = make(map[string]struct{})
 		for p := range strings.SplitSeq(v, ",") {

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -177,11 +177,12 @@ func TestLoad(t *testing.T) {
 		{
 			name: "optional overrides applied",
 			env: withExtra(minEnv, map[string]string{
-				"EDR_LISTEN_ADDR":      "127.0.0.1:9090",
-				"EDR_LOG_LEVEL":        "debug",
-				"EDR_LOG_FORMAT":       "text",
-				"EDR_PROCESS_INTERVAL": "1s",
-				"EDR_PROCESS_BATCH":    "200",
+				"EDR_LISTEN_ADDR":        "127.0.0.1:9090",
+				"EDR_LOG_LEVEL":          "debug",
+				"EDR_LOG_FORMAT":         "text",
+				"EDR_PROCESS_INTERVAL":   "1s",
+				"EDR_PROCESS_BATCH":      "200",
+				"EDR_LOGIN_RATE_PER_MIN": "20",
 			}),
 			validate: func(t *testing.T, c *Config) {
 				t.Helper()
@@ -191,7 +192,22 @@ func TestLoad(t *testing.T) {
 				assert.Equal(t, "text", c.LogFormat)
 				assert.Equal(t, time.Second, c.ProcessInterval)
 				assert.Equal(t, 200, c.ProcessBatch)
+				assert.Equal(t, 20, c.LoginRatePerMin)
 			},
+		},
+		{
+			name: "invalid login rate rejected",
+			env: withExtra(minEnv, map[string]string{
+				"EDR_LOGIN_RATE_PER_MIN": "banana",
+			}),
+			wantErr: "EDR_LOGIN_RATE_PER_MIN",
+		},
+		{
+			name: "zero login rate rejected",
+			env: withExtra(minEnv, map[string]string{
+				"EDR_LOGIN_RATE_PER_MIN": "0",
+			}),
+			wantErr: "EDR_LOGIN_RATE_PER_MIN=0 must be positive",
 		},
 	}
 

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -20,7 +20,6 @@ func TestLoad(t *testing.T) {
 	minEnv := map[string]string{
 		"EDR_DSN":                 "root@tcp(127.0.0.1:3306)/edr?parseTime=true",
 		"EDR_ENROLL_SECRET":       "enroll-me",
-		"EDR_ADMIN_TOKEN":         "admin-me",
 		"EDR_ALLOW_INSECURE_HTTP": "1",
 	}
 
@@ -37,7 +36,6 @@ func TestLoad(t *testing.T) {
 				t.Helper()
 				assert.Equal(t, "root@tcp(127.0.0.1:3306)/edr?parseTime=true", c.DSN)
 				assert.Equal(t, "enroll-me", c.EnrollSecret)
-				assert.Equal(t, "admin-me", c.AdminToken)
 				assert.True(t, c.AllowInsecureHTTP)
 				assert.Equal(t, ":8088", c.ListenAddr)
 				assert.Equal(t, "info", c.LogLevel)
@@ -45,6 +43,7 @@ func TestLoad(t *testing.T) {
 				assert.Equal(t, 500*time.Millisecond, c.ProcessInterval)
 				assert.Equal(t, 500, c.ProcessBatch)
 				assert.Equal(t, 30, c.EnrollRatePerMin)
+				assert.Equal(t, 6, c.LoginRatePerMin)
 				assert.False(t, c.TLSEnabled())
 			},
 		},
@@ -52,7 +51,6 @@ func TestLoad(t *testing.T) {
 			name: "missing EDR_DSN",
 			env: map[string]string{
 				"EDR_ENROLL_SECRET":       "s",
-				"EDR_ADMIN_TOKEN":         "a",
 				"EDR_ALLOW_INSECURE_HTTP": "1",
 			},
 			wantErr: "EDR_DSN",
@@ -61,26 +59,15 @@ func TestLoad(t *testing.T) {
 			name: "missing EDR_ENROLL_SECRET",
 			env: map[string]string{
 				"EDR_DSN":                 "x",
-				"EDR_ADMIN_TOKEN":         "a",
 				"EDR_ALLOW_INSECURE_HTTP": "1",
 			},
 			wantErr: "EDR_ENROLL_SECRET",
-		},
-		{
-			name: "missing EDR_ADMIN_TOKEN",
-			env: map[string]string{
-				"EDR_DSN":                 "x",
-				"EDR_ENROLL_SECRET":       "s",
-				"EDR_ALLOW_INSECURE_HTTP": "1",
-			},
-			wantErr: "EDR_ADMIN_TOKEN",
 		},
 		{
 			name: "TLS required unless EDR_ALLOW_INSECURE_HTTP=1",
 			env: map[string]string{
 				"EDR_DSN":           "x",
 				"EDR_ENROLL_SECRET": "s",
-				"EDR_ADMIN_TOKEN":   "a",
 			},
 			wantErr: "EDR_TLS_CERT_FILE is required",
 		},
@@ -91,7 +78,7 @@ func TestLoad(t *testing.T) {
 				t.Helper()
 				t.Fatalf("validate should not be called when wantErr is set")
 			},
-			wantErr: "EDR_DSN\nrequired env var EDR_ENROLL_SECRET\nrequired env var EDR_ADMIN_TOKEN",
+			wantErr: "EDR_DSN\nrequired env var EDR_ENROLL_SECRET",
 		},
 		{
 			name: "TLS key without cert",

--- a/server/enrollment/handler.go
+++ b/server/enrollment/handler.go
@@ -333,31 +333,52 @@ func remoteIP(r *http.Request, trimHost bool) string {
 	return host
 }
 
-// ipLimiter is a naive per-source-IP rate limiter keyed on the IP string. Each key owns its
-// own `rate.Limiter`. The map grows without bound, but MVP fleet sizes and typical pilot
-// deployments bound this at low thousands of IPs and we can reap stale entries later.
+// ipLimiter is a per-source-IP rate limiter keyed on the IP string. Each key owns its
+// own `rate.Limiter`. We cap the map at `maxBuckets` and evict idle entries older than
+// `bucketIdleTTL` when the cap is exceeded, so an attacker rotating source IPs cannot
+// turn the brute-force defence into an unbounded-memory-growth vector.
+
+const (
+	bucketIdleTTL = 2 * time.Hour
+	maxBuckets    = 1024
+)
+
+type ipBucket struct {
+	limiter  *rate.Limiter
+	lastSeen time.Time
+}
+
 type ipLimiter struct {
-	mu     sync.Mutex
-	limit  rate.Limit
-	burst  int
-	limit2 map[string]*rate.Limiter
+	mu      sync.Mutex
+	limit   rate.Limit
+	burst   int
+	buckets map[string]*ipBucket
 }
 
 func newIPLimiter(limit rate.Limit, burst int) *ipLimiter {
 	return &ipLimiter{
-		limit:  limit,
-		burst:  burst,
-		limit2: make(map[string]*rate.Limiter),
+		limit:   limit,
+		burst:   burst,
+		buckets: make(map[string]*ipBucket),
 	}
 }
 
 func (l *ipLimiter) allow(ip string) bool {
+	now := time.Now()
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	rl, ok := l.limit2[ip]
-	if !ok {
-		rl = rate.NewLimiter(l.limit, l.burst)
-		l.limit2[ip] = rl
+	if len(l.buckets) > maxBuckets {
+		for k, b := range l.buckets {
+			if now.Sub(b.lastSeen) > bucketIdleTTL {
+				delete(l.buckets, k)
+			}
+		}
 	}
-	return rl.Allow()
+	b, ok := l.buckets[ip]
+	if !ok {
+		b = &ipBucket{limiter: rate.NewLimiter(l.limit, l.burst)}
+		l.buckets[ip] = b
+	}
+	b.lastSeen = now
+	return b.limiter.Allow()
 }

--- a/server/seed/admin.go
+++ b/server/seed/admin.go
@@ -1,0 +1,91 @@
+// Package seed bootstraps the first-boot state that is too opinionated for DDL: the
+// single admin user that the UI logs in as. Called from main.go right after the store
+// is open but before the HTTP server starts accepting traffic.
+//
+// Design note: the seeded password is printed to stderr exactly once. If an operator
+// misses the print (container stdout rotated, terminal cleared, etc.) the recovery
+// path is to `DELETE FROM users WHERE email='admin@fleet-edr.local'` and restart —
+// the seeder sees the empty table and generates a new password. That's not elegant,
+// but a password-reset flow is explicitly out of scope for Phase 3.
+package seed
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"log/slog"
+
+	"github.com/fleetdm/edr/server/users"
+)
+
+// DefaultAdminEmail is the well-known first-admin email. Operators can create further
+// accounts post-v1.1; for MVP this is the only one.
+const DefaultAdminEmail = "admin@fleet-edr.local"
+
+// PasswordBytes is the size (in random bytes, pre-base64) of the generated admin
+// password. 24 bytes → 32 base64url characters → ~192 bits of entropy, plenty against
+// offline argon2 attacks.
+const PasswordBytes = 24
+
+// Admin seeds the initial admin user if the users table is empty. Returns the admin
+// user (if any seeding happened) and the plaintext password that should be shown to
+// the operator. If a user already exists it returns (nil, "", nil) so the caller can
+// log at debug.
+func Admin(ctx context.Context, us *users.Store, logger *slog.Logger, stderr io.Writer) (*users.User, string, error) {
+	if us == nil {
+		return nil, "", fmt.Errorf("seed.Admin: users store required")
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	n, err := us.Count(ctx)
+	if err != nil {
+		return nil, "", fmt.Errorf("count users: %w", err)
+	}
+	if n > 0 {
+		logger.DebugContext(ctx, "admin seed skipped — users table non-empty")
+		return nil, "", nil
+	}
+
+	pw, err := randomPassword()
+	if err != nil {
+		return nil, "", fmt.Errorf("generate admin password: %w", err)
+	}
+	u, err := us.Create(ctx, users.CreateRequest{Email: DefaultAdminEmail, Password: pw})
+	if err != nil {
+		return nil, "", fmt.Errorf("create admin user: %w", err)
+	}
+
+	// stderr banner so a human watching the log sees it during `docker run`. Not logged
+	// through slog because even slog's text handler can quote / escape the string in
+	// ways that make copy-paste tricky; raw writes win.
+	if stderr != nil {
+		fmt.Fprintln(stderr, "================================================================")
+		fmt.Fprintln(stderr, "SEEDED ADMIN USER (captured once — save the password now)")
+		fmt.Fprintf(stderr, "  Email:    %s\n", u.Email)
+		fmt.Fprintf(stderr, "  Password: %s\n", pw)
+		fmt.Fprintln(stderr, "================================================================")
+	}
+
+	// Structured log WITHOUT the password so SigNoz has the event without leaking the
+	// credential. Audit reviewers can correlate this line to a `login ok` line later.
+	logger.InfoContext(ctx, "admin user seeded",
+		"edr.user.id", u.ID,
+		"edr.user.email", u.Email,
+	)
+	return u, pw, nil
+}
+
+// randomPassword returns a base64url-encoded 24-byte random password. Base64url rather
+// than base62 because the stdlib gives it to us for free and the trailing `=` padding
+// is irrelevant for us (rawURLEncoding omits it).
+func randomPassword() (string, error) {
+	buf := make([]byte, PasswordBytes)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(buf), nil
+}

--- a/server/seed/admin.go
+++ b/server/seed/admin.go
@@ -61,13 +61,23 @@ func Admin(ctx context.Context, us *users.Store, logger *slog.Logger, stderr io.
 
 	// stderr banner so a human watching the log sees it during `docker run`. Not logged
 	// through slog because even slog's text handler can quote / escape the string in
-	// ways that make copy-paste tricky; raw writes win.
+	// ways that make copy-paste tricky; raw writes win. Build the banner once and
+	// write it in a single call so a partial-write failure can't leave the operator
+	// staring at half the password; any write error is surfaced to the caller so
+	// main.go can choose to abort startup rather than continue with an admin account
+	// whose password was never shown.
 	if stderr != nil {
-		fmt.Fprintln(stderr, "================================================================")
-		fmt.Fprintln(stderr, "SEEDED ADMIN USER (captured once — save the password now)")
-		fmt.Fprintf(stderr, "  Email:    %s\n", u.Email)
-		fmt.Fprintf(stderr, "  Password: %s\n", pw)
-		fmt.Fprintln(stderr, "================================================================")
+		banner := fmt.Sprintf(
+			"================================================================\n"+
+				"SEEDED ADMIN USER (captured once — save the password now)\n"+
+				"  Email:    %s\n"+
+				"  Password: %s\n"+
+				"================================================================\n",
+			u.Email, pw,
+		)
+		if _, err := io.WriteString(stderr, banner); err != nil {
+			return u, pw, fmt.Errorf("write admin seed banner: %w", err)
+		}
 	}
 
 	// Structured log WITHOUT the password so SigNoz has the event without leaking the

--- a/server/seed/admin_test.go
+++ b/server/seed/admin_test.go
@@ -1,0 +1,78 @@
+package seed
+
+import (
+	"bytes"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fleetdm/edr/server/store"
+	"github.com/fleetdm/edr/server/users"
+)
+
+func newUsersStore(t *testing.T) *users.Store {
+	t.Helper()
+	return users.New(store.OpenTestStore(t).DB())
+}
+
+func TestAdmin_SeedsOnEmptyTable(t *testing.T) {
+	us := newUsersStore(t)
+	var stderr bytes.Buffer
+
+	u, pw, err := Admin(t.Context(), us, slog.Default(), &stderr)
+	require.NoError(t, err)
+	require.NotNil(t, u)
+	assert.Equal(t, DefaultAdminEmail, u.Email)
+	assert.NotEmpty(t, pw)
+	assert.Len(t, pw, 32, "24 random bytes base64url-encodes to 32 chars")
+
+	// stderr banner printed the password exactly once.
+	banner := stderr.String()
+	assert.Contains(t, banner, "SEEDED ADMIN USER")
+	assert.Contains(t, banner, DefaultAdminEmail)
+	assert.Contains(t, banner, pw)
+
+	// The password we returned round-trips to login: the user store can verify it.
+	verified, err := us.VerifyPassword(t.Context(), DefaultAdminEmail, pw)
+	require.NoError(t, err)
+	assert.Equal(t, u.ID, verified.ID)
+}
+
+func TestAdmin_IdempotentWhenUsersExist(t *testing.T) {
+	us := newUsersStore(t)
+	// Pre-seed a different admin. Admin() should leave it alone.
+	existing, err := us.Create(t.Context(), users.CreateRequest{
+		Email: "first@example.com", Password: "pw",
+	})
+	require.NoError(t, err)
+
+	var stderr bytes.Buffer
+	u, pw, err := Admin(t.Context(), us, slog.Default(), &stderr)
+	require.NoError(t, err)
+	assert.Nil(t, u)
+	assert.Empty(t, pw)
+	assert.Empty(t, stderr.String(), "must not print the banner when seeding is skipped")
+
+	// Pre-existing user is untouched.
+	got, err := us.Get(t.Context(), existing.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "first@example.com", got.Email)
+}
+
+func TestAdmin_NilStoreErrors(t *testing.T) {
+	_, _, err := Admin(t.Context(), nil, slog.Default(), nil)
+	require.Error(t, err)
+}
+
+// TestAdmin_PasswordEntropy is a sanity check that two seeded passwords differ. Crypto
+// guarantees this with overwhelming probability; the test is here to catch an accidental
+// "use a constant for determinism" regression in randomPassword.
+func TestAdmin_PasswordEntropy(t *testing.T) {
+	a, err := randomPassword()
+	require.NoError(t, err)
+	b, err := randomPassword()
+	require.NoError(t, err)
+	assert.NotEqual(t, a, b)
+}

--- a/server/session/handler.go
+++ b/server/session/handler.go
@@ -1,0 +1,358 @@
+// Package session serves the Phase 3 login / logout / session-check endpoints.
+//
+//	POST   /api/v1/session  — public, rate-limited, validates email+password, creates
+//	                          session row, sets Set-Cookie, returns {user, csrf_token}.
+//	GET    /api/v1/session  — session-required, returns the current {user, csrf_token}.
+//	DELETE /api/v1/session  — session-required, deletes the session row, clears cookie.
+//
+// The shape of the login response body intentionally returns both the user AND the CSRF
+// token so the UI can store the CSRF for unsafe methods without a round-trip. The
+// cookie itself is HttpOnly + Secure (when TLS is on) + SameSite=Lax so JS cannot read
+// the session id.
+package session
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+	"golang.org/x/time/rate"
+
+	"github.com/fleetdm/edr/server/authn"
+	"github.com/fleetdm/edr/server/sessions"
+	"github.com/fleetdm/edr/server/users"
+)
+
+// Handler serves the session endpoints.
+type Handler struct {
+	users     *users.Store
+	sessions  *sessions.Store
+	logger    *slog.Logger
+	limiter   *ipLimiter
+	cookieSec bool // Secure flag on the Set-Cookie; driven by TLSEnabled at construction time
+}
+
+// Options tune handler behaviour.
+type Options struct {
+	// RatePerMinute is the per-source-IP login attempt cap. Defaults to 6 (same order
+	// as enrollment's default). An operator can raise this for automated testing but
+	// the default keeps brute-force expensive.
+	RatePerMinute int
+	// CookieSecure controls the `Secure` cookie flag. Set to true when TLS is on; false
+	// only for local dev with EDR_ALLOW_INSECURE_HTTP=1 (browsers reject Secure cookies
+	// on plain HTTP, so dev mode would otherwise break the UI).
+	CookieSecure bool
+	// Logger for audit lines.
+	Logger *slog.Logger
+}
+
+// New builds a session handler. Panics if either store is nil.
+func New(us *users.Store, ss *sessions.Store, opts Options) *Handler {
+	if us == nil {
+		panic("session.New: users store must not be nil")
+	}
+	if ss == nil {
+		panic("session.New: sessions store must not be nil")
+	}
+	if opts.RatePerMinute <= 0 {
+		opts.RatePerMinute = 6
+	}
+	logger := opts.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Handler{
+		users:     us,
+		sessions:  ss,
+		logger:    logger,
+		limiter:   newIPLimiter(rate.Every(time.Minute/time.Duration(opts.RatePerMinute)), opts.RatePerMinute),
+		cookieSec: opts.CookieSecure,
+	}
+}
+
+// RegisterPublicRoutes wires POST /api/v1/session on the given mux. The login endpoint
+// is public (there is no session yet); the server caller is responsible for keeping
+// GET + DELETE behind the Session middleware.
+func (h *Handler) RegisterPublicRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("POST /api/v1/session", h.handleLogin)
+}
+
+// RegisterAuthedRoutes wires GET + DELETE /api/v1/session on the given mux. Caller
+// wraps the mux in `authn.Session` + `authn.CSRF` at mount time — see main.go.
+func (h *Handler) RegisterAuthedRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("GET /api/v1/session", h.handleGet)
+	mux.HandleFunc("DELETE /api/v1/session", h.handleLogout)
+}
+
+type loginRequest struct {
+	Email    string `json:"email"`
+	Password string `json:"password"`
+}
+
+// String redacts the password so an accidental %v / slog("req", r) never leaks. Same
+// pattern as enrollment.enrollRequest.
+func (r loginRequest) String() string {
+	return "loginRequest{email=" + r.Email + " password=REDACTED}"
+}
+
+type userResponse struct {
+	ID    int64  `json:"id"`
+	Email string `json:"email"`
+}
+
+type sessionResponse struct {
+	User      userResponse `json:"user"`
+	CSRFToken string       `json:"csrf_token"`
+}
+
+type errBody struct {
+	Error string `json:"error"`
+}
+
+// loginBodyCap bounds the POST body — login payloads are tiny (email + password);
+// anything larger is either a misuse or a DoS probe.
+const loginBodyCap = 4 << 10 // 4 KiB
+
+func (h *Handler) handleLogin(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	span := trace.SpanFromContext(ctx)
+	ip := remoteIP(r)
+	span.SetAttributes(attribute.String("edr.remote_addr", ip))
+
+	if !h.limiter.allow(ip) {
+		w.Header().Set("Retry-After", "60")
+		h.fail(ctx, w, http.StatusTooManyRequests, "rate_limited", ip, 0, "",
+			"edr.auth.reason", "rate_limited")
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, loginBodyCap)
+	var req loginRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		h.fail(ctx, w, http.StatusBadRequest, "bad_body", ip, 0, "",
+			"edr.auth.reason", "bad_body", "err", err.Error())
+		return
+	}
+	if req.Email == "" || req.Password == "" {
+		h.fail(ctx, w, http.StatusBadRequest, "bad_body", ip, 0, req.Email,
+			"edr.auth.reason", "bad_body", "missing_fields", true)
+		return
+	}
+
+	u, err := h.users.VerifyPassword(ctx, req.Email, req.Password)
+	switch {
+	case errors.Is(err, users.ErrNotFound):
+		// Same wire response as ErrBadPassword so the caller cannot enumerate emails.
+		// The server-side audit log records the distinction so forensics can tell
+		// "hit a real account with wrong password" apart from "probed unknown email".
+		h.fail(ctx, w, http.StatusUnauthorized, "invalid_credentials", ip, 0, req.Email,
+			"edr.auth.reason", "user_not_found")
+		return
+	case errors.Is(err, users.ErrBadPassword):
+		h.fail(ctx, w, http.StatusUnauthorized, "invalid_credentials", ip, 0, req.Email,
+			"edr.auth.reason", "password_mismatch")
+		return
+	case err != nil:
+		h.logger.ErrorContext(ctx, "login verify", "err", err)
+		h.fail(ctx, w, http.StatusInternalServerError, "internal", ip, 0, req.Email,
+			"edr.auth.reason", "internal")
+		return
+	}
+
+	sess, err := h.sessions.Create(ctx, u.ID)
+	if err != nil {
+		h.logger.ErrorContext(ctx, "session create", "err", err, "edr.user.id", u.ID)
+		h.fail(ctx, w, http.StatusInternalServerError, "internal", ip, u.ID, req.Email,
+			"edr.auth.reason", "session_create_failed")
+		return
+	}
+
+	http.SetCookie(w, h.buildCookie(sess))
+	span.SetAttributes(
+		attribute.String("edr.auth.action", "login"),
+		attribute.String("edr.auth.result", "ok"),
+		attribute.Int64("edr.user.id", u.ID),
+	)
+	h.logger.InfoContext(ctx, "login ok",
+		"edr.auth.action", "login",
+		"edr.user.id", u.ID,
+		"edr.user.email", u.Email,
+		"edr.session.id_prefix", idPrefix(sess.ID),
+		"edr.remote_addr", ip,
+	)
+
+	h.writeSessionJSON(w, u, sess)
+}
+
+func (h *Handler) handleGet(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	sess, ok := authn.SessionFromContext(ctx)
+	if !ok {
+		// Middleware mis-wiring; fail loud so the ops team sees it.
+		h.logger.ErrorContext(ctx, "GET /session hit without Session on ctx — middleware wiring broken")
+		writeJSON(ctx, h.logger, w, http.StatusInternalServerError, errBody{Error: "session_misconfigured"})
+		return
+	}
+	u, err := h.users.Get(ctx, sess.UserID)
+	if err != nil {
+		h.logger.ErrorContext(ctx, "get user for session", "err", err, "edr.user.id", sess.UserID)
+		writeJSON(ctx, h.logger, w, http.StatusInternalServerError, errBody{Error: "internal"})
+		return
+	}
+	h.writeSessionJSON(w, u, sess)
+}
+
+func (h *Handler) handleLogout(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	sess, ok := authn.SessionFromContext(ctx)
+	if !ok {
+		// No session on ctx — the Session middleware would normally 401 before we got
+		// here, but treat this as a permissive "already logged out" and clear the
+		// cookie anyway. The logout endpoint is one of those places where being lax
+		// about a missing credential is the right UX.
+		http.SetCookie(w, h.expireCookie())
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	if err := h.sessions.Delete(ctx, sess.ID); err != nil {
+		h.logger.ErrorContext(ctx, "session delete", "err", err, "edr.user.id", sess.UserID)
+		writeJSON(ctx, h.logger, w, http.StatusInternalServerError, errBody{Error: "internal"})
+		return
+	}
+	trace.SpanFromContext(ctx).SetAttributes(
+		attribute.String("edr.auth.action", "logout"),
+		attribute.Int64("edr.user.id", sess.UserID),
+	)
+	h.logger.InfoContext(ctx, "logout ok",
+		"edr.auth.action", "logout",
+		"edr.user.id", sess.UserID,
+		"edr.session.id_prefix", idPrefix(sess.ID),
+	)
+	http.SetCookie(w, h.expireCookie())
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *Handler) writeSessionJSON(w http.ResponseWriter, u *users.User, sess *sessions.Session) {
+	writeJSON(context.Background(), h.logger, w, http.StatusOK, sessionResponse{
+		User:      userResponse{ID: u.ID, Email: u.Email},
+		CSRFToken: authn.EncodeSessionID(sess.CSRFToken),
+	})
+}
+
+func (h *Handler) buildCookie(sess *sessions.Session) *http.Cookie {
+	return &http.Cookie{
+		Name:     authn.SessionCookieName,
+		Value:    authn.EncodeSessionID(sess.ID),
+		Path:     "/",
+		HttpOnly: true,
+		Secure:   h.cookieSec,
+		SameSite: http.SameSiteLaxMode,
+		Expires:  sess.ExpiresAt,
+		MaxAge:   int(time.Until(sess.ExpiresAt).Seconds()),
+	}
+}
+
+func (h *Handler) expireCookie() *http.Cookie {
+	return &http.Cookie{
+		Name:     authn.SessionCookieName,
+		Value:    "",
+		Path:     "/",
+		HttpOnly: true,
+		Secure:   h.cookieSec,
+		SameSite: http.SameSiteLaxMode,
+		MaxAge:   -1,
+	}
+}
+
+// idPrefix returns the first 8 hex chars of the session id for audit logs. Full ids
+// must never land in logs because they're the bearer of session auth.
+func idPrefix(id []byte) string {
+	const n = 4 // 4 bytes = 8 hex chars
+	if len(id) < n {
+		return ""
+	}
+	return toHex(id[:n])
+}
+
+func toHex(b []byte) string {
+	const hex = "0123456789abcdef"
+	out := make([]byte, 0, len(b)*2)
+	for _, v := range b {
+		out = append(out, hex[v>>4], hex[v&0x0f])
+	}
+	return string(out)
+}
+
+// fail writes a typed 4xx/5xx JSON error + audit log. userID is best-effort (0 when the
+// email didn't resolve). email in the audit helps forensics but we never echo it in the
+// response body so the client cannot enumerate.
+func (h *Handler) fail(ctx context.Context, w http.ResponseWriter, status int, code, ip string, userID int64, email string, attrs ...any) {
+	span := trace.SpanFromContext(ctx)
+	span.SetAttributes(
+		attribute.String("edr.auth.result", "fail"),
+		attribute.Int("http.response.status_code", status),
+	)
+	logAttrs := append([]any{
+		"edr.auth.result", "fail",
+		"edr.remote_addr", ip,
+		"edr.user.email", email,
+	}, attrs...)
+	if userID > 0 {
+		logAttrs = append(logAttrs, "edr.user.id", userID)
+	}
+	h.logger.WarnContext(ctx, "login failed", logAttrs...)
+	writeJSON(ctx, h.logger, w, status, errBody{Error: code})
+}
+
+func writeJSON(ctx context.Context, logger *slog.Logger, w http.ResponseWriter, status int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(body); err != nil {
+		logger.ErrorContext(ctx, "session encode response", "err", err)
+	}
+}
+
+// --- ipLimiter mirrors enrollment.ipLimiter. Duplicated to avoid a cross-package
+// private export; both packages are short enough that the duplication is a smaller
+// cost than the coupling. Refactor into a shared limiter package when we add a third.
+
+type ipLimiter struct {
+	mu      sync.Mutex
+	limit   rate.Limit
+	burst   int
+	buckets map[string]*rate.Limiter
+}
+
+func newIPLimiter(limit rate.Limit, burst int) *ipLimiter {
+	return &ipLimiter{limit: limit, burst: burst, buckets: make(map[string]*rate.Limiter)}
+}
+
+func (l *ipLimiter) allow(ip string) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	rl, ok := l.buckets[ip]
+	if !ok {
+		rl = rate.NewLimiter(l.limit, l.burst)
+		l.buckets[ip] = rl
+	}
+	return rl.Allow()
+}
+
+// remoteIP strips the port from r.RemoteAddr. Falls back to the raw field if the host
+// portion is ambiguous (IPv6 without port, etc).
+func remoteIP(r *http.Request) string {
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return strings.TrimSpace(r.RemoteAddr)
+	}
+	return host
+}

--- a/server/session/handler.go
+++ b/server/session/handler.go
@@ -78,18 +78,27 @@ func New(us *users.Store, ss *sessions.Store, opts Options) *Handler {
 	}
 }
 
-// RegisterPublicRoutes wires POST /api/v1/session on the given mux. The login endpoint
-// is public (there is no session yet); the server caller is responsible for keeping
-// GET + DELETE behind the Session middleware.
+// RegisterPublicRoutes wires POST /api/v1/session (login) and DELETE /api/v1/session
+// (logout) on the given mux. Both are public because neither has a valid session to
+// authenticate with at call time: login is the mint-it step, logout is permissive by
+// design (a stale / expired / missing cookie still needs to produce a Set-Cookie that
+// clears the client's copy, or the browser keeps sending a dead session id forever).
+// Logout's handler reads the cookie itself, best-effort deletes the matching row, and
+// always emits the clearing Set-Cookie.
+//
+// CSRF concern: logout is exempt from CSRF by design. The cookie's SameSite=Lax flag
+// already prevents cross-site XHRs from including it, so an attacker cannot trigger
+// logout via a forged fetch. A top-level cross-site navigation could send the cookie
+// on DELETE, but the blast radius is "user gets logged out" — annoying, not a breach.
 func (h *Handler) RegisterPublicRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("POST /api/v1/session", h.handleLogin)
+	mux.HandleFunc("DELETE /api/v1/session", h.handleLogout)
 }
 
-// RegisterAuthedRoutes wires GET + DELETE /api/v1/session on the given mux. Caller
-// wraps the mux in `authn.Session` + `authn.CSRF` at mount time — see main.go.
+// RegisterAuthedRoutes wires GET /api/v1/session on the given mux. Caller wraps the
+// mux in `authn.Session` + `authn.CSRF` at mount time — see main.go.
 func (h *Handler) RegisterAuthedRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/v1/session", h.handleGet)
-	mux.HandleFunc("DELETE /api/v1/session", h.handleLogout)
 }
 
 type loginRequest struct {
@@ -189,7 +198,7 @@ func (h *Handler) handleLogin(w http.ResponseWriter, r *http.Request) {
 		"edr.remote_addr", ip,
 	)
 
-	h.writeSessionJSON(w, u, sess)
+	h.writeSessionJSON(ctx, w, u, sess)
 }
 
 func (h *Handler) handleGet(w http.ResponseWriter, r *http.Request) {
@@ -207,41 +216,54 @@ func (h *Handler) handleGet(w http.ResponseWriter, r *http.Request) {
 		writeJSON(ctx, h.logger, w, http.StatusInternalServerError, errBody{Error: "internal"})
 		return
 	}
-	h.writeSessionJSON(w, u, sess)
+	h.writeSessionJSON(ctx, w, u, sess)
 }
 
+// handleLogout is public (not behind Session middleware). It does its own cookie
+// lookup so a stale / expired / unknown cookie still produces a clearing Set-Cookie —
+// otherwise the browser keeps re-sending the dead session id forever. The
+// Set-Cookie header MUST be written before the response status because Go's
+// http.ResponseWriter silently drops header mutations after WriteHeader; splitting
+// the "try to delete the row" and "always clear the cookie" phases keeps that ordering
+// explicit.
 func (h *Handler) handleLogout(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	sess, ok := authn.SessionFromContext(ctx)
-	if !ok {
-		// No session on ctx — the Session middleware would normally 401 before we got
-		// here, but treat this as a permissive "already logged out" and clear the
-		// cookie anyway. The logout endpoint is one of those places where being lax
-		// about a missing credential is the right UX.
-		http.SetCookie(w, h.expireCookie())
-		w.WriteHeader(http.StatusNoContent)
-		return
+
+	// Phase 1: best-effort session deletion. Any failure here is swallowed (logged on
+	// the unexpected-error path only) because logout must be idempotent; the client
+	// has already decided to forget this session.
+	if cookie, err := r.Cookie(authn.SessionCookieName); err == nil && cookie.Value != "" {
+		if raw, err := authn.DecodeSessionIDForTest(cookie.Value); err == nil {
+			if sess, err := h.sessions.Get(ctx, raw); err == nil {
+				if delErr := h.sessions.Delete(ctx, sess.ID); delErr != nil {
+					h.logger.ErrorContext(ctx, "session delete", "err", delErr, "edr.user.id", sess.UserID)
+				} else {
+					trace.SpanFromContext(ctx).SetAttributes(
+						attribute.String("edr.auth.action", "logout"),
+						attribute.Int64("edr.user.id", sess.UserID),
+					)
+					h.logger.InfoContext(ctx, "logout ok",
+						"edr.auth.action", "logout",
+						"edr.user.id", sess.UserID,
+						"edr.session.id_prefix", idPrefix(sess.ID),
+					)
+				}
+			}
+			// Unknown / expired / decode error all fall through to the clear-cookie
+			// step below — the client's view of "am I logged in?" should converge on
+			// "no" regardless of the server-side reality.
+		}
 	}
-	if err := h.sessions.Delete(ctx, sess.ID); err != nil {
-		h.logger.ErrorContext(ctx, "session delete", "err", err, "edr.user.id", sess.UserID)
-		writeJSON(ctx, h.logger, w, http.StatusInternalServerError, errBody{Error: "internal"})
-		return
-	}
-	trace.SpanFromContext(ctx).SetAttributes(
-		attribute.String("edr.auth.action", "logout"),
-		attribute.Int64("edr.user.id", sess.UserID),
-	)
-	h.logger.InfoContext(ctx, "logout ok",
-		"edr.auth.action", "logout",
-		"edr.user.id", sess.UserID,
-		"edr.session.id_prefix", idPrefix(sess.ID),
-	)
+
+	// Phase 2: always clear the cookie. Must happen before WriteHeader.
 	http.SetCookie(w, h.expireCookie())
 	w.WriteHeader(http.StatusNoContent)
 }
 
-func (h *Handler) writeSessionJSON(w http.ResponseWriter, u *users.User, sess *sessions.Session) {
-	writeJSON(context.Background(), h.logger, w, http.StatusOK, sessionResponse{
+func (h *Handler) writeSessionJSON(ctx context.Context, w http.ResponseWriter, u *users.User, sess *sessions.Session) {
+	// Passing the request ctx (rather than context.Background) keeps the response-
+	// encode error log tied to the originating trace + span for SigNoz correlation.
+	writeJSON(ctx, h.logger, w, http.StatusOK, sessionResponse{
 		User:      userResponse{ID: u.ID, Email: u.Email},
 		CSRFToken: authn.EncodeSessionID(sess.CSRFToken),
 	})
@@ -324,27 +346,58 @@ func writeJSON(ctx context.Context, logger *slog.Logger, w http.ResponseWriter, 
 // --- ipLimiter mirrors enrollment.ipLimiter. Duplicated to avoid a cross-package
 // private export; both packages are short enough that the duplication is a smaller
 // cost than the coupling. Refactor into a shared limiter package when we add a third.
+//
+// Bucket GC: the map grows with distinct client IPs. Left unbounded, a long-running
+// server under IP rotation (NAT with churning source ports is rare, but attacker-
+// driven probing is not) would accumulate dead rate.Limiter entries forever. When the
+// map crosses `maxBuckets`, we evict any bucket whose lastSeen is older than
+// `bucketIdleTTL` in the same request's critical section. The eviction is O(N) but
+// only runs when the map is actually large, so amortised cost stays negligible.
+
+const (
+	bucketIdleTTL = 2 * time.Hour
+	maxBuckets    = 1024
+)
+
+type ipBucket struct {
+	limiter  *rate.Limiter
+	lastSeen time.Time
+}
 
 type ipLimiter struct {
 	mu      sync.Mutex
 	limit   rate.Limit
 	burst   int
-	buckets map[string]*rate.Limiter
+	buckets map[string]*ipBucket
 }
 
 func newIPLimiter(limit rate.Limit, burst int) *ipLimiter {
-	return &ipLimiter{limit: limit, burst: burst, buckets: make(map[string]*rate.Limiter)}
+	return &ipLimiter{limit: limit, burst: burst, buckets: make(map[string]*ipBucket)}
 }
 
 func (l *ipLimiter) allow(ip string) bool {
+	now := time.Now()
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	rl, ok := l.buckets[ip]
-	if !ok {
-		rl = rate.NewLimiter(l.limit, l.burst)
-		l.buckets[ip] = rl
+
+	// Opportunistic sweep: only when the map is above the soft cap, and only walks
+	// entries that actually look dead. Under normal load (few IPs, all active) this
+	// branch never fires.
+	if len(l.buckets) > maxBuckets {
+		for k, b := range l.buckets {
+			if now.Sub(b.lastSeen) > bucketIdleTTL {
+				delete(l.buckets, k)
+			}
+		}
 	}
-	return rl.Allow()
+
+	b, ok := l.buckets[ip]
+	if !ok {
+		b = &ipBucket{limiter: rate.NewLimiter(l.limit, l.burst)}
+		l.buckets[ip] = b
+	}
+	b.lastSeen = now
+	return b.limiter.Allow()
 }
 
 // remoteIP strips the port from r.RemoteAddr. Falls back to the raw field if the host

--- a/server/session/handler_test.go
+++ b/server/session/handler_test.go
@@ -35,14 +35,17 @@ func setupServer(t *testing.T, ratePerMinute int) (*httptest.Server, *users.Stor
 	publicMux := http.NewServeMux()
 	h.RegisterPublicRoutes(publicMux)
 
+	// Mirror production: authed routes (GET /session) go through Session → CSRF.
+	// CSRF is safe for GET (passes through) but including it in the stack makes this
+	// test setup accurate for any PUT/PATCH/DELETE the handler might grow later.
 	authedSub := http.NewServeMux()
 	h.RegisterAuthedRoutes(authedSub)
-	authedWrap := authn.Session(ss, slog.Default())(authedSub)
+	authedWrap := authn.Session(ss, slog.Default())(authn.CSRF(slog.Default())(authedSub))
 
 	root := http.NewServeMux()
-	root.Handle("POST /api/v1/session", publicMux)
+	root.Handle("POST /api/v1/session", publicMux)   // login: public
+	root.Handle("DELETE /api/v1/session", publicMux) // logout: public (reads cookie itself)
 	root.Handle("GET /api/v1/session", authedWrap)
-	root.Handle("DELETE /api/v1/session", authedWrap)
 
 	srv := httptest.NewServer(root)
 	t.Cleanup(srv.Close)

--- a/server/session/handler_test.go
+++ b/server/session/handler_test.go
@@ -1,0 +1,245 @@
+package session
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fleetdm/edr/server/authn"
+	"github.com/fleetdm/edr/server/sessions"
+	"github.com/fleetdm/edr/server/store"
+	"github.com/fleetdm/edr/server/users"
+)
+
+// setupServer wires a full session handler + middleware stack backed by real stores,
+// exactly like main.go does. Returns the HTTP server + the userStore so tests can seed
+// an initial user.
+func setupServer(t *testing.T, ratePerMinute int) (*httptest.Server, *users.Store, *sessions.Store) {
+	t.Helper()
+	s := store.OpenTestStore(t)
+	us := users.New(s.DB())
+	ss := sessions.New(s.DB(), sessions.Options{})
+
+	h := New(us, ss, Options{
+		RatePerMinute: ratePerMinute,
+		CookieSecure:  false, // httptest is plain HTTP; browsers would reject Secure anyway.
+		Logger:        slog.Default(),
+	})
+
+	publicMux := http.NewServeMux()
+	h.RegisterPublicRoutes(publicMux)
+
+	authedSub := http.NewServeMux()
+	h.RegisterAuthedRoutes(authedSub)
+	authedWrap := authn.Session(ss, slog.Default())(authedSub)
+
+	root := http.NewServeMux()
+	root.Handle("POST /api/v1/session", publicMux)
+	root.Handle("GET /api/v1/session", authedWrap)
+	root.Handle("DELETE /api/v1/session", authedWrap)
+
+	srv := httptest.NewServer(root)
+	t.Cleanup(srv.Close)
+	return srv, us, ss
+}
+
+func postJSON(t *testing.T, srv *httptest.Server, path string, body any) *http.Response {
+	t.Helper()
+	buf := new(bytes.Buffer)
+	require.NoError(t, json.NewEncoder(buf).Encode(body))
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, srv.URL+path, buf)
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := srv.Client().Do(req)
+	require.NoError(t, err)
+	return resp
+}
+
+func TestLogin_HappyPath(t *testing.T) {
+	srv, us, _ := setupServer(t, 30)
+	_, err := us.Create(t.Context(), users.CreateRequest{Email: "admin@example.com", Password: "rightpassword"})
+	require.NoError(t, err)
+
+	resp := postJSON(t, srv, "/api/v1/session", map[string]string{
+		"email": "admin@example.com", "password": "rightpassword",
+	})
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Set-Cookie is populated with HttpOnly + SameSite=Lax.
+	cookies := resp.Cookies()
+	require.Len(t, cookies, 1)
+	c := cookies[0]
+	assert.Equal(t, authn.SessionCookieName, c.Name)
+	assert.True(t, c.HttpOnly)
+	assert.Equal(t, http.SameSiteLaxMode, c.SameSite)
+	assert.NotEmpty(t, c.Value)
+
+	var body sessionResponse
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	assert.Equal(t, "admin@example.com", body.User.Email)
+	assert.Positive(t, body.User.ID)
+	assert.NotEmpty(t, body.CSRFToken)
+}
+
+func TestLogin_WrongPasswordReturnsGeneric401(t *testing.T) {
+	srv, us, _ := setupServer(t, 30)
+	_, err := us.Create(t.Context(), users.CreateRequest{Email: "admin@example.com", Password: "rightpassword"})
+	require.NoError(t, err)
+
+	resp := postJSON(t, srv, "/api/v1/session", map[string]string{
+		"email": "admin@example.com", "password": "wrong",
+	})
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+
+	var body errBody
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	assert.Equal(t, "invalid_credentials", body.Error, "must not leak whether email exists")
+}
+
+func TestLogin_UnknownEmailReturnsGeneric401(t *testing.T) {
+	srv, _, _ := setupServer(t, 30)
+	resp := postJSON(t, srv, "/api/v1/session", map[string]string{
+		"email": "nobody@example.com", "password": "anything",
+	})
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+
+	var body errBody
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	assert.Equal(t, "invalid_credentials", body.Error,
+		"unknown-email 401 must be indistinguishable from wrong-password 401")
+}
+
+func TestLogin_RateLimit(t *testing.T) {
+	srv, us, _ := setupServer(t, 2) // 2/min so burst of 2, then 429
+	_, err := us.Create(t.Context(), users.CreateRequest{Email: "admin@example.com", Password: "pw"})
+	require.NoError(t, err)
+
+	// Burst 2 failures: both 401.
+	for range 2 {
+		resp := postJSON(t, srv, "/api/v1/session", map[string]string{
+			"email": "admin@example.com", "password": "wrong",
+		})
+		resp.Body.Close()
+		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	}
+
+	// Third burst attempt: the limiter returns false, we respond with 429 + Retry-After.
+	resp := postJSON(t, srv, "/api/v1/session", map[string]string{
+		"email": "admin@example.com", "password": "wrong",
+	})
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusTooManyRequests, resp.StatusCode)
+	assert.Equal(t, "60", resp.Header.Get("Retry-After"))
+}
+
+func TestLogin_MalformedBody(t *testing.T) {
+	srv, _, _ := setupServer(t, 30)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, srv.URL+"/api/v1/session",
+		bytes.NewBufferString("{"))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := srv.Client().Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+// sessionCookie logs in and returns the resulting session cookie + CSRF token from the
+// login response. Tests use it for GET / DELETE coverage.
+func sessionCookie(t *testing.T, srv *httptest.Server, us *users.Store) (*http.Cookie, string) {
+	t.Helper()
+	_, err := us.Create(t.Context(), users.CreateRequest{Email: "admin@example.com", Password: "pw"})
+	require.NoError(t, err)
+
+	resp := postJSON(t, srv, "/api/v1/session", map[string]string{
+		"email": "admin@example.com", "password": "pw",
+	})
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var body sessionResponse
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	cookies := resp.Cookies()
+	require.Len(t, cookies, 1)
+	return cookies[0], body.CSRFToken
+}
+
+func TestGet_ReturnsCurrentSession(t *testing.T) {
+	srv, us, _ := setupServer(t, 30)
+	cookie, csrf := sessionCookie(t, srv, us)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+"/api/v1/session", nil)
+	require.NoError(t, err)
+	req.AddCookie(cookie)
+	resp, err := srv.Client().Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var body sessionResponse
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	assert.Equal(t, csrf, body.CSRFToken, "GET must return the same CSRF token as login issued")
+}
+
+func TestGet_MissingCookieReturns401(t *testing.T) {
+	srv, _, _ := setupServer(t, 30)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+"/api/v1/session", nil)
+	require.NoError(t, err)
+	resp, err := srv.Client().Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+}
+
+func TestLogout_DeletesSessionAndClearsCookie(t *testing.T) {
+	srv, us, ss := setupServer(t, 30)
+	cookie, _ := sessionCookie(t, srv, us)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodDelete, srv.URL+"/api/v1/session", nil)
+	require.NoError(t, err)
+	req.AddCookie(cookie)
+	resp, err := srv.Client().Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+
+	// Cookie explicitly cleared (MaxAge<0, empty value).
+	clears := resp.Cookies()
+	require.Len(t, clears, 1)
+	assert.Empty(t, clears[0].Value)
+	assert.Negative(t, clears[0].MaxAge)
+
+	// Subsequent GET with the old cookie → 401 (session row is gone).
+	req2, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+"/api/v1/session", nil)
+	require.NoError(t, err)
+	req2.AddCookie(cookie)
+	resp2, err := srv.Client().Do(req2)
+	require.NoError(t, err)
+	defer resp2.Body.Close()
+	assert.Equal(t, http.StatusUnauthorized, resp2.StatusCode)
+
+	// Belt-and-suspenders: the row really is gone from the DB, not just expired.
+	raw, err := authn.DecodeSessionIDForTest(cookie.Value)
+	require.NoError(t, err)
+	_, err = ss.Get(t.Context(), raw)
+	require.Error(t, err)
+}
+
+func TestLogin_RedactsPasswordInErrorLogs(t *testing.T) {
+	// The String() method on loginRequest is the guard we care about — it must never
+	// include the password. Assert directly rather than through a log capture to keep
+	// the test fast and deterministic.
+	req := loginRequest{Email: "a@b.com", Password: "hunter2"}
+	s := req.String()
+	assert.NotContains(t, s, "hunter2")
+	assert.Contains(t, s, "REDACTED")
+}

--- a/server/sessions/sessions.go
+++ b/server/sessions/sessions.go
@@ -1,0 +1,164 @@
+// Package sessions owns the `sessions` table that backs Phase 3 UI cookie auth. A
+// session is a server-side row keyed by a 32-byte random id; the cookie value IS the
+// id (base64url-encoded on the wire, raw bytes in the DB). CSRF tokens are per-session,
+// also 32 random bytes, returned to the client in the login response body and sent
+// back as `X-CSRF-Token` on unsafe methods.
+package sessions
+
+import (
+	"context"
+	"crypto/rand"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+)
+
+// DefaultTTL is the session lifetime. 12 hours matches common SaaS admin-console
+// defaults: long enough that operators aren't constantly re-logging in, short enough
+// that a stolen cookie expires before the end of a work day.
+const DefaultTTL = 12 * time.Hour
+
+// IDLen is the session id + CSRF token length in bytes. 32 bytes ≈ 256 bits of entropy,
+// well past any practical guessing bound.
+const IDLen = 32
+
+// ErrNotFound is returned by Get when no active session matches the id. Expired rows
+// are treated as not-found so callers can translate both to the same 401.
+var ErrNotFound = errors.New("sessions: not found or expired")
+
+// Session is the fully-loaded row. IDBytes + CSRFToken are kept as []byte rather than
+// encoded strings so constant-time compares in the authn middleware stay honest.
+type Session struct {
+	ID         []byte
+	UserID     int64
+	CSRFToken  []byte
+	CreatedAt  time.Time
+	LastSeenAt time.Time
+	ExpiresAt  time.Time
+}
+
+// Store owns the sessions table.
+type Store struct {
+	db  *sqlx.DB
+	ttl time.Duration
+	// now is the clock source; overridable for tests that need to manipulate expires_at
+	// without wall-clock coupling. Defaults to time.Now.UTC.
+	now func() time.Time
+}
+
+// Options customise Store behaviour. Leave unset fields as zero values to use defaults.
+type Options struct {
+	// TTL is the session lifetime. Zero means DefaultTTL.
+	TTL time.Duration
+	// Now is the clock source. Nil means time.Now.UTC.
+	Now func() time.Time
+}
+
+// New constructs a Store over an existing sqlx.DB handle.
+func New(db *sqlx.DB, opts Options) *Store {
+	ttl := opts.TTL
+	if ttl <= 0 {
+		ttl = DefaultTTL
+	}
+	now := opts.Now
+	if now == nil {
+		now = func() time.Time { return time.Now().UTC() }
+	}
+	return &Store{db: db, ttl: ttl, now: now}
+}
+
+// Create inserts a new session for userID and returns the fully-populated row. The
+// caller serialises the raw id bytes into the Set-Cookie header (base64url).
+func (s *Store) Create(ctx context.Context, userID int64) (*Session, error) {
+	id, err := randomBytes(IDLen)
+	if err != nil {
+		return nil, fmt.Errorf("generate session id: %w", err)
+	}
+	csrf, err := randomBytes(IDLen)
+	if err != nil {
+		return nil, fmt.Errorf("generate csrf token: %w", err)
+	}
+	now := s.now()
+	expires := now.Add(s.ttl)
+	if _, err := s.db.ExecContext(ctx, `
+		INSERT INTO sessions (id, user_id, csrf_token, expires_at)
+		VALUES (?, ?, ?, ?)
+	`, id, userID, csrf, expires); err != nil {
+		return nil, fmt.Errorf("insert session: %w", err)
+	}
+	return &Session{
+		ID: id, UserID: userID, CSRFToken: csrf,
+		CreatedAt: now, LastSeenAt: now, ExpiresAt: expires,
+	}, nil
+}
+
+// Get returns the session for id, or ErrNotFound if missing / expired. We filter
+// `expires_at > NOW()` inside the SQL so a stale row is indistinguishable from a
+// nonexistent one — the middleware can treat both as "401 invalid_session".
+func (s *Store) Get(ctx context.Context, id []byte) (*Session, error) {
+	if len(id) != IDLen {
+		return nil, ErrNotFound
+	}
+	var row struct {
+		ID         []byte    `db:"id"`
+		UserID     int64     `db:"user_id"`
+		CSRFToken  []byte    `db:"csrf_token"`
+		CreatedAt  time.Time `db:"created_at"`
+		LastSeenAt time.Time `db:"last_seen_at"`
+		ExpiresAt  time.Time `db:"expires_at"`
+	}
+	// `now` is passed in so tests can drive the clock; production uses s.now().
+	err := s.db.GetContext(ctx, &row, `
+		SELECT id, user_id, csrf_token, created_at, last_seen_at, expires_at
+		FROM sessions
+		WHERE id = ? AND expires_at > ?
+	`, id, s.now())
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("query session: %w", err)
+	}
+	return &Session{
+		ID: row.ID, UserID: row.UserID, CSRFToken: row.CSRFToken,
+		CreatedAt: row.CreatedAt, LastSeenAt: row.LastSeenAt, ExpiresAt: row.ExpiresAt,
+	}, nil
+}
+
+// Delete removes a session. Idempotent — no error on a row that doesn't exist so logout
+// works even when the cookie is already stale on the client.
+func (s *Store) Delete(ctx context.Context, id []byte) error {
+	if len(id) != IDLen {
+		return nil
+	}
+	if _, err := s.db.ExecContext(ctx, `DELETE FROM sessions WHERE id = ?`, id); err != nil {
+		return fmt.Errorf("delete session: %w", err)
+	}
+	return nil
+}
+
+// CleanupExpired removes every expired session row. Intended to be called on a timer
+// by main.go so the table doesn't grow unbounded. Returns the number of rows removed.
+func (s *Store) CleanupExpired(ctx context.Context) (int64, error) {
+	res, err := s.db.ExecContext(ctx, `DELETE FROM sessions WHERE expires_at <= ?`, s.now())
+	if err != nil {
+		return 0, fmt.Errorf("cleanup expired sessions: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	return n, nil
+}
+
+// TTL returns the configured session lifetime. Exposed so the session handler can set
+// the cookie's Max-Age consistently with the DB row's expires_at.
+func (s *Store) TTL() time.Duration { return s.ttl }
+
+func randomBytes(n int) ([]byte, error) {
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		return nil, err
+	}
+	return b, nil
+}

--- a/server/sessions/sessions.go
+++ b/server/sessions/sessions.go
@@ -1,13 +1,17 @@
 // Package sessions owns the `sessions` table that backs Phase 3 UI cookie auth. A
-// session is a server-side row keyed by a 32-byte random id; the cookie value IS the
-// id (base64url-encoded on the wire, raw bytes in the DB). CSRF tokens are per-session,
-// also 32 random bytes, returned to the client in the login response body and sent
-// back as `X-CSRF-Token` on unsafe methods.
+// session is a server-side row keyed by the SHA-256 digest of a 32-byte random token.
+// The cookie carries the raw token (base64url-encoded); the DB stores only the digest,
+// mirroring the pattern enrollment tokens use so a database compromise does not
+// immediately yield replayable bearer credentials. CSRF tokens are per-session, also
+// 32 random bytes, returned to the client in the login response body and sent back as
+// `X-CSRF-Token` on unsafe methods — those are stored raw because CSRF comparisons
+// happen via constant-time compare, not indexed lookup.
 package sessions
 
 import (
 	"context"
 	"crypto/rand"
+	"crypto/sha256"
 	"database/sql"
 	"errors"
 	"fmt"
@@ -29,8 +33,11 @@ const IDLen = 32
 // are treated as not-found so callers can translate both to the same 401.
 var ErrNotFound = errors.New("sessions: not found or expired")
 
-// Session is the fully-loaded row. IDBytes + CSRFToken are kept as []byte rather than
-// encoded strings so constant-time compares in the authn middleware stay honest.
+// Session is the fully-loaded row as the caller sees it. ID is the PLAINTEXT token —
+// what the client puts in its cookie. The server only ever persists SHA-256(ID); the
+// plaintext lives in memory for the lifetime of the request that created it and
+// inside the cookie the client holds. CSRFToken is kept as []byte rather than an
+// encoded string so constant-time compares in the authn middleware stay honest.
 type Session struct {
 	ID         []byte
 	UserID     int64
@@ -38,6 +45,13 @@ type Session struct {
 	CreatedAt  time.Time
 	LastSeenAt time.Time
 	ExpiresAt  time.Time
+}
+
+// digest returns SHA-256 of the session's raw-bytes id. It's the value we store and
+// look up by — the one-way hash ensures a DB leak does not yield replayable cookies.
+func digest(id []byte) []byte {
+	h := sha256.Sum256(id)
+	return h[:]
 }
 
 // Store owns the sessions table.
@@ -70,8 +84,10 @@ func New(db *sqlx.DB, opts Options) *Store {
 	return &Store{db: db, ttl: ttl, now: now}
 }
 
-// Create inserts a new session for userID and returns the fully-populated row. The
-// caller serialises the raw id bytes into the Set-Cookie header (base64url).
+// Create inserts a new session for userID and returns the fully-populated row with
+// the PLAINTEXT id in Session.ID (that's what the caller puts in the Set-Cookie). The
+// DB row stores SHA-256(id) so a dump of the sessions table cannot be replayed as
+// active cookies.
 func (s *Store) Create(ctx context.Context, userID int64) (*Session, error) {
 	id, err := randomBytes(IDLen)
 	if err != nil {
@@ -86,7 +102,7 @@ func (s *Store) Create(ctx context.Context, userID int64) (*Session, error) {
 	if _, err := s.db.ExecContext(ctx, `
 		INSERT INTO sessions (id, user_id, csrf_token, expires_at)
 		VALUES (?, ?, ?, ?)
-	`, id, userID, csrf, expires); err != nil {
+	`, digest(id), userID, csrf, expires); err != nil {
 		return nil, fmt.Errorf("insert session: %w", err)
 	}
 	return &Session{
@@ -95,15 +111,15 @@ func (s *Store) Create(ctx context.Context, userID int64) (*Session, error) {
 	}, nil
 }
 
-// Get returns the session for id, or ErrNotFound if missing / expired. We filter
-// `expires_at > NOW()` inside the SQL so a stale row is indistinguishable from a
-// nonexistent one — the middleware can treat both as "401 invalid_session".
-func (s *Store) Get(ctx context.Context, id []byte) (*Session, error) {
-	if len(id) != IDLen {
+// Get takes the plaintext id from the cookie, hashes it, and looks up the row by that
+// digest. Returns ErrNotFound if missing / expired. We filter `expires_at > NOW()`
+// inside the SQL so a stale row is indistinguishable from a nonexistent one — the
+// middleware can treat both as "401 invalid_session".
+func (s *Store) Get(ctx context.Context, plaintextID []byte) (*Session, error) {
+	if len(plaintextID) != IDLen {
 		return nil, ErrNotFound
 	}
 	var row struct {
-		ID         []byte    `db:"id"`
 		UserID     int64     `db:"user_id"`
 		CSRFToken  []byte    `db:"csrf_token"`
 		CreatedAt  time.Time `db:"created_at"`
@@ -112,10 +128,10 @@ func (s *Store) Get(ctx context.Context, id []byte) (*Session, error) {
 	}
 	// `now` is passed in so tests can drive the clock; production uses s.now().
 	err := s.db.GetContext(ctx, &row, `
-		SELECT id, user_id, csrf_token, created_at, last_seen_at, expires_at
+		SELECT user_id, csrf_token, created_at, last_seen_at, expires_at
 		FROM sessions
 		WHERE id = ? AND expires_at > ?
-	`, id, s.now())
+	`, digest(plaintextID), s.now())
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, ErrNotFound
 	}
@@ -123,18 +139,20 @@ func (s *Store) Get(ctx context.Context, id []byte) (*Session, error) {
 		return nil, fmt.Errorf("query session: %w", err)
 	}
 	return &Session{
-		ID: row.ID, UserID: row.UserID, CSRFToken: row.CSRFToken,
+		// Return the plaintext id the caller passed in so downstream code (e.g.
+		// idPrefix for audit logs) can render a stable prefix for correlation.
+		ID: plaintextID, UserID: row.UserID, CSRFToken: row.CSRFToken,
 		CreatedAt: row.CreatedAt, LastSeenAt: row.LastSeenAt, ExpiresAt: row.ExpiresAt,
 	}, nil
 }
 
-// Delete removes a session. Idempotent — no error on a row that doesn't exist so logout
-// works even when the cookie is already stale on the client.
-func (s *Store) Delete(ctx context.Context, id []byte) error {
-	if len(id) != IDLen {
+// Delete removes a session by plaintext id. Idempotent — no error on a row that
+// doesn't exist so logout works even when the cookie is already stale on the client.
+func (s *Store) Delete(ctx context.Context, plaintextID []byte) error {
+	if len(plaintextID) != IDLen {
 		return nil
 	}
-	if _, err := s.db.ExecContext(ctx, `DELETE FROM sessions WHERE id = ?`, id); err != nil {
+	if _, err := s.db.ExecContext(ctx, `DELETE FROM sessions WHERE id = ?`, digest(plaintextID)); err != nil {
 		return fmt.Errorf("delete session: %w", err)
 	}
 	return nil

--- a/server/sessions/sessions_test.go
+++ b/server/sessions/sessions_test.go
@@ -1,0 +1,131 @@
+package sessions
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fleetdm/edr/server/store"
+)
+
+func newTestStore(t *testing.T, opts Options) *Store {
+	t.Helper()
+	return New(store.OpenTestStore(t).DB(), opts)
+}
+
+// frozenClock returns a controllable time.Now for deterministic expiry tests. Starts at
+// a fixed instant so changing the machine wall clock doesn't perturb assertions.
+func frozenClock(start time.Time) (now func() time.Time, advance func(time.Duration)) {
+	cur := start
+	return func() time.Time { return cur }, func(d time.Duration) { cur = cur.Add(d) }
+}
+
+func TestCreate_ReturnsNewRow(t *testing.T) {
+	s := newTestStore(t, Options{})
+	ctx := t.Context()
+
+	sess, err := s.Create(ctx, 42)
+	require.NoError(t, err)
+	assert.Len(t, sess.ID, IDLen)
+	assert.Len(t, sess.CSRFToken, IDLen)
+	assert.Equal(t, int64(42), sess.UserID)
+	assert.False(t, sess.CreatedAt.IsZero())
+	assert.True(t, sess.ExpiresAt.After(sess.CreatedAt))
+}
+
+func TestCreate_IDsAreUnique(t *testing.T) {
+	s := newTestStore(t, Options{})
+	ctx := t.Context()
+
+	a, err := s.Create(ctx, 1)
+	require.NoError(t, err)
+	b, err := s.Create(ctx, 1)
+	require.NoError(t, err)
+	assert.False(t, bytes.Equal(a.ID, b.ID), "session ids must differ")
+	assert.False(t, bytes.Equal(a.CSRFToken, b.CSRFToken), "csrf tokens must differ")
+}
+
+func TestGet_ActiveRoundTrip(t *testing.T) {
+	s := newTestStore(t, Options{})
+	ctx := t.Context()
+
+	created, err := s.Create(ctx, 7)
+	require.NoError(t, err)
+
+	got, err := s.Get(ctx, created.ID)
+	require.NoError(t, err)
+	assert.Equal(t, created.ID, got.ID)
+	assert.Equal(t, int64(7), got.UserID)
+	assert.Equal(t, created.CSRFToken, got.CSRFToken)
+}
+
+func TestGet_WrongLengthReturnsNotFound(t *testing.T) {
+	s := newTestStore(t, Options{})
+	_, err := s.Get(t.Context(), []byte("short"))
+	require.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestGet_UnknownIDReturnsNotFound(t *testing.T) {
+	s := newTestStore(t, Options{})
+	_, err := s.Get(t.Context(), make([]byte, IDLen))
+	require.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestGet_ExpiredReturnsNotFound(t *testing.T) {
+	// Drive the clock backwards so the row we just created is already past its
+	// expires_at when Get runs. This is more reliable than time.Sleep(ttl+1) and
+	// doesn't tie the test to wall-clock duration.
+	start := time.Date(2026, 4, 19, 0, 0, 0, 0, time.UTC)
+	nowFn, advance := frozenClock(start)
+	s := newTestStore(t, Options{TTL: time.Hour, Now: nowFn})
+	ctx := t.Context()
+
+	created, err := s.Create(ctx, 1)
+	require.NoError(t, err)
+
+	advance(2 * time.Hour) // past the 1 hour TTL
+	_, err = s.Get(ctx, created.ID)
+	require.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestDelete_IsIdempotent(t *testing.T) {
+	s := newTestStore(t, Options{})
+	ctx := t.Context()
+
+	sess, err := s.Create(ctx, 1)
+	require.NoError(t, err)
+	require.NoError(t, s.Delete(ctx, sess.ID))
+	require.NoError(t, s.Delete(ctx, sess.ID), "second delete of same id must not error")
+	require.NoError(t, s.Delete(ctx, make([]byte, IDLen)), "delete of unknown id must not error")
+}
+
+func TestCleanupExpired_RemovesOnlyExpired(t *testing.T) {
+	start := time.Date(2026, 4, 19, 0, 0, 0, 0, time.UTC)
+	nowFn, advance := frozenClock(start)
+	s := newTestStore(t, Options{TTL: time.Hour, Now: nowFn})
+	ctx := t.Context()
+
+	active, err := s.Create(ctx, 1)
+	require.NoError(t, err)
+
+	// Advance past TTL so the first row expires, then create a fresh row.
+	advance(2 * time.Hour)
+	stillActive, err := s.Create(ctx, 2)
+	require.NoError(t, err)
+
+	removed, err := s.CleanupExpired(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), removed)
+
+	// The expired row is gone.
+	_, err = s.Get(ctx, active.ID)
+	require.ErrorIs(t, err, ErrNotFound)
+
+	// The fresh row is still there.
+	got, err := s.Get(ctx, stillActive.ID)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), got.UserID)
+}

--- a/server/sessions/sessions_test.go
+++ b/server/sessions/sessions_test.go
@@ -11,9 +11,35 @@ import (
 	"github.com/fleetdm/edr/server/store"
 )
 
+// newTestStore opens a fresh DB and pre-inserts a stub users row whose id is the
+// userID tests reference (1, 2, 7, 42 — whatever the test passes to Create). Without
+// this the Phase 3 FK constraint sessions.user_id → users(id) rejects inserts.
 func newTestStore(t *testing.T, opts Options) *Store {
 	t.Helper()
-	return New(store.OpenTestStore(t).DB(), opts)
+	s := store.OpenTestStore(t)
+	for _, uid := range []int64{1, 2, 7, 42} {
+		_, err := s.DB().ExecContext(t.Context(),
+			`INSERT INTO users (id, email, password_hash, password_salt) VALUES (?, ?, ?, ?)`,
+			uid, "u"+intToStr(uid)+"@test", []byte("stub-hash"), []byte("stub-salt"))
+		if err != nil {
+			t.Fatalf("seed test user %d: %v", uid, err)
+		}
+	}
+	return New(s.DB(), opts)
+}
+
+func intToStr(i int64) string {
+	// Tiny stdlib-free int→string to keep the test helper dependency-light.
+	if i == 0 {
+		return "0"
+	}
+	const digits = "0123456789"
+	var out []byte
+	for i > 0 {
+		out = append([]byte{digits[i%10]}, out...)
+		i /= 10
+	}
+	return string(out)
 }
 
 // frozenClock returns a controllable time.Now for deterministic expiry tests. Starts at

--- a/server/store/alert.go
+++ b/server/store/alert.go
@@ -158,8 +158,11 @@ func (s *Store) GetAlertEventIDs(ctx context.Context, alertID int64) ([]string, 
 }
 
 // UpdateAlertStatus changes the status of an alert. If the new status is "resolved", resolved_at is set
-// (only on the first resolve — subsequent resolves preserve the original timestamp).
-func (s *Store) UpdateAlertStatus(ctx context.Context, id int64, status string) error {
+// (only on the first resolve — subsequent resolves preserve the original timestamp). userID is the id
+// of the authenticated user making the change (from Phase 3 session auth); pass 0 to leave updated_by
+// untouched (e.g. an internal backfill). userID is written to alerts.updated_by so SOC forensics can
+// reconstruct who resolved what.
+func (s *Store) UpdateAlertStatus(ctx context.Context, id int64, status string, userID int64) error {
 	// Check existence first so we can distinguish "not found" from "no change" (RowsAffected=0).
 	var exists int64
 	if err := s.db.GetContext(ctx, &exists, "SELECT id FROM alerts WHERE id = ?", id); err != nil {
@@ -169,13 +172,26 @@ func (s *Store) UpdateAlertStatus(ctx context.Context, id int64, status string) 
 		return fmt.Errorf("check alert existence %d: %w", id, err)
 	}
 
+	// When userID is zero we leave updated_by alone (COALESCE(existing, NULL)) so
+	// internal backfills don't clobber the last real user. When non-zero we overwrite;
+	// the last responder's identity is what forensics cares about.
 	var err error
 	if status == "resolved" {
-		_, err = s.db.ExecContext(ctx,
-			"UPDATE alerts SET status = ?, resolved_at = IFNULL(resolved_at, NOW(6)) WHERE id = ?", status, id)
+		_, err = s.db.ExecContext(ctx, `
+			UPDATE alerts
+			SET status = ?,
+			    resolved_at = IFNULL(resolved_at, NOW(6)),
+			    updated_by = IF(? = 0, updated_by, ?)
+			WHERE id = ?
+		`, status, userID, userID, id)
 	} else {
-		_, err = s.db.ExecContext(ctx,
-			"UPDATE alerts SET status = ?, resolved_at = NULL WHERE id = ?", status, id)
+		_, err = s.db.ExecContext(ctx, `
+			UPDATE alerts
+			SET status = ?,
+			    resolved_at = NULL,
+			    updated_by = IF(? = 0, updated_by, ?)
+			WHERE id = ?
+		`, status, userID, userID, id)
 	}
 	if err != nil {
 		return fmt.Errorf("update alert status %d: %w", id, err)

--- a/server/store/alert.go
+++ b/server/store/alert.go
@@ -172,9 +172,9 @@ func (s *Store) UpdateAlertStatus(ctx context.Context, id int64, status string, 
 		return fmt.Errorf("check alert existence %d: %w", id, err)
 	}
 
-	// When userID is zero we leave updated_by alone (COALESCE(existing, NULL)) so
-	// internal backfills don't clobber the last real user. When non-zero we overwrite;
-	// the last responder's identity is what forensics cares about.
+	// When userID is zero we preserve the existing updated_by value via IF(?=0, col, ?)
+	// so internal backfills don't clobber the last real user. When non-zero we
+	// overwrite; the last responder's identity is what forensics cares about.
 	var err error
 	if status == "resolved" {
 		_, err = s.db.ExecContext(ctx, `

--- a/server/store/alert_test.go
+++ b/server/store/alert_test.go
@@ -130,7 +130,7 @@ func TestUpdateAlertStatus(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("acknowledge", func(t *testing.T) {
-		err := s.UpdateAlertStatus(ctx, id, "acknowledged")
+		err := s.UpdateAlertStatus(ctx, id, "acknowledged", 0)
 		require.NoError(t, err)
 
 		got, err := s.GetAlert(ctx, id)
@@ -140,7 +140,7 @@ func TestUpdateAlertStatus(t *testing.T) {
 	})
 
 	t.Run("resolve", func(t *testing.T) {
-		err := s.UpdateAlertStatus(ctx, id, "resolved")
+		err := s.UpdateAlertStatus(ctx, id, "resolved", 0)
 		require.NoError(t, err)
 
 		got, err := s.GetAlert(ctx, id)
@@ -150,7 +150,7 @@ func TestUpdateAlertStatus(t *testing.T) {
 	})
 
 	t.Run("reopen clears resolved_at", func(t *testing.T) {
-		err := s.UpdateAlertStatus(ctx, id, "open")
+		err := s.UpdateAlertStatus(ctx, id, "open", 0)
 		require.NoError(t, err)
 
 		got, err := s.GetAlert(ctx, id)

--- a/server/store/store.go
+++ b/server/store/store.go
@@ -224,8 +224,14 @@ func New(ctx context.Context, dsn string) (*Store, error) {
 	for _, m := range migrations {
 		if _, err := db.ExecContext(ctx, m); err != nil {
 			var mysqlErr *mysql.MySQLError
-			// 1060 = duplicate column, 1061 = duplicate key name — already applied.
-			if errors.As(err, &mysqlErr) && (mysqlErr.Number == 1060 || mysqlErr.Number == 1061) {
+			// Already-applied variants:
+			//   1060 = duplicate column
+			//   1061 = duplicate key name
+			//   1826 = duplicate FK name
+			//   1022 = duplicate key on add (older MySQL error code for FK name clash)
+			if errors.As(err, &mysqlErr) &&
+				(mysqlErr.Number == 1060 || mysqlErr.Number == 1061 ||
+					mysqlErr.Number == 1826 || mysqlErr.Number == 1022) {
 				continue
 			}
 			db.Close()
@@ -253,6 +259,15 @@ var migrations = []string{
 	// to render. The migration loop above swallows "duplicate column name" errors, so
 	// re-running on an already-migrated DB is a no-op.
 	`ALTER TABLE alerts ADD COLUMN updated_by BIGINT NULL`,
+	// Phase 3 FK constraints: enforce that sessions point at live users (CASCADE on
+	// user delete so stale sessions die with their owner) and alert audit references
+	// are either a real user or NULL (SET NULL on delete so a removed admin doesn't
+	// erase their historical acknowledgements). Indexes on the FK columns are
+	// required for InnoDB to accept the constraint and make JOIN-based queries cheap.
+	`ALTER TABLE sessions ADD INDEX idx_sessions_user_id (user_id)`,
+	`ALTER TABLE sessions ADD CONSTRAINT fk_sessions_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE`,
+	`ALTER TABLE alerts ADD INDEX idx_alerts_updated_by (updated_by)`,
+	`ALTER TABLE alerts ADD CONSTRAINT fk_alerts_updated_by FOREIGN KEY (updated_by) REFERENCES users(id) ON DELETE SET NULL`,
 }
 
 // postSchemaMigrations run after schema creation and idempotent ALTER migrations. They use INSERT IGNORE / INSERT ...

--- a/server/store/store.go
+++ b/server/store/store.go
@@ -129,6 +129,33 @@ var schemaStatements = []string{
 	// row. The initial blocklist is empty — operators opt in to blocking via PUT.
 	`INSERT IGNORE INTO policies (name, version, blocklist, updated_by)
 	 VALUES ('default', 1, JSON_OBJECT('paths', JSON_ARRAY(), 'hashes', JSON_ARRAY()), 'system')`,
+	// Phase 3: users table for UI auth. password_hash is argon2id output (32 bytes);
+	// password_salt is 16 random bytes (same argon params as enrollment host tokens).
+	// email is UNIQUE so duplicate invites fail cleanly at the DB boundary.
+	`CREATE TABLE IF NOT EXISTS users (
+		id             BIGINT AUTO_INCREMENT PRIMARY KEY,
+		email          VARCHAR(255)   NOT NULL,
+		password_hash  VARBINARY(255) NOT NULL,
+		password_salt  VARBINARY(32)  NOT NULL,
+		created_at     TIMESTAMP(6)   NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+		updated_at     TIMESTAMP(6)   NOT NULL DEFAULT CURRENT_TIMESTAMP(6)
+		                              ON UPDATE CURRENT_TIMESTAMP(6),
+		UNIQUE KEY uk_users_email (email)
+	)`,
+	// Phase 3: sessions table for UI cookie auth. id is 32 random bytes (~256 bits of
+	// entropy) — acts as its own unguessable lookup key, no separate index needed.
+	// csrf_token is 32 random bytes; compared constant-time against X-CSRF-Token header
+	// on unsafe methods.
+	`CREATE TABLE IF NOT EXISTS sessions (
+		id            VARBINARY(32)  PRIMARY KEY,
+		user_id       BIGINT         NOT NULL,
+		csrf_token    VARBINARY(32)  NOT NULL,
+		created_at    TIMESTAMP(6)   NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+		last_seen_at  TIMESTAMP(6)   NOT NULL DEFAULT CURRENT_TIMESTAMP(6)
+		                             ON UPDATE CURRENT_TIMESTAMP(6),
+		expires_at    TIMESTAMP(6)   NOT NULL,
+		INDEX idx_sessions_expires (expires_at)
+	)`,
 }
 
 // Event represents the canonical event envelope.
@@ -221,6 +248,11 @@ func New(ctx context.Context, dsn string) (*Store, error) {
 var migrations = []string{
 	`ALTER TABLE events ADD COLUMN processed TINYINT(1) NOT NULL DEFAULT 0`,
 	`ALTER TABLE events ADD INDEX idx_events_processed (processed, host_id, timestamp_ns)`,
+	// Phase 3: alert audit trail. updated_by references users.id for SOC forensics.
+	// NULL is allowed so pre-Phase-3 rows (written before the column existed) continue
+	// to render. The migration loop above swallows "duplicate column name" errors, so
+	// re-running on an already-migrated DB is a no-op.
+	`ALTER TABLE alerts ADD COLUMN updated_by BIGINT NULL`,
 }
 
 // postSchemaMigrations run after schema creation and idempotent ALTER migrations. They use INSERT IGNORE / INSERT ...

--- a/server/users/users.go
+++ b/server/users/users.go
@@ -143,8 +143,10 @@ func (s *Store) VerifyPassword(ctx context.Context, email, password string) (*Us
 	`, email)
 	if errors.Is(err, sql.ErrNoRows) {
 		// Burn the argon2 cycles anyway so we don't leak via timing. The dummy salt is a
-		// per-process constant — argon2id is deterministic given the same salt so this
-		// produces a stable "unknown email" timing profile without allocating.
+		// per-process constant — argon2id is deterministic given the same salt, producing
+		// a stable "unknown email" timing profile. (argon2.IDKey still allocates its
+		// output slice; the timing property we care about is work done under the same
+		// memory + cost parameters as the real path, not allocation-free execution.)
 		_ = argon2.IDKey([]byte(password), dummySalt, argonTime, argonMemory, argonThreads, argonKeyLen)
 		return nil, ErrNotFound
 	}

--- a/server/users/users.go
+++ b/server/users/users.go
@@ -1,0 +1,185 @@
+// Package users owns the `users` table that backs Phase 3 UI login. The store exposes
+// a minimal CRUD surface (Create, GetByEmail) because MVP has exactly one admin account
+// — anything more is v1.1. Password hashing uses argon2id with the same parameter set
+// as the enrollment token hash so a future consolidation into a shared `passcrypto`
+// package is mechanical.
+package users
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/subtle"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+	"golang.org/x/crypto/argon2"
+)
+
+// argon2id parameters per OWASP Password Storage Cheat Sheet 2024. ~30 ms per hash on
+// M-series Mac; the hot path (login verify) hashes at most once per login attempt and
+// we rate-limit logins, so CPU-DoS via login-storm is capped.
+const (
+	argonTime    uint32 = 3
+	argonMemory  uint32 = 64 * 1024 // 64 MiB
+	argonThreads uint8  = 4
+	argonKeyLen  uint32 = 32
+	argonSaltLen        = 16
+)
+
+// User is the storage row. The password_hash / password_salt columns are intentionally
+// not exposed on the struct so callers that log a User can't accidentally leak them.
+type User struct {
+	ID        int64     `db:"id" json:"id"`
+	Email     string    `db:"email" json:"email"`
+	CreatedAt time.Time `db:"created_at" json:"created_at"`
+	UpdatedAt time.Time `db:"updated_at" json:"updated_at"`
+}
+
+// ErrNotFound is returned by GetByEmail when no row matches.
+var ErrNotFound = errors.New("users: not found")
+
+// ErrBadPassword is returned by VerifyPassword when the presented password doesn't
+// match the stored hash. Kept separate from ErrNotFound so callers can emit identical
+// 401s to the client (preventing email enumeration) while differentiating reasons in
+// the server-side audit log.
+var ErrBadPassword = errors.New("users: password mismatch")
+
+// Store owns the users table.
+type Store struct {
+	db *sqlx.DB
+}
+
+// New constructs a Store over an existing sqlx.DB handle.
+func New(db *sqlx.DB) *Store {
+	return &Store{db: db}
+}
+
+// CreateRequest is the shape accepted by Create. The plaintext password is hashed before
+// it touches the DB; the caller never sees the hash bytes.
+type CreateRequest struct {
+	Email    string
+	Password string
+}
+
+// Create inserts a new user and returns the row (without the hash/salt). Email is
+// normalised to lowercase + trimmed before the uniqueness check — customer admins like
+// to type "Admin@Example.COM" and expect it to resolve to the same account.
+func (s *Store) Create(ctx context.Context, req CreateRequest) (*User, error) {
+	email := strings.ToLower(strings.TrimSpace(req.Email))
+	if email == "" {
+		return nil, errors.New("users: email is required")
+	}
+	if req.Password == "" {
+		return nil, errors.New("users: password is required")
+	}
+	hash, salt, err := hashPassword(req.Password)
+	if err != nil {
+		return nil, err
+	}
+	res, err := s.db.ExecContext(ctx, `
+		INSERT INTO users (email, password_hash, password_salt) VALUES (?, ?, ?)
+	`, email, hash, salt)
+	if err != nil {
+		return nil, fmt.Errorf("insert user: %w", err)
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		return nil, fmt.Errorf("last insert id: %w", err)
+	}
+	return s.Get(ctx, id)
+}
+
+// Get returns a user by id without hash/salt. Returns ErrNotFound if absent.
+func (s *Store) Get(ctx context.Context, id int64) (*User, error) {
+	var u User
+	err := s.db.GetContext(ctx, &u, `
+		SELECT id, email, created_at, updated_at FROM users WHERE id = ?
+	`, id)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get user %d: %w", id, err)
+	}
+	return &u, nil
+}
+
+// Count returns the number of users. Used by the first-boot seeder to decide whether to
+// create the initial admin. A bare Count query is faster than SELECT ... LIMIT 1.
+func (s *Store) Count(ctx context.Context) (int64, error) {
+	var n int64
+	if err := s.db.GetContext(ctx, &n, `SELECT COUNT(*) FROM users`); err != nil {
+		return 0, fmt.Errorf("count users: %w", err)
+	}
+	return n, nil
+}
+
+// VerifyPassword looks up a user by email and verifies the presented password. On
+// success it returns the user without hash/salt. On any failure it returns
+// ErrNotFound (unknown email) or ErrBadPassword (wrong password) — callers should map
+// both to the same client-facing 401 to prevent email enumeration.
+//
+// Runs the argon2id computation even when the email is unknown so the timing profile
+// of "unknown email" matches "known email + wrong password". Without this, an attacker
+// can probe valid emails via login latency.
+func (s *Store) VerifyPassword(ctx context.Context, email, password string) (*User, error) {
+	email = strings.ToLower(strings.TrimSpace(email))
+
+	var row struct {
+		ID           int64     `db:"id"`
+		Email        string    `db:"email"`
+		PasswordHash []byte    `db:"password_hash"`
+		PasswordSalt []byte    `db:"password_salt"`
+		CreatedAt    time.Time `db:"created_at"`
+		UpdatedAt    time.Time `db:"updated_at"`
+	}
+	err := s.db.GetContext(ctx, &row, `
+		SELECT id, email, password_hash, password_salt, created_at, updated_at
+		FROM users WHERE email = ?
+	`, email)
+	if errors.Is(err, sql.ErrNoRows) {
+		// Burn the argon2 cycles anyway so we don't leak via timing. The dummy salt is a
+		// per-process constant — argon2id is deterministic given the same salt so this
+		// produces a stable "unknown email" timing profile without allocating.
+		_ = argon2.IDKey([]byte(password), dummySalt, argonTime, argonMemory, argonThreads, argonKeyLen)
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("query user by email: %w", err)
+	}
+	if !verifyHash(password, row.PasswordHash, row.PasswordSalt) {
+		return nil, ErrBadPassword
+	}
+	return &User{
+		ID: row.ID, Email: row.Email, CreatedAt: row.CreatedAt, UpdatedAt: row.UpdatedAt,
+	}, nil
+}
+
+// dummySalt is the constant-time fallback salt used when an email lookup misses. Its
+// content doesn't matter — we throw away the hash — but its length must match the real
+// salt length or the argon2 cost won't match exactly.
+var dummySalt = make([]byte, argonSaltLen)
+
+// hashPassword generates a fresh salt + argon2id hash for the plaintext password.
+func hashPassword(password string) (hash, salt []byte, err error) {
+	salt = make([]byte, argonSaltLen)
+	if _, err = rand.Read(salt); err != nil {
+		return nil, nil, fmt.Errorf("generate salt: %w", err)
+	}
+	hash = argon2.IDKey([]byte(password), salt, argonTime, argonMemory, argonThreads, argonKeyLen)
+	return hash, salt, nil
+}
+
+// verifyHash returns true when `password` hashes to `wantHash` under `salt`. Uses
+// subtle.ConstantTimeCompare to prevent the hash-compare step from leaking timing info.
+func verifyHash(password string, wantHash, salt []byte) bool {
+	if len(wantHash) == 0 || len(salt) == 0 {
+		return false
+	}
+	got := argon2.IDKey([]byte(password), salt, argonTime, argonMemory, argonThreads, argonKeyLen)
+	return subtle.ConstantTimeCompare(got, wantHash) == 1
+}

--- a/server/users/users_test.go
+++ b/server/users/users_test.go
@@ -1,0 +1,111 @@
+package users
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fleetdm/edr/server/store"
+)
+
+func newTestStore(t *testing.T) *Store {
+	t.Helper()
+	return New(store.OpenTestStore(t).DB())
+}
+
+func TestCreate_HappyPath(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+
+	u, err := s.Create(ctx, CreateRequest{Email: "Admin@Example.com", Password: "Corr3ct!H0rseBattery"})
+	require.NoError(t, err)
+	assert.Positive(t, u.ID)
+	assert.Equal(t, "admin@example.com", u.Email, "email must be lowercased before storage")
+	assert.False(t, u.CreatedAt.IsZero())
+}
+
+func TestCreate_RejectsEmptyInputs(t *testing.T) {
+	s := newTestStore(t)
+	cases := []struct{ email, password, wantSub string }{
+		{"", "x", "email is required"},
+		{"  ", "x", "email is required"},
+		{"a@b", "", "password is required"},
+	}
+	for _, tc := range cases {
+		_, err := s.Create(t.Context(), CreateRequest{Email: tc.email, Password: tc.password})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), tc.wantSub)
+	}
+}
+
+func TestCreate_DuplicateEmailFails(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+
+	_, err := s.Create(ctx, CreateRequest{Email: "admin@example.com", Password: "pw1"})
+	require.NoError(t, err)
+
+	_, err = s.Create(ctx, CreateRequest{Email: "ADMIN@example.com", Password: "pw2"})
+	require.Error(t, err, "case-insensitive duplicate must fail")
+}
+
+func TestVerifyPassword_HappyPath(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+
+	created, err := s.Create(ctx, CreateRequest{Email: "admin@example.com", Password: "rightpassword"})
+	require.NoError(t, err)
+
+	u, err := s.VerifyPassword(ctx, "ADMIN@example.com", "rightpassword")
+	require.NoError(t, err)
+	assert.Equal(t, created.ID, u.ID)
+	assert.Equal(t, "admin@example.com", u.Email)
+}
+
+func TestVerifyPassword_WrongPassword(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+
+	_, err := s.Create(ctx, CreateRequest{Email: "admin@example.com", Password: "rightpassword"})
+	require.NoError(t, err)
+
+	_, err = s.VerifyPassword(ctx, "admin@example.com", "wrongpassword")
+	require.ErrorIs(t, err, ErrBadPassword)
+}
+
+func TestVerifyPassword_UnknownEmail(t *testing.T) {
+	s := newTestStore(t)
+	_, err := s.VerifyPassword(t.Context(), "nobody@example.com", "anything")
+	require.ErrorIs(t, err, ErrNotFound)
+}
+
+// TestVerifyPassword_TimingInsensitiveToEmail locks in the constant-time property: an
+// unknown email must still run the argon2 computation so the presence/absence of an
+// account is not leakable via response time. We can't measure wall time reliably in a
+// unit test, but we can assert the fallback dummy-salt path exists — errors.Is still
+// returns ErrNotFound, but the function did not return early before the hash loop.
+func TestVerifyPassword_UnknownEmailStillHashes(t *testing.T) {
+	s := newTestStore(t)
+	// Two lookups against an empty table — both must fail with ErrNotFound, neither
+	// with a DB error. Coverage-wise this ensures the dummy-salt branch is exercised.
+	for range 2 {
+		_, err := s.VerifyPassword(t.Context(), "nobody@example.com", "whatever")
+		require.ErrorIs(t, err, ErrNotFound)
+	}
+}
+
+func TestCount(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	n, err := s.Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), n)
+
+	_, err = s.Create(ctx, CreateRequest{Email: "a@b.com", Password: "p"})
+	require.NoError(t, err)
+
+	n, err = s.Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), n)
+}

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -20,24 +20,26 @@ export function App() {
   const [auth, setAuth] = useState<AuthState>({ status: "loading" });
 
   useEffect(() => {
-    let cancelled = false;
-    (async () => {
+    const controller = new AbortController();
+    // `void` marks the floating promise as intentional for
+    // @typescript-eslint/no-floating-promises. We don't need to await it — React's
+    // useEffect already handles async component lifecycle via the cleanup closure.
+    void (async () => {
       try {
         const info = await currentSession();
-        if (!cancelled) setAuth({ status: "authed", user: info.user });
+        if (!controller.signal.aborted) setAuth({ status: "authed", user: info.user });
       } catch (err) {
-        if (!cancelled) {
-          if (err instanceof Unauthorized401Error) {
-            setAuth({ status: "anon" });
-          } else {
-            // Unknown error (network, 5xx) — fall back to the login page rather than
-            // render with no data. The user can retry after fixing the network.
-            setAuth({ status: "anon" });
-          }
+        if (controller.signal.aborted) return;
+        if (err instanceof Unauthorized401Error) {
+          setAuth({ status: "anon" });
+        } else {
+          // Unknown error (network, 5xx) — fall back to the login page rather than
+          // render with no data. The user can retry after fixing the network.
+          setAuth({ status: "anon" });
         }
       }
     })();
-    return () => { cancelled = true; };
+    return () => { controller.abort(); };
   }, []);
 
   async function handleLogout() {

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,23 +1,76 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import { HostList } from "./components/HostList";
 import { ProcessTreeView } from "./components/ProcessTree";
 import { AlertList } from "./components/AlertList";
 import { Login } from "./components/Login";
 import { TopNav } from "./components/ui/TopNav";
+import { currentSession, logout, Unauthorized401Error, SessionInfo } from "./api";
 
+type AuthState =
+  | { status: "loading" }
+  | { status: "anon" }
+  | { status: "authed"; user: SessionInfo["user"] };
+
+// Phase 3: the UI probes GET /api/v1/session on mount. On 200 we render the app; on
+// 401 we render the Login component. The old sessionStorage "edr_api_key" probe is
+// gone — the cookie is HttpOnly so JS can't see it directly, and the server is the
+// source of truth for "am I logged in?".
 export function App() {
-  const [authenticated, setAuthenticated] = useState(
-    () => sessionStorage.getItem("edr_api_key") !== null,
-  );
+  const [auth, setAuth] = useState<AuthState>({ status: "loading" });
 
-  if (!authenticated) {
-    return <Login onLogin={() => { setAuthenticated(true); }} />;
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const info = await currentSession();
+        if (!cancelled) setAuth({ status: "authed", user: info.user });
+      } catch (err) {
+        if (!cancelled) {
+          if (err instanceof Unauthorized401Error) {
+            setAuth({ status: "anon" });
+          } else {
+            // Unknown error (network, 5xx) — fall back to the login page rather than
+            // render with no data. The user can retry after fixing the network.
+            setAuth({ status: "anon" });
+          }
+        }
+      }
+    })();
+    return () => { cancelled = true; };
+  }, []);
+
+  async function handleLogout() {
+    await logout().catch(() => { /* Logout failures are best-effort; we still clear locally. */ });
+    setAuth({ status: "anon" });
+  }
+
+  if (auth.status === "loading") {
+    // Tiny blank state — the session probe is ~100ms; rendering a spinner here caused
+    // more layout flash than the blank did in informal testing.
+    return <div className="app-loading" />;
+  }
+
+  if (auth.status === "anon") {
+    return (
+      <Login
+        onLogin={() => {
+          // The login() call in the Login component already set the CSRF token; we
+          // just need to re-read the session to populate the user info for TopNav.
+          void (async () => {
+            try {
+              const info = await currentSession();
+              setAuth({ status: "authed", user: info.user });
+            } catch { /* shouldn't happen immediately after a successful login */ }
+          })();
+        }}
+      />
+    );
   }
 
   return (
     <BrowserRouter basename="/ui">
-      <TopNav />
+      <TopNav user={auth.user} onLogout={() => { void handleLogout(); }} />
       <main className="app-page">
         <Routes>
           <Route path="/" element={<HostList />} />

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -1,31 +1,102 @@
+// Phase 3: the UI authenticates with the server via a HttpOnly session cookie
+// (automatic on every fetch when credentials: 'include') + a per-session CSRF token
+// that the JS attaches as X-CSRF-Token on unsafe methods. The old sessionStorage
+// "edr_api_key" bearer is gone; see POST /api/v1/session for the login round-trip
+// that issues both the cookie and the CSRF token.
 import type { HostSummary, TreeResponse, ProcessDetail, Alert, AlertDetail, Command } from "./types";
 
 const API_BASE = "/api/v1";
 
-function getApiKey(): string {
-  return sessionStorage.getItem("edr_api_key") || "";
+const CSRF_KEY = "edr_csrf_token";
+
+// Unauthorized401Error is thrown whenever the server returns 401. App.tsx catches it
+// to decide "show the login page", so callers don't need to know the status code.
+export class Unauthorized401Error extends Error {
+  constructor() { super("unauthorized"); this.name = "Unauthorized401Error"; }
 }
 
-export function setApiKey(key: string) {
-  sessionStorage.setItem("edr_api_key", key);
+export interface SessionInfo {
+  user: { id: number; email: string };
+  csrf_token: string;
+}
+
+export function getCsrfToken(): string {
+  return sessionStorage.getItem(CSRF_KEY) || "";
+}
+
+export function setCsrfToken(token: string): void {
+  sessionStorage.setItem(CSRF_KEY, token);
+}
+
+export function clearCsrfToken(): void {
+  sessionStorage.removeItem(CSRF_KEY);
+}
+
+function unsafeMethod(method?: string): boolean {
+  if (!method) return false;
+  const m = method.toUpperCase();
+  return m === "POST" || m === "PUT" || m === "PATCH" || m === "DELETE";
 }
 
 async function fetchJSON<T>(path: string, init?: RequestInit): Promise<T> {
-  const apiKey = getApiKey();
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
     ...(init?.headers as Record<string, string> | undefined),
   };
-  if (apiKey) {
-    headers["Authorization"] = `Bearer ${apiKey}`;
+  // Attach CSRF on unsafe methods only — GET/HEAD never need it, and sending an
+  // expired token on those is harmless but wasted bytes.
+  if (unsafeMethod(init?.method)) {
+    const csrf = getCsrfToken();
+    if (csrf) headers["X-CSRF-Token"] = csrf;
   }
 
-  const res = await fetch(`${API_BASE}${path}`, { ...init, headers });
+  const res = await fetch(`${API_BASE}${path}`, {
+    ...init,
+    headers,
+    credentials: "include",
+  });
+  if (res.status === 401) {
+    // Session expired or never existed. Clear local CSRF so a stale token doesn't
+    // linger and trip us up on the next login.
+    clearCsrfToken();
+    throw new Unauthorized401Error();
+  }
   if (!res.ok) {
     throw new Error(`API error: ${String(res.status)} ${res.statusText}`);
   }
+  // DELETE /api/v1/session returns 204 with no body; handle the empty-body case.
+  if (res.status === 204) return undefined as T;
   return res.json() as Promise<T>;
 }
+
+// --- Session endpoints ---
+
+export async function login(email: string, password: string): Promise<SessionInfo> {
+  const info = await fetchJSON<SessionInfo>("/session", {
+    method: "POST",
+    body: JSON.stringify({ email, password }),
+  });
+  setCsrfToken(info.csrf_token);
+  return info;
+}
+
+export async function currentSession(): Promise<SessionInfo> {
+  const info = await fetchJSON<SessionInfo>("/session");
+  // The server issues a fresh CSRF per session; on page reload we fetch it here
+  // and re-prime sessionStorage so every subsequent unsafe method has a header.
+  setCsrfToken(info.csrf_token);
+  return info;
+}
+
+export async function logout(): Promise<void> {
+  try {
+    await fetchJSON<void>("/session", { method: "DELETE" });
+  } finally {
+    clearCsrfToken();
+  }
+}
+
+// --- Domain endpoints ---
 
 export async function listHosts(): Promise<HostSummary[]> {
   return fetchJSON<HostSummary[]>("/hosts");
@@ -74,18 +145,10 @@ export async function getAlertDetail(id: number): Promise<AlertDetail> {
 }
 
 export async function updateAlertStatus(id: number, status: string): Promise<void> {
-  const apiKey = getApiKey();
-  const headers: Record<string, string> = { "Content-Type": "application/json" };
-  if (apiKey) headers["Authorization"] = `Bearer ${apiKey}`;
-
-  const res = await fetch(`${API_BASE}/alerts/${String(id)}`, {
+  await fetchJSON<void>(`/alerts/${String(id)}`, {
     method: "PUT",
-    headers,
     body: JSON.stringify({ status }),
   });
-  if (!res.ok) {
-    throw new Error(`API error: ${String(res.status)} ${res.statusText}`);
-  }
 }
 
 export async function listAlertsByProcessId(processId: number): Promise<Alert[]> {

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -90,7 +90,7 @@ export async function currentSession(): Promise<SessionInfo> {
 
 export async function logout(): Promise<void> {
   try {
-    await fetchJSON<void>("/session", { method: "DELETE" });
+    await fetchJSON<unknown>("/session", { method: "DELETE" });
   } finally {
     clearCsrfToken();
   }
@@ -145,7 +145,7 @@ export async function getAlertDetail(id: number): Promise<AlertDetail> {
 }
 
 export async function updateAlertStatus(id: number, status: string): Promise<void> {
-  await fetchJSON<void>(`/alerts/${String(id)}`, {
+  await fetchJSON<unknown>(`/alerts/${String(id)}`, {
     method: "PUT",
     body: JSON.stringify({ status }),
   });

--- a/ui/src/components/Login.tsx
+++ b/ui/src/components/Login.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { setApiKey, listHosts } from "../api";
+import { login, Unauthorized401Error } from "../api";
 import { Button } from "./ui/Button";
 import { Card } from "./ui/Card";
 import { Input } from "./ui/Input";
@@ -9,8 +9,12 @@ interface LoginProps {
   onLogin: () => void;
 }
 
+// Phase 3 login: email + password → POST /api/v1/session → server sets HttpOnly
+// session cookie and returns the per-session CSRF token. api.ts stashes the CSRF in
+// sessionStorage; App.tsx re-renders with the logged-in view.
 export function Login({ onLogin }: LoginProps) {
-  const [key, setKey] = useState("");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
 
@@ -19,17 +23,23 @@ export function Login({ onLogin }: LoginProps) {
     setError("");
     setLoading(true);
 
-    setApiKey(key);
     try {
-      await listHosts();
+      await login(email.trim(), password);
       onLogin();
-    } catch {
-      setApiKey("");
-      setError("Invalid API key");
+    } catch (err) {
+      if (err instanceof Unauthorized401Error) {
+        // The server returns a generic 401 for both "unknown email" and "wrong
+        // password" so the UI cannot be used to enumerate accounts. Show the same.
+        setError("Invalid email or password.");
+      } else {
+        setError("Sign-in failed. Please try again.");
+      }
     } finally {
       setLoading(false);
     }
   }
+
+  const submitDisabled = email.length === 0 || password.length === 0;
 
   return (
     <div className="login-page">
@@ -42,26 +52,35 @@ export function Login({ onLogin }: LoginProps) {
             </h1>
           </div>
           <p className="login-card__subtitle">
-            Enter your API key to sign in
+            Sign in with your admin email and password
           </p>
         </div>
 
         <form onSubmit={(e) => { void handleSubmit(e); }} className="login-card__form">
           <Input
-            id="api-key"
-            label="API key"
-            type="password"
-            value={key}
-            onChange={(e) => { setKey(e.target.value); }}
+            id="email"
+            label="Email"
+            type="email"
+            autoComplete="username"
+            value={email}
+            onChange={(e) => { setEmail(e.target.value); }}
             autoFocus
+          />
+          <Input
+            id="password"
+            label="Password"
+            type="password"
+            autoComplete="current-password"
+            value={password}
+            onChange={(e) => { setPassword(e.target.value); }}
           />
           {error && <div className="login-card__error">{error}</div>}
           <Button
             type="submit"
-            disabled={key.length === 0}
+            disabled={submitDisabled}
             isLoading={loading}
           >
-            {loading ? "Checking..." : "Log in"}
+            {loading ? "Signing in…" : "Sign in"}
           </Button>
         </form>
       </Card>

--- a/ui/src/components/ui/TopNav.tsx
+++ b/ui/src/components/ui/TopNav.tsx
@@ -12,7 +12,15 @@ const LINKS: NavLink[] = [
   { to: "/alerts", label: "Alerts" },
 ];
 
-export function TopNav() {
+interface TopNavProps {
+  // user + onLogout are optional for pre-Phase-3 callers. Post-Phase-3 both are set
+  // from App.tsx whenever a session is active; when absent we just hide the identity
+  // + logout UI.
+  user?: { id: number; email: string };
+  onLogout?: () => void;
+}
+
+export function TopNav({ user, onLogout }: TopNavProps) {
   const location = useLocation();
 
   return (
@@ -42,6 +50,18 @@ export function TopNav() {
             );
           })}
         </ul>
+        {user && onLogout && (
+          <div className="top-nav__account">
+            <span className="top-nav__user">{user.email}</span>
+            <button
+              type="button"
+              className="top-nav__logout"
+              onClick={onLogout}
+            >
+              Log out
+            </button>
+          </div>
+        )}
       </div>
     </nav>
   );


### PR DESCRIPTION
- Add `server/seed` package for initial admin user creation, including password generation and structured logging.
- Introduce `server/session` package for login/logout/session-check functionality, with CSRF token support.
- Provide test coverage for both `seed` and `session` packages, covering main paths, edge cases, and misconfigurations.
- Add rate-limiting for login attempts via `session` package to mitigate brute-force attacks.
- Include support for secure cookie flags and detailed audit logs during session operations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Replaced API key authentication with session-based login using email and password credentials.
  * Added logout functionality with secure session termination.
  * Implemented CSRF token protection for state-changing requests.
  * Added HttpOnly session cookies for enhanced security.

* **Tests**
  * Added comprehensive test coverage for authentication, session management, user operations, and login/logout flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->