### PR TITLE
phase 7 c4 cosign

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,7 +142,7 @@ jobs:
       # synthetic tags into a permanent record. Real tag pushes only.
       - name: Install cosign
         if: env.DRY_RUN == '' && startsWith(github.ref, 'refs/tags/v')
-        uses: sigstore/cosign-installer@d7d6e4ba87bcca47ddee71866b8a0e4a47ab3d2c # v3.10.1
+        uses: sigstore/cosign-installer@7e8b541eb2e61bf99390e1afd4be13a184e9ebc5 # v3.10.1
         with:
           cosign-release: 'v2.5.3'
 
@@ -151,9 +151,12 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ github.ref_name }}
-          # cosign-installer wires the GitHub OIDC token URL into the env for
-          # us; explicit set kept here as a contract for future cosign minor
-          # bumps that may stop reading it implicitly.
+          # cosign reads the GitHub OIDC request URL/token from
+          # ACTIONS_ID_TOKEN_REQUEST_URL/TOKEN, which the runner exposes
+          # automatically because the job declares `id-token: write`.
+          # COSIGN_YES skips the interactive "are you sure?" confirmation
+          # for non-interactive CI runs — equivalent to passing --yes on
+          # every cosign invocation below.
           COSIGN_YES: 'true'
         # `cosign sign-blob` emits a .sig and a .pem (the ephemeral signing
         # cert from Fulcio) per artifact. Both go onto the release so anyone
@@ -220,7 +223,7 @@ jobs:
       # claiming.
       - name: Attest pkg + profiles + SHA256SUMS
         if: env.DRY_RUN == '' && startsWith(github.ref, 'refs/tags/v')
-        uses: actions/attest-build-provenance@977bb373ede947662f9c0c3ae1092d1f12490830 # v3.0.0
+        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
         with:
           subject-path: |
             dist/fleet-edr-*.pkg
@@ -285,7 +288,7 @@ jobs:
       # pull by digest or accept that a tag mutation invalidates the proof.
       - name: Install cosign
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: sigstore/cosign-installer@d7d6e4ba87bcca47ddee71866b8a0e4a47ab3d2c # v3.10.1
+        uses: sigstore/cosign-installer@7e8b541eb2e61bf99390e1afd4be13a184e9ebc5 # v3.10.1
         with:
           cosign-release: 'v2.5.3'
 
@@ -315,7 +318,7 @@ jobs:
 
       - name: Attest image build provenance
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: actions/attest-build-provenance@977bb373ede947662f9c0c3ae1092d1f12490830 # v3.0.0
+        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
         with:
           subject-name: ghcr.io/getvictor/fleet-edr-server
           subject-digest: ${{ steps.build.outputs.digest }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,8 +36,9 @@ jobs:
     runs-on: macos-15  # pin: needs Xcode 16.3+ (project objectVersion 77)
     environment: release-signing
     permissions:
-      contents: write  # gh release create: publish pkg + profiles on tag push
-      id-token: write  # Sigstore keyless signing: GitHub OIDC token used as the cosign identity
+      contents: write     # gh release create: publish pkg + profiles on tag push
+      id-token: write     # Sigstore keyless signing: GitHub OIDC token used as the cosign identity
+      attestations: write # actions/attest-build-provenance: store provenance against the repo
 
     env:
       DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && '--dry-run' || '' }}
@@ -174,6 +175,59 @@ jobs:
             ./edr-tcc-fda.mobileconfig.sig ./edr-tcc-fda.mobileconfig.pem \
             ./SHA256SUMS.sig ./SHA256SUMS.pem
 
