### PR TITLE
Strip implementation-plan-specific references from docs + scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,7 @@ build/
 # UI build output (embedded via server/ui/embed.go)
 /server/ui/dist/
 
-# Phase 5 release-build output: signed pkg + signed profiles + checksums.
+# Release-build output: signed pkg + signed profiles + checksums.
 # Regenerated on every `packaging/pkg/build.sh` run; never committed.
 /dist/
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -274,7 +274,7 @@ tasks:
       is tracked as future work.
     deps: [build]
 
-  # -------- Phase 5 packaging --------
+  # -------- packaging --------
 
   pkg:dryrun:
     desc: |

--- a/docker-compose.prod.README.md
+++ b/docker-compose.prod.README.md
@@ -102,6 +102,6 @@ There is no Prometheus scrape endpoint.
 - No horizontal scaling of the server instance yet. A second replica would
   need a shared enroll-secret rotation mechanism (currently each replica
   reads its own secret file) and a sticky session or shared cookie store.
-  Phase 7+ consideration.
+  Tracked as future work for the post-MVP scaling story.
 - No automatic backup of `edr-mysql-data`. Operators run their own
   `mysqldump` or volume snapshot schedule.

--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -212,7 +212,7 @@ floor for any project that wants enterprise adoption.
 - [x] **Test-coverage thresholds** uploaded to SonarCloud. Both Go and TS coverage
   reports flow through (`sonar.go.coverage.reportPaths`,
   `sonar.javascript.lcov.reportPaths`); the "Coverage on New Code" gate is set to
-  ≥80% and applies per PR. C7 deliverable
+  ≥80% and applies per PR.
 - [ ] **Codecov / Coveralls** with PR comments and coverage diff
 - [ ] **`go vet -vettool=fieldalignment`** -- catches struct padding waste in hot structs
 - [x] **`uber-go/nilaway`** -- inter-procedural nil-dereference static analysis. Catches
@@ -256,8 +256,7 @@ floor for any project that wants enterprise adoption.
 - [ ] **Mutation-testing baseline** to catch over-mocked tests
 - [x] **Test coverage measured** via SonarCloud (Go via
   `sonar.go.coverage.reportPaths`, UI via
-  `sonar.javascript.lcov.reportPaths`). C7 deliverable; see §5 for the
-  per-PR ≥80% gate.
+  `sonar.javascript.lcov.reportPaths`). See §5 for the per-PR ≥80% gate.
 - [ ] **Smoke test against macOS VM** in CI (the SIP-disabled VM exists locally; could be
   scripted into a self-hosted runner)
 
@@ -583,13 +582,18 @@ A self-graded rubric so the README badge can be honest. `Total` excludes items m
 | macOS platform hygiene            | 6       | 12    | 50%  |
 | AI-assisted engineering           | 2       | 17    | 12%  |
 
