### PR TITLE
Add API and deployment docs for Fleet EDR

### DIFF
--- a/.github/workflows/openapi-lint.yml
+++ b/.github/workflows/openapi-lint.yml
@@ -1,0 +1,36 @@
+name: OpenAPI lint
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/api/openapi.yaml"
+      - ".github/workflows/openapi-lint.yml"
+  pull_request:
+    paths:
+      - "docs/api/openapi.yaml"
+      - ".github/workflows/openapi-lint.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: redocly lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: 22
+
+      - name: Run redocly lint
+        run: npx -y @redocly/cli@2.29.2 lint docs/api/openapi.yaml

--- a/README.md
+++ b/README.md
@@ -8,6 +8,23 @@
 A macOS Endpoint Detection and Response (EDR) system. It provides
 real-time process monitoring, network attribution, behavioral detection, and response capabilities.
 
+## Operator docs
+
+Running Fleet EDR (not developing it)? Start with [`docs/`](docs/):
+
+- [`docs/install-server.md`](docs/install-server.md) -- stand up the
+  Docker Compose stack.
+- [`docs/install-agent-manual.md`](docs/install-agent-manual.md) --
+  evaluate on 1-5 Macs without an MDM.
+- [`docs/mdm-deployment.md`](docs/mdm-deployment.md) -- deploy via any
+  MDM (Jamf, Kandji, Intune, mosyle, Fleet).
+- [`docs/fleet-deployment.md`](docs/fleet-deployment.md) -- Fleet
+  MDM-specific recipe.
+- [`docs/operations.md`](docs/operations.md) -- day-2 ops runbook
+  (upgrades, rotations, backups, troubleshooting).
+- [`docs/api.md`](docs/api.md) + [`docs/api/openapi.yaml`](docs/api/openapi.yaml)
+  -- HTTP API reference.
+
 ## Architecture
 
 ### On-device

--- a/docker-compose.prod.README.md
+++ b/docker-compose.prod.README.md
@@ -85,7 +85,14 @@ endpoint. The server emits:
 
 - Traces for every HTTP request + DB query.
 - Logs via `otelslog` with `service.name=fleet-edr-server`.
