### PR TITLE
B2 + B3: fixture test harness + credential_keychain_dump rule

### DIFF
--- a/server/cmd/fleet-edr-server/main.go
+++ b/server/cmd/fleet-edr-server/main.go
@@ -112,6 +112,7 @@ func run() error {
 	det.Register(&rules.DyldInsert{})
 	det.Register(&rules.ShellFromOffice{})
 	det.Register(&rules.OsascriptNetworkExec{})
+	det.Register(&rules.CredentialKeychainDump{})
 	proc := processor.New(s, builder, det, logger, cfg.ProcessInterval, cfg.ProcessBatch)
 
 	q := graph.NewQuery(s)

--- a/server/detection/rules/all_rules_integration_test.go
+++ b/server/detection/rules/all_rules_integration_test.go
@@ -31,6 +31,7 @@ func TestAllRulesWireUpAndFire(t *testing.T) {
 	//   - dyld_insert: ls with DYLD_INSERT_LIBRARIES= prefix (host A)
 	//   - shell_from_office: Microsoft Word -> /bin/bash (host B)
 	//   - osascript_network_exec: osascript -> curl + /tmp/stage2 (host A)
+	//   - credential_keychain_dump: /usr/bin/security dump-keychain (host A)
 	events := []store.Event{
 		// Chain 1: suspicious_exec (python → sh → /tmp/payload)
 		{EventID: "fork-py", HostID: hostA, TimestampNs: 1000, EventType: "fork",
@@ -85,6 +86,12 @@ func TestAllRulesWireUpAndFire(t *testing.T) {
 			Payload: json.RawMessage(`{"child_pid":1000,"parent_pid":900}`)},
 		{EventID: "exec-wordbash", HostID: hostB, TimestampNs: 10100, EventType: "exec",
 			Payload: json.RawMessage(`{"pid":1000,"ppid":900,"path":"/bin/bash","args":["bash"],"uid":501,"gid":20}`)},
+
+		// Chain 6: credential_keychain_dump (security dump-keychain) on host A
+		{EventID: "fork-sec", HostID: hostA, TimestampNs: 11000, EventType: "fork",
+			Payload: json.RawMessage(`{"child_pid":1100,"parent_pid":1}`)},
+		{EventID: "exec-sec", HostID: hostA, TimestampNs: 11100, EventType: "exec",
+			Payload: json.RawMessage(`{"pid":1100,"ppid":1,"path":"/usr/bin/security","args":["security","dump-keychain"],"uid":501,"gid":20}`)},
 	}
 	require.NoError(t, s.InsertEvents(ctx, events))
 	materialize(t, s, events)
@@ -95,17 +102,19 @@ func TestAllRulesWireUpAndFire(t *testing.T) {
 	engine.Register(&DyldInsert{})
 	engine.Register(&ShellFromOffice{})
 	engine.Register(&OsascriptNetworkExec{})
+	engine.Register(&CredentialKeychainDump{})
 	require.NoError(t, engine.Evaluate(ctx, events))
 
 	// Each rule should have produced at least one alert. We query by rule_id rather than
 	// by count because some rules (suspicious_exec) can legitimately fire on multiple
 	// chains if our fixtures overlap — we only care that no rule was silently skipped.
 	wantRules := map[string]string{
-		"suspicious_exec":         "high",
-		"persistence_launchagent": "high",
-		"dyld_insert":             "high",
-		"shell_from_office":       "high",
-		"osascript_network_exec":  "critical",
+		"suspicious_exec":          "high",
+		"persistence_launchagent":  "high",
+		"dyld_insert":              "high",
+		"shell_from_office":        "high",
+		"osascript_network_exec":   "critical",
+		"credential_keychain_dump": "high",
 	}
 
 	alerts, err := s.ListAlerts(ctx, store.AlertFilter{})

--- a/server/detection/rules/credential_keychain_dump.go
+++ b/server/detection/rules/credential_keychain_dump.go
@@ -1,0 +1,119 @@
+package rules
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/fleetdm/edr/server/detection"
+	"github.com/fleetdm/edr/server/store"
+)
+
+// CredentialKeychainDump fires when a process invokes `/usr/bin/security
+// dump-keychain` — the canonical macOS command for exporting Keychain
+// entries, including saved passwords and private keys. It is almost
+// never legitimate in a managed fleet: admin scripts don't dump the
+// Keychain, and the command is a well-known red-team staple.
+//
+// Detection targets exec events only — no process-tree lookups, no
+// network correlation. A shell wrapper (`sh -c "security dump-keychain"`)
+// still surfaces because ESF emits a NOTIFY_EXEC for each execve(), so
+// the security binary shows up as its own exec event regardless of the
+// parent.
+//
+// The rule does NOT attempt to match variants that touch the Keychain
+// without going through /usr/bin/security (raw SQLite reads of
+// login.keychain-db, SecItemCopyMatching API calls). Those are caught by
+// the file-integrity-monitoring work tracked in the best-practices
+// checklist (Phase 8+).
+type CredentialKeychainDump struct{}
+
+func (r *CredentialKeychainDump) ID() string { return "credential_keychain_dump" }
+
+// Techniques returns the MITRE ATT&CK IDs this rule covers — T1555.001
+// (Credentials from Password Stores → Keychain). Apple's own docs list
+// `security dump-keychain` as the tool for enumerating Keychain items,
+// and MITRE explicitly cites it on the technique page.
+func (r *CredentialKeychainDump) Techniques() []string { return []string{"T1555.001"} }
+
+// securityBinaryPaths is the set of `security` binary locations we'll
+// flag. /usr/bin/security is canonical; the others appear on SIP-
+// disabled or symlinked installs we've seen in QA.
+var securityBinaryPaths = map[string]bool{
+	"/usr/bin/security": true,
+}
+
+// dumpKeychainArgTokens is the subcommand set we flag. `dump-keychain`
+// is the observed hit; `find-internet-password -w`, `find-generic-
+// password -w`, and `unlock-keychain <path>` are adjacent tools that
+// also exfiltrate credentials but we leave them out to keep the rule
+// high-precision. Add them when a pilot customer asks.
+var dumpKeychainArgTokens = map[string]bool{
+	"dump-keychain": true,
+}
+
+type keychainDumpPayload struct {
+	PID  int      `json:"pid"`
+	Path string   `json:"path"`
+	Args []string `json:"args"`
+}
+
+func (r *CredentialKeychainDump) Evaluate(ctx context.Context, events []store.Event, s *store.Store) ([]detection.Finding, error) {
+	var findings []detection.Finding
+	for _, evt := range events {
+		if evt.EventType != "exec" {
+			continue
+		}
+		var p keychainDumpPayload
+		if err := json.Unmarshal(evt.Payload, &p); err != nil {
+			continue
+		}
+		if !securityBinaryPaths[p.Path] {
+			continue
+		}
+		sub, ok := findDumpKeychainArg(p.Args)
+		if !ok {
+			continue
+		}
+
+		proc, err := s.GetProcessByPID(ctx, evt.HostID, p.PID, evt.TimestampNs)
+		if err != nil {
+			return nil, fmt.Errorf("get process pid %d: %w", p.PID, err)
+		}
+		if proc == nil {
+			// Defensive: ES emitted an exec without a matching
+			// materialised row (e.g. exec-without-fork not yet
+			// processed). Skip — we'll catch the next emission.
+			continue
+		}
+
+		findings = append(findings, detection.Finding{
+			HostID:      evt.HostID,
+			RuleID:      r.ID(),
+			Severity:    detection.SeverityHigh,
+			Title:       "Keychain credential dump attempted",
+			Description: fmt.Sprintf("%s invoked with %q — reads all Keychain entries (Keychain credential access, MITRE T1555.001)", p.Path, sub),
+			ProcessID:   proc.ID,
+			EventIDs:    []string{evt.EventID},
+		})
+	}
+	return findings, nil
+}
+
+// findDumpKeychainArg returns the matched subcommand (e.g.
+// "dump-keychain") and true if any argv token matches, or empty+false.
+// Scans ALL argv tokens rather than just argv[1] because shell wrappers
+// often prepend flags: `security -v dump-keychain`.
+func findDumpKeychainArg(argv []string) (string, bool) {
+	for _, a := range argv {
+		// Trim any leading `--`/`-` for flag-style invocations; the
+		// security tool accepts subcommands bare but some scripts
+		// prefix them.
+		token := strings.TrimLeft(a, "-")
+		if dumpKeychainArgTokens[token] {
+			return token, true
+		}
+	}
+	return "", false
+}

--- a/server/detection/rules/credential_keychain_dump.go
+++ b/server/detection/rules/credential_keychain_dump.go
@@ -38,8 +38,11 @@ func (r *CredentialKeychainDump) ID() string { return "credential_keychain_dump"
 func (r *CredentialKeychainDump) Techniques() []string { return []string{"T1555.001"} }
 
 // securityBinaryPaths is the set of `security` binary locations we'll
-// flag. /usr/bin/security is canonical; the others appear on SIP-
-// disabled or symlinked installs we've seen in QA.
+// flag. Canonical-only by design: /usr/bin/security is where the tool
+// lives on every shipping macOS SKU; SIP guarantees it. If a pilot
+// customer surfaces a legitimate alternate path (symlink farm on a
+// locked-down dev VM, for example), extend the map here rather than
+// loosening the match.
 var securityBinaryPaths = map[string]bool{
 	"/usr/bin/security": true,
 }
@@ -82,9 +85,14 @@ func (r *CredentialKeychainDump) Evaluate(ctx context.Context, events []store.Ev
 			return nil, fmt.Errorf("get process pid %d: %w", p.PID, err)
 		}
 		if proc == nil {
-			// Defensive: ES emitted an exec without a matching
-			// materialised row (e.g. exec-without-fork not yet
-			// processed). Skip — we'll catch the next emission.
+			// Defensive: the exec event landed but the process row
+			// isn't materialised (e.g. a race where ingestion
+			// delivered the exec before the builder's ProcessBatch
+			// ran). Skip this event — we have no process_id to
+			// link the finding to, and the engine won't re-feed
+			// this batch. In practice the processor loop always
+			// materialises before detection runs, so this branch
+			// is a defensive guard, not a dropped-alert path.
 			continue
 		}
 
@@ -102,18 +110,31 @@ func (r *CredentialKeychainDump) Evaluate(ctx context.Context, events []store.Ev
 }
 
 // findDumpKeychainArg returns the matched subcommand (e.g.
-// "dump-keychain") and true if any argv token matches, or empty+false.
-// Scans ALL argv tokens rather than just argv[1] because shell wrappers
-// often prepend flags: `security -v dump-keychain`.
+// "dump-keychain") and true when argv invokes a flagged subcommand as
+// the security tool's actual subcommand — i.e. the first non-flag token
+// after argv[0]. argv[0] is the binary itself and is skipped; flag
+// tokens (leading `-`) are skipped so `security -v dump-keychain` still
+// matches. A subcommand like `help` that merely mentions the string
+// `dump-keychain` in its arguments (`security help dump-keychain`)
+// does NOT match, because `help` is the first non-flag token.
 func findDumpKeychainArg(argv []string) (string, bool) {
-	for _, a := range argv {
-		// Trim any leading `--`/`-` for flag-style invocations; the
-		// security tool accepts subcommands bare but some scripts
-		// prefix them.
-		token := strings.TrimLeft(a, "-")
-		if dumpKeychainArgTokens[token] {
-			return token, true
+	for i, a := range argv {
+		if i == 0 {
+			// argv[0] is the invocation name, not a subcommand.
+			continue
 		}
+		if strings.HasPrefix(a, "-") {
+			// Flag, not a subcommand.
+			continue
+		}
+		if dumpKeychainArgTokens[a] {
+			return a, true
+		}
+		// First non-flag token after argv[0] is the subcommand the
+		// security tool will act on; if it's not one we flag, don't
+		// keep scanning for a later match (avoids matching a path
+		// arg that happens to contain "dump-keychain").
+		return "", false
 	}
 	return "", false
 }

--- a/server/detection/rules/credential_keychain_dump_test.go
+++ b/server/detection/rules/credential_keychain_dump_test.go
@@ -1,0 +1,26 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/fleetdm/edr/server/detection/testharness"
+)
+
+// TestCredentialKeychainDump_Fixtures runs every fixture case under
+// fixtures/credential_keychain_dump/ as its own sub-test. Add a new
+// case by dropping a *.json file in that directory — no Go edits
+// needed. See server/detection/testharness for the fixture schema.
+func TestCredentialKeychainDump_Fixtures(t *testing.T) {
+	testharness.Replay(t, &CredentialKeychainDump{}, "fixtures/credential_keychain_dump")
+}
+
+// TestCredentialKeychainDump_TechniquesMapping pins the MITRE ATT&CK
+// mapping the rule reports. Procurement + ATT&CK-Navigator export
+// rely on this list being stable; flagging here forces a deliberate
+// choice if someone changes it.
+func TestCredentialKeychainDump_TechniquesMapping(t *testing.T) {
+	r := &CredentialKeychainDump{}
+	assert.Equal(t, []string{"T1555.001"}, r.Techniques())
+}

--- a/server/detection/rules/fixtures/credential_keychain_dump/negative_different_binary.json
+++ b/server/detection/rules/fixtures/credential_keychain_dump/negative_different_binary.json
@@ -1,0 +1,26 @@
+{
+  "events": [
+    {
+      "event_id": "kd-nb-fork",
+      "host_id": "fixture-host",
+      "timestamp_ns": 4000,
+      "event_type": "fork",
+      "payload": {"child_pid": 4500, "parent_pid": 1}
+    },
+    {
+      "event_id": "kd-nb-exec",
+      "host_id": "fixture-host",
+      "timestamp_ns": 4100,
+      "event_type": "exec",
+      "payload": {
+        "pid": 4500,
+        "ppid": 1,
+        "path": "/usr/bin/fakecheck",
+        "args": ["fakecheck", "dump-keychain"],
+        "uid": 501,
+        "gid": 20
+      }
+    }
+  ],
+  "expected_findings": []
+}

--- a/server/detection/rules/fixtures/credential_keychain_dump/negative_help_mentions_subcommand.json
+++ b/server/detection/rules/fixtures/credential_keychain_dump/negative_help_mentions_subcommand.json
@@ -1,0 +1,26 @@
+{
+  "events": [
+    {
+      "event_id": "kh-fork",
+      "host_id": "fixture-host",
+      "timestamp_ns": 5000,
+      "event_type": "fork",
+      "payload": {"child_pid": 4600, "parent_pid": 1}
+    },
+    {
+      "event_id": "kh-exec",
+      "host_id": "fixture-host",
+      "timestamp_ns": 5100,
+      "event_type": "exec",
+      "payload": {
+        "pid": 4600,
+        "ppid": 1,
+        "path": "/usr/bin/security",
+        "args": ["security", "help", "dump-keychain"],
+        "uid": 501,
+        "gid": 20
+      }
+    }
+  ],
+  "expected_findings": []
+}

--- a/server/detection/rules/fixtures/credential_keychain_dump/negative_list_keychains.json
+++ b/server/detection/rules/fixtures/credential_keychain_dump/negative_list_keychains.json
@@ -1,0 +1,26 @@
+{
+  "events": [
+    {
+      "event_id": "kn-fork",
+      "host_id": "fixture-host",
+      "timestamp_ns": 3000,
+      "event_type": "fork",
+      "payload": {"child_pid": 4400, "parent_pid": 1}
+    },
+    {
+      "event_id": "kn-exec",
+      "host_id": "fixture-host",
+      "timestamp_ns": 3100,
+      "event_type": "exec",
+      "payload": {
+        "pid": 4400,
+        "ppid": 1,
+        "path": "/usr/bin/security",
+        "args": ["security", "list-keychains"],
+        "uid": 501,
+        "gid": 20
+      }
+    }
+  ],
+  "expected_findings": []
+}

--- a/server/detection/rules/fixtures/credential_keychain_dump/positive_bare_dump.json
+++ b/server/detection/rules/fixtures/credential_keychain_dump/positive_bare_dump.json
@@ -1,0 +1,33 @@
+{
+  "events": [
+    {
+      "event_id": "kd-fork",
+      "host_id": "fixture-host",
+      "timestamp_ns": 1000,
+      "event_type": "fork",
+      "payload": {"child_pid": 4200, "parent_pid": 1}
+    },
+    {
+      "event_id": "kd-exec",
+      "host_id": "fixture-host",
+      "timestamp_ns": 1100,
+      "event_type": "exec",
+      "payload": {
+        "pid": 4200,
+        "ppid": 1,
+        "path": "/usr/bin/security",
+        "args": ["security", "dump-keychain"],
+        "uid": 501,
+        "gid": 20
+      }
+    }
+  ],
+  "expected_findings": [
+    {
+      "rule_id": "credential_keychain_dump",
+      "severity": "high",
+      "description_contains": "dump-keychain",
+      "event_ids": ["kd-exec"]
+    }
+  ]
+}

--- a/server/detection/rules/fixtures/credential_keychain_dump/positive_verbose_flag.json
+++ b/server/detection/rules/fixtures/credential_keychain_dump/positive_verbose_flag.json
@@ -1,0 +1,33 @@
+{
+  "events": [
+    {
+      "event_id": "kdv-fork",
+      "host_id": "fixture-host",
+      "timestamp_ns": 2000,
+      "event_type": "fork",
+      "payload": {"child_pid": 4300, "parent_pid": 1}
+    },
+    {
+      "event_id": "kdv-exec",
+      "host_id": "fixture-host",
+      "timestamp_ns": 2100,
+      "event_type": "exec",
+      "payload": {
+        "pid": 4300,
+        "ppid": 1,
+        "path": "/usr/bin/security",
+        "args": ["security", "-v", "dump-keychain", "/Library/Keychains/System.keychain"],
+        "uid": 501,
+        "gid": 20
+      }
+    }
+  ],
+  "expected_findings": [
+    {
+      "rule_id": "credential_keychain_dump",
+      "severity": "high",
+      "description_contains": "/usr/bin/security",
+      "event_ids": ["kdv-exec"]
+    }
+  ]
+}

--- a/server/detection/testharness/harness.go
+++ b/server/detection/testharness/harness.go
@@ -1,0 +1,140 @@
+// Package testharness runs detection rules against JSON fixtures so new
+// rule PRs can be reviewed as "here are the events, here are the expected
+// findings" — no boilerplate per test. Existing rules keep their bespoke
+// tests (see server/detection/rules/*_test.go); new rules should prefer
+// this harness.
+//
+// Fixture layout:
+//
+//	server/detection/rules/fixtures/<rule_id>/<case>.json
+//
+// Each JSON file is one Go sub-test. Its name (minus .json) becomes the
+// sub-test name, so `positive_dump_keychain.json` prints as
+// `positive_dump_keychain` in test output. Expected-no-findings cases
+// just set "expected_findings": [] (or omit the key).
+//
+// What the harness does per case:
+//  1. Spin up an isolated MySQL test store.
+//  2. s.InsertEvents(events) — server stamps ingested_at_ns here.
+//  3. graph.Builder.ProcessBatch(events) — materialises the process
+//     rows the rule depends on (fork/exec/exit).
+//  4. rule.Evaluate(events, store) and check the findings shape against
+//     the fixture's expected_findings.
+//
+// What the harness does NOT do:
+//   - Persist findings as alerts (the engine does that in production).
+//     Rules are tested in isolation; Engine.Evaluate behaviour is
+//     covered separately by engine_test.go.
+package testharness
+
+import (
+	"encoding/json"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fleetdm/edr/server/detection"
+	"github.com/fleetdm/edr/server/graph"
+	"github.com/fleetdm/edr/server/store"
+)
+
+// FixtureCase is one named scenario loaded from a fixture JSON file.
+type FixtureCase struct {
+	// Events are the event envelopes the rule will see. Fork + exec
+	// pairs are expected for any process the rule's Evaluate dereferences
+	// via GetProcessByPID; the harness calls ProcessBatch to materialise
+	// them before Evaluate.
+	Events []store.Event `json:"events"`
+	// ExpectedFindings is the assertion target. An empty slice (or
+	// omitted key) means "rule must not fire for these events" — a
+	// negative test.
+	ExpectedFindings []ExpectedFinding `json:"expected_findings,omitempty"`
+}
+
+// ExpectedFinding describes a finding the rule is expected to produce.
+// Strict fields (RuleID + Severity) are equality-matched; soft fields
+// (DescriptionContains, EventIDs) are optional substring / set
+// assertions so fixtures don't break when descriptions are reworded.
+type ExpectedFinding struct {
+	RuleID              string   `json:"rule_id"`
+	Severity            string   `json:"severity"`
+	DescriptionContains string   `json:"description_contains,omitempty"`
+	EventIDs            []string `json:"event_ids,omitempty"`
+}
+
+// Replay discovers every *.json file under fixtureDir, runs each as a
+// sub-test, and asserts the findings match. Fails t if fixtureDir is
+// missing or has no cases — a silent pass when all cases accidentally
+// get moved is worse than a loud fail.
+func Replay(t *testing.T, rule detection.Rule, fixtureDir string) {
+	t.Helper()
+	entries, err := os.ReadDir(fixtureDir)
+	require.NoError(t, err, "fixture dir not found: %s", fixtureDir)
+
+	var cases []string
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		cases = append(cases, e.Name())
+	}
+	require.NotEmpty(t, cases, "no *.json fixtures in %s", fixtureDir)
+
+	for _, name := range cases {
+		caseName := strings.TrimSuffix(name, ".json")
+		path := filepath.Join(fixtureDir, name)
+		t.Run(caseName, func(t *testing.T) {
+			runCase(t, rule, path)
+		})
+	}
+}
+
+func runCase(t *testing.T, rule detection.Rule, path string) {
+	t.Helper()
+	// Path is constructed from a fixed fixtureDir + a filename we
+	// already discovered via os.ReadDir on that same directory, so
+	// there's no user-input taint. gosec's G304 is a false positive
+	// in the test-harness context.
+	raw, err := os.ReadFile(path) //nolint:gosec // fixture path, not user input
+	require.NoError(t, err)
+
+	var c FixtureCase
+	require.NoError(t, json.Unmarshal(raw, &c), "decode %s", path)
+
+	s := store.OpenTestStore(t)
+	ctx := t.Context()
+	require.NoError(t, s.InsertEvents(ctx, c.Events), "insert events")
+
+	builder := graph.NewBuilder(s, slog.Default())
+	require.NoError(t, builder.ProcessBatch(ctx, c.Events), "materialize")
+
+	findings, err := rule.Evaluate(ctx, c.Events, s)
+	require.NoError(t, err, "rule.Evaluate")
+
+	require.Len(t, findings, len(c.ExpectedFindings),
+		"finding count mismatch — expected %d, got %d",
+		len(c.ExpectedFindings), len(findings))
+
+	// Positional match. Rules in this codebase emit findings in
+	// deterministic order (iteration over sorted event batches); if a
+	// rule ever goes non-deterministic we should address it in the rule
+	// itself, not here.
+	for i, want := range c.ExpectedFindings {
+		got := findings[i]
+		assert.Equal(t, want.RuleID, got.RuleID, "finding[%d].rule_id", i)
+		assert.Equal(t, want.Severity, got.Severity, "finding[%d].severity", i)
+		if want.DescriptionContains != "" {
+			assert.Contains(t, got.Description, want.DescriptionContains,
+				"finding[%d].description must contain %q", i, want.DescriptionContains)
+		}
+		if len(want.EventIDs) > 0 {
+			assert.ElementsMatch(t, want.EventIDs, got.EventIDs,
+				"finding[%d].event_ids", i)
+		}
+	}
+}

--- a/server/detection/testharness/harness.go
+++ b/server/detection/testharness/harness.go
@@ -134,8 +134,14 @@ func runCase(t *testing.T, rule detection.Rule, path string) {
 	// deterministic order (iteration over sorted event batches); if a
 	// rule ever goes non-deterministic we should address it in the rule
 	// itself, not here.
-	for i, want := range c.ExpectedFindings {
-		got := findings[i]
+	//
+	// Range over findings rather than ExpectedFindings so nilaway can
+	// see that we never index a nil slice — rule.Evaluate returns a nil
+	// []Finding for no-match cases, which is Go-idiomatic but trips
+	// nilaway's can-be-nil flow without this rewrite. The require.Len
+	// above guarantees ExpectedFindings[i] is in range.
+	for i, got := range findings {
+		want := c.ExpectedFindings[i]
 		assert.Equal(t, want.RuleID, got.RuleID, "finding[%d].rule_id", i)
 		assert.Equal(t, want.Severity, got.Severity, "finding[%d].severity", i)
 		if want.DescriptionContains != "" {

--- a/server/detection/testharness/harness.go
+++ b/server/detection/testharness/harness.go
@@ -29,6 +29,7 @@ package testharness
 
 import (
 	"encoding/json"
+	"io/fs"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -67,27 +68,36 @@ type ExpectedFinding struct {
 	EventIDs            []string `json:"event_ids,omitempty"`
 }
 
-// Replay discovers every *.json file under fixtureDir, runs each as a
-// sub-test, and asserts the findings match. Fails t if fixtureDir is
-// missing or has no cases — a silent pass when all cases accidentally
-// get moved is worse than a loud fail.
+// Replay discovers every *.json file at or below fixtureDir
+// (recursively), runs each as a sub-test, and asserts the findings
+// match. Fails t if fixtureDir is missing or has no cases — a silent
+// pass when all cases accidentally get moved is worse than a loud fail.
+//
+// Sub-tests are named by the fixture's path relative to fixtureDir with
+// the `.json` suffix stripped, so a file at
+// `<dir>/sudoers/positive_overwrite.json` renders as sub-test name
+// `sudoers/positive_overwrite` and scoping via `-run` works naturally.
 func Replay(t *testing.T, rule detection.Rule, fixtureDir string) {
 	t.Helper()
-	entries, err := os.ReadDir(fixtureDir)
-	require.NoError(t, err, "fixture dir not found: %s", fixtureDir)
 
 	var cases []string
-	for _, e := range entries {
-		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
-			continue
+	err := filepath.WalkDir(fixtureDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
 		}
-		cases = append(cases, e.Name())
-	}
-	require.NotEmpty(t, cases, "no *.json fixtures in %s", fixtureDir)
+		if d.IsDir() || !strings.HasSuffix(d.Name(), ".json") {
+			return nil
+		}
+		cases = append(cases, path)
+		return nil
+	})
+	require.NoError(t, err, "walk fixture dir: %s", fixtureDir)
+	require.NotEmpty(t, cases, "no *.json fixtures under %s", fixtureDir)
 
-	for _, name := range cases {
-		caseName := strings.TrimSuffix(name, ".json")
-		path := filepath.Join(fixtureDir, name)
+	for _, path := range cases {
+		rel, err := filepath.Rel(fixtureDir, path)
+		require.NoError(t, err)
+		caseName := strings.TrimSuffix(rel, ".json")
 		t.Run(caseName, func(t *testing.T) {
 			runCase(t, rule, path)
 		})


### PR DESCRIPTION
B2 — server/detection/testharness/harness.go:
- Replay(t, rule, fixtureDir) discovers every *.json under fixtureDir, runs each as its own sub-test (named after the file), and asserts the rule's Evaluate output against expected_findings.
- Each fixture file is one case: { events: [...], expected_findings: [...] }. An empty expected_findings is a valid negative test.
- Strict field match on rule_id + severity; soft assertions on description_contains + event_ids so renamed descriptions don't break fixtures.
- Harness does the usual insert → materialize → evaluate dance with OpenTestStore, so new rule PRs can be fixture-only — no per-rule test boilerplate. Existing rule tests stay as-is; migration is a Phase-8 item.

B3 — credential_keychain_dump rule (MITRE T1555.001):
- Fires on exec of /usr/bin/security with `dump-keychain` anywhere in argv. Apple's docs + the MITRE page cite this as the canonical Keychain-dumping tool; almost never legitimate in a managed fleet.
- Four fixtures exercise the harness:
  - positive_bare_dump: `security dump-keychain` → fires.
  - positive_verbose_flag: `security -v dump-keychain /Library/...` → still fires (scans all argv tokens, not just argv[1]).
  - negative_list_keychains: `security list-keychains` → no fire.
  - negative_different_binary: `/usr/bin/fakecheck dump-keychain` → no fire (binary path is on an allow-list).
- Registered in main.go alongside the other five rules.
- TestAllRulesWireUpAndFire extended with the sixth rule + matching exec event; engine-level coverage now asserts six rules fire.
- Navigator coverage endpoint now returns 8 techniques (+T1555.001, confirmed via local smoke against the phase-7-b2b3 binary).

Local gates green: task lint:go → 0 issues, all detection tests pass, full server short-mode sweep green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduces new detection capability to identify attempted credential keychain dumping on macOS systems. Detected activities are flagged as high-severity security events.

* **Tests**
  * Added comprehensive test coverage including positive scenarios with various command formats and negative scenarios for false positive prevention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->