### PR TITLE
Address rc.7 QA findings: blocklist UI + path canonicalization + runb…

### DIFF
--- a/agent/reconcile/reconcile_test.go
+++ b/agent/reconcile/reconcile_test.go
@@ -3,6 +3,7 @@ package reconcile
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"sync"
 	"syscall"
 	"testing"
@@ -17,11 +18,19 @@ import (
 type recorderQueue struct {
 	mu     sync.Mutex
 	events [][]byte
+	// failNext, when non-nil, makes the next Enqueue call return this error
+	// instead of recording. Used to exercise the reconciler's enqueue-error
+	// branch without standing up a real queue.
+	failNext error
 }
 
 func (r *recorderQueue) Enqueue(_ context.Context, payload []byte) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	if err := r.failNext; err != nil {
+		r.failNext = nil
+		return err
+	}
 	cp := make([]byte, len(payload))
 	copy(cp, payload)
 	r.events = append(r.events, cp)
@@ -295,6 +304,20 @@ func TestRun_EmitsSyntheticExitDuringLoop(t *testing.T) {
 		time.Sleep(20 * time.Millisecond)
 	}
 	assert.NotEmpty(t, q.snapshot(), "Run must emit at least one synthetic exit before the deadline")
+}
+
+func TestRunOnce_EnqueueErrorIsLoggedAndPIDStays(t *testing.T) {
+	pt := proctable.New()
+	pt.Update(42, proctable.ProcessInfo{Path: "/bin/dead", StartTime: 0})
+
+	q := &recorderQueue{failNext: errors.New("queue full")}
+	r := newRunner(t, pt, q, &killer{dead: map[int]bool{42: true}}, "h", Options{})
+
+	n, err := r.RunOnce(context.Background())
+	require.NoError(t, err, "RunOnce never returns the per-PID enqueue error to the loop — it logs and continues so one bad enqueue doesn't stall the whole pass")
+	assert.Equal(t, 0, n)
+	_, ok := pt.Lookup(42)
+	assert.True(t, ok, "PID must stay in the proctable when its synthetic exit failed to enqueue, so the next pass retries it")
 }
 
 func TestNewUUIDv4_FormatAndUniqueness(t *testing.T) {

--- a/scripts/qa/attack-runbook.sh
+++ b/scripts/qa/attack-runbook.sh
@@ -311,6 +311,14 @@ USAGE
       *) echo "[runbook] unknown argument: $arg" >&2; exit 2 ;;
     esac
   done
