### PR TITLE
Bump Sonar coverage to clear gate + raise OpenSSF Scorecard score

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -94,3 +94,21 @@ updates:
     labels: ["dependencies", "ci"]
     commit-message:
       prefix: "deps(ci)"
+
+  # Docker base images for the server runtime. We pin both the tag and the
+  # manifest digest in Dockerfile FROM lines so OpenSSF Scorecard's
+  # Pinned-Dependencies check is satisfied; Dependabot keeps the digest in
+  # sync as upstream tags get rebuilt with security updates.
+  - package-ecosystem: "docker"
+    directory: "/server"
+    schedule:
+      interval: "weekly"
+      day: "friday"
+      time: "06:00"
+      timezone: "America/Chicago"
+    open-pull-requests-limit: 3
+    cooldown:
+      default-days: 7
+    labels: ["dependencies", "docker"]
+    commit-message:
+      prefix: "deps(docker)"

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -31,6 +31,12 @@ jobs:
       # Scorecard's Pinned-Dependencies check flags as `downloadThenRun`). The
       # tarball + checksum are published per release on the rhysd/actionlint
       # repo; Dependabot's github-actions ecosystem keeps this version current.
+      #
+      # `--proto =https` rejects any redirect to a non-HTTPS scheme, closing
+      # the Sonar `githubactions:S6506` "redirection to insecure website"
+      # hotspot. We install into `$HOME/.local/bin` and prepend it to
+      # `$GITHUB_PATH` so the step works under the unprivileged `runner`
+      # user without sudo (Copilot review on PR #55).
       - name: Install actionlint
         env:
           ACTIONLINT_VERSION: "1.7.12"
@@ -38,11 +44,14 @@ jobs:
         run: |
           set -euo pipefail
           tarball="actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
-          curl -fsSL --retry 3 -o "$tarball" \
+          curl -fsSL --proto '=https' --retry 3 -o "$tarball" \
             "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/${tarball}"
           echo "${ACTIONLINT_SHA256}  ${tarball}" | sha256sum -c -
           tar -xzf "$tarball" actionlint
-          install -m 0755 actionlint /usr/local/bin/actionlint
+          bindir="$HOME/.local/bin"
+          mkdir -p "$bindir"
+          install -m 0755 actionlint "$bindir/actionlint"
+          echo "$bindir" >> "$GITHUB_PATH"
 
       - name: Run actionlint
         run: actionlint

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -26,10 +26,23 @@ jobs:
         with:
           persist-credentials: false
 
+      # Pull a fixed actionlint version from a published release (instead of the
+      # `bash <(curl …main/download-actionlint.bash)` pattern that OpenSSF
+      # Scorecard's Pinned-Dependencies check flags as `downloadThenRun`). The
+      # tarball + checksum are published per release on the rhysd/actionlint
+      # repo; Dependabot's github-actions ecosystem keeps this version current.
       - name: Install actionlint
+        env:
+          ACTIONLINT_VERSION: "1.7.12"
+          ACTIONLINT_SHA256: "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8"
         run: |
