### PR TITLE
B3 round 3: sudoers_tamper detection rule

### DIFF
--- a/docs/install-server.md
+++ b/docs/install-server.md
@@ -207,7 +207,7 @@ unset uses the documented default.
 | `EDR_RETENTION_INTERVAL` | no | 1h | How often the retention job runs |
 | `EDR_LAUNCHAGENT_ALLOWLIST` | no | — | Comma-separated absolute paths the `persistence_launchagent` rule treats as benign |
 | `EDR_LAUNCHDAEMON_TEAMID_ALLOWLIST` | no | — | Comma-separated code-signing team IDs the `privilege_launchd_plist_write` rule treats as benign |
-| `EDR_SUDOERS_WRITER_ALLOWLIST` | no | — | Comma-separated writer-process absolute paths the `sudoers_tamper` rule treats as benign |
+| `EDR_SUDOERS_WRITER_ALLOWLIST` | no | — | Comma-separated writer-process absolute paths the `sudoers_tamper` rule treats as benign; alerts may surface either `/etc/sudoers...` or `/private/etc/sudoers...` because `/etc` is a symlink and ES reports the path as opened |
 | `EDR_LOG_LEVEL` | no | info | `debug` / `info` / `warn` / `error` |
 | `EDR_LOG_FORMAT` | no | json | `json` or `text` |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | no | — | `host:port` of an OTLP/gRPC collector; unset disables metrics export |

--- a/docs/install-server.md
+++ b/docs/install-server.md
@@ -206,6 +206,7 @@ unset uses the documented default.
 | `EDR_RETENTION_DAYS` | no | 30 | Event TTL, 0 disables retention |
 | `EDR_RETENTION_INTERVAL` | no | 1h | How often the retention job runs |
 | `EDR_LAUNCHAGENT_ALLOWLIST` | no | — | Comma-separated absolute paths the `persistence_launchagent` rule treats as benign |
+| `EDR_SUDOERS_WRITER_ALLOWLIST` | no | — | Comma-separated writer-process absolute paths the `sudoers_tamper` rule treats as benign |
 | `EDR_LOG_LEVEL` | no | info | `debug` / `info` / `warn` / `error` |
 | `EDR_LOG_FORMAT` | no | json | `json` or `text` |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | no | — | `host:port` of an OTLP/gRPC collector; unset disables metrics export |

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -288,6 +288,15 @@ server's `persistence_launchagent` detection rule which LaunchAgent
 paths are benign and should not trigger alerts. Set it as a
 comma-separated list of absolute paths.
 
+`EDR_SUDOERS_WRITER_ALLOWLIST` is the parallel knob for the
+`sudoers_tamper` rule. Direct writes to `/etc/sudoers` or
+`/etc/sudoers.d/*` always fire unless the writing process's path is
+on this list. visudo / sudoedit don't need to be allowlisted — they
+write a temp file and atomically rename it, so the rule never sees
+their open events. The typical use case is allowlisting an MDM
+agent's binary path. Set it as a comma-separated list of absolute
+paths, e.g. `/usr/local/bin/munki-managed-installer`.
+
 ## Common troubleshooting
 
 **Readyz says `db: error`.**

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -297,13 +297,18 @@ a comma-separated list of code-signing team IDs, e.g.
 `T4SK8ZXCXG,XYZW0KL1Q9`.
 
 `EDR_SUDOERS_WRITER_ALLOWLIST` is the parallel knob for the
-`sudoers_tamper` rule. Direct writes to `/etc/sudoers` or
-`/etc/sudoers.d/*` always fire unless the writing process's path is
-on this list. visudo / sudoedit don't need to be allowlisted — they
-write a temp file and atomically rename it, so the rule never sees
-their open events. The typical use case is allowlisting an MDM
-agent's binary path. Set it as a comma-separated list of absolute
-paths, e.g. `/usr/local/bin/munki-managed-installer`.
+`sudoers_tamper` rule. Direct writes to `/etc/sudoers`,
+`/etc/sudoers.d/*`, `/private/etc/sudoers`, or
+`/private/etc/sudoers.d/*` always fire unless the writing process's
+path is on this list. The two path forms are the same file —
+`/etc` is a symlink to `/private/etc` on macOS and ES reports
+whichever path the caller opened — so alerts can surface either,
+but the allowlist still applies in both cases. visudo / sudoedit
+don't need to be allowlisted — they write a temp file and
+atomically rename it, so the rule never sees their open events.
+The typical use case is allowlisting an MDM agent's binary path.
+Set it as a comma-separated list of absolute paths, e.g.
+`/usr/local/bin/munki-managed-installer`.
 
 ## Common troubleshooting
 

