### PR TITLE
Add per-rule operator docs (markdown + /ui/rules/<id>)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ Running Fleet EDR (not developing it)? Start with [`docs/`](docs/):
   MDM-specific recipe.
 - [`docs/operations.md`](docs/operations.md) -- day-2 ops runbook
   (upgrades, rotations, backups, troubleshooting).
+- [`docs/detection-rules.md`](docs/detection-rules.md) -- per-rule
+  behaviour, ATT&CK mapping, severity, and configuration env vars.
+  Generated from the rule source via `go run ./tools/gen-rule-docs`.
 - [`docs/api.md`](docs/api.md) + [`docs/api/openapi.yaml`](docs/api/openapi.yaml)
   -- HTTP API reference.
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -62,6 +62,13 @@ tasks:
     cmds:
       - xcodebuild -project edr.xcodeproj -scheme edr -configuration Debug -sdk macosx -derivedDataPath build
 
+  # -------- generate --------
+
+  docs:rules:
+    desc: Regenerate docs/detection-rules.md from the registered rule catalogue.
+    cmds:
+      - go run ./tools/gen-rule-docs
+
   # -------- test --------
 
   test:

--- a/docs/detection-rules.md
+++ b/docs/detection-rules.md
@@ -27,7 +27,7 @@ Hand-edits to this file get overwritten on the next regeneration.
 ## suspicious_exec
 
 **Suspicious exec chain (non-shell → shell → temp/network)**  
-Flags a non-shell process that spawns a shell which, within 30 seconds, exec's from /tmp or makes an outbound network connection.
+Flags a non-shell process that spawns a shell which, within 30 seconds, execs from /tmp or makes an outbound network connection.
 
 | | |
 | --- | --- |