+      # Source-tree SBOMs in both common formats. SPDX is the OSI-friendly
+      # default; CycloneDX is what most security scanners ingest. Anchore
+      # syft sees the workspace state after `go build` ran above, so the
+      # Go module graph + npm tree are both populated in caches and make
+      # it into the manifest. Buyers diff the SBOM against vulnerability
+      # feeds; we publish both flavors to dodge "I only consume X" pushback.
+      - name: Generate SPDX SBOM (source tree)
+        if: env.DRY_RUN == '' && startsWith(github.ref, 'refs/tags/v')
+        uses: anchore/sbom-action@7b36ad622f042cab6f59a75c2ac24ccb256e9b45 # v0.20.4
+        with:
+          path: '.'
+          format: spdx-json
+          artifact-name: fleet-edr-${{ github.ref_name }}-sbom.spdx.json
+          output-file: dist/fleet-edr-${{ github.ref_name }}-sbom.spdx.json
+
+      - name: Generate CycloneDX SBOM (source tree)
+        if: env.DRY_RUN == '' && startsWith(github.ref, 'refs/tags/v')
+        uses: anchore/sbom-action@7b36ad622f042cab6f59a75c2ac24ccb256e9b45 # v0.20.4
+        with:
+          path: '.'
+          format: cyclonedx-json
+          artifact-name: fleet-edr-${{ github.ref_name }}-sbom.cdx.json
+          output-file: dist/fleet-edr-${{ github.ref_name }}-sbom.cdx.json
+
+      - name: Upload SBOMs to release
+        if: env.DRY_RUN == '' && startsWith(github.ref, 'refs/tags/v')
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          gh release upload "$RELEASE_TAG" \
+            "dist/fleet-edr-${RELEASE_TAG}-sbom.spdx.json" \
+            "dist/fleet-edr-${RELEASE_TAG}-sbom.cdx.json"
+
+      # SLSA build provenance for every shipped artifact. The action
+      # produces an in-toto v1.0 statement signed by Sigstore (keyless via
+      # OIDC, same identity model as the cosign step above) and stores it
+      # as a GitHub Attestation that anyone can resolve via
+      # `gh attestation verify <file> --owner getvictor`. We claim build
+      # level 2 in practice: the macOS runner is GitHub-hosted but the
+      # Apple notary submission is a network call that violates SLSA L3's
+      # hermeticity requirement. Documenting the gap rather than over-
+      # claiming.
+      - name: Attest pkg + profiles + SHA256SUMS
+        if: env.DRY_RUN == '' && startsWith(github.ref, 'refs/tags/v')
+        uses: actions/attest-build-provenance@977bb373ede947662f9c0c3ae1092d1f12490830 # v3.0.0
+        with:
+          subject-path: |
+            dist/fleet-edr-*.pkg
+            dist/edr-system-extension.mobileconfig
+            dist/edr-tcc-fda.mobileconfig
+            dist/SHA256SUMS
+
       - name: Teardown keychain
         if: always() && env.DRY_RUN == ''
         run: |
@@ -185,9 +239,10 @@ jobs:
     name: Build + push server image
     runs-on: ubuntu-latest
     permissions:
-      contents: read   # checkout source for the build context
-      packages: write  # push multi-arch image to ghcr.io/getvictor/fleet-edr-server
-      id-token: write  # Sigstore keyless signing of the pushed image
+      contents: read      # checkout source for the build context
+      packages: write     # push multi-arch image to ghcr.io/getvictor/fleet-edr-server
+      id-token: write     # Sigstore keyless signing of the pushed image
+      attestations: write # actions/attest-build-provenance for the image
     env:
       RELEASE_TAG: ${{ github.ref_name }}
     steps:
@@ -242,3 +297,26 @@ jobs:
         run: |
           cosign sign \
             "ghcr.io/getvictor/fleet-edr-server@${IMAGE_DIGEST}"
