### PR TITLE
UI polish: 7 demo-blocking findings from claude/mvp/wip.txt

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -44,6 +44,17 @@ sonar.javascript.lcov.reportPaths=ui/coverage/lcov.info
 #                                       first ui/src/**/*.test.{ts,tsx} lands.
 sonar.coverage.exclusions=**/cmd/**/main.go,server/detection/testharness/**,schema/**,extension/edr/**,agent/receiver/**,agent/logging/**,server/bootstrap/**,server/httpserver/**,test/**,ui/src/**
 
+# Exclude static catalog / lookup tables from copy-paste duplication detection.
+# Files where every entry repeats the same property names (id/name/tactic per
+# row, etc.) are 60-90% "duplicated" by Sonar's CPD heuristic, but it's not
+# real code duplication — it's data shape. The new-code duplication gate
+# (3% threshold) goes ERROR on a single such file. Add specific paths here
+# rather than a broad glob so genuinely repetitive code doesn't sneak past.
+#
+#   - ui/src/components/attack-techniques.ts  MITRE ATT&CK technique catalog
+#                                             (id/name/tactic per technique).
+sonar.cpd.exclusions=ui/src/components/attack-techniques.ts
+
 # Skip C/C++/Objective-C analysis (requires a compilation database we don't generate).
 # The only C in the repo is small CGo bridge files in agent/.
 sonar.c.file.suffixes=-

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -4,6 +4,7 @@ import { HostList } from "./components/HostList";
 import { ProcessTreeView } from "./components/ProcessTree";
 import { AlertList } from "./components/AlertList";
 import { PolicyEditor } from "./components/PolicyEditor";
+import { AttackCoverage } from "./components/AttackCoverage";
 import { Login } from "./components/Login";
 import { TopNav } from "./components/ui/TopNav";
 import { currentSession, logout, Unauthorized401Error, SessionInfo } from "./api";
@@ -78,6 +79,7 @@ export function App() {
           <Route path="/" element={<HostList />} />
           <Route path="/alerts" element={<AlertList />} />
           <Route path="/policy" element={<PolicyEditor actor={auth.user.email} />} />
+          <Route path="/coverage" element={<AttackCoverage />} />
           <Route path="/hosts/:hostId" element={<ProcessTreeView />} />
           <Route path="*" element={<Navigate to="/" replace />} />
         </Routes>

--- a/ui/src/components/AlertList.tsx
+++ b/ui/src/components/AlertList.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { listAlerts, updateAlertStatus, fetchAttackNavigatorLayer } from "../api";
+import { listAlerts, updateAlertStatus } from "../api";
 import type { Alert } from "../types";
 import { Table, EmptyState } from "./ui/Table";
 import { Badge, type BadgeVariant } from "./ui/Badge";
@@ -32,7 +32,7 @@ export function AlertList() {
 
   useEffect(() => {
     let cancelled = false;
-    setLoading(true);  
+    setLoading(true); // eslint-disable-line react-hooks/set-state-in-effect -- data fetch pattern
     setError(null);
     listAlerts({
       status: statusFilter || undefined,
@@ -66,38 +66,6 @@ export function AlertList() {
       });
   };
 
-  // downloadNavigatorLayer is the ATT&CK Navigator export. It pulls the
-  // server-rendered layer JSON and triggers a file download; the operator
-  // then uploads the file to https://mitre-attack.github.io/attack-navigator/
-  // (or pastes the contents) to see the matrix heatmap of which techniques
-  // the deployed detection rules cover. This is one of the more reliable
-  // demo / procurement signals — see B4 in phase-7-pilot-hardening.md.
-  const downloadNavigatorLayer = () => {
-    fetchAttackNavigatorLayer()
-      .then((layer) => {
-        const blob = new Blob([JSON.stringify(layer, null, 2)], { type: "application/json" });
-        const url = URL.createObjectURL(blob);
-        // try/finally so a synchronous DOM error between createObjectURL and
-        // revokeObjectURL doesn't leak the blob for the page lifetime.
-        try {
-          const a = document.createElement("a");
-          a.href = url;
-          a.download = "fleet-edr-attack-coverage.json";
-          document.body.appendChild(a);
-          try {
-            a.click();
-          } finally {
-            a.remove();
-          }
-        } finally {
-          URL.revokeObjectURL(url);
-        }
-      })
-      .catch((err: unknown) => {
-        setError(err instanceof Error ? err.message : "Failed to fetch ATT&CK coverage layer");
-      });
-  };
-
   const filters = (
     <div className="alert-filters">
       <Select
@@ -120,9 +88,6 @@ export function AlertList() {
           <option key={s} value={s}>{s || "All"}</option>
         ))}
       </Select>
-      <Button size="small" variant="inverse" onClick={downloadNavigatorLayer}>
-        Download ATT&amp;CK coverage
-      </Button>
     </div>
   );
 

--- a/ui/src/components/AttackCoverage.scss
+++ b/ui/src/components/AttackCoverage.scss
@@ -1,0 +1,77 @@
+@use "../styles/var/colors" as *;
+@use "../styles/var/fonts" as *;
+@use "../styles/var/padding" as *;
+
+.attack-coverage {
+  &__actions {
+    display: flex;
+    align-items: center;
+    gap: $pad-medium;
+  }
+
+  &__navigator-link {
+    color: $core-fleet-green;
+    text-decoration: none;
+    font-weight: $bold;
+    font-size: 0.95em;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+
+  &__summary {
+    display: flex;
+    gap: $pad-large;
+    margin: $pad-medium 0 $pad-large;
+    flex-wrap: wrap;
+  }
+
+  &__metric {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: $pad-xxsmall;
+    padding: $pad-medium $pad-large;
+    background: $ui-fleet-black-5;
+    border-left: 4px solid $core-fleet-green;
+    border-radius: 4px;
+    min-width: 180px;
+  }
+
+  &__metric-num {
+    font-size: 2rem;
+    font-weight: $bold;
+    color: $core-fleet-black;
+    line-height: 1;
+  }
+
+  &__metric-label {
+    font-size: 0.85em;
+    color: $ui-fleet-black-50;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+  }
+
+  &__tactic {
+    margin: $pad-large 0;
+  }
+
+  &__tactic-name {
+    font-size: 1.05rem;
+    margin: 0 0 $pad-small;
+    padding-bottom: $pad-xsmall;
+    border-bottom: 1px solid $ui-fleet-black-10;
+  }
+
+  &__technique-id {
+    color: $core-fleet-green;
+    text-decoration: none;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-weight: $bold;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+}

--- a/ui/src/components/AttackCoverage.tsx
+++ b/ui/src/components/AttackCoverage.tsx
@@ -1,0 +1,213 @@
+import { useEffect, useState } from "react";
+import { fetchAttackNavigatorLayer, type AttackNavigatorLayer } from "../api";
+import { Table, EmptyState } from "./ui/Table";
+import { PageHeader } from "./ui/PageHeader";
+import { Button } from "./ui/Button";
+import { TECHNIQUE_CATALOG, type TechniqueMeta } from "./attack-techniques";
+import "./AttackCoverage.scss";
+
+// AttackCoverage renders the MITRE ATT&CK technique coverage that the
+// registered detection rules provide. The data comes from the same
+// /api/v1/admin/attack-coverage endpoint that procurement teams ingest as a
+// Navigator layer JSON — but we render it in-app as a tactic-grouped table
+// because a JSON download is unsatisfying as a demo prop. The pattern matches
+// what Crowdstrike Falcon, SentinelOne Singularity, and Elastic Security all
+// expose: tactic columns, technique rows, "covered by" linkable rule list.
+//
+// We still ship the JSON via the "Download Navigator layer" button so an
+// operator can drop it into the upstream MITRE Navigator UI for the full
+// matrix view if they want — that's the right tool for "look at all 14 tactics
+// at once" and there's no point in re-implementing the matrix renderer here.
+
+type TechniqueWithCoverage = TechniqueMeta & {
+  coveringRules: string[];
+  color: string;
+};
+
+interface CoverageGroup {
+  tactic: string;
+  techniques: TechniqueWithCoverage[];
+}
+
+const TACTIC_ORDER = [
+  "Initial Access",
+  "Execution",
+  "Persistence",
+  "Privilege Escalation",
+  "Defense Evasion",
+  "Credential Access",
+  "Discovery",
+  "Lateral Movement",
+  "Collection",
+  "Command and Control",
+  "Exfiltration",
+  "Impact",
+];
+
+export function AttackCoverage() {
+  const [layer, setLayer] = useState<AttackNavigatorLayer | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchAttackNavigatorLayer()
+      .then((l) => { if (!cancelled) setLayer(l); })
+      .catch((err: unknown) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : "Failed to load coverage");
+      })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, []);
+
+  const downloadLayer = () => {
+    if (!layer) return;
+    const blob = new Blob([JSON.stringify(layer, null, 2)], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    try {
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = "fleet-edr-attack-coverage.json";
+      document.body.appendChild(a);
+      try { a.click(); } finally { a.remove(); }
+    } finally {
+      URL.revokeObjectURL(url);
+    }
+  };
+
+  const groups: CoverageGroup[] = [];
+  if (layer) {
+    // Index by technique id, attach catalog metadata, group by tactic.
+    const byTactic = new Map<string, TechniqueWithCoverage[]>();
+    for (const t of layer.techniques) {
+      const meta = TECHNIQUE_CATALOG[t.techniqueID] ?? {
+        id: t.techniqueID,
+        name: t.techniqueID,
+        tactic: "Unmapped",
+      };
+      const rules = parseCoveringRules(t.comment);
+      const row: TechniqueWithCoverage = { ...meta, coveringRules: rules, color: t.color ?? "" };
+      const list = byTactic.get(meta.tactic) ?? [];
+      list.push(row);
+      byTactic.set(meta.tactic, list);
+    }
+    for (const tactic of TACTIC_ORDER) {
+      const list = byTactic.get(tactic);
+      if (list) {
+        list.sort((a, b) => a.id.localeCompare(b.id));
+        groups.push({ tactic, techniques: list });
+      }
+    }
+    const unmapped = byTactic.get("Unmapped");
+    if (unmapped) {
+      unmapped.sort((a, b) => a.id.localeCompare(b.id));
+      groups.push({ tactic: "Unmapped", techniques: unmapped });
+    }
+  }
+
+  const totalCovered = layer?.techniques.length ?? 0;
+  const distinctRules = new Set<string>();
+  if (layer) {
+    for (const t of layer.techniques) {
+      for (const r of parseCoveringRules(t.comment)) distinctRules.add(r);
+    }
+  }
+
+  return (
+    <>
+      <PageHeader
+        title="ATT&CK coverage"
+        subtitle="MITRE ATT&CK techniques the deployed detection rules cover today."
+        actions={
+          <div className="attack-coverage__actions">
+            <Button size="small" variant="inverse" onClick={downloadLayer} disabled={!layer}>
+              Download Navigator layer
+            </Button>
+            <a
+              className="attack-coverage__navigator-link"
+              href="https://mitre-attack.github.io/attack-navigator/"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Open MITRE Navigator &rarr;
+            </a>
+          </div>
+        }
+      />
+
+      {error && <div className="form-error" role="alert">Error: {error}</div>}
+      {loading && <EmptyState>Loading coverage...</EmptyState>}
+
+      {!loading && layer && (
+        <>
+          <div className="attack-coverage__summary">
+            <div className="attack-coverage__metric">
+              <span className="attack-coverage__metric-num">{totalCovered}</span>
+              <span className="attack-coverage__metric-label">techniques covered</span>
+            </div>
+            <div className="attack-coverage__metric">
+              <span className="attack-coverage__metric-num">{distinctRules.size}</span>
+              <span className="attack-coverage__metric-label">detection rules</span>
+            </div>
+            <div className="attack-coverage__metric">
+              <span className="attack-coverage__metric-num">{groups.length}</span>
+              <span className="attack-coverage__metric-label">tactics with coverage</span>
+            </div>
+          </div>
+
+          {groups.length === 0
+            ? <EmptyState>No coverage data yet.</EmptyState>
+            : groups.map((g) => (
+              <section key={g.tactic} className="attack-coverage__tactic">
+                <h2 className="attack-coverage__tactic-name">{g.tactic}</h2>
+                <Table>
+                  <thead>
+                    <tr>
+                      <th style={{ width: "11ch" }}>Technique</th>
+                      <th>Name</th>
+                      <th>Covered by</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {g.techniques.map((t) => (
+                      <tr key={t.id}>
+                        <td>
+                          <a
+                            className="attack-coverage__technique-id"
+                            href={`https://attack.mitre.org/techniques/${t.id.replace(".", "/")}/`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                          >
+                            {t.id}
+                          </a>
+                        </td>
+                        <td>{t.name}</td>
+                        <td>
+                          {t.coveringRules.map((r, i) => (
+                            <span key={r}>
+                              {i > 0 && ", "}
+                              <code>{r}</code>
+                            </span>
+                          ))}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </Table>
+              </section>
+            ))}
+        </>
+      )}
+    </>
+  );
+}
+
+// parseCoveringRules pulls rule IDs out of the Navigator-layer "Covered by:"
+// comment string. The server formats it as "Covered by: rule_a, rule_b". We
+// keep this lenient: anything after the first colon, split on ", ".
+function parseCoveringRules(comment: string | undefined): string[] {
+  if (!comment) return [];
+  const colon = comment.indexOf(":");
+  const tail = colon === -1 ? comment : comment.slice(colon + 1);
+  return tail.split(",").map((s) => s.trim()).filter(Boolean);
+}

--- a/ui/src/components/AttackCoverage.tsx
+++ b/ui/src/components/AttackCoverage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { fetchAttackNavigatorLayer, type AttackNavigatorLayer } from "../api";
 import { Table, EmptyState } from "./ui/Table";
 import { PageHeader } from "./ui/PageHeader";
@@ -29,7 +29,12 @@ interface CoverageGroup {
   techniques: TechniqueWithCoverage[];
 }
 
+// All 14 enterprise tactics in MITRE's canonical kill-chain order. Anything
+// the catalog or server emits that isn't on this list lands at the end via
+// the "leftover" pass below — never silently dropped.
 const TACTIC_ORDER = [
+  "Reconnaissance",
+  "Resource Development",
   "Initial Access",
   "Execution",
   "Persistence",
@@ -75,43 +80,11 @@ export function AttackCoverage() {
     }
   };
 
-  const groups: CoverageGroup[] = [];
-  if (layer) {
-    // Index by technique id, attach catalog metadata, group by tactic.
-    const byTactic = new Map<string, TechniqueWithCoverage[]>();
-    for (const t of layer.techniques) {
-      const meta = TECHNIQUE_CATALOG[t.techniqueID] ?? {
-        id: t.techniqueID,
-        name: t.techniqueID,
-        tactic: "Unmapped",
-      };
-      const rules = parseCoveringRules(t.comment);
-      const row: TechniqueWithCoverage = { ...meta, coveringRules: rules, color: t.color ?? "" };
-      const list = byTactic.get(meta.tactic) ?? [];
-      list.push(row);
-      byTactic.set(meta.tactic, list);
-    }
-    for (const tactic of TACTIC_ORDER) {
-      const list = byTactic.get(tactic);
-      if (list) {
-        list.sort((a, b) => a.id.localeCompare(b.id));
-        groups.push({ tactic, techniques: list });
-      }
-    }
-    const unmapped = byTactic.get("Unmapped");
-    if (unmapped) {
-      unmapped.sort((a, b) => a.id.localeCompare(b.id));
-      groups.push({ tactic: "Unmapped", techniques: unmapped });
-    }
-  }
-
+  const { groups, distinctRules } = useMemo(
+    () => buildCoverageGroups(layer),
+    [layer],
+  );
   const totalCovered = layer?.techniques.length ?? 0;
-  const distinctRules = new Set<string>();
-  if (layer) {
-    for (const t of layer.techniques) {
-      for (const r of parseCoveringRules(t.comment)) distinctRules.add(r);
-    }
-  }
 
   return (
     <>
@@ -204,10 +177,55 @@ export function AttackCoverage() {
 
 // parseCoveringRules pulls rule IDs out of the Navigator-layer "Covered by:"
 // comment string. The server formats it as "Covered by: rule_a, rule_b". We
-// keep this lenient: anything after the first colon, split on ", ".
+// keep this lenient: anything after the first colon, split on "," and trim
+// whitespace from each piece — so a missing space after the comma still
+// parses cleanly.
 function parseCoveringRules(comment: string | undefined): string[] {
   if (!comment) return [];
   const colon = comment.indexOf(":");
   const tail = colon === -1 ? comment : comment.slice(colon + 1);
   return tail.split(",").map((s) => s.trim()).filter(Boolean);
+}
+
+// buildCoverageGroups runs once per layer fetch (memoised by the caller) and
+// returns the rendered shape: tactics in MITRE order followed by anything
+// else (Unmapped, novel tactics) at the end. It also collects the distinct
+// covering-rule set in the same pass so we don't walk the techniques twice.
+function buildCoverageGroups(
+  layer: AttackNavigatorLayer | null,
+): { groups: CoverageGroup[]; distinctRules: Set<string> } {
+  const distinctRules = new Set<string>();
+  const groups: CoverageGroup[] = [];
+  if (!layer) return { groups, distinctRules };
+
+  const byTactic = new Map<string, TechniqueWithCoverage[]>();
+  for (const t of layer.techniques) {
+    const meta = TECHNIQUE_CATALOG[t.techniqueID] ?? {
+      id: t.techniqueID,
+      name: t.techniqueID,
+      tactic: "Unmapped",
+    };
+    const rules = parseCoveringRules(t.comment);
+    for (const r of rules) distinctRules.add(r);
+    const list = byTactic.get(meta.tactic) ?? [];
+    list.push({ ...meta, coveringRules: rules, color: t.color ?? "" });
+    byTactic.set(meta.tactic, list);
+  }
+
+  const seen = new Set<string>();
+  const push = (tactic: string) => {
+    const list = byTactic.get(tactic);
+    if (!list) return;
+    list.sort((a, b) => a.id.localeCompare(b.id));
+    groups.push({ tactic, techniques: list });
+    seen.add(tactic);
+  };
+  for (const tactic of TACTIC_ORDER) push(tactic);
+  // Render anything that didn't match TACTIC_ORDER at the end (Unmapped,
+  // future ATT&CK additions, casing/spelling drift) so coverage rows can
+  // never silently disappear.
+  for (const tactic of byTactic.keys()) {
+    if (!seen.has(tactic)) push(tactic);
+  }
+  return { groups, distinctRules };
 }

--- a/ui/src/components/PolicyEditor.scss
+++ b/ui/src/components/PolicyEditor.scss
@@ -1,4 +1,5 @@
 @use "../styles/var/colors" as *;
+@use "../styles/var/fonts" as *;
 @use "../styles/var/padding" as *;
 
 .policy-section {
@@ -47,4 +48,59 @@
   border-radius: 4px;
   background: rgba(255, 92, 131, 0.1);
   color: $core-vibrant-red;
+}
+
+.policy-flash {
+  margin: $pad-small 0;
+  padding: $pad-small $pad-medium;
+  border-radius: 4px;
+  background: rgba(0, 154, 125, 0.1);
+  border: 1px solid rgba(0, 154, 125, 0.3);
+  color: $core-fleet-green;
+  font-size: 0.95em;
+}
+
+// Sticky save bar — only renders while policy is dirty. Sits at the bottom of
+// the viewport so the operator never has to scroll-hunt for the Save button
+// after editing rows mid-list. Pattern matches GitHub's branch-protection
+// editor and AWS Console settings flows: explicit "you have unsaved changes"
+// summary on the left, in-line audit reason + Save + Discard on the right.
+.policy-savebar {
+  position: sticky;
+  bottom: 0;
+  margin: $pad-large -#{$pad-page} 0;
+  padding: $pad-medium $pad-page;
+  background: $core-fleet-white;
+  border-top: 2px solid $core-fleet-green;
+  box-shadow: 0 -4px 12px rgba(0, 0, 0, 0.08);
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: $pad-medium;
+  flex-wrap: wrap;
+  z-index: 5;
+
+  &__summary {
+    color: $ui-fleet-black-75;
+    font-size: 0.95em;
+  }
+
+  &__delta {
+    color: $core-fleet-green;
+    font-weight: $bold;
+  }
+
+  &__form {
+    display: flex;
+    align-items: flex-end;
+    gap: $pad-small;
+    flex: 1;
+    min-width: 320px;
+    justify-content: flex-end;
+
+    .field {
+      flex: 1;
+      max-width: 480px;
+    }
+  }
 }

--- a/ui/src/components/PolicyEditor.tsx
+++ b/ui/src/components/PolicyEditor.tsx
@@ -31,13 +31,17 @@ function sortedEqual(a: readonly string[], b: readonly string[]): boolean {
 }
 
 // PolicyEditor is the operator-facing surface for the server-driven blocklist
-// (the same Policy that GET/PUT /api/v1/admin/policy serves). The UI deliberately
-// stays bare — list paths and hashes, add a row, remove a row, save with a
-// required reason. Every save bumps the policy version on the server and fans
-// out a set_blocklist command to every active host. The server canonicalises
-// macOS symlink prefixes (/tmp/ → /private/tmp/, /var/ → /private/var/, /etc/
-// → /private/etc/) so an operator who types /tmp/payload still gets a working
-// block at the kernel.
+// (the same Policy that GET/PUT /api/v1/admin/policy serves). The flow follows
+// the pattern most enterprise dashboards use (GitHub, Atlassian, AWS Console):
+// the page edits a *staged* copy of the policy; nothing hits the server until
+// the operator clicks "Save changes" in a sticky footer that only appears when
+// there are unsaved edits. Add/remove buttons mutate the staged copy, not
+// the live policy. The footer also takes the audit reason in-line so the
+// operator sees both controls together.
+//
+// The server canonicalises macOS symlink prefixes (/tmp/ → /private/tmp/,
+// /var/ → /private/var/, /etc/ → /private/etc/) so an operator who types
+// /tmp/payload still gets a working block at the kernel.
 export function PolicyEditor({ actor }: PolicyEditorProps) {
   const [policy, setPolicy] = useState<Policy | null>(null);
   const [paths, setPaths] = useState<string[]>([]);
@@ -48,7 +52,7 @@ export function PolicyEditor({ actor }: PolicyEditorProps) {
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
-  const [savedAt, setSavedAt] = useState<string | null>(null);
+  const [savedFlash, setSavedFlash] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -73,6 +77,13 @@ export function PolicyEditor({ actor }: PolicyEditorProps) {
     && (!sortedEqual(paths, policy.blocklist.paths)
       || !sortedEqual(hashes, policy.blocklist.hashes));
 
+  const pathDelta = policy
+    ? paths.length - policy.blocklist.paths.length
+    : 0;
+  const hashDelta = policy
+    ? hashes.length - policy.blocklist.hashes.length
+    : 0;
+
   const addPath = () => {
     const p = newPath.trim();
     if (!p) return;
@@ -87,6 +98,7 @@ export function PolicyEditor({ actor }: PolicyEditorProps) {
     setError(null);
     setPaths([...paths, p].sort((a, b) => a.localeCompare(b)));
     setNewPath("");
+    setSavedFlash(false);
   };
 
   const addHash = () => {
@@ -103,14 +115,31 @@ export function PolicyEditor({ actor }: PolicyEditorProps) {
     setError(null);
     setHashes([...hashes, h].sort((a, b) => a.localeCompare(b)));
     setNewHash("");
+    setSavedFlash(false);
   };
 
-  const removePath = (p: string) => { setPaths(paths.filter((x) => x !== p)); };
-  const removeHash = (h: string) => { setHashes(hashes.filter((x) => x !== h)); };
+  const removePath = (p: string) => {
+    setPaths(paths.filter((x) => x !== p));
+    setSavedFlash(false);
+  };
+  const removeHash = (h: string) => {
+    setHashes(hashes.filter((x) => x !== h));
+    setSavedFlash(false);
+  };
+
+  const discardChanges = () => {
+    if (!policy) return;
+    setPaths(policy.blocklist.paths);
+    setHashes(policy.blocklist.hashes);
+    setNewPath("");
+    setNewHash("");
+    setReason("");
+    setError(null);
+  };
 
   const handleSave = () => {
     if (!reason.trim()) {
-      setError("Reason is required for every policy change.");
+      setError("A reason is required for the audit log.");
       return;
     }
     setSaving(true);
@@ -121,7 +150,7 @@ export function PolicyEditor({ actor }: PolicyEditorProps) {
         setPaths(p.blocklist.paths);
         setHashes(p.blocklist.hashes);
         setReason("");
-        setSavedAt(p.updated_at);
+        setSavedFlash(true);
       })
       .catch((err: unknown) => {
         setError(err instanceof Error ? err.message : "Save failed");
@@ -141,6 +170,12 @@ export function PolicyEditor({ actor }: PolicyEditorProps) {
 
       {!loading && (
         <>
+          {savedFlash && !dirty && (
+            <div className="policy-flash" role="status">
+              Policy saved. Version {policy?.version}, fanned out to all active hosts.
+            </div>
+          )}
+
           <section className="policy-section">
             <h2>Blocked paths</h2>
             <p className="policy-hint">
@@ -168,16 +203,19 @@ export function PolicyEditor({ actor }: PolicyEditorProps) {
                   </tbody>
                 </Table>
               )}
-            <div className="policy-add-row">
+            <form
+              className="policy-add-row"
+              onSubmit={(e) => { e.preventDefault(); addPath(); }}
+            >
               <Input
                 id="new-path"
                 label="Add path:"
                 value={newPath}
                 onChange={(e) => { setNewPath(e.target.value); }}
-                placeholder="/private/tmp/payload"
+                placeholder="e.g. /private/tmp/payload"
               />
-              <Button size="small" onClick={addPath}>Add</Button>
-            </div>
+              <Button size="small" type="submit">Add path</Button>
+            </form>
           </section>
 
           <section className="policy-section">
@@ -205,47 +243,60 @@ export function PolicyEditor({ actor }: PolicyEditorProps) {
                   </tbody>
                 </Table>
               )}
-            <div className="policy-add-row">
+            <form
+              className="policy-add-row"
+              onSubmit={(e) => { e.preventDefault(); addHash(); }}
+            >
               <Input
                 id="new-hash"
                 label="Add hash:"
                 value={newHash}
                 onChange={(e) => { setNewHash(e.target.value); }}
-                placeholder="aaaaaaaa..."
+                placeholder="e.g. e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
               />
-              <Button size="small" onClick={addHash}>Add</Button>
-            </div>
+              <Button size="small" type="submit">Add hash</Button>
+            </form>
           </section>
 
-          <section className="policy-section">
-            <h2>Save</h2>
-            <p className="policy-hint">
-              Every save bumps the policy version and fans the new blocklist out
-              to every active host. The reason is recorded in the audit log
-              alongside your account.
+          {policy && (
+            <p className="policy-meta">
+              Currently live: version {policy.version}, last changed{" "}
+              {new Date(policy.updated_at).toLocaleString()} by {policy.updated_by}.
             </p>
-            <Input
-              id="policy-reason"
-              label="Reason:"
-              value={reason}
-              onChange={(e) => { setReason(e.target.value); }}
-              placeholder="why are you changing the policy?"
-            />
-            <div className="policy-save-row">
-              <Button onClick={handleSave} disabled={!dirty || saving || !reason.trim()}>
-                {saving ? "Saving..." : "Save policy"}
-              </Button>
-              {policy && (
-                <span className="policy-meta">
-                  version {policy.version}, last changed{" "}
-                  {new Date(policy.updated_at).toLocaleString()} by {policy.updated_by}
+          )}
+
+          {dirty && (
+            <div className="policy-savebar" role="region" aria-label="unsaved changes">
+              <div className="policy-savebar__summary">
+                <strong>Unsaved changes:</strong>{" "}
+                <span className="policy-savebar__delta">
+                  {pathDelta !== 0 && (
+                    <>{pathDelta > 0 ? `+${String(pathDelta)}` : String(pathDelta)} path{Math.abs(pathDelta) === 1 ? "" : "s"}</>
+                  )}
+                  {pathDelta !== 0 && hashDelta !== 0 && ", "}
+                  {hashDelta !== 0 && (
+                    <>{hashDelta > 0 ? `+${String(hashDelta)}` : String(hashDelta)} hash{Math.abs(hashDelta) === 1 ? "" : "es"}</>
+                  )}
+                  {pathDelta === 0 && hashDelta === 0 && "list reordered"}
                 </span>
-              )}
-              {savedAt && !dirty && (
-                <span className="policy-saved">Saved.</span>
-              )}
+              </div>
+              <div className="policy-savebar__form">
+                <Input
+                  id="policy-reason"
+                  label="Reason:"
+                  value={reason}
+                  onChange={(e) => { setReason(e.target.value); }}
+                  placeholder="e.g. blocking known-bad stage-2 dropper from 2026-04-22 incident"
+                />
+                <Button onClick={handleSave} disabled={saving || !reason.trim()}>
+                  {saving ? "Saving..." : "Save changes"}
+                </Button>
+                <Button variant="inverse" onClick={discardChanges} disabled={saving}>
+                  Discard
+                </Button>
+              </div>
             </div>
-          </section>
+          )}
         </>
       )}
     </>

--- a/ui/src/components/PolicyEditor.tsx
+++ b/ui/src/components/PolicyEditor.tsx
@@ -30,6 +30,33 @@ function sortedEqual(a: readonly string[], b: readonly string[]): boolean {
   return sa.every((v, i) => v === sb[i]);
 }
 
+// listDiff returns the count of items added vs removed when going from `prev`
+// to `next`. Used by the save bar so the operator sees true change shape (e.g.
+// "+1, -1") rather than just the net length delta.
+function listDiff(next: readonly string[], prev: readonly string[]): { added: number; removed: number } {
+  const prevSet = new Set(prev);
+  const nextSet = new Set(next);
+  let added = 0;
+  let removed = 0;
+  for (const v of next) if (!prevSet.has(v)) added += 1;
+  for (const v of prev) if (!nextSet.has(v)) removed += 1;
+  return { added, removed };
+}
+
+function hasDiff(d: { added: number; removed: number }): boolean {
+  return d.added > 0 || d.removed > 0;
+}
+
+function renderDiff(d: { added: number; removed: number }, singular: string, plural: string): string {
+  if (!hasDiff(d)) return "";
+  const total = d.added + d.removed;
+  const noun = total === 1 ? singular : plural;
+  const parts: string[] = [];
+  if (d.added > 0) parts.push(`+${String(d.added)}`);
+  if (d.removed > 0) parts.push(`-${String(d.removed)}`);
+  return `${parts.join("/")} ${noun}`;
+}
+
 // PolicyEditor is the operator-facing surface for the server-driven blocklist
 // (the same Policy that GET/PUT /api/v1/admin/policy serves). The flow follows
 // the pattern most enterprise dashboards use (GitHub, Atlassian, AWS Console):
@@ -77,12 +104,11 @@ export function PolicyEditor({ actor }: PolicyEditorProps) {
     && (!sortedEqual(paths, policy.blocklist.paths)
       || !sortedEqual(hashes, policy.blocklist.hashes));
 
-  const pathDelta = policy
-    ? paths.length - policy.blocklist.paths.length
-    : 0;
-  const hashDelta = policy
-    ? hashes.length - policy.blocklist.hashes.length
-    : 0;
+  // Real add/remove counts (not just net length deltas) — operators often add
+  // one entry while removing another during cleanup, and a length-only delta
+  // would silently report "list reordered" when the content actually changed.
+  const pathDiff = policy ? listDiff(paths, policy.blocklist.paths) : { added: 0, removed: 0 };
+  const hashDiff = policy ? listDiff(hashes, policy.blocklist.hashes) : { added: 0, removed: 0 };
 
   const addPath = () => {
     const p = newPath.trim();
@@ -171,9 +197,9 @@ export function PolicyEditor({ actor }: PolicyEditorProps) {
       {!loading && (
         <>
           {savedFlash && !dirty && (
-            <div className="policy-flash" role="status">
+            <output className="policy-flash">
               Policy saved. Version {policy?.version}, fanned out to all active hosts.
-            </div>
+            </output>
           )}
 
           <section className="policy-section">
@@ -266,21 +292,23 @@ export function PolicyEditor({ actor }: PolicyEditorProps) {
           )}
 
           {dirty && (
-            <div className="policy-savebar" role="region" aria-label="unsaved changes">
+            <section
+              className="policy-savebar"
+              aria-labelledby="policy-savebar-heading"
+            >
               <div className="policy-savebar__summary">
-                <strong>Unsaved changes:</strong>{" "}
+                <strong id="policy-savebar-heading">Unsaved changes:</strong>{" "}
                 <span className="policy-savebar__delta">
-                  {pathDelta !== 0 && (
-                    <>{pathDelta > 0 ? `+${String(pathDelta)}` : String(pathDelta)} path{Math.abs(pathDelta) === 1 ? "" : "s"}</>
-                  )}
-                  {pathDelta !== 0 && hashDelta !== 0 && ", "}
-                  {hashDelta !== 0 && (
-                    <>{hashDelta > 0 ? `+${String(hashDelta)}` : String(hashDelta)} hash{Math.abs(hashDelta) === 1 ? "" : "es"}</>
-                  )}
-                  {pathDelta === 0 && hashDelta === 0 && "list reordered"}
+                  {renderDiff(pathDiff, "path", "paths")}
+                  {hasDiff(pathDiff) && hasDiff(hashDiff) && ", "}
+                  {renderDiff(hashDiff, "hash", "hashes")}
+                  {!hasDiff(pathDiff) && !hasDiff(hashDiff) && "items reordered"}
                 </span>
               </div>
-              <div className="policy-savebar__form">
+              <form
+                className="policy-savebar__form"
+                onSubmit={(e) => { e.preventDefault(); handleSave(); }}
+              >
                 <Input
                   id="policy-reason"
                   label="Reason:"
@@ -288,14 +316,14 @@ export function PolicyEditor({ actor }: PolicyEditorProps) {
                   onChange={(e) => { setReason(e.target.value); }}
                   placeholder="e.g. blocking known-bad stage-2 dropper from 2026-04-22 incident"
                 />
-                <Button onClick={handleSave} disabled={saving || !reason.trim()}>
+                <Button type="submit" disabled={saving || !reason.trim()}>
                   {saving ? "Saving..." : "Save changes"}
                 </Button>
                 <Button variant="inverse" onClick={discardChanges} disabled={saving}>
                   Discard
                 </Button>
-              </div>
-            </div>
+              </form>
+            </section>
           )}
         </>
       )}

--- a/ui/src/components/ProcessTree.scss
+++ b/ui/src/components/ProcessTree.scss
@@ -10,10 +10,20 @@
     gap: $pad-medium;
   }
 
-  &__back {
+  &__crumb {
     font-size: $x-small;
     font-weight: $regular;
     color: $core-fleet-green;
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+
+  &__crumb-sep {
+    font-size: $x-small;
+    color: $ui-fleet-black-25;
   }
 
   &__host {
@@ -235,8 +245,11 @@
   gap: $pad-small;
   padding: $pad-small $pad-medium;
   margin-bottom: $pad-medium;
-  background-color: rgba(255, 232, 236, 0.6);
-  border: 1px solid rgba(255, 92, 131, 0.4);
+  // Neutral grey container — the page already shows alert severity via the
+  // badge inside this row. The previous pink fill + red border read as a
+  // status indicator and confused operators ("is this an error?").
+  background-color: $ui-fleet-black-5;
+  border: 1px solid $ui-fleet-black-10;
   border-radius: $border-radius;
   font-size: $x-small;
   color: $core-fleet-black;

--- a/ui/src/components/ProcessTree.scss
+++ b/ui/src/components/ProcessTree.scss
@@ -245,6 +245,7 @@
   gap: $pad-small;
   padding: $pad-small $pad-medium;
   margin-bottom: $pad-medium;
+
   // Neutral grey container — the page already shows alert severity via the
   // badge inside this row. The previous pink fill + red border read as a
   // status indicator and confused operators ("is this an error?").

--- a/ui/src/components/ProcessTree.tsx
+++ b/ui/src/components/ProcessTree.tsx
@@ -153,16 +153,21 @@ export function ProcessTreeView() {
     return keep;
   }, [roots, query]);
   const visibleRoots = useMemo(() => {
+    // Predicate for "is this node visible at all" — pulled out to keep the
+    // recursive walk below under Sonar's cognitive-complexity cap.
+    const isVisible = (n: ProcessNode): boolean => {
+      if (alertChainIds && !alertChainIds.has(n.id)) return false;
+      if (!showSystem && isSystemPath(n.path) && !preservedIds.has(n.id)) return false;
+      // Search filter: hide everything outside the matches-plus-ancestors set so
+      // a query like "60289" reduces a 200-node tree to the few rows that matter,
+      // instead of dimming 195 nodes the user has to visually skip past.
+      if (queryFilterIds && !queryFilterIds.has(n.id)) return false;
+      return true;
+    };
     const apply = (nodes: ProcessNode[]): ProcessNode[] => {
       const out: ProcessNode[] = [];
       for (const n of nodes) {
-        // In alert focus mode, drop anything that isn't on the alert's ancestor/descendant chain.
-        if (alertChainIds && !alertChainIds.has(n.id)) continue;
-        if (!showSystem && isSystemPath(n.path) && !preservedIds.has(n.id)) continue;
-        // Search filter: hide everything outside the matches-plus-ancestors set so
-        // a query like "60289" reduces a 200-node tree to the few rows that matter,
-        // instead of dimming 195 nodes the user has to visually skip past.
-        if (queryFilterIds && !queryFilterIds.has(n.id)) continue;
+        if (!isVisible(n)) continue;
         const kids = n.children ? apply(n.children) : undefined;
         if (applyCollapse && collapsedIds.has(n.id) && kids && kids.length > 0) {
           const collapsedTotal = kids.reduce((acc, c) => acc + 1 + countDescendants(c), 0);
@@ -489,26 +494,27 @@ function collectMatches(
   return { matches, pathNodes };
 }
 
-function nodeMatchesQuery(d: D3Node, q: string): boolean {
-  if (d.name.toLowerCase().includes(q)) return true;
-  if (d.path.toLowerCase().includes(q)) return true;
-  if (String(d.pid).includes(q)) return true;
-  if (d.data.args?.some((a) => a.toLowerCase().includes(q))) return true;
+// matchFields holds the four node fields the search box compares against.
+// Both the d3-layout-time matcher and the data-side pre-filter funnel into
+// this so the matching rules can't drift between them.
+function matchFields(name: string, path: string, pid: number, args: string[] | undefined, q: string): boolean {
+  if (name.toLowerCase().includes(q)) return true;
+  if (path.toLowerCase().includes(q)) return true;
+  if (String(pid).includes(q)) return true;
+  if (args?.some((a) => a.toLowerCase().includes(q))) return true;
   return false;
 }
 
-// matchesQueryRaw is the data-side mirror of nodeMatchesQuery — same matching
-// rules, but operating on raw ProcessNode rows before the d3 layout runs.
-// The visible-tree pre-filter uses this so the canvas only ever lays out the
-// matches-plus-ancestors set, instead of laying out everything and dimming the
-// non-matches in CSS.
+function nodeMatchesQuery(d: D3Node, q: string): boolean {
+  return matchFields(d.name, d.path, d.pid, d.data.args, q);
+}
+
+// matchesQueryRaw is the data-side mirror of nodeMatchesQuery — operates on
+// raw ProcessNode rows before the d3 layout runs. Used by the visible-tree
+// pre-filter so the canvas only ever lays out the matches-plus-ancestors set.
 function matchesQueryRaw(n: ProcessNode, q: string): boolean {
-  const name = (n.path.split("/").pop() ?? "").toLowerCase();
-  if (name.includes(q)) return true;
-  if (n.path.toLowerCase().includes(q)) return true;
-  if (String(n.pid).includes(q)) return true;
-  if (n.args?.some((a) => a.toLowerCase().includes(q))) return true;
-  return false;
+  const name = n.path.split("/").pop() ?? "";
+  return matchFields(name, n.path, n.pid, n.args, q);
 }
 
 function isSystemPath(path: string): boolean {
@@ -656,9 +662,12 @@ function renderTree(
   // roots we add a parent node with pid=0 so d3.tree() has a single layout
   // anchor, but that node isn't drawn — and without this filter the edges
   // FROM that invisible parent show up in the canvas as ghost lines drifting
-  // off the left side of the tree.
+  // off the left side of the tree. The filter is gated on roots.length > 1
+  // so a single real root with pid=0 (rare but legal) still gets its outgoing
+  // edges drawn.
+  const hasSyntheticRoot = roots.length > 1;
   g.selectAll("path.link")
-    .data(links.filter((l) => l.source.data.pid !== 0))
+    .data(links.filter((l) => !hasSyntheticRoot || l.source.depth !== 0))
     .join("path")
     .attr("class", "link")
     .attr("fill", "none")

--- a/ui/src/components/ProcessTree.tsx
+++ b/ui/src/components/ProcessTree.tsx
@@ -129,8 +129,29 @@ export function ProcessTreeView() {
   // unconditionally (except preserved), optionally restrict to the alert chain, and drop
   // children of collapsed nodes while stashing the hidden-count on the surviving parent so
   // we can render it as "+N". While a search query is active, skip the collapse step so the
-  // user never sees "0 matches" when a match is only hidden inside a collapsed subtree.
+  // user never sees "0 matches" when a match is only hidden inside a collapsed subtree
+  // AND prune to just matches + ancestors so the canvas isn't a wall of dimmed noise.
   const applyCollapse = query.trim() === "";
+  const queryFilterIds = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return null;
+    const keep = new Set<number>();
+    const visit = (nodes: ProcessNode[], ancestors: number[]): boolean => {
+      let anyMatch = false;
+      for (const n of nodes) {
+        const matches = matchesQueryRaw(n, q);
+        const childMatches = n.children ? visit(n.children, [...ancestors, n.id]) : false;
+        if (matches || childMatches) {
+          keep.add(n.id);
+          for (const a of ancestors) keep.add(a);
+          anyMatch = true;
+        }
+      }
+      return anyMatch;
+    };
+    visit(roots, []);
+    return keep;
+  }, [roots, query]);
   const visibleRoots = useMemo(() => {
     const apply = (nodes: ProcessNode[]): ProcessNode[] => {
       const out: ProcessNode[] = [];
@@ -138,6 +159,10 @@ export function ProcessTreeView() {
         // In alert focus mode, drop anything that isn't on the alert's ancestor/descendant chain.
         if (alertChainIds && !alertChainIds.has(n.id)) continue;
         if (!showSystem && isSystemPath(n.path) && !preservedIds.has(n.id)) continue;
+        // Search filter: hide everything outside the matches-plus-ancestors set so
+        // a query like "60289" reduces a 200-node tree to the few rows that matter,
+        // instead of dimming 195 nodes the user has to visually skip past.
+        if (queryFilterIds && !queryFilterIds.has(n.id)) continue;
         const kids = n.children ? apply(n.children) : undefined;
         if (applyCollapse && collapsedIds.has(n.id) && kids && kids.length > 0) {
           const collapsedTotal = kids.reduce((acc, c) => acc + 1 + countDescendants(c), 0);
@@ -149,7 +174,7 @@ export function ProcessTreeView() {
       return out;
     };
     return apply(roots);
-  }, [roots, showSystem, collapsedIds, preservedIds, applyCollapse, alertChainIds]);
+  }, [roots, showSystem, collapsedIds, preservedIds, applyCollapse, alertChainIds, queryFilterIds]);
 
   const toggleCollapsed = useCallback((nodeId: number) => {
     setCollapsedIds((prev) => {
@@ -168,6 +193,10 @@ export function ProcessTreeView() {
     const atParam = searchParams.get("at");
     const anchorMs = atParam ? Number(atParam) : Date.now();
     const to = anchorMs * 1_000_000;
+    // rangeIdx is the user's pick from the segmented control above; it's
+    // bounded to [0, TIME_RANGES.length-1] by the click handlers, so this
+    // bracket access is safe even though the static analyzer can't prove it.
+    // eslint-disable-next-line security/detect-object-injection
     const range = TIME_RANGES[rangeIdx];
     const from = to - range.ms * 1_000_000;
 
@@ -255,7 +284,6 @@ export function ProcessTreeView() {
 
     const { matches, pathNodes } = collectMatches(layoutNodesRef.current, q);
     matchesRef.current = matches;
-    /* eslint-disable react-hooks/set-state-in-effect -- derived from DOM walk after tree render */
     setMatchCount(matches.length);
     let targetIdx = 0;
     if (matches.length === 0) {
@@ -266,7 +294,6 @@ export function ProcessTreeView() {
         return targetIdx;
       });
     }