-- Metrics listed in `claude/mvp/phase-4-lifecycle-observability.md`.
+- Metrics: `edr.events.ingested`, `edr.alerts.created`,
+  `edr.enrolled.hosts`, `edr.offline.hosts`,
+  `edr.retention.rows_deleted`, `edr.db.query.duration`,
+  `edr.agent.queue.dropped`. See
+  [docs/install-server.md](docs/install-server.md#otel-metrics-and-logs)
+  for the full list and
+  [docs/operations.md](docs/operations.md#metrics-and-monitoring) for
+  what to alert on.
 
 There is no Prometheus scrape endpoint.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,45 @@
+# Fleet EDR documentation
+
+Operator-facing documentation for Fleet EDR. For developer setup see the
+repo-root `README.md`.
+
+## Who reads what
+
+| You are | Start here |
+|---|---|
+| Standing up the server for the first time | [`install-server.md`](install-server.md) |
+| Evaluating the agent on a handful of Macs without MDM | [`install-agent-manual.md`](install-agent-manual.md) |
+| Deploying to a fleet via any MDM (Jamf, Kandji, Intune, mosyle, Fleet) | [`mdm-deployment.md`](mdm-deployment.md) |
+| Deploying specifically via Fleet MDM | [`fleet-deployment.md`](fleet-deployment.md) |
+| Upgrading, rotating secrets, recovering from a wiped server, reading logs | [`operations.md`](operations.md) |
+| Integrating with the server's HTTP API | [`api.md`](api.md) |
+| Understanding how the pieces fit together | [`architecture.md`](architecture.md) |
+
+## Shape of a Fleet EDR deployment
+
+- **Server**: container image `ghcr.io/getvictor/fleet-edr-server` running
+  behind your TLS-terminating ingress, backed by MySQL 8.4. Serves the
+  agent ingestion API, the admin web UI, and the OTel metric pipeline.
+- **Agent**: signed + notarized `.pkg` installed on each macOS endpoint.
+  Runs as a LaunchDaemon, receives events from an embedded system
+  extension over XPC, queues them in SQLite, uploads to the server.
+- **MDM profiles**: two signed `.mobileconfig` files that pre-approve the
+  system extension and grant Full Disk Access. Delivered by whichever
+  MDM the customer uses.
+- **Install script**: a one-line Bash snippet your MDM runs before the
+  `.pkg` installer to drop the enroll secret into `/etc/fleet-edr.conf`.
+
+Artifacts ship on each [GitHub Release](https://github.com/getvictor/fleet-edr/releases):
+
+- `fleet-edr-<version>.pkg` (signed + notarized)
+- `edr-system-extension.mobileconfig` (signed)
+- `edr-tcc-fda.mobileconfig` (signed)
+- `SHA256SUMS` (verify your downloads)
+
+Server image is tagged on each release: `ghcr.io/getvictor/fleet-edr-server:<version>`.
+`:latest` only advances on stable (non-`-rc`, non-`-beta`) tags.
+
+## Support
+
+- Issues: https://github.com/getvictor/fleet-edr/issues
+- Security reports: follow the SECURITY.md process at the repo root.

--- a/docs/adr/0003-standalone-product-not-fleet-integrated.md
+++ b/docs/adr/0003-standalone-product-not-fleet-integrated.md
@@ -112,4 +112,4 @@ customers who don't run Fleet.
 ## References
 
 - Jamf Protect + Jamf Pro as the two-independent-products reference model.
-- MVP plan (local, `claude/mvp/plan.md`) with the deployment contract spec.
+- MVP plan at `claude/mvp/plan.md` (gitignored, local) with the deployment contract spec.

--- a/docs/api.md
+++ b/docs/api.md
@@ -27,9 +27,10 @@ UI. There is no versioning header; when v2 lands it gets a parallel
 
 ## Content type
 
-Every request and response body is `application/json; charset=utf-8`.
-Event ingest accepts gzip-encoded requests if `Content-Encoding: gzip`
-is set.
+Request bodies are `application/json; charset=utf-8`. Response bodies,
+when present, use the same type; several endpoints return `204 No
+Content` with an empty body. Compressed request bodies are not
+currently supported — do not set `Content-Encoding: gzip`.
 
 ## Auth models
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,146 @@
+# HTTP API
+
+Fleet EDR exposes a single HTTP API surface split across three audience
+tiers:
+
+- **Agents** on macOS endpoints post telemetry and poll for commands.
+  They authenticate with a per-host bearer token.
+- **Browsers** (the admin UI) authenticate with a session cookie + CSRF
+  token. Everything the UI does is reachable as a JSON API from the
+  same endpoints.
+- **Operators / load balancers** hit `/livez`, `/readyz`, `/health`
+  unauthenticated.
+
+The machine-consumable spec is
+[`api/openapi.yaml`](api/openapi.yaml). The OpenAPI 3.1 file is the
+source of truth — this doc is the human overview.
+
+## Base URL
+
+```
+https://<your-server>/
+```
+
+All endpoints are rooted at `/api/v1/` except the health probes and the
+UI. There is no versioning header; when v2 lands it gets a parallel
+`/api/v2/` tree.
+
+## Content type
+
+Every request and response body is `application/json; charset=utf-8`.
+Event ingest accepts gzip-encoded requests if `Content-Encoding: gzip`
+is set.
+
+## Auth models
+
+### Host token (agents)
+
+An agent POSTs `/api/v1/enroll` once with the shared enroll secret and
+its hardware UUID. It receives an opaque `host_token`, stored in
+`/var/db/fleet-edr/enrolled.plist`. Every subsequent request carries:
+
+```
+Authorization: Bearer <host_token>
+```
+
+Tokens are scoped to the host: agent A's token cannot read agent B's
+commands or post events with `host_id=B`. Revoking an enrollment via
+the admin UI invalidates the token immediately.
+
+Endpoints that require a host token:
+- `POST /api/v1/events`
+- `GET  /api/v1/commands` (returns only the authenticated host's queue)
+- `PUT  /api/v1/commands/{id}` (only commands owned by the host)
+
+### Session cookie + CSRF (browsers)
+
+The admin UI posts `/api/v1/session` with email + password. The
+response sets `edr_session` (HttpOnly, Secure, SameSite=Lax) and
+returns a `csrf_token` the UI stores client-side. Subsequent unsafe
+requests (`POST`, `PUT`, `DELETE`) carry:
+
+```
+Cookie: edr_session=<opaque>
+X-CSRF-Token: <csrf_token>
+```
+
+GET requests only need the cookie. Logout is `DELETE /api/v1/session`.
+
+Endpoints that require the session cookie:
+- `GET /api/v1/hosts`, `/api/v1/hosts/{id}/tree`,
+  `/api/v1/hosts/{id}/processes/{pid}`
+- `GET /api/v1/alerts`, `/api/v1/alerts/{id}`; `PUT /api/v1/alerts/{id}`
+- `GET /api/v1/commands/{id}`, `POST /api/v1/commands`
+- `GET /api/v1/admin/enrollments`,
+  `POST /api/v1/admin/enrollments/{host_id}/revoke`
+- `GET /api/v1/admin/policy`, `PUT /api/v1/admin/policy`
+
+### No auth
+
+- `GET /livez`
+- `GET /readyz` (used by LBs; leaks nothing beyond version + DB status)
+- `GET /health` (alias of `/readyz`)
+
+## Rate limits
+
+Two IP-scoped buckets guard the auth boundary:
+
+| Endpoint | Knob | Default |
+|---|---|---|
+| `POST /api/v1/enroll` | `EDR_ENROLL_RATE_PER_MIN` | 30/min/IP |
+| `POST /api/v1/session` | `EDR_LOGIN_RATE_PER_MIN` | 6/min/IP |
+
+Over-limit requests return `429 Too Many Requests` with a
+`Retry-After` header.
+
+Ingestion (`POST /api/v1/events`), command polling, and UI read
+endpoints are not rate limited. If you proxy thousands of agents
+through a single IP (NAT), monitor `edr.enroll.attempts` in OTel
+metrics to confirm you're not hitting the enroll cap.
+
+## Errors
+
+Error responses use the following shape consistently:
+
+```json
+{"error": "unauthorized"}
+```
+
+Status codes follow HTTP semantics:
+
+- `400` — malformed request body, invalid query param, wrong enum value
+- `401` — missing / invalid auth (host token or session cookie)
+- `403` — auth present but the caller isn't allowed (revoked
+  enrollment, event `host_id` doesn't match token, etc.)
+- `404` — row not found OR row not visible to this caller (we don't
+  leak existence)
+- `409` — conflict (e.g., enrollment already revoked)
+- `429` — rate limited
+- `500` — server-side error. Expect a retry to succeed.
+- `503` — `/readyz` returns this when the DB is unreachable
+
+## Generating clients
+
+The OpenAPI 3.1 spec is usable with any modern codegen. Examples:
+
+```sh
+# TypeScript (via openapi-typescript)
+npx openapi-typescript docs/api/openapi.yaml -o src/edr-api.ts
+
+# Go (via oapi-codegen)
+oapi-codegen -package edrapi docs/api/openapi.yaml > edrapi/client.gen.go
+
+# Python (via openapi-python-client)
+openapi-python-client generate --path docs/api/openapi.yaml
+```
+
+## What's not in the API (yet)
+
+- Webhook / SIEM push. The server doesn't POST alerts outward;
+  integrators poll `GET /api/v1/alerts`. Outbound integrations ship in
+  v1.1+.
+- Multi-tenant routing. All endpoints operate on a single customer
+  boundary per server instance.
+- Bulk enrollment / import. Agents enroll one at a time on first boot.
+- Query language for events. Process tree + host list is what the UI
+  exposes today; a flexible event query API is on the roadmap.

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -88,6 +88,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ReadinessResponse"
+        "503":
+          description: Server not ready
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ReadinessResponse"
 
   /api/v1/enroll:
     post:
@@ -133,6 +139,10 @@ paths:
                 $ref: "#/components/schemas/ErrorResponse"
         "429":
           description: Rate limited
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying.
+              schema: {type: integer}
           content:
             application/json:
               schema:
@@ -143,9 +153,10 @@ paths:
       tags: [Agent]
       summary: Ingest a batch of endpoint security events
       description: |
-        Agents post newline-delimited JSON events here. Each event's
-        `host_id` must match the token's authenticated host_id; mismatches
-        are rejected. The server returns the count of events accepted.
+        Agents POST a JSON array of event envelopes. Each event's
+        `host_id` must match the token's authenticated host_id;
+        mismatches reject the whole batch. The body is capped at 10 MB.
+        The server returns the count of events persisted.
       security:
         - HostToken: []
       requestBody:
@@ -153,20 +164,20 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/EventBatch"
+              type: array
+              items:
+                $ref: "#/components/schemas/EventEnvelope"
       responses:
-        "202":
-          description: Events accepted
+        "200":
+          description: Events persisted
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/IngestResponse"
         "400":
-          description: Invalid JSON or schema violation
+          description: Invalid JSON, missing required fields, or host_id mismatch
         "401":
           description: Missing or invalid host token
-        "403":
-          description: Event host_id does not match token host
 
   /api/v1/session:
     post:
@@ -202,6 +213,14 @@ paths:
           description: Wrong email or password
         "429":
           description: Rate limited
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying.
+              schema: {type: integer}
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
     get:
       tags: [Session]
       summary: Get the current session
@@ -222,6 +241,7 @@ paths:
       description: Clears the session row and expires the cookie.
       security:
         - SessionCookie: []
+          CSRF: []
       responses:
         "204":
           description: Logged out
@@ -635,7 +655,7 @@ components:
       type: object
       required: [status, uptime_seconds, checks]
       properties:
-        status: {type: string, enum: [ok, error]}
+        status: {type: string, enum: [ok, degraded]}
         version: {type: string}
         commit: {type: string}
         build_time: {type: string}
@@ -655,10 +675,12 @@ components:
 
     EnrollRequest:
       type: object
-      required: [enroll_secret, hardware_uuid, hostname]
+      required: [enroll_secret, hardware_uuid, hostname, os_version, agent_version]
       properties:
         enroll_secret: {type: string}
-        hardware_uuid: {type: string}
+        hardware_uuid:
+          type: string
+          description: Apple hardware UUID; validated server-side against a UUID regex.
         hostname: {type: string}
         os_version: {type: string}
         agent_version: {type: string}
@@ -698,20 +720,13 @@ components:
       properties:
         error: {type: string}
 
-    EventBatch:
-      type: object
-      required: [events]
-      properties:
-        events:
-          type: array
-          items:
-            $ref: "#/components/schemas/EventEnvelope"
-
     EventEnvelope:
       type: object
       required: [event_id, host_id, timestamp_ns, event_type, payload]
       properties:
-        event_id: {type: string, format: uuid}
+        event_id:
+          type: string
+          description: Opaque unique event identifier (the agent emits UUIDs; the server treats it as an opaque string).
         host_id: {type: string}
         timestamp_ns: {type: integer, format: int64}
         event_type:
@@ -723,9 +738,11 @@ components:
 
     IngestResponse:
       type: object
+      required: [accepted]
       properties:
-        accepted: {type: integer}
-        rejected: {type: integer}
+        accepted:
+          type: integer
+          description: Number of events successfully persisted.
 
     HostSummary:
       type: object

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1,0 +1,849 @@
+openapi: 3.1.0
+info:
+  title: Fleet EDR API
+  version: "0.1.0"
+  description: |
+    HTTP API for Fleet EDR. Three audience tiers:
+
+    - **Agents** (macOS endpoints) authenticate with a per-host bearer
+      token obtained at enrollment. They call `POST /api/v1/enroll`,
+      `POST /api/v1/events`, and the host-scoped `/commands` endpoints.
+    - **Browsers** (admin UI) authenticate with an `edr_session` cookie
+      (HttpOnly, Secure, SameSite=Lax) plus an `X-CSRF-Token` header on
+      unsafe methods. They call the session-protected endpoints.
+    - **Operators** hit `/livez`, `/readyz`, `/health` with no auth.
+
+    For prose context see [api.md](../api.md). For a human-readable
+    host/agent install guide see
+    [install-agent-manual.md](../install-agent-manual.md).
+  license:
+    name: Fleet EDR License
+    url: https://github.com/getvictor/fleet-edr/blob/main/LICENSE
+servers:
+  - url: https://edr.example.com
+    description: Your EDR server
+tags:
+  - name: Health
+    description: Liveness / readiness probes (no auth)
+  - name: Agent
+    description: Endpoints called by the macOS agent
+  - name: Session
+    description: Browser login / logout
+  - name: Hosts
+    description: Host + process graph (UI)
+  - name: Alerts
+    description: Detection alerts (UI)
+  - name: Commands
+    description: Command queue (UI + Agent)
+  - name: Admin
+    description: Enrollment + policy management (UI, admin-only)
+
+paths:
+  /livez:
+    get:
+      tags: [Health]
+      summary: Liveness probe
+      description: Returns 200 as long as the process is up. Does not touch the DB.
+      security: []
+      responses:
+        "200":
+          description: Process alive
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/LivenessResponse"
+
+  /readyz:
+    get:
+      tags: [Health]
+      summary: Readiness probe
+      description: |
+        Returns 200 only when the server is ready to handle traffic. Fails
+        with 503 if the DB is unreachable. Use this behind a load balancer.
+      security: []
+      responses:
+        "200":
+          description: Server ready
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ReadinessResponse"
+        "503":
+          description: Server not ready
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ReadinessResponse"
+
+  /health:
+    get:
+      tags: [Health]
+      summary: Alias for /readyz
+      description: Retained for human convenience and existing monitors.
+      security: []
+      responses:
+        "200":
+          description: Server ready
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ReadinessResponse"
+
+  /api/v1/enroll:
+    post:
+      tags: [Agent]
+      summary: Enroll a new host
+      description: |
+        Exchanges the shared enroll secret + hardware fingerprint for a
+        per-host bearer token. Re-enrollment of an existing hardware UUID
+        returns the existing token and bumps `enrolled_at`.
+
+        Rate-limited per-IP at `EDR_ENROLL_RATE_PER_MIN` (default 30).
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/EnrollRequest"
+      responses:
+        "200":
+          description: Enrolled or re-enrolled
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EnrollResponse"
+        "400":
+          description: Missing required fields
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          description: Wrong enroll secret
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Enrollment revoked
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "429":
+          description: Rate limited
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /api/v1/events:
+    post:
+      tags: [Agent]
+      summary: Ingest a batch of endpoint security events
+      description: |
+        Agents post newline-delimited JSON events here. Each event's
+        `host_id` must match the token's authenticated host_id; mismatches
+        are rejected. The server returns the count of events accepted.
+      security:
+        - HostToken: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/EventBatch"
+      responses:
+        "202":
+          description: Events accepted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/IngestResponse"
+        "400":
+          description: Invalid JSON or schema violation
+        "401":
+          description: Missing or invalid host token
+        "403":
+          description: Event host_id does not match token host
+
+  /api/v1/session:
+    post:
+      tags: [Session]
+      summary: Log in with email + password
+      description: |
+        Validates credentials, creates a session row, sets `edr_session`
+        cookie, returns the user + CSRF token. Rate-limited per-IP at
+        `EDR_LOGIN_RATE_PER_MIN` (default 6).
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/LoginRequest"
+      responses:
+        "200":
+          description: Logged in
+          headers:
+            Set-Cookie:
+              description: Session cookie (HttpOnly, Secure, SameSite=Lax)
+              schema:
+                type: string
+                example: edr_session=<opaque>; Path=/; HttpOnly; Secure; SameSite=Lax
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/LoginResponse"
+        "400":
+          description: Malformed request
+        "401":
+          description: Wrong email or password
+        "429":
+          description: Rate limited
+    get:
+      tags: [Session]
+      summary: Get the current session
+      security:
+        - SessionCookie: []
+      responses:
+        "200":
+          description: Current user
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/LoginResponse"
+        "401":
+          description: Not logged in
+    delete:
+      tags: [Session]
+      summary: Log out
+      description: Clears the session row and expires the cookie.
+      security:
+        - SessionCookie: []
+      responses:
+        "204":
+          description: Logged out
+
+  /api/v1/hosts:
+    get:
+      tags: [Hosts]
+      summary: List hosts
+      security:
+        - SessionCookie: []
+      responses:
+        "200":
+          description: Host summaries
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/HostSummary"
+
+  /api/v1/hosts/{host_id}/tree:
+    get:
+      tags: [Hosts]
+      summary: Process tree for a host
+      security:
+        - SessionCookie: []
+      parameters:
+        - $ref: "#/components/parameters/HostID"
+        - name: from
+          in: query
+          schema: {type: integer, format: int64}
+          description: Lower bound, ns since epoch. Default `now - 1h`.
+        - name: to
+          in: query
+          schema: {type: integer, format: int64}
+          description: Upper bound, ns since epoch. Default `now`.
+        - name: limit
+          in: query
+          schema: {type: integer, minimum: 1, maximum: 5000, default: 2000}
+      responses:
+        "200":
+          description: Forest of process roots
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  roots:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/ProcessNode"
+
+  /api/v1/hosts/{host_id}/processes/{pid}:
+    get:
+      tags: [Hosts]
+      summary: Process detail
+      security:
+        - SessionCookie: []
+      parameters:
+        - $ref: "#/components/parameters/HostID"
+        - name: pid
+          in: path
+          required: true
+          schema: {type: integer}
+        - name: at
+          in: query
+          schema: {type: integer, format: int64}
+          description: Point-in-time ns since epoch. Default `now`.
+      responses:
+        "200":
+          description: Process detail
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Process"
+        "404":
+          description: No process found at the given coordinates
+
+  /api/v1/alerts:
+    get:
+      tags: [Alerts]
+      summary: List alerts
+      security:
+        - SessionCookie: []
+      parameters:
+        - name: host_id
+          in: query
+          schema: {type: string}
+        - name: status
+          in: query
+          schema:
+            type: string
+            enum: [open, acknowledged, resolved]
+        - name: severity
+          in: query
+          schema:
+            type: string
+            enum: [low, medium, high, critical]
+        - name: process_id
+          in: query
+          schema: {type: integer, format: int64}
+        - name: limit
+          in: query
+          schema: {type: integer, minimum: 1, default: 100}
+      responses:
+        "200":
+          description: Alert list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Alert"
+
+  /api/v1/alerts/{id}:
+    get:
+      tags: [Alerts]
+      summary: Alert detail (with event IDs)
+      security:
+        - SessionCookie: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: {type: integer, format: int64}
+      responses:
+        "200":
+          description: Alert with linked events
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AlertDetail"
+        "404":
+          description: Alert not found
+    put:
+      tags: [Alerts]
+      summary: Update alert status
+      security:
+        - SessionCookie: []
+          CSRF: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: {type: integer, format: int64}
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [status]
+              properties:
+                status:
+                  type: string
+                  enum: [open, acknowledged, resolved]
+      responses:
+        "204":
+          description: Status updated
+        "400":
+          description: Invalid status value
+        "404":
+          description: Alert not found
+
+  /api/v1/commands:
+    get:
+      tags: [Commands]
+      summary: List commands for the authenticated host
+      description: |
+        Host-token-only. The `host_id` is always the authenticated host's
+        id; any query parameter is ignored. Polling this endpoint also
+        refreshes the host's `last_seen` timestamp.
+      security:
+        - HostToken: []
+      parameters:
+        - name: status
+          in: query
+          schema:
+            type: string
+            enum: [queued, acked, completed, failed]
+      responses:
+        "200":
+          description: Command list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Command"
+    post:
+      tags: [Commands]
+      summary: Enqueue a command for a host (admin)
+      security:
+        - SessionCookie: []
+          CSRF: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [host_id, command_type]
+              properties:
+                host_id: {type: string}
+                command_type: {type: string}
+                payload: {type: object, additionalProperties: true}
+      responses:
+        "201":
+          description: Command created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id: {type: integer, format: int64}
+
+  /api/v1/commands/{id}:
+    get:
+      tags: [Commands]
+      summary: Get a single command (admin)
+      security:
+        - SessionCookie: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: {type: integer, format: int64}
+      responses:
+        "200":
+          description: Command
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Command"
+        "404":
+          description: Not found
+    put:
+      tags: [Commands]
+      summary: Update command status (agent)
+      description: |
+        Agents call this with `status=acked` once they pick up a command
+        and with `status=completed` or `status=failed` once they finish.
+        The handler enforces that the command belongs to the authenticated
+        host — agent A cannot touch agent B's commands.
+      security:
+        - HostToken: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: {type: integer, format: int64}
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [status]
+              properties:
+                status:
+                  type: string
+                  enum: [acked, completed, failed]
+                result:
+                  type: object
+                  description: Command-type-specific result blob, free-form JSON
+      responses:
+        "204":
+          description: Status updated
+        "400":
+          description: Invalid status
+        "404":
+          description: Command not found (or not owned by authenticated host)
+
+  /api/v1/admin/enrollments:
+    get:
+      tags: [Admin]
+      summary: List enrollments
+      security:
+        - SessionCookie: []
+      responses:
+        "200":
+          description: Enrollment rows
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Enrollment"
+
+  /api/v1/admin/enrollments/{host_id}/revoke:
+    post:
+      tags: [Admin]
+      summary: Revoke a host enrollment
+      description: |
+        After revocation the host's token stops working on all
+        host-token endpoints. A revoked host cannot re-enroll without
+        admin approval (reusing the same hardware UUID still returns
+        403).
+      security:
+        - SessionCookie: []
+          CSRF: []
+      parameters:
+        - $ref: "#/components/parameters/HostID"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                reason: {type: string}
+                actor: {type: string}
+      responses:
+        "204":
+          description: Revoked
+        "404":
+          description: Host not found
+
+  /api/v1/admin/policy:
+    get:
+      tags: [Admin]
+      summary: Current blocklist policy
+      security:
+        - SessionCookie: []
+      responses:
+        "200":
+          description: Current policy
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Policy"
+    put:
+      tags: [Admin]
+      summary: Replace blocklist policy
+      description: |
+        Replaces the entire policy atomically and fans out a
+        `policy.update` command to every active host. The response
+        reports how many hosts received the fan-out; failed hosts will
+        pick it up on their next poll.
+      security:
+        - SessionCookie: []
+          CSRF: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                paths:
+                  type: array
+                  items: {type: string}
+                hashes:
+                  type: array
+                  items: {type: string}
+                reason: {type: string}
+                actor: {type: string}
+      responses:
+        "200":
+          description: Policy updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PolicyUpdateResult"
+
+components:
+  securitySchemes:
+    HostToken:
+      type: http
+      scheme: bearer
+      bearerFormat: opaque
+      description: |
+        Per-host bearer token issued by `POST /api/v1/enroll`. Pass as
+        `Authorization: Bearer <host_token>`.
+    SessionCookie:
+      type: apiKey
+      in: cookie
+      name: edr_session
+      description: |
+        HttpOnly cookie set by `POST /api/v1/session`. The browser
+        attaches it automatically.
+    CSRF:
+      type: apiKey
+      in: header
+      name: X-CSRF-Token
+      description: |
+        Required on unsafe methods (`POST`, `PUT`, `DELETE`) for
+        session-cookie-authenticated endpoints. Value comes from the
+        login response's `csrf_token` field.
+
+  parameters:
+    HostID:
+      name: host_id
+      in: path
+      required: true
+      description: Host identifier (UUID-shaped opaque string)
+      schema: {type: string}
+
+  schemas:
+    LivenessResponse:
+      type: object
+      required: [status, uptime_seconds]
+      properties:
+        status: {type: string, enum: [ok]}
+        version: {type: string}
+        commit: {type: string}
+        build_time: {type: string}
+        uptime_seconds: {type: integer, format: int64}
+
+    ReadinessResponse:
+      type: object
+      required: [status, uptime_seconds, checks]
+      properties:
+        status: {type: string, enum: [ok, error]}
+        version: {type: string}
+        commit: {type: string}
+        build_time: {type: string}
+        uptime_seconds: {type: integer, format: int64}
+        checks:
+          type: object
+          additionalProperties:
+            $ref: "#/components/schemas/CheckResult"
+
+    CheckResult:
+      type: object
+      required: [status]
+      properties:
+        status: {type: string, enum: [ok, error, unavailable]}
+        latency_ms: {type: integer, format: int64}
+        error: {type: string}
+
+    EnrollRequest:
+      type: object
+      required: [enroll_secret, hardware_uuid, hostname]
+      properties:
+        enroll_secret: {type: string}
+        hardware_uuid: {type: string}
+        hostname: {type: string}
+        os_version: {type: string}
+        agent_version: {type: string}
+
+    EnrollResponse:
+      type: object
+      required: [host_id, host_token, enrolled_at]
+      properties:
+        host_id: {type: string}
+        host_token:
+          type: string
+          description: Opaque bearer token. Store securely; do not log.
+        enrolled_at: {type: string, format: date-time}
+
+    LoginRequest:
+      type: object
+      required: [email, password]
+      properties:
+        email: {type: string, format: email}
+        password: {type: string, format: password}
+
+    LoginResponse:
+      type: object
+      required: [user, csrf_token]
+      properties:
+        user:
+          type: object
+          required: [id, email]
+          properties:
+            id: {type: integer, format: int64}
+            email: {type: string, format: email}
+        csrf_token: {type: string}
+
+    ErrorResponse:
+      type: object
+      required: [error]
+      properties:
+        error: {type: string}
+
+    EventBatch:
+      type: object
+      required: [events]
+      properties:
+        events:
+          type: array
+          items:
+            $ref: "#/components/schemas/EventEnvelope"
+
+    EventEnvelope:
+      type: object
+      required: [event_id, host_id, timestamp_ns, event_type, payload]
+      properties:
+        event_id: {type: string, format: uuid}
+        host_id: {type: string}
+        timestamp_ns: {type: integer, format: int64}
+        event_type:
+          type: string
+          enum: [exec, fork, exit, open, network_connect, dns_query]
+        payload:
+          type: object
+          description: Event-type-specific body; see schema/events.json in the repo
+
+    IngestResponse:
+      type: object
+      properties:
+        accepted: {type: integer}
+        rejected: {type: integer}
+
+    HostSummary:
+      type: object
+      properties:
+        host_id: {type: string}
+        event_count: {type: integer, format: int64}
+        last_seen_ns: {type: integer, format: int64}
+
+    Process:
+      type: object
+      properties:
+        id: {type: integer, format: int64}
+        host_id: {type: string}
+        pid: {type: integer}
+        ppid: {type: integer}
+        path: {type: string}
+        args: {type: array, items: {type: string}}
+        uid: {type: integer}
+        gid: {type: integer}
+        code_signing:
+          type: object
+          properties:
+            team_id: {type: string}
+            signing_id: {type: string}
+            flags: {type: integer}
+            is_platform_binary: {type: boolean}
+        sha256: {type: string}
+        fork_time_ns: {type: integer, format: int64}
+        exec_time_ns: {type: integer, format: int64}
+        exit_time_ns: {type: integer, format: int64}
+        exit_code: {type: integer}
+
+    ProcessNode:
+      allOf:
+        - $ref: "#/components/schemas/Process"
+        - type: object
+          properties:
+            children:
+              type: array
+              items:
+                $ref: "#/components/schemas/ProcessNode"
+
+    Alert:
+      type: object
+      required: [id, host_id, rule_id, severity, title, process_id, status, created_at, updated_at]
+      properties:
+        id: {type: integer, format: int64}
+        host_id: {type: string}
+        rule_id: {type: string}
+        severity: {type: string, enum: [low, medium, high, critical]}
+        title: {type: string}
+        description: {type: string}
+        process_id: {type: integer, format: int64}
+        status: {type: string, enum: [open, acknowledged, resolved]}
+        created_at: {type: string, format: date-time}
+        updated_at: {type: string, format: date-time}
+        resolved_at: {type: string, format: date-time}
+
+    AlertDetail:
+      allOf:
+        - $ref: "#/components/schemas/Alert"
+        - type: object
+          properties:
+            event_ids:
+              type: array
+              items: {type: string, format: uuid}
+
+    Command:
+      type: object
+      required: [id, host_id, command_type, status, created_at]
+      properties:
+        id: {type: integer, format: int64}
+        host_id: {type: string}
+        command_type: {type: string}
+        payload:
+          type: object
+          additionalProperties: true
+        status:
+          type: string
+          enum: [queued, acked, completed, failed]
+        created_at: {type: string, format: date-time}
+        acked_at: {type: string, format: date-time}
+        completed_at: {type: string, format: date-time}
+        result:
+          type: object
+          additionalProperties: true
+
+    Enrollment:
+      type: object
+      properties:
+        host_id: {type: string}
+        hostname: {type: string}
+        agent_version: {type: string}
+        os_version: {type: string}
+        source_ip: {type: string}
+        enrolled_at: {type: string, format: date-time}
+        expires_at: {type: string, format: date-time}
+        revoked_at: {type: string, format: date-time}
+        revoke_reason: {type: string}
+        revoked_by: {type: string}
+
+    Policy:
+      type: object
+      properties:
+        version: {type: integer, format: int64}
+        blocklist:
+          type: object
+          properties:
+            paths:
+              type: array
+              items: {type: string}
+            hashes:
+              type: array
+              items: {type: string}
+
+    PolicyUpdateResult:
+      type: object
+      properties:
+        version: {type: integer, format: int64}
+        fanout_hosts: {type: integer}
+        fanout_failed: {type: integer}

--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -292,12 +292,21 @@ genuine differentiator versus most competitors.
 - [x] Standard JSON error responses with `Cache-Control: no-store` on health endpoints
 - [x] Per-route auth-domain composition (public / host-token / session) at registration
   time so the policy is reviewable in `main.go`
-- [ ] **OpenAPI 3.1 spec** committed under `docs/api/` and rendered via Redoc / Stoplight;
-  use `oapi-codegen` to generate handlers + client code (no spec drift)
+- [~] **OpenAPI 3.1 spec** committed at `docs/api/openapi.yaml` and prose overview at
+  `docs/api.md`. Still missing: hosted rendering (Redoc / Stoplight / Swagger UI) and
+  handler/client codegen via `oapi-codegen` / `openapi-typescript`, so today the spec and
+  the Go handlers can drift without CI catching it
 - [ ] **AsyncAPI 3.0 spec** for the event envelope (the JSON Schema covers payload but not
   the upload contract)
-- [ ] **Spectral** linting of the OpenAPI spec in CI
-- [ ] **API contract tests** generated from OpenAPI via `schemathesis` or `dredd`
+- [ ] **OpenAPI lint in CI** -- either `@redocly/cli lint` (what this repo uses ad-hoc
+  today) or `stoplightio/spectral` with a shared ruleset. Both enforce structural validity
+  + style rules (`operationId`, `4XX` coverage, `tags`, descriptions); Redocly has a
+  lighter default ruleset and integrates with Redocly Portal if we ever host rendered docs.
+  Spectral has a larger community ruleset ecosystem. Pick one, pin the version in CI, fail
+  the build on errors
+- [ ] **API contract tests** generated from OpenAPI via `schemathesis` (property-based,
+  hits a live server, catches handler/spec drift) or `dredd`. Pairs naturally with the
+  lint job above
 - [ ] **Pagination contract** (cursor-based) with documented limit defaults across all
   list endpoints
 - [ ] **Idempotency keys** on the event upload endpoint so retries are safe end-to-end
@@ -403,7 +412,9 @@ These cost almost nothing and disproportionately drive adoption.
 - [x] Lessons-and-gotchas log (`docs/lessons-and-gotchas.md`)
 - [x] Go conventions doc (`docs/go-conventions.md`)
 - [x] DNS monitoring design doc (`docs/dns-monitoring.md`)
-- [x] Issue templates (per `.claude/skills/create-*` skills referencing `.github/ISSUE_TEMPLATE/`)
+- [ ] Issue templates at `.github/ISSUE_TEMPLATE/` (bug, story, reliability). Not committed
+  yet; slash-skills that reference them (`create-bug`, `create-story`, `create-reliability`)
+  live in the user's global `~/.claude/skills/` only.
 - [ ] **`LICENSE`** file at the repo root (unclear which license applies today; pick one
   -- MIT, Apache-2.0, AGPL-3.0 are the obvious candidates and the choice signals
   intent to commercial adopters)

--- a/docs/fleet-deployment.md
+++ b/docs/fleet-deployment.md
@@ -1,0 +1,241 @@
+# Fleet MDM deployment
+
+This is the Fleet-specific recipe for deploying the Fleet EDR agent to a
+fleet of Macs. For the vendor-neutral contract (what the three artifacts
+are and why) see [mdm-deployment.md](mdm-deployment.md).
+
+Fleet and Fleet EDR are independent products. Fleet owns MDM + osquery;
+Fleet EDR owns the endpoint security / detection data plane. The contact
+between them is a deployment contract: Fleet delivers a signed `.pkg`,
+two `.mobileconfig` profiles, and an install script. The EDR server
+receives events from the resulting agents directly, not via Fleet.
+
+## Prerequisites
+
+- A Fleet server (version 4.48+) with MDM turned on and an Apple APNs +
+  ABM (Apple Business Manager) push certificate uploaded. Macs must be
+  ADE-enrolled or manually UAMDM-enrolled. Without UAMDM, macOS refuses
+  the restricted payloads in our two profiles.
+- `fleetctl` installed locally and authenticated (`fleetctl login`). The
+  UI also works; this doc uses `fleetctl` because every step is
+  reproducible.
+- A running Fleet EDR server with a known enroll secret (the value in
+  `./secrets/enroll_secret` from [install-server.md](install-server.md)).
+- Downloaded release artifacts from
+  [GitHub Releases](https://github.com/getvictor/fleet-edr/releases):
+  - `fleet-edr-<version>.pkg`
+  - `edr-system-extension.mobileconfig`
+  - `edr-tcc-fda.mobileconfig`
+  - `SHA256SUMS`
+
+## Scope
+
+Decide which Macs get the EDR before you start. In Fleet this is a
+**team**. Every artifact below scopes to a team; to ship to "all Macs",
+use the No-team special team.
+
+```sh
+fleetctl get teams
+# Pick the team id + name. Examples below assume team "EDR pilot".
+```
+
+## Step 1: push the two profiles
+
+Fleet's "custom settings" feature sends a `.mobileconfig` verbatim to the
+Macs in a team's scope. Both of our profiles go here.
+
+```sh
+fleetctl apply -f - <<'EOF'
+apiVersion: v1
+kind: team
+spec:
+  team:
+    name: EDR pilot
+    mdm:
+      macos_settings:
+        custom_settings:
+          - path: ./edr-system-extension.mobileconfig
+          - path: ./edr-tcc-fda.mobileconfig
+EOF
+```
+
+Fleet hashes each file and pushes it as an MDM profile install command.
+The osquery agent (`fleetd`) reports profile install status back to
+Fleet, so you can watch progress in **Controls > macOS settings** in the
+UI or via `fleetctl get mdm profile-status`.
+
+Each profile has a `PayloadIdentifier` that Fleet uses to track
+uniqueness; keep the filenames as shipped so future `fleetctl apply`
+runs replace-in-place rather than creating duplicates.
+
+Verify on a target Mac:
+
+```sh
+sudo profiles list | grep fleetdm
+# Expect:
+#   com.fleetdm.edr.profile.system-extension
+#   com.fleetdm.edr.profile.tcc-fda
+```
+
+## Step 2: upload the pkg + install script together
+
+Fleet's software installer bundles a `.pkg` and an optional
+pre-install script into a single "software package". We use that bundle
+to ship the pkg AND the enroll-secret write in one deploy step.
+
+Write the install script to a local file:
+
+```sh
+cat > fleet-edr-install.sh <<'EOF'
+#!/bin/sh
+set -eu
+
+# Fleet's agent expands $FLEET_SECRET_* into the value of the
+# corresponding custom variable at runtime. Define them at
+# Settings > Integrations > MDM > Variables (or via fleetctl).
+EDR_SERVER_URL="${FLEET_SECRET_EDR_SERVER_URL:-https://edr.example.com}"
+EDR_ENROLL_SECRET="$FLEET_SECRET_EDR_ENROLL_SECRET"
+
+install -m 0644 /dev/null /etc/fleet-edr.conf
+cat > /etc/fleet-edr.conf <<CONF
+EDR_SERVER_URL=$EDR_SERVER_URL
+EDR_ENROLL_SECRET=$EDR_ENROLL_SECRET
+CONF
+EOF
+```
+
+Define the two secrets in Fleet so the script can reference them without
+ever committing them to your repo. In the Fleet UI:
+
+1. **Settings > Integrations > MDM > Custom variables**.
+2. Add `EDR_SERVER_URL` with your server's URL.
+3. Add `EDR_ENROLL_SECRET` with the value from
+   `./secrets/enroll_secret` on the server.
+
+Upload the pkg + script bundle:
+
+```sh
+fleetctl software add \
+    --team "EDR pilot" \
+    --path fleet-edr-v0.1.0.pkg \
+    --pre-install-script fleet-edr-install.sh
+```
+
+Fleet runs the pre-install script first, then `installer -pkg` against
+the uploaded `.pkg`. The script writes the config file the pkg's
+postinstall step needs, so the sequencing is guaranteed (unlike generic
+MDMs where you fight with install-script ordering).
+
+Verify on a target Mac after Fleet runs the install:
+
+```sh
+# Daemon loaded and running
+sudo launchctl print system/com.fleetdm.edr.agent | grep 'state ='
+# Expect: state = running
+
+# Sysext activated silently (thanks to the system-extension profile)
+systemextensionsctl list | grep fleetdm
+# Expect: * * FDG8Q7N4CC com.fleetdm.edr.securityextension ... [activated enabled]
+
+# Agent enrolled with the server
+sudo tail -n 20 /var/log/fleet-edr-agent.log | grep enrolled
+```
+
+## Step 3: confirm in the EDR admin UI
+
+Open `https://<your-edr-server>/ui/`. The Macs that finished the
+Fleet-driven install appear on the Hosts page with their hardware UUID
+and a `last_seen` timestamp that updates every ~5s.
+
+## Upgrade
+
+Push a new pkg version by re-running `fleetctl software add` with the
+newer file. Fleet replaces the software package in-place; the install
+script doesn't change.
+
+```sh
+fleetctl software add \
+    --team "EDR pilot" \
+    --path fleet-edr-v0.1.1.pkg \
+    --pre-install-script fleet-edr-install.sh
+```
+
+On each Mac the EDR pkg's preinstall stops the old daemon and the
+postinstall starts the new one. The host token at
+`/var/db/fleet-edr/enrolled.plist` survives the upgrade so agents don't
+re-enroll.
+
+If the new release changes one of the two `.mobileconfig` profiles,
+push the new profile first (Step 1), wait for Fleet to confirm
+delivery, then push the new pkg. The reverse order risks an activation
+prompt if the pkg expects a payload that hasn't landed yet.
+
+## Uninstall
+
+Fleet's software UI supports uninstall scripts on a software package.
+Add one:
+
+```sh
+cat > fleet-edr-uninstall.sh <<'EOF'
+#!/bin/sh
+set -eu
+if [ -x "/Library/Application Support/com.fleetdm.edr/uninstall.sh" ]; then
+    "/Library/Application Support/com.fleetdm.edr/uninstall.sh"
+fi
+EOF
+
+fleetctl software add \
+    --team "EDR pilot" \
+    --path fleet-edr-v0.1.1.pkg \
+    --pre-install-script fleet-edr-install.sh \
+    --uninstall-script fleet-edr-uninstall.sh
+```
+
+To remove the profiles as well, edit the team's YAML and drop the two
+`custom_settings` entries. Fleet removes the profiles from each Mac on
+the next check-in; macOS tears down the TCC grants and sysext
+allow-list within minutes.
+
+## Rotate the enroll secret
+
+The secret is stored as a Fleet custom variable (`FLEET_SECRET_EDR_ENROLL_SECRET`),
+not hardcoded in the install script.
+
+1. Generate a new value on the EDR server and write it to
+   `./secrets/enroll_secret` (see
+   [install-server.md](install-server.md#rotate-secrets)).
+2. Restart the server so the new secret takes effect:
+   `docker compose restart server`.
+3. In Fleet: **Settings > Integrations > MDM > Custom variables**,
+   update `EDR_ENROLL_SECRET` to the new value.
+4. Re-run `fleetctl software add` so Fleet re-pushes the install script
+   with the new variable value.
+
+Existing hosts keep working because they authenticate with their
+per-host token, not the enroll secret. The rotated secret only matters
+the next time a brand-new Mac enrolls.
+
+## Troubleshoot
+
+**Profile stuck at "pending" in Fleet.**
+The Mac isn't UAMDM-enrolled. Open **Hosts > <host> > MDM** in Fleet;
+if it says "Enrolled (manual)" without UAMDM, re-enroll via ADE or
+walk the user through the manual UAMDM prompt in System Settings.
+Restricted payloads will not install otherwise.
+
+**Software package says "installed" but the pkg never ran.**
+Fleet considers a package "installed" once the pre-install script
+succeeds and the installer command starts. If the pkg itself fails,
+check **Hosts > <host> > Scripts** for the installer stdout/stderr.
+
+**Agent enrolls but events don't appear in the EDR UI.**
+The TCC FDA profile didn't reach the Mac. Check
+`sudo profiles list | grep tcc-fda` on the host; if missing, re-scope
+the profile to the team. After it lands, kick the daemon:
+`sudo launchctl kickstart -k system/com.fleetdm.edr.agent`.
+
+**Install script runs but `/etc/fleet-edr.conf` is empty or missing a
+variable.**
+A custom variable referenced by the script isn't defined in Fleet. The
+script uses `set -eu`, so an unset `FLEET_SECRET_*` fails fast; check
+**Settings > Integrations > MDM > Custom variables**.

--- a/docs/fleet-deployment.md
+++ b/docs/fleet-deployment.md
@@ -96,7 +96,7 @@ set -eu
 EDR_SERVER_URL="${FLEET_SECRET_EDR_SERVER_URL:-https://edr.example.com}"
 EDR_ENROLL_SECRET="$FLEET_SECRET_EDR_ENROLL_SECRET"
 
-install -m 0644 /dev/null /etc/fleet-edr.conf
+install -m 0600 /dev/null /etc/fleet-edr.conf
 cat > /etc/fleet-edr.conf <<CONF
 EDR_SERVER_URL=$EDR_SERVER_URL
 EDR_ENROLL_SECRET=$EDR_ENROLL_SECRET

--- a/docs/install-agent-manual.md
+++ b/docs/install-agent-manual.md
@@ -77,10 +77,12 @@ EDR_SERVER_URL=https://edr.example.com
 EDR_ENROLL_SECRET=paste-the-enroll-secret-here
 # Optional: pin the server's TLS cert by SHA-256 fingerprint. Leave blank
 # to validate against the system trust store. Use this when the server
-# uses a self-signed cert (lab / air-gapped pilot).
-# EDR_SERVER_FINGERPRINT=sha256//abc...
+# uses a self-signed cert (lab / air-gapped pilot). Accepts the output
+# of `openssl x509 -noout -fingerprint -sha256` (hex, optionally with
+# `sha256:` prefix and/or `:` separators).
+# EDR_SERVER_FINGERPRINT=sha256:AA:BB:CC:DD:EE:FF:...
 EOF
-sudo chmod 0644 /etc/fleet-edr.conf
+sudo chmod 0600 /etc/fleet-edr.conf
 ```
 
 Replace `https://edr.example.com` with your server URL and
@@ -243,10 +245,11 @@ trailing newline). Restart with
 **Agent log shows `tls: failed to verify certificate: x509: ...`.**
 Server's TLS cert isn't trusted by the system. Either install the CA
 that signed it into the system trust store, or use the
-`EDR_SERVER_FINGERPRINT` pin (computed via
-`openssl x509 -in fullchain.pem -noout -fingerprint -sha256`, formatted
-as `sha256//<base64>`). Don't set `EDR_ALLOW_INSECURE=1` unless you're
-in a lab.
+`EDR_SERVER_FINGERPRINT` pin. Compute the value with
+`openssl x509 -in fullchain.pem -noout -fingerprint -sha256` and paste
+the hex output into the config file (optionally with a `sha256:`
+prefix; the `:` separators between bytes are accepted too). Don't set
+`EDR_ALLOW_INSECURE=1` unless you're in a lab.
 
 **System extension stays in `activated waiting for user` forever.**
 Someone disabled Automation + extensions in the OS. Easiest fix: revoke

--- a/docs/install-agent-manual.md
+++ b/docs/install-agent-manual.md
@@ -1,0 +1,259 @@
+# Manual agent install (no MDM)
+
+Use this path to:
+
+- Evaluate Fleet EDR on one to five Macs.
+- Install on a dev machine that isn't MDM-enrolled.
+- Reproduce a customer's install-time issue without their full MDM.
+
+For production deployments of more than a handful of Macs, use
+[mdm-deployment.md](mdm-deployment.md) instead. The manual path requires
+a human to click through the sysext approval and the Full Disk Access
+grant, which doesn't scale.
+
+## Prerequisites
+
+- macOS 13 (Ventura) or later, Apple Silicon only.
+- Admin (sudo) on the Mac.
+- A reachable Fleet EDR server. You need its URL and the `enroll_secret`
+  from the server's `./secrets/enroll_secret`.
+- Optionally, the SHA-256 fingerprint of the server's TLS cert, for
+  pinned installs. Otherwise the agent validates against the system
+  trust store.
+
+## Step 1: download the pkg
+
+Pick a release from https://github.com/getvictor/fleet-edr/releases and
+download the `.pkg` to the target Mac. Example for v0.1.0:
+
+```sh
+cd ~/Downloads
+curl -fLO https://github.com/getvictor/fleet-edr/releases/download/v0.1.0/fleet-edr-v0.1.0.pkg
+```
+
+Verify the download against the published SHA256SUMS:
+
+```sh
+curl -fLO https://github.com/getvictor/fleet-edr/releases/download/v0.1.0/SHA256SUMS
+shasum -a 256 -c SHA256SUMS --ignore-missing
+```
+
+Expect: `fleet-edr-v0.1.0.pkg: OK`.
+
+## Step 2: verify the signature
+
+Before you run an installer you didn't build, confirm Gatekeeper trusts
+it. These checks pass without any developer tools installed; they use
+binaries shipped in the base macOS image.
+
+```sh
+# Signed by us + notarized by Apple
+pkgutil --check-signature fleet-edr-v0.1.0.pkg
+# Expect:
+#   Status: signed by a developer certificate issued by Apple for distribution
+#   Notarization: trusted by the Apple notary service
+
+# Stapled ticket embedded (works offline)
+xcrun stapler validate fleet-edr-v0.1.0.pkg
+# Expect: "The validate action worked!"
+
+# Gatekeeper's install assessment
+spctl -a -v --type install fleet-edr-v0.1.0.pkg
+# Expect: "accepted / source=Notarized Developer ID"
+```
+
+If any of these fail, STOP. Don't install. File an issue at
+https://github.com/getvictor/fleet-edr/issues.
+
+## Step 3: write the config file
+
+The agent reads `/etc/fleet-edr.conf` on every start. Without that file,
+the daemon logs "EDR_SERVER_URL is not set" and exits. Create it BEFORE
+running the installer so the daemon enrolls on its first boot:
+
+```sh
+sudo tee /etc/fleet-edr.conf >/dev/null <<'EOF'
+EDR_SERVER_URL=https://edr.example.com
+EDR_ENROLL_SECRET=paste-the-enroll-secret-here
+# Optional: pin the server's TLS cert by SHA-256 fingerprint. Leave blank
+# to validate against the system trust store. Use this when the server
+# uses a self-signed cert (lab / air-gapped pilot).
+# EDR_SERVER_FINGERPRINT=sha256//abc...
+EOF
+sudo chmod 0644 /etc/fleet-edr.conf
+```
+
+Replace `https://edr.example.com` with your server URL and
+`paste-the-enroll-secret-here` with the value from the server's
+`./secrets/enroll_secret` file.
+
+## Step 4: install the pkg
+
+```sh
+sudo installer -pkg ~/Downloads/fleet-edr-v0.1.0.pkg -target /
+```
+
+Expect:
+
+```
+installer: Package name is Fleet EDR
+installer: Installing at base path /
+installer: The install was successful.
+```
+
+What the installer laid down:
+
+| Path | Purpose |
+|---|---|
+| `/usr/local/bin/fleet-edr-agent` | agent daemon binary (Go, hardened runtime) |
+| `/Applications/Fleet EDR.app` | host app containing the embedded sysext |
+| `/Library/LaunchDaemons/com.fleetdm.edr.agent.plist` | LaunchDaemon config |
+| `/Library/Application Support/com.fleetdm.edr/uninstall.sh` | uninstaller |
+| `/Library/Application Support/com.fleetdm.edr/VERSION` | installed version string |
+| `/var/db/fleet-edr/` | queue database + enrolled token (created post-install) |
+| `/var/log/fleet-edr-agent.log` | agent stdout/stderr |
+
+The postinstall script loads the LaunchDaemon. The agent starts
+immediately, reads `/etc/fleet-edr.conf`, enrolls with the server, and
+begins polling for commands.
+
+## Step 5: approve the system extension
+
+The installer only stages the sysext; activating it requires a human
+click on a Mac that isn't MDM-managed. macOS shows a "System Extension
+Blocked" notification the first time the host app tries to activate it.
+
+1. Open **System Settings > Privacy & Security**.
+2. Scroll to "Security". You'll see
+   *"System extension blocked. Click to allow"* or a similar message.
+3. Click **Allow**. Authenticate with your user password.
+4. The sysext enters `activated waiting for user` → `activated enabled`.
+
+Verify:
+
+```sh
+systemextensionsctl list
+# Expect a row showing:
+#   * * FDG8Q7N4CC com.fleetdm.edr.securityextension (x.y.z) Fleet EDR Security Extension [activated enabled]
+```
+
+Until the sysext is activated, the agent runs but sees no ES events. The
+agent log repeats `receiver reconnecting ...` while it waits for the
+sysext's XPC service to come up. That's expected.
+
+## Step 6: grant Full Disk Access
+
+The sysext's Endpoint Security client requires Full Disk Access to
+observe file events. Without it, `es_new_client` returns
+`ERR_NOT_PERMITTED` and no events flow.
+
+1. Open **System Settings > Privacy & Security > Full Disk Access**.
+2. Click the `+` button. Authenticate.
+3. Navigate to `/Applications/Fleet EDR.app` and add it.
+4. Also add `/usr/local/bin/fleet-edr-agent` (use
+   Cmd+Shift+G in the file picker to type the path directly).
+5. Toggle both entries ON.
+
+## Step 7: verify end-to-end
+
+The agent should be enrolled and posting events to the server.
+
+On the Mac:
+
+```sh
+# Daemon is running
+sudo launchctl print system/com.fleetdm.edr.agent | grep state
+# Expect: "state = running"
+
+# Recent log
+sudo tail -n 20 /var/log/fleet-edr-agent.log
+# Expect an "agent enrolled" line near the top, then periodic
+# "http request" lines as the commander polls.
+```
+
+In the admin UI (https://edr.example.com/ui/):
+
+1. Log in as `admin@fleet-edr.local` with the password captured at
+   server boot.
+2. Open the Hosts page. The new host appears with its hardware UUID,
+   hostname, and a "last seen" timestamp that updates every ~5 seconds.
+3. Run a process on the Mac (e.g., `ls -la`). It appears in the host's
+   process tree within a few seconds.
+
+## Upgrade
+
+Download the newer `.pkg` and run `installer -pkg` again. The installer
+detects the existing receipts and performs an upgrade:
+
+```sh
+sudo installer -pkg fleet-edr-v0.1.1.pkg -target /
+```
+
+The preinstall script stops the old daemon, the postinstall script
+starts the new one. The persisted host token at
+`/var/db/fleet-edr/enrolled.plist` survives, so the agent keeps its
+existing enrollment — no re-approval needed.
+
+## Uninstall
+
+```sh
+sudo /Library/Application\ Support/com.fleetdm.edr/uninstall.sh
+```
+
+The script tears down everything the pkg installed + deletes the runtime
+state under `/var/db/fleet-edr` and `/var/log/fleet-edr-agent.log`. It
+DELIBERATELY preserves `/etc/fleet-edr.conf` so a subsequent re-install
+picks up the same enroll config. If you want a truly clean slate:
+
+```sh
+sudo rm /etc/fleet-edr.conf
+```
+
+After uninstall, the host disappears from the admin UI only after its
+`last_seen` threshold (default 5 min) elapses. You can also revoke the
+enrollment manually via `POST /api/v1/admin/enrollments/{host_id}/revoke`
+(see [api.md](api.md)).
+
+## Troubleshoot
+
+**`installer: Error - Fleet EDR requires Apple Silicon (M1 or later).`**
+You're on an Intel Mac. We don't ship Intel builds. Apple Silicon only.
+
+**`installer: Error - Fleet EDR requires macOS 13 (Ventura) or later.`**
+Upgrade macOS before installing.
+
+**Installer runs but the daemon never starts. `launchctl print` says
+"Could not find service".**
+The postinstall script probably failed. Check
+`sudo tail /var/log/install.log`. Common causes: `/Library/LaunchDaemons`
+owned by the wrong user, or `launchctl bootstrap` hit a permission error.
+Run:
+
+```sh
+sudo launchctl bootstrap system /Library/LaunchDaemons/com.fleetdm.edr.agent.plist
+sudo launchctl kickstart -k system/com.fleetdm.edr.agent
+```
+
+**Agent log shows `enrollment failed: unauthorized (401)`.**
+The `EDR_ENROLL_SECRET` in `/etc/fleet-edr.conf` doesn't match what the
+server has in `./secrets/enroll_secret`. Copy the exact value (no
+trailing newline). Restart with
+`sudo launchctl kickstart -k system/com.fleetdm.edr.agent`.
+
+**Agent log shows `tls: failed to verify certificate: x509: ...`.**
+Server's TLS cert isn't trusted by the system. Either install the CA
+that signed it into the system trust store, or use the
+`EDR_SERVER_FINGERPRINT` pin (computed via
+`openssl x509 -in fullchain.pem -noout -fingerprint -sha256`, formatted
+as `sha256//<base64>`). Don't set `EDR_ALLOW_INSECURE=1` unless you're
+in a lab.
+
+**System extension stays in `activated waiting for user` forever.**
+Someone disabled Automation + extensions in the OS. Easiest fix: revoke
+the install, reinstall with the MDM path (which pushes the
+sysext-allow-list profile so the prompt doesn't appear).
+
+**Full Disk Access grant gets wiped after every reboot.**
+Probably a TCC-database issue after a macOS point upgrade. Re-add the
+entries in Privacy & Security. If it recurs on a managed Mac, deploy
+the TCC profile via MDM instead.

--- a/docs/install-server.md
+++ b/docs/install-server.md
@@ -1,0 +1,327 @@
+# Install the Fleet EDR server
+
+The reference deployment is Docker Compose: MySQL + the server image,
+with a TLS-terminating ingress in front. The stack is sized for a single
+customer with 10 to 500 endpoints. Larger fleets should split MySQL onto
+its own instance and run the server image behind a load balancer, using
+this setup as the starting shape.
+
+## Prerequisites
+
+- A Linux host with Docker Engine 24+ and Docker Compose v2 (`docker
+  compose`, not `docker-compose`).
+- 4 GB RAM, 2 CPU cores, 20 GB disk.
+- A hostname + TLS certificate (see "TLS setup" below), or an intention
+  to run without TLS for a lab.
+- Inbound TCP to the server's ingress (default port 8088). Outbound to
+  nothing except your OTel collector if you enable metrics.
+
+## Setup
+
+### 1. Choose a directory
+
+Anywhere; the examples assume `/srv/fleet-edr/`.
+
+```sh
+sudo mkdir -p /srv/fleet-edr
+sudo chown "$USER" /srv/fleet-edr
+cd /srv/fleet-edr
+```
+
+### 2. Get the compose file
+
+```sh
+curl -fsSL -o docker-compose.prod.yml \
+    https://raw.githubusercontent.com/getvictor/fleet-edr/main/docker-compose.prod.yml
+```
+
+### 3. Create secret files
+
+Three secret files live under `./secrets/` with mode 0600. Docker Compose
+bind-mounts them into the server + mysql containers as
+`/run/secrets/<name>`. None of the values land in any env block or
+`docker inspect` output.
+
+```sh
+mkdir -p secrets
+MYSQL_PASS=$(openssl rand -hex 24)
+printf '%s' "$MYSQL_PASS" > secrets/mysql_root
+printf 'root:%s@tcp(mysql:3306)/edr?parseTime=true&tls=false' "$MYSQL_PASS" > secrets/edr_dsn
+ENROLL_SECRET=$(openssl rand -hex 32)
+printf '%s' "$ENROLL_SECRET" > secrets/enroll_secret
+chmod 0600 secrets/*
+```
+
+The `edr_dsn` file contains the same MySQL password embedded into a Go
+DSN. The server reads it via the `EDR_DSN_FILE` pattern (see
+`server/config/file_env.go`) so the password never appears in a compose
+env block.
+
+Keep `MYSQL_PASS` and `ENROLL_SECRET` somewhere safe. You'll paste
+`ENROLL_SECRET` into your MDM install-script config when you deploy
+agents.
+
+### 4. TLS setup
+
+Two options.
+
+**Option A: let the server terminate TLS.**
+Drop `fullchain.pem` + `privkey.pem` into `./tls/` (certbot output works
+directly). The compose bind-mounts `./tls` read-only into the server
+container.
+
+```sh
+mkdir -p tls
+cp /etc/letsencrypt/live/edr.example.com/fullchain.pem tls/
+cp /etc/letsencrypt/live/edr.example.com/privkey.pem tls/
+chmod 0644 tls/fullchain.pem
+chmod 0600 tls/privkey.pem
+```
+
+In your `.env` (next step), set:
+
+```
+EDR_TLS_CERT_FILE=/tls/fullchain.pem
+EDR_TLS_KEY_FILE=/tls/privkey.pem
+```
+
+**Option B: terminate TLS upstream (nginx, Caddy, an ALB, Cloudflare Tunnel).**
+The server runs in plaintext HTTP on 8088 inside the compose network; your
+upstream handles TLS. Set:
+
+```
+EDR_ALLOW_INSECURE_HTTP=1
+```
+
+Never set that flag on an internet-exposed server that isn't behind a
+TLS-terminating proxy. The agent refuses `http://` URLs unless its own
+`EDR_ALLOW_INSECURE` flag is also set, so a misconfigured customer would
+fail closed rather than silently deploy unencrypted telemetry.
+
+### 5. Pin a version in .env
+
+```sh
+cat > .env <<'EOF'
+EDR_VERSION=v0.1.0
+OTEL_EXPORTER_OTLP_ENDPOINT=
+EOF
+```
+
+Use the exact tag from the [Releases page](https://github.com/getvictor/fleet-edr/releases).
+`latest` is fine for a lab but unsafe for a pilot because the digest
+drifts silently on each release.
+
+### 6. Boot the stack
+
+```sh
+docker compose -f docker-compose.prod.yml --env-file .env up -d
+```
+
+MySQL starts first (healthcheck gates the server), then the server image
+pulls from ghcr.io and comes up.
+
+## Verify
+
+### Readiness probe
+
+TLS-terminated deployment:
+
+```sh
+curl -sk https://edr.example.com/readyz | jq .
+```
+
+Insecure-HTTP deployment (dev / behind-proxy):
+
+```sh
+curl -s http://localhost:8088/readyz | jq .
+```
+
+Expect:
+
+```json
+{
+  "status": "ok",
+  "version": "v0.1.0",
+  "uptime_seconds": 12,
+  "checks": {
+    "db": {"status": "ok", "latency_ms": 2}
+  }
+}
+```
+
+If `db.status` is `error` / `unavailable`, MySQL isn't reachable. Check
+`docker compose logs mysql`.
+
+### Capture the admin password
+
+The server seeds a single admin account on first boot. The password
+prints to the log exactly once:
+
+```sh
+docker compose -f docker-compose.prod.yml --env-file .env logs server \
+    | grep -A 1 SEEDED
+```
+
+Expected output:
+
+```
+================================================================
+SEEDED ADMIN USER (captured once — save the password now)
+  Email:    admin@fleet-edr.local
+  Password: <random>
+================================================================
+```
+
+Paste the password into your secret store. If you miss it you have to
+stop the server, delete the admin row from MySQL, and restart to
+re-seed. Don't lose it.
+
+### Log into the UI
+
+Open `https://edr.example.com/ui/` (or `http://localhost:8088/ui/` in
+dev). Sign in with `admin@fleet-edr.local` + the password above. The
+hosts page should be empty; that changes when the first agent enrolls.
+
+## Configuration reference
+
+Non-exhaustive; see `server/config/config.go` for every knob. Anything
+unset uses the documented default.
+
+| Env var | Required | Default | Purpose |
+|---|---|---|---|
+| `EDR_DSN` / `EDR_DSN_FILE` | yes | — | MySQL DSN, `user:pass@tcp(host:port)/db?parseTime=true` |
+| `EDR_ENROLL_SECRET` / `EDR_ENROLL_SECRET_FILE` | yes | — | Shared secret agents present at enrollment |
+| `EDR_LISTEN_ADDR` | no | `:8088` | TCP address the HTTP server binds |
+| `EDR_TLS_CERT_FILE` | no | — | PEM cert for TLS termination (pair with key) |
+| `EDR_TLS_KEY_FILE` | no | — | PEM key (pair with cert) |
+| `EDR_ALLOW_INSECURE_HTTP` | no | 0 | Set to `1` to skip TLS (only behind an upstream terminator) |
+| `EDR_TLS_ALLOW_TLS12` | no | 0 | Allow TLS 1.2 (default is 1.3-only) |
+| `EDR_ENROLL_RATE_PER_MIN` | no | 30 | Per-IP enroll rate limit |
+| `EDR_LOGIN_RATE_PER_MIN` | no | 6 | Per-IP UI login rate limit |
+| `EDR_RETENTION_DAYS` | no | 30 | Event TTL, 0 disables retention |
+| `EDR_RETENTION_INTERVAL` | no | 1h | How often the retention job runs |
+| `EDR_LAUNCHAGENT_ALLOWLIST` | no | — | Comma-separated absolute paths the `persistence_launchagent` rule treats as benign |
+| `EDR_LOG_LEVEL` | no | info | `debug` / `info` / `warn` / `error` |
+| `EDR_LOG_FORMAT` | no | json | `json` or `text` |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | no | — | `host:port` of an OTLP/gRPC collector; unset disables metrics export |
+
+Every string knob accepts a `_FILE` variant (`EDR_ENROLL_SECRET_FILE`,
+`EDR_DSN_FILE`, etc.) that points at a file whose trimmed contents
+become the value. That's how the compose stack delivers secrets.
+
+## OTel metrics and logs
+
+Set `OTEL_EXPORTER_OTLP_ENDPOINT` to your collector (SigNoz, Tempo,
+Datadog OTel, etc.). The server exports:
+
+- **Traces** for every HTTP request + DB query.
+- **Logs** via `otelslog` with `service.name=fleet-edr-server`.
+- **Metrics** listed in `claude/mvp/phase-4-lifecycle-observability.md`
+  (`edr.events.ingested`, `edr.alerts.created`,
+  `edr.enrolled.hosts`, `edr.offline.hosts`, `edr.retention.rows_deleted`,
+  `edr.db.query.duration`).
+
+There is no Prometheus scrape endpoint; this is OTel-only.
+
+## Upgrade
+
+```sh
+# Edit .env to set the new EDR_VERSION.
+docker compose -f docker-compose.prod.yml --env-file .env pull server
+docker compose -f docker-compose.prod.yml --env-file .env up -d
+```
+
+MySQL is not recreated on upgrade; its volume persists. No schema
+migration needed within the v0.1.x series because the DDL is
+`CREATE TABLE IF NOT EXISTS` throughout.
+
+## Rotate secrets
+
+**Enroll secret**:
+
+```sh
+NEW_ENROLL_SECRET=$(openssl rand -hex 32)
+printf '%s' "$NEW_ENROLL_SECRET" > secrets/enroll_secret
+docker compose -f docker-compose.prod.yml --env-file .env restart server
+```
+
+Existing agents keep working because they authenticate with the per-host
+token they got at enrollment, not the enroll secret. Push the new value
+to your MDM install-script so the next Mac to enroll uses it.
+
+`kill -s HUP` does NOT rotate the enroll secret; only the TLS cert. Use
+`docker compose restart server`.
+
+**TLS cert**:
+
+Drop replacement `fullchain.pem` + `privkey.pem` into `./tls/` and send
+the server a SIGHUP:
+
+```sh
+docker compose -f docker-compose.prod.yml --env-file .env kill -s HUP server
+```
+
+Active connections are not dropped; new handshakes pick up the new cert.
+
+**MySQL root password**:
+
+```sh
+NEW_MYSQL_PASS=$(openssl rand -hex 24)
+printf '%s' "$NEW_MYSQL_PASS" > secrets/mysql_root
+printf 'root:%s@tcp(mysql:3306)/edr?parseTime=true&tls=false' "$NEW_MYSQL_PASS" > secrets/edr_dsn
+docker compose -f docker-compose.prod.yml --env-file .env up -d --force-recreate mysql server
+```
+
+The named volume persists across recreate so no data loss.
+
+## Backup
+
+The entire state fits in the MySQL volume.
+
+```sh
+# Live logical backup (safe on InnoDB):
+docker compose -f docker-compose.prod.yml exec -T mysql \
+    mysqldump --single-transaction -uroot -p"$(cat secrets/mysql_root)" edr \
+    | gzip > "edr-$(date +%Y%m%d).sql.gz"
+```
+
+Restore into a fresh server:
+
+```sh
+gunzip -c edr-YYYYMMDD.sql.gz \
+    | docker compose -f docker-compose.prod.yml exec -T mysql \
+      mysql -uroot -p"$(cat secrets/mysql_root)" edr
+```
+
+Test your restore path quarterly.
+
+## Troubleshoot
+
+**"unknown database 'edr'"** at server startup — MySQL booted but
+didn't create the `edr` schema. The compose file sets
+`MYSQL_DATABASE: edr` so this means MySQL initialized earlier without
+that var set (pre-Phase-5 behavior) and its volume persisted.
+
+```sh
+docker compose -f docker-compose.prod.yml exec mysql \
+    mysql -uroot -p"$(cat secrets/mysql_root)" \
+    -e "CREATE DATABASE IF NOT EXISTS edr;"
+docker compose -f docker-compose.prod.yml restart server
+```
+
+**Server keeps exiting with "EDR_DSN is required"** — the `edr_dsn`
+secret file is missing or unreadable. Re-run the secrets step in Setup.
+
+**Server exits with "EDR_TLS_CERT_FILE is required"** — you're running
+without TLS and forgot `EDR_ALLOW_INSECURE_HTTP=1`. Either provide a
+cert+key or set the flag.
+
+**Agents see "enrollment failed: unauthorized"** — the `enroll_secret`
+on the server and the `EDR_ENROLL_SECRET` the agent reads from
+`/etc/fleet-edr.conf` are different. Confirm the MDM install-script
+writes the exact value from `secrets/enroll_secret`.
+
+**Server log shows "exporter export timeout"** — OTel collector is
+unreachable. Either fix connectivity to `OTEL_EXPORTER_OTLP_ENDPOINT`
+or unset the var. Server functionality is unaffected; only telemetry
+is dropped.

--- a/docs/install-server.md
+++ b/docs/install-server.md
@@ -127,8 +127,13 @@ pulls from ghcr.io and comes up.
 TLS-terminated deployment:
 
 ```sh
-curl -sk https://edr.example.com/readyz | jq .
+curl -s https://edr.example.com/readyz | jq .
 ```
+
+If you're running with a self-signed cert (lab / air-gapped pilot),
+either add the CA to the local trust store, pass
+`--cacert /path/to/ca.pem`, or temporarily use `-k` for this probe.
+Don't paper over a trust failure with `-k` in an automation script.
 
 Insecure-HTTP deployment (dev / behind-proxy):
 
@@ -216,10 +221,17 @@ Datadog OTel, etc.). The server exports:
 
 - **Traces** for every HTTP request + DB query.
 - **Logs** via `otelslog` with `service.name=fleet-edr-server`.
-- **Metrics** listed in `claude/mvp/phase-4-lifecycle-observability.md`
-  (`edr.events.ingested`, `edr.alerts.created`,
-  `edr.enrolled.hosts`, `edr.offline.hosts`, `edr.retention.rows_deleted`,
-  `edr.db.query.duration`).
+- **Metrics**:
+  - `edr.events.ingested` (counter, by `host_id`) — accepted events.
+  - `edr.alerts.created` (counter, by `rule_id` + `severity`).
+  - `edr.enrolled.hosts` (gauge) — current enrolled count.
+  - `edr.offline.hosts` (gauge) — hosts unseen >5 min.
+  - `edr.retention.rows_deleted` (counter) — rows pruned per run.
+  - `edr.db.query.duration` (histogram, by `op`).
+  - `edr.agent.queue.dropped` (counter) — agent-side drops reported back.
+
+  See [operations.md](operations.md#metrics-and-monitoring) for what to
+  alert on.
 
 There is no Prometheus scrape endpoint; this is OTel-only.
 

--- a/docs/mdm-deployment.md
+++ b/docs/mdm-deployment.md
@@ -1,0 +1,292 @@
+# MDM deployment (vendor-neutral)
+
+Fleet EDR is designed to ship through any MDM that can deliver a
+`.pkg` + two `.mobileconfig` profiles + a one-line install script.
+This works with Jamf Pro, Kandji, Intune, mosyle, Fleet, and any
+equivalent platform.
+
+For the Fleet-specific recipe see [fleet-deployment.md](fleet-deployment.md).
+For single-Mac eval without an MDM see [install-agent-manual.md](install-agent-manual.md).
+
+## The deployment contract
+
+Three artifacts, delivered in this order:
+
+1. **Two signed `.mobileconfig` profiles** pushed via MDM "custom
+   settings". Pre-approves the ES system extension and grants Full Disk
+   Access. These must arrive BEFORE the pkg so the sysext activates
+   silently on install.
+2. **An install script** your MDM runs before the pkg installer. It
+   writes `/etc/fleet-edr.conf` with the enroll secret + server URL.
+3. **The signed `.pkg`** pushed via MDM "software installer".
+
+Every MDM exposes these three primitives under different names. The
+mapping is in the vendor-specific section at the bottom.
+
+## Why this shape
+
+Restricted Apple payload types (`com.apple.system-extension-policy`,
+`com.apple.TCC.configuration-profile-policy`) require delivery by an
+MDM the Mac has user-approved. Any other delivery path (web download,
+`profiles install`) is rejected on modern macOS. That's why the two
+profiles MUST come from your MDM; there's no workaround.
+
+The install script is the clean hand-off for the enroll secret. Your
+MDM knows the secret (you configured it as an MDM variable); the pkg
+itself is customer-agnostic so it can ship from our Releases page
+unmodified. The script bridges the gap by dropping the secret into
+`/etc/fleet-edr.conf` on each Mac.
+
+## Artifacts
+
+All three files live on the [GitHub Release page](https://github.com/getvictor/fleet-edr/releases)
+for each version:
+
+| Artifact | Filename on Release | Notes |
+|---|---|---|
+| Pkg installer | `fleet-edr-<version>.pkg` | Signed with Developer ID Installer, notarized, stapled |
+| System-extension profile | `edr-system-extension.mobileconfig` | Signed with Developer ID Installer (CMS) |
+| TCC FDA profile | `edr-tcc-fda.mobileconfig` | Signed with Developer ID Installer (CMS) |
+| Checksums | `SHA256SUMS` | Verify downloads before uploading to your MDM |
+
+Download all four, verify checksums, then upload the three artifacts
+into your MDM.
+
+```sh
+cd ~/Downloads
+curl -fLO https://github.com/getvictor/fleet-edr/releases/download/v0.1.0/fleet-edr-v0.1.0.pkg
+curl -fLO https://github.com/getvictor/fleet-edr/releases/download/v0.1.0/edr-system-extension.mobileconfig
+curl -fLO https://github.com/getvictor/fleet-edr/releases/download/v0.1.0/edr-tcc-fda.mobileconfig
+curl -fLO https://github.com/getvictor/fleet-edr/releases/download/v0.1.0/SHA256SUMS
+shasum -a 256 -c SHA256SUMS --ignore-missing
+# All three artifacts should print "OK".
+```
+
+## Step 1: push the system-extension profile
+
+Upload `edr-system-extension.mobileconfig` to your MDM as a custom
+configuration profile and scope it to the Macs that will run the agent.
+
+What the profile does: pre-approves the bundle ID
+`com.fleetdm.edr.securityextension` under team ID `FDG8Q7N4CC` in the
+`com.apple.system-extension-policy` payload. When the pkg installer runs
+the host app's sysext-activation request, macOS finds the pre-approval,
+skips the user prompt, and activates the sysext immediately.
+
+Verify on a target Mac:
+
+```sh
+profiles list | grep fleetdm
+# Expect two profiles once both are pushed:
+#   com.fleetdm.edr.profile.system-extension
+#   com.fleetdm.edr.profile.tcc-fda
+```
+
+## Step 2: push the TCC FDA profile
+
+Upload `edr-tcc-fda.mobileconfig` the same way.
+
+What the profile does: grants Full Disk Access to the agent
+(`/usr/local/bin/fleet-edr-agent`) and the sysext
+(`com.fleetdm.edr.securityextension`) via a
+`com.apple.TCC.configuration-profile-policy` payload. Without it, the
+sysext's `es_new_client` call returns `ERR_NOT_PERMITTED` and no events
+flow.
+
+Verify after the pkg installs:
+
+```sh
+# The sysext needs to create an ES client; failures would show up here.
+sudo tail -n 50 /var/log/fleet-edr-agent.log | grep -E 'ES|receiver'
+# Expect: receiver connected ... (FDG8Q7N4CC.com.fleetdm.edr.securityextension.xpc)
+```
+
+## Step 3: install script
+
+Your MDM must run this script BEFORE the pkg installer. It writes the
+enroll secret + server URL into `/etc/fleet-edr.conf`. The pkg's
+postinstall starts the agent, which reads that file and enrolls.
+
+```sh
+#!/bin/sh
+set -eu
+
+# Fill these in from your MDM's variables / secrets. Never hardcode.
+EDR_SERVER_URL="${EDR_SERVER_URL:-https://edr.example.com}"
+EDR_ENROLL_SECRET="${EDR_ENROLL_SECRET:?EDR_ENROLL_SECRET must be set}"
+
+# Optional: pin the server's TLS cert by SHA-256 fingerprint.
+# Useful for self-signed certs in isolated deployments.
+# EDR_SERVER_FINGERPRINT="sha256//..."
+
+install -m 0644 /dev/null /etc/fleet-edr.conf
+cat > /etc/fleet-edr.conf <<EOF
+EDR_SERVER_URL=$EDR_SERVER_URL
+EDR_ENROLL_SECRET=$EDR_ENROLL_SECRET
+${EDR_SERVER_FINGERPRINT:+EDR_SERVER_FINGERPRINT=$EDR_SERVER_FINGERPRINT}
+EOF
+```
+
+`$EDR_ENROLL_SECRET` is the value from your server's
+`./secrets/enroll_secret`. Store it as an MDM secret variable; don't
+inline it in the script in your MDM repo.
+
+## Step 4: push the pkg
+
+Upload `fleet-edr-v<version>.pkg` to your MDM as a software installer
+and scope to the same Macs.
+
+The pkg's install flow:
+
+1. `installationCheck()` validates the Mac is Apple Silicon + macOS 13+.
+2. Preinstall script stops any existing `com.fleetdm.edr.agent`
+   LaunchDaemon and deactivates any prior sysext (idempotent; no-op on
+   fresh installs).
+3. Payload lands under `/usr/local/bin`, `/Applications`,
+   `/Library/LaunchDaemons`, `/Library/Application Support/com.fleetdm.edr`.
+4. Postinstall script loads the LaunchDaemon
+   (`launchctl bootstrap system ...`) and kickstarts it. The agent reads
+   `/etc/fleet-edr.conf`, enrolls, starts polling.
+5. On first agent-to-sysext XPC call, the host app triggers sysext
+   activation. Thanks to Step 1's profile, this is silent.
+
+Verify on a target Mac:
+
+```sh
+# Daemon loaded and running
+sudo launchctl print system/com.fleetdm.edr.agent | grep 'state ='
+# Expect: "state = running"
+
+# Sysext activated
+systemextensionsctl list | grep fleetdm
+# Expect a row ending "[activated enabled]"
+
+# Recent log
+sudo tail -n 20 /var/log/fleet-edr-agent.log
+# Expect: "agent enrolled" + "commander polling" lines
+```
+
+## Verify in the admin UI
+
+Log into the Fleet EDR server's admin UI at
+`https://<your-server>/ui/`. The Macs you pushed to appear on the Hosts
+page with:
+
+- Hostname
+- Hardware UUID
+- Agent version
+- "last_seen" timestamp that updates every ~5s
+
+Pick any host and view its process tree; executions from that Mac
+appear within seconds of happening.
+
+## Upgrade
+
+Push the newer `.pkg` via your MDM. Same scope. The agent's preinstall
+stops the old daemon, postinstall starts the new one, and the persisted
+token at `/var/db/fleet-edr/enrolled.plist` survives so enrollments
+don't churn.
+
+If a new version changes the two profiles (rare), push the new ones
+first, then the new pkg. Profile changes are live immediately; pkg
+changes require the upgrade cycle.
+
+## Uninstall via MDM
+
+Push this as a run-script action:
+
+```sh
+#!/bin/sh
+set -eu
+if [ -x "/Library/Application Support/com.fleetdm.edr/uninstall.sh" ]; then
+    "/Library/Application Support/com.fleetdm.edr/uninstall.sh"
+fi
+```
+
+The uninstaller removes all binaries, LaunchDaemons, `/var/db/fleet-edr`,
+and `/var/log/fleet-edr-agent.log`. It preserves `/etc/fleet-edr.conf`
+so a future reinstall picks up the same enroll config. If you want a
+truly clean slate, add `rm -f /etc/fleet-edr.conf` to the script above.
+
+The sysext deactivation happens automatically via the uninstaller, which
+reads the installed app's team ID from its codesign output. This keeps
+the uninstaller working even if you re-signed the pkg with a different
+team ID in a fork.
+
+To also remove the MDM profiles, delete them from your MDM's custom
+settings scope; the OS tears down the TCC grants + sysext allow-list
+within minutes.
+
+## Vendor-specific notes
+
+### Jamf Pro
+
+- Pkg upload: **Settings > Computer Management > Packages**. Upload,
+  then assign via a **Policy** with the **Packages** payload.
+- Profiles: **Configuration Profiles**, upload both `.mobileconfig`
+  files. Scope to the same Smart Group as the policy.
+- Install script: in the same policy, add a **Scripts** payload that
+  runs BEFORE the package. Priority: **Before**.
+
+### Kandji
+
+- Pkg upload: **Library > Add new > Custom Apps**, upload pkg.
+- Profiles: **Custom Profile** (one per mobileconfig).
+- Install script: set as a **Pre-install script** on the custom app, or
+  use a **Custom Script** library item scheduled to run before the
+  custom app. Kandji runs library items in alphabetical order within a
+  run interval; name your items accordingly
+  (`01-edr-conf.sh`, `02-edr-app.pkg`).
+
+### Microsoft Intune
+
+- Pkg upload: **Apps > macOS > Add > Line-of-business app** (.pkg file).
+  Intune requires `.pkg` files to be Developer ID-signed AND the install
+  binaries to be in `/Applications` OR have `install-location="/"`.
+  Ours does.
+- Profiles: **Devices > Configuration profiles > Create profile >
+  Templates > Custom**. Upload each `.mobileconfig`.
+- Install script: **Devices > Scripts and remediations**. Run the
+  install script in the same assignment group.
+
+### mosyle
+
+- Pkg upload: **Management > Applications > Applications Catalog > Add
+  Enterprise Application**. Upload the `.pkg`.
+- Profiles: **Management > Profiles > Custom Profiles**. Upload both
+  `.mobileconfig` files and assign to the same device group.
+- Install script: **Management > Commands > Scripts**. Schedule to run
+  before the enterprise app install.
+
+### Fleet MDM
+
+See [fleet-deployment.md](fleet-deployment.md) for the full Fleet
+workflow.
+
+## Troubleshoot
+
+**pkg installs but sysext stays in `activated waiting for user`.**
+The system-extension profile hasn't reached the Mac yet, or it was
+scoped differently. Check `profiles list | grep fleetdm` for the
+`com.fleetdm.edr.profile.system-extension` entry. Re-scope + re-push if
+missing.
+
+**Agent log shows `ES_NEW_CLIENT_RESULT_ERR_NOT_PERMITTED`.**
+TCC FDA profile not pushed, or scoped to a different set of Macs than
+the pkg. Check `profiles list` for `com.fleetdm.edr.profile.tcc-fda`.
+
+**`installer: Error - Fleet EDR requires Apple Silicon (M1 or later).`**
+Intel Mac scoped into the deployment. Narrow the scope by model type.
+
+**Install script writes the conf file but the agent still fails to
+enroll.**
+The install script probably ran AFTER the pkg. Most MDMs run scripts + 
+pkgs in parallel by default. Force "script first" via your MDM's
+ordering controls (see vendor notes above).
+
+**Agent enrolls but events don't appear in the admin UI.**
+TCC FDA profile not applied to the sysext. The agent daemon ENROLLS
+fine without FDA (it only talks HTTP); it's the sysext's ES client that
+needs FDA to observe events. Verify TCC profile delivery, then
+`sudo launchctl kickstart -k system/com.fleetdm.edr.agent` to force a
+sysext reconnect.

--- a/docs/mdm-deployment.md
+++ b/docs/mdm-deployment.md
@@ -116,10 +116,12 @@ EDR_SERVER_URL="${EDR_SERVER_URL:-https://edr.example.com}"
 EDR_ENROLL_SECRET="${EDR_ENROLL_SECRET:?EDR_ENROLL_SECRET must be set}"
 
 # Optional: pin the server's TLS cert by SHA-256 fingerprint.
-# Useful for self-signed certs in isolated deployments.
-# EDR_SERVER_FINGERPRINT="sha256//..."
+# Useful for self-signed certs in isolated deployments. Output of
+# `openssl x509 -noout -fingerprint -sha256` pasted directly; the
+# `sha256:` prefix and `:` byte separators are accepted but not required.
+# EDR_SERVER_FINGERPRINT="sha256:AA:BB:CC:DD:EE:FF:..."
 
-install -m 0644 /dev/null /etc/fleet-edr.conf
+install -m 0600 /dev/null /etc/fleet-edr.conf
 cat > /etc/fleet-edr.conf <<EOF
 EDR_SERVER_URL=$EDR_SERVER_URL
 EDR_ENROLL_SECRET=$EDR_ENROLL_SECRET
@@ -133,8 +135,9 @@ inline it in the script in your MDM repo.
 
 ## Step 4: push the pkg
 
-Upload `fleet-edr-v<version>.pkg` to your MDM as a software installer
-and scope to the same Macs.
+Upload `fleet-edr-<version>.pkg` to your MDM as a software installer
+and scope to the same Macs. The release tag is part of the filename
+verbatim (e.g., tag `v0.1.0` ships as `fleet-edr-v0.1.0.pkg`).
 
 The pkg's install flow:
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,0 +1,325 @@
+# Day-2 operations
+
+This is the runbook for operating a Fleet EDR server + agent fleet
+that's already deployed. If you're setting it up for the first time,
+start with [install-server.md](install-server.md) and
+[mdm-deployment.md](mdm-deployment.md).
+
+## Quick reference
+
+| Task | Command |
+|---|---|
+| Server health | `curl -sk https://<server>/readyz \| jq .` |
+| Server version | `curl -sk https://<server>/readyz \| jq -r .version` |
+| Tail server log | `docker compose logs -f server` |
+| Tail agent log (on Mac) | `sudo tail -f /var/log/fleet-edr-agent.log` |
+| Agent state (on Mac) | `sudo launchctl print system/com.fleetdm.edr.agent` |
+| Reload TLS cert | `docker compose kill -s HUP server` |
+| Restart server | `docker compose restart server` |
+| Backup DB | `docker compose exec -T mysql mysqldump --single-transaction -uroot -p"$(cat secrets/mysql_root)" edr \| gzip > edr-$(date +%F).sql.gz` |
+
+## Upgrade the server
+
+Server releases are tagged images at
+`ghcr.io/getvictor/fleet-edr-server:<version>` and new pkg / profile
+bundles on the GitHub Releases page. Server + agent versions are
+independent; upgrade them on separate schedules.
+
+```sh
+# 1. Decide on the version. Use the exact tag from the releases page;
+#    do not use :latest in production.
+# 2. Edit /srv/fleet-edr/.env and bump EDR_VERSION.
+# 3. Pull the new image and restart.
+cd /srv/fleet-edr
+docker compose -f docker-compose.prod.yml --env-file .env pull server
+docker compose -f docker-compose.prod.yml --env-file .env up -d
+
+# 4. Verify.
+curl -sk https://<server>/readyz | jq .
+```
+
+There is no downtime tolerated by MySQL during this. The server
+container restarts in place; MySQL keeps running. Expect ~2s of
+HTTP 503 while the new server boots; agents retry automatically.
+
+DDL in the v0.1.x line is `CREATE TABLE IF NOT EXISTS` throughout, so
+minor upgrades don't require a MySQL migration. Major-version upgrades
+will ship with a migration runbook in the release notes.
+
+## Upgrade agents
+
+Agents upgrade by pushing a newer `.pkg` through your MDM. See your
+MDM's section in [mdm-deployment.md](mdm-deployment.md); for Fleet, see
+[fleet-deployment.md](fleet-deployment.md).
+
+Never hand-install a newer pkg on a single MDM-managed Mac to "test
+the upgrade path". The MDM will re-deploy the old version on the next
+sync and you'll waste time debugging a drift you caused.
+
+Validate a handful of Macs before rolling fleet-wide:
+
+1. Scope the new pkg to a small canary team (5-10 Macs).
+2. Wait 24h. Check the EDR admin UI: all canary hosts back online,
+   `last_seen` fresh, no alert spike.
+3. Re-scope to the full fleet.
+
+## Rotate secrets
+
+### Enroll secret
+
+The enroll secret is shared between the server and the install script
+your MDM runs. Rotate it when you suspect it's leaked (committed to
+a public repo, shared over an insecure channel). Existing agents are
+unaffected — they authenticate with their per-host token.
+
+```sh
+cd /srv/fleet-edr
+NEW_ENROLL_SECRET=$(openssl rand -hex 32)
+printf '%s' "$NEW_ENROLL_SECRET" > secrets/enroll_secret
+docker compose -f docker-compose.prod.yml --env-file .env restart server
+```
+
+Then update your MDM's secret variable (see your vendor's section in
+[mdm-deployment.md](mdm-deployment.md)) so freshly-enrolled Macs pick
+up the new value.
+
+Important: `docker compose kill -s HUP server` does NOT rotate the
+enroll secret. SIGHUP is TLS-only. Use `restart`.
+
+### TLS cert
+
+```sh
+# Drop the new cert and key alongside the old ones.
+sudo cp /etc/letsencrypt/live/edr.example.com/fullchain.pem /srv/fleet-edr/tls/
+sudo cp /etc/letsencrypt/live/edr.example.com/privkey.pem /srv/fleet-edr/tls/
+sudo chmod 0644 /srv/fleet-edr/tls/fullchain.pem
+sudo chmod 0600 /srv/fleet-edr/tls/privkey.pem
+
+# Tell the running server to re-read them.
+docker compose -f docker-compose.prod.yml --env-file .env kill -s HUP server
+```
+
+Active TLS connections stay up. New handshakes pick up the new cert on
+the next `ClientHello`. Verify with:
+
+```sh
+openssl s_client -connect <server>:443 -servername <server> </dev/null 2>/dev/null \
+    | openssl x509 -noout -dates
+```
+
+Wire this into your Let's Encrypt renewal hook so it happens
+automatically on renewal.
+
+### MySQL root password
+
+Less common (MySQL isn't exposed outside the Compose network), but:
+
+```sh
+cd /srv/fleet-edr
+NEW_MYSQL_PASS=$(openssl rand -hex 24)
+printf '%s' "$NEW_MYSQL_PASS" > secrets/mysql_root
+printf 'root:%s@tcp(mysql:3306)/edr?parseTime=true&tls=false' "$NEW_MYSQL_PASS" > secrets/edr_dsn
+docker compose -f docker-compose.prod.yml --env-file .env up -d --force-recreate mysql server
+```
+
+The named volume persists across recreate; no data loss. The server
+restarts once mysql is ready (Compose healthcheck gates it).
+
+## Backup and restore
+
+The entire EDR state is in the MySQL `edr` schema. The named volume
+`mysql-data` is the source of truth; nothing else is stateful.
+
+### Logical backup
+
+```sh
+docker compose -f docker-compose.prod.yml exec -T mysql \
+    mysqldump --single-transaction --routines --triggers \
+    -uroot -p"$(cat secrets/mysql_root)" edr \
+    | gzip > "edr-$(date +%Y%m%d).sql.gz"
+```
+
+`--single-transaction` works because every EDR table is InnoDB, so the
+backup doesn't block writes.
+
+Ship the `.sql.gz` off-host (S3, Backblaze B2, borg, whatever your
+standard is). Keep at least 30 days, longer if your compliance regime
+says so.
+
+### Restore
+
+Spin up a fresh server stack with empty volumes, then:
+
+```sh
+gunzip -c edr-YYYYMMDD.sql.gz \
+    | docker compose -f docker-compose.prod.yml exec -T mysql \
+      mysql -uroot -p"$(cat secrets/mysql_root)" edr
+```
+
+The agents' persisted host tokens keep working after a restore — the
+`hosts` table survives, so enrollments don't churn. Expect the
+`last_seen` gauge to tick back to current within ~30s as agents
+reconnect.
+
+Test your restore path quarterly. An untested backup is a hope, not a
+backup.
+
+### Volume snapshots
+
+If your host filesystem is ZFS / Btrfs / LVM-thin, volume snapshots are
+faster than logical backups. Point-in-time recovery via binlog replay
+is not supported in v0.1 because the server doesn't emit binlogs by
+default; rely on logical backups + snapshots for now.
+
+## Retention tuning
+
+The server deletes events older than `EDR_RETENTION_DAYS` (default 30)
+on a schedule set by `EDR_RETENTION_INTERVAL` (default 1h). Both knobs
+live in the server's environment; restart to take effect.
+
+Three common scenarios:
+
+1. **Compliance requires 90 days of event history.**
+   Set `EDR_RETENTION_DAYS=90`. Monitor `edr.retention.rows_deleted`
+   and the DB disk usage for a week to confirm storage is sized right.
+2. **Disk is filling up, want to shrink window.**
+   Set a smaller `EDR_RETENTION_DAYS` value. The next retention run
+   will delete events older than the new cutoff. Expect one large
+   deletion, then normal churn.
+3. **Want to keep events forever for a forensic investigation.**
+   Set `EDR_RETENTION_DAYS=0`. Retention is disabled. Re-enable once
+   the investigation is complete to avoid unbounded growth.
+
+Alerts are NOT deleted by retention. They stay until you delete them
+via the admin UI. A resolved alert pointing at an event that retention
+has purged will still render, with the event references 404ing.
+
+## Metrics and monitoring
+
+Server exports OpenTelemetry metrics via OTLP/gRPC to the endpoint in
+`OTEL_EXPORTER_OTLP_ENDPOINT`. No Prometheus scrape endpoint is
+provided. See [install-server.md](install-server.md#otel-metrics-and-logs).
+
+Core metrics to chart:
+
+| Metric | Type | What to watch |
+|---|---|---|
+| `edr.events.ingested` | counter | Spikes up = agent fleet healthy. Drop to zero = ingress wedged |
+| `edr.alerts.created` | counter | By `rule_id` + `severity`. Sudden spike warrants a look |
+| `edr.enrolled.hosts` | gauge | Should match your MDM's scoped Mac count |
+| `edr.offline.hosts` | gauge | Hosts whose `last_seen` is older than 5 min. Keep near zero |
+| `edr.retention.rows_deleted` | counter | Should tick up every `EDR_RETENTION_INTERVAL` |
+| `edr.db.query.duration` | histogram | p99 creeping up = DB overloaded or a slow query regressed |
+| `edr.agent.queue.dropped` | counter | Non-zero = agent's local SQLite queue hit its cap. Investigate connectivity |
+| `edr.policy.fanout_failed` | counter | Policy updates that failed to reach at least one host |
+
+Recommended alerts (SigNoz, Grafana, wherever your OTel backend lives):
+
+- `edr.offline.hosts > 10% of edr.enrolled.hosts for 15m` — fleet-wide
+  connectivity issue.
+- `rate(edr.events.ingested[5m]) == 0 for 5m` — server isn't receiving
+  events. Either all agents are offline (see above), ingress is
+  broken, or the server wedged.
+- `rate(edr.retention.rows_deleted[1h]) == 0 for 2h` when
+  `EDR_RETENTION_DAYS > 0` — retention job stuck.
+- `rate(edr.agent.queue.dropped[5m]) > 0` — endpoints losing data.
+
+Server logs go through the same OTLP pipeline (via `otelslog`) with
+`service.name=fleet-edr-server`. Use them for audit-style queries like
+"who resolved alert X" (look for `edr.admin.action=alert_update` log
+events with `user.id`).
+
+## Handling offline hosts
+
+A host is "offline" when the server hasn't heard from it in >5 min.
+The admin UI tags these rows with a red dot.
+
+Common causes, in order:
+
+1. **Endpoint is powered off / asleep.** Nothing to do; the host
+   reconnects on next wake.
+2. **Network-level change.** Moved to a VPN / Wi-Fi with egress
+   filtering. Validate `curl -v https://<edr-server>/livez` from the
+   endpoint.
+3. **Agent crashed.**
+   `sudo launchctl print system/com.fleetdm.edr.agent` shows `state =
+   running`? If not:
+   `sudo launchctl kickstart -k system/com.fleetdm.edr.agent`.
+4. **Enrollment revoked.** Check
+   `POST /api/v1/admin/enrollments/{host_id}/revoke` logs. Re-enroll
+   by re-running the MDM install-script and restarting the daemon.
+5. **DB clock skew / server down.** `edr.enrolled.hosts` gauge
+   returning -1 means the DB query failed.
+
+If a host has been offline for >30 days and you expect it to be
+permanently gone (retired laptop), revoke the enrollment from the UI
+(`Hosts > <host> > Revoke enrollment`) so its host-token can no longer
+be used.
+
+## Managing the blocklist (policy)
+
+The blocklist is a server-driven policy pushed to every enrolled host
+via the command queue. One policy per server; all hosts see the same
+list.
+
+```sh
+# View current policy.
+curl -sk -b cookies.txt https://<server>/api/v1/admin/policy | jq .
+
+# Update policy (requires login + CSRF token).
+# Easier via the admin UI: Settings > Policy > Blocklist.
+```
+
+The policy has two fields:
+
+- `blocklist.paths` — absolute paths. Any exec() with an `argv[0]` or
+  resolved executable path matching the list triggers an alert and
+  (for the sysext) kills the process before it executes.
+- `blocklist.hashes` — SHA-256 of the binary. Same behavior, matched
+  on digest.
+
+The `EDR_LAUNCHAGENT_ALLOWLIST` env var is different: it tells the
+server's `persistence_launchagent` detection rule which LaunchAgent
+paths are benign and should not trigger alerts. Set it as a
+comma-separated list of absolute paths.
+
+## Common troubleshooting
+
+**Readyz says `db: error`.**
+MySQL unreachable. Check `docker compose ps` and
+`docker compose logs mysql`. Restart the stack if MySQL is stuck in a
+restart loop.
+
+**Server log: `exporter export timeout`.**
+OTel collector unreachable. Fix connectivity to
+`OTEL_EXPORTER_OTLP_ENDPOINT` or unset the var to disable metrics
+export. Server functionality is unaffected; only telemetry is dropped.
+
+**Admin UI shows a host but `last_seen` is stuck >30 min ago.**
+Either the host is offline (see above) or its agent is running but
+failing to post events. SSH to the host, tail
+`/var/log/fleet-edr-agent.log`; expect TLS / network / 401 errors if
+the agent is failing to reach the server.
+
+**Alerts appear for a binary you know is benign.**
+Add its path to `EDR_LAUNCHAGENT_ALLOWLIST` (if it's a LaunchAgent),
+or add an allow rule in the UI for the rule that fired. Mark the
+existing alerts as `resolved` once you've confirmed they're false
+positives.
+
+**All agents went offline at once.**
+Check the EDR server first (`/readyz`), then your ingress / LB, then
+your TLS cert's expiry. If the cert expired, see "Rotate secrets >
+TLS cert" above; agents will reconnect once the cert is fixed without
+needing a restart on their end.
+
+**MySQL disk is full.**
+Shrink `EDR_RETENTION_DAYS`, restart the server, wait for one
+retention run. If that isn't enough, the events table is larger than
+your disk; you need either more disk or a shorter window. There is no
+online rebalance — expand storage and restart.
+
+**`docker compose up -d` fails with `volume mysql-data is in use`.**
+A previous server process didn't shut down cleanly. `docker compose
+down && docker compose up -d` usually clears it. Do NOT
+`docker volume rm mysql-data`; that wipes the database.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -9,14 +9,19 @@ start with [install-server.md](install-server.md) and
 
 | Task | Command |
 |---|---|
-| Server health | `curl -sk https://<server>/readyz \| jq .` |
-| Server version | `curl -sk https://<server>/readyz \| jq -r .version` |
+| Server health | `curl -s https://<server>/readyz \| jq .` |
+| Server version | `curl -s https://<server>/readyz \| jq -r .version` |
 | Tail server log | `docker compose logs -f server` |
 | Tail agent log (on Mac) | `sudo tail -f /var/log/fleet-edr-agent.log` |
 | Agent state (on Mac) | `sudo launchctl print system/com.fleetdm.edr.agent` |
 | Reload TLS cert | `docker compose kill -s HUP server` |
 | Restart server | `docker compose restart server` |
 | Backup DB | `docker compose exec -T mysql mysqldump --single-transaction -uroot -p"$(cat secrets/mysql_root)" edr \| gzip > edr-$(date +%F).sql.gz` |
+
+The `curl` examples below verify the server's TLS certificate. If you
+deploy with a self-signed cert (lab / air-gapped pilot), either add
+the CA to the machine's trust store or pass `--cacert /path/to/ca.pem`
+rather than bypassing verification with `-k`.
 
 ## Upgrade the server
 
@@ -35,7 +40,7 @@ docker compose -f docker-compose.prod.yml --env-file .env pull server
 docker compose -f docker-compose.prod.yml --env-file .env up -d
 
 # 4. Verify.
-curl -sk https://<server>/readyz | jq .
+curl -s https://<server>/readyz | jq .
 ```
 
 There is no downtime tolerated by MySQL during this. The server
@@ -264,7 +269,7 @@ list.
 
 ```sh
 # View current policy.
-curl -sk -b cookies.txt https://<server>/api/v1/admin/policy | jq .
+curl -s -b cookies.txt https://<server>/api/v1/admin/policy | jq .
 
 # Update policy (requires login + CSRF token).
 # Easier via the admin UI: Settings > Policy > Blocklist.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive operator documentation covering server installation, agent deployment across MDM solutions, and day-2 operations
  * Added HTTP API documentation with OpenAPI 3.1.0 specification
  * Added installation guides for manual agent setup and server stack deployment
  * Added troubleshooting, configuration, and operational runbooks for Fleet EDR deployments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->