-          bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
-          echo "." >> "$GITHUB_PATH"
+          set -euo pipefail
+          tarball="actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          curl -fsSL --retry 3 -o "$tarball" \
+            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/${tarball}"
+          echo "${ACTIONLINT_SHA256}  ${tarball}" | sha256sum -c -
+          tar -xzf "$tarball" actionlint
+          install -m 0755 actionlint /usr/local/bin/actionlint
 
       - name: Run actionlint
         run: actionlint

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,54 @@
+# Security policy
+
+Fleet EDR is a security product. We take vulnerabilities seriously and
+welcome reports from researchers, customers, and the wider community.
+
+## Supported versions
+
+We patch the most recent released minor only. Pilot releases (`v0.x.y-rc.*`)
+are pre-GA and receive fixes on a best-effort basis; once `v1.0.0` ships we
+will publish a formal support window here.
+
+| Version    | Status              | Security fixes |
+| ---------- | ------------------- | -------------- |
+| `0.1.x-rc` | Pilot / pre-GA      | Best-effort    |
+| `< 0.1`    | Unsupported         | None           |
+
+## Reporting a vulnerability
+
+**Please do not open a public GitHub issue for security bugs.** Use GitHub's
+private vulnerability reporting instead: visit
+<https://github.com/getvictor/fleet-edr/security/advisories/new>. This
+creates an embargoed draft advisory that only the maintainers and you can
+see, and is the only channel we accept reports through.
+
+When you report, please include:
+
+- The component (server, agent, system extension, network extension, UI).
+- Affected version(s), commit SHA, or release tag.
+- A proof-of-concept or clear reproduction steps.
+- The impact you observed, and any workarounds you found.
+
+We will acknowledge receipt within **2 business days**. We aim to publish a
+fix within **30 days** for high-severity findings, longer for low-severity
+ones, and will keep you updated on progress along the way. After a fix
+ships we will credit you in the advisory unless you prefer to remain
+anonymous.
+
+## Out of scope
+
+The following classes of finding are not security vulnerabilities for this
+project and do not need to be reported privately:
+
+- Issues that require physical access to an unlocked, enrolled Mac.
+- Findings that depend on a user already holding root or
+  `kTCCServiceSystemPolicyAllFiles` (Full Disk Access) on the endpoint.
+- Reports that the agent is detected by EDR/AV products on managed hosts —
+  the agent does not attempt to evade detection.
+- Denial of service from a single authorised host against its own server
+  (e.g. flooding `/api/v1/events` with valid tokens). DoS that crosses
+  tenant boundaries or affects other hosts is in scope.
+- Findings against `claude/`, scratch, or `tmp/` directories — these are
+  developer aids, not shipped artifacts.
+
+Thank you for helping keep Fleet EDR's users safe.

--- a/agent/hostid/hostid_test.go
+++ b/agent/hostid/hostid_test.go
@@ -93,6 +93,25 @@ func TestGet_ExecError(t *testing.T) {
 	assert.Contains(t, err.Error(), "run ioreg")
 }
 
+// FuzzParseIORegOutput drives the regex-based parser with random bytes. The
+// invariant we care about is "must not panic on any input" — a malformed
+// ioreg(1) output (truncated buffer, encoding glitch) should turn into a
+// "not found" error, never crash the agent's startup path.
+func FuzzParseIORegOutput(f *testing.F) {
+	for _, seed := range []string{
+		`"IOPlatformUUID" = "AAA"`,
+		`"IOPlatformUUID"="BBB"`,
+		`no uuid here`,
+		``,
+		`"IOPlatformUUID" = "" garbage`,
+	} {
+		f.Add([]byte(seed))
+	}
+	f.Fuzz(func(t *testing.T, in []byte) {
+		_, _ = parseIORegOutput(in)
+	})
+}
+
 // TestGet_NoUUIDInOutput covers the case where ioreg ran but its output is
 // missing the IOPlatformUUID line — Get bubbles up the parse error verbatim.
 func TestGet_NoUUIDInOutput(t *testing.T) {

--- a/internal/envparse/envparse_test.go
+++ b/internal/envparse/envparse_test.go
@@ -1,6 +1,7 @@
 package envparse
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -205,6 +206,35 @@ func TestAllowlist(t *testing.T) {
 		// because the caller compares against actual filesystem paths.
 		got := Allowlist("/Foo,/foo")
 		assert.Len(t, got, 2)
+	})
+}
+
+// FuzzAllowlist drives the path-set parser with random comma-separated input.
+// The invariant: never panic, never produce an empty-string key, never include
+// untrimmed whitespace in a key. These match the runtime guarantees the
+// uploader's allowlist matcher relies on.
+func FuzzAllowlist(f *testing.F) {
+	for _, seed := range []string{
+		"",
+		"   ",
+		"/usr/libexec/sshd-session",
+		"a,b,c",
+		" /a , /b ,, /c ,",
+		"\t\n",
+		",,,",
+	} {
+		f.Add(seed)
+	}
+	f.Fuzz(func(t *testing.T, in string) {
+		got := Allowlist(in)
+		for k := range got {
+			if k == "" {
+				t.Fatalf("Allowlist returned empty key from input %q", in)
+			}
+			if k != strings.TrimSpace(k) {
+				t.Fatalf("Allowlist key %q has untrimmed whitespace from input %q", k, in)
+			}
+		}
 	})
 }
 

