### PR TITLE
Apply gate-then-analyze pattern to actionlint workflow

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,13 +1,13 @@
 name: Action lint
 
+# See go-lint.yml for the gate-then-analyze pattern rationale.
+
 on:
   push:
     branches: [main]
     paths:
       - ".github/workflows/**"
   pull_request:
-    paths:
-      - ".github/workflows/**"
   workflow_dispatch:
 
 concurrency:
@@ -15,8 +15,43 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Detect workflow changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read  # gate job reads the PR's file list via gh api pulls/<n>/files
+    outputs:
+      relevant: ${{ steps.detect.outputs.relevant }}
+    steps:
+      - id: detect
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          PATTERN='^\.github/workflows/'
+          if [[ "$EVENT_NAME" != "pull_request" ]]; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            echo "Triggered by $EVENT_NAME; running unconditionally."
+            exit 0
+          fi
+          files=$(gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/files" --jq '.[].filename')
+          if echo "$files" | grep -qE "$PATTERN"; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            echo "Relevant changes:"
+            echo "$files" | grep -E "$PATTERN"
+          else
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+            echo "No relevant changes; skipping actionlint."
+          fi
+
   actionlint:
     name: actionlint
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

- The required `actionlint` status check was previously gated by `on.pull_request.paths: .github/workflows/**`, so it never ran on PRs that didn't touch workflow files. With `actionlint` listed in `required_status_checks`, those PRs are blocked indefinitely waiting for a check that won't arrive (e.g. #69).
- Mirror the gate-then-analyze pattern already applied to `go-lint.yml` and `pkg-dryrun.yml`: trigger on every PR, run a cheap `changes` job that inspects the PR's file list, and skip the lint job via `if:` when no workflow files changed. GitHub treats a skipped required check as success, so the lint requirement is preserved while merges aren't blocked on irrelevant PRs.

## Test plan

- [ ] This PR itself touches `.github/workflows/**`, so `actionlint` should run with `Detect workflow changes = success` and the lint job reporting `success`.
- [ ] After merge, re-check PR #69: `actionlint` should now report (skipped) and the merge should unblock.