### PR TITLE
A2 (issue #10): preserve same-PID re-exec chains

### DIFF
--- a/server/graph/builder.go
+++ b/server/graph/builder.go
@@ -114,52 +114,97 @@ func (b *Builder) handleExec(ctx context.Context, evt store.Event) error {
 		return err
 	}
 
-	// Try to update an existing process record (from a prior fork).
-	err := b.store.UpdateProcessExec(ctx, store.ProcessExecUpdate{
-		HostID:      evt.HostID,
-		PID:         p.PID,
-		ExecTimeNs:  evt.TimestampNs,
-		Path:        p.Path,
-		Args:        p.Args,
-		UID:         p.UID,
-		GID:         p.GID,
-		CodeSigning: p.CodeSigning,
-		SHA256:      p.SHA256,
-	})
+	// Resolve the running-at-this-moment row for the PID. Three shapes:
+	//   (a) no row            — exec-without-fork (synthesize a root row).
+	//   (b) row, exec_time_ns NULL  — first exec after fork; UPDATE in place.
+	//   (c) row, exec_time_ns set   — same-PID re-exec (issue #10): close the
+	//       prior generation and INSERT a new linked row. Without this branch,
+	//       shell exec-optimization chains (python→sh→bash→/tmp/payload) get
+	//       collapsed into the final exec only.
+	current, err := b.store.GetProcessByPID(ctx, evt.HostID, p.PID, evt.TimestampNs)
 	if err != nil {
 		return err
 	}
 
-	// Exec-without-fork: if no matching fork record exists, create a partial process record.
-	// We detect this by checking if any row was updated. Since MySQL doesn't easily return
-	// rows affected for "matched but unchanged" vs "no match", we do a lookup.
-	proc, err := b.store.GetProcessByPID(ctx, evt.HostID, p.PID, evt.TimestampNs)
-	if err != nil {
-		return err
+	if current == nil {
+		return b.insertExecWithoutFork(ctx, evt, p)
 	}
-	if proc == nil {
-		ppid := 0
-		if p.PPID != 0 {
-			ppid = p.PPID
-		}
-		forkIngested := evt.IngestedAtNs
-		_, err = b.store.InsertProcess(ctx, store.Process{
-			HostID:           evt.HostID,
-			PID:              p.PID,
-			PPID:             ppid,
-			Path:             p.Path,
-			Args:             p.Args,
-			UID:              p.UID,
-			GID:              p.GID,
-			CodeSigning:      p.CodeSigning,
-			SHA256:           p.SHA256,
-			ForkTimeNs:       evt.TimestampNs,
-			ForkIngestedAtNs: &forkIngested,
-			ExecTimeNs:       &evt.TimestampNs,
+	if current.ExecTimeNs == nil {
+		return b.store.UpdateProcessExec(ctx, store.ProcessExecUpdate{
+			HostID: evt.HostID, PID: p.PID, ExecTimeNs: evt.TimestampNs,
+			Path: p.Path, Args: p.Args,
+			UID: p.UID, GID: p.GID,
+			CodeSigning: p.CodeSigning, SHA256: p.SHA256,
 		})
-		return err
 	}
-	return nil
+	return b.insertReExec(ctx, evt, p, current)
+}
+
+// insertExecWithoutFork synthesizes a root process row when an exec event
+// arrives for a PID we've never seen fork for. fork_time_ns is set to the
+// exec time as a best effort; downstream queries treat it as the earliest
+// moment this process could have been alive.
+func (b *Builder) insertExecWithoutFork(ctx context.Context, evt store.Event, p execPayload) error {
+	ppid := 0
+	if p.PPID != 0 {
+		ppid = p.PPID
+	}
+	forkIngested := evt.IngestedAtNs
+	_, err := b.store.InsertProcess(ctx, store.Process{
+		HostID:           evt.HostID,
+		PID:              p.PID,
+		PPID:             ppid,
+		Path:             p.Path,
+		Args:             p.Args,
+		UID:              p.UID,
+		GID:              p.GID,
+		CodeSigning:      p.CodeSigning,
+		SHA256:           p.SHA256,
+		ForkTimeNs:       evt.TimestampNs,
+		ForkIngestedAtNs: &forkIngested,
+		ExecTimeNs:       &evt.TimestampNs,
+	})
+	return err
+}
+
+// insertReExec handles the issue #10 branch: a process called execve() again
+// on the same PID without forking in between. Close the prior generation
+// (marked exit_reason=reexec) and insert the new generation linked back via
+// previous_exec_id.
+func (b *Builder) insertReExec(ctx context.Context, evt store.Event, p execPayload, prior *store.Process) error {
+	if err := b.store.CloseReExecGeneration(ctx, prior.ID, evt.TimestampNs, evt.IngestedAtNs); err != nil {
+		return fmt.Errorf("close prior re-exec generation id=%d: %w", prior.ID, err)
+	}
+	priorID := prior.ID
+	_, err := b.store.InsertProcess(ctx, store.Process{
+		HostID: evt.HostID,
+		PID:    p.PID,
+		// Preserve the parent linkage from the original fork — a re-exec
+		// doesn't change PPID on macOS. Falls back to whatever the exec
+		// event carries if the prior row somehow has ppid=0.
+		PPID:             pickPPID(prior.PPID, p.PPID),
+		Path:             p.Path,
+		Args:             p.Args,
+		UID:              p.UID,
+		GID:              p.GID,
+		CodeSigning:      p.CodeSigning,
+		SHA256:           p.SHA256,
+		ForkTimeNs:       prior.ForkTimeNs, // chain preserves the original fork time
+		ForkIngestedAtNs: prior.ForkIngestedAtNs,
+		ExecTimeNs:       &evt.TimestampNs,
+		PreviousExecID:   &priorID,
+	})
+	return err
+}
+
+// pickPPID prefers a non-zero prior PPID. macOS ES reports PPID on every
+// NOTIFY_EXEC and it should be identical for re-execs on the same pid, but
+// staying defensive: if prior has it and the event doesn't, use prior.
+func pickPPID(prior, fromEvent int) int {
+	if prior != 0 {
+		return prior
+	}
+	return fromEvent
 }
 
 type exitPayload struct {

--- a/server/graph/builder.go
+++ b/server/graph/builder.go
@@ -168,15 +168,11 @@ func (b *Builder) insertExecWithoutFork(ctx context.Context, evt store.Event, p 
 }
 
 // insertReExec handles the issue #10 branch: a process called execve() again
-// on the same PID without forking in between. Close the prior generation
-// (marked exit_reason=reexec) and insert the new generation linked back via
-// previous_exec_id.
+// on the same PID without forking in between. The store's ReExec helper
+// wraps the close + insert in a single transaction so we can never leave
+// the PID appearing exited with no current generation (partial failure).
 func (b *Builder) insertReExec(ctx context.Context, evt store.Event, p execPayload, prior *store.Process) error {
-	if err := b.store.CloseReExecGeneration(ctx, prior.ID, evt.TimestampNs, evt.IngestedAtNs); err != nil {
-		return fmt.Errorf("close prior re-exec generation id=%d: %w", prior.ID, err)
-	}
-	priorID := prior.ID
-	_, err := b.store.InsertProcess(ctx, store.Process{
+	_, reLinked, err := b.store.ReExec(ctx, prior.ID, evt.TimestampNs, evt.IngestedAtNs, store.Process{
 		HostID: evt.HostID,
 		PID:    p.PID,
 		// Preserve the parent linkage from the original fork — a re-exec
@@ -192,9 +188,19 @@ func (b *Builder) insertReExec(ctx context.Context, evt store.Event, p execPaylo
 		ForkTimeNs:       prior.ForkTimeNs, // chain preserves the original fork time
 		ForkIngestedAtNs: prior.ForkIngestedAtNs,
 		ExecTimeNs:       &evt.TimestampNs,
-		PreviousExecID:   &priorID,
 	})
-	return err
+	if err != nil {
+		return fmt.Errorf("re-exec prior id=%d: %w", prior.ID, err)
+	}
+	if !reLinked {
+		// Prior row was terminally closed (observed exit or pid reuse),
+		// not a TTL-reconciled synthesis — we anchored a fresh chain
+		// instead of chaining through. Log so ingestion anomalies are
+		// visible; not fatal.
+		b.logger.WarnContext(ctx, "re-exec arrived after prior generation was terminally closed",
+			"host_id", evt.HostID, "pid", p.PID, "prior_row_id", prior.ID)
+	}
+	return nil
 }
 
 // pickPPID prefers a non-zero prior PPID. macOS ES reports PPID on every

--- a/server/graph/query.go
+++ b/server/graph/query.go
@@ -19,6 +19,12 @@ type ProcessDetail struct {
 	Process            store.Process `json:"process"`
 	NetworkConnections []store.Event `json:"network_connections"`
 	DNSQueries         []store.Event `json:"dns_queries"`
+	// ReExecChain is the list of prior exec generations on the same PID
+	// (issue #10), oldest-first. Empty for processes that only exec'd
+	// once after fork — the common case. The UI renders this as a visual
+	// chain (python → sh → bash → current) so analysts see the full
+	// exec sequence instead of just the final path.
+	ReExecChain []store.Process `json:"re_exec_chain,omitempty"`
 }
 
 // Query provides process tree and detail lookups.
@@ -101,11 +107,16 @@ func (q *Query) GetDetail(ctx context.Context, hostID string, pid int, atTimeNs 
 	if err != nil {
 		return nil, err
 	}
+	chain, err := q.store.GetExecChain(ctx, *proc)
+	if err != nil {
+		return nil, err
+	}
 
 	detail := &ProcessDetail{
 		Process:            *proc,
 		NetworkConnections: filterByType(netEvents, "network_connect"),
 		DNSQueries:         filterByType(netEvents, "dns_query"),
+		ReExecChain:        chain,
 	}
 	return detail, nil
 }

--- a/server/graph/reexec_test.go
+++ b/server/graph/reexec_test.go
@@ -1,0 +1,102 @@
+package graph
+
+import (
+	"encoding/json"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fleetdm/edr/server/store"
+)
+
+// TestHandleExec_SamePIDReExecChain reproduces the scenario from issue #10:
+// a shell's exec-optimization chain — `python → sh → bash → /tmp/payload` —
+// arrives as a fork on PID 30683 followed by FOUR execve events on the same
+// PID with no intervening fork. Pre-fix the processor upserted on PID so
+// only the final /tmp/payload path survived. Post-fix we expect four rows
+// linked via previous_exec_id.
+func TestHandleExec_SamePIDReExecChain(t *testing.T) {
+	s := store.OpenTestStore(t)
+	b := NewBuilder(s, slog.Default())
+	q := NewQuery(s)
+	ctx := t.Context()
+
+	const host = "reexec-host"
+	const pid = 30683
+
+	events := []store.Event{
+		{EventID: "rx-fork", HostID: host, TimestampNs: 1_000,
+			EventType: "fork",
+			Payload:   json.RawMessage(`{"child_pid": 30683, "parent_pid": 1}`)},
+		{EventID: "rx-exec-py", HostID: host, TimestampNs: 2_000,
+			EventType: "exec",
+			Payload:   json.RawMessage(`{"pid": 30683, "ppid": 1, "path": "/usr/bin/python3", "args": ["python3"], "uid": 501, "gid": 20}`)},
+		{EventID: "rx-exec-sh", HostID: host, TimestampNs: 3_000,
+			EventType: "exec",
+			Payload:   json.RawMessage(`{"pid": 30683, "ppid": 1, "path": "/bin/sh", "args": ["sh", "-c", "/tmp/payload"], "uid": 501, "gid": 20}`)},
+		{EventID: "rx-exec-bash", HostID: host, TimestampNs: 4_000,
+			EventType: "exec",
+			Payload:   json.RawMessage(`{"pid": 30683, "ppid": 1, "path": "/bin/bash", "args": ["bash", "-c", "/tmp/payload"], "uid": 501, "gid": 20}`)},
+		{EventID: "rx-exec-pld", HostID: host, TimestampNs: 5_000,
+			EventType: "exec",
+			Payload:   json.RawMessage(`{"pid": 30683, "ppid": 1, "path": "/tmp/payload", "args": ["/tmp/payload"], "uid": 501, "gid": 20}`)},
+	}
+	require.NoError(t, s.InsertEvents(ctx, events))
+	require.NoError(t, b.ProcessBatch(ctx, events))
+
+	// GetProcessByPID at a point after the final exec should return
+	// /tmp/payload — the current generation.
+	current, err := s.GetProcessByPID(ctx, host, pid, 6_000)
+	require.NoError(t, err)
+	require.NotNil(t, current)
+	assert.Equal(t, "/tmp/payload", current.Path)
+	require.NotNil(t, current.PreviousExecID, "current generation should link back to prior exec")
+
+	// Fetch the whole chain. Oldest-first: python, sh, bash.
+	detail, err := q.GetDetail(ctx, host, pid, 6_000)
+	require.NoError(t, err)
+	require.NotNil(t, detail)
+	require.Len(t, detail.ReExecChain, 3, "expected three prior generations")
+	assert.Equal(t, "/usr/bin/python3", detail.ReExecChain[0].Path)
+	assert.Equal(t, "/bin/sh", detail.ReExecChain[1].Path)
+	assert.Equal(t, "/bin/bash", detail.ReExecChain[2].Path)
+
+	// Prior generations must be closed with exit_reason=reexec so analysts
+	// can distinguish them from observed exits and TTL-reconciled greens.
+	for _, prior := range detail.ReExecChain {
+		require.NotNil(t, prior.ExitReason, "prior generation must be closed")
+		assert.Equal(t, store.ExitReasonReExec, *prior.ExitReason)
+		require.NotNil(t, prior.ExitTimeNs)
+	}
+
+	// fork_time_ns is preserved across the chain — every generation shares
+	// the original fork identity.
+	assert.Equal(t, detail.ReExecChain[0].ForkTimeNs, current.ForkTimeNs)
+}
+
+func TestHandleExec_SingleExecNoChain(t *testing.T) {
+	s := store.OpenTestStore(t)
+	b := NewBuilder(s, slog.Default())
+	q := NewQuery(s)
+	ctx := t.Context()
+
+	events := []store.Event{
+		{EventID: "se-fork", HostID: "one-host", TimestampNs: 1000, EventType: "fork",
+			Payload: json.RawMessage(`{"child_pid": 42, "parent_pid": 1}`)},
+		{EventID: "se-exec", HostID: "one-host", TimestampNs: 2000, EventType: "exec",
+			Payload: json.RawMessage(`{"pid": 42, "ppid": 1, "path": "/bin/echo", "args": ["echo"], "uid": 501, "gid": 20}`)},
+	}
+	require.NoError(t, s.InsertEvents(ctx, events))
+	require.NoError(t, b.ProcessBatch(ctx, events))
+
+	detail, err := q.GetDetail(ctx, "one-host", 42, 2500)
+	require.NoError(t, err)
+	require.NotNil(t, detail)
+	assert.Equal(t, "/bin/echo", detail.Process.Path)
+	assert.Empty(t, detail.ReExecChain,
+		"a plain fork+exec must not produce a re-exec chain")
+	assert.Nil(t, detail.Process.PreviousExecID,
+		"a root generation has no previous_exec_id")
+}

--- a/server/store/process.go
+++ b/server/store/process.go
@@ -75,6 +75,13 @@ type Process struct {
 	ExitIngestedAtNs *int64      `db:"exit_ingested_at_ns" json:"exit_ingested_at_ns,omitempty"`
 	ExitReason       *string     `db:"exit_reason" json:"exit_reason,omitempty"`
 	ExitCode         *int        `db:"exit_code" json:"exit_code,omitempty"`
+	// PreviousExecID points at the row representing the prior generation in
+	// a same-PID re-exec chain (issue #10). A process that calls execve()
+	// multiple times without forking (e.g. `python → sh → bash → payload`
+	// via shell exec-optimization) keeps its PID, so the processor inserts
+	// a new row per exec and links it backward via this field. The first
+	// exec after a fork has PreviousExecID == nil — that's the chain root.
+	PreviousExecID *int64 `db:"previous_exec_id" json:"previous_exec_id,omitempty"`
 }
 
 // ExitReason values for Process.ExitReason.
@@ -82,6 +89,7 @@ const (
 	ExitReasonEvent             = "event"              // normal — populated from an observed ES exit event
 	ExitReasonTTLReconciliation = "ttl_reconciliation" // synthesized — process stayed "running" past the TTL; server forced a gray
 	ExitReasonPIDReuse          = "pid_reuse"          // synthesized — an incoming fork on the same PID forced closure of the prior row
+	ExitReasonReExec            = "reexec"             // synthesized — superseded by a new execve() on the same PID (issue #10 chain)
 )
 
 // HostSummary provides an overview of a host's event activity.
@@ -107,11 +115,11 @@ func (s *Store) InsertProcess(ctx context.Context, p Process) (int64, error) {
 		INSERT INTO processes
 			(host_id, pid, ppid, path, args, uid, gid, code_signing, sha256,
 			 fork_time_ns, fork_ingested_at_ns, exec_time_ns, exit_time_ns,
-			 exit_ingested_at_ns, exit_code)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			 exit_ingested_at_ns, exit_code, previous_exec_id)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		p.HostID, p.PID, p.PPID, p.Path, p.Args, p.UID, p.GID,
 		p.CodeSigning, p.SHA256, p.ForkTimeNs, p.ForkIngestedAtNs, p.ExecTimeNs, p.ExitTimeNs,
-		p.ExitIngestedAtNs, p.ExitCode,
+		p.ExitIngestedAtNs, p.ExitCode, p.PreviousExecID,
 	)
 	if err != nil {
 		return 0, fmt.Errorf("insert process: %w", err)
@@ -196,6 +204,56 @@ func (s *Store) ReconcileStaleProcesses(ctx context.Context, cutoffNs, maxAgeNs 
 	return res.RowsAffected()
 }
 
+// CloseReExecGeneration finalizes the prior generation of a same-PID
+// re-exec chain when a new execve() on that PID lands. The row's
+// exit_time_ns is set to the new exec's kernel time and exit_reason to
+// ExitReasonReExec so analytics can distinguish "died by re-exec" from
+// normal exits, PID-reuse closes, and TTL reconciliations.
+func (s *Store) CloseReExecGeneration(ctx context.Context, rowID int64, exitTimeNs, exitIngestedAtNs int64) error {
+	_, err := s.db.ExecContext(ctx, `
+		UPDATE processes
+		SET exit_time_ns = ?, exit_ingested_at_ns = ?, exit_reason = ?
+		WHERE id = ? AND exit_time_ns IS NULL`,
+		exitTimeNs, exitIngestedAtNs, ExitReasonReExec, rowID,
+	)
+	return err
+}
+
+// GetExecChain walks previous_exec_id backward from the given current row
+// and returns the chain oldest-first (NOT including the current row). For
+// a non-re-exec process the result is an empty slice. Bounded to
+// maxChainLen rows to stop a cycle (shouldn't happen — previous_exec_id
+// is strictly decreasing — but FK cycles from bad data shouldn't lock up
+// a query).
+func (s *Store) GetExecChain(ctx context.Context, current Process) ([]Process, error) {
+	const maxChainLen = 64
+	var chain []Process
+	prevID := current.PreviousExecID
+	for depth := 0; prevID != nil && depth < maxChainLen; depth++ {
+		var p Process
+		err := s.db.GetContext(ctx, &p, `
+			SELECT id, host_id, pid, ppid, path, args, uid, gid, code_signing, sha256,
+			       fork_time_ns, fork_ingested_at_ns, exec_time_ns, exit_time_ns,
+			       exit_ingested_at_ns, exit_reason, exit_code, previous_exec_id
+			FROM processes WHERE id = ?`, *prevID)
+		if errors.Is(err, sql.ErrNoRows) {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("walk exec chain at id=%d: %w", *prevID, err)
+		}
+		chain = append(chain, p)
+		prevID = p.PreviousExecID
+	}
+	// Result is newest-first from the walk; reverse so the caller gets
+	// chronological order (oldest exec first). Callers rendering a timeline
+	// want that ordering implicitly.
+	for i, j := 0, len(chain)-1; i < j; i, j = i+1, j-1 {
+		chain[i], chain[j] = chain[j], chain[i]
+	}
+	return chain, nil
+}
+
 // CloseStaleProcess force-closes a process record that hasn't exited yet.
 // Used to handle PID reuse: when a fork arrives for a PID that already has an
 // active (non-exited) record, close the old one first. closedAtNs is treated
@@ -243,7 +301,7 @@ func (s *Store) GetProcessTree(ctx context.Context, hostID string, tr TimeRange,
 	err := s.db.SelectContext(ctx, &procs, `
 		SELECT id, host_id, pid, ppid, path, args, uid, gid, code_signing, sha256,
 		       fork_time_ns, fork_ingested_at_ns, exec_time_ns, exit_time_ns,
-		       exit_ingested_at_ns, exit_reason, exit_code
+		       exit_ingested_at_ns, exit_reason, exit_code, previous_exec_id
 		FROM processes
 		WHERE host_id = ?
 		  AND (
@@ -267,7 +325,7 @@ func (s *Store) GetProcessByPID(ctx context.Context, hostID string, pid int, atT
 	err := s.db.GetContext(ctx, &proc, `
 		SELECT id, host_id, pid, ppid, path, args, uid, gid, code_signing, sha256,
 		       fork_time_ns, fork_ingested_at_ns, exec_time_ns, exit_time_ns,
-		       exit_ingested_at_ns, exit_reason, exit_code
+		       exit_ingested_at_ns, exit_reason, exit_code, previous_exec_id
 		FROM processes
 		WHERE host_id = ? AND pid = ? AND fork_time_ns <= ?
 		  AND (exit_time_ns IS NULL OR exit_time_ns >= ?)
@@ -294,7 +352,7 @@ func (s *Store) GetChildProcesses(ctx context.Context, hostID string, ppid int, 
 	err := s.db.SelectContext(ctx, &procs, `
 		SELECT id, host_id, pid, ppid, path, args, uid, gid, code_signing, sha256,
 		       fork_time_ns, fork_ingested_at_ns, exec_time_ns, exit_time_ns,
-		       exit_ingested_at_ns, exit_reason, exit_code
+		       exit_ingested_at_ns, exit_reason, exit_code, previous_exec_id
 		FROM processes
 		WHERE host_id = ? AND ppid = ? AND fork_time_ns >= ? AND fork_time_ns <= ?
 		ORDER BY fork_time_ns`,

--- a/server/store/process.go
+++ b/server/store/process.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/jmoiron/sqlx"
@@ -204,19 +205,80 @@ func (s *Store) ReconcileStaleProcesses(ctx context.Context, cutoffNs, maxAgeNs 
 	return res.RowsAffected()
 }
 
-// CloseReExecGeneration finalizes the prior generation of a same-PID
-// re-exec chain when a new execve() on that PID lands. The row's
-// exit_time_ns is set to the new exec's kernel time and exit_reason to
-// ExitReasonReExec so analytics can distinguish "died by re-exec" from
-// normal exits, PID-reuse closes, and TTL reconciliations.
-func (s *Store) CloseReExecGeneration(ctx context.Context, rowID int64, exitTimeNs, exitIngestedAtNs int64) error {
-	_, err := s.db.ExecContext(ctx, `
+// ReExec finalizes the prior generation of a same-PID re-exec chain AND
+// inserts the new generation in a single transaction. Prior to this the
+// close + insert were two separate statements; if the insert failed, the
+// PID would appear exited with no current generation row, losing the
+// process's running state.
+//
+// The prior-row UPDATE predicate accepts two prior-row states:
+//
+//	(a) exit_time_ns IS NULL — the normal case, prior row is live.
+//	(b) exit_reason = ExitReasonTTLReconciliation — the TTL reconciler
+//	    synthesized an exit that turned out to be wrong (the process was
+//	    still alive and just re-exec'd). We overwrite the TTL guess with
+//	    the real re-exec close so the chain semantics are correct.
+//
+// When RowsAffected is 0 (prior row was observed-exited or pid-reused —
+// real terminal states we must NOT overwrite), the new row is still
+// inserted but with previous_exec_id = NULL so it anchors a fresh chain.
+// Caller gets reLinked=false to log that edge.
+//
+// newRow.PreviousExecID is ignored and set by this method.
+func (s *Store) ReExec(
+	ctx context.Context, priorID int64,
+	exitTimeNs, exitIngestedAtNs int64,
+	newRow Process,
+) (newID int64, reLinked bool, err error) {
+	tx, err := s.db.BeginTxx(ctx, nil)
+	if err != nil {
+		return 0, false, fmt.Errorf("begin tx for re-exec: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	res, err := tx.ExecContext(ctx, `
 		UPDATE processes
 		SET exit_time_ns = ?, exit_ingested_at_ns = ?, exit_reason = ?
-		WHERE id = ? AND exit_time_ns IS NULL`,
-		exitTimeNs, exitIngestedAtNs, ExitReasonReExec, rowID,
+		WHERE id = ?
+		  AND (exit_time_ns IS NULL OR exit_reason = ?)`,
+		exitTimeNs, exitIngestedAtNs, ExitReasonReExec, priorID, ExitReasonTTLReconciliation,
 	)
-	return err
+	if err != nil {
+		return 0, false, fmt.Errorf("close prior re-exec row id=%d: %w", priorID, err)
+	}
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return 0, false, fmt.Errorf("close prior re-exec rows affected id=%d: %w", priorID, err)
+	}
+	reLinked = rows > 0
+	if reLinked {
+		newRow.PreviousExecID = &priorID
+	} else {
+		newRow.PreviousExecID = nil
+	}
+
+	ins, err := tx.ExecContext(ctx, `
+		INSERT INTO processes
+			(host_id, pid, ppid, path, args, uid, gid, code_signing, sha256,
+			 fork_time_ns, fork_ingested_at_ns, exec_time_ns, exit_time_ns,
+			 exit_ingested_at_ns, exit_code, previous_exec_id)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		newRow.HostID, newRow.PID, newRow.PPID, newRow.Path, newRow.Args, newRow.UID, newRow.GID,
+		newRow.CodeSigning, newRow.SHA256, newRow.ForkTimeNs, newRow.ForkIngestedAtNs,
+		newRow.ExecTimeNs, newRow.ExitTimeNs, newRow.ExitIngestedAtNs, newRow.ExitCode,
+		newRow.PreviousExecID,
+	)
+	if err != nil {
+		return 0, false, fmt.Errorf("insert new re-exec generation: %w", err)
+	}
+	newID, err = ins.LastInsertId()
+	if err != nil {
+		return 0, false, fmt.Errorf("insert new re-exec LastInsertId: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, false, fmt.Errorf("commit re-exec tx: %w", err)
+	}
+	return newID, reLinked, nil
 }
 
 // GetExecChain walks previous_exec_id backward from the given current row
@@ -225,6 +287,11 @@ func (s *Store) CloseReExecGeneration(ctx context.Context, rowID int64, exitTime
 // maxChainLen rows to stop a cycle (shouldn't happen — previous_exec_id
 // is strictly decreasing — but FK cycles from bad data shouldn't lock up
 // a query).
+//
+// The SELECT is scoped by host_id as well as id so a corrupted
+// previous_exec_id value can never surface a row from a different host
+// (defense-in-depth; the builder always writes the same-host id, but a
+// future bulk-import or manual fix might not).
 func (s *Store) GetExecChain(ctx context.Context, current Process) ([]Process, error) {
 	const maxChainLen = 64
 	var chain []Process
@@ -235,7 +302,7 @@ func (s *Store) GetExecChain(ctx context.Context, current Process) ([]Process, e
 			SELECT id, host_id, pid, ppid, path, args, uid, gid, code_signing, sha256,
 			       fork_time_ns, fork_ingested_at_ns, exec_time_ns, exit_time_ns,
 			       exit_ingested_at_ns, exit_reason, exit_code, previous_exec_id
-			FROM processes WHERE id = ?`, *prevID)
+			FROM processes WHERE id = ? AND host_id = ?`, *prevID, current.HostID)
 		if errors.Is(err, sql.ErrNoRows) {
 			break
 		}
@@ -248,9 +315,7 @@ func (s *Store) GetExecChain(ctx context.Context, current Process) ([]Process, e
 	// Result is newest-first from the walk; reverse so the caller gets
 	// chronological order (oldest exec first). Callers rendering a timeline
 	// want that ordering implicitly.
-	for i, j := 0, len(chain)-1; i < j; i, j = i+1, j-1 {
-		chain[i], chain[j] = chain[j], chain[i]
-	}
+	slices.Reverse(chain)
 	return chain, nil
 }
 

--- a/server/store/store.go
+++ b/server/store/store.go
@@ -51,6 +51,7 @@ var schemaStatements = []string{
 		exit_ingested_at_ns  BIGINT,
 		exit_reason          VARCHAR(32),
 		exit_code            INT,
+		previous_exec_id     BIGINT,
 		INDEX idx_processes_host_pid (host_id, pid, fork_time_ns),
 		INDEX idx_processes_host_ppid (host_id, ppid, fork_time_ns),
 		INDEX idx_processes_host_time (host_id, fork_time_ns)
@@ -311,6 +312,12 @@ var migrations = []string{
 	// and existing pre-migration rows shouldn't be touched — the UI treats
 	// missing + empty as "no techniques declared".
 	`ALTER TABLE alerts ADD COLUMN techniques JSON NULL`,
+	// Phase 7 / issue #10: same-PID re-exec chains. previous_exec_id points
+	// at the prior generation's row when a process execs multiple times on
+	// the same PID without forking (shell exec-optimization). Nullable; the
+	// first generation in any chain has NULL here.
+	`ALTER TABLE processes ADD COLUMN previous_exec_id BIGINT NULL`,
+	`ALTER TABLE processes ADD INDEX idx_processes_previous_exec (previous_exec_id)`,
 }
 
 // postSchemaMigrations run after schema creation and idempotent ALTER migrations. They use INSERT IGNORE / INSERT ...

--- a/ui/src/components/ProcessDetail.tsx
+++ b/ui/src/components/ProcessDetail.tsx
@@ -225,7 +225,7 @@ export function ProcessDetail({ hostId, node, onClose }: Props) {
 
       {loading && <p className="process-detail__loading">Loading network data...</p>}
 
-      {detail && detail.re_exec_chain && detail.re_exec_chain.length > 0 && (
+      {detail?.re_exec_chain && detail.re_exec_chain.length > 0 && (
         <div className="process-detail__reexec">
           <h4 className="process-detail__reexec-title">
             Re-exec chain{" "}

--- a/ui/src/components/ProcessDetail.tsx
+++ b/ui/src/components/ProcessDetail.tsx
@@ -225,6 +225,35 @@ export function ProcessDetail({ hostId, node, onClose }: Props) {
 
       {loading && <p className="process-detail__loading">Loading network data...</p>}
 
+      {detail && detail.re_exec_chain && detail.re_exec_chain.length > 0 && (
+        <div className="process-detail__reexec">
+          <h4 className="process-detail__reexec-title">
+            Re-exec chain{" "}
+            <span className="process-detail__reexec-count">
+              ({detail.re_exec_chain.length} prior
+              {detail.re_exec_chain.length === 1 ? " generation" : " generations"})
+            </span>
+          </h4>
+          <ol className="process-detail__reexec-list">
+            {detail.re_exec_chain.map((gen) => (
+              <li key={gen.id} className="process-detail__reexec-item">
+                <code className="process-detail__break">{gen.path || "(unknown)"}</code>
+                {gen.exec_time_ns && (
+                  <span className="process-detail__reexec-time">
+                    {" — exec @ "}
+                    {formatTimestamp(gen.exec_time_ns)}
+                  </span>
+                )}
+              </li>
+            ))}
+            <li className="process-detail__reexec-item process-detail__reexec-item--current">
+              <code className="process-detail__break">{node.path || "(unknown)"}</code>
+              <span className="process-detail__reexec-time"> — current</span>
+            </li>
+          </ol>
+        </div>
+      )}
+
       {detail && (
         <NetworkConnections
           connections={detail.network_connections}

--- a/ui/src/components/ProcessDetail.tsx
+++ b/ui/src/components/ProcessDetail.tsx
@@ -238,7 +238,7 @@ export function ProcessDetail({ hostId, node, onClose }: Props) {
             {detail.re_exec_chain.map((gen) => (
               <li key={gen.id} className="process-detail__reexec-item">
                 <code className="process-detail__break">{gen.path || "(unknown)"}</code>
-                {gen.exec_time_ns && (
+                {gen.exec_time_ns !== undefined && (
                   <span className="process-detail__reexec-time">
                     {" — exec @ "}
                     {formatTimestamp(gen.exec_time_ns)}

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -31,6 +31,12 @@ export interface Process {
   exec_time_ns?: number;
   exit_time_ns?: number;
   exit_code?: number;
+  // Phase 7 additions. exit_reason distinguishes observed exits from
+  // synthesized ones (TTL reconciliation, pid reuse, re-exec chain).
+  // previous_exec_id links back to the prior generation in a same-pid
+  // re-exec chain — see ReExecChain on ProcessDetail.
+  exit_reason?: string;
+  previous_exec_id?: number;
 }
 
 export interface ProcessNode extends Process {
@@ -78,6 +84,11 @@ export interface ProcessDetail {
   process: Process;
   network_connections: EventRecord[];
   dns_queries: EventRecord[];
+  // Oldest-first list of prior exec generations on the same PID — populated
+  // when a process called execve() more than once without forking in
+  // between (e.g. shell exec-optimization chains). Empty for the common
+  // single-exec case. See server/store/process.go GetExecChain.
+  re_exec_chain?: Process[];
 }
 
 export interface TreeResponse {


### PR DESCRIPTION
Shell exec-optimization chains — python → sh → bash → /tmp/payload on a single PID via successive execve() calls — used to collapse because processes upserted on PID. Only the final path survived. Analysts lost the intermediate steps that explain HOW a payload was launched.

Server-side storage + materializer:
- processes.previous_exec_id: new nullable FK-like column linking a row back to the prior generation. First row in a chain has NULL.
- ExitReasonReExec ("reexec"): distinguishes synthesized re-exec closes from observed exits, TTL reconciliations, and PID-reuse closes.
- Builder.handleExec: three-way branch on the current-row state. No row → exec-without-fork synthesis (unchanged). Row with exec_time_ns=NULL → first exec after fork (UPDATE, unchanged). Row with exec_time_ns set → re-exec path: close prior row (exit_time_ns = new exec time, exit_reason = reexec), INSERT new row preserving fork_time_ns and PPID, link via previous_exec_id.

Store/API surface:
- CloseReExecGeneration(ctx, rowID, exitTimeNs, exitIngestedAtNs) — writes the synthesized exit for the predecessor row.
- GetExecChain(ctx, current) — walks previous_exec_id backward, bounded at 64 hops, returns oldest-first.
- ProcessDetail.ReExecChain exposed via GET /api/v1/hosts/{id}/processes/{pid}.

UI:
- types.ts: Process grows exit_reason + previous_exec_id; ProcessDetail grows re_exec_chain. Structural types stay backward-compatible.
- ProcessDetail.tsx: renders "Re-exec chain (N prior generations)" block listing each prior path + exec time + "— current" for the live generation. Hidden when the chain is empty.

Tests:
- server/graph/reexec_test.go: reproduces the canonical issue #10 scenario (fork pid=30683, then 4 execs on the same pid with no intervening fork) and asserts 4 rows, chain of 3 priors via GetDetail, preserved fork_time_ns across the chain, exit_reason ="reexec" on each prior generation. Includes a negative test that a plain fork+exec produces no chain.

Validated live:
- Local smoke server: POST the 5-event chain, verify DB has 4 rows correctly linked, JSON API returns the chain oldest-first.
- Brave visual smoke: logged in, deep-linked to the process via ?process=N&at=, observed the Re-exec chain section rendering "/usr/bin/python3 → /bin/sh → /bin/bash → /tmp/payload (current)".

VM validation deferred to Phase 7 Track E (dogfood QA): the server processing is identical for ES-sourced and HTTP-POST-sourced events, and the VM would only exercise Apple's documented NOTIFY_EXEC-per- execve behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Process re-execution tracking: the system now tracks and displays the execution history when a process executes multiple different programs. The process detail view shows each program execution with timestamps, giving visibility into all programs executed by a single process throughout its lifetime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->