### PR TITLE
Move the rule-doc link from alerts list to alert detail breadcrumb

### DIFF
--- a/ui/src/components/AlertList.tsx
+++ b/ui/src/components/AlertList.tsx
@@ -123,29 +123,30 @@ export function AlertList() {
                   </Badge>
                 </td>
                 <td>
-                  {/* Title links to the rule's documentation page so an
-                      analyst seeing an unfamiliar finding can read what the
-                      rule does, why it's almost always malicious, and what
-                      the false-positive sources are without leaving the
-                      app. The host process-tree pivot moved to the Host
-                      column below. */}
+                  {/* Title is the primary alert pivot — it opens the host's
+                      process tree pinned to the moment the alert fired, with
+                      the alert breadcrumb visible. The "what does this rule
+                      do" link to /ui/rules/<id> lives inside that breadcrumb,
+                      not here, so an analyst clicks the title once to land
+                      on the alert's investigation surface and gets the doc
+                      jump as a sibling control. */}
                   <Link
                     className="link-button"
-                    to={`/rules/${encodeURIComponent(a.rule_id)}`}
-                    title={`Open documentation for the ${a.rule_id} rule`}
+                    to={`/hosts/${encodeURIComponent(a.host_id)}?alert=${String(a.id)}&process=${String(a.process_id)}&at=${String(new Date(a.created_at).getTime())}`}
+                    title="Open this alert's process tree at the alert time"
                   >
                     {a.title}
                   </Link>
                 </td>
                 <td>
-                  {/* Link, not a button — preserves middle-click-open-in-new-tab,
-                      cmd/ctrl-click, copy-link-address, and a href that screen
-                      readers announce as a link rather than an action button
-                      (Copilot review on PR #59). */}
+                  {/* Host links to the host's full process tree without
+                      pinning to any particular alert. Distinct destination
+                      from the title above: title = "this alert", host =
+                      "the whole host". */}
                   <Link
                     className="link-button"
-                    to={`/hosts/${encodeURIComponent(a.host_id)}?alert=${String(a.id)}&process=${String(a.process_id)}&at=${String(new Date(a.created_at).getTime())}`}
-                    title="Open process tree on this host at the alert time"
+                    to={`/hosts/${encodeURIComponent(a.host_id)}`}
+                    title="Open the full process tree for this host"
                   >
                     {a.host_id}
                   </Link>

--- a/ui/src/components/ProcessTree.scss
+++ b/ui/src/components/ProcessTree.scss
@@ -268,9 +268,10 @@
 
   // When the title is rendered as an anchor (linking to /ui/rules/<id>),
   // strip the default browser underline + colour so it still reads as a
-  // breadcrumb label, and reveal the link affordance only on hover. Keeps
-  // the bar visually identical to the previous span-based version while
-  // exposing middle-click + copy-link-address through the underlying <a>.
+  // breadcrumb label, and reveal the link affordance only on hover or
+  // keyboard focus. Keeps the bar visually identical to the previous
+  // span-based version while exposing middle-click + copy-link-address
+  // through the underlying <a>.
   &__title--link {
     color: inherit;
     text-decoration: none;
@@ -278,6 +279,17 @@
     &:hover {
       color: $core-fleet-green;
       text-decoration: underline;
+    }
+
+    // Keyboard users tabbing to the breadcrumb need a visible focus
+    // indicator. Without :focus-visible the link is invisible to
+    // anyone navigating without a mouse (Copilot review on PR #61).
+    &:focus-visible {
+      color: $core-fleet-green;
+      text-decoration: underline;
+      outline: 2px solid $core-fleet-green;
+      outline-offset: 2px;
+      border-radius: 2px;
     }
   }
 

--- a/ui/src/components/ProcessTree.scss
+++ b/ui/src/components/ProcessTree.scss
@@ -266,6 +266,21 @@
     font-weight: $bold;
   }
 
