### PR TITLE
UI polish round 2: process tree breadcrumb, coverage column alignment…

### DIFF
--- a/ui/src/components/AttackCoverage.scss
+++ b/ui/src/components/AttackCoverage.scss
@@ -3,23 +3,6 @@
 @use "../styles/var/padding" as *;
 
 .attack-coverage {
-  &__actions {
-    display: flex;
-    align-items: center;
-    gap: $pad-medium;
-  }
-
-  &__navigator-link {
-    color: $core-fleet-green;
-    text-decoration: none;
-    font-weight: $bold;
-    font-size: 0.95em;
-
-    &:hover {
-      text-decoration: underline;
-    }
-  }
-
   &__summary {
     display: flex;
     gap: $pad-large;
@@ -47,21 +30,47 @@
   }
 
   &__metric-label {
-    font-size: 0.85em;
+    font-size: 0.85rem;
     color: $ui-fleet-black-50;
     text-transform: uppercase;
     letter-spacing: 0.5px;
   }
 
-  &__tactic {
-    margin: $pad-large 0;
+  // Single-table layout. table-layout:fixed makes the colgroup widths
+  // authoritative so every section's columns line up — without it, each
+  // tactic group inside the table would still default-size from its widest
+  // cell and the visual alignment promise would silently break the day a
+  // long technique name lands in one tactic.
+  &__table {
+    table-layout: fixed;
+    width: 100%;
   }
 
-  &__tactic-name {
-    font-size: 1.05rem;
-    margin: 0 0 $pad-small;
-    padding-bottom: $pad-xsmall;
-    border-bottom: 1px solid $ui-fleet-black-10;
+  &__col-id {
+    width: 12ch;
+  }
+
+  &__col-name {
+    width: auto;
+  }
+
+  &__col-rules {
+    width: 35%;
+  }
+
+  // Tactic header row: re-use a <th> with colspan inside the body so it
+  // groups the techniques visually. The light-grey background + bold name
+  // matches Crowdstrike Falcon and Elastic Security's coverage tables.
+  &__tactic-row {
+    th {
+      background: $ui-fleet-black-5;
+      color: $core-fleet-black;
+      font-weight: $bold;
+      text-transform: none;
+      letter-spacing: 0;
+      padding-top: $pad-medium;
+      padding-bottom: $pad-medium;
+    }
   }
 
   &__technique-id {

--- a/ui/src/components/AttackCoverage.tsx
+++ b/ui/src/components/AttackCoverage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { Fragment, useEffect, useMemo, useState } from "react";
 import { fetchAttackNavigatorLayer, type AttackNavigatorLayer } from "../api";
 import { Table, EmptyState } from "./ui/Table";
 import { PageHeader } from "./ui/PageHeader";
@@ -92,19 +92,15 @@ export function AttackCoverage() {
         title="ATT&CK coverage"
         subtitle="MITRE ATT&CK techniques the deployed detection rules cover today."
         actions={
-          <div className="attack-coverage__actions">
-            <Button size="small" variant="inverse" onClick={downloadLayer} disabled={!layer}>
-              Download Navigator layer
-            </Button>
-            <a
-              className="attack-coverage__navigator-link"
-              href="https://mitre-attack.github.io/attack-navigator/"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Open MITRE Navigator &rarr;
-            </a>
-          </div>
+          <Button
+            size="small"
+            variant="inverse"
+            onClick={downloadLayer}
+            disabled={!layer}
+            title="Export the same data as a MITRE ATT&CK Navigator layer JSON. Useful for procurement / threat-modeling teams who use the upstream Navigator UI; sec ops can read everything they need on this page."
+          >
+            Export JSON
+          </Button>
         }
       />
 
@@ -130,45 +126,60 @@ export function AttackCoverage() {
 
           {groups.length === 0
             ? <EmptyState>No coverage data yet.</EmptyState>
-            : groups.map((g) => (
-              <section key={g.tactic} className="attack-coverage__tactic">
-                <h2 className="attack-coverage__tactic-name">{g.tactic}</h2>
-                <Table>
-                  <thead>
-                    <tr>
-                      <th style={{ width: "11ch" }}>Technique</th>
-                      <th>Name</th>
-                      <th>Covered by</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {g.techniques.map((t) => (
-                      <tr key={t.id}>
-                        <td>
-                          <a
-                            className="attack-coverage__technique-id"
-                            href={`https://attack.mitre.org/techniques/${t.id.replace(".", "/")}/`}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                          >
-                            {t.id}
-                          </a>
-                        </td>
-                        <td>{t.name}</td>
-                        <td>
-                          {t.coveringRules.map((r, i) => (
-                            <span key={r}>
-                              {i > 0 && ", "}
-                              <code>{r}</code>
-                            </span>
-                          ))}
-                        </td>
+            : (
+              // Single table for the whole page so column widths line up
+              // across tactics (a per-tactic <Table> sized columns from
+              // its own widest cell, producing a different layout per
+              // section). Tactic names land in colspan rows that act as
+              // visual section headers — same pattern Crowdstrike Falcon
+              // and Elastic Security use for their ATT&CK coverage tables.
+              <Table className="attack-coverage__table">
+                <colgroup>
+                  <col className="attack-coverage__col-id" />
+                  <col className="attack-coverage__col-name" />
+                  <col className="attack-coverage__col-rules" />
+                </colgroup>
+                <thead>
+                  <tr>
+                    <th>Technique</th>
+                    <th>Name</th>
+                    <th>Covered by</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {groups.map((g) => (
+                    <Fragment key={g.tactic}>
+                      <tr className="attack-coverage__tactic-row">
+                        <th colSpan={3} scope="colgroup">{g.tactic}</th>
                       </tr>
-                    ))}
-                  </tbody>
-                </Table>
-              </section>
-            ))}
+                      {g.techniques.map((t) => (
+                        <tr key={t.id}>
+                          <td>
+                            <a
+                              className="attack-coverage__technique-id"
+                              href={`https://attack.mitre.org/techniques/${t.id.replace(".", "/")}/`}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                            >
+                              {t.id}
+                            </a>
+                          </td>
+                          <td>{t.name}</td>
+                          <td>
+                            {t.coveringRules.map((r, i) => (
+                              <span key={r}>
+                                {i > 0 && ", "}
+                                <code>{r}</code>
+                              </span>
+                            ))}
+                          </td>
+                        </tr>
+                      ))}
+                    </Fragment>
+                  ))}
+                </tbody>
+              </Table>
+            )}
         </>
       )}
     </>

--- a/ui/src/components/AttackCoverage.tsx
+++ b/ui/src/components/AttackCoverage.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { fetchAttackNavigatorLayer, type AttackNavigatorLayer } from "../api";
 import { Table, EmptyState } from "./ui/Table";
 import { PageHeader } from "./ui/PageHeader";
@@ -14,10 +14,10 @@ import "./AttackCoverage.scss";
 // what Crowdstrike Falcon, SentinelOne Singularity, and Elastic Security all
 // expose: tactic columns, technique rows, "covered by" linkable rule list.
 //
-// We still ship the JSON via the "Download Navigator layer" button so an
-// operator can drop it into the upstream MITRE Navigator UI for the full
-// matrix view if they want — that's the right tool for "look at all 14 tactics
-// at once" and there's no point in re-implementing the matrix renderer here.
+// We still ship the JSON via the "Export JSON" button so an operator can
+// drop it into the upstream MITRE Navigator UI for the full matrix view if
+// they want — that's the right tool for "look at all 14 tactics at once" and
+// there's no point in re-implementing the matrix renderer here.
 
 type TechniqueWithCoverage = TechniqueMeta & {
   coveringRules: string[];
@@ -146,38 +146,41 @@ export function AttackCoverage() {
                     <th>Covered by</th>
                   </tr>
                 </thead>
-                <tbody>
-                  {groups.map((g) => (
-                    <Fragment key={g.tactic}>
-                      <tr className="attack-coverage__tactic-row">
-                        <th colSpan={3} scope="colgroup">{g.tactic}</th>
+                {/* One <tbody> per tactic with scope="rowgroup" on the
+                    header — that's the HTML5 idiom for grouping rows under a
+                    label, which lets screen readers announce the tactic as
+                    context for each technique row. Visually identical to a
+                    Fragment-with-shared-tbody approach. */}
+                {groups.map((g) => (
+                  <tbody key={g.tactic}>
+                    <tr className="attack-coverage__tactic-row">
+                      <th colSpan={3} scope="rowgroup">{g.tactic}</th>
+                    </tr>
+                    {g.techniques.map((t) => (
+                      <tr key={t.id}>
+                        <td>
+                          <a
+                            className="attack-coverage__technique-id"
+                            href={`https://attack.mitre.org/techniques/${t.id.replace(".", "/")}/`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                          >
+                            {t.id}
+                          </a>
+                        </td>
+                        <td>{t.name}</td>
+                        <td>
+                          {t.coveringRules.map((r, i) => (
+                            <span key={r}>
+                              {i > 0 && ", "}
+                              <code>{r}</code>
+                            </span>
+                          ))}
+                        </td>
                       </tr>
-                      {g.techniques.map((t) => (
-                        <tr key={t.id}>
-                          <td>
-                            <a
-                              className="attack-coverage__technique-id"
-                              href={`https://attack.mitre.org/techniques/${t.id.replace(".", "/")}/`}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                            >
-                              {t.id}
-                            </a>
-                          </td>
-                          <td>{t.name}</td>
-                          <td>
-                            {t.coveringRules.map((r, i) => (
-                              <span key={r}>
-                                {i > 0 && ", "}
-                                <code>{r}</code>
-                              </span>
-                            ))}
-                          </td>
-                        </tr>
-                      ))}
-                    </Fragment>
-                  ))}
-                </tbody>
+                    ))}
+                  </tbody>
+                ))}
               </Table>
             )}
         </>

--- a/ui/src/components/ProcessTree.scss
+++ b/ui/src/components/ProcessTree.scss
@@ -10,26 +10,16 @@
     gap: $pad-medium;
   }
 
-  &__crumb {
+  &__host-link {
+    color: $core-fleet-black;
     font-size: $x-small;
-    font-weight: $regular;
-    color: $core-fleet-green;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
     text-decoration: none;
 
     &:hover {
       text-decoration: underline;
+      color: $core-fleet-green;
     }
-  }
-
-  &__crumb-sep {
-    font-size: $x-small;
-    color: $ui-fleet-black-25;
-  }
-
-  &__host {
-    color: $ui-fleet-black-75;
-    font-size: $x-small;
-    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   }
 
   &__controls {

--- a/ui/src/components/ProcessTree.tsx
+++ b/ui/src/components/ProcessTree.tsx
@@ -413,9 +413,14 @@ export function ProcessTreeView() {
       <PageHeader
         title={
           <span className="process-tree__title">
-            <Link to="/" className="process-tree__crumb">Hosts</Link>
-            <span className="process-tree__crumb-sep" aria-hidden="true">/</span>
-            <span className="process-tree__host">{hostId}</span>
+            {/* "Hosts" lives in the top nav already — repeating it here is
+                noise. Link the host id itself to the bare host page so the
+                operator can click out of an alert-context view (drops the
+                ?alert=…&process=…&at=… query params) back to the full host
+                tree without round-tripping through the host list. */}
+            <Link to={`/hosts/${encodeURIComponent(hostId)}`} className="process-tree__host-link">
+              {hostId}
+            </Link>
           </span>
         }
         actions={headerActions}


### PR DESCRIPTION
…, drop external Navigator link

From claude/mvp/wip.txt rounds 8-10:

1. ProcessTree title was "Hosts / <hostid>", but Hosts is already in the top nav — repeating it inside the page header is noise. Drop the prefix and link the host_id itself to /hosts/<hostid> (no query params), so an operator on an alert-context view (?alert=…) can click out of alert focus to the full host tree without round-tripping through the host list.

2. AttackCoverage page rendered one <Table> per tactic, which let each table size its columns independently from its widest cell — Technique / Name / Covered-by columns drifted by tactic. Switch to a single fixed-layout table with <colgroup> widths (12ch / auto / 35%) and tactic-header rows inside <tbody> via colspan=3. Same pattern Crowdstrike Falcon and Elastic Security use for their ATT&CK coverage tables.

3. "Open MITRE Navigator →" external link was noise: sec ops doesn't need it (the in-product table is now the workflow), and clicking it just opens the Navigator UI with no payload — the operator would have to download the JSON separately and re-upload. Remove. Keep the JSON download but rename to "Export JSON" with a tooltip that calls out the actual audience: procurement / threat-modeling teams who use the upstream Navigator. Sec ops reads everything on the page itself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**New Features**
- New "Export JSON" button provides streamlined Attack Coverage data export functionality with explanatory tooltip guidance.

**Style**
- Consolidated Attack Coverage tactic display from multiple sections into a single unified table layout for consistent column alignment.
- Updated Process Tree breadcrumb navigation to provide direct links to individual host detail pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->