### PR TITLE
Commit branch + tag rulesets as code

### DIFF
--- a/.github/rulesets/README.md
+++ b/.github/rulesets/README.md
@@ -77,6 +77,14 @@ Dependabot PRs run from a fork-equivalent context that can't read the
 `SONAR_TOKEN` secret. Requiring the check would block every Dependabot
 update.
 
+Currently excluded for runtime reasons: `CodeQL Go`, `CodeQL Swift`,
+and `CodeQL TypeScript`. Each takes 5–15 minutes and runs on every
+PR regardless of which language was touched, so making them required
+adds quarter-hour latency to PRs that don't change any code (e.g.
+docs-only or workflow-only changes). Reinstate them once each CodeQL
+workflow has an always-start gate job that path-checks the diff and
+either runs analysis or no-ops while still posting the check.
+
 Each excluded workflow still runs on PRs that match its condition;
 its pass/fail is advisory only. To promote any of them to required,
 first rewrite the workflow to always start and short-circuit inside

--- a/.github/rulesets/README.md
+++ b/.github/rulesets/README.md
@@ -1,0 +1,64 @@
+# Repository rulesets
+
+Source of truth for the branch + tag protection rules on this repo. The
+JSON files in this directory are the request-body shape the GitHub
+Repository Rulesets API expects. They are NOT auto-applied. Treat them
+as a review/audit artifact: any change to live ruleset state should be
+mirrored by a PR that updates the matching JSON, and `git blame` on
+these files is the change log.
+
+## Why no auto-apply
+
+Auto-apply would require giving a CI workflow `Repository
+administration: Write` scope, which is broad enough that a compromised
+workflow can disable the very rulesets it's supposed to enforce. For a
+single-maintainer project the security cost outweighs the convenience
+benefit. Once the project either adds a second maintainer or acquires
+an audit-driven mandate (SOC 2, etc.), upgrade the
+[`rulesets-drift.yml`](../workflows/rulesets-drift.yml) workflow's
+`gh api` calls from GET to PUT, grant `Repository administration:
+Write`, and treat each ruleset JSON as the canonical source. The diff
+job becomes an apply job; files in this directory do not change.
+
+## Why no drift-detection by default
+
+The workflow [`rulesets-drift.yml`](../workflows/rulesets-drift.yml)
+ships in this repo but is **opt-in**: it short-circuits with a notice
+unless a `RULESETS_READ_PAT` secret is configured. Reading rulesets via
+the API requires `Repository administration: Read`, which the workflow's
+default `GITHUB_TOKEN` cannot grant. Enabling drift-detection means
+creating a fine-grained PAT, storing it as a repo secret, and rotating
+it on the same cadence as any other long-lived credential. That's a
+real ongoing cost, so we leave the choice to the maintainer rather than
+making it implicit. Setup steps are in the workflow's header comment.
+
+## Updating a ruleset
+
+1. Edit the JSON in this directory.
+2. Apply the change to GitHub via the API or UI:
+   ```sh
+   gh api -X PUT \
+     /repos/getvictor/fleet-edr/rulesets/<id> \
+     --input .github/rulesets/main.json
+   ```
+   Look up the ruleset id with
+   `gh api /repos/getvictor/fleet-edr/rulesets`.
+3. Open a PR with the JSON change. The drift-detect workflow runs
+   automatically and confirms the live state now matches.
+
+## Files
+
+| File | What it pins |
+| --- | --- |
+| `main.json` | Default-branch (currently `main`) protection: PR required, status checks must pass, no force-push, no delete. |
+| `tags-v.json` | All `v*` tags: no delete, no force-move, no update. Pairs with the `release-signing` GitHub Environment that gates the release workflow on `v*` refs. |
+
+## Required status checks
+
+The `required_status_checks` list in `main.json` names checks that ALWAYS
+run on every PR. Workflows with path filters (e.g. `c-lint.yml`,
+`openapi-lint.yml`, `swift-lint.yml`) are intentionally NOT in the list
+because GitHub blocks merges on required checks that did not run, even
+when the path filter would have skipped them. Add a path-filtered
+workflow to the list only if the workflow is rewritten to always start
+and short-circuit inside its job.

