### PR TITLE
UI polish: wider policy inputs, alert→rule-doc link, drop claude/ refs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@
 # The macos-pkg job is gated on the `release-signing` environment so the
 # Developer ID certs + notarytool credentials only decrypt when this workflow
 # runs against an allowed tag. Branch protection on the environment must list
-# `v*` as the only allowed ref (see claude/mvp/phase-5-apple-signing-setup.md).
+# `v*` as the only allowed ref.
 
 name: release
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -292,8 +292,8 @@ tasks:
     desc: |
       Build a signed + notarized .pkg locally. Requires Developer ID
       Application + Installer certs installed in the login keychain and
-      the APPLE_* env vars set (see claude/mvp/phase-5-apple-signing-setup.md).
-      For routine releases, push a v* tag instead and let CI do this.
+      the APPLE_* env vars set. For routine releases, push a v* tag
+      instead and let CI do this.
     vars:
       TAG: '{{.TAG}}'
     # Separate preconditions per env var so each missing one reports itself.

--- a/docs/adr/0002-macos-apple-silicon-mvp-only.md
+++ b/docs/adr/0002-macos-apple-silicon-mvp-only.md
@@ -78,5 +78,4 @@ direction.
 
 - `docs/best-practices.md` section 2 (Cross-platform reach) captures the
   partial-adoption state.
-- `claude/mvp/plan.md` -- approved MVP plan (gitignored, local).
 - Apple [deprecation of kernel extensions](https://developer.apple.com/support/kernel-extensions/).

--- a/docs/adr/0003-standalone-product-not-fleet-integrated.md
+++ b/docs/adr/0003-standalone-product-not-fleet-integrated.md
@@ -112,4 +112,3 @@ customers who don't run Fleet.
 ## References
 
 - Jamf Protect + Jamf Pro as the two-independent-products reference model.
-- MVP plan at `claude/mvp/plan.md` (gitignored, local) with the deployment contract spec.

--- a/scripts/qa/README.md
+++ b/scripts/qa/README.md
@@ -1,7 +1,6 @@
 # Phase-7 dogfood QA scripts
 
-Four scripts plus this README make up the Phase-7 dogfood QA harness
-(plan reference: `claude/mvp/phase-7-pilot-hardening.md` Track E).
+Four scripts plus this README make up the Phase-7 dogfood QA harness.
 Each script is self-contained and runnable from this workstation; the
 work happens via `ssh` to the dev VM.
 
@@ -74,18 +73,14 @@ across the round-trip).
 
 ## Filing the QA report
 
-After running the suite, capture the results in
-`claude/mvp/phase-7-qa-YYYY-MM-DD.md` following the Phase 5 template.
-The report should record:
+After running the suite, capture the results so the Phase-7
+acceptance deliverable has a paper trail. The report should record:
 
 - Per-milestone PASS / FAIL with one-line evidence.
 - Any deviations (e.g. E3 `--short` because the operator was iterating).
 - Anything observed that wasn't in the plan: stale alerts, log
   warnings, UI glitches.
 - Open issues to file before pilot ship-go.
-
-The report is the gating Phase-7 acceptance deliverable
-(`claude/mvp/phase-7-pilot-hardening.md` E5).
 
 ## Known gaps the scripts surface
 

--- a/scripts/qa/attack-runbook.sh
+++ b/scripts/qa/attack-runbook.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Phase-7 dogfood attack runbook (issue: claude/mvp/phase-7-pilot-hardening.md E1).
+# Phase-7 dogfood attack runbook (Track E1).
 #
 # What this is
 # ============

