### PR TITLE
Apply entitlements when re-signing release artifacts (Phase-7 ship bl…

### DIFF
--- a/packaging/pkg/build.sh
+++ b/packaging/pkg/build.sh
@@ -184,7 +184,17 @@ else
 
     PROFILE_NET="$ROOT/packaging/provisioning/networkextension.provisionprofile"
     NETEXT="$STAGE/app-root/Applications/Fleet EDR.app/Contents/Library/SystemExtensions/com.fleetdm.edr.networkextension.systemextension"
-    if [ -f "$PROFILE_NET" ] && [ -d "$NETEXT" ]; then
+    # Whenever the NE bundle is present we re-sign it below with restricted
+    # entitlements. Without an embedded provisioning profile that re-sign
+    # produces a NE that fails activation on SIP-on hosts — the exact bug
+    # the entitlements re-sign exists to fix on the sysext side. Fail-fast
+    # rather than silently shipping the same broken shape.
+    if [ -d "$NETEXT" ]; then
+        if [ ! -f "$PROFILE_NET" ]; then
+            echo "ERROR: NE bundle present at $NETEXT but $PROFILE_NET is missing." >&2
+            echo "       A NE re-signed without an embedded profile fails activation on SIP-on hosts." >&2
+            exit 8
+        fi
         cp "$PROFILE_NET" "$NETEXT/Contents/embedded.provisionprofile"
     fi
 
@@ -211,9 +221,10 @@ else
         [ -f "$f" ] || { echo "missing entitlements file: $f" >&2; exit 6; }
     done
     # NETEXT entitlements only required when the NE bundle is present.
+    # Distinct exit code so CI triage can tell which precondition failed.
     if [ -d "$NETEXT" ] && [ ! -f "$NETEXT_ENTITLEMENTS" ]; then
         echo "missing entitlements file: $NETEXT_ENTITLEMENTS" >&2
-        exit 6
+        exit 7
     fi
 
     # shellcheck disable=SC2086

--- a/packaging/pkg/build.sh
+++ b/packaging/pkg/build.sh
@@ -189,18 +189,44 @@ else
     fi
 
     # Re-sign every bundle the edr.app embeds, bottom-up, with the hardened
-    # runtime flag. Notary rejects any Mach-O inside the outer bundle that
-    # lacks `--options runtime`, so all three inner bundles + the app bundle
-    # itself get re-signed after the provisioning profile embed above (which
-    # invalidates the Xcode-time signature).
+    # runtime flag AND the per-binary entitlements. Notary rejects any
+    # Mach-O inside the outer bundle that lacks `--options runtime`, so
+    # all three inner bundles + the app bundle itself get re-signed after
+    # the provisioning profile embed above (which invalidates the
+    # Xcode-time signature).
+    #
+    # `--entitlements` is load-bearing: a bare `codesign --sign` strips
+    # whatever entitlements the Xcode build embedded, leaving the binaries
+    # signed but with an empty entitlements blob. On SIP-disabled dev
+    # Macs that's fine — entitlements aren't enforced — but on a SIP-on
+    # pilot Mac OSSystemExtensionRequest fails before sysextd can stage
+    # the extension, with the user-visible symptom being "I never got the
+    # System Settings approval prompt." The entitlement plists below are
+    # the ones the Xcode targets reference; keep this codesign call in
+    # sync with the project's CODE_SIGN_ENTITLEMENTS settings.
+    SYSEXT_ENTITLEMENTS="$ROOT/extension/edr/extension/extension.entitlements"
+    NETEXT_ENTITLEMENTS="$ROOT/extension/edr/networkextension/networkextension.entitlements"
+    APP_ENTITLEMENTS="$ROOT/extension/edr/edr/edr.entitlements"
+    for f in "$SYSEXT_ENTITLEMENTS" "$APP_ENTITLEMENTS"; do
+        [ -f "$f" ] || { echo "missing entitlements file: $f" >&2; exit 6; }
+    done
+    # NETEXT entitlements only required when the NE bundle is present.
+    if [ -d "$NETEXT" ] && [ ! -f "$NETEXT_ENTITLEMENTS" ]; then
+        echo "missing entitlements file: $NETEXT_ENTITLEMENTS" >&2
+        exit 6
+    fi
+
     # shellcheck disable=SC2086
-    codesign $CODESIGN_FLAGS --sign "$APP_IDENTITY" $KEYCHAIN_ARG "$SYSEXT"
+    codesign $CODESIGN_FLAGS --sign "$APP_IDENTITY" $KEYCHAIN_ARG \
+        --entitlements "$SYSEXT_ENTITLEMENTS" "$SYSEXT"
     if [ -d "$NETEXT" ]; then
         # shellcheck disable=SC2086
-        codesign $CODESIGN_FLAGS --sign "$APP_IDENTITY" $KEYCHAIN_ARG "$NETEXT"
+        codesign $CODESIGN_FLAGS --sign "$APP_IDENTITY" $KEYCHAIN_ARG \
+            --entitlements "$NETEXT_ENTITLEMENTS" "$NETEXT"
     fi
     # shellcheck disable=SC2086
     codesign $CODESIGN_FLAGS --sign "$APP_IDENTITY" $KEYCHAIN_ARG \
+        --entitlements "$APP_ENTITLEMENTS" \
         "$STAGE/app-root/Applications/Fleet EDR.app"
 fi
 


### PR DESCRIPTION
…ocker)

v0.1.0-rc.3's host app + both system extensions ship with empty entitlements blobs, even though the per-binary entitlement plists exist in extension/edr/{edr,extension,networkextension}/*.entitlements and Xcode references them at build time.

Root cause: build.sh re-signs all three bundles after embedding the provisioning profile (which invalidates the Xcode-time signature), but the bare `codesign --sign` calls don't pass `--entitlements`, so the resulting binaries are signed with an empty entitlements blob.

User-visible symptom on a SIP-enabled (i.e. pilot-customer) Mac:
* Install the .pkg, double-click /Applications/Fleet EDR.app.
* Host app silently submits OSSystemExtensionRequest.activationRequest.
* macOS rejects the request before it reaches sysextd because the caller lacks `com.apple.developer.system-extension.install`.
* The "System Extension Blocked — Click to allow" prompt that System Settings normally shows never appears, because nothing was ever staged.
* Agent log spams `xpc error code 1, expected` forever as it retries XPC to extensions that aren't loaded.

This was masked all along by edr-dev being SIP-disabled — without SIP enforcing entitlements, ESF + NE load anyway. The bug only surfaces on the SIP-on QA VM that's meant to simulate a real pilot customer Mac, which is exactly where it matters.

Fix: each post-Xcode `codesign --sign` re-sign call now passes `--entitlements <file>` with the matching plist. The plists already exist and have the right contents:
  * edr.entitlements — com.apple.developer.system-extension.install + networkextension types
  * extension.entitlements — com.apple.developer.endpoint-security.client
  * networkextension.entitlements — networkextension provider types
    + application-groups for IPC

Also added explicit existence checks so a missing plist fails the build loudly instead of silently producing another broken release.

Validated locally with bash -n + shellcheck. The next release tag will exercise this end-to-end; the canary is "OSSystemExtensionRequest no longer fails immediately on SIP-on hosts" → System Settings shows the approval prompt as expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the build process to apply per-binary entitlements during code signing for the EDR app and system extensions, with validation to ensure entitlements files are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->