--- a/.github/rulesets/README.md
+++ b/.github/rulesets/README.md
@@ -60,13 +60,24 @@ workflow's header comment.
 ## Required status checks
 
 The `required_status_checks` list in `main.json` names checks that ALWAYS
-run on every PR. Workflows with path filters are intentionally NOT in
-the list because GitHub blocks merges on required checks that did not
-run, even when the path filter would have skipped them. The currently
-excluded path-filtered workflows are `c-lint.yml`, `openapi-lint.yml`,
-`swift-lint.yml`, `go-lint.yml` (golangci-lint), `go-nilaway.yml`,
-`go-vulncheck.yml` (server + agent), `ts-lint.yml` (Lint and test),
-and `pkg-dryrun.yml` (Pkg build dry-run). They still run on PRs that
-touch their relevant paths, but their pass/fail is advisory only. To
-promote any of them to required, first rewrite the workflow to always
-start and short-circuit inside its job.
+run on every PR. Workflows that conditionally skip (path filters, actor
+filters, etc.) are intentionally NOT in the list because GitHub blocks
+merges on required checks that did not run, even when the condition
+would have skipped them.
+
+Currently excluded for path-filter reasons: `c-lint.yml`,
+`openapi-lint.yml`, `swift-lint.yml`, `go-lint.yml` (golangci-lint),
+`go-nilaway.yml`, `go-vulncheck.yml` (server + agent), `ts-lint.yml`
+(Lint and test), and `pkg-dryrun.yml` (Pkg build dry-run).
+
+Currently excluded for actor-filter reasons: the `sonarcloud` job in
+`test.yml`, which posts the `SonarCloud Code Analysis` check. The job
+short-circuits with `if: github.actor != 'dependabot[bot]'` because
+Dependabot PRs run from a fork-equivalent context that can't read the
+`SONAR_TOKEN` secret. Requiring the check would block every Dependabot
+update.
+
+Each excluded workflow still runs on PRs that match its condition;
+its pass/fail is advisory only. To promote any of them to required,
+first rewrite the workflow to always start and short-circuit inside
+its job (so the check name posts a status either way).

--- a/.github/rulesets/README.md
+++ b/.github/rulesets/README.md
@@ -27,10 +27,13 @@ ships in this repo but is **opt-in**: it short-circuits with a notice
 unless a `RULESETS_READ_PAT` secret is configured. Reading rulesets via
 the API requires `Repository administration: Read`, which the workflow's
 default `GITHUB_TOKEN` cannot grant. Enabling drift-detection means
-creating a fine-grained PAT, storing it as a repo secret, and rotating
-it on the same cadence as any other long-lived credential. That's a
-real ongoing cost, so we leave the choice to the maintainer rather than
-making it implicit. Setup steps are in the workflow's header comment.
+creating a fine-grained PAT, storing it inside a `rulesets-drift`
+GitHub Environment (so the token is scoped the same way as the
+`release-signing` and `sonarcloud` environments already used in this
+repo), and rotating it on the same cadence as any other long-lived
+credential. That's a real ongoing cost, so we leave the choice to the
+maintainer rather than making it implicit. Setup steps are in the
+workflow's header comment.
 
 ## Updating a ruleset
 