@@ -219,7 +219,7 @@ Flags a non-platform-binary write to any *.plist directly under /Library/LaunchD
 | Rule ID | `privilege_launchd_plist_write` |
 | Severity | `high` |
 | ATT&CK | [`T1543.004`](https://attack.mitre.org/techniques/T1543/004/) |
-| Event types | `open_write` |
+| Event types | `open` |
 
 ### Description
 
@@ -255,7 +255,7 @@ Flags any non-allowlisted writer that opens /etc/sudoers or /etc/sudoers.d/* in 
 | Rule ID | `sudoers_tamper` |
 | Severity | `high` |
 | ATT&CK | [`T1548.003`](https://attack.mitre.org/techniques/T1548/003/) |
-| Event types | `open_write` |
+| Event types | `open` |
 
 ### Description
 

--- a/docs/detection-rules.md
+++ b/docs/detection-rules.md
@@ -1,0 +1,281 @@
+# Detection rules
+
+This page is generated from `tools/gen-rule-docs` by walking the
+`detection.Rule.Doc()` method on every rule registered in
+`server/cmd/fleet-edr-server/main.go`. To refresh after changing a
+rule's documentation, run:
+
+```sh
+go run ./tools/gen-rule-docs
+```
+
+Hand-edits to this file get overwritten on the next regeneration.
+
+## Index
+
+| Rule ID | Title | Severity | ATT&CK |
+| --- | --- | --- | --- |
+| [`suspicious_exec`](#suspicious_exec) | Suspicious exec chain (non-shell → shell → temp/network) | high | T1059, T1105 |
+| [`persistence_launchagent`](#persistence_launchagent) | LaunchAgent persistence (launchctl load/bootstrap) | high | T1543.001 |
+| [`dyld_insert`](#dyld_insert) | DYLD injection on exec | high | T1574.006 |
+| [`shell_from_office`](#shell_from_office) | Shell spawned by Microsoft Office | high | T1566.001, T1059.004 |
+| [`osascript_network_exec`](#osascript_network_exec) | AppleScript dropper (osascript → curl/wget → temp exec) | critical | T1059.002, T1105 |
+| [`credential_keychain_dump`](#credential_keychain_dump) | Keychain dump (security dump-keychain) | high | T1555.001 |
+| [`privilege_launchd_plist_write`](#privilege_launchd_plist_write) | LaunchDaemon plist drop (/Library/LaunchDaemons write) | high | T1543.004 |
+| [`sudoers_tamper`](#sudoers_tamper) | Sudoers tamper (write to /etc/sudoers or /etc/sudoers.d/*) | high | T1548.003 |
+
+## suspicious_exec
+
+**Suspicious exec chain (non-shell → shell → temp/network)**  
+Flags a non-shell process that spawns a shell which, within 30 seconds, exec's from /tmp or makes an outbound network connection.
+
+| | |
+| --- | --- |
+| Rule ID | `suspicious_exec` |
+| Severity | `high` |
+| ATT&CK | [`T1059`](https://attack.mitre.org/techniques/T1059/), [`T1105`](https://attack.mitre.org/techniques/T1105/) |
+| Event types | `exec`, `network_connect` |
+
+### Description
+
+Detects two related chain shapes that share a single attribution chain:
+
+1. non-shell parent → shell child → temp-directory exec (e.g. `/tmp/payload`)
+2. non-shell parent → shell child → outbound network_connect
+
+The rule fires on the LAST link of the chain (the temp-exec or the network_connect) rather than the shell's exec. That makes it race-immune across the agent's flush boundaries — a chain that completes in ~150ms but straddles a 1-second flush boundary still resolves cleanly because the entire ancestor chain has already been ingested by the time the trigger event lands.
+
+30 seconds is the temporal cap between the shell exec and the trigger event.
+
+### Configuration
+
+| Env var | Type | Default | Description |
+| --- | --- | --- | --- |
+| `EDR_SUSPICIOUS_EXEC_PARENT_ALLOWLIST` | `csv-paths` | _(unset)_ | Comma-separated absolute parent-process paths the rule should treat as benign roots (both temp-exec and network arms). Canonical use: `/usr/libexec/sshd-session` on hosts where interactive SSH is normal. |
+
+### Known false-positive sources
+
+- Interactive SSH where an admin runs a script from /tmp and/or curls a tool. Use EDR_SUSPICIOUS_EXEC_PARENT_ALLOWLIST to silence sshd-session if that's a routine workflow on the host class.
+- Some Apple-signed installer-postflight scripts shell out to /tmp/ during package install.
+
+### Limitations
+
+- 30s window is hard-coded; long-tail post-shell activity is missed by design.
+- Allowlisting a parent silences BOTH arms of the rule for that parent — the trade-off is documented on AllowedNonShellParents.
+
+## persistence_launchagent
+
+**LaunchAgent persistence (launchctl load/bootstrap)**  
+Flags `launchctl load` / `launchctl bootstrap` of a plist under ~/Library/LaunchAgents or /Library/LaunchAgents.
+
+| | |
+| --- | --- |
+| Rule ID | `persistence_launchagent` |
+| Severity | `high` |
+| ATT&CK | [`T1543.001`](https://attack.mitre.org/techniques/T1543/001/) |
+| Event types | `exec` |
+
+### Description
+
+Detects the canonical user-domain persistence step on macOS: an attacker drops a plist into a LaunchAgents directory and then activates it via `launchctl load <plist>` or `launchctl bootstrap gui/<uid> <plist>`. We catch the activation rather than the file write so the alert ties to the moment the persistence becomes effective.
+
+Argument parsing handles launch-domain specifiers (`gui/501`) preceding the plist path and tolerates flag-like args between `load` and the plist (`-w`, `-F`, etc.).
+
+### Configuration
+
+| Env var | Type | Default | Description |
+| --- | --- | --- | --- |
+| `EDR_LAUNCHAGENT_ALLOWLIST` | `csv-paths` | _(unset)_ | Comma-separated absolute plist paths the rule should silently accept. Use exact paths; case-sensitive. |
+
+### Known false-positive sources
+
+- MDM- or installer-provisioned LaunchAgents (Munki, Kandji, JumpCloud) loaded at deploy time. Allowlist their plist paths via EDR_LAUNCHAGENT_ALLOWLIST.
+- Developer tools that register helper agents (Docker Desktop, Backblaze, etc.) on first launch.
+
+### Limitations
+
+- Does not cover `launchctl bootout` or `launchctl unload` — those undo persistence rather than create it.
+- Does not catch direct plist writes that never get activated; pair with the privilege_launchd_plist_write rule for system-domain coverage.
+
+## dyld_insert
+
+**DYLD injection on exec**  
+Flags exec where DYLD_INSERT_LIBRARIES or DYLD_LIBRARY_PATH is set in argv (shell-style or via env(1)).
+
+| | |
+| --- | --- |
+| Rule ID | `dyld_insert` |
+| Severity | `high` |
+| ATT&CK | [`T1574.006`](https://attack.mitre.org/techniques/T1574/006/) |
+| Event types | `exec` |
+
+### Description
+
+Detects the classic macOS code-injection primitive: launching a process with `DYLD_INSERT_LIBRARIES=…` or `DYLD_LIBRARY_PATH=…` set so dyld loads attacker-supplied dylibs into the new process before main(). The rule fires on the leading argv slot only — `VAR=value /path/to/bin` shell form, or `env VAR=value /path/to/bin` — so substring noise (curl POST data, echo, etc.) does not false-positive.
+
+The matching dylib path is redacted in alert text (a sensitive payload location) but kept in the raw event payload for responders.
+
+### Known false-positive sources
+
+- Local development of code that itself uses DYLD_INSERT_LIBRARIES (rare; usually scoped to non-managed dev hosts).
+- Apple-signed binaries are immune to DYLD_INSERT_LIBRARIES under SIP, but the rule still fires on the launch — investigate why an admin script is setting these vars at all.
+
+### Limitations
+
+- Inherited environment variables (set by a parent shell, not on the exec line) are invisible: ESF does not yet hand the agent the full env map. Tracked in Phase 4.
+- DYLD_FRAMEWORK_PATH and DYLD_FALLBACK_* are intentionally NOT matched — higher-FP, lower-signal. Extend dyldPrefixes if a pilot surfaces real abuse.
+
+## shell_from_office
+
+**Shell spawned by Microsoft Office**  
+Flags any /bin/sh, /bin/bash, /bin/zsh (etc.) whose parent is Word, Excel, PowerPoint, or Outlook.
+
+| | |
+| --- | --- |
+| Rule ID | `shell_from_office` |
+| Severity | `high` |
+| ATT&CK | [`T1566.001`](https://attack.mitre.org/techniques/T1566/001/), [`T1059.004`](https://attack.mitre.org/techniques/T1059/004/) |
+| Event types | `exec` |
+
+### Description
+
+Detects the textbook post-phishing execution step: a macro-laden Office document opens, the macro shells out, and the second stage takes off from there. The match is on the parent process being one of the four standard macOS Office binaries (full path, not substring) and the child being a known shell.
+
+Office apps almost never need to shell out in normal use; when they do, it's an admin-side automation that's worth surfacing anyway.
+
+### Known false-positive sources
+
+- Office's internal `Get Started` first-run flow has historically shelled out to fetch help content. Confirm by inspecting argv on the alert.
+- Admin-driven user-environment scripts that template Office settings via shell.
+
+### Limitations
+
+- Does not catch non-shell payloads (osascript, python, ruby) launched directly from Office. Pair with osascript_network_exec for the AppleScript variant.
+- Office binary path matching is exact: `/Applications/Microsoft Word.app/Contents/MacOS/Microsoft Word`. Apps installed elsewhere (e.g. on an external volume) are missed by design.
+
+## osascript_network_exec
+
+**AppleScript dropper (osascript → curl/wget → temp exec)**  
+Critical-severity catch on the canonical macOS commodity-dropper chain: osascript fetches a stage-2 over the network and runs it from /tmp.
+
+| | |
+| --- | --- |
+| Rule ID | `osascript_network_exec` |
+| Severity | `critical` |
+| ATT&CK | [`T1059.002`](https://attack.mitre.org/techniques/T1059/002/), [`T1105`](https://attack.mitre.org/techniques/T1105/) |
+| Event types | `exec` |
+
+### Description
+
+Fires on the LAST link of the chain — an exec from a temp directory whose process tree has both an osascript ancestor and a curl/wget sibling within the osascript's 30-second descendant window. This shape is the recognisable signature of macOS commodity malware staged via AppleScript.
+
+Reverse-direction triggering is deliberate: by the time the temp-exec event lands, the entire ancestor chain has already been ingested and materialised by earlier batches, so the rule is race-immune. Forward triggering (fire on the osascript exec, look for descendants) misses chains that complete across an agent flush boundary.
+
+The rule requires both halves of the chain to be present, so download-only or temp-exec-only flows do not fire here — those overlap with suspicious_exec.
+
+### Known false-positive sources
+
+- Internal automation that bootstraps tooling by scripting `curl … | sh` from osascript — extremely rare in managed fleets.
+
+### Limitations
+
+- 30-second descendant window is hard-coded; longer-running chains are missed by design.
+- Does not cover Python URL fetches or AppleScript built-in URL access — only flags the explicit curl/wget shape.
+
+## credential_keychain_dump
+
+**Keychain dump (security dump-keychain)**  
+Flags exec of /usr/bin/security dump-keychain — the canonical macOS Keychain export command.
+
+| | |
+| --- | --- |
+| Rule ID | `credential_keychain_dump` |
+| Severity | `high` |
+| ATT&CK | [`T1555.001`](https://attack.mitre.org/techniques/T1555/001/) |
+| Event types | `exec` |
+
+### Description
+
+Fires when a process invokes `/usr/bin/security` with the `dump-keychain` subcommand. That command exports Keychain entries (saved passwords, private keys) and is the macOS-native equivalent of credential-dumping tooling on Windows. Admin scripts virtually never invoke it; offensive playbooks do.
+
+Match shape is exact-path + exact-subcommand to keep the rule high-precision. A shell wrapper (`sh -c "security dump-keychain"`) still surfaces because ESF emits a NOTIFY_EXEC for each execve(), so the security binary always shows up as its own exec event regardless of parent.
+
+### Known false-positive sources
+
+- An IT admin running a one-off keychain audit. Rare in managed fleets; confirm with the user before treating as benign.
+
+### Limitations
+
+- Does not cover Keychain reads via the Security framework (SecItemCopyMatching, etc.) or raw SQLite scrapes of login.keychain-db. Those paths are tracked for a future file-integrity rule.
+- Does not cover adjacent enumerative subcommands (find-internet-password -w, find-generic-password -w) — left out for precision; add them to dumpKeychainArgTokens if a pilot fleet surfaces real abuse.
+
+## privilege_launchd_plist_write
+
+**LaunchDaemon plist drop (/Library/LaunchDaemons write)**  
+Flags a non-platform-binary write to any *.plist directly under /Library/LaunchDaemons.
+
+| | |
+| --- | --- |
+| Rule ID | `privilege_launchd_plist_write` |
+| Severity | `high` |
+| ATT&CK | [`T1543.004`](https://attack.mitre.org/techniques/T1543/004/) |
+| Event types | `open_write` |
+
+### Description
+
+Detects the canonical system-domain persistence drop: writing a plist into `/Library/LaunchDaemons/`. Once that lands, the next `launchctl bootstrap system/<name>` (or a reboot) gives the attacker root-running persistence.
+
+Paired with `persistence_launchagent` — that rule catches user-domain LaunchAgent activation via `launchctl load`, this one catches the system-domain drop step. We catch this at the file-write rather than the activation step because LaunchDaemon activation is often deferred until reboot.
+
+To stay high-precision, writes by Apple-signed platform binaries (installd, system_installd, sysadminctl, package post-flight scripts) are skipped — they're the legitimate path. Non-Apple MDM agents (Munki, JumpCloud, Kandji's daemon) need their team ID allowlisted.
+
+### Configuration
+
+| Env var | Type | Default | Description |
+| --- | --- | --- | --- |
+| `EDR_LAUNCHDAEMON_TEAMID_ALLOWLIST` | `csv-team-ids` | _(unset)_ | Comma-separated Apple Developer Program team IDs (10-character strings, e.g. `8VBZ3948LU`) whose code-signed binaries may write to /Library/LaunchDaemons silently. |
+
+### Known false-positive sources
+
+- Non-Apple MDM agent installations dropping their own LaunchDaemon. Allowlist the agent's signing team ID via EDR_LAUNCHDAEMON_TEAMID_ALLOWLIST.
+- Custom in-house pkg installers signed by your developer team — same allowlist applies.
+
+### Limitations
+
+- Atomic-rename writes (temp file + rename onto the destination) are missed; the extension does not subscribe to NOTIFY_RENAME today. Tracked for Phase 8.
+- Drops via Apple platform binaries (e.g. `sudo cp` where cp is Apple-signed) are skipped here — pair with suspicious_exec for parent-shell visibility.
+
+## sudoers_tamper
+
+**Sudoers tamper (write to /etc/sudoers or /etc/sudoers.d/*)**  
+Flags any non-allowlisted writer that opens /etc/sudoers or /etc/sudoers.d/* in write mode.
+
+| | |
+| --- | --- |
+| Rule ID | `sudoers_tamper` |
+| Severity | `high` |
+| ATT&CK | [`T1548.003`](https://attack.mitre.org/techniques/T1548/003/) |
+| Event types | `open_write` |
+
+### Description
+
+Detects an instant escalation primitive: writing to `/etc/sudoers` or any direct child of `/etc/sudoers.d/`. A successful tamper grants future shell sessions arbitrary command execution as root.
+
+Unlike the persistence rules, this one deliberately does NOT key on Apple-signed platform binaries — the canonical attacker tools for sudoers tampering ARE platform binaries (cp, tee, redirected shells, even `sudo vi /etc/sudoers`), so a platform-binary filter would silence every realistic attack while admitting almost nothing of value. Operators tune via EDR_SUDOERS_WRITER_ALLOWLIST instead.
+
+`visudo` and `sudoedit` use atomic-rename semantics and never open /etc/sudoers in write mode, so the rule does not see them at all.
+
+### Configuration
+
+| Env var | Type | Default | Description |
+| --- | --- | --- | --- |
+| `EDR_SUDOERS_WRITER_ALLOWLIST` | `csv-paths` | _(unset)_ | Comma-separated absolute writer-process paths to silently accept (e.g. `/usr/local/bin/ansible`). |
+
+### Known false-positive sources
+
+- Configuration-management agents (Ansible, Chef, Puppet, MDM-driven scripts) that drop a sudoers fragment under /etc/sudoers.d. Allowlist their absolute writer paths.
+
+### Limitations
+
+- Atomic-rename writes (write a temp file, rename onto /etc/sudoers) are missed: ESF NOTIFY_OPEN doesn't fire on rename, and the extension does not subscribe to NOTIFY_RENAME today. Tracked for Phase 8.
+

--- a/server/admin/admin.go
+++ b/server/admin/admin.go
@@ -42,13 +42,37 @@ type Cataloger interface {
 	Catalog() []RuleMetadata
 }
 
-// RuleMetadata is the minimal per-rule descriptor the Navigator-export
-// endpoint needs. Mirrors detection.RuleMetadata; duplicated here so admin
-// doesn't import detection (which would pull the whole engine into admin's
-// build graph + tests).
+// RuleMetadata is the per-rule descriptor the admin endpoints render.
+// Mirrors detection.RuleMetadata; duplicated here so admin doesn't import
+// detection (which would pull the whole engine into admin's build graph
+// + tests). Doc carries the operator-facing documentation surfaced by
+// GET /api/v1/admin/rules and the markdown generator.
 type RuleMetadata struct {
 	ID         string
 	Techniques []string
+	Doc        RuleDoc
+}
+
+// RuleDoc mirrors detection.Documentation. Same duplication rationale as
+// RuleMetadata above. Field tags match what the UI consumes from
+// GET /api/v1/admin/rules.
+type RuleDoc struct {
+	Title          string       `json:"title"`
+	Summary        string       `json:"summary"`
+	Description    string       `json:"description"`
+	Severity       string       `json:"severity"`
+	EventTypes     []string     `json:"event_types"`
+	FalsePositives []string     `json:"false_positives,omitempty"`
+	Limitations    []string     `json:"limitations,omitempty"`
+	Config         []RuleConfig `json:"config,omitempty"`
+}
+
+// RuleConfig mirrors detection.ConfigKnob.
+type RuleConfig struct {
+	EnvVar      string `json:"env_var"`
+	Type        string `json:"type"`
+	Default     string `json:"default"`
+	Description string `json:"description"`
 }
 
 // Handler serves the admin endpoints. Construct it with the enrollment + policy stores,
@@ -95,6 +119,37 @@ func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/v1/admin/policy", h.handleGetPolicy)
 	mux.HandleFunc("PUT /api/v1/admin/policy", h.handlePutPolicy)
 	mux.HandleFunc("GET /api/v1/admin/attack-coverage", h.handleATTACKCoverage)
+	mux.HandleFunc("GET /api/v1/admin/rules", h.handleListRules)
+}
+
+// handleListRules returns the structured per-rule documentation for every
+// registered detection rule. Used by the UI's rule-detail page and by the
+// `tools/gen-rule-docs` markdown generator. Order is the engine's
+// registration order so the response is deterministic and snapshot-testable.
+//
+// Stable wire shape — the UI's RuleDetail.tsx and the generator both depend
+// on this; field renames here ripple through both. Add new fields, don't
+// remove or rename existing ones.
+func (h *Handler) handleListRules(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	type ruleResponse struct {
+		ID         string   `json:"id"`
+		Techniques []string `json:"techniques"`
+		Doc        RuleDoc  `json:"doc"`
+	}
+	var catalog []RuleMetadata
+	if h.catalog != nil {
+		catalog = h.catalog.Catalog()
+	}
+	// Field-for-field conversion: ruleResponse exists only to attach the
+	// JSON tags the wire shape needs without putting json tags on the
+	// public RuleMetadata struct (which is also used by the navigator
+	// endpoint and would be over-serialised there).
+	out := make([]ruleResponse, 0, len(catalog))
+	for _, rm := range catalog {
+		out = append(out, ruleResponse(rm))
+	}
+	writeJSON(ctx, h.logger, w, http.StatusOK, map[string]any{"rules": out})
 }
 
 func (h *Handler) handleList(w http.ResponseWriter, r *http.Request) {

--- a/server/admin/rules_endpoint_test.go
+++ b/server/admin/rules_endpoint_test.go
@@ -1,0 +1,132 @@
+package admin
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fleetdm/edr/server/enrollment"
+	"github.com/fleetdm/edr/server/policy"
+	"github.com/fleetdm/edr/server/store"
+)
+
+// TestHandleListRules_RoundTrips proves the new /api/v1/admin/rules endpoint
+// renders every field the UI's RuleDetail.tsx consumes, in registration order,
+// without dropping or transforming the documentation payload. Order is
+// load-bearing: the UI uses the catalog order to render the rules index.
+func TestHandleListRules_RoundTrips(t *testing.T) {
+	s := store.OpenTestStore(t)
+	es := enrollment.NewStore(s.DB())
+	ps := policy.New(s.DB())
+
+	catalog := &stubCatalog{rules: []RuleMetadata{
+		{
+			ID:         "alpha",
+			Techniques: []string{"T1059"},
+			Doc: RuleDoc{
+				Title:          "Alpha rule",
+				Summary:        "alpha summary",
+				Description:    "alpha long description",
+				Severity:       "high",
+				EventTypes:     []string{"exec"},
+				FalsePositives: []string{"some FP"},
+				Limitations:    []string{"some limit"},
+				Config: []RuleConfig{
+					{EnvVar: "EDR_ALPHA", Type: "csv-paths", Default: "", Description: "tune alpha"},
+				},
+			},
+		},
+		{
+			ID:         "beta",
+			Techniques: []string{"T1574.006"},
+			Doc: RuleDoc{
+				Title:      "Beta rule",
+				Summary:    "beta summary",
+				Severity:   "critical",
+				EventTypes: []string{"exec", "open_write"},
+			},
+		},
+	}}
+	h := New(es, ps, s, catalog, slog.Default())
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+"/api/v1/admin/rules", nil)
+	require.NoError(t, err)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, "application/json", resp.Header.Get("Content-Type"))
+
+	var body struct {
+		Rules []struct {
+			ID         string   `json:"id"`
+			Techniques []string `json:"techniques"`
+			Doc        struct {
+				Title          string   `json:"title"`
+				Summary        string   `json:"summary"`
+				Description    string   `json:"description"`
+				Severity       string   `json:"severity"`
+				EventTypes     []string `json:"event_types"`
+				FalsePositives []string `json:"false_positives"`
+				Limitations    []string `json:"limitations"`
+				Config         []struct {
+					EnvVar      string `json:"env_var"`
+					Type        string `json:"type"`
+					Default     string `json:"default"`
+					Description string `json:"description"`
+				} `json:"config"`
+			} `json:"doc"`
+		} `json:"rules"`
+	}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+
+	require.Len(t, body.Rules, 2)
+	assert.Equal(t, "alpha", body.Rules[0].ID, "registration order must round-trip")
+	assert.Equal(t, "Alpha rule", body.Rules[0].Doc.Title)
+	assert.Equal(t, "high", body.Rules[0].Doc.Severity)
+	require.Len(t, body.Rules[0].Doc.Config, 1)
+	assert.Equal(t, "EDR_ALPHA", body.Rules[0].Doc.Config[0].EnvVar)
+	assert.Equal(t, "csv-paths", body.Rules[0].Doc.Config[0].Type)
+
+	assert.Equal(t, "beta", body.Rules[1].ID)
+	assert.Equal(t, "critical", body.Rules[1].Doc.Severity)
+	assert.Empty(t, body.Rules[1].Doc.FalsePositives,
+		"empty omitempty fields must round-trip as null/empty, not as a fabricated entry")
+}
+
+// TestHandleListRules_NilCatalog covers the same defensive path attack-coverage
+// uses: a server constructed without a Cataloger should return an empty list,
+// not 500.
+func TestHandleListRules_NilCatalog(t *testing.T) {
+	s := store.OpenTestStore(t)
+	es := enrollment.NewStore(s.DB())
+	ps := policy.New(s.DB())
+
+	h := New(es, ps, s, nil, slog.Default())
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+"/api/v1/admin/rules", nil)
+	require.NoError(t, err)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var body struct {
+		Rules []any `json:"rules"`
+	}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	assert.Empty(t, body.Rules)
+}

--- a/server/cmd/fleet-edr-server/main.go
+++ b/server/cmd/fleet-edr-server/main.go
@@ -107,14 +107,14 @@ func run() error {
 	ingestHandler := ingest.New(s, logger, build)
 	builder := graph.NewBuilder(s, logger)
 	det := detection.NewEngine(s, logger)
-	det.Register(&rules.SuspiciousExec{AllowedNonShellParents: cfg.SuspiciousExecParentAllowlist})
-	det.Register(&rules.PersistenceLaunchAgent{AllowedPlists: cfg.LaunchAgentAllowlist})
-	det.Register(&rules.DyldInsert{})
-	det.Register(&rules.ShellFromOffice{})
-	det.Register(&rules.OsascriptNetworkExec{})
-	det.Register(&rules.CredentialKeychainDump{})
-	det.Register(&rules.PrivilegeLaunchdPlistWrite{AllowedTeamIDs: cfg.LaunchDaemonTeamIDAllowlist})
-	det.Register(&rules.SudoersTamper{AllowedWriters: cfg.SudoersWriterAllowlist})
+	for _, r := range rules.All(rules.RegistryOptions{
+		SuspiciousExecParentAllowlist: cfg.SuspiciousExecParentAllowlist,
+		LaunchAgentAllowlist:          cfg.LaunchAgentAllowlist,
+		LaunchDaemonTeamIDAllowlist:   cfg.LaunchDaemonTeamIDAllowlist,
+		SudoersWriterAllowlist:        cfg.SudoersWriterAllowlist,
+	}) {
+		det.Register(r)
+	}
 	proc := processor.New(s, builder, det, logger, cfg.ProcessInterval, cfg.ProcessBatch)
 
 	q := graph.NewQuery(s)

--- a/server/cmd/fleet-edr-server/main.go
+++ b/server/cmd/fleet-edr-server/main.go
@@ -336,6 +336,7 @@ func registerSessionRoutes(mux *http.ServeMux, d muxDeps) {
 		"GET /api/v1/admin/enrollments", "POST /api/v1/admin/enrollments/{host_id}/revoke",
 		"GET /api/v1/admin/policy", "PUT /api/v1/admin/policy",
 		"GET /api/v1/admin/attack-coverage",
+		"GET /api/v1/admin/rules",
 		"GET /api/v1/session",
 	} {
 		mux.Handle(p, sessionProtected)
@@ -388,7 +389,29 @@ func (a engineCatalogAdapter) Catalog() []admin.RuleMetadata {
 	src := a.engine.Catalog()
 	out := make([]admin.RuleMetadata, len(src))
 	for i, r := range src {
-		out[i] = admin.RuleMetadata{ID: r.ID, Techniques: r.Techniques}
+		cfg := make([]admin.RuleConfig, len(r.Doc.Config))
+		for j, c := range r.Doc.Config {
+			cfg[j] = admin.RuleConfig{
+				EnvVar:      c.EnvVar,
+				Type:        c.Type,
+				Default:     c.Default,
+				Description: c.Description,
+			}
+		}
+		out[i] = admin.RuleMetadata{
+			ID:         r.ID,
+			Techniques: r.Techniques,
+			Doc: admin.RuleDoc{
+				Title:          r.Doc.Title,
+				Summary:        r.Doc.Summary,
+				Description:    r.Doc.Description,
+				Severity:       r.Doc.Severity,
+				EventTypes:     r.Doc.EventTypes,
+				FalsePositives: r.Doc.FalsePositives,
+				Limitations:    r.Doc.Limitations,
+				Config:         cfg,
+			},
+		}
 	}
 	return out
 }

--- a/server/detection/engine.go
+++ b/server/detection/engine.go
@@ -40,12 +40,13 @@ func (e *Engine) Register(r Rule) {
 }
 
 // RuleMetadata describes a registered rule for callers outside the engine
-// (e.g. the Navigator-export handler in server/admin). Kept intentionally
-// minimal — ID + Techniques — because any more structure pulls detection
-// concerns into the admin surface.
+// (e.g. the Navigator-export handler in server/admin). Carries the structured
+// Documentation so the admin /rules endpoint and the markdown generator both
+// see the same data without each having to reach back into the rule slice.
 type RuleMetadata struct {
 	ID         string
 	Techniques []string
+	Doc        Documentation
 }
 
 // Catalog returns the metadata for every registered rule. Order matches
@@ -53,7 +54,11 @@ type RuleMetadata struct {
 func (e *Engine) Catalog() []RuleMetadata {
 	out := make([]RuleMetadata, 0, len(e.rules))
 	for _, r := range e.rules {
-		out = append(out, RuleMetadata{ID: r.ID(), Techniques: r.Techniques()})
+		out = append(out, RuleMetadata{
+			ID:         r.ID(),
+			Techniques: r.Techniques(),
+			Doc:        r.Doc(),
+		})
 	}
 	return out
 }

--- a/server/detection/engine_test.go
+++ b/server/detection/engine_test.go
@@ -21,6 +21,9 @@ type stubRule struct {
 
 func (r *stubRule) ID() string           { return r.id }
 func (r *stubRule) Techniques() []string { return nil }
+func (r *stubRule) Doc() Documentation {
+	return Documentation{Title: r.id, Severity: SeverityHigh}
+}
 func (r *stubRule) Evaluate(_ context.Context, _ []store.Event, _ *store.Store) ([]Finding, error) {
 	return r.findings, r.err
 }
@@ -37,6 +40,9 @@ func (r *recordingRule) ID() string { return r.id }
 // Techniques returns an empty slice (not nil) to match the Rule interface
 // contract; the production rules all do the same.
 func (r *recordingRule) Techniques() []string { return []string{} }
+func (r *recordingRule) Doc() Documentation {
+	return Documentation{Title: r.id, Severity: SeverityHigh}
+}
 func (r *recordingRule) Evaluate(_ context.Context, events []store.Event, _ *store.Store) ([]Finding, error) {
 	r.seen = append(r.seen, events...)
 	return nil, nil

--- a/server/detection/rule.go
+++ b/server/detection/rule.go
@@ -42,5 +42,61 @@ type Rule interface {
 	// (e.g. []string{"T1059.002", "T1105"}). Used for Navigator export + UI
 	// badging. Return an empty slice, not nil, for "no mapping".
 	Techniques() []string
+	// Doc returns the operator-facing documentation for the rule. Surfaces
+	// in /docs/detection-rules.md and the UI's per-rule detail page; the
+	// generator at tools/gen-rule-docs reads it directly. Required (not
+	// optional) so a new rule cannot ship without a description and a
+	// severity attestation — the compile error is the gate.
+	Doc() Documentation
 	Evaluate(ctx context.Context, events []store.Event, s *store.Store) ([]Finding, error)
+}
+
+// Documentation is the structured per-rule descriptor consumed by the markdown
+// generator, the /api/v1/admin/rules endpoint, and the UI's rule detail page.
+// Single source of truth — the markdown file in docs/ is generated from this,
+// so behaviour and documentation cannot drift.
+type Documentation struct {
+	// Title is the operator-facing display name (e.g. "Keychain dump"). Distinct
+	// from ID(): IDs are stable identifiers used in alert rows; titles are the
+	// human-readable label rendered in tables and headings.
+	Title string `json:"title"`
+	// Summary is a one-sentence elevator pitch shown in lists / tooltips.
+	Summary string `json:"summary"`
+	// Description is the long-form behavioural spec (a few short paragraphs).
+	// Plain text; renderers may turn newlines into paragraphs.
+	Description string `json:"description"`
+	// Severity is the SeverityLow|Medium|High|Critical constant the rule emits.
+	// Stored separately from per-finding severities because a single rule
+	// always emits a single class today; if that ever changes we'll add a
+	// `Severities []string` field.
+	Severity string `json:"severity"`
+	// EventTypes lists the agent event types the rule consumes (e.g. "exec",
+	// "open_write"). Helps operators decide which ESF/NE subscriptions a
+	// minimal deployment must keep enabled.
+	EventTypes []string `json:"event_types"`
+	// FalsePositives names well-known legitimate sources that can trip the
+	// rule. Each entry is one short sentence — UI renders as a bullet list.
+	FalsePositives []string `json:"false_positives,omitempty"`
+	// Limitations names known coverage gaps so an operator knows what the
+	// rule does NOT catch (atomic renames, env-inherited DYLD vars, etc.).
+	Limitations []string `json:"limitations,omitempty"`
+	// Config enumerates the env var knobs the rule honours. Empty for rules
+	// without configuration (e.g. credential_keychain_dump).
+	Config []ConfigKnob `json:"config,omitempty"`
+}
+
+// ConfigKnob describes one operator-facing tuning env var.
+type ConfigKnob struct {
+	// EnvVar is the canonical name (e.g. EDR_LAUNCHAGENT_ALLOWLIST).
+	EnvVar string `json:"env_var"`
+	// Type tells the operator what value-shape the env var expects:
+	// "csv-paths" for absolute filesystem paths, "csv-team-ids" for Apple
+	// team-ID strings, "duration" for time.ParseDuration values, etc.
+	Type string `json:"type"`
+	// Default is the literal value the rule uses when the env var is unset.
+	// Empty string means "feature off until configured".
+	Default string `json:"default"`
+	// Description is one-sentence guidance for what the operator is buying
+	// by setting this knob.
+	Description string `json:"description"`
 }

--- a/server/detection/rules/credential_keychain_dump.go
+++ b/server/detection/rules/credential_keychain_dump.go
@@ -37,6 +37,30 @@ func (r *CredentialKeychainDump) ID() string { return "credential_keychain_dump"
 // and MITRE explicitly cites it on the technique page.
 func (r *CredentialKeychainDump) Techniques() []string { return []string{"T1555.001"} }
 
+// Doc surfaces the operator-facing description in /api/v1/admin/rules and
+// the generated docs/detection-rules.md.
+func (r *CredentialKeychainDump) Doc() detection.Documentation {
+	return detection.Documentation{
+		Title:   "Keychain dump (security dump-keychain)",
+		Summary: "Flags exec of /usr/bin/security dump-keychain — the canonical macOS Keychain export command.",
+		Description: "Fires when a process invokes `/usr/bin/security` with the `dump-keychain` subcommand. " +
+			"That command exports Keychain entries (saved passwords, private keys) and is the macOS-native equivalent " +
+			"of credential-dumping tooling on Windows. Admin scripts virtually never invoke it; offensive playbooks do.\n\n" +
+			"Match shape is exact-path + exact-subcommand to keep the rule high-precision. A shell wrapper " +
+			"(`sh -c \"security dump-keychain\"`) still surfaces because ESF emits a NOTIFY_EXEC for each execve(), " +
+			"so the security binary always shows up as its own exec event regardless of parent.",
+		Severity:   detection.SeverityHigh,
+		EventTypes: []string{"exec"},
+		FalsePositives: []string{
+			"An IT admin running a one-off keychain audit. Rare in managed fleets; confirm with the user before treating as benign.",
+		},
+		Limitations: []string{
+			"Does not cover Keychain reads via the Security framework (SecItemCopyMatching, etc.) or raw SQLite scrapes of login.keychain-db. Those paths are tracked for a future file-integrity rule.",
+			"Does not cover adjacent enumerative subcommands (find-internet-password -w, find-generic-password -w) — left out for precision; add them to dumpKeychainArgTokens if a pilot fleet surfaces real abuse.",
+		},
+	}
+}
+
 // securityBinaryPaths is the set of `security` binary locations we'll
 // flag. Canonical-only by design: /usr/bin/security is where the tool
 // lives on every shipping macOS SKU; SIP guarantees it. If a pilot

--- a/server/detection/rules/dyld_insert.go
+++ b/server/detection/rules/dyld_insert.go
@@ -31,6 +31,32 @@ func (r *DyldInsert) ID() string { return "dyld_insert" }
 // broader "Hijack Execution Flow" parent.
 func (r *DyldInsert) Techniques() []string { return []string{"T1574.006"} }
 
+// Doc surfaces the operator-facing description in /api/v1/admin/rules and
+// the generated docs/detection-rules.md.
+func (r *DyldInsert) Doc() detection.Documentation {
+	return detection.Documentation{
+		Title:   "DYLD injection on exec",
+		Summary: "Flags exec where DYLD_INSERT_LIBRARIES or DYLD_LIBRARY_PATH is set in argv (shell-style or via env(1)).",
+		Description: "Detects the classic macOS code-injection primitive: launching a process with " +
+			"`DYLD_INSERT_LIBRARIES=…` or `DYLD_LIBRARY_PATH=…` set so dyld loads attacker-supplied dylibs into " +
+			"the new process before main(). The rule fires on the leading argv slot only — `VAR=value /path/to/bin` " +
+			"shell form, or `env VAR=value /path/to/bin` — so substring noise (curl POST data, echo, etc.) does " +
+			"not false-positive.\n\n" +
+			"The matching dylib path is redacted in alert text (a sensitive payload location) but kept in the raw " +
+			"event payload for responders.",
+		Severity:   detection.SeverityHigh,
+		EventTypes: []string{"exec"},
+		FalsePositives: []string{
+			"Local development of code that itself uses DYLD_INSERT_LIBRARIES (rare; usually scoped to non-managed dev hosts).",
+			"Apple-signed binaries are immune to DYLD_INSERT_LIBRARIES under SIP, but the rule still fires on the launch — investigate why an admin script is setting these vars at all.",
+		},
+		Limitations: []string{
+			"Inherited environment variables (set by a parent shell, not on the exec line) are invisible: ESF does not yet hand the agent the full env map. Tracked in Phase 4.",
+			"DYLD_FRAMEWORK_PATH and DYLD_FALLBACK_* are intentionally NOT matched — higher-FP, lower-signal. Extend dyldPrefixes if a pilot surfaces real abuse.",
+		},
+	}
+}
+
 // Dangerous env prefixes. DYLD_FRAMEWORK_PATH + DYLD_FALLBACK_* also exist but are
 // higher-false-positive (SIP disables them for Apple binaries anyway); we leave them
 // out for MVP and revisit if pilot customers surface real evasion.

--- a/server/detection/rules/osascript_network_exec.go
+++ b/server/detection/rules/osascript_network_exec.go
@@ -45,6 +45,33 @@ func (r *OsascriptNetworkExec) Techniques() []string {
 	return []string{"T1059.002", "T1105"}
 }
 
+// Doc surfaces the operator-facing description in /api/v1/admin/rules and
+// the generated docs/detection-rules.md.
+func (r *OsascriptNetworkExec) Doc() detection.Documentation {
+	return detection.Documentation{
+		Title:   "AppleScript dropper (osascript → curl/wget → temp exec)",
+		Summary: "Critical-severity catch on the canonical macOS commodity-dropper chain: osascript fetches a stage-2 over the network and runs it from /tmp.",
+		Description: "Fires on the LAST link of the chain — an exec from a temp directory whose process tree has " +
+			"both an osascript ancestor and a curl/wget sibling within the osascript's 30-second descendant window. " +
+			"This shape is the recognisable signature of macOS commodity malware staged via AppleScript.\n\n" +
+			"Reverse-direction triggering is deliberate: by the time the temp-exec event lands, the entire ancestor " +
+			"chain has already been ingested and materialised by earlier batches, so the rule is race-immune. " +
+			"Forward triggering (fire on the osascript exec, look for descendants) misses chains that complete " +
+			"across an agent flush boundary.\n\n" +
+			"The rule requires both halves of the chain to be present, so download-only or temp-exec-only flows do " +
+			"not fire here — those overlap with suspicious_exec.",
+		Severity:   detection.SeverityCritical,
+		EventTypes: []string{"exec"},
+		FalsePositives: []string{
+			"Internal automation that bootstraps tooling by scripting `curl … | sh` from osascript — extremely rare in managed fleets.",
+		},
+		Limitations: []string{
+			"30-second descendant window is hard-coded; longer-running chains are missed by design.",
+			"Does not cover Python URL fetches or AppleScript built-in URL access — only flags the explicit curl/wget shape.",
+		},
+	}
+}
+
 var osascriptPaths = map[string]bool{
 	"/usr/bin/osascript": true,
 }

--- a/server/detection/rules/persistence_launchagent.go
+++ b/server/detection/rules/persistence_launchagent.go
@@ -31,6 +31,39 @@ func (r *PersistenceLaunchAgent) ID() string { return "persistence_launchagent" 
 // sub-technique's scope.
 func (r *PersistenceLaunchAgent) Techniques() []string { return []string{"T1543.001"} }
 
+// Doc surfaces the operator-facing description in /api/v1/admin/rules and
+// the generated docs/detection-rules.md.
+func (r *PersistenceLaunchAgent) Doc() detection.Documentation {
+	return detection.Documentation{
+		Title:   "LaunchAgent persistence (launchctl load/bootstrap)",
+		Summary: "Flags `launchctl load` / `launchctl bootstrap` of a plist under ~/Library/LaunchAgents or /Library/LaunchAgents.",
+		Description: "Detects the canonical user-domain persistence step on macOS: an attacker drops a plist into a " +
+			"LaunchAgents directory and then activates it via `launchctl load <plist>` or `launchctl bootstrap " +
+			"gui/<uid> <plist>`. We catch the activation rather than the file write so the alert ties to the moment " +
+			"the persistence becomes effective.\n\n" +
+			"Argument parsing handles launch-domain specifiers (`gui/501`) preceding the plist path and tolerates " +
+			"flag-like args between `load` and the plist (`-w`, `-F`, etc.).",
+		Severity:   detection.SeverityHigh,
+		EventTypes: []string{"exec"},
+		FalsePositives: []string{
+			"MDM- or installer-provisioned LaunchAgents (Munki, Kandji, JumpCloud) loaded at deploy time. Allowlist their plist paths via EDR_LAUNCHAGENT_ALLOWLIST.",
+			"Developer tools that register helper agents (Docker Desktop, Backblaze, etc.) on first launch.",
+		},
+		Limitations: []string{
+			"Does not cover `launchctl bootout` or `launchctl unload` — those undo persistence rather than create it.",
+			"Does not catch direct plist writes that never get activated; pair with the privilege_launchd_plist_write rule for system-domain coverage.",
+		},
+		Config: []detection.ConfigKnob{
+			{
+				EnvVar:      "EDR_LAUNCHAGENT_ALLOWLIST",
+				Type:        "csv-paths",
+				Default:     "",
+				Description: "Comma-separated absolute plist paths the rule should silently accept. Use exact paths; case-sensitive.",
+			},
+		},
+	}
+}
+
 // launchctlPaths covers the common macOS launchctl binary locations.
 var launchctlPaths = map[string]bool{
 	"/bin/launchctl":     true,

--- a/server/detection/rules/privilege_launchd_plist_write.go
+++ b/server/detection/rules/privilege_launchd_plist_write.go
@@ -50,6 +50,42 @@ func (r *PrivilegeLaunchdPlistWrite) ID() string { return "privilege_launchd_pli
 // (Boot or Logon Autostart Execution → Launch Daemon).
 func (r *PrivilegeLaunchdPlistWrite) Techniques() []string { return []string{"T1543.004"} }
 
+// Doc surfaces the operator-facing description in /api/v1/admin/rules and
+// the generated docs/detection-rules.md.
+func (r *PrivilegeLaunchdPlistWrite) Doc() detection.Documentation {
+	return detection.Documentation{
+		Title:   "LaunchDaemon plist drop (/Library/LaunchDaemons write)",
+		Summary: "Flags a non-platform-binary write to any *.plist directly under /Library/LaunchDaemons.",
+		Description: "Detects the canonical system-domain persistence drop: writing a plist into " +
+			"`/Library/LaunchDaemons/`. Once that lands, the next `launchctl bootstrap system/<name>` (or a reboot) " +
+			"gives the attacker root-running persistence.\n\n" +
+			"Paired with `persistence_launchagent` — that rule catches user-domain LaunchAgent activation via " +
+			"`launchctl load`, this one catches the system-domain drop step. We catch this at the file-write rather " +
+			"than the activation step because LaunchDaemon activation is often deferred until reboot.\n\n" +
+			"To stay high-precision, writes by Apple-signed platform binaries (installd, system_installd, " +
+			"sysadminctl, package post-flight scripts) are skipped — they're the legitimate path. Non-Apple MDM " +
+			"agents (Munki, JumpCloud, Kandji's daemon) need their team ID allowlisted.",
+		Severity:   detection.SeverityHigh,
+		EventTypes: []string{"open_write"},
+		FalsePositives: []string{
+			"Non-Apple MDM agent installations dropping their own LaunchDaemon. Allowlist the agent's signing team ID via EDR_LAUNCHDAEMON_TEAMID_ALLOWLIST.",
+			"Custom in-house pkg installers signed by your developer team — same allowlist applies.",
+		},
+		Limitations: []string{
+			"Atomic-rename writes (temp file + rename onto the destination) are missed; the extension does not subscribe to NOTIFY_RENAME today. Tracked for Phase 8.",
+			"Drops via Apple platform binaries (e.g. `sudo cp` where cp is Apple-signed) are skipped here — pair with suspicious_exec for parent-shell visibility.",
+		},
+		Config: []detection.ConfigKnob{
+			{
+				EnvVar:      "EDR_LAUNCHDAEMON_TEAMID_ALLOWLIST",
+				Type:        "csv-team-ids",
+				Default:     "",
+				Description: "Comma-separated Apple Developer Program team IDs (10-character strings, e.g. `8VBZ3948LU`) whose code-signed binaries may write to /Library/LaunchDaemons silently.",
+			},
+		},
+	}
+}
+
 // launchDaemonPath matches a plist directly under /Library/LaunchDaemons.
 // The trailing `[^/]+` excludes nested paths (e.g.
 // /Library/LaunchDaemons/foo/bar.plist isn't a real LaunchDaemon location)

--- a/server/detection/rules/privilege_launchd_plist_write.go
+++ b/server/detection/rules/privilege_launchd_plist_write.go
@@ -66,7 +66,7 @@ func (r *PrivilegeLaunchdPlistWrite) Doc() detection.Documentation {
 			"sysadminctl, package post-flight scripts) are skipped — they're the legitimate path. Non-Apple MDM " +
 			"agents (Munki, JumpCloud, Kandji's daemon) need their team ID allowlisted.",
 		Severity:   detection.SeverityHigh,
-		EventTypes: []string{"open_write"},
+		EventTypes: []string{"open"},
 		FalsePositives: []string{
 			"Non-Apple MDM agent installations dropping their own LaunchDaemon. Allowlist the agent's signing team ID via EDR_LAUNCHDAEMON_TEAMID_ALLOWLIST.",
 			"Custom in-house pkg installers signed by your developer team — same allowlist applies.",

--- a/server/detection/rules/registry.go
+++ b/server/detection/rules/registry.go
@@ -1,0 +1,41 @@
+package rules
+
+import "github.com/fleetdm/edr/server/detection"
+
+// RegistryOptions carries the config knobs that production-side rule
+// instances need at construction time. Test code that doesn't care about
+// allowlists can pass the zero value to All; the rules then run with empty
+// allowlists, which is the documented "no operator tuning yet" mode.
+//
+// Fields here mirror the relevant ones on server/config.Config; pulling
+// just the rule-shaped subset keeps this package free of a dependency on
+// the full server config struct (which would create an import cycle the
+// moment server/config grows a rules import for any reason).
+type RegistryOptions struct {
+	SuspiciousExecParentAllowlist map[string]struct{}
+	LaunchAgentAllowlist          map[string]struct{}
+	LaunchDaemonTeamIDAllowlist   map[string]struct{}
+	SudoersWriterAllowlist        map[string]struct{}
+}
+
+// All returns every detection rule the server registers with the engine,
+// in the canonical registration order. Single source of truth for the
+// docs generator (tools/gen-rule-docs), the all_rules_integration_test
+// harness, and the production server's main.go — keeping them in sync
+// prevents the docs/runtime drift CodeRabbit flagged on PR #58.
+//
+// Pass the zero value of RegistryOptions for non-production callers
+// (docs generator, tests). Production main.go threads the operator-
+// configured allowlists through.
+func All(opts RegistryOptions) []detection.Rule {
+	return []detection.Rule{
+		&SuspiciousExec{AllowedNonShellParents: opts.SuspiciousExecParentAllowlist},
+		&PersistenceLaunchAgent{AllowedPlists: opts.LaunchAgentAllowlist},
+		&DyldInsert{},
+		&ShellFromOffice{},
+		&OsascriptNetworkExec{},
+		&CredentialKeychainDump{},
+		&PrivilegeLaunchdPlistWrite{AllowedTeamIDs: opts.LaunchDaemonTeamIDAllowlist},
+		&SudoersTamper{AllowedWriters: opts.SudoersWriterAllowlist},
+	}
+}

--- a/server/detection/rules/registry_test.go
+++ b/server/detection/rules/registry_test.go
@@ -1,0 +1,93 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fleetdm/edr/server/detection"
+)
+
+// TestAll_RegisterEveryShippedRule pins down the registration order + size of
+// the registry, so a new rule cannot land without explicitly being added here.
+// The slice this returns is the single source of truth used by the production
+// server's main.go and the docs generator (tools/gen-rule-docs); a silent
+// drift between the two would mean operators see a different surface than
+// the ATT&CK coverage promises.
+func TestAll_RegisterEveryShippedRule(t *testing.T) {
+	got := All(RegistryOptions{})
+	wantIDs := []string{
+		"suspicious_exec",
+		"persistence_launchagent",
+		"dyld_insert",
+		"shell_from_office",
+		"osascript_network_exec",
+		"credential_keychain_dump",
+		"privilege_launchd_plist_write",
+		"sudoers_tamper",
+	}
+	require.Len(t, got, len(wantIDs))
+	for i, want := range wantIDs {
+		assert.Equal(t, want, got[i].ID(), "rule at index %d", i)
+	}
+}
+
+// TestAll_DocStructIsPopulated walks every shipped rule's Doc() and locks in
+// the operator-facing invariants. Drives coverage of each rule's Doc() body
+// from the rules package itself so SonarCloud's Go coverage profile attributes
+// the lines correctly (cross-package coverage isn't aggregated under the
+// project's current `-coverprofile` setup). Same checks as the gate in
+// tools/gen-rule-docs, repeated here so a future tool can be deleted without
+// losing the contract.
+func TestAll_DocStructIsPopulated(t *testing.T) {
+	allowedSeverities := map[string]struct{}{
+		detection.SeverityLow:      {},
+		detection.SeverityMedium:   {},
+		detection.SeverityHigh:     {},
+		detection.SeverityCritical: {},
+	}
+	for _, r := range All(RegistryOptions{}) {
+		t.Run(r.ID(), func(t *testing.T) {
+			d := r.Doc()
+			assert.NotEmpty(t, d.Title, "Title must be set for %s", r.ID())
+			assert.NotEmpty(t, d.Summary, "Summary must be set for %s", r.ID())
+			assert.NotEmpty(t, d.Description, "Description must be set for %s", r.ID())
+			assert.Contains(t, allowedSeverities, d.Severity,
+				"%s declares severity %q; expected one of the SeverityLow|Medium|High|Critical constants",
+				r.ID(), d.Severity)
+			assert.NotEmpty(t, d.EventTypes, "EventTypes must list at least one type for %s", r.ID())
+			for _, c := range d.Config {
+				assert.NotEmpty(t, c.EnvVar, "%s config knob missing EnvVar", r.ID())
+				assert.NotEmpty(t, c.Type, "%s config knob %s missing Type", r.ID(), c.EnvVar)
+				assert.NotEmpty(t, c.Description, "%s config knob %s missing Description", r.ID(), c.EnvVar)
+			}
+		})
+	}
+}
+
+// TestAll_AppliesAllowlists confirms that the four configurable rules actually
+// thread the supplied allowlists through onto the rule struct. Without this,
+// a refactor of `All` could silently drop the maps and every fleet would
+// suddenly see the alerts they thought they'd silenced. We only check the
+// rules that have a configurable allowlist; the others have empty Doc().Config.
+func TestAll_AppliesAllowlists(t *testing.T) {
+	susParents := map[string]struct{}{"/usr/libexec/sshd-session": {}}
+	plists := map[string]struct{}{"/Library/LaunchAgents/com.example.foo.plist": {}}
+	teamIDs := map[string]struct{}{"8VBZ3948LU": {}}
+	writers := map[string]struct{}{"/usr/local/bin/ansible": {}}
+	rs := All(RegistryOptions{
+		SuspiciousExecParentAllowlist: susParents,
+		LaunchAgentAllowlist:          plists,
+		LaunchDaemonTeamIDAllowlist:   teamIDs,
+		SudoersWriterAllowlist:        writers,
+	})
+	byID := map[string]detection.Rule{}
+	for _, r := range rs {
+		byID[r.ID()] = r
+	}
+	assert.Equal(t, susParents, byID["suspicious_exec"].(*SuspiciousExec).AllowedNonShellParents)
+	assert.Equal(t, plists, byID["persistence_launchagent"].(*PersistenceLaunchAgent).AllowedPlists)
+	assert.Equal(t, teamIDs, byID["privilege_launchd_plist_write"].(*PrivilegeLaunchdPlistWrite).AllowedTeamIDs)
+	assert.Equal(t, writers, byID["sudoers_tamper"].(*SudoersTamper).AllowedWriters)
+}

--- a/server/detection/rules/shell_from_office.go
+++ b/server/detection/rules/shell_from_office.go
@@ -26,6 +26,30 @@ func (r *ShellFromOffice) ID() string { return "shell_from_office" }
 // post-phish execution step.
 func (r *ShellFromOffice) Techniques() []string { return []string{"T1566.001", "T1059.004"} }
 
+// Doc surfaces the operator-facing description in /api/v1/admin/rules and
+// the generated docs/detection-rules.md.
+func (r *ShellFromOffice) Doc() detection.Documentation {
+	return detection.Documentation{
+		Title:   "Shell spawned by Microsoft Office",
+		Summary: "Flags any /bin/sh, /bin/bash, /bin/zsh (etc.) whose parent is Word, Excel, PowerPoint, or Outlook.",
+		Description: "Detects the textbook post-phishing execution step: a macro-laden Office document opens, the macro " +
+			"shells out, and the second stage takes off from there. The match is on the parent process being one of " +
+			"the four standard macOS Office binaries (full path, not substring) and the child being a known shell.\n\n" +
+			"Office apps almost never need to shell out in normal use; when they do, it's an admin-side automation " +
+			"that's worth surfacing anyway.",
+		Severity:   detection.SeverityHigh,
+		EventTypes: []string{"exec"},
+		FalsePositives: []string{
+			"Office's internal `Get Started` first-run flow has historically shelled out to fetch help content. Confirm by inspecting argv on the alert.",
+			"Admin-driven user-environment scripts that template Office settings via shell.",
+		},
+		Limitations: []string{
+			"Does not catch non-shell payloads (osascript, python, ruby) launched directly from Office. Pair with osascript_network_exec for the AppleScript variant.",
+			"Office binary path matching is exact: `/Applications/Microsoft Word.app/Contents/MacOS/Microsoft Word`. Apps installed elsewhere (e.g. on an external volume) are missed by design.",
+		},
+	}
+}
+
 // officeBinaries is the set of macOS Office executable paths that, as a parent, make a
 // shell exec suspicious. We match full paths, not substrings, so a user-named file
 // like `/tmp/Microsoft Word` cannot accidentally silence or spoof a finding.

--- a/server/detection/rules/sudoers_tamper.go
+++ b/server/detection/rules/sudoers_tamper.go
@@ -51,6 +51,40 @@ func (r *SudoersTamper) ID() string { return "sudoers_tamper" }
 // (Abuse Elevation Control Mechanism: Sudo and Sudo Caching).
 func (r *SudoersTamper) Techniques() []string { return []string{"T1548.003"} }
 
+// Doc surfaces the operator-facing description in /api/v1/admin/rules and
+// the generated docs/detection-rules.md.
+func (r *SudoersTamper) Doc() detection.Documentation {
+	return detection.Documentation{
+		Title:   "Sudoers tamper (write to /etc/sudoers or /etc/sudoers.d/*)",
+		Summary: "Flags any non-allowlisted writer that opens /etc/sudoers or /etc/sudoers.d/* in write mode.",
+		Description: "Detects an instant escalation primitive: writing to `/etc/sudoers` or any direct child of " +
+			"`/etc/sudoers.d/`. A successful tamper grants future shell sessions arbitrary command execution as " +
+			"root.\n\n" +
+			"Unlike the persistence rules, this one deliberately does NOT key on Apple-signed platform binaries — " +
+			"the canonical attacker tools for sudoers tampering ARE platform binaries (cp, tee, redirected shells, " +
+			"even `sudo vi /etc/sudoers`), so a platform-binary filter would silence every realistic attack while " +
+			"admitting almost nothing of value. Operators tune via EDR_SUDOERS_WRITER_ALLOWLIST instead.\n\n" +
+			"`visudo` and `sudoedit` use atomic-rename semantics and never open /etc/sudoers in write mode, so the " +
+			"rule does not see them at all.",
+		Severity:   detection.SeverityHigh,
+		EventTypes: []string{"open_write"},
+		FalsePositives: []string{
+			"Configuration-management agents (Ansible, Chef, Puppet, MDM-driven scripts) that drop a sudoers fragment under /etc/sudoers.d. Allowlist their absolute writer paths.",
+		},
+		Limitations: []string{
+			"Atomic-rename writes (write a temp file, rename onto /etc/sudoers) are missed: ESF NOTIFY_OPEN doesn't fire on rename, and the extension does not subscribe to NOTIFY_RENAME today. Tracked for Phase 8.",
+		},
+		Config: []detection.ConfigKnob{
+			{
+				EnvVar:      "EDR_SUDOERS_WRITER_ALLOWLIST",
+				Type:        "csv-paths",
+				Default:     "",
+				Description: "Comma-separated absolute writer-process paths to silently accept (e.g. `/usr/local/bin/ansible`).",
+			},
+		},
+	}
+}
+
 // sudoersPath matches /etc/sudoers itself and any direct child of
 // /etc/sudoers.d/. ESF reports both forms (/etc/...  and
 // /private/etc/... since /etc is a symlink); we accept either. Nested

--- a/server/detection/rules/sudoers_tamper.go
+++ b/server/detection/rules/sudoers_tamper.go
@@ -67,7 +67,7 @@ func (r *SudoersTamper) Doc() detection.Documentation {
 			"`visudo` and `sudoedit` use atomic-rename semantics and never open /etc/sudoers in write mode, so the " +
 			"rule does not see them at all.",
 		Severity:   detection.SeverityHigh,
-		EventTypes: []string{"open_write"},
+		EventTypes: []string{"open"},
 		FalsePositives: []string{
 			"Configuration-management agents (Ansible, Chef, Puppet, MDM-driven scripts) that drop a sudoers fragment under /etc/sudoers.d. Allowlist their absolute writer paths.",
 		},

--- a/server/detection/rules/suspicious_exec.go
+++ b/server/detection/rules/suspicious_exec.go
@@ -85,7 +85,7 @@ func (r *SuspiciousExec) Techniques() []string {
 func (r *SuspiciousExec) Doc() detection.Documentation {
 	return detection.Documentation{
 		Title:   "Suspicious exec chain (non-shell → shell → temp/network)",
-		Summary: "Flags a non-shell process that spawns a shell which, within 30 seconds, exec's from /tmp or makes an outbound network connection.",
+		Summary: "Flags a non-shell process that spawns a shell which, within 30 seconds, execs from /tmp or makes an outbound network connection.",
 		Description: "Detects two related chain shapes that share a single attribution chain:\n\n" +
 			"1. non-shell parent → shell child → temp-directory exec (e.g. `/tmp/payload`)\n" +
 			"2. non-shell parent → shell child → outbound network_connect\n\n" +

--- a/server/detection/rules/suspicious_exec.go
+++ b/server/detection/rules/suspicious_exec.go
@@ -80,6 +80,41 @@ func (r *SuspiciousExec) Techniques() []string {
 	return []string{"T1059", "T1105"}
 }
 
+// Doc surfaces the operator-facing description in /api/v1/admin/rules and
+// the generated docs/detection-rules.md.
+func (r *SuspiciousExec) Doc() detection.Documentation {
+	return detection.Documentation{
+		Title:   "Suspicious exec chain (non-shell → shell → temp/network)",
+		Summary: "Flags a non-shell process that spawns a shell which, within 30 seconds, exec's from /tmp or makes an outbound network connection.",
+		Description: "Detects two related chain shapes that share a single attribution chain:\n\n" +
+			"1. non-shell parent → shell child → temp-directory exec (e.g. `/tmp/payload`)\n" +
+			"2. non-shell parent → shell child → outbound network_connect\n\n" +
+			"The rule fires on the LAST link of the chain (the temp-exec or the network_connect) rather than the " +
+			"shell's exec. That makes it race-immune across the agent's flush boundaries — a chain that completes " +
+			"in ~150ms but straddles a 1-second flush boundary still resolves cleanly because the entire ancestor " +
+			"chain has already been ingested by the time the trigger event lands.\n\n" +
+			"30 seconds is the temporal cap between the shell exec and the trigger event.",
+		Severity:   detection.SeverityHigh,
+		EventTypes: []string{"exec", "network_connect"},
+		FalsePositives: []string{
+			"Interactive SSH where an admin runs a script from /tmp and/or curls a tool. Use EDR_SUSPICIOUS_EXEC_PARENT_ALLOWLIST to silence sshd-session if that's a routine workflow on the host class.",
+			"Some Apple-signed installer-postflight scripts shell out to /tmp/ during package install.",
+		},
+		Limitations: []string{
+			"30s window is hard-coded; long-tail post-shell activity is missed by design.",
+			"Allowlisting a parent silences BOTH arms of the rule for that parent — the trade-off is documented on AllowedNonShellParents.",
+		},
+		Config: []detection.ConfigKnob{
+			{
+				EnvVar:      "EDR_SUSPICIOUS_EXEC_PARENT_ALLOWLIST",
+				Type:        "csv-paths",
+				Default:     "",
+				Description: "Comma-separated absolute parent-process paths the rule should treat as benign roots (both temp-exec and network arms). Canonical use: `/usr/libexec/sshd-session` on hosts where interactive SSH is normal.",
+			},
+		},
+	}
+}
+
 const (
 	// suspiciousExecWindowNs bounds the temporal distance between the shell
 	// exec and the trigger event (temp-exec or network_connect). Real chains

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -38,11 +38,18 @@ sonar.javascript.lcov.reportPaths=ui/coverage/lcov.info
 #   - server/bootstrap/**               process-init wiring, called once.
 #   - server/httpserver/**              net/http server lifecycle wiring.
 #   - test/**                           load-test harness, not production code.
+#   - tools/**                          Build-time CLIs (tools/gen-rule-docs
+#                                       generates docs/detection-rules.md).
+#                                       Tested at the package level, but the
+#                                       project's coverage profiles upload only
+#                                       ./agent/... and ./server/... so the
+#                                       generator's lines never reach Sonar
+#                                       even though they ARE exercised.
 #   - ui/src/**                         React UI; Vitest is wired but no UI
 #                                       tests exist yet. Re-enable coverage
 #                                       by removing this glob the moment the
 #                                       first ui/src/**/*.test.{ts,tsx} lands.
-sonar.coverage.exclusions=**/cmd/**/main.go,server/detection/testharness/**,schema/**,extension/edr/**,agent/receiver/**,agent/logging/**,server/bootstrap/**,server/httpserver/**,test/**,ui/src/**
+sonar.coverage.exclusions=**/cmd/**/main.go,server/detection/testharness/**,schema/**,extension/edr/**,agent/receiver/**,agent/logging/**,server/bootstrap/**,server/httpserver/**,test/**,tools/**,ui/src/**
 
 # Exclude static catalog / lookup tables from copy-paste duplication detection.
 # Files where every entry repeats the same property names (id/name/tactic per

--- a/tools/gen-rule-docs/main.go
+++ b/tools/gen-rule-docs/main.go
@@ -1,0 +1,186 @@
+// gen-rule-docs renders docs/detection-rules.md from the structured Documentation
+// each rule exposes via detection.Rule.Doc(). Run via:
+//
+//	go run ./tools/gen-rule-docs
+//
+// Output is intentionally deterministic (registration order, no timestamps) so
+// the generated file is diff-friendly and CI-checkable. A future CI step can
+// re-run the generator and fail on drift.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/fleetdm/edr/server/detection"
+	"github.com/fleetdm/edr/server/detection/rules"
+)
+
+// allRegisteredRules mirrors the registration list in
+// server/cmd/fleet-edr-server/main.go. We intentionally instantiate with EMPTY
+// allowlists here — the documentation is not a function of a particular
+// deployment's tuning, it documents the shape of the knob.
+//
+// Order matches main.go so the generated markdown lists rules in the same
+// order they fire at runtime.
+func allRegisteredRules() []detection.Rule {
+	return []detection.Rule{
+		&rules.SuspiciousExec{},
+		&rules.PersistenceLaunchAgent{},
+		&rules.DyldInsert{},
+		&rules.ShellFromOffice{},
+		&rules.OsascriptNetworkExec{},
+		&rules.CredentialKeychainDump{},
+		&rules.PrivilegeLaunchdPlistWrite{},
+		&rules.SudoersTamper{},
+	}
+}
+
+func main() {
+	out := flag.String("out", "docs/detection-rules.md", "destination markdown file")
+	flag.Parse()
+
+	if err := generate(*out); err != nil {
+		log.Fatalf("%v", err)
+	}
+}
+
+// generate is split out so the deferred close runs even on a render error.
+// `main` calling log.Fatalf with a defer in scope leaves the file unclosed
+// (gocritic exitAfterDefer); pulling the body up here makes the close happen
+// before main exits.
+func generate(out string) error {
+	f, err := os.Create(out) //nolint:gosec // path is operator-controlled
+	if err != nil {
+		return fmt.Errorf("create %s: %w", out, err)
+	}
+	defer func() { _ = f.Close() }()
+	if err := render(f, allRegisteredRules()); err != nil {
+		return fmt.Errorf("render: %w", err)
+	}
+	return nil
+}
+
+// render writes the full document body to w. Split out from main so a test can
+// drive it against a buffer and snapshot-compare against the committed file.
+func render(w io.Writer, rs []detection.Rule) error {
+	var b strings.Builder
+	b.WriteString("# Detection rules\n\n")
+	b.WriteString("This page is generated from `tools/gen-rule-docs` by walking the\n")
+	b.WriteString("`detection.Rule.Doc()` method on every rule registered in\n")
+	b.WriteString("`server/cmd/fleet-edr-server/main.go`. To refresh after changing a\n")
+	b.WriteString("rule's documentation, run:\n\n")
+	b.WriteString("```sh\n")
+	b.WriteString("go run ./tools/gen-rule-docs\n")
+	b.WriteString("```\n\n")
+	b.WriteString("Hand-edits to this file get overwritten on the next regeneration.\n\n")
+
+	// Index — operators jumping in from a CVE or alert title want a fast\n
+	// lookup. ID is what shows up in alert rows; title is the friendly name.
+	b.WriteString("## Index\n\n")
+	b.WriteString("| Rule ID | Title | Severity | ATT&CK |\n")
+	b.WriteString("| --- | --- | --- | --- |\n")
+	for _, r := range rs {
+		d := r.Doc()
+		fmt.Fprintf(&b, "| [`%s`](#%s) | %s | %s | %s |\n",
+			r.ID(), anchor(r.ID()), d.Title, d.Severity, strings.Join(r.Techniques(), ", "))
+	}
+	b.WriteString("\n")
+
+	for _, r := range rs {
+		writeRule(&b, r)
+	}
+
+	_, err := io.WriteString(w, b.String())
+	return err
+}
+
+func writeRule(b *strings.Builder, r detection.Rule) {
+	d := r.Doc()
+	id := r.ID()
+
+	fmt.Fprintf(b, "## %s\n\n", id)
+	fmt.Fprintf(b, "**%s**  \n", d.Title)
+	if d.Summary != "" {
+		fmt.Fprintf(b, "%s\n\n", d.Summary)
+	}
+
+	b.WriteString("| | |\n| --- | --- |\n")
+	fmt.Fprintf(b, "| Rule ID | `%s` |\n", id)
+	fmt.Fprintf(b, "| Severity | `%s` |\n", d.Severity)
+	if techs := r.Techniques(); len(techs) > 0 {
+		fmt.Fprintf(b, "| ATT&CK | %s |\n", joinTechniqueLinks(techs))
+	}
+	if len(d.EventTypes) > 0 {
+		fmt.Fprintf(b, "| Event types | %s |\n", joinCode(d.EventTypes))
+	}
+	b.WriteString("\n")
+
+	if d.Description != "" {
+		b.WriteString("### Description\n\n")
+		b.WriteString(d.Description)
+		b.WriteString("\n\n")
+	}
+
+	if len(d.Config) > 0 {
+		b.WriteString("### Configuration\n\n")
+		b.WriteString("| Env var | Type | Default | Description |\n")
+		b.WriteString("| --- | --- | --- | --- |\n")
+		for _, c := range d.Config {
+			def := c.Default
+			if def == "" {
+				def = "_(unset)_"
+			} else {
+				def = "`" + def + "`"
+			}
+			fmt.Fprintf(b, "| `%s` | `%s` | %s | %s |\n", c.EnvVar, c.Type, def, c.Description)
+		}
+		b.WriteString("\n")
+	}
+
+	if len(d.FalsePositives) > 0 {
+		b.WriteString("### Known false-positive sources\n\n")
+		for _, fp := range d.FalsePositives {
+			fmt.Fprintf(b, "- %s\n", fp)
+		}
+		b.WriteString("\n")
+	}
+
+	if len(d.Limitations) > 0 {
+		b.WriteString("### Limitations\n\n")
+		for _, l := range d.Limitations {
+			fmt.Fprintf(b, "- %s\n", l)
+		}
+		b.WriteString("\n")
+	}
+}
+
+// anchor produces the GitHub-flavoured-markdown anchor slug for a heading.
+// Our heading is the bare rule ID, which is already lowercase + underscored
+// + ASCII, so the slug is the ID verbatim. Centralised so a future ID with
+// less-friendly characters has one place to fix.
+func anchor(id string) string { return id }
+
+// joinTechniqueLinks renders each technique ID as a link to its MITRE page.
+// Sub-techniques (e.g. T1574.006) need the dot translated to a slash in the
+// URL path: attack.mitre.org/techniques/T1574/006/.
+func joinTechniqueLinks(techs []string) string {
+	out := make([]string, len(techs))
+	for i, t := range techs {
+		urlPath := strings.ReplaceAll(t, ".", "/")
+		out[i] = fmt.Sprintf("[`%s`](https://attack.mitre.org/techniques/%s/)", t, urlPath)
+	}
+	return strings.Join(out, ", ")
+}
+
+func joinCode(xs []string) string {
+	out := make([]string, len(xs))
+	for i, x := range xs {
+		out[i] = "`" + x + "`"
+	}
+	return strings.Join(out, ", ")
+}

--- a/tools/gen-rule-docs/main.go
+++ b/tools/gen-rule-docs/main.go
@@ -20,24 +20,14 @@ import (
 	"github.com/fleetdm/edr/server/detection/rules"
 )
 
-// allRegisteredRules mirrors the registration list in
-// server/cmd/fleet-edr-server/main.go. We intentionally instantiate with EMPTY
-// allowlists here — the documentation is not a function of a particular
-// deployment's tuning, it documents the shape of the knob.
-//
-// Order matches main.go so the generated markdown lists rules in the same
-// order they fire at runtime.
+// allRegisteredRules delegates to rules.All so the docs generator and the
+// production server's main.go are guaranteed to walk the same set of rules
+// in the same order. Documentation is not a function of a particular
+// deployment's tuning, so we pass the zero value of RegistryOptions —
+// allowlists default to empty, which is what the rule structs treat as
+// "no operator tuning yet."
 func allRegisteredRules() []detection.Rule {
-	return []detection.Rule{
-		&rules.SuspiciousExec{},
-		&rules.PersistenceLaunchAgent{},
-		&rules.DyldInsert{},
-		&rules.ShellFromOffice{},
-		&rules.OsascriptNetworkExec{},
-		&rules.CredentialKeychainDump{},
-		&rules.PrivilegeLaunchdPlistWrite{},
-		&rules.SudoersTamper{},
-	}
+	return rules.All(rules.RegistryOptions{})
 }
 
 func main() {
@@ -79,7 +69,7 @@ func render(w io.Writer, rs []detection.Rule) error {
 	b.WriteString("```\n\n")
 	b.WriteString("Hand-edits to this file get overwritten on the next regeneration.\n\n")
 
-	// Index — operators jumping in from a CVE or alert title want a fast\n
+	// Index — operators jumping in from a CVE or alert title want a fast
 	// lookup. ID is what shows up in alert rows; title is the friendly name.
 	b.WriteString("## Index\n\n")
 	b.WriteString("| Rule ID | Title | Severity | ATT&CK |\n")
@@ -87,7 +77,9 @@ func render(w io.Writer, rs []detection.Rule) error {
 	for _, r := range rs {
 		d := r.Doc()
 		fmt.Fprintf(&b, "| [`%s`](#%s) | %s | %s | %s |\n",
-			r.ID(), anchor(r.ID()), d.Title, d.Severity, strings.Join(r.Techniques(), ", "))
+			r.ID(), anchor(r.ID()),
+			mdCell(d.Title), mdCell(d.Severity),
+			mdCell(strings.Join(r.Techniques(), ", ")))
 	}
 	b.WriteString("\n")
 
@@ -99,64 +91,89 @@ func render(w io.Writer, rs []detection.Rule) error {
 	return err
 }
 
+// writeRule is intentionally a thin sequencer over per-section helpers so
+// each helper stays trivially testable and the whole function stays under
+// the project cognitive-complexity cap (Sonar go:S3776). Adding a new
+// section means adding a new helper + a single Fprintf-style call here.
 func writeRule(b *strings.Builder, r detection.Rule) {
 	d := r.Doc()
 	id := r.ID()
+	writeRuleHeading(b, id, d)
+	writeRuleMeta(b, id, d, r.Techniques())
+	writeRuleDescription(b, d)
+	writeRuleConfig(b, d.Config)
+	writeRuleBulletSection(b, "Known false-positive sources", d.FalsePositives)
+	writeRuleBulletSection(b, "Limitations", d.Limitations)
+}
 
+func writeRuleHeading(b *strings.Builder, id string, d detection.Documentation) {
 	fmt.Fprintf(b, "## %s\n\n", id)
 	fmt.Fprintf(b, "**%s**  \n", d.Title)
 	if d.Summary != "" {
 		fmt.Fprintf(b, "%s\n\n", d.Summary)
 	}
+}
 
+func writeRuleMeta(b *strings.Builder, id string, d detection.Documentation, techs []string) {
 	b.WriteString("| | |\n| --- | --- |\n")
 	fmt.Fprintf(b, "| Rule ID | `%s` |\n", id)
 	fmt.Fprintf(b, "| Severity | `%s` |\n", d.Severity)
-	if techs := r.Techniques(); len(techs) > 0 {
+	if len(techs) > 0 {
 		fmt.Fprintf(b, "| ATT&CK | %s |\n", joinTechniqueLinks(techs))
 	}
 	if len(d.EventTypes) > 0 {
 		fmt.Fprintf(b, "| Event types | %s |\n", joinCode(d.EventTypes))
 	}
 	b.WriteString("\n")
+}
 
-	if d.Description != "" {
-		b.WriteString("### Description\n\n")
-		b.WriteString(d.Description)
-		b.WriteString("\n\n")
+func writeRuleDescription(b *strings.Builder, d detection.Documentation) {
+	if d.Description == "" {
+		return
 	}
+	b.WriteString("### Description\n\n")
+	b.WriteString(d.Description)
+	b.WriteString("\n\n")
+}
 
-	if len(d.Config) > 0 {
-		b.WriteString("### Configuration\n\n")
-		b.WriteString("| Env var | Type | Default | Description |\n")
-		b.WriteString("| --- | --- | --- | --- |\n")
-		for _, c := range d.Config {
-			def := c.Default
-			if def == "" {
-				def = "_(unset)_"
-			} else {
-				def = "`" + def + "`"
-			}
-			fmt.Fprintf(b, "| `%s` | `%s` | %s | %s |\n", c.EnvVar, c.Type, def, c.Description)
+func writeRuleConfig(b *strings.Builder, knobs []detection.ConfigKnob) {
+	if len(knobs) == 0 {
+		return
+	}
+	b.WriteString("### Configuration\n\n")
+	b.WriteString("| Env var | Type | Default | Description |\n")
+	b.WriteString("| --- | --- | --- | --- |\n")
+	for _, c := range knobs {
+		def := "_(unset)_"
+		if c.Default != "" {
+			def = "`" + c.Default + "`"
 		}
-		b.WriteString("\n")
+		fmt.Fprintf(b, "| `%s` | `%s` | %s | %s |\n", c.EnvVar, c.Type, def, mdCell(c.Description))
 	}
+	b.WriteString("\n")
+}
 
-	if len(d.FalsePositives) > 0 {
-		b.WriteString("### Known false-positive sources\n\n")
-		for _, fp := range d.FalsePositives {
-			fmt.Fprintf(b, "- %s\n", fp)
-		}
-		b.WriteString("\n")
+func writeRuleBulletSection(b *strings.Builder, heading string, items []string) {
+	if len(items) == 0 {
+		return
 	}
+	fmt.Fprintf(b, "### %s\n\n", heading)
+	for _, it := range items {
+		fmt.Fprintf(b, "- %s\n", it)
+	}
+	b.WriteString("\n")
+}
 
-	if len(d.Limitations) > 0 {
-		b.WriteString("### Limitations\n\n")
-		for _, l := range d.Limitations {
-			fmt.Fprintf(b, "- %s\n", l)
-		}
-		b.WriteString("\n")
-	}
+// mdCell escapes a string for safe insertion into a markdown table cell.
+// Pipes have to be backslash-escaped or they end the column; newlines
+// have to become <br> or they break the row. Today's Doc() values are
+// well-behaved, but a future operator who pastes a paragraph containing
+// either character into a Description should not silently corrupt the
+// generated markdown.
+func mdCell(s string) string {
+	s = strings.ReplaceAll(s, "|", `\|`)
+	s = strings.ReplaceAll(s, "\n", "<br>")
+	return s
 }
 
 // anchor produces the GitHub-flavoured-markdown anchor slug for a heading.

--- a/tools/gen-rule-docs/main_test.go
+++ b/tools/gen-rule-docs/main_test.go
@@ -6,13 +6,24 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/fleetdm/edr/server/detection"
 )
 
 // TestEveryRuleHasDocs is the gate that prevents shipping a new detection
 // rule without operator-facing documentation. detection.Rule.Doc() returns
 // a struct, so a rule can technically return the zero value — this test
-// catches that.
+// catches that. Severity is also gated to one of the documented constants
+// so a typo'd value (e.g. "urgent") fails the test instead of silently
+// producing a broken UI severity pill class name and a markdown reference
+// that disagrees with the rest of the codebase.
 func TestEveryRuleHasDocs(t *testing.T) {
+	allowedSeverities := map[string]struct{}{
+		detection.SeverityLow:      {},
+		detection.SeverityMedium:   {},
+		detection.SeverityHigh:     {},
+		detection.SeverityCritical: {},
+	}
 	for _, r := range allRegisteredRules() {
 		t.Run(r.ID(), func(t *testing.T) {
 			d := r.Doc()
@@ -20,6 +31,8 @@ func TestEveryRuleHasDocs(t *testing.T) {
 			assert.NotEmpty(t, d.Summary, "Doc().Summary must be set (one-line tooltip)")
 			assert.NotEmpty(t, d.Description, "Doc().Description must be set (long-form spec)")
 			assert.NotEmpty(t, d.Severity, "Doc().Severity must be set")
+			assert.Contains(t, allowedSeverities, d.Severity,
+				"Doc().Severity must be one of detection.SeverityLow|Medium|High|Critical")
 			assert.NotEmpty(t, d.EventTypes, "Doc().EventTypes must list at least one event type")
 		})
 	}

--- a/tools/gen-rule-docs/main_test.go
+++ b/tools/gen-rule-docs/main_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEveryRuleHasDocs is the gate that prevents shipping a new detection
+// rule without operator-facing documentation. detection.Rule.Doc() returns
+// a struct, so a rule can technically return the zero value — this test
+// catches that.
+func TestEveryRuleHasDocs(t *testing.T) {
+	for _, r := range allRegisteredRules() {
+		t.Run(r.ID(), func(t *testing.T) {
+			d := r.Doc()
+			assert.NotEmpty(t, d.Title, "Doc().Title must be set")
+			assert.NotEmpty(t, d.Summary, "Doc().Summary must be set (one-line tooltip)")
+			assert.NotEmpty(t, d.Description, "Doc().Description must be set (long-form spec)")
+			assert.NotEmpty(t, d.Severity, "Doc().Severity must be set")
+			assert.NotEmpty(t, d.EventTypes, "Doc().EventTypes must list at least one event type")
+		})
+	}
+}
+
+// TestRenderProducesIndexEntryPerRule sanity-checks the markdown structure:
+// the index table at the top of the doc must contain a row for every
+// registered rule. Without this, a missing rule could slip through if the
+// generator's loop somehow short-circuited.
+func TestRenderProducesIndexEntryPerRule(t *testing.T) {
+	rs := allRegisteredRules()
+	var buf bytes.Buffer
+	require.NoError(t, render(&buf, rs))
+	out := buf.String()
+
+	for _, r := range rs {
+		// Index entry: the row link uses a backtick-wrapped code span.
+		assert.Contains(t, out, "[`"+r.ID()+"`]", "rule %q missing from index table", r.ID())
+		// Section heading: "## <id>".
+		assert.Contains(t, out, "## "+r.ID()+"\n", "rule %q missing as a section heading", r.ID())
+	}
+}
+
+// TestRenderTechniqueLinks checks that every technique in the catalog is
+// rendered as a clickable MITRE link, with sub-technique dots translated to
+// slashes (the URL convention attack.mitre.org expects).
+func TestRenderTechniqueLinks(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, render(&buf, allRegisteredRules()))
+	out := buf.String()
+
+	// Sub-technique: T1574.006 must appear as both the visible label
+	// (with the dot) AND inside a URL where the dot is a slash.
+	assert.Contains(t, out, "[`T1574.006`]")
+	assert.Contains(t, out, "https://attack.mitre.org/techniques/T1574/006/")
+	// Top-level technique: no slash translation needed.
+	assert.Contains(t, out, "https://attack.mitre.org/techniques/T1059/")
+}
+
+// TestRenderConfigKnobsListed confirms that rules with config knobs surface
+// their env var, type, and description in the per-rule Configuration table.
+func TestRenderConfigKnobsListed(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, render(&buf, allRegisteredRules()))
+	out := buf.String()
+
+	for _, env := range []string{
+		"EDR_LAUNCHAGENT_ALLOWLIST",
+		"EDR_LAUNCHDAEMON_TEAMID_ALLOWLIST",
+		"EDR_SUDOERS_WRITER_ALLOWLIST",
+		"EDR_SUSPICIOUS_EXEC_PARENT_ALLOWLIST",
+	} {
+		assert.Contains(t, out, "`"+env+"`",
+			"expected config env var %q to appear in generated docs", env)
+	}
+}

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -5,6 +5,7 @@ import { ProcessTreeView } from "./components/ProcessTree";
 import { AlertList } from "./components/AlertList";
 import { PolicyEditor } from "./components/PolicyEditor";
 import { AttackCoverage } from "./components/AttackCoverage";
+import { RuleDetail } from "./components/RuleDetail";
 import { Login } from "./components/Login";
 import { TopNav } from "./components/ui/TopNav";
 import { currentSession, logout, Unauthorized401Error, SessionInfo } from "./api";
@@ -80,6 +81,7 @@ export function App() {
           <Route path="/alerts" element={<AlertList />} />
           <Route path="/policy" element={<PolicyEditor actor={auth.user.email} />} />
           <Route path="/coverage" element={<AttackCoverage />} />
+          <Route path="/rules/:ruleId" element={<RuleDetail />} />
           <Route path="/hosts/:hostId" element={<ProcessTreeView />} />
           <Route path="*" element={<Navigate to="/" replace />} />
         </Routes>

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -260,6 +260,44 @@ export async function fetchAttackNavigatorLayer(): Promise<AttackNavigatorLayer>
   return fetchJSON<AttackNavigatorLayer>("/admin/attack-coverage");
 }
 
+// RuleConfig describes one operator-tuning env var. Wire shape matches
+// admin.RuleConfig in the server.
+export interface RuleConfig {
+  env_var: string;
+  type: string;
+  default: string;
+  description: string;
+}
+
+// RuleDoc is the structured per-rule documentation surfaced by GET
+// /api/v1/admin/rules. Mirrors detection.Documentation on the server, with
+// the JSON tag spellings the wire format uses.
+export interface RuleDoc {
+  title: string;
+  summary: string;
+  description: string;
+  severity: string;
+  event_types: string[];
+  false_positives?: string[];
+  limitations?: string[];
+  config?: RuleConfig[];
+}
+
+export interface RuleDocEntry {
+  id: string;
+  techniques: string[];
+  doc: RuleDoc;
+}
+
+// fetchRuleDocs returns every registered detection rule with its operator-
+// facing documentation. Drives the /ui/rules/<id> sub-page and the rule-name
+// links on /ui/coverage. Order mirrors the server's registration order, so
+// the UI can iterate without resorting.
+export async function fetchRuleDocs(): Promise<RuleDocEntry[]> {
+  const body = await fetchJSON<{ rules: RuleDocEntry[] }>("/admin/rules");
+  return body.rules;
+}
+
 export async function createCommand(hostId: string, commandType: string, payload: Record<string, unknown>): Promise<{ id: number }> {
   return fetchJSON<{ id: number }>("/commands", {
     method: "POST",

--- a/ui/src/components/AttackCoverage.scss
+++ b/ui/src/components/AttackCoverage.scss
@@ -83,4 +83,20 @@
       text-decoration: underline;
     }
   }
+
+  // Rule names in the "Covered by" column link to /rules/<id>. Style
+  // matches the technique-id link colour so the row reads as two parallel
+  // jump-off points (technique → MITRE; rule → in-app docs).
+  &__rule-link {
+    color: $core-fleet-green;
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+
+    code {
+      color: inherit;
+    }
+  }
 }

--- a/ui/src/components/AttackCoverage.tsx
+++ b/ui/src/components/AttackCoverage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
 import { fetchAttackNavigatorLayer, type AttackNavigatorLayer } from "../api";
 import { Table, EmptyState } from "./ui/Table";
 import { PageHeader } from "./ui/PageHeader";
@@ -173,7 +174,13 @@ export function AttackCoverage() {
                           {t.coveringRules.map((r, i) => (
                             <span key={r}>
                               {i > 0 && ", "}
-                              <code>{r}</code>
+                              <Link
+                                className="attack-coverage__rule-link"
+                                to={`/rules/${r}`}
+                                title="Open this detection rule's documentation"
+                              >
+                                <code>{r}</code>
+                              </Link>
                             </span>
                           ))}
                         </td>

--- a/ui/src/components/RuleDetail.scss
+++ b/ui/src/components/RuleDetail.scss
@@ -54,6 +54,12 @@
     line-height: 1.5;
     margin: 0 0 $pad-medium;
     color: $core-fleet-black;
+    // Preserve single newlines inside a paragraph so list-style content
+    // (e.g. "1. ...\n2. ..." in suspicious_exec's description) survives
+    // rendering. Blank-line splitting still happens at the React level
+    // — this rule only protects the in-paragraph linebreaks HTML would
+    // otherwise collapse into a space.
+    white-space: pre-line;
   }
 
   &__muted {
@@ -83,24 +89,34 @@
     background: $ui-fleet-black-10;
     color: $core-fleet-black;
 
+    // Severity colours pair a tinted pill background with a fully-opaque
+    // dark foreground that hits WCAG AA contrast (4.5:1+) against the
+    // composited pill. Earlier iterations layered alpha tints over white,
+    // which Sonar (css:S7924) and a colour-contrast checker both flagged
+    // as <4.5:1 in some browsers.
     &--low {
-      background: rgba(0, 154, 125, 0.15);
-      color: #006858;
+      background: #d0eee7;
+      color: #08443a;
     }
 
     &--medium {
-      background: rgba(255, 200, 0, 0.18);
-      color: #806100;
+      background: #f7e6b3;
+      color: #5a4500;
     }
 
     &--high {
-      background: rgba(255, 92, 0, 0.15);
-      color: #983400;
+      background: #f7d7c2;
+      color: #6b2400;
     }
 
     &--critical {
-      background: rgba(207, 0, 0, 0.18);
-      color: #8a0000;
+      background: #f1c2c2;
+      color: #5d0000;
+    }
+
+    &--unknown {
+      background: $ui-fleet-black-10;
+      color: $core-fleet-black;
     }
   }
 }

--- a/ui/src/components/RuleDetail.scss
+++ b/ui/src/components/RuleDetail.scss
@@ -1,0 +1,106 @@
+@use "../styles/var/colors" as *;
+@use "../styles/var/fonts" as *;
+@use "../styles/var/padding" as *;
+
+.rule-detail {
+  &__id {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 0.95rem;
+    color: $ui-fleet-black-75;
+  }
+
+  &__summary {
+    font-size: 1.05rem;
+    line-height: 1.5;
+    margin: $pad-medium 0 $pad-large;
+    color: $core-fleet-black;
+  }
+
+  // The Severity / ATT&CK / Event-types meta block: small inline table with
+  // labels in the left column and values on the right.
+  &__meta {
+    width: auto;
+    margin-bottom: $pad-large;
+
+    th, td {
+      padding-top: $pad-small;
+      padding-bottom: $pad-small;
+    }
+
+    th[scope="row"] {
+      text-align: left;
+      font-weight: $bold;
+      color: $ui-fleet-black-75;
+      padding-right: $pad-large;
+      width: 1%;
+      white-space: nowrap;
+    }
+  }
+
+  &__config th {
+    text-align: left;
+  }
+
+  &__list {
+    padding-left: $pad-large;
+    line-height: 1.5;
+
+    li {
+      margin-bottom: $pad-xsmall;
+    }
+  }
+
+  &__para {
+    line-height: 1.5;
+    margin: 0 0 $pad-medium;
+    color: $core-fleet-black;
+  }
+
+  &__muted {
+    color: $ui-fleet-black-50;
+  }
+
+  &__back {
+    margin-top: $pad-large;
+
+    a {
+      color: $core-fleet-green;
+      text-decoration: none;
+
+      &:hover { text-decoration: underline; }
+    }
+  }
+
+  // Severity pill — same colour vocabulary as the alerts page so an analyst
+  // moving between alert rows and rule details sees a consistent visual.
+  &__sev {
+    display: inline-block;
+    padding: 2px 10px;
+    border-radius: 999px;
+    font-size: 0.85rem;
+    font-weight: $bold;
+    text-transform: capitalize;
+    background: $ui-fleet-black-10;
+    color: $core-fleet-black;
+
+    &--low {
+      background: rgba(0, 154, 125, 0.15);
+      color: #006858;
+    }
+
+    &--medium {
+      background: rgba(255, 200, 0, 0.18);
+      color: #806100;
+    }
+
+    &--high {
+      background: rgba(255, 92, 0, 0.15);
+      color: #983400;
+    }
+
+    &--critical {
+      background: rgba(207, 0, 0, 0.18);
+      color: #8a0000;
+    }
+  }
+}

--- a/ui/src/components/RuleDetail.tsx
+++ b/ui/src/components/RuleDetail.tsx
@@ -1,0 +1,173 @@
+import { useEffect, useMemo, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+import { fetchRuleDocs, type RuleDocEntry } from "../api";
+import { PageHeader } from "./ui/PageHeader";
+import { Table, EmptyState } from "./ui/Table";
+import "./RuleDetail.scss";
+
+// RuleDetail renders a single detection rule's documentation: behaviour,
+// severity, ATT&CK mapping, configuration knobs, false-positive sources, and
+// limitations. Data comes from /api/v1/admin/rules — the same JSON the
+// markdown generator consumes — so this page can never drift from the
+// generated docs/detection-rules.md.
+//
+// The /ui/coverage page links rule names here; if a future page lists alerts
+// with rule IDs they should link here too. Unknown :ruleId renders an empty
+// state pointing at the index, not a 404, so an old bookmark to a deleted
+// rule still navigates somewhere actionable.
+
+export function RuleDetail() {
+  const { ruleId } = useParams<{ ruleId: string }>();
+  const [entries, setEntries] = useState<RuleDocEntry[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchRuleDocs()
+      .then((rs) => { if (!cancelled) setEntries(rs); })
+      .catch((err: unknown) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : "Failed to load rule docs");
+      });
+    return () => { cancelled = true; };
+  }, []);
+
+  const entry = useMemo(
+    () => entries?.find((e) => e.id === ruleId) ?? null,
+    [entries, ruleId],
+  );
+
+  return (
+    <>
+      <PageHeader
+        title={entry ? entry.doc.title : "Detection rule"}
+        subtitle={entry ? <code className="rule-detail__id">{entry.id}</code> : ruleId}
+      />
+
+      {error && <div className="form-error" role="alert">Error: {error}</div>}
+      {!error && entries === null && <EmptyState>Loading rule documentation...</EmptyState>}
+
+      {!error && entries !== null && !entry && (
+        <EmptyState>
+          Unknown rule <code>{ruleId}</code>. <Link to="/coverage">Back to coverage</Link>.
+        </EmptyState>
+      )}
+
+      {entry && <RuleBody entry={entry} />}
+    </>
+  );
+}
+
+function RuleBody({ entry }: { entry: RuleDocEntry }) {
+  const { doc, techniques } = entry;
+  return (
+    <div className="rule-detail">
+      <p className="rule-detail__summary">{doc.summary}</p>
+
+      <Table className="rule-detail__meta">
+        <tbody>
+          <tr>
+            <th scope="row">Severity</th>
+            <td><SeverityBadge severity={doc.severity} /></td>
+          </tr>
+          <tr>
+            <th scope="row">ATT&amp;CK</th>
+            <td>
+              {techniques.length === 0
+                ? <span className="rule-detail__muted">no mapping</span>
+                : techniques.map((t, i) => (
+                    <span key={t}>
+                      {i > 0 && ", "}
+                      <a
+                        href={`https://attack.mitre.org/techniques/${t.replace(".", "/")}/`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        <code>{t}</code>
+                      </a>
+                    </span>
+                  ))}
+            </td>
+          </tr>
+          <tr>
+            <th scope="row">Event types</th>
+            <td>
+              {doc.event_types.map((t, i) => (
+                <span key={t}>
+                  {i > 0 && ", "}
+                  <code>{t}</code>
+                </span>
+              ))}
+            </td>
+          </tr>
+        </tbody>
+      </Table>
+
+      <h2>Description</h2>
+      {/* Description is plain text from the Go side; we split on blank lines
+          so paragraphs render. Keying on a stable derivation of the entry
+          ID + paragraph index keeps React's reconciler happy without an
+          array-index lint warning, and is fine here because the paragraph
+          list is a deterministic function of the rule. */}
+      {doc.description.split("\n\n").map((para, i) => (
+        <p key={`${entry.id}-p${String(i)}`} className="rule-detail__para">{para}</p>
+      ))}
+
+      {doc.config && doc.config.length > 0 && (
+        <>
+          <h2>Configuration</h2>
+          <Table className="rule-detail__config">
+            <thead>
+              <tr>
+                <th>Env var</th>
+                <th>Type</th>
+                <th>Default</th>
+                <th>Description</th>
+              </tr>
+            </thead>
+            <tbody>
+              {doc.config.map((c) => (
+                <tr key={c.env_var}>
+                  <td><code>{c.env_var}</code></td>
+                  <td><code>{c.type}</code></td>
+                  <td>{c.default === "" ? <span className="rule-detail__muted">(unset)</span> : <code>{c.default}</code>}</td>
+                  <td>{c.description}</td>
+                </tr>
+              ))}
+            </tbody>
+          </Table>
+        </>
+      )}
+
+      {doc.false_positives && doc.false_positives.length > 0 && (
+        <>
+          <h2>Known false-positive sources</h2>
+          <ul className="rule-detail__list">
+            {doc.false_positives.map((fp) => <li key={fp}>{fp}</li>)}
+          </ul>
+        </>
+      )}
+
+      {doc.limitations && doc.limitations.length > 0 && (
+        <>
+          <h2>Limitations</h2>
+          <ul className="rule-detail__list">
+            {doc.limitations.map((l) => <li key={l}>{l}</li>)}
+          </ul>
+        </>
+      )}
+
+      <p className="rule-detail__back">
+        <Link to="/coverage">&larr; Back to ATT&amp;CK coverage</Link>
+      </p>
+    </div>
+  );
+}
+
+// SeverityBadge picks a colour for the severity string. The four levels match
+// the constants in server/detection/rule.go; an unknown level falls back to
+// the neutral pill so a future fifth level renders something rather than
+// crashing.
+function SeverityBadge({ severity }: { severity: string }) {
+  const klass = `rule-detail__sev rule-detail__sev--${severity}`;
+  return <span className={klass}>{severity}</span>;
+}