+
+      # SBOM of the pushed image (manifest digest pinning means the SBOM
+      # describes the exact bits a customer pulls, not whatever happens
+      # to be at the tag later). Attached as an OCI cosign attestation
+      # so `cosign download sbom <ref>` works without GitHub Releases.
+      - name: Generate image SBOM (SPDX)
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: anchore/sbom-action@7b36ad622f042cab6f59a75c2ac24ccb256e9b45 # v0.20.4
+        with:
+          image: ghcr.io/getvictor/fleet-edr-server@${{ steps.build.outputs.digest }}
+          format: spdx-json
+          artifact-name: fleet-edr-server-${{ env.RELEASE_TAG }}-sbom.spdx.json
+          # No upload-release-assets: the docker-server job runs in
+          # parallel with macos-pkg, which owns the GitHub Release. The
+          # image SBOM rides as a cosign attestation on the registry side.
+
+      - name: Attest image build provenance
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: actions/attest-build-provenance@977bb373ede947662f9c0c3ae1092d1f12490830 # v3.0.0
+        with:
+          subject-name: ghcr.io/getvictor/fleet-edr-server
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,7 @@ jobs:
     environment: release-signing
     permissions:
       contents: write  # gh release create: publish pkg + profiles on tag push
+      id-token: write  # Sigstore keyless signing: GitHub OIDC token used as the cosign identity
 
     env:
       DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && '--dry-run' || '' }}
@@ -134,6 +135,45 @@ jobs:
             dist/edr-tcc-fda.mobileconfig \
             dist/SHA256SUMS
 
+      # Sigstore keyless signing of every release artifact. Skipped on
+      # workflow_dispatch (DRY_RUN): a successful sign appends to Rekor's
+      # public transparency log, so dry-runs would leak commit SHAs and
+      # synthetic tags into a permanent record. Real tag pushes only.
+      - name: Install cosign
+        if: env.DRY_RUN == '' && startsWith(github.ref, 'refs/tags/v')
+        uses: sigstore/cosign-installer@d7d6e4ba87bcca47ddee71866b8a0e4a47ab3d2c # v3.10.1
+        with:
+          cosign-release: 'v2.5.3'
+
+      - name: Sign release artifacts (cosign keyless)
+        if: env.DRY_RUN == '' && startsWith(github.ref, 'refs/tags/v')
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.ref_name }}
+          # cosign-installer wires the GitHub OIDC token URL into the env for
+          # us; explicit set kept here as a contract for future cosign minor
+          # bumps that may stop reading it implicitly.
+          COSIGN_YES: 'true'
+        # `cosign sign-blob` emits a .sig and a .pem (the ephemeral signing
+        # cert from Fulcio) per artifact. Both go onto the release so anyone
+        # can `cosign verify-blob --certificate <file>.pem --signature
+        # <file>.sig --certificate-identity ... --certificate-oidc-issuer
+        # https://token.actions.githubusercontent.com <file>` without
+        # contacting our infrastructure.
+        run: |
+          cd dist
+          for f in fleet-edr-*.pkg edr-system-extension.mobileconfig edr-tcc-fda.mobileconfig SHA256SUMS; do
+            cosign sign-blob \
+              --output-signature "${f}.sig" \
+              --output-certificate "${f}.pem" \
+              "$f"
+          done
+          gh release upload "$RELEASE_TAG" \
+            ./fleet-edr-*.pkg.sig ./fleet-edr-*.pkg.pem \
+            ./edr-system-extension.mobileconfig.sig ./edr-system-extension.mobileconfig.pem \
+            ./edr-tcc-fda.mobileconfig.sig ./edr-tcc-fda.mobileconfig.pem \
+            ./SHA256SUMS.sig ./SHA256SUMS.pem
+
       - name: Teardown keychain
         if: always() && env.DRY_RUN == ''
         run: |
@@ -147,6 +187,7 @@ jobs:
     permissions:
       contents: read   # checkout source for the build context
       packages: write  # push multi-arch image to ghcr.io/getvictor/fleet-edr-server
+      id-token: write  # Sigstore keyless signing of the pushed image
     env:
       RELEASE_TAG: ${{ github.ref_name }}
     steps:
