### PR TITLE
Add CONTRIBUTING.md, license + release badges, fix SLSA badge to L2

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,78 @@
+# Contributing to Fleet EDR
+
+Thanks for your interest in contributing. This guide covers what an external contributor needs to get a change reviewed and merged.
+
+If you are reporting a security vulnerability, **do not open a public issue**. Follow [`SECURITY.md`](SECURITY.md) instead.
+
+## Before you start
+
+- Read [`README.md`](README.md) for the quick start (toolchain pins, MySQL setup, dev server).
+- Read [`docs/architecture.md`](docs/architecture.md) so you know which component (system extension, network extension, agent,
+  server, UI) your change touches.
+- For non-trivial changes, open an issue first describing the problem you are solving. We would rather discuss the approach
+  before you write the code than reject a finished PR for being out of scope.
+
+## Toolchain
+
+Pinned in [`.tool-versions`](.tool-versions). Install [`mise`](https://mise.jdx.dev/) (or `asdf`) and run `mise install` to
+match local, CI, and AI-agent sandbox versions. Pre-commit hooks live in [`lefthook.yml`](lefthook.yml); install once with
+`lefthook install`.
+
+CI is the backstop, not the floor. If a check fails locally fix it locally; do not push hoping CI will pass.
+
+## Style and conventions
+
+| Surface | Source of truth |
+| --- | --- |
+| Go | [`docs/go-conventions.md`](docs/go-conventions.md), [`.golangci.yml`](.golangci.yml) |
+| TypeScript / React | `ui/eslint.config.js`, `ui/tsconfig.json` (strict mode + `eslint-plugin-security`) |
+| Swift | [`.swiftlint.yml`](.swiftlint.yml) (run with `--strict`) |
+| C bridge | [`.clang-tidy`](.clang-tidy), [`.clang-format`](.clang-format) |
+| GitHub Actions | `actionlint` + `zizmor` (security audit) |
+| Markdown / prose | Sentence case headings, wrap at 140 chars, no em-dashes |
+| Commits | Imperative mood, focused scope, one logical change per commit |
+
+If a linter disagrees with a specific change, prefer fixing the code over disabling the rule. Suppression with a `nolint` /
+`eslint-disable` / `swiftlint:disable` directive needs a one-line justification on the same line.
+
+## Tests
+
+Run `task test` before pushing. Targeted runs: `task test:go`, `task test:ui`. Use subtests (`t.Run`) and table-driven cases
+in Go. Integration tests hit a real MySQL on port 3317; do not mock the database in store-layer tests.
+
+Coverage is measured by SonarCloud; the new-code coverage gate is 80%. PRs that add code without adding tests will fail the
+gate.
+
+## Pull requests
+
+- Branch off `main`. Keep the diff focused; large refactors should be split into reviewable chunks.
+- Write a PR description that explains the *why*, not just the *what*. Link the issue it closes.
+- A PR is ready to merge when CI is green, the SonarCloud quality gate is green, and at least one maintainer has approved.
+- Do **not** add `Co-Authored-By` lines to commits. AI-assisted code is welcome; the assistant is a tool, not a co-author.
+- Sign your commits if you can (`git commit -S`); we do not require this today, but plan to.
+
+## Security-sensitive changes
+
+Touching auth, crypto, the network extension, or the ingestion pipeline triggers extra scrutiny:
+
+- Reviewers will look for the threat-model implications. Read [`docs/threat-model.md`](docs/threat-model.md) and call out the
+  STRIDE category your change affects in the PR description.
+- Constant-time comparisons for any token / hash check (`subtle.ConstantTimeCompare`).
+- No new untrusted-input -> SQL / shell / log-injection sinks.
+- Add a test that exercises the failure path, not just the happy path.
+
+## Reporting bugs
+
+For non-security bugs, open a [GitHub issue](https://github.com/getvictor/fleet-edr/issues/new) with:
+
+- Affected component (server, agent, system extension, network extension, UI).
+- Version or commit SHA.
+- Reproduction steps.
+- Expected vs. actual behaviour.
+- Relevant logs (`log show --predicate 'subsystem == "com.fleetdm.edr"'` for macOS components, server stdout for the daemon).
+
+## License
+
+By contributing, you agree that your contribution is licensed under the [MIT License](LICENSE) and that you have the right
+to grant that license. We do not require a CLA today; we may add a DCO sign-off requirement before opening the project to
+broader external contribution.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,14 +18,14 @@ Pinned in [`.tool-versions`](.tool-versions). Install [`mise`](https://mise.jdx.
 match local, CI, and AI-agent sandbox versions. Pre-commit hooks live in [`lefthook.yml`](lefthook.yml); install once with
 `lefthook install`.
 
-CI is the backstop, not the floor. If a check fails locally fix it locally; do not push hoping CI will pass.
+CI is the backstop, not the floor. If a check fails locally, fix it before pushing; do not push hoping CI will pass.
 
 ## Style and conventions
 
 | Surface | Source of truth |
 | --- | --- |
 | Go | [`docs/go-conventions.md`](docs/go-conventions.md), [`.golangci.yml`](.golangci.yml) |
-| TypeScript / React | `ui/eslint.config.js`, `ui/tsconfig.json` (strict mode + `eslint-plugin-security`) |
+| TypeScript / React | `ui/eslint.config.mjs`, `ui/tsconfig.json` (strict mode + `eslint-plugin-security`) |
 | Swift | [`.swiftlint.yml`](.swiftlint.yml) (run with `--strict`) |
 | C bridge | [`.clang-tidy`](.clang-tidy), [`.clang-format`](.clang-format) |
 | GitHub Actions | `actionlint` + `zizmor` (security audit) |

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Fleet EDR
 
+<!-- License & release -->
+[![License: MIT](https://img.shields.io/github/license/getvictor/fleet-edr?style=flat-square)](LICENSE)
+[![Release](https://img.shields.io/github/v/release/getvictor/fleet-edr?include_prereleases&style=flat-square)](https://github.com/getvictor/fleet-edr/releases)
+
 <!-- Build & quality -->
 ![Go version](https://img.shields.io/github/go-mod/go-version/getvictor/fleet-edr?filename=go.mod&style=flat-square)
 [![Tests](https://img.shields.io/github/actions/workflow/status/getvictor/fleet-edr/test.yml?branch=main&label=tests&style=flat-square)](https://github.com/getvictor/fleet-edr/actions/workflows/test.yml)
@@ -12,7 +16,7 @@
 
 <!-- Supply chain -->
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/getvictor/fleet-edr/badge)](https://scorecard.dev/viewer/?uri=github.com/getvictor/fleet-edr)
-[![SLSA 3](https://slsa.dev/images/gh-badge-level3.svg)](https://slsa.dev/spec/v1.0/levels#build-l3)
+[![SLSA 2](https://slsa.dev/images/gh-badge-level2.svg)](https://slsa.dev/spec/v1.0/levels#build-l2)
 [![cosign keyless](https://img.shields.io/badge/cosign-keyless-9cf?style=flat-square&logo=sigstore)](docs/best-practices.md#4-supply-chain-security)
 
 A macOS Endpoint Detection and Response (EDR) system. It provides

--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -394,12 +394,20 @@ genuine differentiator versus most competitors.
 - [x] Build info (`version`, `commit`, `buildTime`) injected via `-ldflags` and surfaced
   in startup logs + OTel `service.version`
 - [x] Multi-stage local dev (Docker Compose for MySQL; `go run` for server)
-- [ ] **GoReleaser** for cross-arch binary releases with checksums
-- [ ] **Notarized signed `.pkg` installer** (per the MVP plan; not yet automated)
+- [-] **GoReleaser** -- **will not do**. The custom `release.yml` workflow already
+  ships the same outcomes (signed multi-arch artifacts + `SHA256SUMS` + SBOMs)
+  without taking on the GoReleaser config surface. Reconsider only if releases
+  need to expand to many more cross-platform Go binaries
+- [x] **Notarized signed `.pkg` installer** for darwin/arm64. Built, signed
+  (Developer ID Application + Installer), and notarized via `notarytool` in
+  `release.yml`'s `macos-pkg` job; gated on the `release-signing` GitHub
+  environment so signing creds only decrypt for `v*` tag pushes
 - [ ] **Apple Hardened Runtime** entitlements on the agent + extension binaries
 - [ ] **Reproducible-build verification** job in CI
-- [ ] **Multi-arch container image** for the server (linux/amd64, linux/arm64) signed by
-  cosign
+- [x] **Multi-arch container image** for the server (linux/amd64, linux/arm64)
+  signed by cosign. Built and pushed by the `docker-server` job in
+  `release.yml` to `ghcr.io/getvictor/fleet-edr-server:{tag,latest}`; cosign
+  keyless signature + SBOM attestation pushed alongside on every tag
 - [ ] **Helm chart** + Kustomize overlays for k8s deployments
 - [ ] **systemd unit** + RPM / DEB for self-hosted Linux deployments
 - [-] **In-product auto-update channel** (Sparkle / custom signed-manifest fetcher) --
@@ -434,7 +442,12 @@ These cost almost nothing and disproportionately drive adoption.
   private vulnerability reporting flow (`/security/advisories/new`).
   Scoped to the maintainer-only mailbox without exposing a personal email
   address. Lifts OpenSSF Scorecard's Security-Policy check from 0 → 10.
-- [ ] **`CONTRIBUTING.md`** with build / test / DCO + style pointers
+- [x] **`CONTRIBUTING.md`** at the repo root: pointers to build / test (Taskfile,
+  lefthook, `.tool-versions`), per-language style sources of truth
+  (`docs/go-conventions.md`, `.golangci.yml`, ESLint, swiftlint), Sonar
+  new-code coverage gate, the `Co-Authored-By` policy, and a security-PR
+  checklist tied back to `docs/threat-model.md`. DCO sign-off noted as a
+  future requirement, not enforced today
 - [ ] **`CODE_OF_CONDUCT.md`** (Contributor Covenant 2.1)
 - [ ] **`CODEOWNERS`** for review routing
 - [ ] **PR template** with checklist (tests, docs, security review)
@@ -584,8 +597,8 @@ A self-graded rubric so the README badge can be honest. `Total` excludes items m
 | API design                        | 5.5     | 16    | 34%  |
 | Frontend                          | 6       | 14    | 43%  |
 | Data layer                        | 9       | 17    | 53%  |
-| Build / release / packaging       | 2       | 12    | 17%  |
-| Community signals                 | 12      | 24    | 50%  |
+| Build / release / packaging       | 4       | 11    | 36%  |
+| Community signals                 | 13      | 24    | 54%  |
 | Compliance + privacy              | 1       | 13    | 8%   |
 | macOS platform hygiene            | 6       | 12    | 50%  |
 | AI-assisted engineering           | 2       | 17    | 12%  |
@@ -597,16 +610,21 @@ OpenSSF Scorecard, and OSV-Scanner alongside the existing govulncheck.
 A real SonarCloud coverage gate (≥80% on new code, per PR) closed the
 last big code-quality gap. That moved §4 from 37% to 57% and §5 from 59%
 to 64%. Hosting Redoc at `/api/docs` plus a Redocly OpenAPI lint job
-moved §8 from 25% to 34%. Adding `LICENSE` (MIT) + `SECURITY.md` lifted
-§12 Community signals from 42% to 50% and unblocked the rest of that
-section's doc items. `docs/threat-model.md` (STRIDE per component)
+moved §8 from 25% to 34%. The `release.yml` workflow shipping notarized
+signed `.pkg` plus a multi-arch cosign-signed server image lifted §11
+Build/release from 17% to 36% (with GoReleaser flipped to will-not-do
+since the custom workflow already covers its scope). Adding `LICENSE`
+(MIT) + `SECURITY.md` + `CONTRIBUTING.md` lifted §12 Community signals
+from 42% to 54% and unblocked the rest of that section's doc items.
+`docs/threat-model.md` (STRIDE per component)
 opened §13 Compliance + privacy from 0% to 8% — that section was the
 last fully-empty area on the checklist.
 
 The remaining big gaps that buyers ask about are RBAC + MFA on the UI
 (§3, the highest-severity item left in the top-3 missing list now that
-LICENSE and the threat model have shipped), CONTRIBUTING.md and the
-rest of the §12 community-signals checklist, the detection-content
+LICENSE, the threat model, and CONTRIBUTING.md have shipped), the rest
+of the §12 community-signals checklist (CODE_OF_CONDUCT, CODEOWNERS, PR
+template, OpenSSF CII Best Practices badge), the detection-content
 surface (ATT&CK mapping is wired but Sigma / YARA / IOC management
 still wait for v1.1), and the AI-era hygiene that enterprise
 procurement is starting to ask for (CISA Secure by Design, OWASP LLM

--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -406,14 +406,30 @@ genuine differentiator versus most competitors.
   (Developer ID Application + Installer), and notarized via `notarytool` in
   `release.yml`'s `macos-pkg` job; gated on the `release-signing` GitHub
   environment so signing creds only decrypt for `v*` tag pushes
-- [ ] **Apple Hardened Runtime** entitlements on the agent + extension binaries
-- [ ] **Reproducible-build verification** job in CI
+- [x] **Apple Hardened Runtime** with the minimum entitlement set audited.
+  `packaging/pkg/build.sh` re-signs the agent, system extension, network
+  extension, and the outer `Fleet EDR.app` bundle with `--options runtime`
+  + `--timestamp` and per-binary entitlements files. Each entitlements
+  plist carries only what the OS requires for that component to function:
+  `endpoint-security.client` on the sysext;
+  `networking.networkextension` + an app-group on the netext;
+  `system-extension.install` + `networking.networkextension` on the host
+  app. Notary's bottom-up Mach-O scan rejects anything missing the
+  hardened runtime flag, so a successful notarization is itself the gate
+- [ ] **Reproducible-build verification** job in CI (the agent and server
+  builds already pass `-trimpath` + pinned `-ldflags`; what's missing is a
+  job that diffs two independent rebuilds and fails on byte drift)
 - [x] **Multi-arch container image** for the server (linux/amd64, linux/arm64)
   signed by cosign. Built and pushed by the `docker-server` job in
   `release.yml` to `ghcr.io/getvictor/fleet-edr-server:{tag,latest}`; cosign
   keyless signature + SBOM attestation pushed alongside on every tag
 - [ ] **Helm chart** + Kustomize overlays for k8s deployments
-- [ ] **systemd unit** + RPM / DEB for self-hosted Linux deployments
+- [-] **systemd unit** + RPM / DEB for self-hosted Linux deployments --
+  **will not do** for the macOS-only MVP. The agent is Apple-Silicon only
+  per ADR-0002 and there is no Linux endpoint surface yet, so shipping a
+  Linux init-system + distro packaging surface for a server-only deploy
+  duplicates what the existing Docker Compose stack already covers.
+  Reconsider when a Linux agent lands (§2)
 - [-] **In-product auto-update channel** (Sparkle / custom signed-manifest fetcher) --
   **will not do**. Enterprise endpoint software updates flow through the customer's MDM
   channel (Fleet, Jamf, Kandji, Intune); in-product self-update bypasses change management
@@ -601,7 +617,7 @@ A self-graded rubric so the README badge can be honest. `Total` excludes items m
 | API design                        | 5.5     | 16    | 34%  |
 | Frontend                          | 6       | 14    | 43%  |
 | Data layer                        | 9       | 17    | 53%  |
-| Build / release / packaging       | 4       | 11    | 36%  |
+| Build / release / packaging       | 5       | 10    | 50%  |
 | Community signals                 | 13      | 24    | 54%  |
 | Compliance + privacy              | 1       | 13    | 8%   |
 | macOS platform hygiene            | 6       | 12    | 50%  |
@@ -615,9 +631,12 @@ A real SonarCloud coverage gate (≥80% on new code, per PR) closed the
 last big code-quality gap. That moved §4 from 37% to 57% and §5 from 59%
 to 64%. Hosting Redoc at `/api/docs` plus a Redocly OpenAPI lint job
 moved §8 from 25% to 34%. The `release.yml` workflow shipping notarized
-signed `.pkg` plus a multi-arch cosign-signed server image lifted §11
-Build/release from 17% to 36% (with GoReleaser flipped to will-not-do
-since the custom workflow already covers its scope). Adding `LICENSE`
+signed `.pkg` plus a multi-arch cosign-signed server image, plus auditing
+the existing hardened-runtime + minimal-entitlements pipeline that
+notarization already enforces, lifted §11 Build/release from 17% to 50%
+(with GoReleaser and Linux init-system + distro packaging both flipped
+to will-not-do since the custom workflow + Apple-Silicon-only MVP scope
+already cover those). Adding `LICENSE`
 (MIT) + `SECURITY.md` + `CONTRIBUTING.md` lifted §12 Community signals
 from 42% to 54% and unblocked the rest of that section's doc items.
 `docs/threat-model.md` (STRIDE per component)

--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -27,8 +27,12 @@ testable, and mapped to a public taxonomy.
 - [x] Server-driven blocklist policy with versioning (`policies` table, agent diffs by
   version)
 - [x] Response action: command queue (kill, block) with ack/complete lifecycle
-- [ ] **MITRE ATT&CK mapping** on every rule (technique IDs as rule metadata, surfaced in UI
-  and exports). Required to talk to SOCs.
+- [x] **MITRE ATT&CK mapping** on every rule. Each detection rule implements
+  `Techniques()` returning the ATT&CK technique IDs it maps to
+  (`server/detection/rule.go`); the engine threads them onto every alert so
+  they survive the rule lifecycle. Surfaced in the UI (`AttackCoverage.tsx`,
+  `RuleDetail.tsx`) and exposed as an ATT&CK Navigator JSON export
+  (`server/admin/admin.go` `navigatorTechnique`).
 - [ ] **Sigma rule support** (import community rules; transpile to native rule format)
 - [ ] **YARA scanning** for file-based detections (signature + heuristic)
 - [ ] **IOC management**: bulk import of hashes / domains / IPs from STIX/TAXII feeds
@@ -587,7 +591,7 @@ A self-graded rubric so the README badge can be honest. `Total` excludes items m
 
 | Area                              | Adopted | Total | %    |
 |-----------------------------------|---------|-------|------|
-| Detection content + response      | 6       | 36    | 17%  |
+| Detection content + response      | 7       | 36    | 19%  |
 | Cross-platform reach              | 1       | 8     | 12%  |
 | AuthN / AuthZ / crypto            | 13      | 25    | 52%  |
 | Supply-chain security             | 15.5    | 27    | 57%  |


### PR DESCRIPTION
Closes the PR-1 scope of issue #26 (Tier 1 enterprise-signal badges):

- CONTRIBUTING.md at the repo root, scoped to build/test pointers, per-language style sources of truth, the Co-Authored-By policy, and a security-PR checklist tied to docs/threat-model.md. Unblocks the OpenSSF Best Practices (CII) self-assessment as a follow-up.

- README badge bar: new License & release group at the top (license badge links to LICENSE, release badge includes pre-releases since v0.1.0-rc.x is the current state).

- README SLSA badge corrected from L3 to L2 to match what the release pipeline actually achieves; Apple notarytool's network call breaks SLSA L3 hermeticity, documented in best-practices.md §4.

- best-practices.md §11: GoReleaser flipped to [-] will-not-do (the custom release.yml workflow already ships signed multi-arch artifacts + SHA256SUMS + SBOMs); notarized signed .pkg and multi-arch cosign-signed server image marked [x] with release.yml job names.

- best-practices.md §12: CONTRIBUTING.md marked [x]; scoring summary refreshed (§11 17%->36%, §12 50%->54%) and the closing paragraphs updated to match.

Out of scope (filed as separate issues): Codecov + coverage badge wiring, OpenSSF Best Practices CII self-assessment, cutting v0.1.0 stable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Introduced a comprehensive contributing guide covering development setup, code standards, testing requirements, pull request practices, and security review processes.
  * Enhanced README with MIT licensing and release version badges.
  * Refreshed best-practices documentation reflecting current implementation status and roadmap priorities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->