-    /* eslint-enable react-hooks/set-state-in-effect */
 
     svg.selectAll<SVGGElement, D3PointNode>("g.node")
       .classed("node--match", (d) => matches.includes(d))
@@ -284,6 +311,9 @@ export function ProcessTreeView() {
           && !(pathNodes.has(d.source as D3PointNode) && pathNodes.has(d.target as D3PointNode)),
       );
 
+    // targetIdx is bounded by matches.length above; the bracket-access here
+    // can't go out of range. eslint's plugin can't prove that.
+    // eslint-disable-next-line security/detect-object-injection
     if (matches.length > 0) zoomToNode(matches[targetIdx]);
   }, [query, visibleRoots, alertProcessIds, zoomToNode]);
 
@@ -307,6 +337,8 @@ export function ProcessTreeView() {
     if (total === 0) return;
     setMatchIdx((prev) => {
       const next = (prev + delta + total) % total;
+      // next is bounded by total via the modulo above.
+      // eslint-disable-next-line security/detect-object-injection
       zoomToNode(matchesRef.current[next]);
       return next;
     });
@@ -376,7 +408,8 @@ export function ProcessTreeView() {
       <PageHeader
         title={
           <span className="process-tree__title">
-            <Link to="/" className="process-tree__back">&larr; Hosts</Link>
+            <Link to="/" className="process-tree__crumb">Hosts</Link>
+            <span className="process-tree__crumb-sep" aria-hidden="true">/</span>
             <span className="process-tree__host">{hostId}</span>
           </span>
         }
@@ -461,6 +494,20 @@ function nodeMatchesQuery(d: D3Node, q: string): boolean {
   if (d.path.toLowerCase().includes(q)) return true;
   if (String(d.pid).includes(q)) return true;
   if (d.data.args?.some((a) => a.toLowerCase().includes(q))) return true;
+  return false;
+}
+
+// matchesQueryRaw is the data-side mirror of nodeMatchesQuery — same matching
+// rules, but operating on raw ProcessNode rows before the d3 layout runs.
+// The visible-tree pre-filter uses this so the canvas only ever lays out the
+// matches-plus-ancestors set, instead of laying out everything and dimming the
+// non-matches in CSS.
+function matchesQueryRaw(n: ProcessNode, q: string): boolean {
+  const name = (n.path.split("/").pop() ?? "").toLowerCase();
+  if (name.includes(q)) return true;
+  if (n.path.toLowerCase().includes(q)) return true;
+  if (String(n.pid).includes(q)) return true;
+  if (n.args?.some((a) => a.toLowerCase().includes(q))) return true;
   return false;
 }
 
@@ -605,9 +652,13 @@ function renderTree(
   // eslint-disable-next-line @typescript-eslint/unbound-method
   sel.call(zoom.transform, d3.zoomIdentity.translate(margin - minY, margin - minX));
 
-  // Links.
+  // Links. Skip the synthetic-root edges: when there are multiple top-level
+  // roots we add a parent node with pid=0 so d3.tree() has a single layout
+  // anchor, but that node isn't drawn — and without this filter the edges
+  // FROM that invisible parent show up in the canvas as ghost lines drifting
+  // off the left side of the tree.
   g.selectAll("path.link")
-    .data(links)
+    .data(links.filter((l) => l.source.data.pid !== 0))
     .join("path")
     .attr("class", "link")
     .attr("fill", "none")

--- a/ui/src/components/attack-techniques.ts
+++ b/ui/src/components/attack-techniques.ts
@@ -1,0 +1,71 @@
+// Static catalog of MITRE ATT&CK technique metadata for the techniques the
+// shipped detection rules cover. We don't ship the full ATT&CK enterprise
+// matrix (~600 techniques) into the UI bundle — that's what the upstream
+// Navigator exists for. This catalog is just the techniques we trigger on
+// today, with their human-readable name and tactic.
+//
+// When a rule starts covering a new technique, add the entry here. Missing
+// entries fall back to "Unmapped" in the AttackCoverage view, which is a
+// loud-but-not-broken hint that this file needs an update.
+
+export interface TechniqueMeta {
+  id: string;
+  name: string;
+  // ATT&CK has 14 enterprise tactics. We label with the human-readable name
+  // (matching attack.mitre.org URLs) so the UI doesn't need a tactic-id
+  // lookup.
+  tactic: string;
+}
+
+export const TECHNIQUE_CATALOG: Record<string, TechniqueMeta> = {
+  "T1059": {
+    id: "T1059",
+    name: "Command and Scripting Interpreter",
+    tactic: "Execution",
+  },
+  "T1059.002": {
+    id: "T1059.002",
+    name: "AppleScript",
+    tactic: "Execution",
+  },
+  "T1059.004": {
+    id: "T1059.004",
+    name: "Unix Shell",
+    tactic: "Execution",
+  },
+  "T1105": {
+    id: "T1105",
+    name: "Ingress Tool Transfer",
+    tactic: "Command and Control",
+  },
+  "T1543.001": {
+    id: "T1543.001",
+    name: "Launch Agent",
+    tactic: "Persistence",
+  },
+  "T1543.004": {
+    id: "T1543.004",
+    name: "Launch Daemon",
+    tactic: "Persistence",
+  },
+  "T1548.003": {
+    id: "T1548.003",
+    name: "Sudo and Sudo Caching",
+    tactic: "Privilege Escalation",
+  },
+  "T1555.001": {
+    id: "T1555.001",
+    name: "Keychain",
+    tactic: "Credential Access",
+  },
+  "T1566.001": {
+    id: "T1566.001",
+    name: "Spearphishing Attachment",
+    tactic: "Initial Access",
+  },
+  "T1574.006": {
+    id: "T1574.006",
+    name: "Dynamic Linker Hijacking",
+    tactic: "Defense Evasion",
+  },
+};

--- a/ui/src/components/ui/Input.scss
+++ b/ui/src/components/ui/Input.scss
@@ -48,6 +48,15 @@
       border-color: $core-fleet-green;
       box-shadow: 0 0 0 3px rgba(0, 154, 125, 0.15);
     }
+
+    // Placeholder reads as a hint, not as a default value the user must clear.
+    // The previous browser default looked too much like real text — operators
+    // reported clicking on /private/tmp/payload thinking it was already there.
+    &::placeholder {
+      color: $ui-fleet-black-50;
+      font-style: italic;
+      opacity: 1; // Firefox defaults to 0.54; force the colour we set instead.
+    }
   }
 }
 