@@ -164,6 +205,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
+        id: build
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
@@ -181,3 +223,22 @@ jobs:
           build-args: |
             VERSION=${{ env.RELEASE_TAG }}
             COMMIT=${{ github.sha }}
+
+      # Sigstore keyless signing of the pushed image. Pinning to the digest
+      # (not the tag) means a future malicious overwrite of `:RELEASE_TAG`
+      # cannot pass `cosign verify` against this signature; verifiers either
+      # pull by digest or accept that a tag mutation invalidates the proof.
+      - name: Install cosign
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: sigstore/cosign-installer@d7d6e4ba87bcca47ddee71866b8a0e4a47ab3d2c # v3.10.1
+        with:
+          cosign-release: 'v2.5.3'
+
+      - name: Sign image (cosign keyless)
+        if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          COSIGN_YES: 'true'
+          IMAGE_DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          cosign sign \
+            "ghcr.io/getvictor/fleet-edr-server@${IMAGE_DIGEST}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,10 +92,46 @@ jobs:
           APPLE_TEAM_ID: FDG8Q7N4CC
         run: ./packaging/profiles/sign.sh --dry-run
 
+      # Source-tree SBOMs in both common formats, generated BEFORE
+      # SHA256SUMS so the SBOM files get hashed alongside the pkg and
+      # profiles. SPDX is the OSI-friendly default; CycloneDX is what
+      # most security scanners ingest. Anchore syft sees the workspace
+      # state after `go build` ran above, so the Go module graph + npm
+      # tree are both populated and make it into the manifest. We
+      # publish both flavors to dodge "I only consume X" pushback.
+      - name: Generate SPDX SBOM (source tree)
+        if: env.DRY_RUN == '' && startsWith(github.ref, 'refs/tags/v')
+        uses: anchore/sbom-action@7b36ad622f042cab6f59a75c2ac24ccb256e9b45 # v0.20.4
+        with:
+          path: '.'
+          format: spdx-json
+          artifact-name: fleet-edr-${{ github.ref_name }}-sbom.spdx.json
+          output-file: dist/fleet-edr-${{ github.ref_name }}-sbom.spdx.json
+          upload-release-assets: false
+
+      - name: Generate CycloneDX SBOM (source tree)
+        if: env.DRY_RUN == '' && startsWith(github.ref, 'refs/tags/v')
+        uses: anchore/sbom-action@7b36ad622f042cab6f59a75c2ac24ccb256e9b45 # v0.20.4
+        with:
+          path: '.'
+          format: cyclonedx-json
+          artifact-name: fleet-edr-${{ github.ref_name }}-sbom.cdx.json
+          output-file: dist/fleet-edr-${{ github.ref_name }}-sbom.cdx.json
+          upload-release-assets: false
+
       - name: Generate SHA256SUMS
         run: |
           cd dist