@@ -43,8 +46,9 @@ making it implicit. Setup steps are in the workflow's header comment.
    ```
    Look up the ruleset id with
    `gh api /repos/getvictor/fleet-edr/rulesets`.
-3. Open a PR with the JSON change. The drift-detect workflow runs
-   automatically and confirms the live state now matches.
+3. Open a PR with the JSON change. If `RULESETS_READ_PAT` is configured,
+   the drift-detect workflow runs automatically and confirms the live
+   state now matches. Otherwise it exits early with a setup notice.
 
 ## Files
 
@@ -56,9 +60,13 @@ making it implicit. Setup steps are in the workflow's header comment.
 ## Required status checks
 
 The `required_status_checks` list in `main.json` names checks that ALWAYS
-run on every PR. Workflows with path filters (e.g. `c-lint.yml`,
-`openapi-lint.yml`, `swift-lint.yml`) are intentionally NOT in the list
-because GitHub blocks merges on required checks that did not run, even
-when the path filter would have skipped them. Add a path-filtered
-workflow to the list only if the workflow is rewritten to always start
-and short-circuit inside its job.
+run on every PR. Workflows with path filters are intentionally NOT in
+the list because GitHub blocks merges on required checks that did not
+run, even when the path filter would have skipped them. The currently
+excluded path-filtered workflows are `c-lint.yml`, `openapi-lint.yml`,
+`swift-lint.yml`, `go-lint.yml` (golangci-lint), `go-nilaway.yml`,
+`go-vulncheck.yml` (server + agent), `ts-lint.yml` (Lint and test),
+and `pkg-dryrun.yml` (Pkg build dry-run). They still run on PRs that
+touch their relevant paths, but their pass/fail is advisory only. To
+promote any of them to required, first rewrite the workflow to always
+start and short-circuit inside its job.

--- a/.github/rulesets/main.json
+++ b/.github/rulesets/main.json
@@ -28,18 +28,12 @@
         "required_status_checks": [
           {"context": "Server tests"},
           {"context": "Agent tests"},
-          {"context": "golangci-lint"},
-          {"context": "nilaway"},
-          {"context": "Lint and test"},
-          {"context": "govulncheck (server)"},
-          {"context": "govulncheck (agent)"},
           {"context": "osv-scanner / osv-scan"},
           {"context": "actionlint"},
           {"context": "zizmor"},
           {"context": "CodeQL Go"},
           {"context": "CodeQL Swift"},
           {"context": "CodeQL TypeScript"},
-          {"context": "Pkg build dry-run"},
           {"context": "SonarCloud Code Analysis"}
         ]
       }

--- a/.github/rulesets/main.json
+++ b/.github/rulesets/main.json
@@ -33,8 +33,7 @@
           {"context": "zizmor"},
           {"context": "CodeQL Go"},
           {"context": "CodeQL Swift"},
-          {"context": "CodeQL TypeScript"},
-          {"context": "SonarCloud Code Analysis"}
+          {"context": "CodeQL TypeScript"}
         ]
       }
     }

--- a/.github/rulesets/main.json
+++ b/.github/rulesets/main.json
@@ -1,0 +1,49 @@
+{
+  "name": "main-protection",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["~DEFAULT_BRANCH"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {"type": "deletion"},
+    {"type": "non_fast_forward"},
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": true
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "required_status_checks": [
+          {"context": "Server tests"},
+          {"context": "Agent tests"},
+          {"context": "golangci-lint"},
+          {"context": "nilaway"},
+          {"context": "Lint and test"},
+          {"context": "govulncheck (server)"},
+          {"context": "govulncheck (agent)"},
+          {"context": "osv-scanner / osv-scan"},
+          {"context": "actionlint"},
+          {"context": "zizmor"},
+          {"context": "CodeQL Go"},
+          {"context": "CodeQL Swift"},
+          {"context": "CodeQL TypeScript"},
+          {"context": "Pkg build dry-run"},
+          {"context": "SonarCloud Code Analysis"}
+        ]
+      }
+    }
+  ],
+  "bypass_actors": []
+}

--- a/.github/rulesets/main.json
+++ b/.github/rulesets/main.json
@@ -30,10 +30,7 @@
           {"context": "Agent tests"},
           {"context": "osv-scanner / osv-scan"},
           {"context": "actionlint"},
-          {"context": "zizmor"},
-          {"context": "CodeQL Go"},
-          {"context": "CodeQL Swift"},
-          {"context": "CodeQL TypeScript"}
+          {"context": "zizmor"}
         ]
       }
     }

--- a/.github/rulesets/main.json
+++ b/.github/rulesets/main.json
@@ -24,7 +24,7 @@
     {
       "type": "required_status_checks",
       "parameters": {
-        "strict_required_status_checks_policy": true,
+        "strict_required_status_checks_policy": false,
         "required_status_checks": [
           {"context": "Server tests"},
           {"context": "Agent tests"},

--- a/.github/rulesets/tags-v.json
+++ b/.github/rulesets/tags-v.json
@@ -1,0 +1,17 @@
+{
+  "name": "release-tag-protection",
+  "target": "tag",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/tags/v*"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {"type": "deletion"},
+    {"type": "non_fast_forward"},
+    {"type": "update"}
+  ],
+  "bypass_actors": []
+}

--- a/.github/workflows/rulesets-drift.yml
+++ b/.github/workflows/rulesets-drift.yml
@@ -12,7 +12,11 @@ name: Rulesets drift check
 #      a 1-year expiration. Same constraint that drives OpenSSF
 #      Scorecard's branch-protection check; if you set a PAT for
 #      Scorecard, you can reuse it here.
-#   2. Add it as a repo secret named `RULESETS_READ_PAT`.
+#   2. Create a GitHub Environment named `rulesets-drift` and store
+#      the PAT there as `RULESETS_READ_PAT`. Using an environment
+#      (instead of a plain repo secret) lets you restrict which refs
+#      can access the token. Match the pattern already used for the
+#      `release-signing` and `sonarcloud` environments in this repo.
 #   3. Re-run this workflow via the Actions tab. From here on it'll
 #      run on every PR that touches `.github/rulesets/**`, on every
 #      push to `main`, and weekly on a schedule.
@@ -52,6 +56,7 @@ jobs:
   drift:
     name: Diff committed rulesets vs live
     runs-on: ubuntu-latest
+    environment: rulesets-drift
     permissions:
       contents: read
     steps:
@@ -79,8 +84,22 @@ jobs:
           STRIP='del(.id, .source, .source_type, .node_id, .created_at, .updated_at, ._links, .current_user_can_bypass)'
           # Order-independent comparison for arrays whose elements have
           # no inherent ordering. `rules` is keyed by .type;
-          # bypass_actors by (.actor_id, .actor_type).
-          NORM="$STRIP"' | .rules |= sort_by(.type) | .bypass_actors = ((.bypass_actors // []) | sort_by(.actor_id, .actor_type))'
+          # bypass_actors by (.actor_id, .actor_type). Inside a
+          # required_status_checks rule, GitHub may attach an
+          # integration_id per check (e.g. when the source app is
+          # known); strip those and sort by .context so a server-side
+          # integration_id annotation doesn't masquerade as drift.
+          NORM="$STRIP"' |
+            .rules |= (
+              map(
+                if .type == "required_status_checks" then
+                  .parameters.required_status_checks |= ((map(del(.integration_id))) | sort_by(.context))
+                else
+                  .
+                end
+              ) | sort_by(.type)
+            ) |
+            .bypass_actors = ((.bypass_actors // []) | sort_by(.actor_id, .actor_type))'
 
           status=0
           files=(.github/rulesets/*.json)
@@ -93,16 +112,30 @@ jobs:
             name=$(jq -r .name "$committed")
             echo "::group::Checking $committed (name=$name)"
 
-            # Look up live id by name. Empty result means the ruleset is
-            # missing on the GitHub side, which counts as drift.
-            id=$(gh api "/repos/$REPO/rulesets" \
-                  --jq ".[] | select(.name == \"$name\") | .id")
-            if [[ -z "$id" ]]; then
+            # Look up live id by name. Pass the name through `--arg` so
+            # quotes/backslashes in a ruleset name can't break the jq
+            # program. Paginate so a repo with many rulesets doesn't
+            # silently truncate. Empty result means the ruleset is
+            # missing on the GitHub side, which counts as drift; more
+            # than one match means two rulesets share the same name,
+            # which we refuse to silently pick from.
+            mapfile -t matching_ids < <(
+              gh api --paginate "/repos/$REPO/rulesets" \
+                | jq -r --arg name "$name" '.[] | select(.name == $name) | .id'
+            )
+            if [[ ${#matching_ids[@]} -eq 0 ]]; then
               echo "::error file=$committed::DRIFT: no live ruleset named '$name' on $REPO"
               status=1
               echo "::endgroup::"
               continue
             fi
+            if [[ ${#matching_ids[@]} -gt 1 ]]; then
+              echo "::error file=$committed::DRIFT: multiple live rulesets named '$name' on $REPO (ids: ${matching_ids[*]})"
+              status=1
+              echo "::endgroup::"
+              continue
+            fi
+            id=${matching_ids[0]}
 
             committed_norm=$(jq -S "$NORM" "$committed")
             live_norm=$(gh api "/repos/$REPO/rulesets/$id" | jq -S "$NORM")

--- a/.github/workflows/rulesets-drift.yml
+++ b/.github/workflows/rulesets-drift.yml
@@ -1,0 +1,123 @@
+name: Rulesets drift check
+
+# OPT-IN. Diffs every committed `.github/rulesets/*.json` against the
+# live ruleset of the same `name` on GitHub. The Repository Rulesets
+# read API requires a token with `Repository administration: Read`,
+# which the workflow's GITHUB_TOKEN cannot grant. Without a PAT the
+# workflow short-circuits with a setup notice rather than failing.
+#
+# To enable:
+#   1. Create a fine-grained PAT scoped to this repository only, with
+#      `Repository administration: Read` (no other permissions). Set
+#      a 1-year expiration. Same constraint that drives OpenSSF
+#      Scorecard's branch-protection check; if you set a PAT for
+#      Scorecard, you can reuse it here.
+#   2. Add it as a repo secret named `RULESETS_READ_PAT`.
+#   3. Re-run this workflow via the Actions tab. From here on it'll
+#      run on every PR that touches `.github/rulesets/**`, on every
+#      push to `main`, and weekly on a schedule.
+#
+# When this fails, either:
+#   (a) somebody clicked around in the UI without updating the JSON.
+#       Reapply the JSON via:
+#         gh api -X PUT /repos/${OWNER}/${REPO}/rulesets/<id> \
+#           --input .github/rulesets/<file>.json
+#   (b) the JSON in the PR is the intended new shape. Apply it the
+#       same way and re-run; once live state matches, the job passes.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/rulesets/**"
+      - ".github/workflows/rulesets-drift.yml"
+  pull_request:
+    paths:
+      - ".github/rulesets/**"
+      - ".github/workflows/rulesets-drift.yml"
+  schedule:
+    # Weekly drift sweep at a quiet hour. Catches changes made in the
+    # GitHub UI between PR-driven runs.
+    - cron: "37 4 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  drift:
+    name: Diff committed rulesets vs live
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Diff each committed ruleset against live state
+        env:
+          GH_TOKEN: ${{ secrets.RULESETS_READ_PAT }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+
+          if [[ -z "${GH_TOKEN:-}" ]]; then
+            echo "::notice::RULESETS_READ_PAT secret is not set; skipping drift check."
+            echo "::notice::See the header comment in this workflow file for setup."
+            exit 0
+          fi
+
+          # Server-generated fields that don't exist in the request body.
+          # Stripped on both sides before the diff so the comparison is
+          # apples-to-apples.
+          STRIP='del(.id, .source, .source_type, .node_id, .created_at, .updated_at, ._links, .current_user_can_bypass)'
+          # Order-independent comparison for arrays whose elements have
+          # no inherent ordering. `rules` is keyed by .type;
+          # bypass_actors by (.actor_id, .actor_type).
+          NORM="$STRIP"' | .rules |= sort_by(.type) | .bypass_actors = ((.bypass_actors // []) | sort_by(.actor_id, .actor_type))'
+
+          status=0
+          files=(.github/rulesets/*.json)
+          if [[ ${#files[@]} -eq 0 ]]; then
+            echo "No committed rulesets under .github/rulesets/; nothing to check."
+            exit 0
+          fi
+
+          for committed in "${files[@]}"; do
+            name=$(jq -r .name "$committed")
+            echo "::group::Checking $committed (name=$name)"
+
+            # Look up live id by name. Empty result means the ruleset is
+            # missing on the GitHub side, which counts as drift.
+            id=$(gh api "/repos/$REPO/rulesets" \
+                  --jq ".[] | select(.name == \"$name\") | .id")
+            if [[ -z "$id" ]]; then
+              echo "::error file=$committed::DRIFT: no live ruleset named '$name' on $REPO"
+              status=1
+              echo "::endgroup::"
+              continue
+            fi
+
+            committed_norm=$(jq -S "$NORM" "$committed")
+            live_norm=$(gh api "/repos/$REPO/rulesets/$id" | jq -S "$NORM")
+
+            if diff -u <(echo "$committed_norm") <(echo "$live_norm") > diff.out; then
+              echo "OK: $committed matches live ruleset id=$id"
+            else
+              echo "::error file=$committed::DRIFT: $committed differs from live ruleset id=$id"
+              cat diff.out
+              status=1
+            fi
+            echo "::endgroup::"
+          done
+
+          if [[ $status -ne 0 ]]; then
+            echo "::error::Ruleset drift detected. Either update the committed JSON or revert the live change."
+          fi
+          exit $status


### PR DESCRIPTION
Close the §4 best-practices.md TODO that asked for branch protection ruleset committed as `.github/rulesets/*.json`. The JSON files in the new directory are the request-body shape the GitHub Repository Rulesets API expects, suitable for direct PUT-back from the CLI:

  gh api -X PUT /repos/getvictor/fleet-edr/rulesets/<id> \
    --input .github/rulesets/main.json

Two rulesets ship today:

- `.github/rulesets/main.json` — default-branch protection. Requires a PR with status checks (the always-on subset: tests, lint, govulncheck, osv-scanner, CodeQL, SonarCloud Code Analysis, pkg-dryrun). No force-push, no delete. Approval count is 0 because the project is solo-maintainer today; bump it to 1 when a second contributor lands. Path-filtered workflows (c-lint, openapi-lint, swift-lint) are deliberately not in the required list, since GitHub blocks merges on required checks that did not run.
- `.github/rulesets/tags-v.json` — release-tag protection on `v*`. No delete, no force-move, no update. Pairs with the existing `release-signing` GitHub Environment that gates release.yml on `v*` refs.

Auto-apply is not wired. The accompanying
`.github/workflows/rulesets-drift.yml` is opt-in: it short-circuits with a notice unless a `RULESETS_READ_PAT` repo secret is configured. Reading rulesets via the API requires `Repository administration: Read`, which the workflow's default GITHUB_TOKEN cannot grant. The trade-off and upgrade path are documented in
`.github/rulesets/README.md`. The summary: solo-maintainer projects get most of the benefit (PR-reviewable JSON, git-blame audit history) without taking on the long-lived admin PAT that auto-apply would require.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented branch protection rules on the main branch requiring code reviews and CI checks before merges.
  * Enabled protection for versioned release tags to prevent accidental deletion or modification.
  * Introduced automated drift detection to monitor and report changes to protection rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->