### PR TITLE
Use -systemextension NE entitlement values to match Developer ID profile

### DIFF
--- a/extension/edr/edr/edr.entitlements
+++ b/extension/edr/edr/edr.entitlements
@@ -6,8 +6,8 @@
 	<true/>
 	<key>com.apple.developer.networking.networkextension</key>
 	<array>
-		<string>content-filter-provider</string>
-		<string>dns-proxy</string>
+		<string>content-filter-provider-systemextension</string>
+		<string>dns-proxy-systemextension</string>
 	</array>
 </dict>
 </plist>

--- a/extension/edr/networkextension/networkextension.entitlements
+++ b/extension/edr/networkextension/networkextension.entitlements
@@ -4,8 +4,8 @@
 <dict>
 	<key>com.apple.developer.networking.networkextension</key>
 	<array>
-		<string>content-filter-provider</string>
-		<string>dns-proxy</string>
+		<string>content-filter-provider-systemextension</string>
+		<string>dns-proxy-systemextension</string>
 	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>


### PR DESCRIPTION
QA on rc.5 (edr-qa, SIP on) showed the host app still gets killed by AMFI, this time with a different unsatisfied entitlement:

  amfid: Unsatisfied Entitlements: com.apple.developer.networking.networkextension
  taskgated-helper: com.fleetdm.edr: Unsatisfied entitlements: ...
  kernel AMFI: code signature validation failed fatally

The host-app provisioning profile we added in rc.5 IS bound to FDG8Q7N4CC.com.fleetdm.edr and DOES authorize NE entitlements — but the values it authorizes are the system-extension flavors:

  content-filter-provider-systemextension
  dns-proxy-systemextension
  packet-tunnel-provider-systemextension
  ...

Apple grants those for Developer-ID-distributed apps that drive system extensions (which is what we are). The binary entitlements blob still declared the legacy app-extension strings (content-filter-provider, dns-proxy), so AMFI's value-subset check failed. SIP-off (edr-dev) didn't enforce the subset, which masked the gap.

Fix: align both binary entitlement declarations with the profile's authorized values:

  edr.entitlements (host app):
    content-filter-provider           -> content-filter-provider-systemextension
    dns-proxy                         -> dns-proxy-systemextension

  networkextension.entitlements (NE sysext):
    same change (the existing NE sysext profile has the same -systemextension-only
    array, so the sysext binary had latent SIP-on rejection waiting for us
    once we got past the host app)

This is also semantically the correct entitlement pair: NEFilterManager + NEDNSProxyManager driving a *system extension* provider use the *-systemextension* entitlement values; the bare strings are for app-extension (.appex) providers, which we are not.