+  // When the title is rendered as an anchor (linking to /ui/rules/<id>),
+  // strip the default browser underline + colour so it still reads as a
+  // breadcrumb label, and reveal the link affordance only on hover. Keeps
+  // the bar visually identical to the previous span-based version while
+  // exposing middle-click + copy-link-address through the underlying <a>.
+  &__title--link {
+    color: inherit;
+    text-decoration: none;
+
+    &:hover {
+      color: $core-fleet-green;
+      text-decoration: underline;
+    }
+  }
+
   &__time {
     color: $ui-fleet-black-50;
     font-family: ui-monospace, SFMono-Regular, Menlo, monospace;

--- a/ui/src/components/ProcessTree.tsx
+++ b/ui/src/components/ProcessTree.tsx
@@ -434,7 +434,18 @@ export function ProcessTreeView() {
           <Badge variant={SEVERITY_VARIANTS[alertDetail.severity] ?? "neutral"}>
             {alertDetail.severity}
           </Badge>
-          <span className="alert-breadcrumb__title">{alertDetail.title}</span>
+          {/* Title links to the rule's documentation page so an analyst
+              standing in front of a fired alert can jump straight to "what
+              does this rule do" without losing the process-tree context.
+              The link sits next to the title rather than replacing it so
+              the breadcrumb still reads as a label, not a CTA. */}
+          <Link
+            to={`/rules/${encodeURIComponent(alertDetail.rule_id)}`}
+            className="alert-breadcrumb__title alert-breadcrumb__title--link"
+            title={`Open documentation for the ${alertDetail.rule_id} rule`}
+          >
+            {alertDetail.title}
+          </Link>
           <span className="alert-breadcrumb__time">
             {new Date(alertDetail.created_at).toLocaleString()}
           </span>

--- a/ui/src/components/ProcessTree.tsx
+++ b/ui/src/components/ProcessTree.tsx
@@ -434,11 +434,13 @@ export function ProcessTreeView() {
           <Badge variant={SEVERITY_VARIANTS[alertDetail.severity] ?? "neutral"}>
             {alertDetail.severity}
           </Badge>
-          {/* Title links to the rule's documentation page so an analyst
-              standing in front of a fired alert can jump straight to "what
-              does this rule do" without losing the process-tree context.
-              The link sits next to the title rather than replacing it so
-              the breadcrumb still reads as a label, not a CTA. */}
+          {/* Render the alert title itself as a link to the rule's
+              documentation page so an analyst standing in front of a
+              fired alert can jump straight to "what does this rule do"
+              without losing the process-tree context. The styling
+              suppresses the default anchor underline + colour so the
+              breadcrumb still reads as a label until the cursor lands
+              on it. */}
           <Link
             to={`/rules/${encodeURIComponent(alertDetail.rule_id)}`}
             className="alert-breadcrumb__title alert-breadcrumb__title--link"


### PR DESCRIPTION
The previous fix put a /ui/rules/<id> link on the alert list's title column, which broke the primary alert pivot — clicking a fired alert no longer opened that alert's process tree, it dumped the analyst onto the rule's documentation page. Wrong workflow.

Restore + relocate:

- ui/src/components/AlertList.tsx
  - Title cell: <Link to="/hosts/<host_id>?alert=...&process=...&at=...">. Single click opens the alert's investigation surface (host process tree pinned to the moment the alert fired with the breadcrumb visible). Same behaviour as before the previous PR.
  - Host cell: <Link to="/hosts/<host_id>"> (no alert pivot params). Distinct destination from the title — title means "this alert", host means "this host". Both are real <a> tags so middle-click and copy-link-address keep working.

- ui/src/components/ProcessTree.tsx
  - Alert breadcrumb's title is now the <Link to="/rules/<rule_id>">. An analyst standing in front of a fired alert can jump straight to "what does this rule do" without losing the process-tree context — the breadcrumb stays put, only the title gains the hover affordance.

- ui/src/components/ProcessTree.scss
  - New &__title--link variant strips the default anchor styling so the breadcrumb still reads as a label, with the green underline appearing only on hover. Visually identical to the previous span-based version when the cursor is elsewhere.

Verified in Chrome:
- /ui/alerts: title → /ui/hosts/<host>?alert=149&process=103463&at=...
- /ui/alerts: host_id → /ui/hosts/<host> (no query string)
- /ui/hosts/<host>?alert=...: breadcrumb title → /ui/rules/credential_keychain_dump