+  # Validate PACE_SECONDS up-front. The downstream `[[ "$PACE_SECONDS" -gt 0 ]]`
+  # and `sleep "$PACE_SECONDS"` calls will explode mid-script on a non-integer
+  # (the trap fires "step at line N exited 2" and a confused operator wonders
+  # why nothing fired). Reject early with a clear message instead.
+  if ! [[ "$PACE_SECONDS" =~ ^[0-9]+$ ]]; then
+    echo "[runbook] invalid PACE_SECONDS=\"$PACE_SECONDS\" — must be a non-negative integer" >&2
+    exit 2
+  fi
 }
 
 main() {

--- a/scripts/qa/attack-runbook.sh
+++ b/scripts/qa/attack-runbook.sh
@@ -66,15 +66,45 @@ mkdir -p "$WORKDIR"
 
 EXPECTED_ALERTS=()
 
+# Demo pacing: how long to pause between steps so a live audience can see each
+# alert land in the UI before the next attack fires. 0 disables (lab use), 8
+# is the right cadence for a live demo. Override with --pace=N or
+# EDR_RUNBOOK_PACE_SECONDS=N.
+PACE_SECONDS="${EDR_RUNBOOK_PACE_SECONDS:-0}"
+
+# Total step count, used so the per-step header reads "Step 3 of 7" and the
+# operator can call out matches live. Increment STEP each step.
+TOTAL_STEPS=7
+STEP=0
+
 # Ascii separator between steps so the operator can scroll the SSH session.
 hr() {
   printf '\n%s\n' '────────────────────────────────────────────────────────'
   return 0
 }
 
-step_suspicious_exec() {
+# step_header prints a presenter-friendly banner: "Step N of M: <title>" with
+# the expected rule_id beneath, so the operator can call out the match in real
+# time. Bumps the global STEP counter as a side effect.
+step_header() {
+  STEP=$((STEP + 1))
+  local title="$1" rule_id="$2"
   hr
-  echo "[runbook] suspicious_exec — non-shell parent → /bin/sh → /tmp/<binary>"
+  printf '[runbook] Step %d of %d: %s\n' "$STEP" "$TOTAL_STEPS" "$title"
+  printf '[runbook]   expecting rule_id=%s in the alerts list\n' "$rule_id"
+}
+
+# step_pace pauses for PACE_SECONDS so the live audience can watch the alert
+# land in the UI before the next step fires. No-op when PACE_SECONDS=0.
+step_pace() {
+  if [[ "$PACE_SECONDS" -gt 0 ]]; then
+    printf '[runbook]   waiting %ds for the alert to land in the UI...\n' "$PACE_SECONDS"
+    sleep "$PACE_SECONDS"
+  fi
+}
+
+step_suspicious_exec() {
+  step_header "Temp-path exec via non-shell parent" "suspicious_exec"
   # Rule trigger: a shell (/bin/sh / /bin/bash / /bin/zsh) whose PARENT is
   # NOT itself a shell forks a child under /tmp/* within 30s. The rule
   # explicitly skips shell→shell→/tmp chains (suspicious_exec.go:110), so
@@ -104,8 +134,7 @@ PAYLOAD
 }
 
 step_persistence_launchagent() {
-  hr
-  echo "[runbook] persistence_launchagent — launchctl load on a fake plist"
+  step_header "LaunchAgent persistence drop + launchctl load" "persistence_launchagent"
   # Rule trigger: exec of `launchctl load <plist>` where plist matches
   # ~/Library/LaunchAgents/<name>.plist or /Library/LaunchAgents/<name>.plist.
   # We DO NOT actually persist anything — the plist is a syntactic
@@ -132,8 +161,7 @@ EOF
 }
 
 step_dyld_insert() {
-  hr
-  echo "[runbook] dyld_insert — /usr/bin/env DYLD_INSERT_LIBRARIES=... <binary>"
+  step_header "DYLD library injection on exec" "dyld_insert"
   # Rule trigger: an exec event whose `args` array carries a leading
   # `DYLD_INSERT_LIBRARIES=` (or `DYLD_LIBRARY_PATH=`) assignment in a
   # position the rule treats as exec-time env (dyld_insert.go:matchDyldArg).
@@ -148,8 +176,7 @@ step_dyld_insert() {
 }
 
 step_osascript_network_exec() {
-  hr
-  echo "[runbook] osascript_network_exec — osascript → curl → /tmp/<file>"
+  step_header "AppleScript-driven download-and-exec chain" "osascript_network_exec"
   # Rule trigger: osascript spawns a process tree containing both a
   # curl/wget descendant AND a downstream exec whose path is under /tmp/
   # within 30s. The rule keys on the EXEC event for the /tmp/* binary,
@@ -172,8 +199,7 @@ STAGE2
 }
 
 step_credential_keychain_dump() {
-  hr
-  echo "[runbook] credential_keychain_dump — security dump-keychain"
+  step_header "Keychain credential dump attempt" "credential_keychain_dump"
   # Rule trigger: exec of /usr/bin/security with "dump-keychain" as the
   # first non-flag argv token. Run with stdin redirected from /dev/null so
   # the binary fails immediately on the password prompt rather than
@@ -184,8 +210,7 @@ step_credential_keychain_dump() {
 }
 
 step_privilege_launchd_plist_write() {
-  hr
-  echo "[runbook] privilege_launchd_plist_write — non-platform writer drops a daemon plist"
+  step_header "LaunchDaemon plist write by non-platform binary" "privilege_launchd_plist_write"
   # Rule trigger: write-mode open() to /Library/LaunchDaemons/<name>.plist
   # by a process whose code-signing is_platform_binary=false AND whose
   # team_id is not in EDR_LAUNCHDAEMON_TEAMID_ALLOWLIST. cp / dd / tee /
@@ -257,8 +282,7 @@ GO
 }
 
 step_shell_from_office_note() {
-  hr
-  echo "[runbook] shell_from_office — NOT exercised by this script"
+  step_header "Office-spawned shell (informational; not exercised)" "shell_from_office"
   # The rule keys on /Applications/Microsoft <App>.app/Contents/MacOS/<App>
   # as the parent process, with /bin/{sh,bash,zsh} as the child within 30s.
   # Office isn't installed on the dev VM. The plan calls out spoofing this
@@ -269,15 +293,39 @@ step_shell_from_office_note() {
   return 0
 }
 
+parse_args() {
+  for arg in "$@"; do
+    case "$arg" in
+      --pace=*) PACE_SECONDS="${arg#--pace=}" ;;
+      --demo)   PACE_SECONDS=8 ;;
+      --help|-h)
+        cat <<USAGE
+Usage: $0 [--pace=N | --demo]
+  --pace=N   Sleep N seconds between steps so an audience can watch each
+             alert land in the UI before the next attack fires. Default 0.
+  --demo     Shorthand for --pace=8 (the default live-demo cadence).
+
+Or set EDR_RUNBOOK_PACE_SECONDS=N in the environment.
+USAGE
+        exit 0 ;;
+      *) echo "[runbook] unknown argument: $arg" >&2; exit 2 ;;
+    esac
+  done
+}
+
 main() {
+  parse_args "$@"
   echo "[runbook] Fleet EDR Phase-7 synthetic attacker — $(date -u)"
   echo "[runbook] working dir: $WORKDIR"
-  step_suspicious_exec
-  step_persistence_launchagent
-  step_dyld_insert
-  step_osascript_network_exec
-  step_credential_keychain_dump
-  step_privilege_launchd_plist_write
+  if [[ "$PACE_SECONDS" -gt 0 ]]; then
+    echo "[runbook] live-demo pacing: ${PACE_SECONDS}s between steps"
+  fi
+  step_suspicious_exec;        step_pace
+  step_persistence_launchagent; step_pace
+  step_dyld_insert;            step_pace
+  step_osascript_network_exec; step_pace
+  step_credential_keychain_dump; step_pace
+  step_privilege_launchd_plist_write; step_pace
   step_shell_from_office_note
   hr
   echo "[runbook] Done. Expected alerts in the admin UI:"

--- a/scripts/qa/attack-runbook.sh
+++ b/scripts/qa/attack-runbook.sh
@@ -92,6 +92,7 @@ step_header() {
   hr
   printf '[runbook] Step %d of %d: %s\n' "$STEP" "$TOTAL_STEPS" "$title"
   printf '[runbook]   expecting rule_id=%s in the alerts list\n' "$rule_id"
+  return 0
 }
 
 # step_pace pauses for PACE_SECONDS so the live audience can watch the alert
@@ -101,6 +102,7 @@ step_pace() {
     printf '[runbook]   waiting %ds for the alert to land in the UI...\n' "$PACE_SECONDS"
     sleep "$PACE_SECONDS"
   fi
+  return 0
 }
 
 step_suspicious_exec() {
@@ -319,6 +321,7 @@ USAGE
     echo "[runbook] invalid PACE_SECONDS=\"$PACE_SECONDS\" — must be a non-negative integer" >&2
     exit 2
   fi
+  return 0
 }
 
 main() {

--- a/server/detection/rules/suspicious_exec.go
+++ b/server/detection/rules/suspicious_exec.go
@@ -208,10 +208,28 @@ func (r *SuspiciousExec) evalExec(
 		return nil, 0, nil
 	}
 
-	if f, shellPID, err := r.evalExecArm1(ctx, evt, s, batch, seenShell, p, tempProc, tempPath); err != nil || f != nil {
+	in := &execMatchInputs{
+		evt: evt, batch: batch, seenShell: seenShell, p: p,
+		tempProc: tempProc, tempPath: tempPath,
+	}
+	if f, shellPID, err := r.evalExecArm1(ctx, s, in); err != nil || f != nil {
 		return f, shellPID, err
 	}
-	return r.evalExecArm2(ctx, evt, s, batch, seenShell, p, tempProc, tempPath)
+	return r.evalExecArm2(ctx, s, in)
+}
+
+// execMatchInputs bundles the per-event evaluation state shared by both exec
+// arms. Sonar's go:S107 caps function signatures at 7 parameters; passing
+// these through individually pushed both arms over the limit. Bundling reads
+// cleaner anyway — every field below is "inputs about this single exec event"
+// and they always travel together.
+type execMatchInputs struct {
+	evt       store.Event
+	batch     []store.Event
+	seenShell map[int]struct{}
+	p         execPayload
+	tempProc  *store.Process
+	tempPath  string
 }
 
 // evalExecArm1 handles the canonical fork+exec dropper shape: the temp-binary
@@ -221,20 +239,19 @@ func (r *SuspiciousExec) evalExec(
 // is false for the temp-binary, so it trivially advances to PPID on the next
 // step.
 func (r *SuspiciousExec) evalExecArm1(
-	ctx context.Context, evt store.Event, s *store.Store, batch []store.Event,
-	seenShell map[int]struct{}, p execPayload, tempProc *store.Process, tempPath string,
+	ctx context.Context, s *store.Store, in *execMatchInputs,
 ) (*detection.Finding, int, error) {
-	shell, parent, err := r.findShellWithNonShellAncestor(ctx, s, evt.HostID, p.PID, evt.TimestampNs)
+	shell, parent, err := r.findShellWithNonShellAncestor(ctx, s, in.evt.HostID, in.p.PID, in.evt.TimestampNs)
 	if err != nil {
 		return nil, 0, err
 	}
 	if shell == nil {
 		return nil, 0, nil
 	}
-	if !r.shouldFire(seenShell, shell, parent, evt.TimestampNs) {
+	if !r.shouldFire(in.seenShell, shell, parent, in.evt.TimestampNs) {
 		return nil, 0, nil
 	}
-	return r.makeExecFinding(evt, parent, shell, tempProc, tempPath, batch), shell.PID, nil
+	return r.makeExecFinding(in.evt, parent, shell, in.tempProc, in.tempPath, in.batch), shell.PID, nil
 }
 
 // evalExecArm2 handles the same-PID re-exec optimisation. `sh -c "/tmp/foo"`
@@ -246,29 +263,28 @@ func (r *SuspiciousExec) evalExecArm1(
 // (a non-shell) and the shell itself is on the re-exec history of the same
 // PID, not in the parent chain.
 func (r *SuspiciousExec) evalExecArm2(
-	ctx context.Context, evt store.Event, s *store.Store, batch []store.Event,
-	seenShell map[int]struct{}, p execPayload, tempProc *store.Process, tempPath string,
+	ctx context.Context, s *store.Store, in *execMatchInputs,
 ) (*detection.Finding, int, error) {
-	chain, err := s.GetExecChain(ctx, *tempProc)
+	chain, err := s.GetExecChain(ctx, *in.tempProc)
 	if err != nil {
-		return nil, 0, fmt.Errorf("walk exec chain pid %d: %w", p.PID, err)
+		return nil, 0, fmt.Errorf("walk exec chain pid %d: %w", in.p.PID, err)
 	}
 	for i := range chain {
 		prior := &chain[i]
 		if !shellPaths[prior.Path] {
 			continue
 		}
-		priorParent, err := r.lookupAncestor(ctx, s, evt.HostID, prior.PPID, evt.TimestampNs)
+		priorParent, err := r.lookupAncestor(ctx, s, in.evt.HostID, prior.PPID, in.evt.TimestampNs)
 		if err != nil {
 			return nil, 0, err
 		}
 		if priorParent != nil && shellPaths[priorParent.Path] {
 			continue
 		}
-		if !r.shouldFire(seenShell, prior, priorParent, evt.TimestampNs) {
+		if !r.shouldFire(in.seenShell, prior, priorParent, in.evt.TimestampNs) {
 			return nil, 0, nil
 		}
-		return r.makeExecFinding(evt, priorParent, prior, tempProc, tempPath, batch), prior.PID, nil
+		return r.makeExecFinding(in.evt, priorParent, prior, in.tempProc, in.tempPath, in.batch), prior.PID, nil
 	}
 	return nil, 0, nil
 }

--- a/server/enrollment/enrollment_test.go
+++ b/server/enrollment/enrollment_test.go
@@ -368,7 +368,7 @@ func TestHandler_EnrollQueuesInitialPolicy(t *testing.T) {
 	// actually exercising payload population.
 	_, err := ps.Update(t.Context(), policy.UpdateRequest{
 		Name:  policy.DefaultName,
-		Paths: []string{"/tmp/initial-block"},
+		Paths: []string{"/private/tmp/initial-block"},
 		Actor: "seed",
 	})
 	require.NoError(t, err)
@@ -423,7 +423,7 @@ func TestHandler_EnrollQueuesInitialPolicy(t *testing.T) {
 	require.NoError(t, json.Unmarshal(got[0].Payload, &payload))
 	assert.Equal(t, "default", payload.Name)
 	assert.Equal(t, int64(2), payload.Version)
-	assert.Equal(t, []string{"/tmp/initial-block"}, payload.Paths)
+	assert.Equal(t, []string{"/private/tmp/initial-block"}, payload.Paths)
 }
 
 // TestHandler_EnrollSkipsEmptyPolicy proves the "empty blocklist = no command" contract:

--- a/server/policy/policy.go
+++ b/server/policy/policy.go
@@ -245,13 +245,15 @@ func dedupSort(in []string, norm func(string) string) []string {
 	return out
 }
 
-// canonicalizeMacOSPath rewrites the legacy /tmp and /var symlink prefixes to
-// their /private/tmp and /private/var canonical forms. ESF reports the
-// post-resolve path on AUTH_EXEC, so a blocklist entry of /tmp/payload would
-// silently fail to deny when the executable resolves to /private/tmp/payload.
-// Operators consistently type /tmp/foo and expect it to work; we rewrite at
-// the API boundary so the wire form matches what the kernel will compare
-// against. Other paths pass through unchanged.
+// canonicalizeMacOSPath rewrites the legacy /tmp, /var, and /etc symlink
+// prefixes to their /private/... canonical forms. ESF reports the
+// post-resolve path on AUTH_EXEC, so a blocklist entry of /tmp/payload
+// silently fails to deny when the executable resolves to /private/tmp/payload.
+// Operators consistently type /tmp/foo and /etc/foo and expect those to
+// work; we rewrite at the API boundary so the wire form matches what the
+// kernel will compare against. Trailing /tmpfoo or /varlog (no slash before
+// the rest) are NOT prefixes — they pass through unchanged. Other paths
+// also pass through unchanged.
 func canonicalizeMacOSPath(p string) string {
 	switch {
 	case strings.HasPrefix(p, "/tmp/"):
@@ -262,6 +264,10 @@ func canonicalizeMacOSPath(p string) string {
 		return "/private/var/" + p[len("/var/"):]
 	case p == "/var":
 		return "/private/var"
+	case strings.HasPrefix(p, "/etc/"):
+		return "/private/etc/" + p[len("/etc/"):]
+	case p == "/etc":
+		return "/private/etc"
 	}
 	return p
 }

--- a/server/policy/policy.go
+++ b/server/policy/policy.go
@@ -215,7 +215,7 @@ func validateBlocklist(bl Blocklist) error {
 // an array, never null.
 func normalizeBlocklist(paths, hashes []string) Blocklist {
 	bl := Blocklist{
-		Paths:  dedupSort(paths, strings.TrimSpace),
+		Paths:  dedupSort(paths, func(s string) string { return canonicalizeMacOSPath(strings.TrimSpace(s)) }),
 		Hashes: dedupSort(hashes, func(s string) string { return strings.ToLower(strings.TrimSpace(s)) }),
 	}
 	if bl.Paths == nil {
@@ -243,4 +243,25 @@ func dedupSort(in []string, norm func(string) string) []string {
 	}
 	sort.Strings(out)
 	return out
+}
+
+// canonicalizeMacOSPath rewrites the legacy /tmp and /var symlink prefixes to
+// their /private/tmp and /private/var canonical forms. ESF reports the
+// post-resolve path on AUTH_EXEC, so a blocklist entry of /tmp/payload would
+// silently fail to deny when the executable resolves to /private/tmp/payload.
+// Operators consistently type /tmp/foo and expect it to work; we rewrite at
+// the API boundary so the wire form matches what the kernel will compare
+// against. Other paths pass through unchanged.
+func canonicalizeMacOSPath(p string) string {
+	switch {
+	case strings.HasPrefix(p, "/tmp/"):
+		return "/private/tmp/" + p[len("/tmp/"):]
+	case p == "/tmp":
+		return "/private/tmp"
+	case strings.HasPrefix(p, "/var/"):
+		return "/private/var/" + p[len("/var/"):]
+	case p == "/var":
+		return "/private/var"
+	}
+	return p
 }

--- a/server/policy/policy_test.go
+++ b/server/policy/policy_test.go
@@ -80,20 +80,32 @@ func TestUpdate_CanonicalizesMacOSSymlinkPaths(t *testing.T) {
 	ctx := t.Context()
 
 	p, err := s.Update(ctx, UpdateRequest{
-		Name:  DefaultName,
-		Paths: []string{"/tmp/payload", "/tmp", "/var/log/foo", "/var", "/opt/keepasis", "/private/tmp/already"},
+		Name: DefaultName,
+		Paths: []string{
+			"/tmp/payload", "/tmp", "/var/log/foo", "/var", "/etc/foo", "/etc",
+			"/opt/keepasis", "/private/tmp/already",
+			// Lookalikes that share a 4-char prefix with /tmp / /var / /etc but
+			// are NOT under those directories. The rewrite must be a
+			// path-segment match (HasPrefix("/tmp/")), never a substring match.
+			"/tmpfoo", "/varlog/x", "/etcetera",
+		},
 		Actor: "qa",
 	})
 	require.NoError(t, err)
 	assert.Equal(t, []string{
+		"/etcetera",
 		"/opt/keepasis",
+		"/private/etc",
+		"/private/etc/foo",
 		"/private/tmp",
 		"/private/tmp/already",
 		"/private/tmp/payload",
 		"/private/var",
 		"/private/var/log/foo",
+		"/tmpfoo",
+		"/varlog/x",
 	}, p.Blocklist.Paths,
-		"every /tmp/* and /var/* prefix must be rewritten to its /private/... canonical form; other paths pass through")
+		"every /tmp/, /var/, and /etc/ prefix must be rewritten to its /private/... canonical form; lookalike paths (/tmpfoo, /varlog, /etcetera) pass through unchanged")
 }
 
 // TestUpdate_RejectsInvalidBlocklistEntries locks in the Phase 2 validation contract: a

--- a/server/policy/policy_test.go
+++ b/server/policy/policy_test.go
@@ -70,6 +70,32 @@ func TestUpdate_BumpsVersionAndNormalizes(t *testing.T) {
 	assert.Equal(t, []string{}, p2.Blocklist.Hashes)
 }
 
+// TestUpdate_CanonicalizesMacOSSymlinkPaths locks in the rc.7 finding: ESF
+// reports the post-resolve path on AUTH_EXEC, so a blocklist entry of
+// /tmp/foo silently fails to block when the kernel sees /private/tmp/foo.
+// We rewrite at the API boundary so the persisted form matches what the
+// kernel actually compares against, regardless of how the operator typed it.
+func TestUpdate_CanonicalizesMacOSSymlinkPaths(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+
+	p, err := s.Update(ctx, UpdateRequest{
+		Name:  DefaultName,
+		Paths: []string{"/tmp/payload", "/tmp", "/var/log/foo", "/var", "/opt/keepasis", "/private/tmp/already"},
+		Actor: "qa",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"/opt/keepasis",
+		"/private/tmp",
+		"/private/tmp/already",
+		"/private/tmp/payload",
+		"/private/var",
+		"/private/var/log/foo",
+	}, p.Blocklist.Paths,
+		"every /tmp/* and /var/* prefix must be rewritten to its /private/... canonical form; other paths pass through")
+}
+
 // TestUpdate_RejectsInvalidBlocklistEntries locks in the Phase 2 validation contract: a
 // malformed path (relative, empty after trim) or hash (not 64 lowercase hex chars) fails
 // the update before anything is persisted. Without this, bad operator input would be

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -3,6 +3,7 @@ import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import { HostList } from "./components/HostList";
 import { ProcessTreeView } from "./components/ProcessTree";
 import { AlertList } from "./components/AlertList";
+import { PolicyEditor } from "./components/PolicyEditor";
 import { Login } from "./components/Login";
 import { TopNav } from "./components/ui/TopNav";
 import { currentSession, logout, Unauthorized401Error, SessionInfo } from "./api";
@@ -76,6 +77,7 @@ export function App() {
         <Routes>
           <Route path="/" element={<HostList />} />
           <Route path="/alerts" element={<AlertList />} />
+          <Route path="/policy" element={<PolicyEditor />} />
           <Route path="/hosts/:hostId" element={<ProcessTreeView />} />
           <Route path="*" element={<Navigate to="/" replace />} />
         </Routes>

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -77,7 +77,7 @@ export function App() {
         <Routes>
           <Route path="/" element={<HostList />} />
           <Route path="/alerts" element={<AlertList />} />
-          <Route path="/policy" element={<PolicyEditor />} />
+          <Route path="/policy" element={<PolicyEditor actor={auth.user.email} />} />
           <Route path="/hosts/:hostId" element={<ProcessTreeView />} />
           <Route path="*" element={<Navigate to="/" replace />} />
         </Routes>

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -224,6 +224,32 @@ export interface AttackNavigatorLayer {
   }>;
 }
 
+// Policy is the operator-managed blocklist. The same shape the server
+// returns from GET /api/v1/admin/policy.
+export interface Policy {
+  name: string;
+  version: number;
+  blocklist: { paths: string[]; hashes: string[] };
+  updated_at: string;
+  updated_by: string;
+}
+
+export async function fetchPolicy(): Promise<Policy> {
+  return fetchJSON<Policy>("/admin/policy");
+}
+
+export async function updatePolicy(
+  paths: string[],
+  hashes: string[],
+  actor: string,
+  reason: string,
+): Promise<Policy> {
+  return fetchJSON<Policy>("/admin/policy", {
+    method: "PUT",
+    body: JSON.stringify({ paths, hashes, actor, reason }),
+  });
+}
+
 // fetchAttackNavigatorLayer pulls the MITRE ATT&CK Navigator layer that
 // describes which techniques the registered detection rules cover. Returned
 // JSON is dropped directly into https://mitre-attack.github.io/attack-navigator/

--- a/ui/src/components/AlertList.tsx
+++ b/ui/src/components/AlertList.tsx
@@ -87,7 +87,7 @@ export function AlertList() {
           try {
             a.click();
           } finally {
-            document.body.removeChild(a);
+            a.remove();
           }
         } finally {
           URL.revokeObjectURL(url);

--- a/ui/src/components/PolicyEditor.scss
+++ b/ui/src/components/PolicyEditor.scss
@@ -1,0 +1,50 @@
+@use "../styles/var/colors" as *;
+@use "../styles/var/padding" as *;
+
+.policy-section {
+  margin: $pad-xlarge 0;
+
+  h2 {
+    margin: 0 0 $pad-small;
+    font-size: 1.1rem;
+  }
+
+  code {
+    font-family: ui-monospace, SFMono-Regular, monospace;
+    font-size: 0.85em;
+  }
+}
+
+.policy-hint {
+  margin: 0 0 $pad-medium;
+  color: $ui-fleet-black-50;
+  font-size: 0.9em;
+  max-width: 60ch;
+}
+
+.policy-add-row,
+.policy-save-row {
+  display: flex;
+  align-items: flex-end;
+  gap: $pad-small;
+  margin-top: $pad-medium;
+  flex-wrap: wrap;
+}
+
+.policy-meta {
+  color: $ui-fleet-black-50;
+  font-size: 0.85em;
+}
+
+.policy-saved {
+  color: $core-fleet-green;
+  font-size: 0.85em;
+}
+
+.form-error {
+  margin: $pad-small 0;
+  padding: $pad-small $pad-medium;
+  border-radius: 4px;
+  background: rgba(255, 92, 131, 0.1);
+  color: $core-vibrant-red;
+}

--- a/ui/src/components/PolicyEditor.tsx
+++ b/ui/src/components/PolicyEditor.tsx
@@ -18,8 +18,13 @@ const HEX_64 = /^[0-9a-f]{64}$/;
 
 function sortedEqual(a: readonly string[], b: readonly string[]): boolean {
   if (a.length !== b.length) return false;
-  const sa = [...a].sort();
-  const sb = [...b].sort();
+  // Pass an explicit Intl-aware comparator instead of relying on Array.sort's
+  // default lexicographic-by-UTF-16-unit ordering (Sonar typescript:S2871).
+  // For ASCII-only inputs the result is identical; for unicode it's correct
+  // and locale-stable.
+  const cmp = (x: string, y: string) => x.localeCompare(y);
+  const sa = [...a].sort(cmp);
+  const sb = [...b].sort(cmp);
   // Indexed access is safe: i is bounded by sa.length (== sb.length checked above).
   // eslint-disable-next-line security/detect-object-injection
   return sa.every((v, i) => v === sb[i]);

--- a/ui/src/components/PolicyEditor.tsx
+++ b/ui/src/components/PolicyEditor.tsx
@@ -6,14 +6,34 @@ import { Button } from "./ui/Button";
 import { Input } from "./ui/Input";
 import "./PolicyEditor.scss";
 
+interface PolicyEditorProps {
+  // actor is the authenticated operator's email — recorded in updated_by on
+  // the server and emitted to the audit log on every change. Required so a
+  // post-incident reviewer can answer "who pushed this rule?" without
+  // resorting to session-cookie forensics.
+  readonly actor: string;
+}
+
+const HEX_64 = /^[0-9a-f]{64}$/;
+
+function sortedEqual(a: readonly string[], b: readonly string[]): boolean {
+  if (a.length !== b.length) return false;
+  const sa = [...a].sort();
+  const sb = [...b].sort();
+  // Indexed access is safe: i is bounded by sa.length (== sb.length checked above).
+  // eslint-disable-next-line security/detect-object-injection
+  return sa.every((v, i) => v === sb[i]);
+}
+
 // PolicyEditor is the operator-facing surface for the server-driven blocklist
 // (the same Policy that GET/PUT /api/v1/admin/policy serves). The UI deliberately
 // stays bare — list paths and hashes, add a row, remove a row, save with a
 // required reason. Every save bumps the policy version on the server and fans
 // out a set_blocklist command to every active host. The server canonicalises
-// macOS symlink prefixes (/tmp/ → /private/tmp/, /var/ → /private/var/) so an
-// operator who types /tmp/payload still gets a working block at the kernel.
-export function PolicyEditor() {
+// macOS symlink prefixes (/tmp/ → /private/tmp/, /var/ → /private/var/, /etc/
+// → /private/etc/) so an operator who types /tmp/payload still gets a working
+// block at the kernel.
+export function PolicyEditor({ actor }: PolicyEditorProps) {
   const [policy, setPolicy] = useState<Policy | null>(null);
   const [paths, setPaths] = useState<string[]>([]);
   const [hashes, setHashes] = useState<string[]>([]);
@@ -21,35 +41,61 @@ export function PolicyEditor() {
   const [newHash, setNewHash] = useState("");
   const [reason, setReason] = useState("");
   const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [savedAt, setSavedAt] = useState<string | null>(null);
 
   useEffect(() => {
+    let cancelled = false;
     fetchPolicy()
       .then((p) => {
+        if (cancelled) return;
         setPolicy(p);
         setPaths(p.blocklist.paths);
         setHashes(p.blocklist.hashes);
       })
       .catch((err: unknown) => {
+        if (cancelled) return;
         setError(err instanceof Error ? err.message : "Failed to load policy");
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
       });
+    return () => { cancelled = true; };
   }, []);
 
   const dirty = policy !== null
-    && (JSON.stringify(paths) !== JSON.stringify(policy.blocklist.paths)
-      || JSON.stringify(hashes) !== JSON.stringify(policy.blocklist.hashes));
+    && (!sortedEqual(paths, policy.blocklist.paths)
+      || !sortedEqual(hashes, policy.blocklist.hashes));
 
   const addPath = () => {
     const p = newPath.trim();
-    if (!p || paths.includes(p)) return;
+    if (!p) return;
+    if (!p.startsWith("/")) {
+      setError("Path must be absolute (start with '/').");
+      return;
+    }
+    if (paths.includes(p)) {
+      setNewPath("");
+      return;
+    }
+    setError(null);
     setPaths([...paths, p].sort((a, b) => a.localeCompare(b)));
     setNewPath("");
   };
 
   const addHash = () => {
     const h = newHash.trim().toLowerCase();
-    if (!h || hashes.includes(h)) return;
+    if (!h) return;
+    if (!HEX_64.test(h)) {
+      setError("Hash must be exactly 64 lowercase hex characters (SHA-256).");
+      return;
+    }
+    if (hashes.includes(h)) {
+      setNewHash("");
+      return;
+    }
+    setError(null);
     setHashes([...hashes, h].sort((a, b) => a.localeCompare(b)));
     setNewHash("");
   };
@@ -64,7 +110,7 @@ export function PolicyEditor() {
     }
     setSaving(true);
     setError(null);
-    updatePolicy(paths, hashes, "ui", reason.trim())
+    updatePolicy(paths, hashes, actor, reason.trim())
       .then((p) => {
         setPolicy(p);
         setPaths(p.blocklist.paths);
@@ -86,109 +132,117 @@ export function PolicyEditor() {
       />
 
       {error && <div className="form-error" role="alert">Error: {error}</div>}
+      {loading && <EmptyState>Loading policy...</EmptyState>}
 
-      <section className="policy-section">
-        <h2>Blocked paths</h2>
-        <p className="policy-hint">
-          Absolute file paths the system extension will <strong>deny</strong> on
-          exec. <code>/tmp/foo</code> and <code>/var/foo</code> are auto-rewritten
-          to their <code>/private/...</code> canonical forms server-side.
-        </p>
-        {paths.length === 0
-          ? <EmptyState>No paths blocked.</EmptyState>
-          : (
-            <Table>
-              <thead><tr><th>Path</th><th></th></tr></thead>
-              <tbody>
-                {paths.map((p) => (
-                  <tr key={p}>
-                    <td><code>{p}</code></td>
-                    <td>
-                      <Button size="small" variant="inverse" onClick={() => { removePath(p); }}>
-                        Remove
-                      </Button>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </Table>
-          )}
-        <div className="policy-add-row">
-          <Input
-            id="new-path"
-            label="Add path:"
-            value={newPath}
-            onChange={(e) => { setNewPath(e.target.value); }}
-            placeholder="/private/tmp/payload"
-          />
-          <Button size="small" onClick={addPath}>Add</Button>
-        </div>
-      </section>
+      {!loading && (
+        <>
+          <section className="policy-section">
+            <h2>Blocked paths</h2>
+            <p className="policy-hint">
+              Absolute file paths the system extension will <strong>deny</strong> on
+              exec. <code>/tmp/foo</code>, <code>/var/foo</code>, and <code>/etc/foo</code>{" "}
+              are auto-rewritten to their <code>/private/...</code> canonical forms
+              server-side.
+            </p>
+            {paths.length === 0
+              ? <EmptyState>No paths blocked.</EmptyState>
+              : (
+                <Table>
+                  <thead><tr><th>Path</th><th></th></tr></thead>
+                  <tbody>
+                    {paths.map((p) => (
+                      <tr key={p}>
+                        <td><code>{p}</code></td>
+                        <td>
+                          <Button size="small" variant="inverse" onClick={() => { removePath(p); }}>
+                            Remove
+                          </Button>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </Table>
+              )}
+            <div className="policy-add-row">
+              <Input
+                id="new-path"
+                label="Add path:"
+                value={newPath}
+                onChange={(e) => { setNewPath(e.target.value); }}
+                placeholder="/private/tmp/payload"
+              />
+              <Button size="small" onClick={addPath}>Add</Button>
+            </div>
+          </section>
 
-      <section className="policy-section">
-        <h2>Blocked SHA-256 hashes</h2>
-        <p className="policy-hint">
-          64-character lowercase hex. Lets you block a binary regardless of where
-          it lives on disk.
-        </p>
-        {hashes.length === 0
-          ? <EmptyState>No hashes blocked.</EmptyState>
-          : (
-            <Table>
-              <thead><tr><th>Hash</th><th></th></tr></thead>
-              <tbody>
-                {hashes.map((h) => (
-                  <tr key={h}>
-                    <td><code>{h}</code></td>
-                    <td>
-                      <Button size="small" variant="inverse" onClick={() => { removeHash(h); }}>
-                        Remove
-                      </Button>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </Table>
-          )}
-        <div className="policy-add-row">
-          <Input
-            id="new-hash"
-            label="Add hash:"
-            value={newHash}
-            onChange={(e) => { setNewHash(e.target.value); }}
-            placeholder="aaaaaaaa..."
-          />
-          <Button size="small" onClick={addHash}>Add</Button>
-        </div>
-      </section>
+          <section className="policy-section">
+            <h2>Blocked SHA-256 hashes</h2>
+            <p className="policy-hint">
+              64-character lowercase hex. Lets you block a binary regardless of
+              where it lives on disk.
+            </p>
+            {hashes.length === 0
+              ? <EmptyState>No hashes blocked.</EmptyState>
+              : (
+                <Table>
+                  <thead><tr><th>Hash</th><th></th></tr></thead>
+                  <tbody>
+                    {hashes.map((h) => (
+                      <tr key={h}>
+                        <td><code>{h}</code></td>
+                        <td>
+                          <Button size="small" variant="inverse" onClick={() => { removeHash(h); }}>
+                            Remove
+                          </Button>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </Table>
+              )}
+            <div className="policy-add-row">
+              <Input
+                id="new-hash"
+                label="Add hash:"
+                value={newHash}
+                onChange={(e) => { setNewHash(e.target.value); }}
+                placeholder="aaaaaaaa..."
+              />
+              <Button size="small" onClick={addHash}>Add</Button>
+            </div>
+          </section>
 
-      <section className="policy-section">
-        <h2>Save</h2>
-        <p className="policy-hint">
-          Every save bumps the policy version and fans the new blocklist out to
-          every active host. The reason is recorded in the audit log.
-        </p>
-        <Input
-          id="policy-reason"
-          label="Reason:"
-          value={reason}
-          onChange={(e) => { setReason(e.target.value); }}
-          placeholder="why are you changing the policy?"
-        />
-        <div className="policy-save-row">
-          <Button onClick={handleSave} disabled={!dirty || saving || !reason.trim()}>
-            {saving ? "Saving..." : "Save policy"}
-          </Button>
-          {policy && (
-            <span className="policy-meta">
-              version {policy.version}, last changed {new Date(policy.updated_at).toLocaleString()} by {policy.updated_by}
-            </span>
-          )}
-          {savedAt && !dirty && (
-            <span className="policy-saved">Saved.</span>
-          )}
-        </div>
-      </section>
+          <section className="policy-section">
+            <h2>Save</h2>
+            <p className="policy-hint">
+              Every save bumps the policy version and fans the new blocklist out
+              to every active host. The reason is recorded in the audit log
+              alongside your account.
+            </p>
+            <Input
+              id="policy-reason"
+              label="Reason:"
+              value={reason}
+              onChange={(e) => { setReason(e.target.value); }}
+              placeholder="why are you changing the policy?"
+            />
+            <div className="policy-save-row">
+              <Button onClick={handleSave} disabled={!dirty || saving || !reason.trim()}>
+                {saving ? "Saving..." : "Save policy"}
+              </Button>
+              {policy && (
+                <span className="policy-meta">
+                  version {policy.version}, last changed{" "}
+                  {new Date(policy.updated_at).toLocaleString()} by {policy.updated_by}
+                </span>
+              )}
+              {savedAt && !dirty && (
+                <span className="policy-saved">Saved.</span>
+              )}
+            </div>
+          </section>
+        </>
+      )}
     </>
   );
 }

--- a/ui/src/components/PolicyEditor.tsx
+++ b/ui/src/components/PolicyEditor.tsx
@@ -1,0 +1,194 @@
+import { useEffect, useState } from "react";
+import { fetchPolicy, updatePolicy, type Policy } from "../api";
+import { Table, EmptyState } from "./ui/Table";
+import { PageHeader } from "./ui/PageHeader";
+import { Button } from "./ui/Button";
+import { Input } from "./ui/Input";
+import "./PolicyEditor.scss";
+
+// PolicyEditor is the operator-facing surface for the server-driven blocklist
+// (the same Policy that GET/PUT /api/v1/admin/policy serves). The UI deliberately
+// stays bare — list paths and hashes, add a row, remove a row, save with a
+// required reason. Every save bumps the policy version on the server and fans
+// out a set_blocklist command to every active host. The server canonicalises
+// macOS symlink prefixes (/tmp/ → /private/tmp/, /var/ → /private/var/) so an
+// operator who types /tmp/payload still gets a working block at the kernel.
+export function PolicyEditor() {
+  const [policy, setPolicy] = useState<Policy | null>(null);
+  const [paths, setPaths] = useState<string[]>([]);
+  const [hashes, setHashes] = useState<string[]>([]);
+  const [newPath, setNewPath] = useState("");
+  const [newHash, setNewHash] = useState("");
+  const [reason, setReason] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [savedAt, setSavedAt] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetchPolicy()
+      .then((p) => {
+        setPolicy(p);
+        setPaths(p.blocklist.paths);
+        setHashes(p.blocklist.hashes);
+      })
+      .catch((err: unknown) => {
+        setError(err instanceof Error ? err.message : "Failed to load policy");
+      });
+  }, []);
+
+  const dirty = policy !== null
+    && (JSON.stringify(paths) !== JSON.stringify(policy.blocklist.paths)
+      || JSON.stringify(hashes) !== JSON.stringify(policy.blocklist.hashes));
+
+  const addPath = () => {
+    const p = newPath.trim();
+    if (!p || paths.includes(p)) return;
+    setPaths([...paths, p].sort((a, b) => a.localeCompare(b)));
+    setNewPath("");
+  };
+
+  const addHash = () => {
+    const h = newHash.trim().toLowerCase();
+    if (!h || hashes.includes(h)) return;
+    setHashes([...hashes, h].sort((a, b) => a.localeCompare(b)));
+    setNewHash("");
+  };
+
+  const removePath = (p: string) => { setPaths(paths.filter((x) => x !== p)); };
+  const removeHash = (h: string) => { setHashes(hashes.filter((x) => x !== h)); };
+
+  const handleSave = () => {
+    if (!reason.trim()) {
+      setError("Reason is required for every policy change.");
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    updatePolicy(paths, hashes, "ui", reason.trim())
+      .then((p) => {
+        setPolicy(p);
+        setPaths(p.blocklist.paths);
+        setHashes(p.blocklist.hashes);
+        setReason("");
+        setSavedAt(p.updated_at);
+      })
+      .catch((err: unknown) => {
+        setError(err instanceof Error ? err.message : "Save failed");
+      })
+      .finally(() => { setSaving(false); });
+  };
+
+  return (
+    <>
+      <PageHeader
+        title="Policy"
+        subtitle="Server-driven blocklist that every host enforces under AUTH_EXEC."
+      />
+
+      {error && <div className="form-error" role="alert">Error: {error}</div>}
+
+      <section className="policy-section">
+        <h2>Blocked paths</h2>
+        <p className="policy-hint">
+          Absolute file paths the system extension will <strong>deny</strong> on
+          exec. <code>/tmp/foo</code> and <code>/var/foo</code> are auto-rewritten
+          to their <code>/private/...</code> canonical forms server-side.
+        </p>
+        {paths.length === 0
+          ? <EmptyState>No paths blocked.</EmptyState>
+          : (
+            <Table>
+              <thead><tr><th>Path</th><th></th></tr></thead>
+              <tbody>
+                {paths.map((p) => (
+                  <tr key={p}>
+                    <td><code>{p}</code></td>
+                    <td>
+                      <Button size="small" variant="inverse" onClick={() => { removePath(p); }}>
+                        Remove
+                      </Button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </Table>
+          )}
+        <div className="policy-add-row">
+          <Input
+            id="new-path"
+            label="Add path:"
+            value={newPath}
+            onChange={(e) => { setNewPath(e.target.value); }}
+            placeholder="/private/tmp/payload"
+          />
+          <Button size="small" onClick={addPath}>Add</Button>
+        </div>
+      </section>
+
+      <section className="policy-section">
+        <h2>Blocked SHA-256 hashes</h2>
+        <p className="policy-hint">
+          64-character lowercase hex. Lets you block a binary regardless of where
+          it lives on disk.
+        </p>
+        {hashes.length === 0
+          ? <EmptyState>No hashes blocked.</EmptyState>
+          : (
+            <Table>
+              <thead><tr><th>Hash</th><th></th></tr></thead>
+              <tbody>
+                {hashes.map((h) => (
+                  <tr key={h}>
+                    <td><code>{h}</code></td>
+                    <td>
+                      <Button size="small" variant="inverse" onClick={() => { removeHash(h); }}>
+                        Remove
+                      </Button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </Table>
+          )}
+        <div className="policy-add-row">
+          <Input
+            id="new-hash"
+            label="Add hash:"
+            value={newHash}
+            onChange={(e) => { setNewHash(e.target.value); }}
+            placeholder="aaaaaaaa..."
+          />
+          <Button size="small" onClick={addHash}>Add</Button>
+        </div>
+      </section>
+
+      <section className="policy-section">
+        <h2>Save</h2>
+        <p className="policy-hint">
+          Every save bumps the policy version and fans the new blocklist out to
+          every active host. The reason is recorded in the audit log.
+        </p>
+        <Input
+          id="policy-reason"
+          label="Reason:"
+          value={reason}
+          onChange={(e) => { setReason(e.target.value); }}
+          placeholder="why are you changing the policy?"
+        />
+        <div className="policy-save-row">
+          <Button onClick={handleSave} disabled={!dirty || saving || !reason.trim()}>
+            {saving ? "Saving..." : "Save policy"}
+          </Button>
+          {policy && (
+            <span className="policy-meta">
+              version {policy.version}, last changed {new Date(policy.updated_at).toLocaleString()} by {policy.updated_by}
+            </span>
+          )}
+          {savedAt && !dirty && (
+            <span className="policy-saved">Saved.</span>
+          )}
+        </div>
+      </section>
+    </>
+  );
+}

--- a/ui/src/components/ui/TopNav.tsx
+++ b/ui/src/components/ui/TopNav.tsx
@@ -10,6 +10,7 @@ interface NavLink {
 const LINKS: NavLink[] = [
   { to: "/", label: "Hosts" },
   { to: "/alerts", label: "Alerts" },
+  { to: "/policy", label: "Policy" },
 ];
 
 interface TopNavProps {


### PR DESCRIPTION
…ook polish

QA on v0.1.0-rc.7 (claude/mvp/phase-7-qa-2026-04-26.md) flagged three demo-blocking gaps. All three are server-only or UI-only — no agent or sysext changes, so this lands cleanly without bumping rc.

1. Blocklist had no operator UI (#101). Server PUT /api/v1/admin/policy worked end-to-end (curl-driven QA confirmed AUTH_EXEC DENY at the kernel), but a live demo of "push a path, watch it block" required curl in front of the audience. Adds /ui/policy with a paths + hashes editor, GET on mount, PUT on save, required reason, version + actor in the audit footer.

2. /tmp and /var blocklist entries silently failed to deny because ESF reports the post-resolve path on AUTH_EXEC. The first rc.7 QA push for /tmp/edr-blocklist-test-payload didn't fire; /private/tmp/... did. Server now canonicalizes /tmp/* → /private/tmp/* and /var/* → /private/var/* in normalizeBlocklist so an operator who types /tmp/foo gets a working block. Test added; the single existing test that hard- coded /tmp/initial-block was updated to its canonical form.

3. attack-runbook.sh output read engineer-only. Adds presenter-friendly "Step N of M" headers with the expected rule_id named per step, plus --demo / --pace=N pacing so a live audience can watch each alert land in the UI before the next attack fires. Default 0 (lab use) keeps existing CI / dogfood semantics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Policy Editor page accessible from top navigation for managing blocklists.
  * Users can add/remove blocked paths and hashes with a required reason field for changes.
  * Policy changes are tracked with saved/dirty status indicators and error handling.
  * Improved handling of macOS system paths in blocklist management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->