### PR TITLE
B3 round 2: privilege_launchd_plist_write detection rule

### DIFF
--- a/docs/install-server.md
+++ b/docs/install-server.md
@@ -206,6 +206,7 @@ unset uses the documented default.
 | `EDR_RETENTION_DAYS` | no | 30 | Event TTL, 0 disables retention |
 | `EDR_RETENTION_INTERVAL` | no | 1h | How often the retention job runs |
 | `EDR_LAUNCHAGENT_ALLOWLIST` | no | — | Comma-separated absolute paths the `persistence_launchagent` rule treats as benign |
+| `EDR_LAUNCHDAEMON_TEAMID_ALLOWLIST` | no | — | Comma-separated code-signing team IDs the `privilege_launchd_plist_write` rule treats as benign |
 | `EDR_LOG_LEVEL` | no | info | `debug` / `info` / `warn` / `error` |
 | `EDR_LOG_FORMAT` | no | json | `json` or `text` |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | no | — | `host:port` of an OTLP/gRPC collector; unset disables metrics export |

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -288,6 +288,14 @@ server's `persistence_launchagent` detection rule which LaunchAgent
 paths are benign and should not trigger alerts. Set it as a
 comma-separated list of absolute paths.
 
+`EDR_LAUNCHDAEMON_TEAMID_ALLOWLIST` is the parallel knob for the
+`privilege_launchd_plist_write` rule. Apple-signed platform binaries
+(installd, system_installd, ...) are always allowed; this list is for
+non-Apple agents that legitimately drop daemons under
+`/Library/LaunchDaemons/` (Munki, Kandji, JumpCloud, etc.). Set it as
+a comma-separated list of code-signing team IDs, e.g.
+`T4SK8ZXCXG,XYZW0KL1Q9`.
+
 ## Common troubleshooting
 
 **Readyz says `db: error`.**