--- a/ui/src/components/RuleDetail.tsx
+++ b/ui/src/components/RuleDetail.tsx
@@ -7,9 +7,10 @@ import "./RuleDetail.scss";
 
 // RuleDetail renders a single detection rule's documentation: behaviour,
 // severity, ATT&CK mapping, configuration knobs, false-positive sources, and
-// limitations. Data comes from /api/v1/admin/rules — the same JSON the
-// markdown generator consumes — so this page can never drift from the
-// generated docs/detection-rules.md.
+// limitations. This page loads rule docs from /api/v1/admin/rules; the
+// markdown reference at docs/detection-rules.md is generated directly from
+// the same Go-side `detection.Rule.Doc()` definitions, so the two surfaces
+// stay aligned even though they don't share a fetch path.
 //
 // The /ui/coverage page links rule names here; if a future page lists alerts
 // with rule IDs they should link here too. Unknown :ruleId renders an empty
@@ -57,7 +58,7 @@ export function RuleDetail() {
   );
 }
 
-function RuleBody({ entry }: { entry: RuleDocEntry }) {
+function RuleBody({ entry }: Readonly<{ entry: RuleDocEntry }>) {
   const { doc, techniques } = entry;
   return (
     <div className="rule-detail">
@@ -74,8 +75,12 @@ function RuleBody({ entry }: { entry: RuleDocEntry }) {
             <td>
               {techniques.length === 0
                 ? <span className="rule-detail__muted">no mapping</span>
+                // Composite key (value + index) defends against an upstream
+                // API ever returning a duplicate technique ID by accident —
+                // React would otherwise reuse one DOM node for both entries
+                // and confuse its reconciler.
                 : techniques.map((t, i) => (
-                    <span key={t}>
+                    <span key={`${t}-${String(i)}`}>
                       {i > 0 && ", "}
                       <a
                         href={`https://attack.mitre.org/techniques/${t.replace(".", "/")}/`}
@@ -92,7 +97,7 @@ function RuleBody({ entry }: { entry: RuleDocEntry }) {
             <th scope="row">Event types</th>
             <td>
               {doc.event_types.map((t, i) => (
-                <span key={t}>
+                <span key={`${t}-${String(i)}`}>
                   {i > 0 && ", "}
                   <code>{t}</code>
                 </span>
@@ -104,10 +109,10 @@ function RuleBody({ entry }: { entry: RuleDocEntry }) {
 
       <h2>Description</h2>
       {/* Description is plain text from the Go side; we split on blank lines
-          so paragraphs render. Keying on a stable derivation of the entry
-          ID + paragraph index keeps React's reconciler happy without an
-          array-index lint warning, and is fine here because the paragraph
-          list is a deterministic function of the rule. */}
+          so paragraphs render. The .rule-detail__para class applies
+          `white-space: pre-line` so single newlines inside a paragraph
+          (e.g. the numbered list in suspicious_exec's description) survive
+          rather than collapsing the way HTML normally would. */}
       {doc.description.split("\n\n").map((para, i) => (
         <p key={`${entry.id}-p${String(i)}`} className="rule-detail__para">{para}</p>
       ))}
@@ -142,7 +147,7 @@ function RuleBody({ entry }: { entry: RuleDocEntry }) {
         <>
           <h2>Known false-positive sources</h2>
           <ul className="rule-detail__list">
-            {doc.false_positives.map((fp) => <li key={fp}>{fp}</li>)}
+            {doc.false_positives.map((fp, i) => <li key={`${fp}-${String(i)}`}>{fp}</li>)}
           </ul>
         </>
       )}
@@ -151,7 +156,7 @@ function RuleBody({ entry }: { entry: RuleDocEntry }) {
         <>
           <h2>Limitations</h2>
           <ul className="rule-detail__list">
-            {doc.limitations.map((l) => <li key={l}>{l}</li>)}
+            {doc.limitations.map((l, i) => <li key={`${l}-${String(i)}`}>{l}</li>)}
           </ul>
         </>
       )}
@@ -163,11 +168,22 @@ function RuleBody({ entry }: { entry: RuleDocEntry }) {
   );
 }
 
-// SeverityBadge picks a colour for the severity string. The four levels match
-// the constants in server/detection/rule.go; an unknown level falls back to
-// the neutral pill so a future fifth level renders something rather than
-// crashing.
-function SeverityBadge({ severity }: { severity: string }) {
-  const klass = `rule-detail__sev rule-detail__sev--${severity}`;
+// KNOWN_SEVERITIES gates which class-name modifier we generate so unexpected
+// upstream values cannot inject extra/empty CSS classes (Sonar
+// typescript:S6749 / S7924). Anything outside this allowlist falls back to
+// the unstyled neutral pill.
+const KNOWN_SEVERITIES = ["low", "medium", "high", "critical"] as const;
+type KnownSeverity = typeof KNOWN_SEVERITIES[number];
+function isKnownSeverity(s: string): s is KnownSeverity {
+  return (KNOWN_SEVERITIES as readonly string[]).includes(s);
+}
+
+// SeverityBadge picks a colour for the severity string. The four levels
+// match the constants in server/detection/rule.go; an unknown level falls
+// back to the neutral pill rather than producing a `rule-detail__sev--`
+// class with whitespace or arbitrary content.
+function SeverityBadge({ severity }: Readonly<{ severity: string }>) {
+  const variant = isKnownSeverity(severity) ? severity : "unknown";
+  const klass = `rule-detail__sev rule-detail__sev--${variant}`;
   return <span className={klass}>{severity}</span>;
 }


### PR DESCRIPTION
The detection rules previously had no user-facing documentation outside the source-file headers, which the demo, pilot security review, and the existing TODO in docs/best-practices.md all need. Add structured documentation as part of the rule contract so the markdown reference and the UI rule-detail page render from one source and cannot drift.

- detection.Rule grows a Doc() method that returns a typed Documentation struct (title, summary, description, severity, event_types, false_positives, limitations, config knobs). Each of the eight registered rules implements it. Compile-time gate: a new rule cannot ship without a description.
- detection.RuleMetadata + admin.RuleMetadata carry the Doc through to the admin layer. New endpoint GET /api/v1/admin/rules returns the catalogue as JSON, registered alongside /admin/attack-coverage and gated by the same session+CSRF stack.
- tools/gen-rule-docs walks the catalogue and writes docs/detection-rules.md with an index table, per-rule sections, ATT&CK technique links, configuration table, FP + limitation lists. Output is byte-stable. Wired to `task docs:rules`.
- UI: new /ui/rules/:ruleId route renders the same data via RuleDetail.tsx. AttackCoverage.tsx wraps rule names in the "Covered by" column with <Link> to the detail page. README links the markdown reference from the operator-docs section.

Tests: full integration test that every registered rule has non-empty Doc().Title/Summary/Description/Severity/EventTypes (the gate on new rules). Generator output sanity-checked: every ID appears in the index table and as a section heading; sub-technique URLs use slash, not dot; config env vars surface in the per-rule table. Admin endpoint round-trip + nil-catalog tests cover the new handler. Manually QA'd in Chrome: coverage page links resolve, persistence_launchagent renders all sections, osascript_network_exec renders Critical-severity badge and the no-config branch correctly skips the Configuration section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive rule documentation system with new admin API endpoint exposing all detection rules, their metadata (severity, ATT&CK mappings, configuration options, false positives, limitations), and new web UI for browsing individual rule details.

* **Documentation**
  * Generated detection rules documentation with rule descriptions, matched event types, and operator guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->