--- a/ui/src/components/ui/TopNav.scss
+++ b/ui/src/components/ui/TopNav.scss
@@ -1,6 +1,7 @@
 @use "../../styles/var/colors" as *;
 @use "../../styles/var/fonts" as *;
 @use "../../styles/var/padding" as *;
+@use "../../styles/var/global" as *;
 
 .top-nav {
   background: $gradients-dark-gradient;
@@ -70,6 +71,61 @@
     &--active {
       color: $core-fleet-white;
       border-bottom-color: $core-fleet-green;
+    }
+  }
+
+  // Account section: pushed to the right with margin-left:auto so the user menu
+  // sits opposite the brand. Avatar + email + log out, in the order Atlassian /
+  // GitHub / Fleet itself use. The avatar is a flat circle with the user's
+  // first letter — no image fetch, fine for a 5-host pilot.
+  &__account {
+    display: flex;
+    align-items: center;
+    gap: $pad-small;
+    margin-left: auto;
+    padding: $pad-small 0;
+  }
+
+  &__avatar {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    background-color: $core-fleet-green;
+    color: $core-fleet-white;
+    font-weight: $bold;
+    font-size: $x-small;
+    text-transform: uppercase;
+  }
+
+  &__user {
+    font-size: $x-small;
+    color: $ui-fleet-black-10;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  }
+
+  &__logout {
+    background: transparent;
+    border: 1px solid $ui-fleet-black-50;
+    border-radius: $border-radius;
+    color: $ui-fleet-black-10;
+    font-size: $xx-small;
+    font-weight: $bold;
+    padding: 6px $pad-smedium;
+    cursor: pointer;
+    transition: background-color 120ms ease, color 120ms ease, border-color 120ms ease;
+
+    &:hover {
+      background-color: rgba(255, 255, 255, 0.1);
+      border-color: $core-fleet-white;
+      color: $core-fleet-white;
+    }
+
+    &:focus-visible {
+      outline: 2px solid $core-fleet-green;
+      outline-offset: 2px;
     }
   }
 }