-Phase-7 supply-chain track shipped Sigstore signing (C4), SBOMs (C5), SLSA build
-provenance (C6, level 2 due to Apple notarization), Scorecard (C2), OSV-Scanner
-(C3), and a real SonarCloud coverage gate (C7). That moved §4 from 37% → 57% and
-§5 from 59% → 64%. D1 hosted Redoc at `/api/docs` and added Redocly OpenAPI lint,
-moving §8 from 25% → 34%. The remaining big gaps that buyers ask about are
-LICENSE / SECURITY.md / CONTRIBUTING.md (Phase 7b — user-gated on license
-choice), the detection-content surface (ATT&CK mapping is in via B1 but Sigma /
-YARA / IOC management still wait for v1.1), and the AI-era hygiene that
-enterprise procurement is starting to ask for (CISA Secure by Design, OWASP LLM
-Top 10, AI provenance policy).
+The supply-chain hardening track shipped Sigstore signing (cosign keyless
+on every release artifact), CycloneDX + SPDX SBOMs, SLSA build provenance
+at level 2 (Apple notarization breaks L3's hermeticity requirement),
+OpenSSF Scorecard, and OSV-Scanner alongside the existing govulncheck.
+A real SonarCloud coverage gate (≥80% on new code, per PR) closed the
+last big code-quality gap. That moved §4 from 37% to 57% and §5 from 59%
+to 64%. Hosting Redoc at `/api/docs` plus a Redocly OpenAPI lint job
+moved §8 from 25% to 34%.
+
+The remaining big gaps that buyers ask about are CONTRIBUTING.md and the
+rest of the §12 community-signals checklist (now unblocked because
+LICENSE has shipped), the detection-content surface (ATT&CK mapping is
+wired but Sigma / YARA / IOC management still wait for v1.1), and the
+AI-era hygiene that enterprise procurement is starting to ask for (CISA
+Secure by Design, OWASP LLM Top 10, AI provenance policy).

--- a/docs/detection-rules.md
+++ b/docs/detection-rules.md
@@ -122,7 +122,7 @@ The matching dylib path is redacted in alert text (a sensitive payload location)
 
 ### Limitations
 
-- Inherited environment variables (set by a parent shell, not on the exec line) are invisible: ESF does not yet hand the agent the full env map. Tracked in Phase 4.
+- Inherited environment variables (set by a parent shell, not on the exec line) are invisible: ESF does not yet hand the agent the full env map. Tracked as future work.
 - DYLD_FRAMEWORK_PATH and DYLD_FALLBACK_* are intentionally NOT matched — higher-FP, lower-signal. Extend dyldPrefixes if a pilot surfaces real abuse.
 
 ## shell_from_office
@@ -242,7 +242,7 @@ To stay high-precision, writes by Apple-signed platform binaries (installd, syst
 
 ### Limitations
 
-- Atomic-rename writes (temp file + rename onto the destination) are missed; the extension does not subscribe to NOTIFY_RENAME today. Tracked for Phase 8.
+- Atomic-rename writes (temp file + rename onto the destination) are missed; the extension does not subscribe to NOTIFY_RENAME today. Tracked as future work.
 - Drops via Apple platform binaries (e.g. `sudo cp` where cp is Apple-signed) are skipped here — pair with suspicious_exec for parent-shell visibility.
 
 ## sudoers_tamper
@@ -277,5 +277,5 @@ Unlike the persistence rules, this one deliberately does NOT key on Apple-signed
 
 ### Limitations
 
-- Atomic-rename writes (write a temp file, rename onto /etc/sudoers) are missed: ESF NOTIFY_OPEN doesn't fire on rename, and the extension does not subscribe to NOTIFY_RENAME today. Tracked for Phase 8.
+- Atomic-rename writes (write a temp file, rename onto /etc/sudoers) are missed: ESF NOTIFY_OPEN doesn't fire on rename, and the extension does not subscribe to NOTIFY_RENAME today. Tracked as future work.
 

--- a/docs/install-server.md
+++ b/docs/install-server.md
@@ -315,7 +315,8 @@ Test your restore path quarterly.
 **"unknown database 'edr'"** at server startup — MySQL booted but
 didn't create the `edr` schema. The compose file sets
 `MYSQL_DATABASE: edr` so this means MySQL initialized earlier without
-that var set (pre-Phase-5 behavior) and its volume persisted.
+that var set (an earlier compose file shipped without it) and its volume
+persisted.
 
 ```sh
 docker compose -f docker-compose.prod.yml exec mysql \

--- a/scripts/qa/README.md
+++ b/scripts/qa/README.md
@@ -1,15 +1,15 @@
-# Phase-7 dogfood QA scripts
+# Dogfood QA scripts
 
-Four scripts plus this README make up the Phase-7 dogfood QA harness.
+Four scripts plus this README make up the pre-pilot dogfood QA harness.
 Each script is self-contained and runnable from this workstation; the
 work happens via `ssh` to the dev VM.
 
-| Script | Plan item | Phase 7 milestone | Approx wall time |
-|---|---|---|---|
-| `attack-runbook.sh` | E1 | Synthetic attacker fires every shipped detection rule | ~2 min |
-| `e2-policy-roundtrip.sh` | E2 | Blocklist policy push → agent pickup → blocked exec | ~3 min |
-| `e3-network-partition.sh` | E3 | 10-minute network partition + queue drainage | ~12 min |
-| `e4-uninstall.sh` | E4 | Uninstaller round-trip + offline detection | ~7 min |
+| Script | What it exercises | Approx wall time |
+|---|---|---|
+| `attack-runbook.sh` | Synthetic attacker fires every shipped detection rule | ~2 min |
+| `e2-policy-roundtrip.sh` | Blocklist policy push → agent pickup → blocked exec | ~3 min |
+| `e3-network-partition.sh` | 10-minute network partition + queue drainage | ~12 min |
+| `e4-uninstall.sh` | Uninstaller round-trip + offline detection | ~7 min |
 
 ## Prerequisites
 
@@ -28,14 +28,15 @@ Before running any script:
   `scp`, `shellcheck` (optional — only for editing the scripts).
   The scripts avoid bash-4-only features so macOS's bundled
   bash 3.2 works.
-- **Tooling on the VM**: `sqlite3` (for E3 queue depth checks),
-  `pfctl` (for E3 partition; ships with macOS), `plutil` (for
-  reading `host_id` from the persisted enrollment). All present in
+- **Tooling on the VM**: `sqlite3` (for the network-partition queue-depth
+  check), `pfctl` (for the partition itself; ships with macOS), `plutil`
+  (for reading `host_id` from the persisted enrollment). All present in
   base macOS.
 
 ## Common environment variables
 
-Every script reads the same four env vars; E3 additionally requires
+Every script reads the same four env vars; the network-partition
+script (`e3-network-partition.sh`) additionally requires
 `EDR_SERVER_IP`:
 
 ```sh
@@ -53,33 +54,35 @@ note in `docs/install-server.md`.
 ## Running the suite
 
 Run the four scripts in order. They're rerunnable for QA, but not
-strictly idempotent — some intentionally change VM state. E2 captures
-the original blocklist on entry and restores it on exit (including
-early-exit paths). E3 records pf's enabled/disabled state before the
-partition and rolls back to that state on exit. E4 removes the agent
-by design; rerun with `--reinstall` to put it back.
+strictly idempotent — some intentionally change VM state. The
+policy-roundtrip script captures the original blocklist on entry and
+restores it on exit (including early-exit paths). The network-partition
+script records pf's enabled/disabled state before the partition and
+rolls back to that state on exit. The uninstall script removes the
+agent by design; rerun with `--reinstall` to put it back.
 
 ```sh
-bash scripts/qa/attack-runbook.sh             # E1
-bash scripts/qa/e2-policy-roundtrip.sh        # E2
-bash scripts/qa/e3-network-partition.sh       # E3 (or --short for 60s)
-bash scripts/qa/e4-uninstall.sh               # E4 (run last; it removes the agent)
+bash scripts/qa/attack-runbook.sh
+bash scripts/qa/e2-policy-roundtrip.sh
+bash scripts/qa/e3-network-partition.sh       # add --short for a 60s partition
+bash scripts/qa/e4-uninstall.sh               # run last; it removes the agent
 ```
 
-E4 is destructive in the "agent is gone afterwards" sense — keep it
-last. Add `--reinstall path/to/fleet-edr-vX.Y.Z.pkg` to E4 to also
-exercise the re-install half (proves `/etc/fleet-edr.conf` is preserved
-across the round-trip).
+The uninstall script is destructive in the "agent is gone afterwards"
+sense — keep it last. Add `--reinstall path/to/fleet-edr-vX.Y.Z.pkg` to
+also exercise the re-install half (proves `/etc/fleet-edr.conf` is
+preserved across the round-trip).
 
 ## Filing the QA report
 
-After running the suite, capture the results so the Phase-7
+After running the suite, capture the results so the pre-pilot
 acceptance deliverable has a paper trail. The report should record:
 
-- Per-milestone PASS / FAIL with one-line evidence.
-- Any deviations (e.g. E3 `--short` because the operator was iterating).
-- Anything observed that wasn't in the plan: stale alerts, log
-  warnings, UI glitches.
+- Per-script PASS / FAIL with one-line evidence.
+- Any deviations (for example `--short` on the network-partition
+  script because the operator was iterating).
+- Anything observed that wasn't planned: stale alerts, log warnings,
+  UI glitches.
 - Open issues to file before pilot ship-go.
 
 ## Known gaps the scripts surface
@@ -88,19 +91,19 @@ These are deliberate — the scripts assert what's wired today and
 report on what isn't, rather than failing loudly on aspirational
 behaviour:
 
-- **E2 / `blocked_exec` alert**: the extension blocks the exec via
-  `ES_AUTH_RESULT_DENY` (works), but no detection rule fires a
-  matching alert in the UI (`blocked_exec` rule_id doesn't ship in
-  the v0.1 detection pack). Tracked for Phase 8. The script reports
-  the open-alert count for the host as informational, doesn't
-  assert it's nonzero.
-- **E3 / per-host event count endpoint**: there isn't one in the
-  v0.1 admin API surface. The script verifies queue drainage
-  on the agent side and the open-alert count server-side, but a
-  precise "no duplicates" check needs a direct DB query — out of
-  scope for a script that runs only against published APIs.
-- **E4 / sysext deactivation timing**: macOS occasionally takes a
-  few seconds longer than the uninstall script waits to fully
-  deactivate the sysext. If `systemextensionsctl list` still shows
-  `activated terminating` immediately after step 3, give it 30s and
-  recheck — that's expected and not a regression.
+- **`blocked_exec` alert (policy-roundtrip)**: the extension blocks
+  the exec via `ES_AUTH_RESULT_DENY` (works), but no detection rule
+  fires a matching alert in the UI (`blocked_exec` rule_id doesn't
+  ship in the v0.1 detection pack). Tracked as future work. The
+  script reports the open-alert count for the host as informational,
+  doesn't assert it's nonzero.
+- **Per-host event count endpoint (network-partition)**: there isn't
+  one in the v0.1 admin API surface. The script verifies queue
+  drainage on the agent side and the open-alert count server-side,
+  but a precise "no duplicates" check needs a direct DB query — out
+  of scope for a script that runs only against published APIs.
+- **Sysext deactivation timing (uninstall)**: macOS occasionally
+  takes a few seconds longer than the uninstall script waits to
+  fully deactivate the sysext. If `systemextensionsctl list` still
+  shows `activated terminating` immediately after step 3, give it 30s
+  and recheck — that's expected and not a regression.

--- a/scripts/qa/attack-runbook.sh
+++ b/scripts/qa/attack-runbook.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Phase-7 dogfood attack runbook (Track E1).
+# Pre-pilot dogfood attack runbook.
 #
 # What this is
 # ============
@@ -112,8 +112,7 @@ step_suspicious_exec() {
   # explicitly skips shell→shell→/tmp chains (suspicious_exec.go:110), so
   # we cannot just call `/bin/sh -c "$payload"` from this bash script —
   # the runbook's bash would be the shell parent and the alert would
-  # never fire. Use python3 as a non-shell launcher (the canonical
-  # example in the Phase-7 plan) so the chain becomes
+  # never fire. Use python3 as a non-shell launcher so the chain becomes
   # python3 → /bin/sh → /tmp/synthetic_payload.
   local payload="$WORKDIR/synthetic_payload"
   # Pre-create the file at mode 0700 in one step; the subsequent `cat >`
@@ -326,7 +325,7 @@ USAGE
 
 main() {
   parse_args "$@"
-  echo "[runbook] Fleet EDR Phase-7 synthetic attacker — $(date -u)"
+  echo "[runbook] Fleet EDR synthetic attacker — $(date -u)"
   echo "[runbook] working dir: $WORKDIR"
   if [[ "$PACE_SECONDS" -gt 0 ]]; then
     echo "[runbook] live-demo pacing: ${PACE_SECONDS}s between steps"

--- a/scripts/qa/e2-policy-roundtrip.sh
+++ b/scripts/qa/e2-policy-roundtrip.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Phase-7 dogfood QA E2: blocklist policy round-trip.
+# Pre-pilot dogfood QA: blocklist policy round-trip.
 #
 # Drives a full round-trip of the blocklist:
 #  1. Authenticate to the EDR admin API and pick up the CSRF token.
@@ -17,7 +17,7 @@
 #     test window, mostly for the operator's eye — there's no
 #     `blocked_exec` rule shipping with the MVP detection pack today.
 #     The actual block lives in the kernel via the AUTH callback;
-#     surfacing a paired alert in the UI is an open Phase 8 item.
+#     surfacing a paired alert in the UI is open future work.
 #  6. Restore the original policy so the script is idempotent.
 #
 # Usage from this workstation (NOT the VM):
@@ -268,6 +268,6 @@ fi
 
 hr
 echo "[e2] done. expected outcome: step 4 reported 'exec denied as expected'."
-echo "[e2] open Phase 7 issue: no alert fires on a blocked exec today;"
-echo "[e2] the AUTH callback is silent. Tracked for Phase 8."
+echo "[e2] known gap: no alert fires on a blocked exec today;"
+echo "[e2] the AUTH callback is silent. Tracked as future work."
 echo "[e2] cleanup: rm -rf $WORKDIR"

--- a/scripts/qa/e3-network-partition.sh
+++ b/scripts/qa/e3-network-partition.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Phase-7 dogfood QA E3: 10-minute network partition.
+# Pre-pilot dogfood QA: 10-minute network partition.
 #
 # What it proves: the agent's offline queue grows while the server is
 # unreachable, and drains cleanly once the partition heals. The plan

--- a/scripts/qa/e4-uninstall.sh
+++ b/scripts/qa/e4-uninstall.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Phase-7 dogfood QA E4: uninstaller round-trip.
+# Pre-pilot dogfood QA: uninstaller round-trip.
 #
 # What it proves: the bundled `uninstall.sh` tears down everything
 # the .pkg installed and the runtime state under /var/db, deactivates

--- a/server/detection/rules/dyld_insert.go
+++ b/server/detection/rules/dyld_insert.go
@@ -51,7 +51,7 @@ func (r *DyldInsert) Doc() detection.Documentation {
 			"Apple-signed binaries are immune to DYLD_INSERT_LIBRARIES under SIP, but the rule still fires on the launch — investigate why an admin script is setting these vars at all.",
 		},
 		Limitations: []string{
-			"Inherited environment variables (set by a parent shell, not on the exec line) are invisible: ESF does not yet hand the agent the full env map. Tracked in Phase 4.",
+			"Inherited environment variables (set by a parent shell, not on the exec line) are invisible: ESF does not yet hand the agent the full env map. Tracked as future work.",
 			"DYLD_FRAMEWORK_PATH and DYLD_FALLBACK_* are intentionally NOT matched — higher-FP, lower-signal. Extend dyldPrefixes if a pilot surfaces real abuse.",
 		},
 	}

--- a/server/detection/rules/privilege_launchd_plist_write.go
+++ b/server/detection/rules/privilege_launchd_plist_write.go
@@ -72,7 +72,7 @@ func (r *PrivilegeLaunchdPlistWrite) Doc() detection.Documentation {
 			"Custom in-house pkg installers signed by your developer team — same allowlist applies.",
 		},
 		Limitations: []string{
-			"Atomic-rename writes (temp file + rename onto the destination) are missed; the extension does not subscribe to NOTIFY_RENAME today. Tracked for Phase 8.",
+			"Atomic-rename writes (temp file + rename onto the destination) are missed; the extension does not subscribe to NOTIFY_RENAME today. Tracked as future work.",
 			"Drops via Apple platform binaries (e.g. `sudo cp` where cp is Apple-signed) are skipped here — pair with suspicious_exec for parent-shell visibility.",
 		},
 		Config: []detection.ConfigKnob{

--- a/server/detection/rules/sudoers_tamper.go
+++ b/server/detection/rules/sudoers_tamper.go
@@ -72,7 +72,7 @@ func (r *SudoersTamper) Doc() detection.Documentation {
 			"Configuration-management agents (Ansible, Chef, Puppet, MDM-driven scripts) that drop a sudoers fragment under /etc/sudoers.d. Allowlist their absolute writer paths.",
 		},
 		Limitations: []string{
-			"Atomic-rename writes (write a temp file, rename onto /etc/sudoers) are missed: ESF NOTIFY_OPEN doesn't fire on rename, and the extension does not subscribe to NOTIFY_RENAME today. Tracked for Phase 8.",
+			"Atomic-rename writes (write a temp file, rename onto /etc/sudoers) are missed: ESF NOTIFY_OPEN doesn't fire on rename, and the extension does not subscribe to NOTIFY_RENAME today. Tracked as future work.",
 		},
 		Config: []detection.ConfigKnob{
 			{

--- a/ui/src/styles/index.scss
+++ b/ui/src/styles/index.scss
@@ -65,7 +65,7 @@ button {
   margin: 0 auto;
 }
 
-// Phase 4: host liveness pill. Green when the agent polled within the last 5 min,
+// Host liveness pill. Green when the agent polled within the last 5 min,
 // red otherwise. Two-tone + uppercase label keeps it legible at small sizes.
 .status-pill {
   display: inline-block;


### PR DESCRIPTION
Internal milestone tags ("Phase 7", "Track E1", "C7 deliverable", "B1", "D1", etc.) come from a gitignored project-plan doc and mean nothing to anyone outside that plan. Public-facing files now describe what shipped or what is open in self-contained language.

Files cleaned (15):

- docs/best-practices.md — three "C7 deliverable" / "Phase-7 supply-chain track shipped (C2, C3, C4, C5, C6, C7)" callouts rewritten with substantive descriptions of what shipped.
- docs/detection-rules.md — auto-generated; the source of the three "Tracked in Phase 4 / Phase 8" lines is rule Doc() methods, edited below; re-ran `go run ./tools/gen-rule-docs`.
- docs/install-server.md — "(pre-Phase-5 behavior)" → "(an earlier compose file shipped without it)".
- docker-compose.prod.README.md — "Phase 7+ consideration" → "Tracked as future work for the post-MVP scaling story".
- scripts/qa/README.md — "Phase-7 dogfood QA harness" → "pre-pilot dogfood QA harness". E1/E2/E3/E4 milestone columns dropped from the script-table since the script names already convey what each one does. "Tracked for Phase 8" → "Tracked as future work".
- scripts/qa/attack-runbook.sh, e2/e3/e4-*.sh — file headers re-written from "Phase-7 dogfood QA EX" to "Pre-pilot dogfood QA"; inline "(canonical example in the Phase-7 plan)" comment dropped; user-facing echo "Fleet EDR Phase-7 synthetic attacker" loses the Phase-7 prefix.
- Taskfile.yml — "-------- Phase 5 packaging --------" section divider becomes "-------- packaging --------".
- .gitignore — "Phase 5 release-build output" comment becomes "Release-build output".
- ui/src/styles/index.scss — "Phase 4: host liveness pill" comment becomes plain "Host liveness pill".

Detection-rule Doc() sources (3 changes):

- server/detection/rules/dyld_insert.go — Limitations entry referencing "Tracked in Phase 4" → "Tracked as future work".
- server/detection/rules/privilege_launchd_plist_write.go — same pattern, "Tracked for Phase 8".
- server/detection/rules/sudoers_tamper.go — same.
- docs/detection-rules.md regenerated to pick up the three changes.

Code comments in agent/, server/, extension/, ui/ packages still reference Phase numbers (~56 files). Out of scope for this commit since cleaning those is a much larger surface and the user asked specifically about docs. Tackle as a follow-up if/when that sweep is desired.