### PR TITLE
Pin go-task version + group README badges by purpose

### DIFF
--- a/.github/workflows/c-lint.yml
+++ b/.github/workflows/c-lint.yml
@@ -41,7 +41,7 @@ jobs:
 
       - uses: go-task/setup-task@3be4020d41929789a01026e0e427a4321ce0ad44 # v2.0.0
         with:
-          version: 3.x
+          version: 3.50.0
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run clang-tidy + clang-format via Taskfile

--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -50,7 +50,7 @@ jobs:
       # golangci-lint across the project (paths, build tags, flags).
       - uses: go-task/setup-task@3be4020d41929789a01026e0e427a4321ce0ad44 # v2.0.0
         with:
-          version: 3.x
+          version: 3.50.0
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       # Install + cache the pinned golangci-lint binary. `install-mode: goinstall`

--- a/.github/workflows/go-nilaway.yml
+++ b/.github/workflows/go-nilaway.yml
@@ -48,7 +48,7 @@ jobs:
 
       - uses: go-task/setup-task@3be4020d41929789a01026e0e427a4321ce0ad44 # v2.0.0
         with:
-          version: 3.x
+          version: 3.50.0
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run nilaway

--- a/.github/workflows/go-vulncheck.yml
+++ b/.github/workflows/go-vulncheck.yml
@@ -48,7 +48,7 @@ jobs:
 
       - uses: go-task/setup-task@3be4020d41929789a01026e0e427a4321ce0ad44 # v2.0.0
         with:
-          version: 3.x
+          version: 3.50.0
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run govulncheck via Taskfile
@@ -74,7 +74,7 @@ jobs:
 
       - uses: go-task/setup-task@3be4020d41929789a01026e0e427a4321ce0ad44 # v2.0.0
         with:
-          version: 3.x
+          version: 3.50.0
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run govulncheck via Taskfile

--- a/.github/workflows/swift-lint.yml
+++ b/.github/workflows/swift-lint.yml
@@ -37,7 +37,7 @@ jobs:
 
       - uses: go-task/setup-task@3be4020d41929789a01026e0e427a4321ce0ad44 # v2.0.0
         with:
-          version: 3.x
+          version: 3.50.0
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run SwiftLint via Taskfile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: go-task/setup-task@3be4020d41929789a01026e0e427a4321ce0ad44 # v2.0.0
         with:
-          version: 3.x
+          version: 3.50.0
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run agent tests with coverage
@@ -64,7 +64,7 @@ jobs:
 
       - uses: go-task/setup-task@3be4020d41929789a01026e0e427a4321ce0ad44 # v2.0.0
         with:
-          version: 3.x
+          version: 3.50.0
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install MySQL 8.4

--- a/.github/workflows/ts-lint.yml
+++ b/.github/workflows/ts-lint.yml
@@ -38,7 +38,7 @@ jobs:
 
       - uses: go-task/setup-task@3be4020d41929789a01026e0e427a4321ce0ad44 # v2.0.0
         with:
-          version: 3.x
+          version: 3.50.0
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install UI dependencies

--- a/README.md
+++ b/README.md
@@ -1,14 +1,19 @@
 # Fleet EDR
 
+<!-- Build & quality -->
 ![Go version](https://img.shields.io/github/go-mod/go-version/getvictor/fleet-edr?filename=go.mod&style=flat-square)
 [![Tests](https://img.shields.io/github/actions/workflow/status/getvictor/fleet-edr/test.yml?branch=main&label=tests&style=flat-square)](https://github.com/getvictor/fleet-edr/actions/workflows/test.yml)
+[![Quality Gate](https://sonarcloud.io/api/project_badges/measure?project=getvictor_fleet-edr&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=getvictor_fleet-edr)
+
+<!-- Security scanners -->
 [![CodeQL](https://img.shields.io/github/actions/workflow/status/getvictor/fleet-edr/codeql.yml?branch=main&label=CodeQL&style=flat-square)](https://github.com/getvictor/fleet-edr/actions/workflows/codeql.yml)
 [![govulncheck](https://img.shields.io/github/actions/workflow/status/getvictor/fleet-edr/go-vulncheck.yml?branch=main&label=govulncheck&style=flat-square)](https://github.com/getvictor/fleet-edr/actions/workflows/go-vulncheck.yml)
 [![OSV-Scanner](https://img.shields.io/github/actions/workflow/status/getvictor/fleet-edr/osv-scanner.yml?branch=main&label=OSV-Scanner&style=flat-square)](https://github.com/getvictor/fleet-edr/actions/workflows/osv-scanner.yml)
+
+<!-- Supply chain -->
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/getvictor/fleet-edr/badge)](https://scorecard.dev/viewer/?uri=github.com/getvictor/fleet-edr)
 [![SLSA 3](https://slsa.dev/images/gh-badge-level3.svg)](https://slsa.dev/spec/v1.0/levels#build-l3)
 [![cosign keyless](https://img.shields.io/badge/cosign-keyless-9cf?style=flat-square&logo=sigstore)](docs/best-practices.md#4-supply-chain-security)
-[![Quality Gate](https://sonarcloud.io/api/project_badges/measure?project=getvictor_fleet-edr&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=getvictor_fleet-edr)
 
 A macOS Endpoint Detection and Response (EDR) system. It provides
 real-time process monitoring, network attribution, behavioral detection, and response capabilities.


### PR DESCRIPTION
CI stability: every Go/Swift/TS workflow uses
go-task/setup-task with `version: 3.x`, which makes the action call GitHub's release API at runtime to resolve the latest 3.x. That endpoint rate-limited on the post-merge run for PR #50 (run id 25007131657), failing four jobs (Go lint, Tests, TS lint and test, govulncheck) with "unable to get latest version". Same workflows passed on the PR run minutes earlier, confirming this is transient infrastructure, not code. Pin to v3.50.0 across all seven workflow files so the lookup is skipped and the failure shape can't recur. Bump to a new tag manually when we want a newer task release; this is the same pattern docs/best-practices.md §4 calls out for third-party actions.

README badges: collapse the nine-badge run-on into three labelled groups separated by HTML comments and blank lines so each group renders on its own visual row on github.com:

  Build & quality:    Go version | Tests | Quality Gate
  Security scanners:  CodeQL | govulncheck | OSV-Scanner
  Supply chain:       OpenSSF Scorecard | SLSA 3 | cosign keyless

Order follows the kubernetes / sigstore / envoy convention: identity
+ "is the build healthy" first, security scanners next, supply-chain last. Same nine badges, same content; only layout changes.

No artifact change. rc.8 stays as the demo build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipelines to use a fixed task runner version across all build and lint workflows for consistency

* **Documentation**
  * Reorganized README badges under thematic sections for improved clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->