--- a/server/detection/rules/shell_from_office.go
+++ b/server/detection/rules/shell_from_office.go
@@ -102,7 +102,7 @@ func (r *ShellFromOffice) evalEvent(ctx context.Context, evt store.Event, s *sto
 	// Parent not yet materialised, or not an Office binary. The processor marks the
 	// whole batch processed after Evaluate returns, so a re-feed does not happen
 	// automatically — missing-parent cases are accepted for Phase 2; a deferred retry
-	// queue is Phase 4 scope (see claude/mvp/plan.md).
+	// queue is Phase 4 scope.
 	if parent == nil || !officeBinaries[parent.Path] {
 		return nil, nil
 	}

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -254,8 +254,7 @@ export async function updatePolicy(
 // describes which techniques the registered detection rules cover. Returned
 // JSON is dropped directly into https://mitre-attack.github.io/attack-navigator/
 // to render as a heatmap. Call site is the "ATT&CK coverage" button in the
-// alerts page; the response is also useful for procurement questionnaires
-// (B4 in claude/mvp/phase-7-pilot-hardening.md).
+// alerts page; the response is also useful for procurement questionnaires.
 export async function fetchAttackNavigatorLayer(): Promise<AttackNavigatorLayer> {
   return fetchJSON<AttackNavigatorLayer>("/admin/attack-coverage");
 }

--- a/ui/src/components/AlertList.tsx
+++ b/ui/src/components/AlertList.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { listAlerts, updateAlertStatus } from "../api";
 import type { Alert } from "../types";
 import { Table, EmptyState } from "./ui/Table";
@@ -124,6 +124,21 @@ export function AlertList() {
                   </Badge>
                 </td>
                 <td>
+                  {/* Title links to the rule's documentation page so an
+                      analyst seeing an unfamiliar finding can read what the
+                      rule does, why it's almost always malicious, and what
+                      the false-positive sources are without leaving the
+                      app. The host process-tree pivot moved to the Host
+                      column below. */}
+                  <Link
+                    className="link-button"
+                    to={`/rules/${encodeURIComponent(a.rule_id)}`}
+                    title={`Open documentation for the ${a.rule_id} rule`}
+                  >
+                    {a.title}
+                  </Link>
+                </td>
+                <td>
                   <button
                     type="button"
                     className="link-button"
@@ -136,11 +151,11 @@ export function AlertList() {
                       // Swallow the promise path; the router already handles cancellation.
                       if (result instanceof Promise) result.catch(() => { /* ignored */ });
                     }}
+                    title="Open process tree on this host at the alert time"
                   >
-                    {a.title}
+                    {a.host_id}
                   </button>
                 </td>
-                <td>{a.host_id}</td>
                 <td>{formatTime(a.created_at)}</td>
                 <td>
                   <span className={`status-text status-text--${a.status}`}>

--- a/ui/src/components/AlertList.tsx
+++ b/ui/src/components/AlertList.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Link, useNavigate } from "react-router-dom";
+import { Link } from "react-router-dom";
 import { listAlerts, updateAlertStatus } from "../api";
 import type { Alert } from "../types";
 import { Table, EmptyState } from "./ui/Table";
@@ -28,7 +28,6 @@ export function AlertList() {
   // one click away via the Status dropdown but don't clutter the default view.
   const [statusFilter, setStatusFilter] = useState("open");
   const [severityFilter, setSeverityFilter] = useState("");
-  const navigate = useNavigate();
 
   useEffect(() => {
     let cancelled = false;
@@ -139,22 +138,17 @@ export function AlertList() {
                   </Link>
                 </td>
                 <td>
-                  <button
-                    type="button"
+                  {/* Link, not a button — preserves middle-click-open-in-new-tab,
+                      cmd/ctrl-click, copy-link-address, and a href that screen
+                      readers announce as a link rather than an action button
+                      (Copilot review on PR #59). */}
+                  <Link
                     className="link-button"
-                    onClick={() => {
-                      const atMs = new Date(a.created_at).getTime();
-                      const result = navigate(
-                        `/hosts/${encodeURIComponent(a.host_id)}?alert=${String(a.id)}&process=${String(a.process_id)}&at=${String(atMs)}`,
-                      );
-                      // navigate() may return void or Promise<void> in react-router v7.
-                      // Swallow the promise path; the router already handles cancellation.
-                      if (result instanceof Promise) result.catch(() => { /* ignored */ });
-                    }}
+                    to={`/hosts/${encodeURIComponent(a.host_id)}?alert=${String(a.id)}&process=${String(a.process_id)}&at=${String(new Date(a.created_at).getTime())}`}
                     title="Open process tree on this host at the alert time"
                   >
                     {a.host_id}
-                  </button>
+                  </Link>
                 </td>
                 <td>{formatTime(a.created_at)}</td>
                 <td>

--- a/ui/src/components/PolicyEditor.scss
+++ b/ui/src/components/PolicyEditor.scss
@@ -47,7 +47,11 @@
 
   .field__input {
     width: 100%;
-    min-width: 64ch;
+    // Cap the floor at the viewport width so the input doesn't force a
+    // horizontal scrollbar on narrow layouts (Copilot review on PR #59).
+    // On any normal desktop the 64ch ceiling wins and the canonical macOS
+    // bundle path / 64-char hash fit end-to-end without truncating.
+    min-width: min(64ch, 100%);
   }
 }
 

--- a/ui/src/components/PolicyEditor.scss
+++ b/ui/src/components/PolicyEditor.scss
@@ -32,6 +32,25 @@
   flex-wrap: wrap;
 }
 
+// The "Add path" / "Add hash" inputs need to fit a real macOS bundle path
+// without truncating mid-cell — the canonical example
+// `/System/Applications/Calculator.app/Contents/MacOS/Calculator` is 62
+// characters, and SHA-256 hashes are 64 hex chars. Force the wrapping
+// .field to grow into the form's available width and the underlying
+// input to render at least the full canonical path before flex shrinks
+// it on narrow viewports.
+.policy-add-row {
+  .field {
+    flex: 1 1 auto;
+    min-width: 0;
+  }
+
+  .field__input {
+    width: 100%;
+    min-width: 64ch;
+  }
+}
+
 .policy-meta {
   color: $ui-fleet-black-50;
   font-size: 0.85em;


### PR DESCRIPTION
Three operator-facing improvements bundled.

1. Widen the Add path / Add hash inputs on /ui/policy. The canonical macOS bundle exec path /System/Applications/Calculator.app/Contents/ MacOS/Calculator is 62 characters; SHA-256 hashes are 64. The default browser input width truncated both. Force the wrapping .field to flex-grow, with a 64ch min-width on the underlying input so the Calculator path renders end-to-end without scroll on a normal viewport. Verified in Chrome.

2. Link alert titles to the rule documentation. Clicking an alert like "Keychain credential dump attempted" now navigates to /ui/rules/<rule_id> so an analyst can read what fired and why without leaving the app. The existing host process-tree pivot moved to the Host column (host_id is now a button-link rather than plain text), so both jumps are still one click away — they just have distinct, labelled destinations now. Verified in Chrome: Keychain alert → credential_keychain_dump rule page; host_id click still routes to the host tree at alert time.

3. Strip claude/mvp references from every tracked file. The claude/ directory is gitignored, so `(see claude/mvp/<doc>.md)` parentheticals in checked-in files were dead links for anyone cloning the repo. Touches: .github/workflows/release.yml, Taskfile.yml, two ADRs, scripts/qa/README.md (×3), scripts/qa/attack-runbook.sh, the shell_from_office detection rule, and ui/src/api.ts comment on the navigator export. Each comment kept its informative text; only the cross-reference parenthetical was dropped. `git ls-files | xargs grep -l 'claude/mvp\|claude/qa\|claude/demo'` now returns empty.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Alert titles now link to rule documentation for quick reference.

* **Improvements**
  * Alert navigation button displays host identifier for better context.
  * Policy editor input fields now properly utilize available horizontal space.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->