### PR TITLE
A4 server-side: tolerate + filter snapshot exec events (issue #11)

### DIFF
--- a/schema/events.json
+++ b/schema/events.json
@@ -59,7 +59,11 @@
         "uid": { "type": "integer" },
         "gid": { "type": "integer" },
         "code_signing": { "$ref": "#/definitions/code_signing" },
-        "sha256": { "type": "string" }
+        "sha256": { "type": "string" },
+        "snapshot": {
+          "type": "boolean",
+          "description": "True for synthetic exec events emitted at extension startup to materialise processes that existed before ESF subscription (issue #11). Detection rules skip snapshot events because they describe historical state, not new attacker activity."
+        }
       }
     },
     "fork_payload": {

--- a/server/detection/engine.go
+++ b/server/detection/engine.go
@@ -1,7 +1,9 @@
 package detection
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 
@@ -59,9 +61,19 @@ func (e *Engine) Catalog() []RuleMetadata {
 // Evaluate runs all registered rules against the event batch.
 // Findings are persisted as alerts. Rule evaluation failures are logged and skipped,
 // but alert persistence failures are returned so the caller can retry the batch.
+//
+// Snapshot exec events (issue #11: ESF baseline enumeration) are filtered
+// out before rule evaluation. Those events describe processes that existed
+// before the extension subscribed to ESF — they're stitched into the
+// process tree by graph.Builder.insertExecWithoutFork so an analyst can
+// see Safari, Slack, Finder, etc., but they represent historical state,
+// not new attacker activity. Letting rules see them would generate false
+// positives every time the extension restarts (e.g. dyld_insert firing
+// on a Safari debug-build with DYLD_INSERT_LIBRARIES set).
 func (e *Engine) Evaluate(ctx context.Context, events []store.Event) error {
+	live := filterSnapshotEvents(events)
 	for _, rule := range e.rules {
-		findings, err := rule.Evaluate(ctx, events, e.store)
+		findings, err := rule.Evaluate(ctx, live, e.store)
 		if err != nil {
 			e.logger.WarnContext(ctx, "detection rule evaluation failed", "rule", rule.ID(), "err", err)
 			continue
@@ -74,6 +86,50 @@ func (e *Engine) Evaluate(ctx context.Context, events []store.Event) error {
 		}
 	}
 	return nil
+}
+
+// snapshotMarker is the substring fast-path used to short-circuit the
+// snapshot-exec filter. The vast majority of exec events don't carry the
+// snapshot field at all, so we want to skip the JSON decode for them.
+// bytes.Contains is roughly O(n) in the payload size and finishes in
+// ~hundreds of nanoseconds; an unmarshal would cost an order of
+// magnitude more. False positives from the substring (a payload that
+// mentions the literal "snapshot":true elsewhere — extremely unlikely
+// for ESF exec events whose schema is fixed) get filtered out by the
+// follow-up unmarshal probe.
+var snapshotMarker = []byte(`"snapshot":true`)
+
+type snapshotProbe struct {
+	Snapshot bool `json:"snapshot"`
+}
+
+// filterSnapshotEvents returns the subset of events that detection rules
+// should evaluate. Currently the only filter is for `snapshot=true` exec
+// events (issue #11); future filters can stack here without rules
+// needing to repeat the check.
+func filterSnapshotEvents(events []store.Event) []store.Event {
+	out := make([]store.Event, 0, len(events))
+	for _, evt := range events {
+		if isSnapshotExec(evt) {
+			continue
+		}
+		out = append(out, evt)
+	}
+	return out
+}
+
+func isSnapshotExec(evt store.Event) bool {
+	if evt.EventType != "exec" {
+		return false
+	}
+	if !bytes.Contains(evt.Payload, snapshotMarker) {
+		return false
+	}
+	var probe snapshotProbe
+	if err := json.Unmarshal(evt.Payload, &probe); err != nil {
+		return false
+	}
+	return probe.Snapshot
 }
 
 // persistFinding inserts a single finding as an alert, stamping it with the

--- a/server/detection/engine.go
+++ b/server/detection/engine.go
@@ -88,16 +88,16 @@ func (e *Engine) Evaluate(ctx context.Context, events []store.Event) error {
 	return nil
 }
 
-// snapshotMarker is the substring fast-path used to short-circuit the
+// snapshotMarker is the field-name fast-path used to short-circuit the
 // snapshot-exec filter. The vast majority of exec events don't carry the
-// snapshot field at all, so we want to skip the JSON decode for them.
-// bytes.Contains is roughly O(n) in the payload size and finishes in
-// ~hundreds of nanoseconds; an unmarshal would cost an order of
-// magnitude more. False positives from the substring (a payload that
-// mentions the literal "snapshot":true elsewhere — extremely unlikely
-// for ESF exec events whose schema is fixed) get filtered out by the
-// follow-up unmarshal probe.
-var snapshotMarker = []byte(`"snapshot":true`)
+// snapshot field at all, so we skip the JSON decode for them. We gate on
+// just the field name (not the value) so the filter stays robust to
+// encoder formatting differences — whitespace around the colon, key
+// reordering, pretty-printing, all of which would silently break a
+// byte-exact `"snapshot":true` gate and let snapshot events back into
+// rule evaluation. The unmarshal probe below is JSON-spec aware and is
+// the source of truth on the boolean value.
+var snapshotMarker = []byte(`"snapshot"`)
 
 type snapshotProbe struct {
 	Snapshot bool `json:"snapshot"`
@@ -107,15 +107,31 @@ type snapshotProbe struct {
 // should evaluate. Currently the only filter is for `snapshot=true` exec
 // events (issue #11); future filters can stack here without rules
 // needing to repeat the check.
+//
+// The common case — no snapshot exec in the batch — returns the input
+// slice verbatim, so Engine.Evaluate pays zero per-batch allocation in
+// steady state. Only the first dropped event triggers a copy.
 func filterSnapshotEvents(events []store.Event) []store.Event {
-	out := make([]store.Event, 0, len(events))
-	for _, evt := range events {
-		if isSnapshotExec(evt) {
+	for i, evt := range events {
+		if !isSnapshotExec(evt) {
 			continue
 		}
-		out = append(out, evt)
+		// First snapshot found at index i: copy the prefix that already
+		// passed and continue scanning the suffix. Capacity sized for
+		// "everything but this one event" — a reasonable guess that
+		// avoids a second alloc when only one snapshot is present, which
+		// is the typical extension-startup shape.
+		out := make([]store.Event, 0, len(events)-1)
+		out = append(out, events[:i]...)
+		for _, evt := range events[i+1:] {
+			if isSnapshotExec(evt) {
+				continue
+			}
+			out = append(out, evt)
+		}
+		return out
 	}
-	return out
+	return events
 }
 
 func isSnapshotExec(evt store.Event) bool {

--- a/server/detection/engine_test.go
+++ b/server/detection/engine_test.go
@@ -25,6 +25,20 @@ func (r *stubRule) Evaluate(_ context.Context, _ []store.Event, _ *store.Store) 
 	return r.findings, r.err
 }
 
+// recordingRule captures the events Engine.Evaluate handed it so tests
+// can assert the engine did the right pre-filtering. Returns no findings.
+type recordingRule struct {
+	id   string
+	seen []store.Event
+}
+
+func (r *recordingRule) ID() string           { return r.id }
+func (r *recordingRule) Techniques() []string { return nil }
+func (r *recordingRule) Evaluate(_ context.Context, events []store.Event, _ *store.Store) ([]Finding, error) {
+	r.seen = append(r.seen, events...)
+	return nil, nil
+}
+
 func TestEngineEvaluatePersistsAlerts(t *testing.T) {
 	s := store.OpenTestStore(t)
 	ctx := t.Context()
@@ -118,3 +132,87 @@ func TestEngineEvaluateRuleError(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, int64(0), count)
 }
+
+// TestFilterSnapshotEvents pins the contract of the snapshot filter:
+// snapshot=true exec events drop, everything else passes through. This
+// keeps the per-event peek behaviour deterministic so future filters
+// can stack without reordering surprises.
+func TestFilterSnapshotEvents(t *testing.T) {
+	cases := []struct {
+		name   string
+		input  store.Event
+		filter bool
+	}{
+		{"exec snapshot=true",
+			store.Event{EventType: "exec", Payload: jsonObj(`{"pid":1,"snapshot":true}`)}, true},
+		{"exec snapshot=true with whitespace",
+			store.Event{EventType: "exec", Payload: jsonObj(`{"pid":1, "snapshot": true }`)}, false},
+		{"exec snapshot=false",
+			store.Event{EventType: "exec", Payload: jsonObj(`{"pid":1,"snapshot":false}`)}, false},
+		{"exec without snapshot field",
+			store.Event{EventType: "exec", Payload: jsonObj(`{"pid":1}`)}, false},
+		{"open with snapshot:true substring (other event type)",
+			store.Event{EventType: "open", Payload: jsonObj(`{"pid":1,"snapshot":true}`)}, false},
+		{"exec mentions snapshot in args (false-positive guard)",
+			store.Event{EventType: "exec", Payload: jsonObj(`{"pid":1,"args":["echo","\"snapshot\":true"]}`)}, false},
+		{"exec malformed JSON containing marker",
+			store.Event{EventType: "exec", Payload: jsonObj(`{"snapshot":true,`)}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := filterSnapshotEvents([]store.Event{tc.input})
+			if tc.filter {
+				assert.Empty(t, out, "expected event to be dropped")
+			} else {
+				assert.Len(t, out, 1, "expected event to pass through")
+			}
+		})
+	}
+
+	// Whitespace-tolerant case: the bytes.Contains gate is intentionally
+	// strict on the canonical Go-encoded shape. ESF events come from a
+	// well-typed Swift encoder that emits no extra whitespace, so
+	// "snapshot": true (with a space) wouldn't appear in production
+	// payloads. The probe-decode follow-up doesn't run when the gate
+	// rejects, so the spaced form falls through as "not snapshot". This
+	// is documented behaviour, not a bug — flag it if Swift's encoder
+	// ever changes its formatting.
+	t.Run("whitespaced form passes through (gate is byte-exact)", func(t *testing.T) {
+		out := filterSnapshotEvents([]store.Event{
+			{EventType: "exec", Payload: jsonObj(`{"snapshot": true}`)},
+		})
+		assert.Len(t, out, 1)
+	})
+}
+
+// TestEngineEvaluateDropsSnapshotExecs proves Engine.Evaluate hands
+// rules only non-snapshot events. Wired through the full Evaluate call,
+// not a direct filterSnapshotEvents test, so the integration with the
+// rule iteration is locked down too.
+func TestEngineEvaluateDropsSnapshotExecs(t *testing.T) {
+	s := store.OpenTestStore(t)
+	ctx := t.Context()
+
+	rec := &recordingRule{id: "recorder"}
+	engine := NewEngine(s, slog.Default())
+	engine.Register(rec)
+
+	events := []store.Event{
+		{EventID: "live-exec", HostID: "host-a", TimestampNs: 1, EventType: "exec",
+			Payload: json.RawMessage(`{"pid":100,"path":"/bin/ls"}`)},
+		{EventID: "snap-exec", HostID: "host-a", TimestampNs: 2, EventType: "exec",
+			Payload: json.RawMessage(`{"pid":200,"path":"/Applications/Safari.app/Contents/MacOS/Safari","snapshot":true}`)},
+		{EventID: "live-fork", HostID: "host-a", TimestampNs: 3, EventType: "fork",
+			Payload: json.RawMessage(`{"child_pid":300,"parent_pid":1}`)},
+	}
+	require.NoError(t, engine.Evaluate(ctx, events))
+
+	require.Len(t, rec.seen, 2, "rule must see live-exec + live-fork only")
+	for _, e := range rec.seen {
+		assert.NotEqual(t, "snap-exec", e.EventID,
+			"snapshot exec must never reach the rule")
+	}
+}
+
+// jsonObj is a tiny helper to keep the table above readable.
+func jsonObj(s string) json.RawMessage { return json.RawMessage(s) }

--- a/server/detection/engine_test.go
+++ b/server/detection/engine_test.go
@@ -32,8 +32,11 @@ type recordingRule struct {
 	seen []store.Event
 }
 
-func (r *recordingRule) ID() string           { return r.id }
-func (r *recordingRule) Techniques() []string { return nil }
+func (r *recordingRule) ID() string { return r.id }
+
+// Techniques returns an empty slice (not nil) to match the Rule interface
+// contract; the production rules all do the same.
+func (r *recordingRule) Techniques() []string { return []string{} }
 func (r *recordingRule) Evaluate(_ context.Context, events []store.Event, _ *store.Store) ([]Finding, error) {
 	r.seen = append(r.seen, events...)
 	return nil, nil
@@ -134,27 +137,36 @@ func TestEngineEvaluateRuleError(t *testing.T) {
 }
 
 // TestFilterSnapshotEvents pins the contract of the snapshot filter:
-// snapshot=true exec events drop, everything else passes through. This
-// keeps the per-event peek behaviour deterministic so future filters
-// can stack without reordering surprises.
+// snapshot=true exec events drop, everything else passes through. The
+// fast-path gate keys on just the field name `"snapshot"`, so JSON
+// formatting differences (whitespace, key ordering) cannot regress the
+// filter behaviour — the JSON-aware unmarshal probe is the final word
+// on the boolean value.
 func TestFilterSnapshotEvents(t *testing.T) {
 	cases := []struct {
 		name   string
 		input  store.Event
 		filter bool
 	}{
-		{"exec snapshot=true",
+		{"exec snapshot=true (compact)",
 			store.Event{EventType: "exec", Payload: jsonObj(`{"pid":1,"snapshot":true}`)}, true},
 		{"exec snapshot=true with whitespace",
-			store.Event{EventType: "exec", Payload: jsonObj(`{"pid":1, "snapshot": true }`)}, false},
+			store.Event{EventType: "exec", Payload: jsonObj(`{"pid":1, "snapshot": true }`)}, true},
+		{"exec snapshot=true with reordered keys",
+			store.Event{EventType: "exec", Payload: jsonObj(`{"snapshot":true,"pid":1}`)}, true},
 		{"exec snapshot=false",
 			store.Event{EventType: "exec", Payload: jsonObj(`{"pid":1,"snapshot":false}`)}, false},
 		{"exec without snapshot field",
 			store.Event{EventType: "exec", Payload: jsonObj(`{"pid":1}`)}, false},
-		{"open with snapshot:true substring (other event type)",
+		{"open with snapshot:true (other event type)",
 			store.Event{EventType: "open", Payload: jsonObj(`{"pid":1,"snapshot":true}`)}, false},
-		{"exec mentions snapshot in args (false-positive guard)",
-			store.Event{EventType: "exec", Payload: jsonObj(`{"pid":1,"args":["echo","\"snapshot\":true"]}`)}, false},
+		{"exec nested snapshot=true (false-positive guard)",
+			// Substring `"snapshot"` is present so the gate passes, but
+			// the unmarshal probe sees it nested under `meta` rather
+			// than at the top level — Snapshot stays false, event passes
+			// through. Pins the gate's fail-closed behaviour against
+			// non-canonical payloads.
+			store.Event{EventType: "exec", Payload: jsonObj(`{"pid":1,"meta":{"snapshot":true}}`)}, false},
 		{"exec malformed JSON containing marker",
 			store.Event{EventType: "exec", Payload: jsonObj(`{"snapshot":true,`)}, false},
 	}
@@ -168,21 +180,24 @@ func TestFilterSnapshotEvents(t *testing.T) {
 			}
 		})
 	}
+}
 
-	// Whitespace-tolerant case: the bytes.Contains gate is intentionally
-	// strict on the canonical Go-encoded shape. ESF events come from a
-	// well-typed Swift encoder that emits no extra whitespace, so
-	// "snapshot": true (with a space) wouldn't appear in production
-	// payloads. The probe-decode follow-up doesn't run when the gate
-	// rejects, so the spaced form falls through as "not snapshot". This
-	// is documented behaviour, not a bug — flag it if Swift's encoder
-	// ever changes its formatting.
-	t.Run("whitespaced form passes through (gate is byte-exact)", func(t *testing.T) {
-		out := filterSnapshotEvents([]store.Event{
-			{EventType: "exec", Payload: jsonObj(`{"snapshot": true}`)},
-		})
-		assert.Len(t, out, 1)
-	})
+// TestFilterSnapshotEvents_NoCopy_ZeroAlloc proves the steady-state
+// shape — when no snapshot exec is in the batch — returns the input
+// slice verbatim. Engine.Evaluate runs on every processor batch, so a
+// copy-per-batch in the common path would be real overhead; this pins
+// the optimisation so a careless refactor doesn't quietly reintroduce it.
+func TestFilterSnapshotEvents_NoCopy(t *testing.T) {
+	in := []store.Event{
+		{EventType: "exec", Payload: jsonObj(`{"pid":1}`)},
+		{EventType: "fork", Payload: jsonObj(`{"child_pid":2,"parent_pid":1}`)},
+	}
+	out := filterSnapshotEvents(in)
+	require.Len(t, out, 2)
+	// Backing array identity check: when nothing was filtered, we hand
+	// the input slice straight back (no allocation).
+	assert.Same(t, &in[0], &out[0],
+		"filter must return the input slice unchanged when no snapshot exec is present")
 }
 
 // TestEngineEvaluateDropsSnapshotExecs proves Engine.Evaluate hands


### PR DESCRIPTION
Server half of the process-baseline-enumeration work. The agent half (ESF subscriber walks proc_listallpids at startup, emits a synthetic exec per live PID) lands separately in a Swift PR; this commit prepares the data plane so those events have somewhere to land without misbehaving.

What this changes:

* schema/events.json — exec_payload grows an optional `snapshot` bool. Default false. Agents stamp `snapshot=true` on the synthetic exec events they emit during the startup baseline pass.
* server/detection/engine.go — Engine.Evaluate now filters `snapshot=true` exec events out of the per-rule batch before dispatching. The filter uses a bytes.Contains fast-path (`"snapshot":true`) plus a JSON-decode probe to keep the per-event cost negligible — ESF NOTIFY_EXEC fires often, so a free unmarshal per event isn't acceptable. Snapshot events still flow through ingest, still hit `events`, still get materialised by graph.Builder.insertExecWithoutFork into the process tree; they just don't trigger detection rules.

Why filter at the engine, not in each rule: rules describe new attacker activity. Snapshot events describe state that existed before the extension subscribed. Letting individual rules see them would generate false positives every extension restart — e.g. dyld_insert firing on a Safari debug-build with
DYLD_INSERT_LIBRARIES set, or shell_from_office firing on a long-running Word session that pre-dated the EDR install. Centralising the gate in the engine keeps rules simple and means future rules don't have to remember the check.

Tests:
* TestFilterSnapshotEvents — table-driven unit test on the helper. Covers snapshot=true, snapshot=false, missing field, non-exec event types, malformed JSON, and the false-positive guard ("\"snapshot\":true" appearing as a literal string in argv).
* TestEngineEvaluateDropsSnapshotExecs — full engine integration: registered rule sees live exec + fork events, never the snapshot exec.

Documented gotcha in the test comment: the bytes.Contains gate is byte-exact on the Go-encoded shape (`"snapshot":true` with no spaces). ESF events come from a typed Swift encoder that emits no extra whitespace, so the spaced form `"snapshot": true` doesn't appear in production. If Swift's encoder ever changes its formatting we'll need to widen the gate; the test pins the current behaviour so the regression is loud.

Build, lint, and full detection + ingest test suites pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection accuracy by filtering out synthetic startup events from rule evaluation, preventing false positives on extension restart.

* **Tests**
  * Added test coverage for startup event filtering and detection engine behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->