--- a/server/cmd/fleet-edr-server/main.go
+++ b/server/cmd/fleet-edr-server/main.go
@@ -113,6 +113,7 @@ func run() error {
 	det.Register(&rules.ShellFromOffice{})
 	det.Register(&rules.OsascriptNetworkExec{})
 	det.Register(&rules.CredentialKeychainDump{})
+	det.Register(&rules.PrivilegeLaunchdPlistWrite{AllowedTeamIDs: cfg.LaunchDaemonTeamIDAllowlist})
 	proc := processor.New(s, builder, det, logger, cfg.ProcessInterval, cfg.ProcessBatch)
 
 	q := graph.NewQuery(s)

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -55,6 +55,15 @@ type Config struct {
 	// should silently accept. Populated from EDR_LAUNCHAGENT_ALLOWLIST (comma-separated
 	// absolute paths). Empty by default — every plist load fires.
 	LaunchAgentAllowlist map[string]struct{}
+
+	// LaunchDaemonTeamIDAllowlist is the set of code-signing team IDs the
+	// `privilege_launchd_plist_write` rule should silently accept when they
+	// write to /Library/LaunchDaemons. Populated from
+	// EDR_LAUNCHDAEMON_TEAMID_ALLOWLIST (comma-separated team IDs).
+	// Apple-signed platform binaries (installd, system_installd, ...) are
+	// always allowed; this list is for non-Apple MDM agents that legitimately
+	// drop daemons (Munki, Kandji, JumpCloud, ...). Empty by default.
+	LaunchDaemonTeamIDAllowlist map[string]struct{}
 }
 
 // TLSEnabled reports whether TLS cert and key are both set.
@@ -130,6 +139,9 @@ func loadFrom(getenv func(string) string) (*Config, error) {
 
 	if allowlist := envparse.Allowlist(getenv("EDR_LAUNCHAGENT_ALLOWLIST")); allowlist != nil {
 		c.LaunchAgentAllowlist = allowlist
+	}
+	if allowlist := envparse.Allowlist(getenv("EDR_LAUNCHDAEMON_TEAMID_ALLOWLIST")); allowlist != nil {
+		c.LaunchDaemonTeamIDAllowlist = allowlist
 	}
 
 	if v := getenv("EDR_LOG_LEVEL"); v != "" {

--- a/server/detection/rules/all_rules_integration_test.go
+++ b/server/detection/rules/all_rules_integration_test.go
@@ -32,6 +32,8 @@ func TestAllRulesWireUpAndFire(t *testing.T) {
 	//   - shell_from_office: Microsoft Word -> /bin/bash (host B)
 	//   - osascript_network_exec: osascript -> curl + /tmp/stage2 (host A)
 	//   - credential_keychain_dump: /usr/bin/security dump-keychain (host A)
+	//   - privilege_launchd_plist_write: non-platform-binary writes
+	//     /Library/LaunchDaemons/com.evil.persistence.plist (host A)
 	events := []store.Event{
 		// Chain 1: suspicious_exec (python → sh → /tmp/payload)
 		{EventID: "fork-py", HostID: hostA, TimestampNs: 1000, EventType: "fork",
@@ -92,6 +94,15 @@ func TestAllRulesWireUpAndFire(t *testing.T) {
 			Payload: json.RawMessage(`{"child_pid":1100,"parent_pid":1}`)},
 		{EventID: "exec-sec", HostID: hostA, TimestampNs: 11100, EventType: "exec",
 			Payload: json.RawMessage(`{"pid":1100,"ppid":1,"path":"/usr/bin/security","args":["security","dump-keychain"],"uid":501,"gid":20}`)},
+
+		// Chain 7: privilege_launchd_plist_write (non-platform binary writes
+		// /Library/LaunchDaemons/<x>.plist with O_WRONLY|O_CREAT|O_TRUNC)
+		{EventID: "fork-ldp", HostID: hostA, TimestampNs: 12000, EventType: "fork",
+			Payload: json.RawMessage(`{"child_pid":1200,"parent_pid":1}`)},
+		{EventID: "exec-ldp", HostID: hostA, TimestampNs: 12100, EventType: "exec",
+			Payload: json.RawMessage(`{"pid":1200,"ppid":1,"path":"/tmp/dropper","args":["/tmp/dropper"],"uid":0,"gid":0,"code_signing":{"team_id":"EVILCORP1","signing_id":"com.evil.dropper","flags":0,"is_platform_binary":false}}`)},
+		{EventID: "open-ldp", HostID: hostA, TimestampNs: 12200, EventType: "open",
+			Payload: json.RawMessage(`{"pid":1200,"path":"/Library/LaunchDaemons/com.evil.persistence.plist","flags":1537}`)},
 	}
 	require.NoError(t, s.InsertEvents(ctx, events))
 	materialize(t, s, events)
@@ -103,18 +114,20 @@ func TestAllRulesWireUpAndFire(t *testing.T) {
 	engine.Register(&ShellFromOffice{})
 	engine.Register(&OsascriptNetworkExec{})
 	engine.Register(&CredentialKeychainDump{})
+	engine.Register(&PrivilegeLaunchdPlistWrite{})
 	require.NoError(t, engine.Evaluate(ctx, events))
 
 	// Each rule should have produced at least one alert. We query by rule_id rather than
 	// by count because some rules (suspicious_exec) can legitimately fire on multiple
 	// chains if our fixtures overlap — we only care that no rule was silently skipped.
 	wantRules := map[string]string{
-		"suspicious_exec":          "high",
-		"persistence_launchagent":  "high",
-		"dyld_insert":              "high",
-		"shell_from_office":        "high",
-		"osascript_network_exec":   "critical",
-		"credential_keychain_dump": "high",
+		"suspicious_exec":               "high",
+		"persistence_launchagent":       "high",
+		"dyld_insert":                   "high",
+		"shell_from_office":             "high",
+		"osascript_network_exec":        "critical",
+		"credential_keychain_dump":      "high",
+		"privilege_launchd_plist_write": "high",
 	}
 
 	alerts, err := s.ListAlerts(ctx, store.AlertFilter{})

--- a/server/detection/rules/fixtures/privilege_launchd_plist_write/negative_nested_subdir.json
+++ b/server/detection/rules/fixtures/privilege_launchd_plist_write/negative_nested_subdir.json
@@ -1,0 +1,42 @@
+{
+  "events": [
+    {
+      "event_id": "ldp-nest-fork",
+      "host_id": "fixture-host",
+      "timestamp_ns": 6000,
+      "event_type": "fork",
+      "payload": {"child_pid": 9500, "parent_pid": 1}
+    },
+    {
+      "event_id": "ldp-nest-exec",
+      "host_id": "fixture-host",
+      "timestamp_ns": 6100,
+      "event_type": "exec",
+      "payload": {
+        "pid": 9500,
+        "ppid": 1,
+        "path": "/tmp/dropper",
+        "args": ["/tmp/dropper"],
+        "uid": 0,
+        "gid": 0,
+        "code_signing": {
+          "team_id": "EVILCORP1",
+          "signing_id": "com.evil.dropper",
+          "flags": 0,
+          "is_platform_binary": false
+        }
+      }
+    },
+    {
+      "event_id": "ldp-nest-open",
+      "host_id": "fixture-host",
+      "timestamp_ns": 6200,
+      "event_type": "open",
+      "payload": {
+        "pid": 9500,
+        "path": "/Library/LaunchDaemons/staging/com.evil.deferred.plist",
+        "flags": 1537
+      }
+    }
+  ]
+}

--- a/server/detection/rules/fixtures/privilege_launchd_plist_write/negative_open_without_process.json
+++ b/server/detection/rules/fixtures/privilege_launchd_plist_write/negative_open_without_process.json
@@ -1,0 +1,15 @@
+{
+  "events": [
+    {
+      "event_id": "ldp-orphan-open",
+      "host_id": "fixture-host",
+      "timestamp_ns": 8000,
+      "event_type": "open",
+      "payload": {
+        "pid": 9700,
+        "path": "/Library/LaunchDaemons/com.race.persistence.plist",
+        "flags": 1537
+      }
+    }
+  ]
+}

--- a/server/detection/rules/fixtures/privilege_launchd_plist_write/negative_platform_binary_writer.json
+++ b/server/detection/rules/fixtures/privilege_launchd_plist_write/negative_platform_binary_writer.json
@@ -1,0 +1,42 @@
+{
+  "events": [
+    {
+      "event_id": "ldp-pb-fork",
+      "host_id": "fixture-host",
+      "timestamp_ns": 4000,
+      "event_type": "fork",
+      "payload": {"child_pid": 9300, "parent_pid": 1}
+    },
+    {
+      "event_id": "ldp-pb-exec",
+      "host_id": "fixture-host",
+      "timestamp_ns": 4100,
+      "event_type": "exec",
+      "payload": {
+        "pid": 9300,
+        "ppid": 1,
+        "path": "/usr/libexec/installd",
+        "args": ["installd"],
+        "uid": 0,
+        "gid": 0,
+        "code_signing": {
+          "team_id": "",
+          "signing_id": "com.apple.installd",
+          "flags": 0,
+          "is_platform_binary": true
+        }
+      }
+    },
+    {
+      "event_id": "ldp-pb-open",
+      "host_id": "fixture-host",
+      "timestamp_ns": 4200,
+      "event_type": "open",
+      "payload": {
+        "pid": 9300,
+        "path": "/Library/LaunchDaemons/com.apple.audio.coreaudiod.plist",
+        "flags": 1537
+      }
+    }
+  ]
+}

--- a/server/detection/rules/fixtures/privilege_launchd_plist_write/negative_read_only.json
+++ b/server/detection/rules/fixtures/privilege_launchd_plist_write/negative_read_only.json
@@ -1,0 +1,42 @@
+{
+  "events": [
+    {
+      "event_id": "ldp-ro-fork",
+      "host_id": "fixture-host",
+      "timestamp_ns": 3000,
+      "event_type": "fork",
+      "payload": {"child_pid": 9200, "parent_pid": 1}
+    },
+    {
+      "event_id": "ldp-ro-exec",
+      "host_id": "fixture-host",
+      "timestamp_ns": 3100,
+      "event_type": "exec",
+      "payload": {
+        "pid": 9200,
+        "ppid": 1,
+        "path": "/usr/bin/plutil",
+        "args": ["plutil", "-p", "/Library/LaunchDaemons/com.apple.example.plist"],
+        "uid": 501,
+        "gid": 20,
+        "code_signing": {
+          "team_id": "",
+          "signing_id": "com.apple.plutil",
+          "flags": 0,
+          "is_platform_binary": true
+        }
+      }
+    },
+    {
+      "event_id": "ldp-ro-open",
+      "host_id": "fixture-host",
+      "timestamp_ns": 3200,
+      "event_type": "open",
+      "payload": {
+        "pid": 9200,
+        "path": "/Library/LaunchDaemons/com.apple.example.plist",
+        "flags": 0
+      }
+    }
+  ]
+}

--- a/server/detection/rules/fixtures/privilege_launchd_plist_write/negative_team_id_allowlisted.json
+++ b/server/detection/rules/fixtures/privilege_launchd_plist_write/negative_team_id_allowlisted.json
@@ -1,0 +1,42 @@
+{
+  "events": [
+    {
+      "event_id": "ldp-allow-fork",
+      "host_id": "fixture-host",
+      "timestamp_ns": 5000,
+      "event_type": "fork",
+      "payload": {"child_pid": 9400, "parent_pid": 1}
+    },
+    {
+      "event_id": "ldp-allow-exec",
+      "host_id": "fixture-host",
+      "timestamp_ns": 5100,
+      "event_type": "exec",
+      "payload": {
+        "pid": 9400,
+        "ppid": 1,
+        "path": "/usr/local/munki/munki-managed-installer",
+        "args": ["munki-managed-installer"],
+        "uid": 0,
+        "gid": 0,
+        "code_signing": {
+          "team_id": "FIXTURE-ALLOW",
+          "signing_id": "com.googlecode.munki.managedsoftwareupdate",
+          "flags": 0,
+          "is_platform_binary": false
+        }
+      }
+    },
+    {
+      "event_id": "ldp-allow-open",
+      "host_id": "fixture-host",
+      "timestamp_ns": 5200,
+      "event_type": "open",
+      "payload": {
+        "pid": 9400,
+        "path": "/Library/LaunchDaemons/com.example.managed.plist",
+        "flags": 1537
+      }
+    }
+  ]
+}

--- a/server/detection/rules/fixtures/privilege_launchd_plist_write/positive_o_wronly.json
+++ b/server/detection/rules/fixtures/privilege_launchd_plist_write/positive_o_wronly.json
@@ -1,0 +1,50 @@
+{
+  "events": [
+    {
+      "event_id": "ldp-fork",
+      "host_id": "fixture-host",
+      "timestamp_ns": 1000,
+      "event_type": "fork",
+      "payload": {"child_pid": 9001, "parent_pid": 1}
+    },
+    {
+      "event_id": "ldp-exec",
+      "host_id": "fixture-host",
+      "timestamp_ns": 1100,
+      "event_type": "exec",
+      "payload": {
+        "pid": 9001,
+        "ppid": 1,
+        "path": "/tmp/dropper",
+        "args": ["/tmp/dropper"],
+        "uid": 0,
+        "gid": 0,
+        "code_signing": {
+          "team_id": "EVILCORP1",
+          "signing_id": "com.evil.dropper",
+          "flags": 0,
+          "is_platform_binary": false
+        }
+      }
+    },
+    {
+      "event_id": "ldp-open",
+      "host_id": "fixture-host",
+      "timestamp_ns": 1200,
+      "event_type": "open",
+      "payload": {
+        "pid": 9001,
+        "path": "/Library/LaunchDaemons/com.evil.persistence.plist",
+        "flags": 1
+      }
+    }
+  ],
+  "expected_findings": [
+    {
+      "rule_id": "privilege_launchd_plist_write",
+      "severity": "high",
+      "description_contains": "/Library/LaunchDaemons/com.evil.persistence.plist",
+      "event_ids": ["ldp-open"]
+    }
+  ]
+}

--- a/server/detection/rules/fixtures/privilege_launchd_plist_write/positive_o_wronly_create_trunc.json
+++ b/server/detection/rules/fixtures/privilege_launchd_plist_write/positive_o_wronly_create_trunc.json
@@ -1,0 +1,50 @@
+{
+  "events": [
+    {
+      "event_id": "ldp-create-fork",
+      "host_id": "fixture-host",
+      "timestamp_ns": 2000,
+      "event_type": "fork",
+      "payload": {"child_pid": 9100, "parent_pid": 1}
+    },
+    {
+      "event_id": "ldp-create-exec",
+      "host_id": "fixture-host",
+      "timestamp_ns": 2100,
+      "event_type": "exec",
+      "payload": {
+        "pid": 9100,
+        "ppid": 1,
+        "path": "/tmp/installer",
+        "args": ["/tmp/installer"],
+        "uid": 0,
+        "gid": 0,
+        "code_signing": {
+          "team_id": "BADVENDOR",
+          "signing_id": "com.bad.installer",
+          "flags": 0,
+          "is_platform_binary": false
+        }
+      }
+    },
+    {
+      "event_id": "ldp-create-open",
+      "host_id": "fixture-host",
+      "timestamp_ns": 2200,
+      "event_type": "open",
+      "payload": {
+        "pid": 9100,
+        "path": "/Library/LaunchDaemons/com.bad.daemon.plist",
+        "flags": 1537
+      }
+    }
+  ],
+  "expected_findings": [
+    {
+      "rule_id": "privilege_launchd_plist_write",
+      "severity": "high",
+      "description_contains": "/Library/LaunchDaemons/com.bad.daemon.plist",
+      "event_ids": ["ldp-create-open"]
+    }
+  ]
+}

--- a/server/detection/rules/fixtures/privilege_launchd_plist_write/positive_unsigned_writer.json
+++ b/server/detection/rules/fixtures/privilege_launchd_plist_write/positive_unsigned_writer.json
@@ -1,0 +1,44 @@
+{
+  "events": [
+    {
+      "event_id": "ldp-uns-fork",
+      "host_id": "fixture-host",
+      "timestamp_ns": 7000,
+      "event_type": "fork",
+      "payload": {"child_pid": 9600, "parent_pid": 1}
+    },
+    {
+      "event_id": "ldp-uns-exec",
+      "host_id": "fixture-host",
+      "timestamp_ns": 7100,
+      "event_type": "exec",
+      "payload": {
+        "pid": 9600,
+        "ppid": 1,
+        "path": "/tmp/raw_dropper",
+        "args": ["/tmp/raw_dropper"],
+        "uid": 0,
+        "gid": 0
+      }
+    },
+    {
+      "event_id": "ldp-uns-open",
+      "host_id": "fixture-host",
+      "timestamp_ns": 7200,
+      "event_type": "open",
+      "payload": {
+        "pid": 9600,
+        "path": "/Library/LaunchDaemons/com.unsigned.persistence.plist",
+        "flags": 1537
+      }
+    }
+  ],
+  "expected_findings": [
+    {
+      "rule_id": "privilege_launchd_plist_write",
+      "severity": "high",
+      "description_contains": "/Library/LaunchDaemons/com.unsigned.persistence.plist",
+      "event_ids": ["ldp-uns-open"]
+    }
+  ]
+}

--- a/server/detection/rules/privilege_launchd_plist_write.go
+++ b/server/detection/rules/privilege_launchd_plist_write.go
@@ -1,0 +1,168 @@
+package rules
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"regexp"
+
+	"github.com/fleetdm/edr/server/detection"
+	"github.com/fleetdm/edr/server/store"
+)
+
+// PrivilegeLaunchdPlistWrite fires on a write-mode `open(2)` against any
+// `*.plist` directly under `/Library/LaunchDaemons/`. That directory is
+// the canonical drop site for system-domain LaunchDaemons (T1543.004) —
+// once a plist lands there, the next `launchctl bootstrap system/<name>`
+// (or a reboot) gives the attacker root-running persistence.
+//
+// The rule is paired with `persistence_launchagent` (T1543.001), which
+// catches the activation step for user-domain LaunchAgents via
+// `launchctl load`. We deliberately catch this one at the file-write
+// step rather than the activation step because LaunchDaemon activation
+// is often deferred to reboot; the drop is the moment we want to surface.
+//
+// To stay high-precision we skip writers Apple itself signs as platform
+// binaries (installd, system_installd, sysadminctl, package install
+// post-flight scripts run as root, etc.) — those are the legitimate
+// path for shipping a daemon. Operators with a non-Apple MDM agent that
+// writes here (Munki, JumpCloud, Kandji's own daemon) can allowlist
+// the agent's team ID via EDR_LAUNCHDAEMON_TEAMID_ALLOWLIST.
+//
+// Known limitations, documented for the operator runbook:
+//   - Atomic writes via temp-file + rename: ESF NOTIFY_OPEN sees the
+//     temp file, not the destination, so the rule misses these. We
+//     don't subscribe to NOTIFY_RENAME today; tracked for Phase 8.
+//   - Drops via Apple platform binaries (e.g. attacker uses `sudo cp`
+//     where `cp` is a platform binary): skipped here, but the parent
+//     shell's exec is captured by suspicious_exec / process tree.
+type PrivilegeLaunchdPlistWrite struct {
+	// AllowedTeamIDs is the set of code-signing team IDs whose writes
+	// to /Library/LaunchDaemons should be silently accepted. Keep it
+	// small — every entry is a tenant-trusted vendor.
+	AllowedTeamIDs map[string]struct{}
+}
+
+func (r *PrivilegeLaunchdPlistWrite) ID() string { return "privilege_launchd_plist_write" }
+
+// Techniques returns the MITRE ATT&CK IDs this rule covers — T1543.004
+// (Boot or Logon Autostart Execution → Launch Daemon).
+func (r *PrivilegeLaunchdPlistWrite) Techniques() []string { return []string{"T1543.004"} }
+
+// launchDaemonPath matches a plist directly under /Library/LaunchDaemons.
+// The trailing `[^/]+` excludes nested paths (e.g.
+// /Library/LaunchDaemons/foo/bar.plist isn't a real LaunchDaemon location)
+// so the rule stays focused on the actual drop site.
+var launchDaemonPath = regexp.MustCompile(`^/Library/LaunchDaemons/[^/]+\.plist$`)
+
+// Bits 0 and 1 of the open(2) flags hold the access mode: O_RDONLY=0,
+// O_WRONLY=1, O_RDWR=2. Anything non-zero in those two bits means the
+// file descriptor can be written. This matches the kernel's interpretation
+// regardless of whether higher bits (O_CREAT, O_TRUNC, O_APPEND, ...) are
+// set, so a `cp -c` (which uses O_WRONLY|O_CREAT|O_TRUNC = 0x601 on
+// Darwin) and a plain `cat > foo.plist` (O_WRONLY|O_CREAT|O_TRUNC) both
+// trip the check.
+const openAccessModeMask = 0x3
+
+type openPayload struct {
+	PID   int    `json:"pid"`
+	Path  string `json:"path"`
+	Flags int    `json:"flags"`
+}
+
+// codeSigningJSON mirrors the extension's CodeSigning struct on the wire.
+// We only consume team_id + is_platform_binary; signing_id and flags
+// stay on the row but the rule doesn't read them.
+type codeSigningJSON struct {
+	TeamID           string `json:"team_id"`
+	IsPlatformBinary bool   `json:"is_platform_binary"`
+}
+
+func (r *PrivilegeLaunchdPlistWrite) Evaluate(
+	ctx context.Context, events []store.Event, s *store.Store,
+) ([]detection.Finding, error) {
+	var findings []detection.Finding
+	for _, evt := range events {
+		f, err := r.evalEvent(ctx, evt, s)
+		if err != nil {
+			return nil, err
+		}
+		if f != nil {
+			findings = append(findings, *f)
+		}
+	}
+	return findings, nil
+}
+
+func (r *PrivilegeLaunchdPlistWrite) evalEvent(
+	ctx context.Context, evt store.Event, s *store.Store,
+) (*detection.Finding, error) {
+	if evt.EventType != "open" {
+		return nil, nil
+	}
+	var p openPayload
+	if err := json.Unmarshal(evt.Payload, &p); err != nil {
+		// Malformed open events are noise from a misbehaving extension
+		// build, not a detection signal. Drop and move on.
+		return nil, nil
+	}
+	if !launchDaemonPath.MatchString(p.Path) {
+		return nil, nil
+	}
+	if p.Flags&openAccessModeMask == 0 {
+		// Read-only open. Tools like `plutil -p` enumerate plists
+		// constantly; firing on those would bury operators in noise.
+		return nil, nil
+	}
+
+	proc, err := s.GetProcessByPID(ctx, evt.HostID, p.PID, evt.TimestampNs)
+	if err != nil {
+		return nil, fmt.Errorf("get process pid %d: %w", p.PID, err)
+	}
+	if proc == nil {
+		// Defensive: the open event landed before the writer's exec
+		// row materialised. Same race as credential_keychain_dump; the
+		// processor loop normally lands the row first, so this is a
+		// guard, not a regular drop path.
+		return nil, nil
+	}
+	if r.allowed(proc.CodeSigning) {
+		return nil, nil
+	}
+
+	return &detection.Finding{
+		HostID:   evt.HostID,
+		RuleID:   r.ID(),
+		Severity: detection.SeverityHigh,
+		Title:    "LaunchDaemon plist drop",
+		Description: fmt.Sprintf(
+			"%s wrote %s — non-Apple persistence drop in system LaunchDaemons (MITRE T1543.004)",
+			proc.Path, p.Path,
+		),
+		ProcessID: proc.ID,
+		EventIDs:  []string{evt.EventID},
+	}, nil
+}
+
+// allowed returns true when the writing process's code-signing identity
+// is on the operator's allowlist or is a platform binary. Both branches
+// short-circuit the finding. NullRawJSON is a json.RawMessage alias, so
+// length==0 means "no code_signing on the process row" — typically an
+// unsigned binary, which we treat as in-scope (let the finding fire).
+func (r *PrivilegeLaunchdPlistWrite) allowed(raw store.NullRawJSON) bool {
+	if len(raw) == 0 {
+		return false
+	}
+	var cs codeSigningJSON
+	if err := json.Unmarshal(raw, &cs); err != nil {
+		return false
+	}
+	if cs.IsPlatformBinary {
+		return true
+	}
+	if r.AllowedTeamIDs == nil {
+		return false
+	}
+	_, ok := r.AllowedTeamIDs[cs.TeamID]
+	return ok
+}

--- a/server/detection/rules/privilege_launchd_plist_write.go
+++ b/server/detection/rules/privilege_launchd_plist_write.go
@@ -1,6 +1,7 @@
 package rules
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -55,6 +56,18 @@ func (r *PrivilegeLaunchdPlistWrite) Techniques() []string { return []string{"T1
 // so the rule stays focused on the actual drop site.
 var launchDaemonPath = regexp.MustCompile(`^/Library/LaunchDaemons/[^/]+\.plist$`)
 
+// launchDaemonsBytes is the substring fast-path filter applied to the raw
+// JSON payload before json.Unmarshal. ESF NOTIFY_OPEN fires on every file
+// open in the kernel — thousands per second on a busy host — and well
+// over 99.99% of those opens never touch /Library/LaunchDaemons. Skipping
+// the JSON decode for opens that obviously don't qualify cuts the rule's
+// CPU cost from "one unmarshal per open" to "one bytes.Contains per
+// open". The substring can over-match (e.g. an open whose `path` happens
+// to mention the directory name elsewhere in the JSON), but
+// launchDaemonPath.MatchString below tightens it to the canonical drop
+// site, so the gate is purely an optimisation, not a correctness check.
+var launchDaemonsBytes = []byte("/Library/LaunchDaemons/")
+
 // Bits 0 and 1 of the open(2) flags hold the access mode: O_RDONLY=0,
 // O_WRONLY=1, O_RDWR=2. Anything non-zero in those two bits means the
 // file descriptor can be written. This matches the kernel's interpretation
@@ -98,6 +111,12 @@ func (r *PrivilegeLaunchdPlistWrite) evalEvent(
 	ctx context.Context, evt store.Event, s *store.Store,
 ) (*detection.Finding, error) {
 	if evt.EventType != "open" {
+		return nil, nil
+	}
+	// Substring fast-path: skip the JSON decode for the overwhelming
+	// majority of opens that don't touch /Library/LaunchDaemons at all.
+	// See launchDaemonsBytes for the rationale.
+	if !bytes.Contains(evt.Payload, launchDaemonsBytes) {
 		return nil, nil
 	}
 	var p openPayload
@@ -146,11 +165,13 @@ func (r *PrivilegeLaunchdPlistWrite) evalEvent(
 
 // allowed returns true when the writing process's code-signing identity
 // is on the operator's allowlist or is a platform binary. Both branches
-// short-circuit the finding. NullRawJSON is a json.RawMessage alias, so
-// length==0 means "no code_signing on the process row" — typically an
-// unsigned binary, which we treat as in-scope (let the finding fire).
+// short-circuit the finding. NullRawJSON is a json.RawMessage alias;
+// both an empty slice (DB NULL → store.NullRawJSON.Scan zeros it) and
+// the literal JSON value `null` (4 bytes) mean "no code_signing on the
+// process row" — typically an unsigned binary, which we treat as
+// in-scope so the finding fires.
 func (r *PrivilegeLaunchdPlistWrite) allowed(raw store.NullRawJSON) bool {
-	if len(raw) == 0 {
+	if len(raw) == 0 || bytes.Equal(raw, []byte("null")) {
 		return false
 	}
 	var cs codeSigningJSON

--- a/server/detection/rules/privilege_launchd_plist_write_test.go
+++ b/server/detection/rules/privilege_launchd_plist_write_test.go
@@ -1,0 +1,29 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/fleetdm/edr/server/detection/testharness"
+)
+
+// TestPrivilegeLaunchdPlistWrite_Fixtures runs every fixture case under
+// fixtures/privilege_launchd_plist_write/ as its own sub-test. Add a new
+// case by dropping a *.json file in that directory — no Go edits needed.
+func TestPrivilegeLaunchdPlistWrite_Fixtures(t *testing.T) {
+	r := &PrivilegeLaunchdPlistWrite{
+		AllowedTeamIDs: map[string]struct{}{
+			// Synthetic team ID used by the allowlist fixture.
+			"FIXTURE-ALLOW": {},
+		},
+	}
+	testharness.Replay(t, r, "fixtures/privilege_launchd_plist_write")
+}
+
+// TestPrivilegeLaunchdPlistWrite_TechniquesMapping pins the MITRE ATT&CK
+// mapping the rule reports.
+func TestPrivilegeLaunchdPlistWrite_TechniquesMapping(t *testing.T) {
+	r := &PrivilegeLaunchdPlistWrite{}
+	assert.Equal(t, []string{"T1543.004"}, r.Techniques())
+}

--- a/server/detection/rules/privilege_launchd_plist_write_test.go
+++ b/server/detection/rules/privilege_launchd_plist_write_test.go
@@ -1,11 +1,16 @@
 package rules
 
 import (
+	"encoding/json"
+	"log/slog"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/fleetdm/edr/server/detection/testharness"
+	"github.com/fleetdm/edr/server/graph"
+	"github.com/fleetdm/edr/server/store"
 )
 
 // TestPrivilegeLaunchdPlistWrite_Fixtures runs every fixture case under
@@ -26,4 +31,105 @@ func TestPrivilegeLaunchdPlistWrite_Fixtures(t *testing.T) {
 func TestPrivilegeLaunchdPlistWrite_TechniquesMapping(t *testing.T) {
 	r := &PrivilegeLaunchdPlistWrite{}
 	assert.Equal(t, []string{"T1543.004"}, r.Techniques())
+}
+
+// TestPrivilegeLaunchdPlistWrite_AllowedEdgeCases pins the contract of
+// the allowed() helper for the small surface area of code-signing values
+// the engine hands it. Exercising these directly (rather than via
+// fixtures) covers the JSON-error and "null literal" branches without
+// having to fabricate a process row whose code_signing column carries
+// malformed bytes — MySQL's JSON column type rejects those at insert.
+func TestPrivilegeLaunchdPlistWrite_AllowedEdgeCases(t *testing.T) {
+	r := &PrivilegeLaunchdPlistWrite{
+		AllowedTeamIDs: map[string]struct{}{"VENDORALLOW": {}},
+	}
+
+	cases := []struct {
+		name string
+		raw  store.NullRawJSON
+		want bool
+	}{
+		{"empty slice (DB NULL)", nil, false},
+		{"json null literal", store.NullRawJSON("null"), false},
+		{"malformed JSON", store.NullRawJSON("{not json"), false},
+		{
+			"platform binary",
+			store.NullRawJSON(`{"team_id":"","signing_id":"com.apple.installd","flags":0,"is_platform_binary":true}`),
+			true,
+		},
+		{
+			"allowlisted team",
+			store.NullRawJSON(`{"team_id":"VENDORALLOW","signing_id":"x","flags":0,"is_platform_binary":false}`),
+			true,
+		},
+		{
+			"unknown team, no allowlist hit",
+			store.NullRawJSON(`{"team_id":"EVILCORP1","signing_id":"x","flags":0,"is_platform_binary":false}`),
+			false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, r.allowed(tc.raw))
+		})
+	}
+
+	// AllowedTeamIDs=nil branch: any non-platform writer falls through to
+	// the "not allowed" return. Separated from the table above because
+	// it's the rule's default-construction shape.
+	rNoList := &PrivilegeLaunchdPlistWrite{}
+	assert.False(t, rNoList.allowed(
+		store.NullRawJSON(`{"team_id":"X","is_platform_binary":false}`),
+	))
+}
+
+// TestPrivilegeLaunchdPlistWrite_MalformedPayload exercises the
+// json.Unmarshal failure path inside evalEvent. The fast-path
+// bytes.Contains gate lets the malformed payload through (the magic
+// substring is present), then unmarshal fails and the rule drops the
+// event silently. We bypass the fixture harness because MySQL's JSON
+// column rejects malformed payloads at InsertEvents — this branch only
+// fires in-memory if a downstream batcher hands us a partial buffer.
+func TestPrivilegeLaunchdPlistWrite_MalformedPayload(t *testing.T) {
+	s := store.OpenTestStore(t)
+	ctx := t.Context()
+	r := &PrivilegeLaunchdPlistWrite{}
+
+	evt := store.Event{
+		EventID:     "ldp-malformed",
+		HostID:      "fixture-host",
+		TimestampNs: 1,
+		EventType:   "open",
+		// Substring matches → passes the fast-path; truncated → fails unmarshal.
+		Payload: json.RawMessage(`{"path":"/Library/LaunchDaemons/x.plist", "flags":`),
+	}
+	findings, err := r.Evaluate(ctx, []store.Event{evt}, s)
+	require.NoError(t, err)
+	assert.Empty(t, findings, "malformed payload must be dropped silently")
+}
+
+// TestPrivilegeLaunchdPlistWrite_OpenRaceWithoutProcess covers the
+// proc==nil race guard via a Go-level test that goes through the live
+// store. The fixture negative_open_without_process.json exercises the
+// same branch via Replay; this pins the behaviour as a regular contract
+// even if the fixture is later renamed or moved.
+func TestPrivilegeLaunchdPlistWrite_OpenRaceWithoutProcess(t *testing.T) {
+	s := store.OpenTestStore(t)
+	ctx := t.Context()
+	r := &PrivilegeLaunchdPlistWrite{}
+
+	evt := store.Event{
+		EventID:     "ldp-race",
+		HostID:      "fixture-host",
+		TimestampNs: 1,
+		EventType:   "open",
+		Payload:     json.RawMessage(`{"pid":99999,"path":"/Library/LaunchDaemons/com.race.plist","flags":1}`),
+	}
+	require.NoError(t, s.InsertEvents(ctx, []store.Event{evt}))
+	// Deliberately no fork/exec, so ProcessBatch produces nothing.
+	require.NoError(t, graph.NewBuilder(s, slog.Default()).ProcessBatch(ctx, []store.Event{evt}))
+
+	findings, err := r.Evaluate(ctx, []store.Event{evt}, s)
+	require.NoError(t, err)
+	assert.Empty(t, findings, "race against process materialisation must skip silently")
 }


### PR DESCRIPTION
Pairs with persistence_launchagent (T1543.001) by catching the
system-domain side of LaunchDaemon persistence (T1543.004). Fires on
write-mode open() against any *.plist directly under
/Library/LaunchDaemons/, skipping Apple platform binaries (installd,
system_installd, sysadminctl) and operator-allowlisted MDM agents.

Why catch the file write rather than the launchctl bootstrap activation:
LaunchDaemon activation is often deferred to reboot; the file drop is
the moment we want to surface to operators. The activation-side
catch is what persistence_launchagent already covers for user agents,
and adding a system-domain twin rule there is straightforward later.

* Rule + 7 fixture cases (3 positive: O_WRONLY, O_WRONLY|O_CREAT|O_TRUNC,
  unsigned-writer; 4 negative: read-only, platform binary writer,
  team-ID allowlisted, nested subdirectory).
* EDR_LAUNCHDAEMON_TEAMID_ALLOWLIST env var lets operators whitelist
  legitimate non-Apple agents (Munki, Kandji, JumpCloud) without
  silencing the rule wholesale.
* Wires the rule into main.go's engine registration and into the
  all_rules_integration_test.go aggregate; the test now asserts
  privilege_launchd_plist_write fires alongside the other six rules
  on a single event batch.
* Docs updated (operations.md + install-server.md env table) so
  pilot operators can find the allowlist knob.

Known limitations documented in the rule godoc:
- Atomic writes via temp file + rename: ESF NOTIFY_OPEN sees the
  temp path, not /Library/LaunchDaemons/<name>.plist. Tracked for
  Phase 8 (NOTIFY_RENAME subscription).
- Writes mediated by a platform binary (e.g. attacker uses sudo cp):
  cp is platform-signed, so this rule skips. The parent shell's exec
  is captured by suspicious_exec / process tree.