--- a/internal/envparse/envparse_test.go
+++ b/internal/envparse/envparse_test.go
@@ -222,6 +222,9 @@ func FuzzAllowlist(f *testing.F) {
 		" /a , /b ,, /c ,",
 		"\t\n",
 		",,,",
+		"\u00a0/a,\u00a0/b\u00a0",     // non-breaking spaces; strings.TrimSpace must strip them
+		"\u2003/a,\u2002/b",           // em + en spaces
+		"\u2028/a\u2029,\u00a0/b\t/c", // line + paragraph separators interleaved with tabs
 	} {
 		f.Add(seed)
 	}

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -19,7 +19,12 @@
 # ---------------------------------------------------------------
 # Stage 1: UI bundle
 # ---------------------------------------------------------------
-FROM --platform=$BUILDPLATFORM node:20 AS ui-build
+# Image SHAs are pinned alongside the human-readable tag so OpenSSF Scorecard's
+# Pinned-Dependencies check sees a digest. Refresh by running e.g.
+# `docker manifest inspect node:20 --verbose` and copying the manifest digest.
+# Dependabot's docker ecosystem keeps these current; do not strip the digest
+# during a tag bump.
+FROM --platform=$BUILDPLATFORM node:20@sha256:8f693eaa7e0a8e71560c9a82b55fd54c2ae920a2ba5d2cde28bac7d1c01c9ba5 AS ui-build
 # package*.json first for layer-cache reuse: npm ci only reruns when
 # dependencies change, not every source edit.
 WORKDIR /src/ui
@@ -36,7 +41,7 @@ RUN npm run build
 # ---------------------------------------------------------------
 # Stage 2: Go binary
 # ---------------------------------------------------------------
-FROM --platform=$BUILDPLATFORM golang:1.26 AS build
+FROM --platform=$BUILDPLATFORM golang:1.26@sha256:b54cbf583d390341599d7bcbc062425c081105cc5ef6d170ced98ef9d047c716 AS build
 ARG TARGETOS
 ARG TARGETARCH
 ARG VERSION=dev
@@ -74,7 +79,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 # ---------------------------------------------------------------
 # Stage 3: runtime
 # ---------------------------------------------------------------
-FROM gcr.io/distroless/static-debian12:nonroot
+FROM gcr.io/distroless/static-debian12:nonroot@sha256:a9329520abc449e3b14d5bc3a6ffae065bdde0f02667fa10880c49b35c109fd1
 
 # Non-secret defaults. Operators override via compose env or EDR_*_FILE mounts.
 ENV EDR_LISTEN_ADDR=":8088" \