--- a/server/cmd/fleet-edr-server/main.go
+++ b/server/cmd/fleet-edr-server/main.go
@@ -113,6 +113,7 @@ func run() error {
 	det.Register(&rules.ShellFromOffice{})
 	det.Register(&rules.OsascriptNetworkExec{})
 	det.Register(&rules.CredentialKeychainDump{})
+	det.Register(&rules.SudoersTamper{AllowedWriters: cfg.SudoersWriterAllowlist})
 	proc := processor.New(s, builder, det, logger, cfg.ProcessInterval, cfg.ProcessBatch)
 
 	q := graph.NewQuery(s)

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -55,6 +55,14 @@ type Config struct {
 	// should silently accept. Populated from EDR_LAUNCHAGENT_ALLOWLIST (comma-separated
 	// absolute paths). Empty by default — every plist load fires.
 	LaunchAgentAllowlist map[string]struct{}
+
+	// SudoersWriterAllowlist is the set of writer-process absolute paths
+	// the `sudoers_tamper` rule should silently accept. Populated from
+	// EDR_SUDOERS_WRITER_ALLOWLIST (comma-separated). Empty by default.
+	// visudo doesn't need to be here — it writes via temp-file + rename
+	// and never opens /etc/sudoers in write mode, so the rule never
+	// sees it.
+	SudoersWriterAllowlist map[string]struct{}
 }
 
 // TLSEnabled reports whether TLS cert and key are both set.
@@ -130,6 +138,9 @@ func loadFrom(getenv func(string) string) (*Config, error) {
 
 	if allowlist := envparse.Allowlist(getenv("EDR_LAUNCHAGENT_ALLOWLIST")); allowlist != nil {
 		c.LaunchAgentAllowlist = allowlist
+	}
+	if allowlist := envparse.Allowlist(getenv("EDR_SUDOERS_WRITER_ALLOWLIST")); allowlist != nil {
+		c.SudoersWriterAllowlist = allowlist
 	}
 
 	if v := getenv("EDR_LOG_LEVEL"); v != "" {

--- a/server/detection/rules/all_rules_integration_test.go
+++ b/server/detection/rules/all_rules_integration_test.go
@@ -32,6 +32,7 @@ func TestAllRulesWireUpAndFire(t *testing.T) {
 	//   - shell_from_office: Microsoft Word -> /bin/bash (host B)
 	//   - osascript_network_exec: osascript -> curl + /tmp/stage2 (host A)
 	//   - credential_keychain_dump: /usr/bin/security dump-keychain (host A)
+	//   - sudoers_tamper: non-allowlisted writer opens /etc/sudoers.d/evil (host A)
 	events := []store.Event{
 		// Chain 1: suspicious_exec (python → sh → /tmp/payload)
 		{EventID: "fork-py", HostID: hostA, TimestampNs: 1000, EventType: "fork",
@@ -92,6 +93,15 @@ func TestAllRulesWireUpAndFire(t *testing.T) {
 			Payload: json.RawMessage(`{"child_pid":1100,"parent_pid":1}`)},
 		{EventID: "exec-sec", HostID: hostA, TimestampNs: 11100, EventType: "exec",
 			Payload: json.RawMessage(`{"pid":1100,"ppid":1,"path":"/usr/bin/security","args":["security","dump-keychain"],"uid":501,"gid":20}`)},
+
+		// Chain 7: sudoers_tamper — non-allowlisted writer opens
+		// /etc/sudoers.d/<x> in write mode.
+		{EventID: "fork-sud", HostID: hostA, TimestampNs: 12000, EventType: "fork",
+			Payload: json.RawMessage(`{"child_pid":1200,"parent_pid":1}`)},
+		{EventID: "exec-sud", HostID: hostA, TimestampNs: 12100, EventType: "exec",
+			Payload: json.RawMessage(`{"pid":1200,"ppid":1,"path":"/bin/bash","args":["bash","-c","echo evil >> /etc/sudoers.d/evil"],"uid":0,"gid":0}`)},
+		{EventID: "open-sud", HostID: hostA, TimestampNs: 12200, EventType: "open",
+			Payload: json.RawMessage(`{"pid":1200,"path":"/etc/sudoers.d/evil","flags":1537}`)},
 	}
 	require.NoError(t, s.InsertEvents(ctx, events))
 	materialize(t, s, events)
@@ -103,6 +113,7 @@ func TestAllRulesWireUpAndFire(t *testing.T) {
 	engine.Register(&ShellFromOffice{})
 	engine.Register(&OsascriptNetworkExec{})
 	engine.Register(&CredentialKeychainDump{})
+	engine.Register(&SudoersTamper{})
 	require.NoError(t, engine.Evaluate(ctx, events))
 
 	// Each rule should have produced at least one alert. We query by rule_id rather than
@@ -115,6 +126,7 @@ func TestAllRulesWireUpAndFire(t *testing.T) {
 		"shell_from_office":        "high",
 		"osascript_network_exec":   "critical",
 		"credential_keychain_dump": "high",
+		"sudoers_tamper":           "high",
 	}
 
 	alerts, err := s.ListAlerts(ctx, store.AlertFilter{})

--- a/server/detection/rules/fixtures/sudoers_tamper/negative_nested_subdir.json
+++ b/server/detection/rules/fixtures/sudoers_tamper/negative_nested_subdir.json
@@ -1,0 +1,36 @@
+{
+  "events": [
+    {
+      "event_id": "sud-nest-fork",
+      "host_id": "fixture-host",
+      "timestamp_ns": 7000,
+      "event_type": "fork",
+      "payload": {"child_pid": 11600, "parent_pid": 1}
+    },
+    {
+      "event_id": "sud-nest-exec",
+      "host_id": "fixture-host",
+      "timestamp_ns": 7100,
+      "event_type": "exec",
+      "payload": {
+        "pid": 11600,
+        "ppid": 1,
+        "path": "/bin/cp",
+        "args": ["cp", "/tmp/x", "/etc/sudoers.d/staging/x"],
+        "uid": 0,
+        "gid": 0
+      }
+    },
+    {
+      "event_id": "sud-nest-open",
+      "host_id": "fixture-host",
+      "timestamp_ns": 7200,
+      "event_type": "open",
+      "payload": {
+        "pid": 11600,
+        "path": "/etc/sudoers.d/staging/x",
+        "flags": 1537
+      }
+    }
+  ]
+}

--- a/server/detection/rules/fixtures/sudoers_tamper/negative_read_only.json
+++ b/server/detection/rules/fixtures/sudoers_tamper/negative_read_only.json
@@ -1,0 +1,36 @@
+{
+  "events": [
+    {
+      "event_id": "sud-ro-fork",
+      "host_id": "fixture-host",
+      "timestamp_ns": 4000,
+      "event_type": "fork",
+      "payload": {"child_pid": 11300, "parent_pid": 1}
+    },
+    {
+      "event_id": "sud-ro-exec",
+      "host_id": "fixture-host",
+      "timestamp_ns": 4100,
+      "event_type": "exec",
+      "payload": {
+        "pid": 11300,
+        "ppid": 1,
+        "path": "/usr/bin/sudo",
+        "args": ["sudo", "-l"],
+        "uid": 501,
+        "gid": 20
+      }
+    },
+    {
+      "event_id": "sud-ro-open",
+      "host_id": "fixture-host",
+      "timestamp_ns": 4200,
+      "event_type": "open",
+      "payload": {
+        "pid": 11300,
+        "path": "/etc/sudoers",
+        "flags": 0
+      }
+    }
+  ]
+}

--- a/server/detection/rules/fixtures/sudoers_tamper/negative_unrelated_path.json
+++ b/server/detection/rules/fixtures/sudoers_tamper/negative_unrelated_path.json
@@ -1,0 +1,36 @@
+{
+  "events": [
+    {
+      "event_id": "sud-other-fork",
+      "host_id": "fixture-host",
+      "timestamp_ns": 6000,
+      "event_type": "fork",
+      "payload": {"child_pid": 11500, "parent_pid": 1}
+    },
+    {
+      "event_id": "sud-other-exec",
+      "host_id": "fixture-host",
+      "timestamp_ns": 6100,
+      "event_type": "exec",
+      "payload": {
+        "pid": 11500,
+        "ppid": 1,
+        "path": "/bin/bash",
+        "args": ["bash", "-c", "echo hi > /etc/sudoers.example"],
+        "uid": 0,
+        "gid": 0
+      }
+    },
+    {
+      "event_id": "sud-other-open",
+      "host_id": "fixture-host",
+      "timestamp_ns": 6200,
+      "event_type": "open",
+      "payload": {
+        "pid": 11500,
+        "path": "/etc/sudoers.example",
+        "flags": 1537
+      }
+    }
+  ]
+}

--- a/server/detection/rules/fixtures/sudoers_tamper/negative_writer_allowlisted.json
+++ b/server/detection/rules/fixtures/sudoers_tamper/negative_writer_allowlisted.json
@@ -1,0 +1,36 @@
+{
+  "events": [
+    {
+      "event_id": "sud-allow-fork",
+      "host_id": "fixture-host",
+      "timestamp_ns": 5000,
+      "event_type": "fork",
+      "payload": {"child_pid": 11400, "parent_pid": 1}
+    },
+    {
+      "event_id": "sud-allow-exec",
+      "host_id": "fixture-host",
+      "timestamp_ns": 5100,
+      "event_type": "exec",
+      "payload": {
+        "pid": 11400,
+        "ppid": 1,
+        "path": "/usr/local/bin/fixture-allowed-writer",
+        "args": ["fixture-allowed-writer"],
+        "uid": 0,
+        "gid": 0
+      }
+    },
+    {
+      "event_id": "sud-allow-open",
+      "host_id": "fixture-host",
+      "timestamp_ns": 5200,
+      "event_type": "open",
+      "payload": {
+        "pid": 11400,
+        "path": "/etc/sudoers.d/managed",
+        "flags": 1537
+      }
+    }
+  ]
+}

--- a/server/detection/rules/fixtures/sudoers_tamper/positive_cp_overwrite.json
+++ b/server/detection/rules/fixtures/sudoers_tamper/positive_cp_overwrite.json
@@ -1,0 +1,44 @@
+{
+  "events": [
+    {
+      "event_id": "sud-cp-fork",
+      "host_id": "fixture-host",
+      "timestamp_ns": 2000,
+      "event_type": "fork",
+      "payload": {"child_pid": 11100, "parent_pid": 1}
+    },
+    {
+      "event_id": "sud-cp-exec",
+      "host_id": "fixture-host",
+      "timestamp_ns": 2100,
+      "event_type": "exec",
+      "payload": {
+        "pid": 11100,
+        "ppid": 1,
+        "path": "/bin/cp",
+        "args": ["cp", "/tmp/evil", "/etc/sudoers"],
+        "uid": 0,
+        "gid": 0
+      }
+    },
+    {
+      "event_id": "sud-cp-open",
+      "host_id": "fixture-host",
+      "timestamp_ns": 2200,
+      "event_type": "open",
+      "payload": {
+        "pid": 11100,
+        "path": "/etc/sudoers",
+        "flags": 1537
+      }
+    }
+  ],
+  "expected_findings": [
+    {
+      "rule_id": "sudoers_tamper",
+      "severity": "high",
+      "description_contains": "/etc/sudoers",
+      "event_ids": ["sud-cp-open"]
+    }
+  ]
+}

--- a/server/detection/rules/fixtures/sudoers_tamper/positive_private_etc_path.json
+++ b/server/detection/rules/fixtures/sudoers_tamper/positive_private_etc_path.json
@@ -1,0 +1,44 @@
+{
+  "events": [
+    {
+      "event_id": "sud-priv-fork",
+      "host_id": "fixture-host",
+      "timestamp_ns": 3000,
+      "event_type": "fork",
+      "payload": {"child_pid": 11200, "parent_pid": 1}
+    },
+    {
+      "event_id": "sud-priv-exec",
+      "host_id": "fixture-host",
+      "timestamp_ns": 3100,
+      "event_type": "exec",
+      "payload": {
+        "pid": 11200,
+        "ppid": 1,
+        "path": "/usr/bin/tee",
+        "args": ["tee", "/private/etc/sudoers.d/backdoor"],
+        "uid": 0,
+        "gid": 0
+      }
+    },
+    {
+      "event_id": "sud-priv-open",
+      "host_id": "fixture-host",
+      "timestamp_ns": 3200,
+      "event_type": "open",
+      "payload": {
+        "pid": 11200,
+        "path": "/private/etc/sudoers.d/backdoor",
+        "flags": 1537
+      }
+    }
+  ],
+  "expected_findings": [
+    {
+      "rule_id": "sudoers_tamper",
+      "severity": "high",
+      "description_contains": "/private/etc/sudoers.d/backdoor",
+      "event_ids": ["sud-priv-open"]
+    }
+  ]
+}

--- a/server/detection/rules/fixtures/sudoers_tamper/positive_shell_redirect.json
+++ b/server/detection/rules/fixtures/sudoers_tamper/positive_shell_redirect.json
@@ -1,0 +1,44 @@
+{
+  "events": [
+    {
+      "event_id": "sud-redir-fork",
+      "host_id": "fixture-host",
+      "timestamp_ns": 1000,
+      "event_type": "fork",
+      "payload": {"child_pid": 11000, "parent_pid": 1}
+    },
+    {
+      "event_id": "sud-redir-exec",
+      "host_id": "fixture-host",
+      "timestamp_ns": 1100,
+      "event_type": "exec",
+      "payload": {
+        "pid": 11000,
+        "ppid": 1,
+        "path": "/bin/bash",
+        "args": ["bash", "-c", "echo 'evil ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers.d/evil"],
+        "uid": 0,
+        "gid": 0
+      }
+    },
+    {
+      "event_id": "sud-redir-open",
+      "host_id": "fixture-host",
+      "timestamp_ns": 1200,
+      "event_type": "open",
+      "payload": {
+        "pid": 11000,
+        "path": "/etc/sudoers.d/evil",
+        "flags": 1537
+      }
+    }
+  ],
+  "expected_findings": [
+    {
+      "rule_id": "sudoers_tamper",
+      "severity": "high",
+      "description_contains": "/etc/sudoers.d/evil",
+      "event_ids": ["sud-redir-open"]
+    }
+  ]
+}

--- a/server/detection/rules/sudoers_tamper.go
+++ b/server/detection/rules/sudoers_tamper.go
@@ -143,7 +143,7 @@ func (r *SudoersTamper) evalEvent(
 		Severity: detection.SeverityHigh,
 		Title:    "Sudoers tamper",
 		Description: fmt.Sprintf(
-			"%s wrote %s — sudo escalation surface (MITRE T1548.003)",
+			"%s opened %s for writing — sudo escalation surface (MITRE T1548.003)",
 			proc.Path, p.Path,
 		),
 		ProcessID: proc.ID,

--- a/server/detection/rules/sudoers_tamper.go
+++ b/server/detection/rules/sudoers_tamper.go
@@ -1,0 +1,160 @@
+package rules
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"regexp"
+
+	"github.com/fleetdm/edr/server/detection"
+	"github.com/fleetdm/edr/server/store"
+)
+
+// SudoersTamper fires on a write-mode `open(2)` against `/etc/sudoers`
+// or any direct child of `/etc/sudoers.d/`. Editing those files grants
+// future shell sessions arbitrary command execution as root, so a
+// successful tamper is an instant escalation primitive — T1548.003.
+//
+// The rule deliberately does NOT key on code-signing platform-binary
+// status the way persistence_launchagent / privilege_launchd_plist_write
+// do, because the canonical attacker tools for sudoers tampering are
+// platform binaries themselves: `cp`, `tee`, shell redirection, even
+// `sudo vi /etc/sudoers`. Filtering platform binaries would silence
+// every realistic attack while admitting basically nothing else of
+// interest. We fire on any non-allowlisted writer instead, and let
+// operators tune via EDR_SUDOERS_WRITER_ALLOWLIST.
+//
+// Why visudo doesn't need to be in the default allowlist: visudo writes
+// to /etc/sudoers.tmp (or $TMPDIR) and atomically renames it onto
+// /etc/sudoers. ESF NOTIFY_OPEN doesn't fire on rename, and visudo
+// never opens /etc/sudoers itself in write mode, so the rule doesn't
+// see visudo's flow at all. Same is true for sudoedit. The rule only
+// trips when something writes to /etc/sudoers directly.
+//
+// Known limitation: an attacker with root could create the temp file
+// and rename it onto /etc/sudoers without ever firing NOTIFY_OPEN on
+// /etc/sudoers. NOTIFY_RENAME would catch that, but the extension
+// doesn't subscribe to it today (tracked for Phase 8 alongside the
+// privilege_launchd_plist_write atomic-rename gap).
+type SudoersTamper struct {
+	// AllowedWriters is the set of absolute writer-process paths the
+	// rule should silently accept. Populated from
+	// EDR_SUDOERS_WRITER_ALLOWLIST. Empty by default — every direct
+	// write to sudoers fires.
+	AllowedWriters map[string]struct{}
+}
+
+func (r *SudoersTamper) ID() string { return "sudoers_tamper" }
+
+// Techniques returns the MITRE ATT&CK IDs this rule covers — T1548.003
+// (Abuse Elevation Control Mechanism: Sudo and Sudo Caching).
+func (r *SudoersTamper) Techniques() []string { return []string{"T1548.003"} }
+
+// sudoersPath matches /etc/sudoers itself and any direct child of
+// /etc/sudoers.d/. ESF reports both forms (/etc/...  and
+// /private/etc/... since /etc is a symlink); we accept either. Nested
+// paths (/etc/sudoers.d/foo/bar) are excluded by `[^/]+` so the rule
+// can't be lured by an attacker creating a same-named subdirectory
+// somewhere unrelated.
+var sudoersPath = regexp.MustCompile(`^(?:/private)?/etc/sudoers(?:\.d/[^/]+)?$`)
+
+// sudoersBytes is the substring fast-path filter applied to the raw
+// JSON payload before json.Unmarshal. NOTIFY_OPEN fires on every file
+// open in the kernel — thousands per second — and writes to sudoers
+// happen on a stable host literally never. Skipping the JSON decode
+// for opens that obviously don't qualify cuts the rule's CPU cost
+// from "one unmarshal per open" to "one bytes.Contains per open".
+// Both /etc/sudoers and /private/etc/sudoers contain the same magic
+// substring, so a single check covers both forms.
+var sudoersBytes = []byte("/etc/sudoers")
+
+// sudoersOpenPayload mirrors the open event shape we care about. Local
+// to this rule rather than a shared package symbol so the
+// privilege_launchd_plist_write rule (in flight on another branch) can
+// keep its own copy without merge collisions; both can dedupe once
+// both rules are on main.
+type sudoersOpenPayload struct {
+	PID   int    `json:"pid"`
+	Path  string `json:"path"`
+	Flags int    `json:"flags"`
+}
+
+// Bits 0 and 1 of open(2) flags hold the access mode: O_RDONLY=0,
+// O_WRONLY=1, O_RDWR=2. Anything non-zero in those two bits means the
+// fd can be written. Higher bits (O_CREAT, O_TRUNC, O_APPEND, ...)
+// don't affect the access mode.
+const sudoersWriteAccessMask = 0x3
+
+func (r *SudoersTamper) Evaluate(
+	ctx context.Context, events []store.Event, s *store.Store,
+) ([]detection.Finding, error) {
+	var findings []detection.Finding
+	for _, evt := range events {
+		f, err := r.evalEvent(ctx, evt, s)
+		if err != nil {
+			return nil, err
+		}
+		if f != nil {
+			findings = append(findings, *f)
+		}
+	}
+	return findings, nil
+}
+
+func (r *SudoersTamper) evalEvent(
+	ctx context.Context, evt store.Event, s *store.Store,
+) (*detection.Finding, error) {
+	if evt.EventType != "open" {
+		return nil, nil
+	}
+	if !bytes.Contains(evt.Payload, sudoersBytes) {
+		return nil, nil
+	}
+	var p sudoersOpenPayload
+	if err := json.Unmarshal(evt.Payload, &p); err != nil {
+		return nil, nil
+	}
+	if !sudoersPath.MatchString(p.Path) {
+		return nil, nil
+	}
+	if p.Flags&sudoersWriteAccessMask == 0 {
+		// Read-only open. cron, sudo itself, and various PAM modules
+		// read /etc/sudoers all the time; none of those are signal.
+		return nil, nil
+	}
+
+	proc, err := s.GetProcessByPID(ctx, evt.HostID, p.PID, evt.TimestampNs)
+	if err != nil {
+		return nil, fmt.Errorf("get process pid %d: %w", p.PID, err)
+	}
+	if proc == nil {
+		// Defensive: race against process materialisation. Same shape
+		// as credential_keychain_dump / privilege_launchd_plist_write.
+		return nil, nil
+	}
+	if r.allowed(proc.Path) {
+		return nil, nil
+	}
+
+	return &detection.Finding{
+		HostID:   evt.HostID,
+		RuleID:   r.ID(),
+		Severity: detection.SeverityHigh,
+		Title:    "Sudoers tamper",
+		Description: fmt.Sprintf(
+			"%s wrote %s — sudo escalation surface (MITRE T1548.003)",
+			proc.Path, p.Path,
+		),
+		ProcessID: proc.ID,
+		EventIDs:  []string{evt.EventID},
+	}, nil
+}
+
+func (r *SudoersTamper) allowed(writerPath string) bool {
+	if r.AllowedWriters == nil {
+		return false
+	}
+	_, ok := r.AllowedWriters[writerPath]
+	return ok
+}

--- a/server/detection/rules/sudoers_tamper_test.go
+++ b/server/detection/rules/sudoers_tamper_test.go
@@ -1,0 +1,93 @@
+package rules
+
+import (
+	"encoding/json"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fleetdm/edr/server/detection/testharness"
+	"github.com/fleetdm/edr/server/graph"
+	"github.com/fleetdm/edr/server/store"
+)
+
+// TestSudoersTamper_Fixtures runs every fixture case under
+// fixtures/sudoers_tamper/ as its own sub-test.
+func TestSudoersTamper_Fixtures(t *testing.T) {
+	r := &SudoersTamper{
+		AllowedWriters: map[string]struct{}{
+			"/usr/local/bin/fixture-allowed-writer": {},
+		},
+	}
+	testharness.Replay(t, r, "fixtures/sudoers_tamper")
+}
+
+// TestSudoersTamper_TechniquesMapping pins the MITRE ATT&CK mapping.
+func TestSudoersTamper_TechniquesMapping(t *testing.T) {
+	r := &SudoersTamper{}
+	assert.Equal(t, []string{"T1548.003"}, r.Techniques())
+}
+
+// TestSudoersTamper_AllowedEdgeCases pins the contract of allowed():
+// nil allowlist always returns false; populated allowlist hits exact
+// path matches. We don't normalise (no trailing-slash stripping, no
+// case folding) — matching is byte-equal.
+func TestSudoersTamper_AllowedEdgeCases(t *testing.T) {
+	rNoList := &SudoersTamper{}
+	assert.False(t, rNoList.allowed("/usr/sbin/visudo"),
+		"nil allowlist must return false for any path")
+
+	r := &SudoersTamper{AllowedWriters: map[string]struct{}{
+		"/usr/sbin/visudo": {},
+	}}
+	assert.True(t, r.allowed("/usr/sbin/visudo"))
+	assert.False(t, r.allowed("/usr/local/bin/visudo"),
+		"matching is exact-path; no PATH-walk fallback")
+	assert.False(t, r.allowed(""),
+		"empty path must not accidentally match an empty-key entry")
+}
+
+// TestSudoersTamper_MalformedPayload exercises the unmarshal-failure
+// path: the fast-path bytes.Contains lets it through (the magic
+// substring is present), then unmarshal trips and the rule drops the
+// event silently.
+func TestSudoersTamper_MalformedPayload(t *testing.T) {
+	s := store.OpenTestStore(t)
+	ctx := t.Context()
+	r := &SudoersTamper{}
+
+	evt := store.Event{
+		EventID:     "sud-malformed",
+		HostID:      "fixture-host",
+		TimestampNs: 1,
+		EventType:   "open",
+		Payload:     json.RawMessage(`{"path":"/etc/sudoers", "flags":`),
+	}
+	findings, err := r.Evaluate(ctx, []store.Event{evt}, s)
+	require.NoError(t, err)
+	assert.Empty(t, findings, "malformed payload must be dropped silently")
+}
+
+// TestSudoersTamper_OpenRaceWithoutProcess covers the proc==nil race
+// guard. Mirrors the same shape as the other open-keyed rules.
+func TestSudoersTamper_OpenRaceWithoutProcess(t *testing.T) {
+	s := store.OpenTestStore(t)
+	ctx := t.Context()
+	r := &SudoersTamper{}
+
+	evt := store.Event{
+		EventID:     "sud-race",
+		HostID:      "fixture-host",
+		TimestampNs: 1,
+		EventType:   "open",
+		Payload:     json.RawMessage(`{"pid":99999,"path":"/etc/sudoers","flags":1}`),
+	}
+	require.NoError(t, s.InsertEvents(ctx, []store.Event{evt}))
+	require.NoError(t, graph.NewBuilder(s, slog.Default()).ProcessBatch(ctx, []store.Event{evt}))
+
+	findings, err := r.Evaluate(ctx, []store.Event{evt}, s)
+	require.NoError(t, err)
+	assert.Empty(t, findings, "race against process materialisation must skip silently")
+}


### PR DESCRIPTION
Closes Track B for Phase 7 (rules 3-of-3). Pairs with credential_keychain_dump (T1555.001) and privilege_launchd_plist_write (T1543.004) by catching the third macOS post-exploitation primitive listed in the plan: writes to /etc/sudoers or /etc/sudoers.d/* by a non-allowlisted process. ATT&CK T1548.003 (Abuse Elevation Control Mechanism: Sudo and Sudo Caching).

Design notes worth recording for future rule authors:

* Unlike the launchd-plist rule, this one does NOT key on is_platform_binary. The canonical attacker tools for sudoers tampering are platform binaries themselves: cp, tee, /bin/bash (shell redirection), even sudo vi. Filtering platform binaries would silence every realistic attack pattern. Instead we fire on every direct write and let operators tune via EDR_SUDOERS_WRITER_ALLOWLIST.
* visudo / sudoedit are NOT in the default allowlist because they don't need to be: both write a temp file and atomically rename it onto /etc/sudoers. ESF NOTIFY_OPEN doesn't fire on rename, so the rule never sees the visudo flow at all.
* The path regex matches both /etc/sudoers and /private/etc/sudoers forms because ESF reports the path as the caller passed it (and /etc is a symlink to /private/etc on macOS). Subdirectories like /etc/sudoers.d/staging/x are excluded by the trailing [^/]+ so the rule can't be lured by an attacker creating a same-named subdirectory somewhere unrelated.

Known limitation: an attacker with root could create the temp file and rename it onto /etc/sudoers without firing NOTIFY_OPEN at all. NOTIFY_RENAME would catch that, but the extension doesn't subscribe to it today (tracked alongside the privilege_launchd_plist_write atomic-rename gap).

Implementation:
* server/detection/rules/sudoers_tamper.go — rule + fast-path bytes filter + path regex + write-mode check + writer-allowlist gate.
* 7 fixture cases (3 positive: shell redirect, cp overwrite, /private/etc/ path; 4 negative: read-only open, allowlisted writer, unrelated path /etc/sudoers.example, nested /etc/sudoers.d/staging/x).
* Go-level unit tests for allowed() edge cases, malformed-payload drop, and the proc==nil race guard. Coverage of the new file: ID/Techniques/allowed at 100%, Evaluate 87.5%, evalEvent 89.5% — the two uncovered lines are pure store-error wrappers.
* Wires through Config.SudoersWriterAllowlist (env var EDR_SUDOERS_WRITER_ALLOWLIST), main.go registration, and the all_rules_integration_test aggregate.
* Docs: operations.md + install-server.md env table updated.

The rule's openPayload struct + write-access mask are named sudoersOpenPayload / sudoersWriteAccessMask to dodge a future merge collision with PR #38's privilege_launchd_plist_write rule, which defines parallel symbols. Once both rules are on main a follow-up can dedupe to a shared open_event.go.