### PR TITLE
Api path cleanup

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -46,7 +46,7 @@ project and do not need to be reported privately:
 - Reports that the agent is detected by EDR/AV products on managed hosts —
   the agent does not attempt to evade detection.
 - Denial of service from a single authorised host against its own server
-  (e.g. flooding `/api/v1/events` with valid tokens). DoS that crosses
+  (e.g. flooding `/api/events` with valid tokens). DoS that crosses
   tenant boundaries or affects other hosts is in scope.
 - Findings against `claude/`, scratch, or `tmp/` directories — these are
   developer aids, not shipped artifacts.

--- a/agent/commander/commander.go
+++ b/agent/commander/commander.go
@@ -118,7 +118,7 @@ func (c *Commander) pollAndDispatch(ctx context.Context) {
 }
 
 func (c *Commander) fetchPending(ctx context.Context) ([]command, error) {
-	reqURL := fmt.Sprintf("%s/api/v1/commands?host_id=%s&status=pending", c.cfg.ServerURL, url.QueryEscape(c.cfg.HostID))
+	reqURL := fmt.Sprintf("%s/api/commands?host_id=%s&status=pending", c.cfg.ServerURL, url.QueryEscape(c.cfg.HostID))
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
 	if err != nil {
@@ -253,7 +253,7 @@ func marshalResult(errMsg string) json.RawMessage {
 }
 
 func (c *Commander) updateStatus(ctx context.Context, cmdID int64, status string, result json.RawMessage) error {
-	reqURL := fmt.Sprintf("%s/api/v1/commands/%d", c.cfg.ServerURL, cmdID)
+	reqURL := fmt.Sprintf("%s/api/commands/%d", c.cfg.ServerURL, cmdID)
 
 	update := statusUpdate{Status: status, Result: result}
 	body, err := json.Marshal(update)

--- a/agent/commander/commander_test.go
+++ b/agent/commander/commander_test.go
@@ -20,7 +20,7 @@ func TestFetchPending(t *testing.T) {
 	}
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "/api/v1/commands", r.URL.Path)
+		assert.Equal(t, "/api/commands", r.URL.Path)
 		assert.Equal(t, "host-a", r.URL.Query().Get("host_id"))
 		assert.Equal(t, "pending", r.URL.Query().Get("status"))
 

--- a/agent/enrollment/enrollment.go
+++ b/agent/enrollment/enrollment.go
@@ -106,7 +106,7 @@ func Ensure(ctx context.Context, opts Options) (TokenProvider, error) {
 		return nil, fmt.Errorf("load token file %q: %w", opts.TokenFile, err)
 	}
 
-	// First boot: need EDR_ENROLL_SECRET to call /api/v1/enroll.
+	// First boot: need EDR_ENROLL_SECRET to call /api/enroll.
 	if opts.EnrollSecret == "" {
 		return nil, fmt.Errorf(
 			"no token file at %q and EDR_ENROLL_SECRET is not set — cannot bootstrap",
@@ -187,7 +187,7 @@ func (p *provider) OnUnauthorized(ctx context.Context) {
 	}
 }
 
-// enroll performs the actual /api/v1/enroll call + persist. Thread-safety is the caller's
+// enroll performs the actual /api/enroll call + persist. Thread-safety is the caller's
 // responsibility: first-boot is single-threaded from Ensure, re-enrolls hold reenrollMu.
 func (p *provider) enroll(ctx context.Context) error {
 	hostID := p.opts.HostIDOverride
@@ -217,7 +217,7 @@ func (p *provider) enroll(ctx context.Context) error {
 	}
 	body, _ := json.Marshal(payload)
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, p.opts.ServerURL+"/api/v1/enroll",
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, p.opts.ServerURL+"/api/enroll",
 		bytes.NewReader(body))
 	if err != nil {
 		return err

--- a/agent/enrollment/enrollment_test.go
+++ b/agent/enrollment/enrollment_test.go
@@ -26,7 +26,7 @@ func fakeEnrollServer(t *testing.T, secret, wantToken string, hits *atomic.Int64
 		if hits != nil {
 			hits.Add(1)
 		}
-		if r.URL.Path != "/api/v1/enroll" {
+		if r.URL.Path != "/api/enroll" {
 			http.NotFound(w, r)
 			return
 		}

--- a/agent/uploader/uploader.go
+++ b/agent/uploader/uploader.go
@@ -144,7 +144,7 @@ func (u *Uploader) drainOnce(ctx context.Context) error {
 }
 
 func (u *Uploader) uploadWithRetry(ctx context.Context, body []byte) error {
-	url := u.cfg.ServerURL + "/api/v1/events"
+	url := u.cfg.ServerURL + "/api/events"
 
 	for attempt := range u.cfg.MaxRetries {
 		err := u.doUpload(ctx, url, body)

--- a/agent/uploader/uploader_test.go
+++ b/agent/uploader/uploader_test.go
@@ -29,7 +29,7 @@ func TestUploadBatch(t *testing.T) {
 
 	var received []json.RawMessage
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/v1/events" {
+		if r.URL.Path != "/api/events" {
 			t.Errorf("unexpected path: %s", r.URL.Path)
 			w.WriteHeader(http.StatusNotFound)
 			return

--- a/docs/adr/0003-standalone-product-not-fleet-integrated.md
+++ b/docs/adr/0003-standalone-product-not-fleet-integrated.md
@@ -63,7 +63,7 @@ The EDR is a standalone product. It ships its own server (`fleet-edr-server`),
 agent (`fleet-edr-agent`), UI (embedded in the server binary), and installer
 (signed `.pkg`). It has its own database (MySQL), its own auth (session
 cookies + CSRF for the UI, bearer tokens for agent-to-server), and its own
-API at `/api/v1/*`.
+API at `/api/*`.
 
 Fleet is one of several supported deployment channels. The contract between
 Fleet and the EDR is deliberately thin and consists of three things the MDM

--- a/docs/api.md
+++ b/docs/api.md
@@ -86,12 +86,12 @@ Endpoints that require the session cookie:
   `/api/v1/hosts/{id}/processes/{pid}`
 - `GET /api/v1/alerts`, `/api/v1/alerts/{id}`; `PUT /api/v1/alerts/{id}`
 - `GET /api/v1/commands/{id}`, `POST /api/v1/commands`
-- `GET /api/v1/admin/enrollments`,
-  `POST /api/v1/admin/enrollments/{host_id}/revoke`
-- `GET /api/v1/admin/policy`, `PUT /api/v1/admin/policy`
-- `GET /api/v1/admin/attack-coverage` -- ATT&CK Navigator layer JSON
+- `GET /api/v1/enrollments`,
+  `POST /api/v1/enrollments/{host_id}/revoke`
+- `GET /api/v1/policy`, `PUT /api/v1/policy`
+- `GET /api/v1/attack-coverage` -- ATT&CK Navigator layer JSON
   describing which techniques the registered rules cover.
-- `GET /api/v1/admin/rules` -- per-rule documentation surfaced by the
+- `GET /api/v1/rules` -- per-rule documentation surfaced by the
   UI's `/ui/rules/<id>` page; same data feeds `docs/detection-rules.md`.
 
 ### No auth

--- a/docs/api.md
+++ b/docs/api.md
@@ -35,7 +35,7 @@ serves them over `http://`. Examples in this doc assume TLS.
 https://<your-server>/
 ```
 
-All endpoints are rooted at `/api/v1/` except the health probes and the
+All endpoints are rooted at `/api/` except the health probes and the
 UI. There is no versioning header; when v2 lands it gets a parallel
 `/api/v2/` tree.
 
@@ -50,7 +50,7 @@ currently supported — do not set `Content-Encoding: gzip`.
 
 ### Host token (agents)
 
-An agent POSTs `/api/v1/enroll` once with the shared enroll secret and
+An agent POSTs `/api/enroll` once with the shared enroll secret and
 its hardware UUID. It receives an opaque `host_token`, stored in
 `/var/db/fleet-edr/enrolled.plist`. Every subsequent request carries:
 
@@ -63,13 +63,13 @@ commands or post events with `host_id=B`. Revoking an enrollment via
 the admin UI invalidates the token immediately.
 
 Endpoints that require a host token:
-- `POST /api/v1/events`
-- `GET  /api/v1/commands` (returns only the authenticated host's queue)
-- `PUT  /api/v1/commands/{id}` (only commands owned by the host)
+- `POST /api/events`
+- `GET  /api/commands` (returns only the authenticated host's queue)
+- `PUT  /api/commands/{id}` (only commands owned by the host)
 
 ### Session cookie + CSRF (browsers)
 
-The admin UI posts `/api/v1/session` with email + password. The
+The admin UI posts `/api/session` with email + password. The
 response sets `edr_session` (HttpOnly, Secure, SameSite=Lax) and
 returns a `csrf_token` the UI stores client-side. Subsequent unsafe
 requests (`POST`, `PUT`, `DELETE`) carry:
@@ -79,19 +79,19 @@ Cookie: edr_session=<opaque>
 X-CSRF-Token: <csrf_token>
 ```
 
-GET requests only need the cookie. Logout is `DELETE /api/v1/session`.
+GET requests only need the cookie. Logout is `DELETE /api/session`.
 
 Endpoints that require the session cookie:
-- `GET /api/v1/hosts`, `/api/v1/hosts/{id}/tree`,
-  `/api/v1/hosts/{id}/processes/{pid}`
-- `GET /api/v1/alerts`, `/api/v1/alerts/{id}`; `PUT /api/v1/alerts/{id}`
-- `GET /api/v1/commands/{id}`, `POST /api/v1/commands`
-- `GET /api/v1/enrollments`,
-  `POST /api/v1/enrollments/{host_id}/revoke`
-- `GET /api/v1/policy`, `PUT /api/v1/policy`
-- `GET /api/v1/attack-coverage` -- ATT&CK Navigator layer JSON
+- `GET /api/hosts`, `/api/hosts/{id}/tree`,
+  `/api/hosts/{id}/processes/{pid}`
+- `GET /api/alerts`, `/api/alerts/{id}`; `PUT /api/alerts/{id}`
+- `GET /api/commands/{id}`, `POST /api/commands`
+- `GET /api/enrollments`,
+  `POST /api/enrollments/{host_id}/revoke`
+- `GET /api/policy`, `PUT /api/policy`
+- `GET /api/attack-coverage` -- ATT&CK Navigator layer JSON
   describing which techniques the registered rules cover.
-- `GET /api/v1/rules` -- per-rule documentation surfaced by the
+- `GET /api/rules` -- per-rule documentation surfaced by the
   UI's `/ui/rules/<id>` page; same data feeds `docs/detection-rules.md`.
 
 ### No auth
@@ -106,13 +106,13 @@ Two IP-scoped buckets guard the auth boundary:
 
 | Endpoint | Knob | Default |
 |---|---|---|
-| `POST /api/v1/enroll` | `EDR_ENROLL_RATE_PER_MIN` | 30/min/IP |
-| `POST /api/v1/session` | `EDR_LOGIN_RATE_PER_MIN` | 6/min/IP |
+| `POST /api/enroll` | `EDR_ENROLL_RATE_PER_MIN` | 30/min/IP |
+| `POST /api/session` | `EDR_LOGIN_RATE_PER_MIN` | 6/min/IP |
 
 Over-limit requests return `429 Too Many Requests` with a
 `Retry-After` header.
 
-Ingestion (`POST /api/v1/events`), command polling, and UI read
+Ingestion (`POST /api/events`), command polling, and UI read
 endpoints are not rate limited. If you proxy thousands of agents
 through a single IP (NAT), monitor `edr.enroll.attempts` in OTel
 metrics to confirm you're not hitting the enroll cap.
@@ -156,7 +156,7 @@ openapi-python-client generate --path docs/api/openapi.yaml
 ## What's not in the API (yet)
 
 - Webhook / SIEM push. The server doesn't POST alerts outward;
-  integrators poll `GET /api/v1/alerts`. Outbound integrations ship in
+  integrators poll `GET /api/alerts`. Outbound integrations ship in
   v1.1+.
 - Multi-tenant routing. All endpoints operate on a single customer
   boundary per server instance.

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -516,7 +516,7 @@ paths:
         "404":
           description: Command not found (or not owned by authenticated host)
 
-  /api/v1/admin/enrollments:
+  /api/v1/enrollments:
     get:
       tags: [Admin]
       summary: List enrollments
@@ -532,7 +532,7 @@ paths:
                 items:
                   $ref: "#/components/schemas/Enrollment"
 
-  /api/v1/admin/enrollments/{host_id}/revoke:
+  /api/v1/enrollments/{host_id}/revoke:
     post:
       tags: [Admin]
       summary: Revoke a host enrollment
@@ -561,7 +561,7 @@ paths:
         "404":
           description: Host not found
 
-  /api/v1/admin/policy:
+  /api/v1/policy:
     get:
       tags: [Admin]
       summary: Current blocklist policy
@@ -608,7 +608,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/PolicyUpdateResult"
 
-  /api/v1/admin/attack-coverage:
+  /api/v1/attack-coverage:
     get:
       tags: [Admin]
       summary: MITRE ATT&CK coverage (Navigator layer)
@@ -630,7 +630,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/NavigatorLayer"
 
-  /api/v1/admin/rules:
+  /api/v1/rules:
     get:
       tags: [Admin]
       summary: Detection rule documentation
@@ -948,7 +948,7 @@ components:
     RulesResponse:
       type: object
       description: |
-        Wrapper returned by `GET /api/v1/admin/rules`. The `rules` array
+        Wrapper returned by `GET /api/v1/rules`. The `rules` array
         is in engine-registration order; clients should not assume any
         particular ordering beyond "stable across calls in the same
         process".

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -6,8 +6,8 @@ info:
     HTTP API for Fleet EDR. Three audience tiers:
 
     - **Agents** (macOS endpoints) authenticate with a per-host bearer
-      token obtained at enrollment. They call `POST /api/v1/enroll`,
-      `POST /api/v1/events`, and the host-scoped `/commands` endpoints.
+      token obtained at enrollment. They call `POST /api/enroll`,
+      `POST /api/events`, and the host-scoped `/commands` endpoints.
     - **Browsers** (admin UI) authenticate with an `edr_session` cookie
       (HttpOnly, Secure, SameSite=Lax) plus an `X-CSRF-Token` header on
       unsafe methods. They call the session-protected endpoints.
@@ -96,7 +96,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/ReadinessResponse"
 
-  /api/v1/enroll:
+  /api/enroll:
     post:
       tags: [Agent]
       summary: Enroll a new host
@@ -149,7 +149,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
 
-  /api/v1/events:
+  /api/events:
     post:
       tags: [Agent]
       summary: Ingest a batch of endpoint security events
@@ -180,7 +180,7 @@ paths:
         "401":
           description: Missing or invalid host token
 
-  /api/v1/session:
+  /api/session:
     post:
       tags: [Session]
       summary: Log in with email + password
@@ -247,7 +247,7 @@ paths:
         "204":
           description: Logged out
 
-  /api/v1/hosts:
+  /api/hosts:
     get:
       tags: [Hosts]
       summary: List hosts
@@ -263,7 +263,7 @@ paths:
                 items:
                   $ref: "#/components/schemas/HostSummary"
 
-  /api/v1/hosts/{host_id}/tree:
+  /api/hosts/{host_id}/tree:
     get:
       tags: [Hosts]
       summary: Process tree for a host
@@ -295,7 +295,7 @@ paths:
                     items:
                       $ref: "#/components/schemas/ProcessNode"
 
-  /api/v1/hosts/{host_id}/processes/{pid}:
+  /api/hosts/{host_id}/processes/{pid}:
     get:
       tags: [Hosts]
       summary: Process detail
@@ -321,7 +321,7 @@ paths:
         "404":
           description: No process found at the given coordinates
 
-  /api/v1/alerts:
+  /api/alerts:
     get:
       tags: [Alerts]
       summary: List alerts
@@ -357,7 +357,7 @@ paths:
                 items:
                   $ref: "#/components/schemas/Alert"
 
-  /api/v1/alerts/{id}:
+  /api/alerts/{id}:
     get:
       tags: [Alerts]
       summary: Alert detail (with event IDs)
@@ -407,7 +407,7 @@ paths:
         "404":
           description: Alert not found
 
-  /api/v1/commands:
+  /api/commands:
     get:
       tags: [Commands]
       summary: List commands for the authenticated host
@@ -459,7 +459,7 @@ paths:
                 properties:
                   id: {type: integer, format: int64}
 
-  /api/v1/commands/{id}:
+  /api/commands/{id}:
     get:
       tags: [Commands]
       summary: Get a single command (admin)
@@ -516,7 +516,7 @@ paths:
         "404":
           description: Command not found (or not owned by authenticated host)
 
-  /api/v1/enrollments:
+  /api/enrollments:
     get:
       tags: [Admin]
       summary: List enrollments
@@ -532,7 +532,7 @@ paths:
                 items:
                   $ref: "#/components/schemas/Enrollment"
 
-  /api/v1/enrollments/{host_id}/revoke:
+  /api/enrollments/{host_id}/revoke:
     post:
       tags: [Admin]
       summary: Revoke a host enrollment
@@ -561,7 +561,7 @@ paths:
         "404":
           description: Host not found
 
-  /api/v1/policy:
+  /api/policy:
     get:
       tags: [Admin]
       summary: Current blocklist policy
@@ -608,7 +608,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/PolicyUpdateResult"
 
-  /api/v1/attack-coverage:
+  /api/attack-coverage:
     get:
       tags: [Admin]
       summary: MITRE ATT&CK coverage (Navigator layer)
@@ -630,7 +630,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/NavigatorLayer"
 
-  /api/v1/rules:
+  /api/rules:
     get:
       tags: [Admin]
       summary: Detection rule documentation
@@ -657,14 +657,14 @@ components:
       scheme: bearer
       bearerFormat: opaque
       description: |
-        Per-host bearer token issued by `POST /api/v1/enroll`. Pass as
+        Per-host bearer token issued by `POST /api/enroll`. Pass as
         `Authorization: Bearer <host_token>`.
     SessionCookie:
       type: apiKey
       in: cookie
       name: edr_session
       description: |
-        HttpOnly cookie set by `POST /api/v1/session`. The browser
+        HttpOnly cookie set by `POST /api/session`. The browser
         attaches it automatically.
     CSRF:
       type: apiKey
@@ -948,7 +948,7 @@ components:
     RulesResponse:
       type: object
       description: |
-        Wrapper returned by `GET /api/v1/rules`. The `rules` array
+        Wrapper returned by `GET /api/rules`. The `rules` array
         is in engine-registration order; clients should not assume any
         particular ordering beyond "stable across calls in the same
         process".

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -7,7 +7,8 @@ info:
 
     - **Agents** (macOS endpoints) authenticate with a per-host bearer
       token obtained at enrollment. They call `POST /api/enroll`,
-      `POST /api/events`, and the host-scoped `/commands` endpoints.
+      `POST /api/events`, and the host-scoped `GET /api/commands` and
+      `PUT /api/commands/{id}` endpoints.
     - **Browsers** (admin UI) authenticate with an `edr_session` cookie
       (HttpOnly, Secure, SameSite=Lax) plus an `X-CSRF-Token` header on
       unsafe methods. They call the session-protected endpoints.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -53,7 +53,7 @@ and presents findings through a web UI with response capabilities.
 │                                                       │
 │         ┌─────────────────┐                           │
 │         │   REST API      │◄──── React UI             │
-│         │   /api/*     │      (embedded)           │
+│         │   /api/*        │      (embedded)           │
 │         └─────────────────┘                           │
 └───────────────────────────────────────────────────────┘
 ```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -28,7 +28,7 @@ and presents findings through a web UI with response capabilities.
 │         │   - Commander   │                           │
 │         └────────┬────────┘                           │
 └──────────────────│────────────────────────────────────┘
-                   │ HTTPS (POST /api/v1/events)
+                   │ HTTPS (POST /api/events)
                    │
 ┌──────────────────│──── Server ────────────────────────┐
 │         ┌────────▼────────┐                           │
@@ -53,7 +53,7 @@ and presents findings through a web UI with response capabilities.
 │                                                       │
 │         ┌─────────────────┐                           │
 │         │   REST API      │◄──── React UI             │
-│         │   /api/v1/*     │      (embedded)           │
+│         │   /api/*     │      (embedded)           │
 │         └─────────────────┘                           │
 └───────────────────────────────────────────────────────┘
 ```
@@ -144,8 +144,8 @@ agent/
 1. `receiver` connects to extension XPC Mach services
 2. Events arrive as raw JSON bytes on Go channels
 3. Events are written to SQLite `queue` (survives restarts)
-4. `uploader` batches events and POSTs to `/api/v1/events`
-5. `commander` polls `/api/v1/commands` and executes responses
+4. `uploader` batches events and POSTs to `/api/events`
+5. `commander` polls `/api/commands` and executes responses
 
 The agent runs two parallel receiver loops (ESF + Network), each with
 exponential backoff reconnection (1s initial, 30s max).
@@ -154,7 +154,7 @@ exponential backoff reconnection (1s initial, 30s max).
 
 ### Ingest handler (`server/ingest/`)
 
-Stateless HTTP endpoint at `POST /api/v1/events`. Validates required fields
+Stateless HTTP endpoint at `POST /api/events`. Validates required fields
 (`event_id`, `host_id`, `event_type`, `timestamp_ns`), enforces 10 MB request
 limit, and inserts into the `events` table with `INSERT IGNORE` for
 idempotent deduplication.
@@ -214,15 +214,15 @@ Read endpoints for the UI:
 
 | Endpoint | Returns |
 |----------|---------|
-| `GET /api/v1/hosts` | Host list with event counts and last-seen |
-| `GET /api/v1/hosts/{id}/tree` | Process forest with children, network events |
-| `GET /api/v1/hosts/{id}/processes/{pid}` | Process detail with network + DNS |
-| `GET /api/v1/alerts` | Filterable alert list |
-| `GET /api/v1/alerts/{id}` | Single alert with linked event IDs |
-| `PUT /api/v1/alerts/{id}` | Update alert status |
-| `GET /api/v1/commands` | Agent command polling |
-| `POST /api/v1/commands` | Create command (from UI) |
-| `PUT /api/v1/commands/{id}` | Agent reports command result |
+| `GET /api/hosts` | Host list with event counts and last-seen |
+| `GET /api/hosts/{id}/tree` | Process forest with children, network events |
+| `GET /api/hosts/{id}/processes/{pid}` | Process detail with network + DNS |
+| `GET /api/alerts` | Filterable alert list |
+| `GET /api/alerts/{id}` | Single alert with linked event IDs |
+| `PUT /api/alerts/{id}` | Update alert status |
+| `GET /api/commands` | Agent command polling |
+| `POST /api/commands` | Create command (from UI) |
+| `PUT /api/commands/{id}` | Agent reports command result |
 | `GET /health` | Health check |
 
 ### Web UI (`ui/`)

--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -299,7 +299,7 @@ genuine differentiator versus most competitors.
 
 ## 8. API and protocol design
 
-- [x] Versioned URL prefix (`/api/v1/`)
+- [x] Versioned URL prefix (`/api/`)
 - [x] JSON event schema (`schema/events.json` -- consumed by both agent and server)
 - [x] Standard JSON error responses with `Cache-Control: no-store` on health endpoints
 - [x] Per-route auth-domain composition (public / host-token / session) at registration

--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -299,7 +299,7 @@ genuine differentiator versus most competitors.
 
 ## 8. API and protocol design
 
-- [x] Versioned URL prefix (`/api/`)
+- [x] Stable API URL prefix (`/api/`); evolve in place rather than bumping a URL version, since v1 → v2 transitions rarely happen and are the wrong layer for protocol versioning when they do
 - [x] JSON event schema (`schema/events.json` -- consumed by both agent and server)
 - [x] Standard JSON error responses with `Cache-Control: no-store` on health endpoints
 - [x] Per-route auth-domain composition (public / host-token / session) at registration

--- a/docs/go-conventions.md
+++ b/docs/go-conventions.md
@@ -177,8 +177,8 @@ Each package exposes a `RegisterRoutes(mux *http.ServeMux)` method:
 
 ```go
 func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
-    mux.HandleFunc("GET /api/v1/hosts", h.listHosts)
-    mux.HandleFunc("GET /api/v1/hosts/{host_id}/tree", h.getTree)
+    mux.HandleFunc("GET /api/hosts", h.listHosts)
+    mux.HandleFunc("GET /api/hosts/{host_id}/tree", h.getTree)
 }
 ```
 

--- a/docs/install-agent-manual.md
+++ b/docs/install-agent-manual.md
@@ -247,7 +247,7 @@ sudo rm /etc/fleet-edr.conf
 
 After uninstall, the host disappears from the admin UI only after its
 `last_seen` threshold (default 5 min) elapses. You can also revoke the
-enrollment manually via `POST /api/v1/admin/enrollments/{host_id}/revoke`
+enrollment manually via `POST /api/v1/enrollments/{host_id}/revoke`
 (see [api.md](api.md)).
 
 ## Troubleshoot

--- a/docs/install-agent-manual.md
+++ b/docs/install-agent-manual.md
@@ -247,7 +247,7 @@ sudo rm /etc/fleet-edr.conf
 
 After uninstall, the host disappears from the admin UI only after its
 `last_seen` threshold (default 5 min) elapses. You can also revoke the
-enrollment manually via `POST /api/v1/enrollments/{host_id}/revoke`
+enrollment manually via `POST /api/enrollments/{host_id}/revoke`
 (see [api.md](api.md)).
 
 ## Troubleshoot

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -286,7 +286,7 @@ Common causes, in order:
    running`? If not:
    `sudo launchctl kickstart -k system/com.fleetdm.edr.agent`.
 4. **Enrollment revoked.** Check
-   `POST /api/v1/admin/enrollments/{host_id}/revoke` logs. Re-enroll
+   `POST /api/v1/enrollments/{host_id}/revoke` logs. Re-enroll
    by re-running the MDM install-script and restarting the daemon.
 5. **DB clock skew / server down.** `edr.enrolled.hosts` gauge
    returning -1 means the DB query failed.
@@ -304,7 +304,7 @@ list.
 
 ```sh
 # View current policy.
-curl -s -b cookies.txt https://<server>/api/v1/admin/policy | jq .
+curl -s -b cookies.txt https://<server>/api/v1/policy | jq .
 
 # Update policy (requires login + CSRF token).
 # Easier via the admin UI: Settings > Policy > Blocklist.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -286,7 +286,7 @@ Common causes, in order:
    running`? If not:
    `sudo launchctl kickstart -k system/com.fleetdm.edr.agent`.
 4. **Enrollment revoked.** Check
-   `POST /api/v1/enrollments/{host_id}/revoke` logs. Re-enroll
+   `POST /api/enrollments/{host_id}/revoke` logs. Re-enroll
    by re-running the MDM install-script and restarting the daemon.
 5. **DB clock skew / server down.** `edr.enrolled.hosts` gauge
    returning -1 means the DB query failed.
@@ -304,7 +304,7 @@ list.
 
 ```sh
 # View current policy.
-curl -s -b cookies.txt https://<server>/api/v1/policy | jq .
+curl -s -b cookies.txt https://<server>/api/policy | jq .
 
 # Update policy (requires login + CSRF token).
 # Easier via the admin UI: Settings > Policy > Blocklist.

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -27,14 +27,14 @@ context: |
                       server/ui/dist/ and embedded via server/ui/
                       embed.go.
   - schema/events.json  JSON Schema for the event envelope agents
-                        send to /api/v1/events.
+                        send to /api/events.
   - packaging/        Sign + notarize .pkg + render .mobileconfig
                       profiles for MDM distribution.
 
   Authentication shapes:
-  - Agents use a per-host bearer token issued at /api/v1/enroll.
+  - Agents use a per-host bearer token issued at /api/enroll.
   - UI operators use a session cookie + CSRF token issued at
-    POST /api/v1/session.
+    POST /api/session.
   - Tags are protected by the release-tag-protection ruleset; the
     release workflow gates Apple signing on the release-signing
     GitHub Environment.

--- a/openspec/specs/server-admin-surface/spec.md
+++ b/openspec/specs/server-admin-surface/spec.md
@@ -16,13 +16,16 @@ without reading the handler source.
 
 ### Requirement: Authenticated admin boundary
 
-Every admin endpoint SHALL require a caller authenticated as an admin user. The server MUST gate all `/api/v1/admin/*` routes
-behind admin authentication middleware so that an unauthenticated or non-admin caller receives `401 Unauthorized`.
+Every endpoint defined by this capability (`/api/v1/enrollments`, `/api/v1/enrollments/{host_id}/revoke`,
+`/api/v1/policy`, `/api/v1/attack-coverage`, and `/api/v1/rules`) SHALL require a caller authenticated as an operator.
+The server MUST gate these routes behind the operator-session middleware so that an unauthenticated caller receives
+`401 Unauthorized`. The endpoints share an authentication boundary with the rest of the operator API; there is no
+separate "admin" auth mode in the current implementation.
 
 #### Scenario: Unauthenticated request is rejected
 
 - **GIVEN** a client that has not authenticated
-- **WHEN** the client requests any `/api/v1/admin/*` endpoint
+- **WHEN** the client requests any endpoint defined by this capability
 - **THEN** the server returns `401 Unauthorized`
 - **AND** the response body uses the standard error shape `{"error": "..."}`
 
@@ -34,27 +37,27 @@ behind admin authentication middleware so that an unauthenticated or non-admin c
 
 ### Requirement: List enrollments
 
-The system SHALL expose `GET /api/v1/admin/enrollments` returning the set of enrolled hosts known to the server. Each entry MUST
+The system SHALL expose `GET /api/v1/enrollments` returning the set of enrolled hosts known to the server. Each entry MUST
 identify the host and carry the metadata needed for the admin host list (host id, hostname, agent version, OS version, last-seen
 timestamp, enrollment status).
 
 #### Scenario: Operator lists enrolled hosts
 
 - **GIVEN** at least one host has enrolled successfully
-- **WHEN** the operator requests `GET /api/v1/admin/enrollments`
+- **WHEN** the operator requests `GET /api/v1/enrollments`
 - **THEN** the server returns `200 OK` with a JSON array of enrollment rows
 - **AND** every row includes the host id and the host's last-seen timestamp
 
 ### Requirement: Revoke a host enrollment
 
-The system SHALL expose `POST /api/v1/admin/enrollments/{host_id}/revoke` to invalidate a host's bearer token immediately. The
+The system SHALL expose `POST /api/v1/enrollments/{host_id}/revoke` to invalidate a host's bearer token immediately. The
 request body MUST carry an operator-supplied `reason` and `actor`; the server MUST reject the request when either is empty. Once
 revoked, the next authenticated request from that host's agent MUST receive `401 Unauthorized`.
 
 #### Scenario: Revoke a known host
 
 - **GIVEN** a host with a currently valid enrollment
-- **WHEN** the operator POSTs to `/api/v1/admin/enrollments/{host_id}/revoke` with a non-empty `reason` and `actor`
+- **WHEN** the operator POSTs to `/api/v1/enrollments/{host_id}/revoke` with a non-empty `reason` and `actor`
 - **THEN** the server returns `204 No Content`
 - **AND** the host's bearer token is invalidated server-side
 - **AND** the next request that agent makes with that token receives `401 Unauthorized`
@@ -73,7 +76,7 @@ revoked, the next authenticated request from that host's agent MUST receive `401
 
 ### Requirement: Read the current blocklist policy
 
-The system SHALL expose `GET /api/v1/admin/policy` returning the current default policy. The response MUST always include a
+The system SHALL expose `GET /api/v1/policy` returning the current default policy. The response MUST always include a
 `name`, a monotonically increasing `version`, a `blocklist` object with `paths` and `hashes` arrays, plus `updated_at` and
 `updated_by` audit fields. On a freshly-seeded server with no operator changes the policy MUST return cleanly with empty `paths`
 and `hashes`.
@@ -81,19 +84,19 @@ and `hashes`.
 #### Scenario: First-query returns the seeded empty policy
 
 - **GIVEN** a server that has never had a policy push
-- **WHEN** the operator requests `GET /api/v1/admin/policy`
+- **WHEN** the operator requests `GET /api/v1/policy`
 - **THEN** the server returns `200 OK`
 - **AND** the response body's `blocklist.paths` and `blocklist.hashes` are present and empty
 
 #### Scenario: Read after operator changes
 
 - **GIVEN** the operator has previously persisted a non-empty blocklist
-- **WHEN** the operator requests `GET /api/v1/admin/policy`
+- **WHEN** the operator requests `GET /api/v1/policy`
 - **THEN** the response carries the latest persisted version, blocklist contents, and updated-by attribution
 
 ### Requirement: Persist and fan out a new blocklist policy
 
-The system SHALL expose `PUT /api/v1/admin/policy` that atomically bumps the policy's version and replaces the blocklist.
+The system SHALL expose `PUT /api/v1/policy` that atomically bumps the policy's version and replaces the blocklist.
 The system SHALL attempt to queue a `set_blocklist` command carrying the new version for every active host on a
 best-effort basis. A failure to enqueue the command for an individual host MUST NOT roll back the policy update; the
 server MUST log the per-host fan-out failures so the next agent poll or admin push can reconcile, and MAY surface
@@ -154,26 +157,26 @@ SIEM and SigNoz queries can filter on so SOC teams can reconstruct who changed w
 
 ### Requirement: ATT&CK coverage layer endpoint
 
-The system SHALL expose `GET /api/v1/admin/attack-coverage` returning a MITRE ATT&CK Navigator layer JSON document that enumerates
+The system SHALL expose `GET /api/v1/attack-coverage` returning a MITRE ATT&CK Navigator layer JSON document that enumerates
 the techniques covered by the registered detection rules. The document MUST be importable directly into the upstream MITRE
 ATT&CK Navigator. Each covered technique MUST identify the rule (or rules) that cover it.
 
 #### Scenario: Coverage when rules are registered
 
 - **GIVEN** at least one detection rule registered with one or more ATT&CK techniques
-- **WHEN** the operator requests `GET /api/v1/admin/attack-coverage`
+- **WHEN** the operator requests `GET /api/v1/attack-coverage`
 - **THEN** the server returns a Navigator layer JSON whose `techniques` array contains an entry for every covered technique
 - **AND** each entry identifies the rule ids that cover that technique
 
 #### Scenario: Coverage with no rules
 
 - **GIVEN** a server with no rules registered
-- **WHEN** the operator requests `GET /api/v1/admin/attack-coverage`
+- **WHEN** the operator requests `GET /api/v1/attack-coverage`
 - **THEN** the server returns a Navigator layer JSON with an empty `techniques` array rather than an error
 
 ### Requirement: Per-rule documentation endpoint
 
-The system SHALL expose `GET /api/v1/admin/rules` returning the per-rule documentation surface the admin UI's rule-detail page
+The system SHALL expose `GET /api/v1/rules` returning the per-rule documentation surface the admin UI's rule-detail page
 relies on. The response MUST include, for every registered rule, the rule's `id`, the list of ATT&CK `techniques` it covers, and
 a `doc` object carrying at least `title`, `summary`, `description`, `severity`, and `event_types`. When a rule declares operator-
 tunable knobs, false-positive sources, or limitations, those MUST be exposed under `config`, `false_positives`, and `limitations`
@@ -182,7 +185,7 @@ respectively.
 #### Scenario: Operator reads the rule catalog
 
 - **GIVEN** a server with one or more rules registered
-- **WHEN** the operator requests `GET /api/v1/admin/rules`
+- **WHEN** the operator requests `GET /api/v1/rules`
 - **THEN** the server returns `200 OK` with a `rules` array
 - **AND** each entry carries `id`, `techniques`, and a non-empty `doc` block with `title`, `summary`, `description`, `severity`,
   and `event_types`

--- a/openspec/specs/server-admin-surface/spec.md
+++ b/openspec/specs/server-admin-surface/spec.md
@@ -16,8 +16,8 @@ without reading the handler source.
 
 ### Requirement: Authenticated admin boundary
 
-Every endpoint defined by this capability (`/api/v1/enrollments`, `/api/v1/enrollments/{host_id}/revoke`,
-`/api/v1/policy`, `/api/v1/attack-coverage`, and `/api/v1/rules`) SHALL require a caller authenticated as an operator.
+Every endpoint defined by this capability (`/api/enrollments`, `/api/enrollments/{host_id}/revoke`,
+`/api/policy`, `/api/attack-coverage`, and `/api/rules`) SHALL require a caller authenticated as an operator.
 The server MUST gate these routes behind the operator-session middleware so that an unauthenticated caller receives
 `401 Unauthorized`. The endpoints share an authentication boundary with the rest of the operator API; there is no
 separate "admin" auth mode in the current implementation.
@@ -37,27 +37,27 @@ separate "admin" auth mode in the current implementation.
 
 ### Requirement: List enrollments
 
-The system SHALL expose `GET /api/v1/enrollments` returning the set of enrolled hosts known to the server. Each entry MUST
+The system SHALL expose `GET /api/enrollments` returning the set of enrolled hosts known to the server. Each entry MUST
 identify the host and carry the metadata needed for the admin host list (host id, hostname, agent version, OS version, last-seen
 timestamp, enrollment status).
 
 #### Scenario: Operator lists enrolled hosts
 
 - **GIVEN** at least one host has enrolled successfully
-- **WHEN** the operator requests `GET /api/v1/enrollments`
+- **WHEN** the operator requests `GET /api/enrollments`
 - **THEN** the server returns `200 OK` with a JSON array of enrollment rows
 - **AND** every row includes the host id and the host's last-seen timestamp
 
 ### Requirement: Revoke a host enrollment
 
-The system SHALL expose `POST /api/v1/enrollments/{host_id}/revoke` to invalidate a host's bearer token immediately. The
+The system SHALL expose `POST /api/enrollments/{host_id}/revoke` to invalidate a host's bearer token immediately. The
 request body MUST carry an operator-supplied `reason` and `actor`; the server MUST reject the request when either is empty. Once
 revoked, the next authenticated request from that host's agent MUST receive `401 Unauthorized`.
 
 #### Scenario: Revoke a known host
 
 - **GIVEN** a host with a currently valid enrollment
-- **WHEN** the operator POSTs to `/api/v1/enrollments/{host_id}/revoke` with a non-empty `reason` and `actor`
+- **WHEN** the operator POSTs to `/api/enrollments/{host_id}/revoke` with a non-empty `reason` and `actor`
 - **THEN** the server returns `204 No Content`
 - **AND** the host's bearer token is invalidated server-side
 - **AND** the next request that agent makes with that token receives `401 Unauthorized`
@@ -76,7 +76,7 @@ revoked, the next authenticated request from that host's agent MUST receive `401
 
 ### Requirement: Read the current blocklist policy
 
-The system SHALL expose `GET /api/v1/policy` returning the current default policy. The response MUST always include a
+The system SHALL expose `GET /api/policy` returning the current default policy. The response MUST always include a
 `name`, a monotonically increasing `version`, a `blocklist` object with `paths` and `hashes` arrays, plus `updated_at` and
 `updated_by` audit fields. On a freshly-seeded server with no operator changes the policy MUST return cleanly with empty `paths`
 and `hashes`.
@@ -84,19 +84,19 @@ and `hashes`.
 #### Scenario: First-query returns the seeded empty policy
 
 - **GIVEN** a server that has never had a policy push
-- **WHEN** the operator requests `GET /api/v1/policy`
+- **WHEN** the operator requests `GET /api/policy`
 - **THEN** the server returns `200 OK`
 - **AND** the response body's `blocklist.paths` and `blocklist.hashes` are present and empty
 
 #### Scenario: Read after operator changes
 
 - **GIVEN** the operator has previously persisted a non-empty blocklist
-- **WHEN** the operator requests `GET /api/v1/policy`
+- **WHEN** the operator requests `GET /api/policy`
 - **THEN** the response carries the latest persisted version, blocklist contents, and updated-by attribution
 
 ### Requirement: Persist and fan out a new blocklist policy
 
-The system SHALL expose `PUT /api/v1/policy` that atomically bumps the policy's version and replaces the blocklist.
+The system SHALL expose `PUT /api/policy` that atomically bumps the policy's version and replaces the blocklist.
 The system SHALL attempt to queue a `set_blocklist` command carrying the new version for every active host on a
 best-effort basis. A failure to enqueue the command for an individual host MUST NOT roll back the policy update; the
 server MUST log the per-host fan-out failures so the next agent poll or admin push can reconcile, and MAY surface
@@ -157,26 +157,26 @@ SIEM and SigNoz queries can filter on so SOC teams can reconstruct who changed w
 
 ### Requirement: ATT&CK coverage layer endpoint
 
-The system SHALL expose `GET /api/v1/attack-coverage` returning a MITRE ATT&CK Navigator layer JSON document that enumerates
+The system SHALL expose `GET /api/attack-coverage` returning a MITRE ATT&CK Navigator layer JSON document that enumerates
 the techniques covered by the registered detection rules. The document MUST be importable directly into the upstream MITRE
 ATT&CK Navigator. Each covered technique MUST identify the rule (or rules) that cover it.
 
 #### Scenario: Coverage when rules are registered
 
 - **GIVEN** at least one detection rule registered with one or more ATT&CK techniques
-- **WHEN** the operator requests `GET /api/v1/attack-coverage`
+- **WHEN** the operator requests `GET /api/attack-coverage`
 - **THEN** the server returns a Navigator layer JSON whose `techniques` array contains an entry for every covered technique
 - **AND** each entry identifies the rule ids that cover that technique
 
 #### Scenario: Coverage with no rules
 
 - **GIVEN** a server with no rules registered
-- **WHEN** the operator requests `GET /api/v1/attack-coverage`
+- **WHEN** the operator requests `GET /api/attack-coverage`
 - **THEN** the server returns a Navigator layer JSON with an empty `techniques` array rather than an error
 
 ### Requirement: Per-rule documentation endpoint
 
-The system SHALL expose `GET /api/v1/rules` returning the per-rule documentation surface the admin UI's rule-detail page
+The system SHALL expose `GET /api/rules` returning the per-rule documentation surface the admin UI's rule-detail page
 relies on. The response MUST include, for every registered rule, the rule's `id`, the list of ATT&CK `techniques` it covers, and
 a `doc` object carrying at least `title`, `summary`, `description`, `severity`, and `event_types`. When a rule declares operator-
 tunable knobs, false-positive sources, or limitations, those MUST be exposed under `config`, `false_positives`, and `limitations`
@@ -185,7 +185,7 @@ respectively.
 #### Scenario: Operator reads the rule catalog
 
 - **GIVEN** a server with one or more rules registered
-- **WHEN** the operator requests `GET /api/v1/rules`
+- **WHEN** the operator requests `GET /api/rules`
 - **THEN** the server returns `200 OK` with a `rules` array
 - **AND** each entry carries `id`, `techniques`, and a non-empty `doc` block with `title`, `summary`, `description`, `severity`,
   and `event_types`

--- a/openspec/specs/server-event-ingestion/spec.md
+++ b/openspec/specs/server-event-ingestion/spec.md
@@ -14,21 +14,21 @@ that traffic spikes from a fleet of agents do not block detection work or the re
 
 ### Requirement: Authenticated batch event submission
 
-The system SHALL expose `POST /api/v1/events` that accepts a JSON array of event envelopes from an enrolled agent. The
+The system SHALL expose `POST /api/events` that accepts a JSON array of event envelopes from an enrolled agent. The
 caller MUST present a per-host bearer token in the `Authorization` header; the system MUST reject requests whose token does
 not resolve to an enrolled host.
 
 #### Scenario: A valid agent posts a batch
 
 - **GIVEN** an enrolled host with a valid bearer token
-- **WHEN** the agent submits a JSON array of well-formed event envelopes to `POST /api/v1/events`
+- **WHEN** the agent submits a JSON array of well-formed event envelopes to `POST /api/events`
 - **THEN** the system responds with HTTP 200 and a JSON body reporting the number of events accepted
 - **AND** every submitted event is persisted before the response is returned
 
 #### Scenario: A request without a host token is rejected
 
 - **GIVEN** a client that omits or supplies an unrecognized bearer token
-- **WHEN** the client submits any payload to `POST /api/v1/events`
+- **WHEN** the client submits any payload to `POST /api/events`
 - **THEN** the system responds with HTTP 401 and does not persist any of the events
 
 ### Requirement: Required field validation
@@ -64,7 +64,7 @@ A compromised or misbehaving agent MUST NOT be able to submit events that claim 
 
 ### Requirement: Body size limit
 
-The system SHALL cap the bytes it reads from the request body of `POST /api/v1/events` at 10 MB. Bodies that exceed the
+The system SHALL cap the bytes it reads from the request body of `POST /api/events` at 10 MB. Bodies that exceed the
 cap MUST result in HTTP 400 with a typed body-read diagnostic, and no events from that batch are persisted. A well-
 behaved agent is expected to split larger telemetry into multiple batches under the cap rather than rely on the server
 to reject oversized bodies.
@@ -111,7 +111,7 @@ or fail because of downstream processing work.
 #### Scenario: Ingestion accepts events while the processor is busy
 
 - **GIVEN** the processor is actively materializing earlier batches
-- **WHEN** an agent submits a new batch to `POST /api/v1/events`
+- **WHEN** an agent submits a new batch to `POST /api/events`
 - **THEN** the system persists the new events and responds with HTTP 200 without waiting for any processing work
 - **AND** the new events become visible to the processor in a subsequent processing cycle
 

--- a/openspec/specs/server-rest-api/spec.md
+++ b/openspec/specs/server-rest-api/spec.md
@@ -29,50 +29,50 @@ rejected before any business logic executes.
 #### Scenario: A state-changing call omits the CSRF token
 
 - **GIVEN** a client with a valid session cookie
-- **WHEN** the client issues `PUT /api/v1/alerts/{id}` without a matching `X-CSRF-Token` header
+- **WHEN** the client issues `PUT /api/alerts/{id}` without a matching `X-CSRF-Token` header
 - **THEN** the system responds with HTTP 403 and the alert is not modified
 
 ### Requirement: List enrolled hosts
 
-The system SHALL expose `GET /api/v1/hosts` returning a JSON array of enrolled hosts. Each entry SHALL include the host
+The system SHALL expose `GET /api/hosts` returning a JSON array of enrolled hosts. Each entry SHALL include the host
 identifier, the count of events seen for that host, and the most recent timestamp at which any event from the host was
 observed.
 
 #### Scenario: An operator opens the hosts dashboard
 
 - **GIVEN** a logged-in operator
-- **WHEN** the client calls `GET /api/v1/hosts`
+- **WHEN** the client calls `GET /api/hosts`
 - **THEN** the system responds with HTTP 200 and a JSON array
 - **AND** every entry contains the host identifier, an event count, and a last-seen timestamp
 
 ### Requirement: Per-host process forest
 
-The system SHALL expose `GET /api/v1/hosts/{host_id}/tree` returning the process forest for that host. The response SHALL
+The system SHALL expose `GET /api/hosts/{host_id}/tree` returning the process forest for that host. The response SHALL
 nest each process under its parent and SHALL attach the network connections and DNS queries that occurred during each
 process's lifetime.
 
 #### Scenario: An operator views a host's process tree
 
 - **GIVEN** a logged-in operator and a known host with recorded activity
-- **WHEN** the client calls `GET /api/v1/hosts/{host_id}/tree`
+- **WHEN** the client calls `GET /api/hosts/{host_id}/tree`
 - **THEN** the system responds with HTTP 200 and a JSON object containing the forest of root processes
 - **AND** each process node carries its child processes and the network connections and DNS queries linked to it
 
 #### Scenario: A time range is supplied
 
 - **GIVEN** a logged-in operator
-- **WHEN** the client calls `GET /api/v1/hosts/{host_id}/tree` with optional `from` or `to` nanosecond bounds
+- **WHEN** the client calls `GET /api/hosts/{host_id}/tree` with optional `from` or `to` nanosecond bounds
 - **THEN** the response is restricted to processes whose lifetime overlaps the specified window
 
 ### Requirement: Per-process detail with re-exec chain
 
-The system SHALL expose `GET /api/v1/hosts/{host_id}/processes/{pid}` returning a single process record together with its
+The system SHALL expose `GET /api/hosts/{host_id}/processes/{pid}` returning a single process record together with its
 network connections, DNS queries, and the ordered re-exec chain of prior generations on the same PID.
 
 #### Scenario: An operator inspects a process detail
 
 - **GIVEN** a logged-in operator and a host plus PID with recorded activity
-- **WHEN** the client calls `GET /api/v1/hosts/{host_id}/processes/{pid}`
+- **WHEN** the client calls `GET /api/hosts/{host_id}/processes/{pid}`
 - **THEN** the system responds with HTTP 200 and a JSON object containing the process record, its network connections, and
   its DNS queries
 - **AND** when the process has prior generations on the same PID the response carries those generations in oldest-first
@@ -81,37 +81,37 @@ network connections, DNS queries, and the ordered re-exec chain of prior generat
 #### Scenario: The PID is not known on the host
 
 - **GIVEN** a logged-in operator
-- **WHEN** the client calls `GET /api/v1/hosts/{host_id}/processes/{pid}` for a PID that has no record on that host
+- **WHEN** the client calls `GET /api/hosts/{host_id}/processes/{pid}` for a PID that has no record on that host
 - **THEN** the system responds with HTTP 404 and an error body
 
 ### Requirement: Filterable alerts list
 
-The system SHALL expose `GET /api/v1/alerts` returning a JSON array of detection alerts. The response SHALL be filterable
+The system SHALL expose `GET /api/alerts` returning a JSON array of detection alerts. The response SHALL be filterable
 by host identifier, status, severity, and linked process identifier.
 
 #### Scenario: An operator filters alerts by host
 
 - **GIVEN** a logged-in operator
-- **WHEN** the client calls `GET /api/v1/alerts?host_id=H`
+- **WHEN** the client calls `GET /api/alerts?host_id=H`
 - **THEN** the system responds with HTTP 200 and a JSON array
 - **AND** every entry's host identifier equals `H`
 
 #### Scenario: An operator combines status and severity filters
 
 - **GIVEN** a logged-in operator
-- **WHEN** the client calls `GET /api/v1/alerts?status=open&severity=critical`
+- **WHEN** the client calls `GET /api/alerts?status=open&severity=critical`
 - **THEN** the response includes only alerts whose status is `open` and whose severity is `critical`
 
 ### Requirement: Alert detail with linked event ids
 
-The system SHALL expose `GET /api/v1/alerts/{id}` returning a single alert. The response SHALL include the alert's host
+The system SHALL expose `GET /api/alerts/{id}` returning a single alert. The response SHALL include the alert's host
 identifier, rule identifier, severity, title, description, linked process identifier, MITRE ATT&CK technique identifiers,
 status, and the list of event identifiers that triggered the alert.
 
 #### Scenario: An operator opens an alert
 
 - **GIVEN** a logged-in operator and an existing alert
-- **WHEN** the client calls `GET /api/v1/alerts/{id}`
+- **WHEN** the client calls `GET /api/alerts/{id}`
 - **THEN** the system responds with HTTP 200 and a JSON object
 - **AND** the object includes the rule identifier, severity, title, description, linked process identifier, technique
   identifiers, status, and the list of triggering event identifiers
@@ -119,19 +119,19 @@ status, and the list of event identifiers that triggered the alert.
 #### Scenario: The alert id is unknown
 
 - **GIVEN** a logged-in operator
-- **WHEN** the client calls `GET /api/v1/alerts/{id}` with an identifier that does not exist
+- **WHEN** the client calls `GET /api/alerts/{id}` with an identifier that does not exist
 - **THEN** the system responds with HTTP 404 and an error body
 
 ### Requirement: Update alert lifecycle status
 
-The system SHALL expose `PUT /api/v1/alerts/{id}` accepting a JSON body that sets the alert status to one of `open`,
+The system SHALL expose `PUT /api/alerts/{id}` accepting a JSON body that sets the alert status to one of `open`,
 `acknowledged`, or `resolved`. Any other status value MUST be rejected. On success the system MUST record which
 authenticated user performed the change.
 
 #### Scenario: An operator resolves an alert
 
 - **GIVEN** a logged-in operator and an existing alert
-- **WHEN** the client issues `PUT /api/v1/alerts/{id}` with body `{"status": "resolved"}`
+- **WHEN** the client issues `PUT /api/alerts/{id}` with body `{"status": "resolved"}`
 - **THEN** the system responds with HTTP 204
 - **AND** the alert's stored status becomes `resolved`
 - **AND** the identity of the operator that performed the change is recorded
@@ -139,7 +139,7 @@ authenticated user performed the change.
 #### Scenario: An invalid status value is supplied
 
 - **GIVEN** a logged-in operator
-- **WHEN** the client issues `PUT /api/v1/alerts/{id}` with a status that is not one of `open`, `acknowledged`, or
+- **WHEN** the client issues `PUT /api/alerts/{id}` with a status that is not one of `open`, `acknowledged`, or
   `resolved`
 - **THEN** the system responds with HTTP 400 and the alert is not modified
 

--- a/server/admin/admin.go
+++ b/server/admin/admin.go
@@ -49,7 +49,7 @@ type Cataloger interface {
 // Mirrors detection.RuleMetadata; duplicated here so admin doesn't import
 // detection (which would pull the whole engine into admin's build graph
 // + tests). Doc carries the operator-facing documentation surfaced by
-// GET /api/v1/rules and the markdown generator.
+// GET /api/rules and the markdown generator.
 type RuleMetadata struct {
 	ID         string
 	Techniques []string
@@ -58,7 +58,7 @@ type RuleMetadata struct {
 
 // RuleDoc mirrors detection.Documentation. Same duplication rationale as
 // RuleMetadata above. Field tags match what the UI consumes from
-// GET /api/v1/rules.
+// GET /api/rules.
 type RuleDoc struct {
 	Title          string       `json:"title"`
 	Summary        string       `json:"summary"`
@@ -119,12 +119,12 @@ func New(es *enrollment.Store, ps *policy.Store, ci CommandInserter, catalog Cat
 // session + CSRF middleware (authn.Session, then authn.CSRF) before mounting; see buildMux
 // in cmd/fleet-edr-server/main.go.
 func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
-	mux.HandleFunc("GET /api/v1/enrollments", h.handleList)
-	mux.HandleFunc("POST /api/v1/enrollments/{host_id}/revoke", h.handleRevoke)
-	mux.HandleFunc("GET /api/v1/policy", h.handleGetPolicy)
-	mux.HandleFunc("PUT /api/v1/policy", h.handlePutPolicy)
-	mux.HandleFunc("GET /api/v1/attack-coverage", h.handleATTACKCoverage)
-	mux.HandleFunc("GET /api/v1/rules", h.handleListRules)
+	mux.HandleFunc("GET /api/enrollments", h.handleList)
+	mux.HandleFunc("POST /api/enrollments/{host_id}/revoke", h.handleRevoke)
+	mux.HandleFunc("GET /api/policy", h.handleGetPolicy)
+	mux.HandleFunc("PUT /api/policy", h.handlePutPolicy)
+	mux.HandleFunc("GET /api/attack-coverage", h.handleATTACKCoverage)
+	mux.HandleFunc("GET /api/rules", h.handleListRules)
 }
 
 // handleListRules returns the structured per-rule documentation for every
@@ -248,7 +248,7 @@ func (h *Handler) handleGetPolicy(w http.ResponseWriter, r *http.Request) {
 	writeJSON(ctx, h.logger, w, http.StatusOK, p)
 }
 
-// putPolicyRequest is the body shape accepted by PUT /api/v1/policy. `Actor` +
+// putPolicyRequest is the body shape accepted by PUT /api/policy. `Actor` +
 // `Reason` are required for audit. `Paths` + `Hashes` are optional individually but the
 // effective blocklist must be one of those two forms; a completely empty PUT is still
 // accepted so operators have a fast "clear everything" path.

--- a/server/admin/admin.go
+++ b/server/admin/admin.go
@@ -49,7 +49,7 @@ type Cataloger interface {
 // Mirrors detection.RuleMetadata; duplicated here so admin doesn't import
 // detection (which would pull the whole engine into admin's build graph
 // + tests). Doc carries the operator-facing documentation surfaced by
-// GET /api/v1/admin/rules and the markdown generator.
+// GET /api/v1/rules and the markdown generator.
 type RuleMetadata struct {
 	ID         string
 	Techniques []string
@@ -58,7 +58,7 @@ type RuleMetadata struct {
 
 // RuleDoc mirrors detection.Documentation. Same duplication rationale as
 // RuleMetadata above. Field tags match what the UI consumes from
-// GET /api/v1/admin/rules.
+// GET /api/v1/rules.
 type RuleDoc struct {
 	Title          string       `json:"title"`
 	Summary        string       `json:"summary"`
@@ -89,7 +89,8 @@ type Handler struct {
 }
 
 // New creates an admin handler. The handler does not perform its own auth — wrap it with
-// authn.AdminToken at registration time.
+// the operator-session middleware (authn.Session, then authn.CSRF on unsafe methods) at
+// registration time.
 //
 // Panics if any required dependency is nil: enrollment Store for /enrollments routes,
 // policy Store + CommandInserter for /policy. Fail-fast at construction mirrors the
@@ -118,12 +119,12 @@ func New(es *enrollment.Store, ps *policy.Store, ci CommandInserter, catalog Cat
 // session + CSRF middleware (authn.Session, then authn.CSRF) before mounting; see buildMux
 // in cmd/fleet-edr-server/main.go.
 func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
-	mux.HandleFunc("GET /api/v1/admin/enrollments", h.handleList)
-	mux.HandleFunc("POST /api/v1/admin/enrollments/{host_id}/revoke", h.handleRevoke)
-	mux.HandleFunc("GET /api/v1/admin/policy", h.handleGetPolicy)
-	mux.HandleFunc("PUT /api/v1/admin/policy", h.handlePutPolicy)
-	mux.HandleFunc("GET /api/v1/admin/attack-coverage", h.handleATTACKCoverage)
-	mux.HandleFunc("GET /api/v1/admin/rules", h.handleListRules)
+	mux.HandleFunc("GET /api/v1/enrollments", h.handleList)
+	mux.HandleFunc("POST /api/v1/enrollments/{host_id}/revoke", h.handleRevoke)
+	mux.HandleFunc("GET /api/v1/policy", h.handleGetPolicy)
+	mux.HandleFunc("PUT /api/v1/policy", h.handlePutPolicy)
+	mux.HandleFunc("GET /api/v1/attack-coverage", h.handleATTACKCoverage)
+	mux.HandleFunc("GET /api/v1/rules", h.handleListRules)
 }
 
 // handleListRules returns the structured per-rule documentation for every
@@ -247,7 +248,7 @@ func (h *Handler) handleGetPolicy(w http.ResponseWriter, r *http.Request) {
 	writeJSON(ctx, h.logger, w, http.StatusOK, p)
 }
 
-// putPolicyRequest is the body shape accepted by PUT /api/v1/admin/policy. `Actor` +
+// putPolicyRequest is the body shape accepted by PUT /api/v1/policy. `Actor` +
 // `Reason` are required for audit. `Paths` + `Hashes` are optional individually but the
 // effective blocklist must be one of those two forms; a completely empty PUT is still
 // accepted so operators have a fast "clear everything" path.

--- a/server/admin/admin_test.go
+++ b/server/admin/admin_test.go
@@ -39,7 +39,7 @@ func TestList_ReturnsEnrollmentRows(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+"/api/v1/admin/enrollments", nil)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+"/api/v1/enrollments", nil)
 	require.NoError(t, err)
 	resp, err := srv.Client().Do(req)
 	require.NoError(t, err)
@@ -66,7 +66,7 @@ func TestRevoke_HappyPath(t *testing.T) {
 		"actor":  "jane@customer.com",
 	})
 	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost,
-		srv.URL+"/api/v1/admin/enrollments/"+testUUID+"/revoke", bytes.NewReader(body))
+		srv.URL+"/api/v1/enrollments/"+testUUID+"/revoke", bytes.NewReader(body))
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := srv.Client().Do(req)
@@ -84,7 +84,7 @@ func TestRevoke_NotFound(t *testing.T) {
 	srv, _, _ := newAdminServer(t)
 	body, _ := json.Marshal(map[string]string{"reason": "x", "actor": "y"})
 	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost,
-		srv.URL+"/api/v1/admin/enrollments/AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA/revoke",
+		srv.URL+"/api/v1/enrollments/AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA/revoke",
 		bytes.NewReader(body))
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
@@ -103,7 +103,7 @@ func TestRevoke_MissingBody(t *testing.T) {
 
 	body, _ := json.Marshal(map[string]string{"reason": ""})
 	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost,
-		srv.URL+"/api/v1/admin/enrollments/"+testUUID+"/revoke", bytes.NewReader(body))
+		srv.URL+"/api/v1/enrollments/"+testUUID+"/revoke", bytes.NewReader(body))
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := srv.Client().Do(req)
@@ -114,7 +114,7 @@ func TestRevoke_MissingBody(t *testing.T) {
 
 func TestGetPolicy_SeedRow(t *testing.T) {
 	srv, _, _ := newAdminServer(t)
-	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+"/api/v1/admin/policy", nil)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+"/api/v1/policy", nil)
 	require.NoError(t, err)
 	resp, err := srv.Client().Do(req)
 	require.NoError(t, err)
@@ -146,7 +146,7 @@ func TestPutPolicy_HappyPath(t *testing.T) {
 		"actor":  "qa-tester",
 		"reason": "phase-2 smoke",
 	})
-	req, err := http.NewRequestWithContext(t.Context(), http.MethodPut, srv.URL+"/api/v1/admin/policy", bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPut, srv.URL+"/api/v1/policy", bytes.NewReader(body))
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := srv.Client().Do(req)
@@ -178,7 +178,7 @@ func TestPutPolicy_HappyPath(t *testing.T) {
 func TestPutPolicy_MissingActor(t *testing.T) {
 	srv, _, _ := newAdminServer(t)
 	body, _ := json.Marshal(map[string]any{"paths": []string{"/tmp/x"}})
-	req, err := http.NewRequestWithContext(t.Context(), http.MethodPut, srv.URL+"/api/v1/admin/policy", bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPut, srv.URL+"/api/v1/policy", bytes.NewReader(body))
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := srv.Client().Do(req)
@@ -192,7 +192,7 @@ func TestPutPolicy_EmptyBlocklistAccepted(t *testing.T) {
 	// edit so operators have a fast panic-button.
 	srv, _, _ := newAdminServer(t)
 	body, _ := json.Marshal(map[string]any{"actor": "qa-tester", "reason": "clear"})
-	req, err := http.NewRequestWithContext(t.Context(), http.MethodPut, srv.URL+"/api/v1/admin/policy", bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPut, srv.URL+"/api/v1/policy", bytes.NewReader(body))
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := srv.Client().Do(req)
@@ -211,7 +211,7 @@ func TestPutPolicy_InvalidBlocklistReturns400(t *testing.T) {
 		"actor":  "qa-tester",
 		"reason": "phase-2 negative",
 	})
-	req, err := http.NewRequestWithContext(t.Context(), http.MethodPut, srv.URL+"/api/v1/admin/policy", bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPut, srv.URL+"/api/v1/policy", bytes.NewReader(body))
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := srv.Client().Do(req)
@@ -234,7 +234,7 @@ func TestRevoke_IdempotentPreservesFirstActor(t *testing.T) {
 	revoke := func(actor, reason string) int {
 		body, _ := json.Marshal(map[string]string{"reason": reason, "actor": actor})
 		req, err := http.NewRequestWithContext(t.Context(), http.MethodPost,
-			srv.URL+"/api/v1/admin/enrollments/"+testUUID+"/revoke", bytes.NewReader(body))
+			srv.URL+"/api/v1/enrollments/"+testUUID+"/revoke", bytes.NewReader(body))
 		require.NoError(t, err)
 		resp, err := srv.Client().Do(req)
 		require.NoError(t, err)

--- a/server/admin/admin_test.go
+++ b/server/admin/admin_test.go
@@ -39,7 +39,7 @@ func TestList_ReturnsEnrollmentRows(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+"/api/v1/enrollments", nil)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+"/api/enrollments", nil)
 	require.NoError(t, err)
 	resp, err := srv.Client().Do(req)
 	require.NoError(t, err)
@@ -66,7 +66,7 @@ func TestRevoke_HappyPath(t *testing.T) {
 		"actor":  "jane@customer.com",
 	})
 	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost,
-		srv.URL+"/api/v1/enrollments/"+testUUID+"/revoke", bytes.NewReader(body))
+		srv.URL+"/api/enrollments/"+testUUID+"/revoke", bytes.NewReader(body))
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := srv.Client().Do(req)
@@ -84,7 +84,7 @@ func TestRevoke_NotFound(t *testing.T) {
 	srv, _, _ := newAdminServer(t)
 	body, _ := json.Marshal(map[string]string{"reason": "x", "actor": "y"})
 	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost,
-		srv.URL+"/api/v1/enrollments/AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA/revoke",
+		srv.URL+"/api/enrollments/AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA/revoke",
 		bytes.NewReader(body))
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
@@ -103,7 +103,7 @@ func TestRevoke_MissingBody(t *testing.T) {
 
 	body, _ := json.Marshal(map[string]string{"reason": ""})
 	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost,
-		srv.URL+"/api/v1/enrollments/"+testUUID+"/revoke", bytes.NewReader(body))
+		srv.URL+"/api/enrollments/"+testUUID+"/revoke", bytes.NewReader(body))
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := srv.Client().Do(req)
@@ -114,7 +114,7 @@ func TestRevoke_MissingBody(t *testing.T) {
 
 func TestGetPolicy_SeedRow(t *testing.T) {
 	srv, _, _ := newAdminServer(t)
-	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+"/api/v1/policy", nil)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+"/api/policy", nil)
 	require.NoError(t, err)
 	resp, err := srv.Client().Do(req)
 	require.NoError(t, err)
@@ -146,7 +146,7 @@ func TestPutPolicy_HappyPath(t *testing.T) {
 		"actor":  "qa-tester",
 		"reason": "phase-2 smoke",
 	})
-	req, err := http.NewRequestWithContext(t.Context(), http.MethodPut, srv.URL+"/api/v1/policy", bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPut, srv.URL+"/api/policy", bytes.NewReader(body))
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := srv.Client().Do(req)
@@ -178,7 +178,7 @@ func TestPutPolicy_HappyPath(t *testing.T) {
 func TestPutPolicy_MissingActor(t *testing.T) {
 	srv, _, _ := newAdminServer(t)
 	body, _ := json.Marshal(map[string]any{"paths": []string{"/tmp/x"}})
-	req, err := http.NewRequestWithContext(t.Context(), http.MethodPut, srv.URL+"/api/v1/policy", bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPut, srv.URL+"/api/policy", bytes.NewReader(body))
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := srv.Client().Do(req)
@@ -192,7 +192,7 @@ func TestPutPolicy_EmptyBlocklistAccepted(t *testing.T) {
 	// edit so operators have a fast panic-button.
 	srv, _, _ := newAdminServer(t)
 	body, _ := json.Marshal(map[string]any{"actor": "qa-tester", "reason": "clear"})
-	req, err := http.NewRequestWithContext(t.Context(), http.MethodPut, srv.URL+"/api/v1/policy", bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPut, srv.URL+"/api/policy", bytes.NewReader(body))
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := srv.Client().Do(req)
@@ -211,7 +211,7 @@ func TestPutPolicy_InvalidBlocklistReturns400(t *testing.T) {
 		"actor":  "qa-tester",
 		"reason": "phase-2 negative",
 	})
-	req, err := http.NewRequestWithContext(t.Context(), http.MethodPut, srv.URL+"/api/v1/policy", bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPut, srv.URL+"/api/policy", bytes.NewReader(body))
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := srv.Client().Do(req)
@@ -234,7 +234,7 @@ func TestRevoke_IdempotentPreservesFirstActor(t *testing.T) {
 	revoke := func(actor, reason string) int {
 		body, _ := json.Marshal(map[string]string{"reason": reason, "actor": actor})
 		req, err := http.NewRequestWithContext(t.Context(), http.MethodPost,
-			srv.URL+"/api/v1/enrollments/"+testUUID+"/revoke", bytes.NewReader(body))
+			srv.URL+"/api/enrollments/"+testUUID+"/revoke", bytes.NewReader(body))
 		require.NoError(t, err)
 		resp, err := srv.Client().Do(req)
 		require.NoError(t, err)

--- a/server/admin/attack_coverage_test.go
+++ b/server/admin/attack_coverage_test.go
@@ -39,7 +39,7 @@ func TestHandleATTACKCoverage_EmitsNavigatorLayer(t *testing.T) {
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
 
-	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+"/api/v1/attack-coverage", nil)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+"/api/attack-coverage", nil)
 	require.NoError(t, err)
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
@@ -94,7 +94,7 @@ func TestHandleATTACKCoverage_IsDeterministic(t *testing.T) {
 
 	fetch := func() []byte {
 		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet,
-			srv.URL+"/api/v1/attack-coverage", nil)
+			srv.URL+"/api/attack-coverage", nil)
 		require.NoError(t, err)
 		resp, err := http.DefaultClient.Do(req)
 		require.NoError(t, err)
@@ -121,7 +121,7 @@ func TestHandleATTACKCoverage_EmptyCatalogStillReturnsLayer(t *testing.T) {
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
 
-	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+"/api/v1/attack-coverage", nil)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+"/api/attack-coverage", nil)
 	require.NoError(t, err)
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)

--- a/server/admin/attack_coverage_test.go
+++ b/server/admin/attack_coverage_test.go
@@ -39,7 +39,7 @@ func TestHandleATTACKCoverage_EmitsNavigatorLayer(t *testing.T) {
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
 
-	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+"/api/v1/admin/attack-coverage", nil)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+"/api/v1/attack-coverage", nil)
 	require.NoError(t, err)
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
@@ -94,7 +94,7 @@ func TestHandleATTACKCoverage_IsDeterministic(t *testing.T) {
 
 	fetch := func() []byte {
 		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet,
-			srv.URL+"/api/v1/admin/attack-coverage", nil)
+			srv.URL+"/api/v1/attack-coverage", nil)
 		require.NoError(t, err)
 		resp, err := http.DefaultClient.Do(req)
 		require.NoError(t, err)
@@ -121,7 +121,7 @@ func TestHandleATTACKCoverage_EmptyCatalogStillReturnsLayer(t *testing.T) {
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
 
-	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+"/api/v1/admin/attack-coverage", nil)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+"/api/v1/attack-coverage", nil)
 	require.NoError(t, err)
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)

--- a/server/admin/rules_endpoint_test.go
+++ b/server/admin/rules_endpoint_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/fleetdm/edr/server/store"
 )
 
-// TestHandleListRules_RoundTrips proves the new /api/v1/admin/rules endpoint
+// TestHandleListRules_RoundTrips proves the new /api/v1/rules endpoint
 // renders every field the UI's RuleDetail.tsx consumes, in registration order,
 // without dropping or transforming the documentation payload. Order is
 // load-bearing: the UI uses the catalog order to render the rules index.
@@ -58,7 +58,7 @@ func TestHandleListRules_RoundTrips(t *testing.T) {
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
 
-	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+"/api/v1/admin/rules", nil)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+"/api/v1/rules", nil)
 	require.NoError(t, err)
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
@@ -117,7 +117,7 @@ func TestHandleListRules_NilCatalog(t *testing.T) {
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
 
-	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+"/api/v1/admin/rules", nil)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+"/api/v1/rules", nil)
 	require.NoError(t, err)
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)

--- a/server/admin/rules_endpoint_test.go
+++ b/server/admin/rules_endpoint_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/fleetdm/edr/server/store"
 )
 
-// TestHandleListRules_RoundTrips proves the new /api/v1/rules endpoint
+// TestHandleListRules_RoundTrips proves the new /api/rules endpoint
 // renders every field the UI's RuleDetail.tsx consumes, in registration order,
 // without dropping or transforming the documentation payload. Order is
 // load-bearing: the UI uses the catalog order to render the rules index.
@@ -58,7 +58,7 @@ func TestHandleListRules_RoundTrips(t *testing.T) {
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
 
-	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+"/api/v1/rules", nil)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+"/api/rules", nil)
 	require.NoError(t, err)
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
@@ -117,7 +117,7 @@ func TestHandleListRules_NilCatalog(t *testing.T) {
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
 
-	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+"/api/v1/rules", nil)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+"/api/rules", nil)
 	require.NoError(t, err)
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)

--- a/server/api/alert_api_test.go
+++ b/server/api/alert_api_test.go
@@ -28,7 +28,7 @@ func setupAlertTestHandler(t *testing.T) (http.Handler, *store.Store) {
 func TestListAlertsEmpty(t *testing.T) {
 	mux, _ := setupAlertTestHandler(t)
 
-	req := httptest.NewRequestWithContext(t.Context(), "GET", "/api/v1/alerts", nil)
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "/api/alerts", nil)
 	w := httptest.NewRecorder()
 	mux.ServeHTTP(w, req)
 
@@ -53,7 +53,7 @@ func TestListAlertsWithFilters(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("filter by severity", func(t *testing.T) {
-		req := httptest.NewRequestWithContext(t.Context(), "GET", "/api/v1/alerts?severity=high", nil)
+		req := httptest.NewRequestWithContext(t.Context(), "GET", "/api/alerts?severity=high", nil)
 		w := httptest.NewRecorder()
 		mux.ServeHTTP(w, req)
 		require.Equal(t, http.StatusOK, w.Code)
@@ -64,7 +64,7 @@ func TestListAlertsWithFilters(t *testing.T) {
 	})
 
 	t.Run("filter by severity no match", func(t *testing.T) {
-		req := httptest.NewRequestWithContext(t.Context(), "GET", "/api/v1/alerts?severity=low", nil)
+		req := httptest.NewRequestWithContext(t.Context(), "GET", "/api/alerts?severity=low", nil)
 		w := httptest.NewRecorder()
 		mux.ServeHTTP(w, req)
 		require.Equal(t, http.StatusOK, w.Code)
@@ -91,7 +91,7 @@ func TestGetAlertDetail(t *testing.T) {
 	}, []string{"evt-1"})
 	require.NoError(t, err)
 
-	req := httptest.NewRequestWithContext(t.Context(), "GET", fmt.Sprintf("/api/v1/alerts/%d", alertID), nil)
+	req := httptest.NewRequestWithContext(t.Context(), "GET", fmt.Sprintf("/api/alerts/%d", alertID), nil)
 	w := httptest.NewRecorder()
 	mux.ServeHTTP(w, req)
 
@@ -106,7 +106,7 @@ func TestGetAlertDetail(t *testing.T) {
 func TestGetAlertNotFoundAPI(t *testing.T) {
 	mux, _ := setupAlertTestHandler(t)
 
-	req := httptest.NewRequestWithContext(t.Context(), "GET", "/api/v1/alerts/99999", nil)
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "/api/alerts/99999", nil)
 	w := httptest.NewRecorder()
 	mux.ServeHTTP(w, req)
 
@@ -127,7 +127,7 @@ func TestUpdateAlertStatusAPI(t *testing.T) {
 
 	t.Run("acknowledge", func(t *testing.T) {
 		body := `{"status":"acknowledged"}`
-		req := httptest.NewRequestWithContext(t.Context(), "PUT", fmt.Sprintf("/api/v1/alerts/%d", alertID), strings.NewReader(body))
+		req := httptest.NewRequestWithContext(t.Context(), "PUT", fmt.Sprintf("/api/alerts/%d", alertID), strings.NewReader(body))
 		w := httptest.NewRecorder()
 		mux.ServeHTTP(w, req)
 		assert.Equal(t, http.StatusNoContent, w.Code)
@@ -139,7 +139,7 @@ func TestUpdateAlertStatusAPI(t *testing.T) {
 
 	t.Run("invalid status", func(t *testing.T) {
 		body := `{"status":"deleted"}`
-		req := httptest.NewRequestWithContext(t.Context(), "PUT", fmt.Sprintf("/api/v1/alerts/%d", alertID), strings.NewReader(body))
+		req := httptest.NewRequestWithContext(t.Context(), "PUT", fmt.Sprintf("/api/alerts/%d", alertID), strings.NewReader(body))
 		w := httptest.NewRecorder()
 		mux.ServeHTTP(w, req)
 		assert.Equal(t, http.StatusBadRequest, w.Code)
@@ -147,7 +147,7 @@ func TestUpdateAlertStatusAPI(t *testing.T) {
 
 	t.Run("not found", func(t *testing.T) {
 		body := `{"status":"resolved"}`
-		req := httptest.NewRequestWithContext(t.Context(), "PUT", "/api/v1/alerts/99999", strings.NewReader(body))
+		req := httptest.NewRequestWithContext(t.Context(), "PUT", "/api/alerts/99999", strings.NewReader(body))
 		w := httptest.NewRecorder()
 		mux.ServeHTTP(w, req)
 		assert.Equal(t, http.StatusNotFound, w.Code)
@@ -179,7 +179,7 @@ func TestUpdateAlertStatus_CapturesUserID(t *testing.T) {
 
 	body := `{"status":"resolved"}`
 	req := httptest.NewRequestWithContext(t.Context(), "PUT",
-		fmt.Sprintf("/api/v1/alerts/%d", alertID), strings.NewReader(body))
+		fmt.Sprintf("/api/alerts/%d", alertID), strings.NewReader(body))
 	req = req.WithContext(authn.WithUserIDForTest(req.Context(), 42))
 	w := httptest.NewRecorder()
 	mux.ServeHTTP(w, req)

--- a/server/api/api.go
+++ b/server/api/api.go
@@ -38,8 +38,9 @@ type Handler struct {
 }
 
 // New creates an API handler. Authorization is NOT enforced in this package anymore; callers
-// wrap the returned mux (or this handler's routes) in the authn.AdminToken middleware (or,
-// when Phase 3 lands, a session-cookie middleware) at registration time.
+// wrap the returned mux (or this handler's routes) in the operator-session middleware
+// (authn.Session, then authn.CSRF on unsafe methods) at registration time. See buildMux in
+// cmd/fleet-edr-server/main.go for the actual wiring.
 func New(q *graph.Query, s *store.Store, logger *slog.Logger) *Handler {
 	if logger == nil {
 		logger = slog.Default()

--- a/server/api/api.go
+++ b/server/api/api.go
@@ -50,18 +50,18 @@ func New(q *graph.Query, s *store.Store, logger *slog.Logger) *Handler {
 
 // RegisterRoutes registers the API routes on the given mux.
 func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
-	mux.HandleFunc("GET /api/v1/hosts", h.handleListHosts)
-	mux.HandleFunc("GET /api/v1/hosts/{host_id}/tree", h.handleProcessTree)
-	mux.HandleFunc("GET /api/v1/hosts/{host_id}/processes/{pid}", h.handleProcessDetail)
+	mux.HandleFunc("GET /api/hosts", h.handleListHosts)
+	mux.HandleFunc("GET /api/hosts/{host_id}/tree", h.handleProcessTree)
+	mux.HandleFunc("GET /api/hosts/{host_id}/processes/{pid}", h.handleProcessDetail)
 
-	mux.HandleFunc("GET /api/v1/alerts", h.handleListAlerts)
-	mux.HandleFunc("GET /api/v1/alerts/{id}", h.handleGetAlert)
-	mux.HandleFunc("PUT /api/v1/alerts/{id}", h.handleUpdateAlertStatus)
+	mux.HandleFunc("GET /api/alerts", h.handleListAlerts)
+	mux.HandleFunc("GET /api/alerts/{id}", h.handleGetAlert)
+	mux.HandleFunc("PUT /api/alerts/{id}", h.handleUpdateAlertStatus)
 
-	mux.HandleFunc("GET /api/v1/commands", h.ListCommands)
-	mux.HandleFunc("GET /api/v1/commands/{id}", h.handleGetCommand)
-	mux.HandleFunc("POST /api/v1/commands", h.handleCreateCommand)
-	mux.HandleFunc("PUT /api/v1/commands/{id}", h.UpdateCommandStatus)
+	mux.HandleFunc("GET /api/commands", h.ListCommands)
+	mux.HandleFunc("GET /api/commands/{id}", h.handleGetCommand)
+	mux.HandleFunc("POST /api/commands", h.handleCreateCommand)
+	mux.HandleFunc("PUT /api/commands/{id}", h.UpdateCommandStatus)
 }
 
 func (h *Handler) handleListHosts(w http.ResponseWriter, r *http.Request) {
@@ -267,7 +267,7 @@ func (h *Handler) ListCommands(w http.ResponseWriter, r *http.Request) {
 	// This handler is only wired under the host-token middleware (agents polling their own
 	// queue). The host_id is always the authenticated host's id — any query parameter is
 	// ignored so a valid token for host A cannot read commands queued for host B. Admin UI
-	// command listing (Phase 3) will live under a separate /api/v1/hosts/{host_id}/commands
+	// command listing (Phase 3) will live under a separate /api/hosts/{host_id}/commands
 	// path so the two auth domains cannot collide on a single mux pattern.
 	hostID, ok := authn.HostIDFromContext(ctx)
 	if !ok {

--- a/server/api/api_test.go
+++ b/server/api/api_test.go
@@ -21,7 +21,7 @@ func TestListHostsEmpty(t *testing.T) {
 
 	mux := testMux(h)
 
-	req := httptest.NewRequestWithContext(t.Context(), "GET", "/api/v1/hosts", nil)
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "/api/hosts", nil)
 	w := httptest.NewRecorder()
 	mux.ServeHTTP(w, req)
 
@@ -40,7 +40,7 @@ func TestProcessTreeEmpty(t *testing.T) {
 
 	mux := testMux(h)
 
-	req := httptest.NewRequestWithContext(t.Context(), "GET", "/api/v1/hosts/nonexistent/tree?from=0&to=999999999999999999", nil)
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "/api/hosts/nonexistent/tree?from=0&to=999999999999999999", nil)
 	w := httptest.NewRecorder()
 	mux.ServeHTTP(w, req)
 
@@ -63,7 +63,7 @@ func TestProcessDetailNotFound(t *testing.T) {
 
 	mux := testMux(h)
 
-	req := httptest.NewRequestWithContext(t.Context(), "GET", "/api/v1/hosts/nonexistent/processes/999?at=1000", nil)
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "/api/hosts/nonexistent/processes/999?at=1000", nil)
 	w := httptest.NewRecorder()
 	mux.ServeHTTP(w, req)
 

--- a/server/api/command_api_test.go
+++ b/server/api/command_api_test.go
@@ -30,7 +30,7 @@ func TestCreateCommand(t *testing.T) {
 	ctx := t.Context()
 
 	body := `{"host_id":"host-a","command_type":"kill_process","payload":{"pid":1234,"path":"/tmp/payload"}}`
-	req := httptest.NewRequestWithContext(ctx, "POST", "/api/v1/commands", strings.NewReader(body))
+	req := httptest.NewRequestWithContext(ctx, "POST", "/api/commands", strings.NewReader(body))
 	w := httptest.NewRecorder()
 	mux.ServeHTTP(w, req)
 
@@ -52,7 +52,7 @@ func TestCreateCommandValidation(t *testing.T) {
 
 	t.Run("missing host_id", func(t *testing.T) {
 		body := `{"command_type":"kill_process","payload":{}}`
-		req := httptest.NewRequestWithContext(t.Context(), "POST", "/api/v1/commands", strings.NewReader(body))
+		req := httptest.NewRequestWithContext(t.Context(), "POST", "/api/commands", strings.NewReader(body))
 		w := httptest.NewRecorder()
 		mux.ServeHTTP(w, req)
 		assert.Equal(t, http.StatusBadRequest, w.Code)
@@ -60,7 +60,7 @@ func TestCreateCommandValidation(t *testing.T) {
 
 	t.Run("missing command_type", func(t *testing.T) {
 		body := `{"host_id":"host-a","payload":{}}`
-		req := httptest.NewRequestWithContext(t.Context(), "POST", "/api/v1/commands", strings.NewReader(body))
+		req := httptest.NewRequestWithContext(t.Context(), "POST", "/api/commands", strings.NewReader(body))
 		w := httptest.NewRecorder()
 		mux.ServeHTTP(w, req)
 		assert.Equal(t, http.StatusBadRequest, w.Code)
@@ -79,7 +79,7 @@ func TestListCommandsAPI(t *testing.T) {
 	}
 
 	t.Run("host-scoped listing", func(t *testing.T) {
-		req := withHostA(httptest.NewRequestWithContext(t.Context(), "GET", "/api/v1/commands", nil))
+		req := withHostA(httptest.NewRequestWithContext(t.Context(), "GET", "/api/commands", nil))
 		w := httptest.NewRecorder()
 		mux.ServeHTTP(w, req)
 		require.Equal(t, http.StatusOK, w.Code)
@@ -90,14 +90,14 @@ func TestListCommandsAPI(t *testing.T) {
 	})
 
 	t.Run("missing host context", func(t *testing.T) {
-		req := httptest.NewRequestWithContext(t.Context(), "GET", "/api/v1/commands", nil)
+		req := httptest.NewRequestWithContext(t.Context(), "GET", "/api/commands", nil)
 		w := httptest.NewRecorder()
 		mux.ServeHTTP(w, req)
 		assert.Equal(t, http.StatusUnauthorized, w.Code)
 	})
 
 	t.Run("status filter", func(t *testing.T) {
-		req := withHostA(httptest.NewRequestWithContext(t.Context(), "GET", "/api/v1/commands?status=pending", nil))
+		req := withHostA(httptest.NewRequestWithContext(t.Context(), "GET", "/api/commands?status=pending", nil))
 		w := httptest.NewRecorder()
 		mux.ServeHTTP(w, req)
 		require.Equal(t, http.StatusOK, w.Code)
@@ -121,7 +121,7 @@ func TestUpdateCommandStatusAPI(t *testing.T) {
 
 	t.Run("ack", func(t *testing.T) {
 		body := `{"status":"acked"}`
-		req := withHostA(httptest.NewRequestWithContext(t.Context(), "PUT", fmt.Sprintf("/api/v1/commands/%d", id), strings.NewReader(body)))
+		req := withHostA(httptest.NewRequestWithContext(t.Context(), "PUT", fmt.Sprintf("/api/commands/%d", id), strings.NewReader(body)))
 		w := httptest.NewRecorder()
 		mux.ServeHTTP(w, req)
 		assert.Equal(t, http.StatusNoContent, w.Code)
@@ -133,7 +133,7 @@ func TestUpdateCommandStatusAPI(t *testing.T) {
 
 	t.Run("complete with result", func(t *testing.T) {
 		body := `{"status":"completed","result":{"killed":true}}`
-		req := withHostA(httptest.NewRequestWithContext(t.Context(), "PUT", fmt.Sprintf("/api/v1/commands/%d", id), strings.NewReader(body)))
+		req := withHostA(httptest.NewRequestWithContext(t.Context(), "PUT", fmt.Sprintf("/api/commands/%d", id), strings.NewReader(body)))
 		w := httptest.NewRecorder()
 		mux.ServeHTTP(w, req)
 		assert.Equal(t, http.StatusNoContent, w.Code)
@@ -146,7 +146,7 @@ func TestUpdateCommandStatusAPI(t *testing.T) {
 
 	t.Run("invalid status", func(t *testing.T) {
 		body := `{"status":"pending"}`
-		req := withHostA(httptest.NewRequestWithContext(t.Context(), "PUT", fmt.Sprintf("/api/v1/commands/%d", id), strings.NewReader(body)))
+		req := withHostA(httptest.NewRequestWithContext(t.Context(), "PUT", fmt.Sprintf("/api/commands/%d", id), strings.NewReader(body)))
 		w := httptest.NewRecorder()
 		mux.ServeHTTP(w, req)
 		assert.Equal(t, http.StatusBadRequest, w.Code)
@@ -154,7 +154,7 @@ func TestUpdateCommandStatusAPI(t *testing.T) {
 
 	t.Run("not found", func(t *testing.T) {
 		body := `{"status":"acked"}`
-		req := withHostA(httptest.NewRequestWithContext(t.Context(), "PUT", "/api/v1/commands/99999", strings.NewReader(body)))
+		req := withHostA(httptest.NewRequestWithContext(t.Context(), "PUT", "/api/commands/99999", strings.NewReader(body)))
 		w := httptest.NewRecorder()
 		mux.ServeHTTP(w, req)
 		assert.Equal(t, http.StatusNotFound, w.Code)
@@ -162,7 +162,7 @@ func TestUpdateCommandStatusAPI(t *testing.T) {
 
 	t.Run("missing host context", func(t *testing.T) {
 		body := `{"status":"acked"}`
-		req := httptest.NewRequestWithContext(t.Context(), "PUT", fmt.Sprintf("/api/v1/commands/%d", id), strings.NewReader(body))
+		req := httptest.NewRequestWithContext(t.Context(), "PUT", fmt.Sprintf("/api/commands/%d", id), strings.NewReader(body))
 		w := httptest.NewRecorder()
 		mux.ServeHTTP(w, req)
 		assert.Equal(t, http.StatusUnauthorized, w.Code)
@@ -171,7 +171,7 @@ func TestUpdateCommandStatusAPI(t *testing.T) {
 
 // TestHostScopedCommandAccess exercises the host-token path: an agent authenticated as host A
 // must only see + modify its own commands, even if it passes another host's id in the query.
-// This is the regression test for the Phase 1 QA bug where GET /api/v1/commands was registered
+// This is the regression test for the Phase 1 QA bug where GET /api/commands was registered
 // under admin auth, locking out the commander entirely.
 func TestHostScopedCommandAccess(t *testing.T) {
 	mux, s := setupCommandTestHandler(t)
@@ -190,7 +190,7 @@ func TestHostScopedCommandAccess(t *testing.T) {
 	}
 
 	t.Run("GET scoped to authenticated host", func(t *testing.T) {
-		req := withHostA(httptest.NewRequestWithContext(t.Context(), "GET", "/api/v1/commands", nil))
+		req := withHostA(httptest.NewRequestWithContext(t.Context(), "GET", "/api/commands", nil))
 		w := httptest.NewRecorder()
 		mux.ServeHTTP(w, req)
 		require.Equal(t, http.StatusOK, w.Code)
@@ -202,7 +202,7 @@ func TestHostScopedCommandAccess(t *testing.T) {
 	})
 
 	t.Run("GET ignores host_id query when host-token authed", func(t *testing.T) {
-		req := withHostA(httptest.NewRequestWithContext(t.Context(), "GET", "/api/v1/commands?host_id="+hostB, nil))
+		req := withHostA(httptest.NewRequestWithContext(t.Context(), "GET", "/api/commands?host_id="+hostB, nil))
 		w := httptest.NewRecorder()
 		mux.ServeHTTP(w, req)
 		require.Equal(t, http.StatusOK, w.Code)
@@ -215,7 +215,7 @@ func TestHostScopedCommandAccess(t *testing.T) {
 
 	t.Run("PUT on foreign command returns 404", func(t *testing.T) {
 		body := `{"status":"acked"}`
-		req := withHostA(httptest.NewRequestWithContext(t.Context(), "PUT", fmt.Sprintf("/api/v1/commands/%d", cmdB), strings.NewReader(body)))
+		req := withHostA(httptest.NewRequestWithContext(t.Context(), "PUT", fmt.Sprintf("/api/commands/%d", cmdB), strings.NewReader(body)))
 		w := httptest.NewRecorder()
 		mux.ServeHTTP(w, req)
 		assert.Equal(t, http.StatusNotFound, w.Code)
@@ -228,7 +228,7 @@ func TestHostScopedCommandAccess(t *testing.T) {
 
 	t.Run("PUT on own command succeeds", func(t *testing.T) {
 		body := `{"status":"completed","result":{"ok":true}}`
-		req := withHostA(httptest.NewRequestWithContext(t.Context(), "PUT", fmt.Sprintf("/api/v1/commands/%d", cmdA), strings.NewReader(body)))
+		req := withHostA(httptest.NewRequestWithContext(t.Context(), "PUT", fmt.Sprintf("/api/commands/%d", cmdA), strings.NewReader(body)))
 		w := httptest.NewRecorder()
 		mux.ServeHTTP(w, req)
 		assert.Equal(t, http.StatusNoContent, w.Code)

--- a/server/api/docs/embed/openapi.yaml
+++ b/server/api/docs/embed/openapi.yaml
@@ -6,8 +6,8 @@ info:
     HTTP API for Fleet EDR. Three audience tiers:
 
     - **Agents** (macOS endpoints) authenticate with a per-host bearer
-      token obtained at enrollment. They call `POST /api/v1/enroll`,
-      `POST /api/v1/events`, and the host-scoped `/commands` endpoints.
+      token obtained at enrollment. They call `POST /api/enroll`,
+      `POST /api/events`, and the host-scoped `/commands` endpoints.
     - **Browsers** (admin UI) authenticate with an `edr_session` cookie
       (HttpOnly, Secure, SameSite=Lax) plus an `X-CSRF-Token` header on
       unsafe methods. They call the session-protected endpoints.
@@ -96,7 +96,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/ReadinessResponse"
 
-  /api/v1/enroll:
+  /api/enroll:
     post:
       tags: [Agent]
       summary: Enroll a new host
@@ -149,7 +149,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
 
-  /api/v1/events:
+  /api/events:
     post:
       tags: [Agent]
       summary: Ingest a batch of endpoint security events
@@ -180,7 +180,7 @@ paths:
         "401":
           description: Missing or invalid host token
 
-  /api/v1/session:
+  /api/session:
     post:
       tags: [Session]
       summary: Log in with email + password
@@ -247,7 +247,7 @@ paths:
         "204":
           description: Logged out
 
-  /api/v1/hosts:
+  /api/hosts:
     get:
       tags: [Hosts]
       summary: List hosts
@@ -263,7 +263,7 @@ paths:
                 items:
                   $ref: "#/components/schemas/HostSummary"
 
-  /api/v1/hosts/{host_id}/tree:
+  /api/hosts/{host_id}/tree:
     get:
       tags: [Hosts]
       summary: Process tree for a host
@@ -295,7 +295,7 @@ paths:
                     items:
                       $ref: "#/components/schemas/ProcessNode"
 
-  /api/v1/hosts/{host_id}/processes/{pid}:
+  /api/hosts/{host_id}/processes/{pid}:
     get:
       tags: [Hosts]
       summary: Process detail
@@ -321,7 +321,7 @@ paths:
         "404":
           description: No process found at the given coordinates
 
-  /api/v1/alerts:
+  /api/alerts:
     get:
       tags: [Alerts]
       summary: List alerts
@@ -357,7 +357,7 @@ paths:
                 items:
                   $ref: "#/components/schemas/Alert"
 
-  /api/v1/alerts/{id}:
+  /api/alerts/{id}:
     get:
       tags: [Alerts]
       summary: Alert detail (with event IDs)
@@ -407,7 +407,7 @@ paths:
         "404":
           description: Alert not found
 
-  /api/v1/commands:
+  /api/commands:
     get:
       tags: [Commands]
       summary: List commands for the authenticated host
@@ -459,7 +459,7 @@ paths:
                 properties:
                   id: {type: integer, format: int64}
 
-  /api/v1/commands/{id}:
+  /api/commands/{id}:
     get:
       tags: [Commands]
       summary: Get a single command (admin)
@@ -516,7 +516,7 @@ paths:
         "404":
           description: Command not found (or not owned by authenticated host)
 
-  /api/v1/enrollments:
+  /api/enrollments:
     get:
       tags: [Admin]
       summary: List enrollments
@@ -532,7 +532,7 @@ paths:
                 items:
                   $ref: "#/components/schemas/Enrollment"
 
-  /api/v1/enrollments/{host_id}/revoke:
+  /api/enrollments/{host_id}/revoke:
     post:
       tags: [Admin]
       summary: Revoke a host enrollment
@@ -561,7 +561,7 @@ paths:
         "404":
           description: Host not found
 
-  /api/v1/policy:
+  /api/policy:
     get:
       tags: [Admin]
       summary: Current blocklist policy
@@ -608,7 +608,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/PolicyUpdateResult"
 
-  /api/v1/attack-coverage:
+  /api/attack-coverage:
     get:
       tags: [Admin]
       summary: MITRE ATT&CK coverage (Navigator layer)
@@ -637,14 +637,14 @@ components:
       scheme: bearer
       bearerFormat: opaque
       description: |
-        Per-host bearer token issued by `POST /api/v1/enroll`. Pass as
+        Per-host bearer token issued by `POST /api/enroll`. Pass as
         `Authorization: Bearer <host_token>`.
     SessionCookie:
       type: apiKey
       in: cookie
       name: edr_session
       description: |
-        HttpOnly cookie set by `POST /api/v1/session`. The browser
+        HttpOnly cookie set by `POST /api/session`. The browser
         attaches it automatically.
     CSRF:
       type: apiKey

--- a/server/api/docs/embed/openapi.yaml
+++ b/server/api/docs/embed/openapi.yaml
@@ -7,7 +7,8 @@ info:
 
     - **Agents** (macOS endpoints) authenticate with a per-host bearer
       token obtained at enrollment. They call `POST /api/enroll`,
-      `POST /api/events`, and the host-scoped `/commands` endpoints.
+      `POST /api/events`, and the host-scoped `GET /api/commands` and
+      `PUT /api/commands/{id}` endpoints.
     - **Browsers** (admin UI) authenticate with an `edr_session` cookie
       (HttpOnly, Secure, SameSite=Lax) plus an `X-CSRF-Token` header on
       unsafe methods. They call the session-protected endpoints.

--- a/server/api/docs/embed/openapi.yaml
+++ b/server/api/docs/embed/openapi.yaml
@@ -516,7 +516,7 @@ paths:
         "404":
           description: Command not found (or not owned by authenticated host)
 
-  /api/v1/admin/enrollments:
+  /api/v1/enrollments:
     get:
       tags: [Admin]
       summary: List enrollments
@@ -532,7 +532,7 @@ paths:
                 items:
                   $ref: "#/components/schemas/Enrollment"
 
-  /api/v1/admin/enrollments/{host_id}/revoke:
+  /api/v1/enrollments/{host_id}/revoke:
     post:
       tags: [Admin]
       summary: Revoke a host enrollment
@@ -561,7 +561,7 @@ paths:
         "404":
           description: Host not found
 
-  /api/v1/admin/policy:
+  /api/v1/policy:
     get:
       tags: [Admin]
       summary: Current blocklist policy
@@ -608,7 +608,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/PolicyUpdateResult"
 
-  /api/v1/admin/attack-coverage:
+  /api/v1/attack-coverage:
     get:
       tags: [Admin]
       summary: MITRE ATT&CK coverage (Navigator layer)

--- a/server/authn/authn.go
+++ b/server/authn/authn.go
@@ -218,7 +218,7 @@ func Session(store *sessions.Store, logger *slog.Logger) func(http.Handler) http
 // Wire it INSIDE Session so Session runs first (outer middleware runs on the way in)
 // and pins the session on ctx before CSRF reads it:
 //
-//	mux.Handle("PUT /api/v1/alerts/{id}", Session(store, logger)(CSRF(logger)(h)))
+//	mux.Handle("PUT /api/alerts/{id}", Session(store, logger)(CSRF(logger)(h)))
 //
 // Safe methods (GET/HEAD/OPTIONS) pass through without any CSRF check. Callers that
 // expose a non-idempotent GET would be making a mistake regardless of auth.

--- a/server/cmd/fleet-edr-ingest/main.go
+++ b/server/cmd/fleet-edr-ingest/main.go
@@ -72,7 +72,7 @@ func run() error {
 	mux := http.NewServeMux()
 	h.RegisterHealthRoutes(mux)
 	enrollHandler.RegisterRoutes(mux)
-	mux.Handle("POST /api/v1/events", hostTokenMW(h.IngestHandler()))
+	mux.Handle("POST /api/events", hostTokenMW(h.IngestHandler()))
 
 	handler := httpserver.Build(mux, httpserver.Options{
 		Logger:      logger,

--- a/server/cmd/fleet-edr-server/main.go
+++ b/server/cmd/fleet-edr-server/main.go
@@ -333,10 +333,10 @@ func registerSessionRoutes(mux *http.ServeMux, d muxDeps) {
 		"GET /api/v1/hosts", "GET /api/v1/hosts/{host_id}/tree", "GET /api/v1/hosts/{host_id}/processes/{pid}",
 		"GET /api/v1/alerts", "GET /api/v1/alerts/{id}", "PUT /api/v1/alerts/{id}",
 		"GET /api/v1/commands/{id}", "POST /api/v1/commands",
-		"GET /api/v1/admin/enrollments", "POST /api/v1/admin/enrollments/{host_id}/revoke",
-		"GET /api/v1/admin/policy", "PUT /api/v1/admin/policy",
-		"GET /api/v1/admin/attack-coverage",
-		"GET /api/v1/admin/rules",
+		"GET /api/v1/enrollments", "POST /api/v1/enrollments/{host_id}/revoke",
+		"GET /api/v1/policy", "PUT /api/v1/policy",
+		"GET /api/v1/attack-coverage",
+		"GET /api/v1/rules",
 		"GET /api/v1/session",
 	} {
 		mux.Handle(p, sessionProtected)

--- a/server/cmd/fleet-edr-server/main.go
+++ b/server/cmd/fleet-edr-server/main.go
@@ -270,11 +270,11 @@ type muxDeps struct {
 }
 
 // buildMux composes the HTTP surface out of three authorization domains:
-//   - public:  /livez, /readyz, /health, POST /api/v1/enroll, POST /api/v1/session
-//   - host:    POST /api/v1/events, GET /api/v1/commands, PUT /api/v1/commands/{id}
+//   - public:  /livez, /readyz, /health, POST /api/enroll, POST /api/session
+//   - host:    POST /api/events, GET /api/commands, PUT /api/commands/{id}
 //     (wrapped in authn.HostToken — the agent polls for + reports on its own commands)
-//   - session: everything under /api/v1/{hosts,alerts,admin}, POST /api/v1/commands,
-//     GET /api/v1/commands/{id}, GET/DELETE /api/v1/session (wrapped in authn.Session;
+//   - session: everything under /api/{hosts,alerts,admin}, POST /api/commands,
+//     GET /api/commands/{id}, GET/DELETE /api/session (wrapped in authn.Session;
 //     unsafe methods additionally gated by authn.CSRF)
 //
 // Middleware is applied per-handler at registration time so one mux serves the whole
@@ -283,7 +283,7 @@ func buildMux(d muxDeps) *http.ServeMux {
 	mux := http.NewServeMux()
 	d.ingestHandler.RegisterHealthRoutes(mux)
 	d.enrollHandler.RegisterRoutes(mux)
-	// POST /api/v1/session is public — there is no session yet. The session handler
+	// POST /api/session is public — there is no session yet. The session handler
 	// does its own rate-limit + audit log so it does not need a wrapper.
 	d.sessionHandler.RegisterPublicRoutes(mux)
 	// Self-hosted Redoc at /api/docs (the matching spec at /api/openapi.yaml).
@@ -302,14 +302,14 @@ func buildMux(d muxDeps) *http.ServeMux {
 func registerHostRoutes(mux *http.ServeMux, d muxDeps) {
 	hostTokenMW := authn.HostToken(d.enrollStore, d.logger)
 	hostMux := http.NewServeMux()
-	hostMux.Handle("POST /api/v1/events", d.ingestHandler.IngestHandler())
-	hostMux.HandleFunc("GET /api/v1/commands", d.apiHandler.ListCommands)
-	hostMux.HandleFunc("PUT /api/v1/commands/{id}", d.apiHandler.UpdateCommandStatus)
+	hostMux.Handle("POST /api/events", d.ingestHandler.IngestHandler())
+	hostMux.HandleFunc("GET /api/commands", d.apiHandler.ListCommands)
+	hostMux.HandleFunc("PUT /api/commands/{id}", d.apiHandler.UpdateCommandStatus)
 	hostProtected := hostTokenMW(hostMux)
 	for _, p := range []string{
-		"POST /api/v1/events",
-		"GET /api/v1/commands",
-		"PUT /api/v1/commands/{id}",
+		"POST /api/events",
+		"GET /api/commands",
+		"PUT /api/commands/{id}",
 	} {
 		mux.Handle(p, hostProtected)
 	}
@@ -320,7 +320,7 @@ func registerHostRoutes(mux *http.ServeMux, d muxDeps) {
 // agent-facing command protocol. Admin UI command management (POST, GET /{id}) goes
 // here. Session first (reads cookie, pins user + session on ctx), CSRF second (reads
 // session off ctx, validates X-CSRF-Token on unsafe methods). GET + DELETE
-// /api/v1/session live under the same stack; login POST is public.
+// /api/session live under the same stack; login POST is public.
 func registerSessionRoutes(mux *http.ServeMux, d muxDeps) {
 	sessionMW := authn.Session(d.sessionStore, d.logger)
 	csrfMW := authn.CSRF(d.logger)
@@ -330,14 +330,14 @@ func registerSessionRoutes(mux *http.ServeMux, d muxDeps) {
 	d.sessionHandler.RegisterAuthedRoutes(apiMux)
 	sessionProtected := sessionMW(csrfMW(apiMux))
 	for _, p := range []string{
-		"GET /api/v1/hosts", "GET /api/v1/hosts/{host_id}/tree", "GET /api/v1/hosts/{host_id}/processes/{pid}",
-		"GET /api/v1/alerts", "GET /api/v1/alerts/{id}", "PUT /api/v1/alerts/{id}",
-		"GET /api/v1/commands/{id}", "POST /api/v1/commands",
-		"GET /api/v1/enrollments", "POST /api/v1/enrollments/{host_id}/revoke",
-		"GET /api/v1/policy", "PUT /api/v1/policy",
-		"GET /api/v1/attack-coverage",
-		"GET /api/v1/rules",
-		"GET /api/v1/session",
+		"GET /api/hosts", "GET /api/hosts/{host_id}/tree", "GET /api/hosts/{host_id}/processes/{pid}",
+		"GET /api/alerts", "GET /api/alerts/{id}", "PUT /api/alerts/{id}",
+		"GET /api/commands/{id}", "POST /api/commands",
+		"GET /api/enrollments", "POST /api/enrollments/{host_id}/revoke",
+		"GET /api/policy", "PUT /api/policy",
+		"GET /api/attack-coverage",
+		"GET /api/rules",
+		"GET /api/session",
 	} {
 		mux.Handle(p, sessionProtected)
 	}
@@ -345,11 +345,11 @@ func registerSessionRoutes(mux *http.ServeMux, d muxDeps) {
 
 // registerUIRoutes serves the embedded React UI at /ui/ and redirects / to /ui/. The bundle
 // itself is intentionally unauthenticated: the React app's Login screen is what collects the
-// email + password via POST /api/v1/session. The server replies with a HttpOnly session
+// email + password via POST /api/session. The server replies with a HttpOnly session
 // cookie and a CSRF token the JS stores in memory. Every subsequent state-changing call
 // carries both the cookie (automatic, HttpOnly) and an X-CSRF-Token header. Gating /ui/
 // itself behind the Session middleware would make the login page unreachable (chicken/egg).
-// The privileged surface is /api/v1/*, which IS session-gated.
+// The privileged surface is /api/*, which IS session-gated.
 func registerUIRoutes(mux *http.ServeMux, logger *slog.Logger) {
 	uiDist, err := fs.Sub(ui.DistFS, "dist")
 	if err != nil {

--- a/server/cmd/fleet-edr-server/main.go
+++ b/server/cmd/fleet-edr-server/main.go
@@ -270,12 +270,16 @@ type muxDeps struct {
 }
 
 // buildMux composes the HTTP surface out of three authorization domains:
-//   - public:  /livez, /readyz, /health, POST /api/enroll, POST /api/session
+//   - public:  /livez, /readyz, /health, POST /api/enroll, POST /api/session,
+//     DELETE /api/session (logout is best-effort and idempotent;
+//     tolerating an unknown session avoids forcing a session probe
+//     before a logout request)
 //   - host:    POST /api/events, GET /api/commands, PUT /api/commands/{id}
 //     (wrapped in authn.HostToken — the agent polls for + reports on its own commands)
-//   - session: everything under /api/{hosts,alerts,admin}, POST /api/commands,
-//     GET /api/commands/{id}, GET/DELETE /api/session (wrapped in authn.Session;
-//     unsafe methods additionally gated by authn.CSRF)
+//   - session: /api/hosts/**, /api/alerts/**, /api/enrollments/**, /api/policy,
+//     /api/attack-coverage, /api/rules, POST /api/commands, GET /api/commands/{id},
+//     GET /api/session (wrapped in authn.Session; unsafe methods additionally
+//     gated by authn.CSRF)
 //
 // Middleware is applied per-handler at registration time so one mux serves the whole
 // surface instead of chaining multiple servers.
@@ -349,7 +353,10 @@ func registerSessionRoutes(mux *http.ServeMux, d muxDeps) {
 // cookie and a CSRF token the JS stores in memory. Every subsequent state-changing call
 // carries both the cookie (automatic, HttpOnly) and an X-CSRF-Token header. Gating /ui/
 // itself behind the Session middleware would make the login page unreachable (chicken/egg).
-// The privileged surface is /api/*, which IS session-gated.
+// The operator surface (everything under /api/* except the agent's host-token
+// endpoints and the public enroll/session pair) IS session-gated; the public
+// agent and login endpoints sit alongside under /api/* but use their own
+// auth.
 func registerUIRoutes(mux *http.ServeMux, logger *slog.Logger) {
 	uiDist, err := fs.Sub(ui.DistFS, "dist")
 	if err != nil {

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -128,7 +128,7 @@ func loadFrom(getenv func(string) string) (*Config, error) {
 	optionalStr(&c.ListenAddr, "EDR_LISTEN_ADDR", getenv)
 	requireStr(&c.EnrollSecret, "EDR_ENROLL_SECRET", getenv, &errs, true)
 	// Phase 3 removed EDR_ADMIN_TOKEN. UI + admin surfaces now authenticate via the
-	// session cookie minted by POST /api/v1/session. The first-boot seeder prints the
+	// session cookie minted by POST /api/session. The first-boot seeder prints the
 	// admin password once so the operator can log in.
 	optionalStr(&c.TLSCertFile, "EDR_TLS_CERT_FILE", getenv)
 	optionalStr(&c.TLSKeyFile, "EDR_TLS_KEY_FILE", getenv)

--- a/server/detection/rule.go
+++ b/server/detection/rule.go
@@ -52,7 +52,7 @@ type Rule interface {
 }
 
 // Documentation is the structured per-rule descriptor consumed by the markdown
-// generator, the /api/v1/rules endpoint, and the UI's rule detail page.
+// generator, the /api/rules endpoint, and the UI's rule detail page.
 // Single source of truth — the markdown file in docs/ is generated from this,
 // so behaviour and documentation cannot drift.
 type Documentation struct {

--- a/server/detection/rule.go
+++ b/server/detection/rule.go
@@ -52,7 +52,7 @@ type Rule interface {
 }
 
 // Documentation is the structured per-rule descriptor consumed by the markdown
-// generator, the /api/v1/admin/rules endpoint, and the UI's rule detail page.
+// generator, the /api/v1/rules endpoint, and the UI's rule detail page.
 // Single source of truth — the markdown file in docs/ is generated from this,
 // so behaviour and documentation cannot drift.
 type Documentation struct {

--- a/server/detection/rules/credential_keychain_dump.go
+++ b/server/detection/rules/credential_keychain_dump.go
@@ -37,7 +37,7 @@ func (r *CredentialKeychainDump) ID() string { return "credential_keychain_dump"
 // and MITRE explicitly cites it on the technique page.
 func (r *CredentialKeychainDump) Techniques() []string { return []string{"T1555.001"} }
 
-// Doc surfaces the operator-facing description in /api/v1/admin/rules and
+// Doc surfaces the operator-facing description in /api/v1/rules and
 // the generated docs/detection-rules.md.
 func (r *CredentialKeychainDump) Doc() detection.Documentation {
 	return detection.Documentation{

--- a/server/detection/rules/credential_keychain_dump.go
+++ b/server/detection/rules/credential_keychain_dump.go
@@ -37,7 +37,7 @@ func (r *CredentialKeychainDump) ID() string { return "credential_keychain_dump"
 // and MITRE explicitly cites it on the technique page.
 func (r *CredentialKeychainDump) Techniques() []string { return []string{"T1555.001"} }
 
-// Doc surfaces the operator-facing description in /api/v1/rules and
+// Doc surfaces the operator-facing description in /api/rules and
 // the generated docs/detection-rules.md.
 func (r *CredentialKeychainDump) Doc() detection.Documentation {
 	return detection.Documentation{

--- a/server/detection/rules/dyld_insert.go
+++ b/server/detection/rules/dyld_insert.go
@@ -31,7 +31,7 @@ func (r *DyldInsert) ID() string { return "dyld_insert" }
 // broader "Hijack Execution Flow" parent.
 func (r *DyldInsert) Techniques() []string { return []string{"T1574.006"} }
 
-// Doc surfaces the operator-facing description in /api/v1/admin/rules and
+// Doc surfaces the operator-facing description in /api/v1/rules and
 // the generated docs/detection-rules.md.
 func (r *DyldInsert) Doc() detection.Documentation {
 	return detection.Documentation{

--- a/server/detection/rules/dyld_insert.go
+++ b/server/detection/rules/dyld_insert.go
@@ -31,7 +31,7 @@ func (r *DyldInsert) ID() string { return "dyld_insert" }
 // broader "Hijack Execution Flow" parent.
 func (r *DyldInsert) Techniques() []string { return []string{"T1574.006"} }
 
-// Doc surfaces the operator-facing description in /api/v1/rules and
+// Doc surfaces the operator-facing description in /api/rules and
 // the generated docs/detection-rules.md.
 func (r *DyldInsert) Doc() detection.Documentation {
 	return detection.Documentation{

--- a/server/detection/rules/osascript_network_exec.go
+++ b/server/detection/rules/osascript_network_exec.go
@@ -45,7 +45,7 @@ func (r *OsascriptNetworkExec) Techniques() []string {
 	return []string{"T1059.002", "T1105"}
 }
 
-// Doc surfaces the operator-facing description in /api/v1/rules and
+// Doc surfaces the operator-facing description in /api/rules and
 // the generated docs/detection-rules.md.
 func (r *OsascriptNetworkExec) Doc() detection.Documentation {
 	return detection.Documentation{

--- a/server/detection/rules/osascript_network_exec.go
+++ b/server/detection/rules/osascript_network_exec.go
@@ -45,7 +45,7 @@ func (r *OsascriptNetworkExec) Techniques() []string {
 	return []string{"T1059.002", "T1105"}
 }
 
-// Doc surfaces the operator-facing description in /api/v1/admin/rules and
+// Doc surfaces the operator-facing description in /api/v1/rules and
 // the generated docs/detection-rules.md.
 func (r *OsascriptNetworkExec) Doc() detection.Documentation {
 	return detection.Documentation{

--- a/server/detection/rules/persistence_launchagent.go
+++ b/server/detection/rules/persistence_launchagent.go
@@ -31,7 +31,7 @@ func (r *PersistenceLaunchAgent) ID() string { return "persistence_launchagent" 
 // sub-technique's scope.
 func (r *PersistenceLaunchAgent) Techniques() []string { return []string{"T1543.001"} }
 
-// Doc surfaces the operator-facing description in /api/v1/admin/rules and
+// Doc surfaces the operator-facing description in /api/v1/rules and
 // the generated docs/detection-rules.md.
 func (r *PersistenceLaunchAgent) Doc() detection.Documentation {
 	return detection.Documentation{

--- a/server/detection/rules/persistence_launchagent.go
+++ b/server/detection/rules/persistence_launchagent.go
@@ -31,7 +31,7 @@ func (r *PersistenceLaunchAgent) ID() string { return "persistence_launchagent" 
 // sub-technique's scope.
 func (r *PersistenceLaunchAgent) Techniques() []string { return []string{"T1543.001"} }
 
-// Doc surfaces the operator-facing description in /api/v1/rules and
+// Doc surfaces the operator-facing description in /api/rules and
 // the generated docs/detection-rules.md.
 func (r *PersistenceLaunchAgent) Doc() detection.Documentation {
 	return detection.Documentation{

--- a/server/detection/rules/privilege_launchd_plist_write.go
+++ b/server/detection/rules/privilege_launchd_plist_write.go
@@ -50,7 +50,7 @@ func (r *PrivilegeLaunchdPlistWrite) ID() string { return "privilege_launchd_pli
 // (Boot or Logon Autostart Execution → Launch Daemon).
 func (r *PrivilegeLaunchdPlistWrite) Techniques() []string { return []string{"T1543.004"} }
 
-// Doc surfaces the operator-facing description in /api/v1/admin/rules and
+// Doc surfaces the operator-facing description in /api/v1/rules and
 // the generated docs/detection-rules.md.
 func (r *PrivilegeLaunchdPlistWrite) Doc() detection.Documentation {
 	return detection.Documentation{

--- a/server/detection/rules/privilege_launchd_plist_write.go
+++ b/server/detection/rules/privilege_launchd_plist_write.go
@@ -50,7 +50,7 @@ func (r *PrivilegeLaunchdPlistWrite) ID() string { return "privilege_launchd_pli
 // (Boot or Logon Autostart Execution → Launch Daemon).
 func (r *PrivilegeLaunchdPlistWrite) Techniques() []string { return []string{"T1543.004"} }
 
-// Doc surfaces the operator-facing description in /api/v1/rules and
+// Doc surfaces the operator-facing description in /api/rules and
 // the generated docs/detection-rules.md.
 func (r *PrivilegeLaunchdPlistWrite) Doc() detection.Documentation {
 	return detection.Documentation{

--- a/server/detection/rules/shell_from_office.go
+++ b/server/detection/rules/shell_from_office.go
@@ -26,7 +26,7 @@ func (r *ShellFromOffice) ID() string { return "shell_from_office" }
 // post-phish execution step.
 func (r *ShellFromOffice) Techniques() []string { return []string{"T1566.001", "T1059.004"} }
 
-// Doc surfaces the operator-facing description in /api/v1/rules and
+// Doc surfaces the operator-facing description in /api/rules and
 // the generated docs/detection-rules.md.
 func (r *ShellFromOffice) Doc() detection.Documentation {
 	return detection.Documentation{

--- a/server/detection/rules/shell_from_office.go
+++ b/server/detection/rules/shell_from_office.go
@@ -26,7 +26,7 @@ func (r *ShellFromOffice) ID() string { return "shell_from_office" }
 // post-phish execution step.
 func (r *ShellFromOffice) Techniques() []string { return []string{"T1566.001", "T1059.004"} }
 
-// Doc surfaces the operator-facing description in /api/v1/admin/rules and
+// Doc surfaces the operator-facing description in /api/v1/rules and
 // the generated docs/detection-rules.md.
 func (r *ShellFromOffice) Doc() detection.Documentation {
 	return detection.Documentation{

--- a/server/detection/rules/sudoers_tamper.go
+++ b/server/detection/rules/sudoers_tamper.go
@@ -51,7 +51,7 @@ func (r *SudoersTamper) ID() string { return "sudoers_tamper" }
 // (Abuse Elevation Control Mechanism: Sudo and Sudo Caching).
 func (r *SudoersTamper) Techniques() []string { return []string{"T1548.003"} }
 
-// Doc surfaces the operator-facing description in /api/v1/admin/rules and
+// Doc surfaces the operator-facing description in /api/v1/rules and
 // the generated docs/detection-rules.md.
 func (r *SudoersTamper) Doc() detection.Documentation {
 	return detection.Documentation{

--- a/server/detection/rules/sudoers_tamper.go
+++ b/server/detection/rules/sudoers_tamper.go
@@ -51,7 +51,7 @@ func (r *SudoersTamper) ID() string { return "sudoers_tamper" }
 // (Abuse Elevation Control Mechanism: Sudo and Sudo Caching).
 func (r *SudoersTamper) Techniques() []string { return []string{"T1548.003"} }
 
-// Doc surfaces the operator-facing description in /api/v1/rules and
+// Doc surfaces the operator-facing description in /api/rules and
 // the generated docs/detection-rules.md.
 func (r *SudoersTamper) Doc() detection.Documentation {
 	return detection.Documentation{

--- a/server/detection/rules/suspicious_exec.go
+++ b/server/detection/rules/suspicious_exec.go
@@ -80,7 +80,7 @@ func (r *SuspiciousExec) Techniques() []string {
 	return []string{"T1059", "T1105"}
 }
 
-// Doc surfaces the operator-facing description in /api/v1/rules and
+// Doc surfaces the operator-facing description in /api/rules and
 // the generated docs/detection-rules.md.
 func (r *SuspiciousExec) Doc() detection.Documentation {
 	return detection.Documentation{

--- a/server/detection/rules/suspicious_exec.go
+++ b/server/detection/rules/suspicious_exec.go
@@ -80,7 +80,7 @@ func (r *SuspiciousExec) Techniques() []string {
 	return []string{"T1059", "T1105"}
 }
 
-// Doc surfaces the operator-facing description in /api/v1/admin/rules and
+// Doc surfaces the operator-facing description in /api/v1/rules and
 // the generated docs/detection-rules.md.
 func (r *SuspiciousExec) Doc() detection.Documentation {
 	return detection.Documentation{

--- a/server/enrollment/enrollment_test.go
+++ b/server/enrollment/enrollment_test.go
@@ -201,7 +201,7 @@ func postEnroll(t *testing.T, srv *httptest.Server, body any) *http.Response {
 	t.Helper()
 	buf := new(bytes.Buffer)
 	require.NoError(t, json.NewEncoder(buf).Encode(body))
-	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, srv.URL+"/api/v1/enroll", buf)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, srv.URL+"/api/enroll", buf)
 	require.NoError(t, err)
 	resp, err := srv.Client().Do(req)
 	require.NoError(t, err)
@@ -251,7 +251,7 @@ func TestEnroll_BadBody(t *testing.T) {
 	srv, _, _ := newHandlerServer(t)
 
 	t.Run("malformed json", func(t *testing.T) {
-		req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, srv.URL+"/api/v1/enroll",
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, srv.URL+"/api/enroll",
 			strings.NewReader("not json"))
 		require.NoError(t, err)
 		resp, err := srv.Client().Do(req)

--- a/server/enrollment/handler.go
+++ b/server/enrollment/handler.go
@@ -39,7 +39,7 @@ type CommandInserter interface {
 	InsertCommand(ctx context.Context, c store.Command) (int64, error)
 }
 
-// Handler serves POST /api/v1/enroll. Unauthenticated; rate-limited per source IP; emits an
+// Handler serves POST /api/enroll. Unauthenticated; rate-limited per source IP; emits an
 // audit log + OTel span attribute set for every enrollment attempt.
 type Handler struct {
 	store    *Store
@@ -97,7 +97,7 @@ func NewHandler(store *Store, opts Options) *Handler {
 
 // RegisterRoutes wires the enrollment endpoint onto the mux.
 func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
-	mux.HandleFunc("POST /api/v1/enroll", h.handleEnroll)
+	mux.HandleFunc("POST /api/enroll", h.handleEnroll)
 }
 
 // enrollRequest is the wire payload. NOTE: its String()/fmt.%v must NEVER include the secret —
@@ -132,7 +132,7 @@ type enrollErrorBody struct {
 // emits unhyphenated 32-hex strings, broaden this regex along with a matching agent change.
 var uuidPattern = regexp.MustCompile(`^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$`)
 
-// maxEnrollBodyBytes caps the enroll request body. /api/v1/enroll is a public, unauthenticated
+// maxEnrollBodyBytes caps the enroll request body. /api/enroll is a public, unauthenticated
 // endpoint; decoding directly from an unbounded r.Body would let any client burn memory/CPU
 // before field validation. The real payload is ~300 bytes; 4 KiB leaves plenty of headroom for
 // metadata but closes the DoS vector.

--- a/server/httpserver/httpserver.go
+++ b/server/httpserver/httpserver.go
@@ -65,7 +65,7 @@ func Build(handler http.Handler, opts Options) http.Handler {
 	h = otelhttp.NewHandler(h, opts.ServiceName,
 		otelhttp.WithSpanNameFormatter(func(_ string, r *http.Request) string {
 			// otelhttp calls the formatter inside its own handler, so r.Pattern may be empty.
-			// Use method + path; patterns like "/api/v1/hosts/{host_id}/tree" appear as literal
+			// Use method + path; patterns like "/api/hosts/{host_id}/tree" appear as literal
 			// paths, which is acceptable for a pilot-scale product.
 			return r.Method + " " + r.URL.Path
 		}),

--- a/server/ingest/handler.go
+++ b/server/ingest/handler.go
@@ -61,7 +61,7 @@ func New(s *store.Store, logger *slog.Logger, info BuildInfo) *Handler {
 // SetMetrics installs the Phase 4 ingest-counter hook. Safe to call after New.
 func (h *Handler) SetMetrics(m MetricsHook) { h.metrics = m }
 
-// IngestHandler returns the POST /api/v1/events handler. Callers wrap it in
+// IngestHandler returns the POST /api/events handler. Callers wrap it in
 // authn.HostToken middleware before mounting.
 func (h *Handler) IngestHandler() http.Handler {
 	return http.HandlerFunc(h.handleIngest)

--- a/server/ingest/handler_test.go
+++ b/server/ingest/handler_test.go
@@ -114,7 +114,7 @@ func serveIngest(t *testing.T, h *Handler, hostID string, req *http.Request) *ht
 func TestIngest_RejectsMissingContext(t *testing.T) {
 	// Direct-dispatch without pinning the host_id must 500 so the misconfiguration is loud.
 	h := New(nil, slog.Default(), BuildInfo{})
-	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/v1/events", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/events", nil)
 	rec := httptest.NewRecorder()
 	h.IngestHandler().ServeHTTP(rec, req)
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
@@ -122,7 +122,7 @@ func TestIngest_RejectsMissingContext(t *testing.T) {
 
 func TestIngest_InvalidJSON(t *testing.T) {
 	h := newHandler(t)
-	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/v1/events", bytes.NewBufferString("not json"))
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/events", bytes.NewBufferString("not json"))
 	rec := serveIngest(t, h, "host-a", req)
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
@@ -132,7 +132,7 @@ func TestIngest_MissingFields(t *testing.T) {
 	events := []store.Event{{EventID: "", HostID: "host-a", TimestampNs: 1, EventType: "exec", Payload: json.RawMessage(`{}`)}}
 	body, err := json.Marshal(events)
 	require.NoError(t, err)
-	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/v1/events", bytes.NewBuffer(body))
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/events", bytes.NewBuffer(body))
 	rec := serveIngest(t, h, "host-a", req)
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
@@ -145,7 +145,7 @@ func TestIngest_HostIDMismatchRejected(t *testing.T) {
 	}}
 	body, err := json.Marshal(events)
 	require.NoError(t, err)
-	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/v1/events", bytes.NewBuffer(body))
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/events", bytes.NewBuffer(body))
 	rec := serveIngest(t, h, "host-a", req)
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 	assert.Contains(t, rec.Body.String(), "host_id_mismatch")
@@ -171,7 +171,7 @@ func TestIngest_LargeBatchNearLimit(t *testing.T) {
 	require.Less(t, len(body), 10*1024*1024)
 	require.Greater(t, len(body), 1*1024*1024)
 
-	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/v1/events", bytes.NewBuffer(body))
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/events", bytes.NewBuffer(body))
 	rec := serveIngest(t, h, "host-large", req)
 	assert.Equal(t, http.StatusOK, rec.Code)
 }
@@ -189,7 +189,7 @@ func TestIngest_DoesNotProcessEvents(t *testing.T) {
 	}
 	body, err := json.Marshal(events)
 	require.NoError(t, err)
-	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/v1/events", bytes.NewBuffer(body))
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/events", bytes.NewBuffer(body))
 	rec := serveIngest(t, h, "host-noproc", req)
 	assert.Equal(t, http.StatusOK, rec.Code)
 

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -78,7 +78,7 @@ func New(gauges GaugeSource, opts Options) *Recorder {
 	// nil-safe method paths below no-op, so a Recorder from New is always usable.
 	r.eventsIngested, _ = meter.Int64Counter(
 		"edr.events.ingested",
-		metric.WithDescription("Events accepted by POST /api/v1/events, by host_id."),
+		metric.WithDescription("Events accepted by POST /api/events, by host_id."),
 		metric.WithUnit("{event}"),
 	)
 	r.alertsCreated, _ = meter.Int64Counter(

--- a/server/session/handler.go
+++ b/server/session/handler.go
@@ -1,9 +1,9 @@
 // Package session serves the Phase 3 login / logout / session-check endpoints.
 //
-//	POST   /api/v1/session  — public, rate-limited, validates email+password, creates
+//	POST   /api/session  — public, rate-limited, validates email+password, creates
 //	                          session row, sets Set-Cookie, returns {user, csrf_token}.
-//	GET    /api/v1/session  — session-required, returns the current {user, csrf_token}.
-//	DELETE /api/v1/session  — session-required, deletes the session row, clears cookie.
+//	GET    /api/session  — session-required, returns the current {user, csrf_token}.
+//	DELETE /api/session  — session-required, deletes the session row, clears cookie.
 //
 // The shape of the login response body intentionally returns both the user AND the CSRF
 // token so the UI can store the CSRF for unsafe methods without a round-trip. The
@@ -79,7 +79,7 @@ func New(us *users.Store, ss *sessions.Store, opts Options) *Handler {
 	}
 }
 
-// RegisterPublicRoutes wires POST /api/v1/session (login) and DELETE /api/v1/session
+// RegisterPublicRoutes wires POST /api/session (login) and DELETE /api/session
 // (logout) on the given mux. Both are public because neither has a valid session to
 // authenticate with at call time: login is the mint-it step, logout is permissive by
 // design (a stale / expired / missing cookie still needs to produce a Set-Cookie that
@@ -92,14 +92,14 @@ func New(us *users.Store, ss *sessions.Store, opts Options) *Handler {
 // logout via a forged fetch. A top-level cross-site navigation could send the cookie
 // on DELETE, but the blast radius is "user gets logged out" — annoying, not a breach.
 func (h *Handler) RegisterPublicRoutes(mux *http.ServeMux) {
-	mux.HandleFunc("POST /api/v1/session", h.handleLogin)
-	mux.HandleFunc("DELETE /api/v1/session", h.handleLogout)
+	mux.HandleFunc("POST /api/session", h.handleLogin)
+	mux.HandleFunc("DELETE /api/session", h.handleLogout)
 }
 
-// RegisterAuthedRoutes wires GET /api/v1/session on the given mux. Caller wraps the
+// RegisterAuthedRoutes wires GET /api/session on the given mux. Caller wraps the
 // mux in `authn.Session` + `authn.CSRF` at mount time — see main.go.
 func (h *Handler) RegisterAuthedRoutes(mux *http.ServeMux) {
-	mux.HandleFunc("GET /api/v1/session", h.handleGet)
+	mux.HandleFunc("GET /api/session", h.handleGet)
 }
 
 type loginRequest struct {

--- a/server/session/handler.go
+++ b/server/session/handler.go
@@ -3,7 +3,10 @@
 //	POST   /api/session  — public, rate-limited, validates email+password, creates
 //	                          session row, sets Set-Cookie, returns {user, csrf_token}.
 //	GET    /api/session  — session-required, returns the current {user, csrf_token}.
-//	DELETE /api/session  — session-required, deletes the session row, clears cookie.
+//	DELETE /api/session  — public (not behind Session middleware), best-effort cookie
+//	                          clear + row delete; safe to call even with a stale cookie
+//	                          since handleLogout idempotently treats unknown sessions
+//	                          as success.
 //
 // The shape of the login response body intentionally returns both the user AND the CSRF
 // token so the UI can store the CSRF for unsafe methods without a round-trip. The

--- a/server/session/handler_test.go
+++ b/server/session/handler_test.go
@@ -43,9 +43,9 @@ func setupServer(t *testing.T, ratePerMinute int) (*httptest.Server, *users.Stor
 	authedWrap := authn.Session(ss, slog.Default())(authn.CSRF(slog.Default())(authedSub))
 
 	root := http.NewServeMux()
-	root.Handle("POST /api/v1/session", publicMux)   // login: public
-	root.Handle("DELETE /api/v1/session", publicMux) // logout: public (reads cookie itself)
-	root.Handle("GET /api/v1/session", authedWrap)
+	root.Handle("POST /api/session", publicMux)   // login: public
+	root.Handle("DELETE /api/session", publicMux) // logout: public (reads cookie itself)
+	root.Handle("GET /api/session", authedWrap)
 
 	srv := httptest.NewServer(root)
 	t.Cleanup(srv.Close)
@@ -69,7 +69,7 @@ func TestLogin_HappyPath(t *testing.T) {
 	_, err := us.Create(t.Context(), users.CreateRequest{Email: "admin@example.com", Password: "rightpassword"})
 	require.NoError(t, err)
 
-	resp := postJSON(t, srv, "/api/v1/session", map[string]string{
+	resp := postJSON(t, srv, "/api/session", map[string]string{
 		"email": "admin@example.com", "password": "rightpassword",
 	})
 	defer resp.Body.Close()
@@ -96,7 +96,7 @@ func TestLogin_WrongPasswordReturnsGeneric401(t *testing.T) {
 	_, err := us.Create(t.Context(), users.CreateRequest{Email: "admin@example.com", Password: "rightpassword"})
 	require.NoError(t, err)
 
-	resp := postJSON(t, srv, "/api/v1/session", map[string]string{
+	resp := postJSON(t, srv, "/api/session", map[string]string{
 		"email": "admin@example.com", "password": "wrong",
 	})
 	defer resp.Body.Close()
@@ -109,7 +109,7 @@ func TestLogin_WrongPasswordReturnsGeneric401(t *testing.T) {
 
 func TestLogin_UnknownEmailReturnsGeneric401(t *testing.T) {
 	srv, _, _ := setupServer(t, 30)
-	resp := postJSON(t, srv, "/api/v1/session", map[string]string{
+	resp := postJSON(t, srv, "/api/session", map[string]string{
 		"email": "nobody@example.com", "password": "anything",
 	})
 	defer resp.Body.Close()
@@ -128,7 +128,7 @@ func TestLogin_RateLimit(t *testing.T) {
 
 	// Burst 2 failures: both 401.
 	for range 2 {
-		resp := postJSON(t, srv, "/api/v1/session", map[string]string{
+		resp := postJSON(t, srv, "/api/session", map[string]string{
 			"email": "admin@example.com", "password": "wrong",
 		})
 		resp.Body.Close()
@@ -136,7 +136,7 @@ func TestLogin_RateLimit(t *testing.T) {
 	}
 
 	// Third burst attempt: the limiter returns false, we respond with 429 + Retry-After.
-	resp := postJSON(t, srv, "/api/v1/session", map[string]string{
+	resp := postJSON(t, srv, "/api/session", map[string]string{
 		"email": "admin@example.com", "password": "wrong",
 	})
 	defer resp.Body.Close()
@@ -146,7 +146,7 @@ func TestLogin_RateLimit(t *testing.T) {
 
 func TestLogin_MalformedBody(t *testing.T) {
 	srv, _, _ := setupServer(t, 30)
-	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, srv.URL+"/api/v1/session",
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, srv.URL+"/api/session",
 		bytes.NewBufferString("{"))
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
@@ -163,7 +163,7 @@ func sessionCookie(t *testing.T, srv *httptest.Server, us *users.Store) (*http.C
 	_, err := us.Create(t.Context(), users.CreateRequest{Email: "admin@example.com", Password: "pw"})
 	require.NoError(t, err)
 
-	resp := postJSON(t, srv, "/api/v1/session", map[string]string{
+	resp := postJSON(t, srv, "/api/session", map[string]string{
 		"email": "admin@example.com", "password": "pw",
 	})
 	defer resp.Body.Close()
@@ -180,7 +180,7 @@ func TestGet_ReturnsCurrentSession(t *testing.T) {
 	srv, us, _ := setupServer(t, 30)
 	cookie, csrf := sessionCookie(t, srv, us)
 
-	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+"/api/v1/session", nil)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+"/api/session", nil)
 	require.NoError(t, err)
 	req.AddCookie(cookie)
 	resp, err := srv.Client().Do(req)
@@ -195,7 +195,7 @@ func TestGet_ReturnsCurrentSession(t *testing.T) {
 
 func TestGet_MissingCookieReturns401(t *testing.T) {
 	srv, _, _ := setupServer(t, 30)
-	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+"/api/v1/session", nil)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+"/api/session", nil)
 	require.NoError(t, err)
 	resp, err := srv.Client().Do(req)
 	require.NoError(t, err)
@@ -207,7 +207,7 @@ func TestLogout_DeletesSessionAndClearsCookie(t *testing.T) {
 	srv, us, ss := setupServer(t, 30)
 	cookie, _ := sessionCookie(t, srv, us)
 
-	req, err := http.NewRequestWithContext(t.Context(), http.MethodDelete, srv.URL+"/api/v1/session", nil)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodDelete, srv.URL+"/api/session", nil)
 	require.NoError(t, err)
 	req.AddCookie(cookie)
 	resp, err := srv.Client().Do(req)
@@ -222,7 +222,7 @@ func TestLogout_DeletesSessionAndClearsCookie(t *testing.T) {
 	assert.Negative(t, clears[0].MaxAge)
 
 	// Subsequent GET with the old cookie → 401 (session row is gone).
-	req2, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+"/api/v1/session", nil)
+	req2, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+"/api/session", nil)
 	require.NoError(t, err)
 	req2.AddCookie(cookie)
 	resp2, err := srv.Client().Do(req2)

--- a/server/store/process.go
+++ b/server/store/process.go
@@ -492,7 +492,7 @@ func (s *Store) CountOfflineHosts(ctx context.Context, threshold time.Duration) 
 }
 
 // UpdateHostLastSeen bumps `hosts.last_seen_ns` to `now.UnixNano()` for hostID. Phase 4
-// uses this from the GET /api/v1/commands path so the 5-second commander poll doubles
+// uses this from the GET /api/commands path so the 5-second commander poll doubles
 // as a liveness heartbeat. The GREATEST guard stops a clock-skewed request from
 // regressing an already-observed fresher timestamp.
 //

--- a/test/loadtest.go
+++ b/test/loadtest.go
@@ -43,7 +43,7 @@ func main() {
 	log.Printf("load test: %d events/min for %v against %s", *rate, *duration, *serverURL)
 
 	client := &http.Client{Timeout: 30 * time.Second}
-	url := *serverURL + "/api/v1/events"
+	url := *serverURL + "/api/events"
 
 	var (
 		sent       atomic.Int64

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -15,7 +15,7 @@ type AuthState =
   | { status: "anon" }
   | { status: "authed"; user: SessionInfo["user"] };
 
-// Phase 3: the UI probes GET /api/v1/session on mount. On 200 we render the app; on
+// Phase 3: the UI probes GET /api/session on mount. On 200 we render the app; on
 // 401 we render the Login component. The old sessionStorage "edr_api_key" probe is
 // gone — the cookie is HttpOnly so JS can't see it directly, and the server is the
 // source of truth for "am I logged in?".

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -225,7 +225,7 @@ export interface AttackNavigatorLayer {
 }
 
 // Policy is the operator-managed blocklist. The same shape the server
-// returns from GET /api/v1/admin/policy.
+// returns from GET /api/v1/policy.
 export interface Policy {
   name: string;
   version: number;
@@ -269,7 +269,7 @@ export interface RuleConfig {
 }
 
 // RuleDoc is the structured per-rule documentation surfaced by GET
-// /api/v1/admin/rules. Mirrors detection.Documentation on the server, with
+// /api/v1/rules. Mirrors detection.Documentation on the server, with
 // the JSON tag spellings the wire format uses.
 export interface RuleDoc {
   title: string;

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -235,7 +235,7 @@ export interface Policy {
 }
 
 export async function fetchPolicy(): Promise<Policy> {
-  return fetchJSON<Policy>("/admin/policy");
+  return fetchJSON<Policy>("/policy");
 }
 
 export async function updatePolicy(
@@ -244,7 +244,7 @@ export async function updatePolicy(
   actor: string,
   reason: string,
 ): Promise<Policy> {
-  return fetchJSON<Policy>("/admin/policy", {
+  return fetchJSON<Policy>("/policy", {
     method: "PUT",
     body: JSON.stringify({ paths, hashes, actor, reason }),
   });
@@ -256,7 +256,7 @@ export async function updatePolicy(
 // to render as a heatmap. Call site is the "ATT&CK coverage" button in the
 // alerts page; the response is also useful for procurement questionnaires.
 export async function fetchAttackNavigatorLayer(): Promise<AttackNavigatorLayer> {
-  return fetchJSON<AttackNavigatorLayer>("/admin/attack-coverage");
+  return fetchJSON<AttackNavigatorLayer>("/attack-coverage");
 }
 
 // RuleConfig describes one operator-tuning env var. Wire shape matches
@@ -293,7 +293,7 @@ export interface RuleDocEntry {
 // links on /ui/coverage. Order mirrors the server's registration order, so
 // the UI can iterate without resorting.
 export async function fetchRuleDocs(): Promise<RuleDocEntry[]> {
-  const body = await fetchJSON<{ rules: RuleDocEntry[] }>("/admin/rules");
+  const body = await fetchJSON<{ rules: RuleDocEntry[] }>("/rules");
   return body.rules;
 }
 

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -1,11 +1,11 @@
 // Phase 3: the UI authenticates with the server via a HttpOnly session cookie
 // (automatic on every fetch when credentials: 'include') + a per-session CSRF token
 // that the JS attaches as X-CSRF-Token on unsafe methods. The old sessionStorage
-// "edr_api_key" bearer is gone; see POST /api/v1/session for the login round-trip
+// "edr_api_key" bearer is gone; see POST /api/session for the login round-trip
 // that issues both the cookie and the CSRF token.
 import type { HostSummary, TreeResponse, ProcessDetail, Alert, AlertDetail, Command } from "./types";
 
-const API_BASE = "/api/v1";
+const API_BASE = "/api";
 
 const CSRF_KEY = "edr_csrf_token";
 
@@ -64,7 +64,7 @@ function unsafeMethod(method?: string): boolean {
 // path. fetchJSON concatenates its path argument with API_BASE and hands the
 // result to fetch(); without this check a caller that accidentally forwards
 // user input (URL from query params, server-returned string, etc.) could steer
-// the request to an unintended origin or walk out of /api/v1 via "..". The
+// the request to an unintended origin or walk out of /api via "..". The
 // whitelist is deliberately narrow: leading slash, then only URL-path +
 // query-string characters we actually use.
 const API_PATH_RE = /^\/[A-Za-z0-9/?=&%:_.@~-]*$/;
@@ -108,7 +108,7 @@ async function fetchJSON<T>(path: string, init?: RequestInit): Promise<T> {
   if (!res.ok) {
     throw new Error(`API error: ${String(res.status)} ${res.statusText}`);
   }
-  // DELETE /api/v1/session returns 204 with no body; handle the empty-body case.
+  // DELETE /api/session returns 204 with no body; handle the empty-body case.
   if (res.status === 204) return undefined as T;
   return res.json() as Promise<T>;
 }
@@ -225,7 +225,7 @@ export interface AttackNavigatorLayer {
 }
 
 // Policy is the operator-managed blocklist. The same shape the server
-// returns from GET /api/v1/policy.
+// returns from GET /api/policy.
 export interface Policy {
   name: string;
   version: number;
@@ -269,7 +269,7 @@ export interface RuleConfig {
 }
 
 // RuleDoc is the structured per-rule documentation surfaced by GET
-// /api/v1/rules. Mirrors detection.Documentation on the server, with
+// /api/rules. Mirrors detection.Documentation on the server, with
 // the JSON tag spellings the wire format uses.
 export interface RuleDoc {
   title: string;

--- a/ui/src/components/AttackCoverage.tsx
+++ b/ui/src/components/AttackCoverage.tsx
@@ -9,7 +9,7 @@ import "./AttackCoverage.scss";
 
 // AttackCoverage renders the MITRE ATT&CK technique coverage that the
 // registered detection rules provide. The data comes from the same
-// /api/v1/attack-coverage endpoint that procurement teams ingest as a
+// /api/attack-coverage endpoint that procurement teams ingest as a
 // Navigator layer JSON — but we render it in-app as a tactic-grouped table
 // because a JSON download is unsatisfying as a demo prop. The pattern matches
 // what Crowdstrike Falcon, SentinelOne Singularity, and Elastic Security all

--- a/ui/src/components/AttackCoverage.tsx
+++ b/ui/src/components/AttackCoverage.tsx
@@ -9,7 +9,7 @@ import "./AttackCoverage.scss";
 
 // AttackCoverage renders the MITRE ATT&CK technique coverage that the
 // registered detection rules provide. The data comes from the same
-// /api/v1/admin/attack-coverage endpoint that procurement teams ingest as a
+// /api/v1/attack-coverage endpoint that procurement teams ingest as a
 // Navigator layer JSON — but we render it in-app as a tactic-grouped table
 // because a JSON download is unsatisfying as a demo prop. The pattern matches
 // what Crowdstrike Falcon, SentinelOne Singularity, and Elastic Security all

--- a/ui/src/components/Login.tsx
+++ b/ui/src/components/Login.tsx
@@ -9,7 +9,7 @@ interface LoginProps {
   readonly onLogin: () => void;
 }
 
-// Phase 3 login: email + password → POST /api/v1/session → server sets HttpOnly
+// Phase 3 login: email + password → POST /api/session → server sets HttpOnly
 // session cookie and returns the per-session CSRF token. api.ts stashes the CSRF in
 // sessionStorage; App.tsx re-renders with the logged-in view.
 export function Login({ onLogin }: LoginProps) {

--- a/ui/src/components/PolicyEditor.tsx
+++ b/ui/src/components/PolicyEditor.tsx
@@ -58,7 +58,7 @@ function renderDiff(d: { added: number; removed: number }, singular: string, plu
 }
 
 // PolicyEditor is the operator-facing surface for the server-driven blocklist
-// (the same Policy that GET/PUT /api/v1/policy serves). The flow follows
+// (the same Policy that GET/PUT /api/policy serves). The flow follows
 // the pattern most enterprise dashboards use (GitHub, Atlassian, AWS Console):
 // the page edits a *staged* copy of the policy; nothing hits the server until
 // the operator clicks "Save changes" in a sticky footer that only appears when

--- a/ui/src/components/PolicyEditor.tsx
+++ b/ui/src/components/PolicyEditor.tsx
@@ -58,7 +58,7 @@ function renderDiff(d: { added: number; removed: number }, singular: string, plu
 }
 
 // PolicyEditor is the operator-facing surface for the server-driven blocklist
-// (the same Policy that GET/PUT /api/v1/admin/policy serves). The flow follows
+// (the same Policy that GET/PUT /api/v1/policy serves). The flow follows
 // the pattern most enterprise dashboards use (GitHub, Atlassian, AWS Console):
 // the page edits a *staged* copy of the policy; nothing hits the server until
 // the operator clicks "Save changes" in a sticky footer that only appears when

--- a/ui/src/components/RuleDetail.tsx
+++ b/ui/src/components/RuleDetail.tsx
@@ -7,7 +7,7 @@ import "./RuleDetail.scss";
 
 // RuleDetail renders a single detection rule's documentation: behaviour,
 // severity, ATT&CK mapping, configuration knobs, false-positive sources, and
-// limitations. This page loads rule docs from /api/v1/rules; the
+// limitations. This page loads rule docs from /api/rules; the
 // markdown reference at docs/detection-rules.md is generated directly from
 // the same Go-side `detection.Rule.Doc()` definitions, so the two surfaces
 // stay aligned even though they don't share a fetch path.

--- a/ui/src/components/RuleDetail.tsx
+++ b/ui/src/components/RuleDetail.tsx
@@ -7,7 +7,7 @@ import "./RuleDetail.scss";
 
 // RuleDetail renders a single detection rule's documentation: behaviour,
 // severity, ATT&CK mapping, configuration knobs, false-positive sources, and
-// limitations. This page loads rule docs from /api/v1/admin/rules; the
+// limitations. This page loads rule docs from /api/v1/rules; the
 // markdown reference at docs/detection-rules.md is generated directly from
 // the same Go-side `detection.Rule.Doc()` definitions, so the two surfaces
 // stay aligned even though they don't share a fetch path.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified API endpoints by removing version prefixes; all routes now use `/api/` instead of `/api/v1/`.

* **Documentation**
  * Updated API documentation, architecture guides, and deployment instructions to reflect new endpoint paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->