--- a/server/config/file_env_test.go
+++ b/server/config/file_env_test.go
@@ -72,16 +72,20 @@ func TestFileBackedGetenv_MissingFileLogsAndReturnsEmpty(t *testing.T) {
 
 // TestFileBackedGetenv_NilLoggerUsesDefault locks in the safe-fallback path so
 // callers (e.g. early bootstrap code that hasn't built a logger yet) can pass
-// nil and still get a working decorator.
+// nil and still get a working decorator. Drives the missing-_FILE branch
+// specifically — that branch is the only one that exercises the nil-logger
+// fallback (`logger.WarnContext` would panic on a nil logger if the fallback
+// weren't applied), so a regression there must be observable in this test.
 func TestFileBackedGetenv_NilLoggerUsesDefault(t *testing.T) {
 	base := func(k string) string {
-		if k == "EDR_ENROLL_SECRET" {
-			return "direct"
+		if k == "EDR_ENROLL_SECRET_FILE" {
+			return filepath.Join(t.TempDir(), "missing")
 		}
 		return ""
 	}
 	get := fileBackedGetenv(base, nil)
-	assert.Equal(t, "direct", get("EDR_ENROLL_SECRET"))
+	assert.NotPanics(t, func() { _ = get("EDR_ENROLL_SECRET") })
+	assert.Empty(t, get("EDR_ENROLL_SECRET"))
 }
 
 // TestWriteSecretFile drives the small helper that compose-fixture tests use to

--- a/server/config/file_env_test.go
+++ b/server/config/file_env_test.go
@@ -70,6 +70,47 @@ func TestFileBackedGetenv_MissingFileLogsAndReturnsEmpty(t *testing.T) {
 	assert.Contains(t, buf.String(), "failed to read *_FILE env var")
 }
 
+// TestFileBackedGetenv_NilLoggerUsesDefault locks in the safe-fallback path so
+// callers (e.g. early bootstrap code that hasn't built a logger yet) can pass
+// nil and still get a working decorator.
+func TestFileBackedGetenv_NilLoggerUsesDefault(t *testing.T) {
+	base := func(k string) string {
+		if k == "EDR_ENROLL_SECRET" {
+			return "direct"
+		}
+		return ""
+	}
+	get := fileBackedGetenv(base, nil)
+	assert.Equal(t, "direct", get("EDR_ENROLL_SECRET"))
+}
+
+// TestWriteSecretFile drives the small helper that compose-fixture tests use to
+// stage a docker-secret-style file. We assert the content is written verbatim
+// and the perms are 0600 (the rest of the security model assumes secrets are
+// not world-readable).
+func TestWriteSecretFile(t *testing.T) {
+	dir := t.TempDir()
+	path, err := WriteSecretFile(dir, "enroll-secret", "supersecret\n")
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(dir, "enroll-secret"), path)
+
+	got, err := os.ReadFile(path) //nolint:gosec // path produced by the helper under test
+	require.NoError(t, err)
+	assert.Equal(t, "supersecret\n", string(got))
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+}
+
+func TestWriteSecretFile_BadDir(t *testing.T) {
+	// Pointing at a path under a non-existent parent surfaces the os.WriteFile
+	// error rather than swallowing it — operators tracing config issues need to
+	// see the path-not-found error verbatim.
+	_, err := WriteSecretFile(filepath.Join(t.TempDir(), "missing-dir"), "x", "v")
+	require.Error(t, err)
+}
+
 func TestFileBackedGetenv_TrimsOnlyOuterWhitespace(t *testing.T) {
 	// Docker secrets often trail a newline. We strip leading + trailing whitespace
 	// but preserve interior characters. A DSN like


### PR DESCRIPTION
Sonar new_coverage was at 79.7% (gate threshold 80%). Add tests for the remaining easy targets so the gate clears, and roll up the Scorecard quick-wins surfaced by the latest scorecard.dev report (current: 5.8/10).

Coverage:

- server/config/file_env.go: 73.7% -> 94.3%. Adds tests for the fileBackedGetenv nil-logger fallback and the WriteSecretFile helper (success + bad-dir error path), the 5 lines Sonar still flagged.

Scorecard fixes:

- Pin the three Dockerfile FROM lines to manifest digests (node:20, golang:1.26, gcr.io/distroless/static-debian12:nonroot). Adds a `docker` ecosystem to dependabot.yml so the digests stay refreshed weekly. Lifts Pinned-Dependencies from 8 -> 10.
- Replace the actionlint `bash <(curl …main/download-actionlint.bash)` pattern with a release-tarball download + sha256 verification (v1.7.12). Drops the last `downloadThenRun` finding from the report.
- Add SECURITY.md pointing reporters at GitHub's private vulnerability reporting (no email channel exposed), with supported-versions table and out-of-scope classes. Lifts Security-Policy from 0 -> 10.
- Add Go fuzz tests for parseIORegOutput and Allowlist (the two pure parser paths in the agent + shared helpers). Lifts Fuzzing from 0 -> 10. Both fuzz cleanly under -fuzztime=2s.

Out of scope here: License (no LICENSE file at root), CII-Best-Practices (needs registration on bestpractices.coreinfrastructure.org), and Code-Review (needs branch protection requiring reviewer approval). Those are policy/admin choices, not code edits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added security vulnerability reporting policy.
* **Tests**
  * Expanded test coverage for input parsing and configuration.
* **Chores**
  * Pinned Docker base images for reproducible builds; improved CI tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->