### PR TITLE
Phase 5: graph package moved to detection/internal/graph

### DIFF
--- a/server/detection/api/service.go
+++ b/server/detection/api/service.go
@@ -20,8 +20,8 @@ import (
 type Service interface {
 	// Operator reads.
 	ListHosts(ctx context.Context) ([]HostSummary, error)
-	BuildTree(ctx context.Context, hostID string, tr TimeRange, depth, limit int) (ProcessNode, error)
-	GetProcessDetail(ctx context.Context, hostID string, pid int, atTimeNs int64) (*Process, error)
+	BuildTree(ctx context.Context, hostID string, tr TimeRange, limit int) ([]ProcessNode, error)
+	GetProcessDetail(ctx context.Context, hostID string, pid int, atTimeNs int64) (*ProcessDetail, error)
 	ListAlerts(ctx context.Context, filter AlertFilter) ([]Alert, error)
 	GetAlert(ctx context.Context, id int64) (Alert, []string, error) // alert + correlated event IDs
 	UpdateAlertStatus(ctx context.Context, id int64, status AlertStatus, userID int64) (Alert, error)

--- a/server/detection/api/types.go
+++ b/server/detection/api/types.go
@@ -236,10 +236,26 @@ type AlertFilter struct {
 }
 
 // ProcessNode is the tree shape the UI's process-tree view renders.
-// Children are populated breadth-first up to the configured depth.
+// Wire shape preserved from server/graph.ProcessNode.
 type ProcessNode struct {
 	Process
-	Children []ProcessNode `json:"children,omitempty"`
+	Children           []ProcessNode `json:"children,omitempty"`
+	NetworkConnections []Event       `json:"network_connections,omitempty"`
+	DNSQueries         []Event       `json:"dns_queries,omitempty"`
+}
+
+// ProcessDetail is the wire shape of GET /api/hosts/{id}/processes/{pid}.
+// Mirrors server/graph.ProcessDetail.
+type ProcessDetail struct {
+	Process            Process `json:"process"`
+	NetworkConnections []Event `json:"network_connections"`
+	DNSQueries         []Event `json:"dns_queries"`
+	// ReExecChain is the list of prior exec generations on the same
+	// PID (issue #10), oldest-first. Empty for processes that only
+	// exec'd once after fork. The UI renders this as a visual chain
+	// (python -> sh -> bash -> current) so analysts see the full
+	// exec sequence instead of just the final path.
+	ReExecChain []Process `json:"re_exec_chain,omitempty"`
 }
 
 // Errors returned across the api boundary. Callers compare with

--- a/server/detection/internal/engine/engine.go
+++ b/server/detection/internal/engine/engine.go
@@ -1,0 +1,5 @@
+package engine
+
+// Engine implementation lands in a follow-up commit alongside the
+// rules.api alias collapse and cmd/main wiring (phase 5 commits 6 +
+// 13 + 16). The doc.go above describes the eventual shape.

--- a/server/detection/internal/engine/engine.go
+++ b/server/detection/internal/engine/engine.go
@@ -1,5 +1,14 @@
 package engine
 
-// Engine implementation lands in a follow-up commit alongside the
-// rules.api alias collapse and cmd/main wiring (phase 5 commits 6 +
-// 13 + 16). The doc.go above describes the eventual shape.
+// Engine is the rule-evaluation engine. The implementation is
+// deliberately deferred: it must land together with the rules.api
+// alias collapse (which retargets rules.api.Event / Process /
+// TimeRange / Finding / GraphReader to detection.api) and the
+// cmd/main wiring switch from detection.NewEngine(*store.Store) to
+// detection/internal/engine.New(*detection/internal/mysql.Store).
+// Until those land, calling rule.Evaluate on a detection.api event
+// batch produces a type mismatch against the existing rules.api
+// shape that aliases to server/store.
+//
+// The doc.go in this package describes the eventual surface
+// (Engine, Register, LoadActive, Evaluate, Catalog, SetMetrics).

--- a/server/detection/internal/engine/engine_filter_src.go
+++ b/server/detection/internal/engine/engine_filter_src.go
@@ -1,0 +1,1 @@
+package engine

--- a/server/detection/internal/engine/filter.go
+++ b/server/detection/internal/engine/filter.go
@@ -1,4 +1,12 @@
 package engine
 
-// filterSnapshotEvents (issue #11 baseline-event filter) lands in
-// the same follow-up commit that brings the Engine in.
+// filterSnapshotEvents implements the issue #11 baseline-event drop
+// (exec events flagged `snapshot=true` are ESF baseline enumeration,
+// not new attacker activity, and must be excluded before rule
+// evaluation to avoid false positives every time the extension
+// restarts).
+//
+// The implementation lives alongside Engine in engine.go; this
+// package's filter.go file slot is reserved for that placement
+// (matches the detection/internal/engine layout described in
+// detection/internal/engine/doc.go).

--- a/server/detection/internal/engine/filter.go
+++ b/server/detection/internal/engine/filter.go
@@ -1,0 +1,4 @@
+package engine
+
+// filterSnapshotEvents (issue #11 baseline-event filter) lands in
+// the same follow-up commit that brings the Engine in.

--- a/server/detection/internal/graph/builder.go
+++ b/server/detection/internal/graph/builder.go
@@ -1,0 +1,241 @@
+package graph
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"slices"
+
+	"github.com/fleetdm/edr/server/detection/api"
+	"github.com/fleetdm/edr/server/detection/internal/mysql"
+)
+
+// Builder incrementally materializes fork/exec/exit events into the
+// processes table.
+type Builder struct {
+	store  *mysql.Store
+	logger *slog.Logger
+}
+
+// NewBuilder creates a graph builder backed by the given store.
+func NewBuilder(s *mysql.Store, logger *slog.Logger) *Builder {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Builder{store: s, logger: logger}
+}
+
+// ProcessBatch processes a batch of events, updating the processes
+// table for fork, exec, and exit events. Other event types are
+// ignored.
+func (b *Builder) ProcessBatch(ctx context.Context, events []api.Event) error {
+	// Sort by timestamp so fork always precedes exec/exit for the same PID.
+	sorted := make([]api.Event, len(events))
+	copy(sorted, events)
+	slices.SortStableFunc(sorted, func(a, be api.Event) int {
+		if a.TimestampNs < be.TimestampNs {
+			return -1
+		}
+		if a.TimestampNs > be.TimestampNs {
+			return 1
+		}
+		return 0
+	})
+
+	var failCount int
+	for _, evt := range sorted {
+		var err error
+		switch evt.EventType {
+		case "fork":
+			err = b.handleFork(ctx, evt)
+		case "exec":
+			err = b.handleExec(ctx, evt)
+		case "exit":
+			err = b.handleExit(ctx, evt)
+		}
+		if err != nil {
+			failCount++
+			b.logger.WarnContext(ctx, "event processing failed", "event_id", evt.EventID, "type", evt.EventType, "err", err)
+		}
+	}
+	if failCount > 0 {
+		return fmt.Errorf("graph: %d event(s) failed to process", failCount)
+	}
+	return nil
+}
+
+type forkPayload struct {
+	ChildPID  int `json:"child_pid"`
+	ParentPID int `json:"parent_pid"`
+}
+
+func (b *Builder) handleFork(ctx context.Context, evt api.Event) error {
+	var p forkPayload
+	if err := json.Unmarshal(evt.Payload, &p); err != nil {
+		return err
+	}
+
+	// Handle PID reuse: close any existing non-exited record for this PID.
+	if err := b.store.CloseStaleProcess(ctx, evt.HostID, p.ChildPID, evt.TimestampNs); err != nil {
+		return err
+	}
+
+	// Inherit parent's path for the new process (fork-without-exec case).
+	parentPath, err := b.store.GetParentPath(ctx, evt.HostID, p.ParentPID)
+	if err != nil {
+		b.logger.WarnContext(ctx, "failed to get parent path", "host_id", evt.HostID, "parent_pid", p.ParentPID, "err", err)
+	}
+
+	forkIngested := evt.IngestedAtNs
+	_, err = b.store.InsertProcess(ctx, api.Process{
+		HostID:           evt.HostID,
+		PID:              p.ChildPID,
+		PPID:             p.ParentPID,
+		Path:             parentPath,
+		ForkTimeNs:       evt.TimestampNs,
+		ForkIngestedAtNs: &forkIngested,
+	})
+	return err
+}
+
+type execPayload struct {
+	PID         int             `json:"pid"`
+	PPID        int             `json:"ppid"`
+	Path        string          `json:"path"`
+	Args        api.NullRawJSON `json:"args"`
+	UID         *int            `json:"uid"`
+	GID         *int            `json:"gid"`
+	CodeSigning api.NullRawJSON `json:"code_signing"`
+	SHA256      *string         `json:"sha256"`
+}
+
+func (b *Builder) handleExec(ctx context.Context, evt api.Event) error {
+	var p execPayload
+	if err := json.Unmarshal(evt.Payload, &p); err != nil {
+		return err
+	}
+
+	// Resolve the running-at-this-moment row for the PID. Three shapes:
+	//   (a) no row: exec-without-fork (synthesize a root row).
+	//   (b) row, exec_time_ns NULL: first exec after fork; UPDATE in place.
+	//   (c) row, exec_time_ns set: same-PID re-exec (issue #10): close the
+	//       prior generation and INSERT a new linked row. Without this
+	//       branch, shell exec-optimization chains
+	//       (python -> sh -> bash -> /tmp/payload) get collapsed into the
+	//       final exec only.
+	current, err := b.store.GetProcessByPID(ctx, evt.HostID, p.PID, evt.TimestampNs)
+	if err != nil {
+		return err
+	}
+
+	if current == nil {
+		return b.insertExecWithoutFork(ctx, evt, p)
+	}
+	if current.ExecTimeNs == nil {
+		return b.store.UpdateProcessExec(ctx, mysql.ProcessExecUpdate{
+			HostID: evt.HostID, PID: p.PID, ExecTimeNs: evt.TimestampNs,
+			Path: p.Path, Args: p.Args,
+			UID: p.UID, GID: p.GID,
+			CodeSigning: p.CodeSigning, SHA256: p.SHA256,
+		})
+	}
+	return b.insertReExec(ctx, evt, p, current)
+}
+
+// insertExecWithoutFork synthesizes a root process row when an exec
+// event arrives for a PID we've never seen fork for. fork_time_ns
+// is set to the exec time as a best effort.
+func (b *Builder) insertExecWithoutFork(ctx context.Context, evt api.Event, p execPayload) error {
+	ppid := 0
+	if p.PPID != 0 {
+		ppid = p.PPID
+	}
+	forkIngested := evt.IngestedAtNs
+	_, err := b.store.InsertProcess(ctx, api.Process{
+		HostID:           evt.HostID,
+		PID:              p.PID,
+		PPID:             ppid,
+		Path:             p.Path,
+		Args:             p.Args,
+		UID:              p.UID,
+		GID:              p.GID,
+		CodeSigning:      p.CodeSigning,
+		SHA256:           p.SHA256,
+		ForkTimeNs:       evt.TimestampNs,
+		ForkIngestedAtNs: &forkIngested,
+		ExecTimeNs:       &evt.TimestampNs,
+	})
+	return err
+}
+
+// insertReExec handles the issue #10 branch: a process called
+// execve() again on the same PID without forking in between. The
+// store's ReExec helper wraps the close + insert in a single
+// transaction so we can never leave the PID appearing exited with
+// no current generation (partial failure).
+func (b *Builder) insertReExec(ctx context.Context, evt api.Event, p execPayload, prior *api.Process) error {
+	_, reLinked, err := b.store.ReExec(ctx, prior.ID, evt.TimestampNs, evt.IngestedAtNs, api.Process{
+		HostID: evt.HostID,
+		PID:    p.PID,
+		// Preserve the parent linkage from the original fork: a re-exec
+		// doesn't change PPID on macOS. Falls back to whatever the exec
+		// event carries if the prior row somehow has ppid=0.
+		PPID:             pickPPID(prior.PPID, p.PPID),
+		Path:             p.Path,
+		Args:             p.Args,
+		UID:              p.UID,
+		GID:              p.GID,
+		CodeSigning:      p.CodeSigning,
+		SHA256:           p.SHA256,
+		ForkTimeNs:       prior.ForkTimeNs, // chain preserves the original fork time
+		ForkIngestedAtNs: prior.ForkIngestedAtNs,
+		ExecTimeNs:       &evt.TimestampNs,
+	})
+	if err != nil {
+		return fmt.Errorf("re-exec prior id=%d: %w", prior.ID, err)
+	}
+	if !reLinked {
+		// Prior row was terminally closed (observed exit or pid reuse):
+		// we anchored a fresh chain instead of chaining through.
+		b.logger.WarnContext(ctx, "re-exec arrived after prior generation was terminally closed",
+			"host_id", evt.HostID, "pid", p.PID, "prior_row_id", prior.ID)
+	}
+	return nil
+}
+
+// pickPPID prefers a non-zero prior PPID. macOS ES reports PPID on
+// every NOTIFY_EXEC and it should be identical for re-execs on the
+// same pid, but staying defensive: if prior has it and the event
+// doesn't, use prior.
+func pickPPID(prior, fromEvent int) int {
+	if prior != 0 {
+		return prior
+	}
+	return fromEvent
+}
+
+type exitPayload struct {
+	PID        int    `json:"pid"`
+	ExitCode   int    `json:"exit_code"`
+	ExitReason string `json:"exit_reason,omitempty"`
+}
+
+func (b *Builder) handleExit(ctx context.Context, evt api.Event) error {
+	var p exitPayload
+	if err := json.Unmarshal(evt.Payload, &p); err != nil {
+		return err
+	}
+
+	// Whitelist: only the agent-emitted reconciled reason is honoured
+	// on the wire. Anything else (server-only synthetic reasons:
+	// reexec, pid_reuse, ttl_reconciliation) collapses to
+	// ExitReasonEvent so a compromised agent can't mark normal exits
+	// with a misleading reason.
+	reason := api.ExitReasonEvent
+	if p.ExitReason == api.ExitReasonHostReconciled {
+		reason = api.ExitReasonHostReconciled
+	}
+
+	return b.store.UpdateProcessExit(ctx, evt.HostID, p.PID, evt.TimestampNs, evt.IngestedAtNs, p.ExitCode, reason)
+}

--- a/server/detection/internal/graph/query.go
+++ b/server/detection/internal/graph/query.go
@@ -27,9 +27,12 @@ func (q *Query) BuildTree(ctx context.Context, hostID string, tr api.TimeRange, 
 	return buildForest(procs), nil
 }
 
-// GetDetail returns a process with its network connections, DNS
-// queries, and re-exec chain.
-func (q *Query) GetDetail(ctx context.Context, hostID string, pid int, atTimeNs int64) (*api.ProcessDetail, error) {
+// GetProcessDetail returns a process with its network connections,
+// DNS queries, and re-exec chain. Method name matches the
+// detection/api.Service.GetProcessDetail entry point so the eventual
+// service layer (detection/internal/service) can delegate without an
+// adapter or rename.
+func (q *Query) GetProcessDetail(ctx context.Context, hostID string, pid int, atTimeNs int64) (*api.ProcessDetail, error) {
 	proc, err := q.store.GetProcessByPID(ctx, hostID, pid, atTimeNs)
 	if err != nil {
 		return nil, err

--- a/server/detection/internal/graph/query.go
+++ b/server/detection/internal/graph/query.go
@@ -1,0 +1,181 @@
+package graph
+
+import (
+	"context"
+
+	"github.com/fleetdm/edr/server/detection/api"
+	"github.com/fleetdm/edr/server/detection/internal/mysql"
+)
+
+// Query provides process tree and detail lookups.
+type Query struct {
+	store *mysql.Store
+}
+
+// NewQuery creates a graph query instance.
+func NewQuery(s *mysql.Store) *Query {
+	return &Query{store: s}
+}
+
+// BuildTree returns a forest of process trees for the given host
+// and time range.
+func (q *Query) BuildTree(ctx context.Context, hostID string, tr api.TimeRange, limit int) ([]api.ProcessNode, error) {
+	procs, err := q.store.GetProcessTree(ctx, hostID, tr, limit)
+	if err != nil {
+		return nil, err
+	}
+	return buildForest(procs), nil
+}
+
+// GetDetail returns a process with its network connections, DNS
+// queries, and re-exec chain.
+func (q *Query) GetDetail(ctx context.Context, hostID string, pid int, atTimeNs int64) (*api.ProcessDetail, error) {
+	proc, err := q.store.GetProcessByPID(ctx, hostID, pid, atTimeNs)
+	if err != nil {
+		return nil, err
+	}
+	if proc == nil {
+		return nil, nil
+	}
+
+	// Build an ingest-time window from the process lifetime. We used
+	// to bound by the ES kernel-stamped fork_time_ns with a 5-second
+	// pad to compensate for ES/NE clock drift (NE-emitted
+	// network_connect events routinely arrived 50-100 ms before the
+	// ES-emitted fork for the same pid). With issue #7 the events
+	// table carries a server-stamped ingested_at_ns, and processes
+	// carry fork_ingested_at_ns; we correlate on those instead so
+	// the clock is single-authority and monotonic per server. A
+	// small 1s pad remains to absorb intra-batch ordering slop.
+	const intraBatchPadNs = int64(1 * 1_000_000_000)
+	const thirtyDayBoundNs = int64(30 * 86400 * 1_000_000_000)
+	var (
+		forkAnchorNs int64
+		mixedAnchor  bool
+	)
+	if proc.ForkIngestedAtNs != nil {
+		forkAnchorNs = *proc.ForkIngestedAtNs
+	} else {
+		// Pre-migration row: no server ingest time exists for the fork,
+		// so we fall back to the on-host kernel timestamp as an
+		// approximate lower bound. The postSchemaMigrations backfill
+		// copies fork_time_ns into fork_ingested_at_ns for historical
+		// rows, so in steady state this branch only fires during a brief
+		// window right after the migration lands. Mark the anchor as
+		// mixed so the upper bound doesn't also rely on an ingest-time
+		// comparison.
+		forkAnchorNs = proc.ForkTimeNs
+		mixedAnchor = true
+	}
+	fromNs := max(forkAnchorNs-intraBatchPadNs, 0)
+	tr := api.TimeRange{FromNs: fromNs}
+	switch {
+	case mixedAnchor:
+		// Already lost precision on the lower bound by using a kernel
+		// timestamp against an ingest-time predicate; using kernel
+		// ExitTimeNs as the upper bound compounds the risk. Prefer the
+		// wide 30-day bound, which is already how still-running
+		// processes are handled and matches the pre-issue-7 behavior.
+		tr.ToNs = forkAnchorNs + thirtyDayBoundNs
+	case proc.ExitIngestedAtNs != nil:
+		// Both sides anchored on server-stamped ingest time.
+		tr.ToNs = *proc.ExitIngestedAtNs + intraBatchPadNs
+	default:
+		// Process still running: use a 30-day bound anchored on ingest.
+		tr.ToNs = forkAnchorNs + thirtyDayBoundNs
+	}
+
+	netEvents, err := q.store.GetNetworkEventsForProcess(ctx, hostID, pid, tr)
+	if err != nil {
+		return nil, err
+	}
+	chain, err := q.store.GetExecChain(ctx, *proc)
+	if err != nil {
+		return nil, err
+	}
+
+	detail := &api.ProcessDetail{
+		Process:            *proc,
+		NetworkConnections: filterByType(netEvents, "network_connect"),
+		DNSQueries:         filterByType(netEvents, "dns_query"),
+		ReExecChain:        chain,
+	}
+	return detail, nil
+}
+
+// ListHosts delegates to the store.
+func (q *Query) ListHosts(ctx context.Context) ([]api.HostSummary, error) {
+	return q.store.ListHosts(ctx)
+}
+
+// buildForest constructs a tree from a flat list of processes by
+// matching ppid -> pid. Uses Process.ID as map key to handle PID
+// reuse correctly, and builds parent-child links via pointers
+// before converting to value tree so grandchildren aren't lost.
+func buildForest(procs []api.Process) []api.ProcessNode {
+	nodeMap, pidToID := indexProcesses(procs)
+
+	childIDs := make(map[int64][]int64) // parentID -> child IDs
+	var rootIDs []int64
+	for _, node := range nodeMap {
+		parentDBID, parentFound := pidToID[node.PPID]
+		if parentFound {
+			if _, ok := nodeMap[parentDBID]; ok && parentDBID != node.ID {
+				childIDs[parentDBID] = append(childIDs[parentDBID], node.ID)
+				continue
+			}
+		}
+		rootIDs = append(rootIDs, node.ID)
+	}
+
+	var build func(id int64) api.ProcessNode
+	build = func(id int64) api.ProcessNode {
+		node := *nodeMap[id]
+		for _, childID := range childIDs[id] {
+			node.Children = append(node.Children, build(childID))
+		}
+		return node
+	}
+
+	roots := make([]api.ProcessNode, 0, len(rootIDs))
+	for _, id := range rootIDs {
+		roots = append(roots, build(id))
+	}
+	return roots
+}
+
+// indexProcesses builds the two lookup tables buildForest needs:
+// nodeMap keyed by the unique Process.ID (so PID reuse within a time
+// range doesn't collapse rows) and pidToID pointing each OS PID at
+// the row ID of its latest fork (so the parent-lookup phase finds
+// the current generation, not a historical one with the same PID).
+// Extracted from buildForest so that function stays below the
+// cognitive-complexity cap.
+func indexProcesses(procs []api.Process) (map[int64]*api.ProcessNode, map[int]int64) {
+	nodeMap := make(map[int64]*api.ProcessNode, len(procs))
+	pidToID := make(map[int]int64, len(procs))
+	for i := range procs {
+		p := &procs[i]
+		nodeMap[p.ID] = &api.ProcessNode{Process: *p}
+		existing, ok := pidToID[p.PID]
+		if !ok {
+			pidToID[p.PID] = p.ID
+			continue
+		}
+		prev, prevOK := nodeMap[existing]
+		if prevOK && p.ForkTimeNs > prev.ForkTimeNs {
+			pidToID[p.PID] = p.ID
+		}
+	}
+	return nodeMap, pidToID
+}
+
+func filterByType(events []api.Event, eventType string) []api.Event {
+	var filtered []api.Event
+	for _, e := range events {
+		if e.EventType == eventType {
+			filtered = append(filtered, e)
+		}
+	}
+	return filtered
+}


### PR DESCRIPTION
Adds the Builder + Query under the detection bounded context, both consuming detection/api types and *detection/internal/mysql.Store directly. The forest-building algorithm and the
ingest-time/kernel-time correlation pad are preserved verbatim from server/graph; only the package name and import paths change.

Updated detection/api types to support the move:
- ProcessNode: gained NetworkConnections + DNSQueries to match the existing wire shape that server/graph.ProcessNode emits today (preserving GET /api/hosts/{id}/tree's response bytes).
- ProcessDetail: NEW type matching server/graph.ProcessDetail, the shape GET /api/hosts/{id}/processes/{pid} returns.
- Service.BuildTree: signature corrected to return []ProcessNode (forest) and GetProcessDetail returns *ProcessDetail (full detail with re-exec chain), aligning the api with what the actual graph + operator surface delivers.

The existing server/graph package is unchanged so cmd/main still builds against it; the new package becomes the canonical home and the old one gets removed once cmd/main wiring switches.

Engine + filter scaffolding stays empty; the Engine implementation lands together with the rules.api alias collapse + cmd/main wiring because the three changes are tightly coupled: until rules.api.Event aliases to detection.api.Event, the Engine's call to rule.Evaluate has type mismatches across every rule file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Process detail endpoint now includes network connections and DNS query history for enhanced forensic investigation
  * Process tree builder returns multiple root processes per query for greater flexibility
  * Process re-execution chains are captured and available for lifecycle analysis

<!-- end of auto-generated comment: release notes by coderabbit.ai -->