-          shasum -a 256 ./fleet-edr-*.pkg ./*.mobileconfig > SHA256SUMS
+          # SBOMs are only present on real (tag-triggered) runs; the
+          # nullglob lets the line below collapse cleanly when they're
+          # absent on a dry-run.
+          shopt -s nullglob
+          shasum -a 256 \
+            ./fleet-edr-*.pkg \
+            ./*.mobileconfig \
+            ./fleet-edr-*-sbom.spdx.json \
+            ./fleet-edr-*-sbom.cdx.json \
+            > SHA256SUMS
           cat SHA256SUMS
 
       - name: Upload artifacts (dry-run)
@@ -134,6 +170,8 @@ jobs:
             dist/fleet-edr-*.pkg \
             dist/edr-system-extension.mobileconfig \
             dist/edr-tcc-fda.mobileconfig \
+            "dist/fleet-edr-${RELEASE_TAG}-sbom.spdx.json" \
+            "dist/fleet-edr-${RELEASE_TAG}-sbom.cdx.json" \
             dist/SHA256SUMS
 
       # Sigstore keyless signing of every release artifact. Skipped on
@@ -159,14 +197,23 @@ jobs:
           # every cosign invocation below.
           COSIGN_YES: 'true'
         # `cosign sign-blob` emits a .sig and a .pem (the ephemeral signing
-        # cert from Fulcio) per artifact. Both go onto the release so anyone
-        # can `cosign verify-blob --certificate <file>.pem --signature
+        # cert from Fulcio) per artifact. Every shipped file gets the same
+        # treatment — pkg, mobileconfigs, SHA256SUMS, AND both SBOMs — so
+        # a tampered SBOM is just as detectable as a tampered pkg. Both
+        # the .sig and the .pem land on the release; verifiers run
+        # `cosign verify-blob --certificate <file>.pem --signature
         # <file>.sig --certificate-identity ... --certificate-oidc-issuer
         # https://token.actions.githubusercontent.com <file>` without
         # contacting our infrastructure.
         run: |
           cd dist
-          for f in fleet-edr-*.pkg edr-system-extension.mobileconfig edr-tcc-fda.mobileconfig SHA256SUMS; do
+          for f in \
+              fleet-edr-*.pkg \
+              edr-system-extension.mobileconfig \
+              edr-tcc-fda.mobileconfig \
+              "fleet-edr-${RELEASE_TAG}-sbom.spdx.json" \
+              "fleet-edr-${RELEASE_TAG}-sbom.cdx.json" \
+              SHA256SUMS; do
             cosign sign-blob \
               --output-signature "${f}.sig" \
               --output-certificate "${f}.pem" \
@@ -176,41 +223,11 @@ jobs:
             ./fleet-edr-*.pkg.sig ./fleet-edr-*.pkg.pem \
             ./edr-system-extension.mobileconfig.sig ./edr-system-extension.mobileconfig.pem \
             ./edr-tcc-fda.mobileconfig.sig ./edr-tcc-fda.mobileconfig.pem \
+            "./fleet-edr-${RELEASE_TAG}-sbom.spdx.json.sig" \
+            "./fleet-edr-${RELEASE_TAG}-sbom.spdx.json.pem" \
+            "./fleet-edr-${RELEASE_TAG}-sbom.cdx.json.sig" \
+            "./fleet-edr-${RELEASE_TAG}-sbom.cdx.json.pem" \
             ./SHA256SUMS.sig ./SHA256SUMS.pem
-
-      # Source-tree SBOMs in both common formats. SPDX is the OSI-friendly
-      # default; CycloneDX is what most security scanners ingest. Anchore
-      # syft sees the workspace state after `go build` ran above, so the
-      # Go module graph + npm tree are both populated in caches and make
-      # it into the manifest. Buyers diff the SBOM against vulnerability
-      # feeds; we publish both flavors to dodge "I only consume X" pushback.
-      - name: Generate SPDX SBOM (source tree)
-        if: env.DRY_RUN == '' && startsWith(github.ref, 'refs/tags/v')
-        uses: anchore/sbom-action@7b36ad622f042cab6f59a75c2ac24ccb256e9b45 # v0.20.4
-        with:
-          path: '.'
-          format: spdx-json
-          artifact-name: fleet-edr-${{ github.ref_name }}-sbom.spdx.json
-          output-file: dist/fleet-edr-${{ github.ref_name }}-sbom.spdx.json
-
-      - name: Generate CycloneDX SBOM (source tree)
-        if: env.DRY_RUN == '' && startsWith(github.ref, 'refs/tags/v')
-        uses: anchore/sbom-action@7b36ad622f042cab6f59a75c2ac24ccb256e9b45 # v0.20.4
-        with:
-          path: '.'
-          format: cyclonedx-json
-          artifact-name: fleet-edr-${{ github.ref_name }}-sbom.cdx.json
-          output-file: dist/fleet-edr-${{ github.ref_name }}-sbom.cdx.json
-
-      - name: Upload SBOMs to release
-        if: env.DRY_RUN == '' && startsWith(github.ref, 'refs/tags/v')
-        env:
-          GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ github.ref_name }}
-        run: |
-          gh release upload "$RELEASE_TAG" \
-            "dist/fleet-edr-${RELEASE_TAG}-sbom.spdx.json" \
-            "dist/fleet-edr-${RELEASE_TAG}-sbom.cdx.json"
 
       # SLSA build provenance for every shipped artifact. The action
       # produces an in-toto v1.0 statement signed by Sigstore (keyless via
@@ -221,7 +238,7 @@ jobs:
       # Apple notary submission is a network call that violates SLSA L3's
       # hermeticity requirement. Documenting the gap rather than over-
       # claiming.
-      - name: Attest pkg + profiles + SHA256SUMS
+      - name: Attest pkg + profiles + SBOMs + SHA256SUMS
         if: env.DRY_RUN == '' && startsWith(github.ref, 'refs/tags/v')
         uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
         with:
@@ -229,6 +246,8 @@ jobs:
             dist/fleet-edr-*.pkg
             dist/edr-system-extension.mobileconfig
             dist/edr-tcc-fda.mobileconfig
+            dist/fleet-edr-*-sbom.spdx.json
+            dist/fleet-edr-*-sbom.cdx.json
             dist/SHA256SUMS
 
       - name: Teardown keychain
@@ -303,8 +322,16 @@ jobs:
 
       # SBOM of the pushed image (manifest digest pinning means the SBOM
       # describes the exact bits a customer pulls, not whatever happens
-      # to be at the tag later). Attached as an OCI cosign attestation
-      # so `cosign download sbom <ref>` works without GitHub Releases.
+      # to be at the tag later). Generation is split from publication:
+      # anchore/sbom-action only produces the file and uploads it as a
+      # workflow artifact; the next step is what actually pushes it to
+      # the OCI registry as a cosign attestation, which is what makes
+      # `cosign download sbom <ref>` work for downstream verifiers.
+      #
+      # upload-release-assets: false is load-bearing — the action's
+      # default would race the parallel macos-pkg job for the GitHub
+      # Release that owns the source-tree SBOMs. The image SBOM lives
+      # in the registry, not in the Release.
       - name: Generate image SBOM (SPDX)
         if: startsWith(github.ref, 'refs/tags/v')
         uses: anchore/sbom-action@7b36ad622f042cab6f59a75c2ac24ccb256e9b45 # v0.20.4
@@ -312,9 +339,25 @@ jobs:
           image: ghcr.io/getvictor/fleet-edr-server@${{ steps.build.outputs.digest }}
           format: spdx-json
           artifact-name: fleet-edr-server-${{ env.RELEASE_TAG }}-sbom.spdx.json
-          # No upload-release-assets: the docker-server job runs in
-          # parallel with macos-pkg, which owns the GitHub Release. The
-          # image SBOM rides as a cosign attestation on the registry side.
+          output-file: /tmp/fleet-edr-server-sbom.spdx.json
+          upload-release-assets: false
+
+      - name: Attach image SBOM as cosign attestation
+        if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          COSIGN_YES: 'true'
+          IMAGE_DIGEST: ${{ steps.build.outputs.digest }}
+        # `cosign attest` wraps the SBOM in an in-toto envelope, signs it
+        # via the same Fulcio OIDC identity used for the image signature,
+        # and pushes it to the registry alongside the manifest. Verifiers
+        # then resolve it with `cosign download sbom <ref>` (returns the
+        # raw predicate) or `cosign verify-attestation --type spdxjson
+        # <ref>` (returns + verifies the signed envelope).
+        run: |
+          cosign attest \
+            --predicate /tmp/fleet-edr-server-sbom.spdx.json \
+            --type spdxjson \
+            "ghcr.io/getvictor/fleet-edr-server@${IMAGE_DIGEST}"
 
       - name: Attest image build provenance
         if: startsWith(github.ref, 'refs/tags/v')

--- a/docs/install-agent-manual.md
+++ b/docs/install-agent-manual.md
@@ -65,6 +65,34 @@ spctl -a -v --type install fleet-edr-v0.1.0.pkg
 If any of these fail, STOP. Don't install. File an issue at
 https://github.com/getvictor/fleet-edr/issues.
 
+### Optional: verify the Sigstore signature
+
+Releases since v0.1.1 are also signed via Sigstore keyless (cosign +
+GitHub OIDC). The signature ties the artifact to the exact GitHub
+Actions workflow run that produced it, which catches the rare attack
+where a Developer ID cert is stolen but the attacker can't push to our
+GitHub repo. Skip this step if you don't have `cosign` installed; the
+Apple-signature checks above are sufficient for most pilots.
+
+```sh
+# Install cosign if you don't have it: brew install cosign
+curl -fLO https://github.com/getvictor/fleet-edr/releases/download/v0.1.0/fleet-edr-v0.1.0.pkg.sig
+curl -fLO https://github.com/getvictor/fleet-edr/releases/download/v0.1.0/fleet-edr-v0.1.0.pkg.pem
+
+cosign verify-blob \
+    --certificate fleet-edr-v0.1.0.pkg.pem \
+    --signature fleet-edr-v0.1.0.pkg.sig \
+    --certificate-identity-regexp '^https://github\.com/getvictor/fleet-edr/\.github/workflows/release\.yml@refs/tags/v' \
+    --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+    fleet-edr-v0.1.0.pkg
+# Expect: "Verified OK"
+```
+
+The same pattern (`<file>.sig` + `<file>.pem`) covers `SHA256SUMS` and
+both `.mobileconfig` profiles. If you're verifying the server image
+instead, use `cosign verify ghcr.io/getvictor/fleet-edr-server:v0.1.0`
+with the same identity / issuer flags.
+
 ## Step 3: write the config file
 
 The agent reads `/etc/fleet-edr.conf` on every start. Without that file,

--- a/docs/install-agent-manual.md
+++ b/docs/install-agent-manual.md
@@ -67,12 +67,18 @@ https://github.com/getvictor/fleet-edr/issues.
 
 ### Optional: verify the Sigstore signature
 
-Releases since v0.1.1 are also signed via Sigstore keyless (cosign +
-GitHub OIDC). The signature ties the artifact to the exact GitHub
-Actions workflow run that produced it, which catches the rare attack
-where a Developer ID cert is stolen but the attacker can't push to our
-GitHub repo. Skip this step if you don't have `cosign` installed; the
-Apple-signature checks above are sufficient for most pilots.
+Releases that ship Sigstore signatures also publish a `<file>.sig` and
+`<file>.pem` next to every artifact. The signature ties the artifact
+to the exact GitHub Actions workflow run that produced it, which
+catches the rare attack where a Developer ID cert is stolen but the
+attacker can't push to our GitHub repo. Skip this step if you don't
+have `cosign` installed; the Apple-signature checks above are
+sufficient for most pilots. (Older releases that pre-date the cosign
+roll-out won't have the `.sig` / `.pem` files — `curl` will return
+404, and there's nothing to verify.)
+
+The example below uses the same `v0.1.0` placeholder as Step 1 above;
+substitute whatever release tag you actually downloaded.
 
 ```sh
 # Install cosign if you don't have it: brew install cosign


### PR DESCRIPTION
- **C4: cosign keyless signing for release artifacts + server image**
- **C5 + C6: source + image SBOMs and SLSA build provenance**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release artifacts and container images are now cryptographically signed using Sigstore
  * Software Bill of Materials (SBOMs) and build provenance are now published with releases

* **Documentation**
  * Added verification instructions for release artifacts and container images using the new signatures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->