--- a/ui/src/components/ui/TopNav.tsx
+++ b/ui/src/components/ui/TopNav.tsx
@@ -10,6 +10,7 @@ interface NavLink {
 const LINKS: NavLink[] = [
   { to: "/", label: "Hosts" },
   { to: "/alerts", label: "Alerts" },
+  { to: "/coverage", label: "Coverage" },
   { to: "/policy", label: "Policy" },
 ];
 
@@ -53,6 +54,9 @@ export function TopNav({ user, onLogout }: TopNavProps) {
         </ul>
         {user && onLogout && (
           <div className="top-nav__account">
+            <span className="top-nav__avatar" aria-hidden="true">
+              {user.email.charAt(0)}
+            </span>
             <span className="top-nav__user">{user.email}</span>
             <button
               type="button"

--- a/ui/src/components/ui/TopNav.tsx
+++ b/ui/src/components/ui/TopNav.tsx
@@ -55,7 +55,7 @@ export function TopNav({ user, onLogout }: TopNavProps) {
         {user && onLogout && (
           <div className="top-nav__account">
             <span className="top-nav__avatar" aria-hidden="true">
-              {user.email.charAt(0)}
+              {user.email.charAt(0) || "?"}
             </span>
             <span className="top-nav__user">{user.email}</span>
             <button


### PR DESCRIPTION
1. TopNav account block was unstyled — "admin@fleet-edr.localLog out" ran together with no visual separation. Add the missing .top-nav__account / __avatar / __user / __logout rules so the user menu sits on the right of the bar (margin-left:auto), with a green avatar circle (initial), monospace email, and an outlined-pill log out button. Pattern matches Fleet's own UI + GitHub / Atlassian conventions.

2. D3 process tree drew links from the synthetic root we add when there are multiple top-level real roots. The synthetic node is filtered out by `pid !== 0` from the rendered nodes set, but its outgoing edges still appeared as ghost lines drifting off-screen left. Filter the links array on the same pid !== 0 check.

3. Search filter previously dimmed non-matches with a CSS opacity class. On a 200-process tree this still leaves 195 dimmed nodes the user has to skim past. Add a queryFilterIds memo that walks the raw tree, keeps every match plus its ancestors, and prunes everything else *before* the d3 layout runs. The dimming classes stay (no-op now since non-matches are gone) so the existing match- highlighting still works without rework.

4. Input placeholders read as default values, not hints. Style ::placeholder explicitly: medium-grey + italic, opacity:1 to defeat Firefox's 0.54 default. Update Policy form placeholders to "e.g. ..." prefix so they're unambiguously hints.

5. Policy save flow had no clear dirty indicator — operators added rows then didn't realise they had to scroll to a separate "Save" section. Replace with a sticky save bar that only appears while dirty, summarising the delta (+1 path, -2 hashes, …), with the audit reason input + Save changes + Discard buttons in line. Matches GitHub's branch-protection editor and AWS Console settings flows. The "policy-flash" status banner replaces the previous one-word "Saved." text after a successful save.

6. ATT&CK coverage was a JSON download only — unsatisfying as a demo prop and harder to read than necessary. New /ui/coverage route renders the same Navigator-layer data as a tactic-grouped table with metric cards (techniques covered / detection rules / tactics with coverage), technique IDs linking to attack.mitre.org, and "Covered by" listing each rule. Keep the JSON download + "Open MITRE Navigator" link in the page header for the procurement workflow. Drop the redundant Download button on the alerts page.

7. Process-tree page had two stacked back arrows ("← Hosts" in the title plus a separate "← Alerts" in the alert breadcrumb) and the alert breadcrumb had a pink/red background that read as an error state. Replace the title's back arrow with a "Hosts / <hostid>" breadcrumb (clickable Hosts) and switch the alert breadcrumb to a neutral grey container — severity is already shown via the badge inside the row, the container itself shouldn't be a status colour.

All 7 verified live via Chrome MCP against the dev server with both hosts (edr-qa + edr-dev) feeding events.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Attack Coverage view displaying detection metrics, technique mappings, and navigator layer download
  * Added Coverage navigation link and user account display in top navigation

* **Improvements**
  * Enhanced Process Tree with query-based filtering and improved breadcrumb navigation
  * Updated Policy Editor with staged edits and explicit save workflow

* **Changes**
  * Removed ATT&CK Navigator download feature from alerts list
  * Various styling refinements throughout the interface

<!-- end of auto-generated comment: release notes by coderabbit.ai -->