### PR TITLE
Phase 7: per-context testkit packages; bootstrap is production-only

### DIFF
--- a/arch-go.yml
+++ b/arch-go.yml
@@ -3,81 +3,160 @@ version: 1
 # Architecture rules for the modular-monolith bounded-context migration.
 # See docs/adr/0004-modular-monolith-bounded-contexts.md for the rationale.
 #
-# Phase 6 strict mode: every transitional allow-list entry from earlier
-# phases (`**.store`, the `**.detection` catch-all) is gone. The five
-# bounded contexts are stable; new violations should fail the build.
+# Phase 7 strict mode: bootstrap is for production wiring only.
+# Per-context internal code may NOT import its own context's bootstrap;
+# tests reach for the per-context testkit instead. Cross-context tests
+# import only **.<Y>.api or **.<Y>.testkit — never **.<Y>.bootstrap and
+# never **.<Y>.internal.**. testkit packages are pinned to their own
+# context so cross-context test allowances cannot be exploited as
+# transitive paths to other bounded contexts.
 
 dependenciesRules:
-  # identity context internals may import only their own context,
-  # platform packages, and standard library / approved third-party.
-  # Other contexts that need identity functionality go through
-  # identity/api.
+  # identity context internals may import only identity's own api +
+  # internals + test-fixture surface, plus platform packages. Other
+  # contexts that need identity functionality go through identity/api.
   - package: "**.identity.internal.**"
     shouldOnlyDependsOn:
       internal:
-        - "**.identity.**"
+        - "**.identity.api"
+        - "**.identity.api.**"
+        - "**.identity.internal.**"
+        - "**.identity.testkit"
         - "**.attrkeys"
         - "**.httpserver"
-        - "**.testdb"  # test fixtures (external _test packages call testdb.Open)
+        - "**.testdb"
 
-  # endpoint context internals may import only their own context,
-  # platform packages, and standard library / approved third-party.
-  # Other contexts that need enrollment / host-token verification go
-  # through endpoint/api.
+  # endpoint context internals.
   - package: "**.endpoint.internal.**"
     shouldOnlyDependsOn:
       internal:
-        - "**.endpoint.**"
+        - "**.endpoint.api"
+        - "**.endpoint.api.**"
+        - "**.endpoint.internal.**"
+        - "**.endpoint.testkit"
         - "**.attrkeys"
         - "**.httpserver"
         - "**.rules.api"   # rules.api.PolicyService satisfies endpoint's PolicyProvider
-        - "**.testdb"      # test fixtures
+        - "**.testdb"
 
-  # rules context internals may import only their own context,
-  # platform packages, the standard library / approved third-party,
-  # endpoint/api (for the ActiveHostsLister adapter), and a narrow
-  # window into detection (api types + the testharness for catalog
-  # tests + bootstrap.ApplySchema for fixture setup).
+  # rules context internals. Cross-context test allowance is
+  # **.detection.testkit (and only testkit) — replaces the
+  # **.detection.bootstrap + **.detection.testharness pair phase 6
+  # carried as transitional exceptions.
   - package: "**.rules.internal.**"
     shouldOnlyDependsOn:
       internal:
-        - "**.rules.**"
+        - "**.rules.api"
+        - "**.rules.api.**"
+        - "**.rules.internal.**"
+        - "**.rules.testkit"
         - "**.attrkeys"
         - "**.httpserver"
-        - "**.endpoint.api"           # ActiveHostsLister uses endpoint.Service for hostID lookup
-        - "**.detection.api"          # detection's domain types (Event, Process, Finding, etc.)
-        - "**.detection.bootstrap"    # catalog tests apply detection schema via bootstrap.ApplySchema
-        - "**.detection.testharness"  # catalog tests use testharness.Scenario
-        - "**.testdb"                 # test fixtures
+        - "**.endpoint.api"
+        - "**.detection.api"
+        - "**.detection.api.**"
+        - "**.detection.testkit"
+        - "**.testdb"
 
-  # response context internals may import only their own context,
-  # platform packages, the standard library / approved third-party,
-  # identity/api (UserIDFromContext on POST /api/commands), and
-  # endpoint/api (HostIDFromContext on agent routes).
+  # response context internals.
   - package: "**.response.internal.**"
     shouldOnlyDependsOn:
       internal:
-        - "**.response.**"
+        - "**.response.api"
+        - "**.response.api.**"
+        - "**.response.internal.**"
+        - "**.response.testkit"
         - "**.attrkeys"
         - "**.httpserver"
-        - "**.endpoint.api"  # HostIDFromContext on agent routes
-        - "**.identity.api"  # reserved for future audit on POST /api/commands
-        - "**.sqlhelpers"    # NullRawJSON
-        - "**.testdb"        # test fixtures
+        - "**.endpoint.api"
+        - "**.identity.api"
+        - "**.sqlhelpers"
+        - "**.testdb"
 
-  # detection context internals may import only their own context,
-  # platform packages, the standard library / approved third-party,
-  # endpoint/api (HostIDFromContext on the ingest route), identity/api
-  # (UserIDFromContext on operator alert updates), and rules/api
-  # (Rule + RuleProvider interfaces the engine consumes).
+  # detection context internals.
   - package: "**.detection.internal.**"
     shouldOnlyDependsOn:
       internal:
-        - "**.detection.**"
+        - "**.detection.api"
+        - "**.detection.api.**"
+        - "**.detection.internal.**"
+        - "**.detection.testkit"
         - "**.attrkeys"
         - "**.httpserver"
-        - "**.endpoint.api"  # HostIDFromContext on POST /api/events
-        - "**.identity.api"  # UserIDFromContext on operator alert lifecycle
-        - "**.rules.api"     # Rule + RuleProvider interfaces
-        - "**.sqlhelpers"    # NullRawJSON
-        - "**.testdb"        # test fixtures
+        - "**.endpoint.api"
+        - "**.identity.api"
+        - "**.rules.api"
+        - "**.sqlhelpers"
+        - "**.testdb"
+
+  # ----- testkit packages -----------------------------------------------------
+  #
+  # testkit is a curated test-fixture surface for each bounded context.
+  # Pinning its dependencies to its own context (plus platform) prevents
+  # cross-context tests from using testkit as a transitive sneak-in
+  # path to a third context: even though rules.internal is allowed to
+  # import detection.testkit, detection.testkit cannot pull in
+  # identity/endpoint/response. arch-go inspects direct imports only,
+  # so this defence-in-depth rule is what makes the layered allow-list
+  # actually airtight.
+
+  - package: "**.identity.testkit"
+    shouldOnlyDependsOn:
+      internal:
+        - "**.identity.api"
+        - "**.identity.api.**"
+        - "**.identity.bootstrap"     # testkit.ApplySchema wraps bootstrap.ApplySchema
+        - "**.identity.internal.**"
+        - "**.attrkeys"
+        - "**.httpserver"
+        - "**.sqlhelpers"
+        - "**.testdb"
+
+  - package: "**.endpoint.testkit"
+    shouldOnlyDependsOn:
+      internal:
+        - "**.endpoint.api"
+        - "**.endpoint.api.**"
+        - "**.endpoint.bootstrap"
+        - "**.endpoint.internal.**"
+        - "**.attrkeys"
+        - "**.httpserver"
+        - "**.sqlhelpers"
+        - "**.testdb"
+
+  - package: "**.rules.testkit"
+    shouldOnlyDependsOn:
+      internal:
+        - "**.rules.api"
+        - "**.rules.api.**"
+        - "**.rules.bootstrap"
+        - "**.rules.internal.**"
+        - "**.attrkeys"
+        - "**.httpserver"
+        - "**.sqlhelpers"
+        - "**.testdb"
+
+  - package: "**.response.testkit"
+    shouldOnlyDependsOn:
+      internal:
+        - "**.response.api"
+        - "**.response.api.**"
+        - "**.response.bootstrap"
+        - "**.response.internal.**"
+        - "**.attrkeys"
+        - "**.httpserver"
+        - "**.sqlhelpers"
+        - "**.testdb"
+
+  - package: "**.detection.testkit"
+    shouldOnlyDependsOn:
+      internal:
+        - "**.detection.api"
+        - "**.detection.api.**"
+        - "**.detection.bootstrap"
+        - "**.detection.internal.**"
+        - "**.rules.api"              # Replay runs rulesapi.Rule against fixtures
+        - "**.attrkeys"
+        - "**.httpserver"
+        - "**.sqlhelpers"
+        - "**.testdb"

--- a/docs/adr/0004-modular-monolith-bounded-contexts.md
+++ b/docs/adr/0004-modular-monolith-bounded-contexts.md
@@ -104,18 +104,19 @@ that `bootstrap/` packages are imported only by `server/cmd/*`, each
 context's own `testkit/`, and integration tests.
 
 Each context also exposes a peer of `api/` / `bootstrap/` / `internal/`
-called `testkit/` — a coordinated test-fixture surface. testkit owns
-the schema-applier wrappers (`Apply`, `Migrate`), context-specific
-fakes/seeders, and (in detection's case) the rule-replay harness used
-by cross-context catalog tests. The split rule is:
+called `testkit/`: a coordinated test-fixture surface. testkit owns
+the schema-applier wrappers (`ApplySchema`, `MigrateSchema`),
+context-specific fakes/seeders, and (in detection's case) the
+rule-replay harness used by cross-context catalog tests. The split
+rule is:
 
-- Production wiring: `cmd/main` (and `server/testdb/full`'s test-only
-  composer) calls `bootstrap`. `bootstrap` is for standing up real
-  service instances.
-- Tests: per-context unit tests, cross-context integration tests, and
-  rule fixture replays all reach for `testkit`. arch-go pins each
-  testkit to its own context so cross-context test allowances cannot
-  be exploited as transitive sneak-in paths to a third context.
+- Production wiring: `cmd/main` calls `bootstrap`; `bootstrap` is for
+  standing up real service instances.
+- Tests: per-context unit tests, cross-context integration tests
+  (including `server/testdb/full`'s composer), and rule fixture
+  replays all reach for `testkit`. arch-go pins each testkit to its
+  own context so cross-context test allowances cannot be exploited as
+  transitive sneak-in paths to a third context.
 
 The migration runs as seven phases, smallest blast radius first
 (`identity` -> `endpoint` -> `rules` -> `response` -> `detection` ->

--- a/docs/adr/0004-modular-monolith-bounded-contexts.md
+++ b/docs/adr/0004-modular-monolith-bounded-contexts.md
@@ -100,9 +100,22 @@ the `internal/` rule. Architecture lint (`arch-go`, programmatic API
 invoked from `go test ./test/arch/...`) covers the rules Go's compiler
 cannot express, namely: which contexts may import which other contexts'
 `api/` packages, that platform packages may not import contexts, and
-that `bootstrap/` packages are imported only by `server/cmd/*`,
-`server/testdb/full` (the test fixture that composes every context's
-`ApplySchema`), and `test/integration/`.
+that `bootstrap/` packages are imported only by `server/cmd/*`, each
+context's own `testkit/`, and integration tests.
+
+Each context also exposes a peer of `api/` / `bootstrap/` / `internal/`
+called `testkit/` — a coordinated test-fixture surface. testkit owns
+the schema-applier wrappers (`Apply`, `Migrate`), context-specific
+fakes/seeders, and (in detection's case) the rule-replay harness used
+by cross-context catalog tests. The split rule is:
+
+- Production wiring: `cmd/main` (and `server/testdb/full`'s test-only
+  composer) calls `bootstrap`. `bootstrap` is for standing up real
+  service instances.
+- Tests: per-context unit tests, cross-context integration tests, and
+  rule fixture replays all reach for `testkit`. arch-go pins each
+  testkit to its own context so cross-context test allowances cannot
+  be exploited as transitive sneak-in paths to a third context.
 
 The migration runs as seven phases, smallest blast radius first
 (`identity` -> `endpoint` -> `rules` -> `response` -> `detection` ->

--- a/server/detection/internal/mysql/store_test.go
+++ b/server/detection/internal/mysql/store_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/fleetdm/edr/server/detection/api"
-	"github.com/fleetdm/edr/server/detection/bootstrap"
 	"github.com/fleetdm/edr/server/detection/internal/mysql"
+	"github.com/fleetdm/edr/server/detection/testkit"
 	"github.com/fleetdm/edr/server/testdb"
 )
 
@@ -23,8 +23,8 @@ func newTestStore(t *testing.T) *mysql.Store {
 	t.Helper()
 	db := testdb.Open(t)
 	ctx := t.Context()
-	require.NoError(t, bootstrap.ApplySchema(ctx, db))
-	require.NoError(t, bootstrap.MigrateSchema(ctx, db))
+	require.NoError(t, testkit.ApplySchema(ctx, db))
+	require.NoError(t, testkit.MigrateSchema(ctx, db))
 	s, err := mysql.New(db)
 	require.NoError(t, err)
 	return s

--- a/server/detection/testkit/replay.go
+++ b/server/detection/testkit/replay.go
@@ -1,31 +1,32 @@
-// Package testharness runs detection rules against JSON fixtures so new
-// rule PRs can be reviewed as "here are the events, here are the expected
-// findings" — no boilerplate per test. Existing rules keep their bespoke
-// tests (see server/detection/rules/*_test.go); new rules should prefer
-// this harness.
+package testkit
+
+// Replay runs detection rules against JSON fixtures so new rule PRs
+// can be reviewed as "here are the events, here are the expected
+// findings" — no per-rule boilerplate.
 //
 // Fixture layout:
 //
-//	server/detection/rules/fixtures/<rule_id>/<case>.json
+//	<fixtureDir>/<case>.json
 //
-// Each JSON file is one Go sub-test. Its name (minus .json) becomes the
-// sub-test name, so `positive_dump_keychain.json` prints as
+// Each JSON file is one Go sub-test. Its name (minus .json) becomes
+// the sub-test name, so `positive_dump_keychain.json` prints as
 // `positive_dump_keychain` in test output. Expected-no-findings cases
 // just set "expected_findings": [] (or omit the key).
 //
-// What the harness does per case:
-//  1. Spin up an isolated MySQL test store.
-//  2. s.InsertEvents(events) — server stamps ingested_at_ns here.
-//  3. graph.Builder.ProcessBatch(events) — materialises the process
+// What Replay does per case:
+//
+//  1. Spin up an isolated MySQL test DB via testdb.Open.
+//  2. Apply detection's schema + migrations via testkit's own helpers
+//     (no bootstrap import needed at the call site).
+//  3. s.InsertEvents(events) — server stamps ingested_at_ns here.
+//  4. graph.Builder.ProcessBatch(events) — materialises the process
 //     rows the rule depends on (fork/exec/exit).
-//  4. rule.Evaluate(events, store) and check the findings shape against
+//  5. rule.Evaluate(events, store) and check the findings shape against
 //     the fixture's expected_findings.
 //
-// What the harness does NOT do:
-//   - Persist findings as alerts (the engine does that in production).
-//     Rules are tested in isolation; Engine.Evaluate behaviour is
-//     covered separately by engine_test.go.
-package testharness
+// What Replay does NOT do: persist findings as alerts (the engine
+// does that in production). Rules are tested in isolation;
+// Engine.Evaluate behaviour is covered by engine_test.go.
 
 import (
 	"encoding/json"
@@ -40,7 +41,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	detectionapi "github.com/fleetdm/edr/server/detection/api"
-	detectionbootstrap "github.com/fleetdm/edr/server/detection/bootstrap"
 	"github.com/fleetdm/edr/server/detection/internal/graph"
 	"github.com/fleetdm/edr/server/detection/internal/mysql"
 	rulesapi "github.com/fleetdm/edr/server/rules/api"
@@ -51,8 +51,8 @@ import (
 type FixtureCase struct {
 	// Events are the event envelopes the rule will see. Fork + exec
 	// pairs are expected for any process the rule's Evaluate dereferences
-	// via GetProcessByPID; the harness calls ProcessBatch to materialise
-	// them before Evaluate.
+	// via GetProcessByPID; Replay calls ProcessBatch to materialise them
+	// before Evaluate.
 	Events []detectionapi.Event `json:"events"`
 	// ExpectedFindings is the assertion target. An empty slice (or
 	// omitted key) means "rule must not fire for these events" — a
@@ -76,8 +76,8 @@ type ExpectedFinding struct {
 // match. Fails t if fixtureDir is missing or has no cases — a silent
 // pass when all cases accidentally get moved is worse than a loud fail.
 //
-// Sub-tests are named by the fixture's path relative to fixtureDir with
-// the `.json` suffix stripped, so a file at
+// Sub-tests are named by the fixture's path relative to fixtureDir
+// with the `.json` suffix stripped, so a file at
 // `<dir>/sudoers/positive_overwrite.json` renders as sub-test name
 // `sudoers/positive_overwrite` and scoping via `-run` works naturally.
 func Replay(t *testing.T, rule rulesapi.Rule, fixtureDir string) {
@@ -110,8 +110,8 @@ func Replay(t *testing.T, rule rulesapi.Rule, fixtureDir string) {
 func runCase(t *testing.T, rule rulesapi.Rule, path string) {
 	t.Helper()
 	// Path is constructed from a fixed fixtureDir + a filename we
-	// already discovered via os.ReadDir on that same directory, so
-	// there's no user-input taint. gosec's G304 is a false positive
+	// already discovered via filepath.WalkDir on that same directory,
+	// so there's no user-input taint. gosec's G304 is a false positive
 	// in the test-harness context.
 	raw, err := os.ReadFile(path) //nolint:gosec // fixture path, not user input
 	require.NoError(t, err)
@@ -121,8 +121,8 @@ func runCase(t *testing.T, rule rulesapi.Rule, path string) {
 
 	db := testdb.Open(t)
 	ctx := t.Context()
-	require.NoError(t, detectionbootstrap.ApplySchema(ctx, db), "apply detection schema")
-	require.NoError(t, detectionbootstrap.MigrateSchema(ctx, db), "apply detection migrations")
+	require.NoError(t, ApplySchema(ctx, db), "apply detection schema")
+	require.NoError(t, MigrateSchema(ctx, db), "apply detection migrations")
 	mysqlStore, err := mysql.New(db)
 	require.NoError(t, err, "wrap test store")
 	require.NoError(t, mysqlStore.InsertEvents(ctx, c.Events), "insert events")
@@ -138,15 +138,15 @@ func runCase(t *testing.T, rule rulesapi.Rule, path string) {
 		len(c.ExpectedFindings), len(findings))
 
 	// Positional match. Rules in this codebase emit findings in
-	// deterministic order (iteration over sorted event batches); if a
-	// rule ever goes non-deterministic we should address it in the rule
-	// itself, not here.
+	// deterministic order (iteration over sorted event batches); if
+	// a rule ever goes non-deterministic we should address it in the
+	// rule itself, not here.
 	//
 	// Range over findings rather than ExpectedFindings so nilaway can
-	// see that we never index a nil slice — rule.Evaluate returns a nil
-	// []Finding for no-match cases, which is Go-idiomatic but trips
-	// nilaway's can-be-nil flow without this rewrite. The require.Len
-	// above guarantees ExpectedFindings[i] is in range.
+	// see that we never index a nil slice — rule.Evaluate returns a
+	// nil []Finding for no-match cases, which is Go-idiomatic but
+	// trips nilaway's can-be-nil flow without this rewrite. The
+	// require.Len above guarantees ExpectedFindings[i] is in range.
 	for i, got := range findings {
 		want := c.ExpectedFindings[i]
 		assert.Equal(t, want.RuleID, got.RuleID, "finding[%d].rule_id", i)

--- a/server/detection/testkit/scenario.go
+++ b/server/detection/testkit/scenario.go
@@ -1,4 +1,4 @@
-package testharness
+package testkit
 
 import (
 	"context"
@@ -15,17 +15,17 @@ import (
 
 // Scenario is a per-test detection-stack fixture: a *mysql.Store
 // wrapping the test DB, and a *graph.Builder that materialises events
-// into the processes table. Catalog tests that need to seed events +
-// reach api.GraphReader without going through the fixture-based
-// Replay path use this helper because they cannot import
-// detection/internal/* directly (Go's internal-package rule).
+// into the processes table. Tests outside detection (e.g. catalog rule
+// tests in server/rules/internal/catalog/) use this to seed events +
+// reach api.GraphReader without going through Go's internal-package
+// rule.
 type Scenario struct {
 	Store   *mysql.Store
 	Builder *graph.Builder
 }
 
 // NewScenario builds a detection fixture wrapping the given test DB
-// (typically returned by server/bootstrap.OpenTestDB).
+// (typically returned by server/testdb.Open).
 func NewScenario(t *testing.T, db *sqlx.DB) *Scenario {
 	t.Helper()
 	s, err := mysql.New(db)

--- a/server/detection/testkit/testkit.go
+++ b/server/detection/testkit/testkit.go
@@ -1,0 +1,51 @@
+// Package testkit is detection's coordinated test-fixture surface.
+//
+// Tests reach for testkit; production wiring (cmd/main, server/testdb/full,
+// test/integration) reaches for bootstrap. The two contracts are
+// deliberately separate so cross-context tests (e.g. rule catalog
+// tests living in server/rules/internal/catalog/) don't couple to
+// detection's wiring layer.
+//
+// Three things live here today:
+//
+//  1. ApplySchema / MigrateSchema — thin wrappers over the same
+//     functions on bootstrap so tests get the same DDL behaviour
+//     production gets.
+//  2. Scenario — a per-test fixture that pairs detection's *mysql.Store
+//     and *graph.Builder so callers can insert events and materialise
+//     the process graph the rule under test will read.
+//  3. Replay — fixture-driven rule-test runner: caller points at a dir
+//     of <case>.json files, each becomes a sub-test asserting the
+//     rule's findings match expected_findings.
+//
+// Replaces the previous server/detection/testharness/ package; the
+// rename also means cross-context tests import a single
+// **.detection.testkit allow-list entry instead of the two
+// **.detection.bootstrap + **.detection.testharness entries that
+// phase 6 carried as transitional exceptions.
+//
+// Constraint: testkit may import detection's own internals (it lives
+// inside detection/) but must NOT import any other bounded context.
+// arch-go pins the rule.
+package testkit
+
+import (
+	"context"
+
+	"github.com/jmoiron/sqlx"
+
+	"github.com/fleetdm/edr/server/detection/bootstrap"
+)
+
+// ApplySchema runs detection's CREATE TABLE statements against db.
+// Thin wrapper over bootstrap.ApplySchema so the test surface is
+// importable separately from the production wiring surface.
+func ApplySchema(ctx context.Context, db *sqlx.DB) error {
+	return bootstrap.ApplySchema(ctx, db)
+}
+
+// MigrateSchema runs detection's idempotent ALTERs against db. Thin
+// wrapper over bootstrap.MigrateSchema for the same reason.
+func MigrateSchema(ctx context.Context, db *sqlx.DB) error {
+	return bootstrap.MigrateSchema(ctx, db)
+}

--- a/server/endpoint/internal/mysql/store_test.go
+++ b/server/endpoint/internal/mysql/store_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/fleetdm/edr/server/endpoint/bootstrap"
 	"github.com/fleetdm/edr/server/endpoint/internal/mysql"
+	"github.com/fleetdm/edr/server/endpoint/testkit"
 	"github.com/fleetdm/edr/server/testdb"
 )
 
@@ -21,13 +21,13 @@ const (
 )
 
 // newTestStore opens an isolated DB and applies endpoint's schema via
-// the canonical bootstrap.ApplySchema. Lives in the external test
+// the canonical testkit.ApplySchema. Lives in the external test
 // package so the testdb -> endpoint/bootstrap -> endpoint/internal/mysql
 // cycle doesn't bite when this file is in `package mysql`.
 func newTestStore(t *testing.T) *mysql.Store {
 	t.Helper()
 	db := testdb.Open(t)
-	require.NoError(t, bootstrap.ApplySchema(t.Context(), db))
+	require.NoError(t, testkit.ApplySchema(t.Context(), db))
 	return mysql.NewStore(db)
 }
 

--- a/server/endpoint/testkit/testkit.go
+++ b/server/endpoint/testkit/testkit.go
@@ -1,0 +1,30 @@
+// Package testkit is endpoint's coordinated test-fixture surface.
+//
+// Tests reach for testkit; production wiring (cmd/main, server/testdb/full,
+// test/integration) reaches for bootstrap. The two contracts are
+// deliberately separate so per-context unit tests don't couple to
+// endpoint's wiring layer.
+//
+// Today the package only exposes ApplySchema. As cross-context tests
+// grow, this is the right home for endpoint-specific seeders
+// (e.g. SeedEnrollment, MintHostToken) and fakes so each test file
+// stops re-implementing them.
+//
+// Constraint: this package must NOT import any other bounded context.
+// arch-go pins the rule.
+package testkit
+
+import (
+	"context"
+
+	"github.com/jmoiron/sqlx"
+
+	"github.com/fleetdm/edr/server/endpoint/bootstrap"
+)
+
+// ApplySchema runs endpoint's DDL against db. Thin wrapper over
+// bootstrap.ApplySchema so the test surface is importable separately
+// from the production wiring surface.
+func ApplySchema(ctx context.Context, db *sqlx.DB) error {
+	return bootstrap.ApplySchema(ctx, db)
+}

--- a/server/identity/internal/login/handler_test.go
+++ b/server/identity/internal/login/handler_test.go
@@ -12,12 +12,12 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/fleetdm/edr/server/identity/api"
-	"github.com/fleetdm/edr/server/identity/bootstrap"
 	"github.com/fleetdm/edr/server/identity/internal/login"
 	"github.com/fleetdm/edr/server/identity/internal/middleware"
 	"github.com/fleetdm/edr/server/identity/internal/service"
 	"github.com/fleetdm/edr/server/identity/internal/sessions"
 	"github.com/fleetdm/edr/server/identity/internal/users"
+	"github.com/fleetdm/edr/server/identity/testkit"
 	"github.com/fleetdm/edr/server/testdb"
 )
 
@@ -42,7 +42,7 @@ type errBody struct {
 func setupServer(t *testing.T, ratePerMinute int) (*httptest.Server, *users.Store, *sessions.Store) {
 	t.Helper()
 	db := testdb.Open(t)
-	require.NoError(t, bootstrap.ApplySchema(t.Context(), db))
+	require.NoError(t, testkit.ApplySchema(t.Context(), db))
 	us := users.New(db)
 	ss := sessions.New(db, sessions.Options{})
 	svc := service.New(us, ss, slog.Default())

--- a/server/identity/internal/middleware/session_test.go
+++ b/server/identity/internal/middleware/session_test.go
@@ -11,11 +11,11 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/fleetdm/edr/server/identity/api"
-	"github.com/fleetdm/edr/server/identity/bootstrap"
 	"github.com/fleetdm/edr/server/identity/internal/middleware"
 	"github.com/fleetdm/edr/server/identity/internal/service"
 	"github.com/fleetdm/edr/server/identity/internal/sessions"
 	"github.com/fleetdm/edr/server/identity/internal/users"
+	"github.com/fleetdm/edr/server/identity/testkit"
 	"github.com/fleetdm/edr/server/testdb"
 )
 
@@ -26,7 +26,7 @@ import (
 func newService(t *testing.T) (api.Service, *sessions.Store) {
 	t.Helper()
 	s := testdb.Open(t)
-	require.NoError(t, bootstrap.ApplySchema(t.Context(), s))
+	require.NoError(t, testkit.ApplySchema(t.Context(), s))
 	for _, uid := range []int64{1, 7, 42} {
 		_, err := s.ExecContext(t.Context(),
 			`INSERT INTO users (id, email, password_hash, password_salt) VALUES (?, ?, ?, ?)`,

--- a/server/identity/internal/seed/admin_test.go
+++ b/server/identity/internal/seed/admin_test.go
@@ -8,16 +8,16 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/fleetdm/edr/server/identity/bootstrap"
 	"github.com/fleetdm/edr/server/identity/internal/seed"
 	"github.com/fleetdm/edr/server/identity/internal/users"
+	"github.com/fleetdm/edr/server/identity/testkit"
 	"github.com/fleetdm/edr/server/testdb"
 )
 
 func newUsersStore(t *testing.T) *users.Store {
 	t.Helper()
 	db := testdb.Open(t)
-	require.NoError(t, bootstrap.ApplySchema(t.Context(), db))
+	require.NoError(t, testkit.ApplySchema(t.Context(), db))
 	return users.New(db)
 }
 

--- a/server/identity/internal/sessions/sessions_test.go
+++ b/server/identity/internal/sessions/sessions_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/fleetdm/edr/server/identity/bootstrap"
 	"github.com/fleetdm/edr/server/identity/internal/sessions"
+	"github.com/fleetdm/edr/server/identity/testkit"
 	"github.com/fleetdm/edr/server/testdb"
 )
 
@@ -19,7 +19,7 @@ import (
 func newTestStore(t *testing.T, opts sessions.Options) *sessions.Store {
 	t.Helper()
 	db := testdb.Open(t)
-	require.NoError(t, bootstrap.ApplySchema(t.Context(), db))
+	require.NoError(t, testkit.ApplySchema(t.Context(), db))
 	for _, uid := range []int64{1, 2, 7, 42} {
 		_, err := db.ExecContext(t.Context(),
 			`INSERT INTO users (id, email, password_hash, password_salt) VALUES (?, ?, ?, ?)`,

--- a/server/identity/internal/users/users_test.go
+++ b/server/identity/internal/users/users_test.go
@@ -6,8 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/fleetdm/edr/server/identity/bootstrap"
 	"github.com/fleetdm/edr/server/identity/internal/users"
+	"github.com/fleetdm/edr/server/identity/testkit"
 	"github.com/fleetdm/edr/server/testdb"
 )
 
@@ -18,7 +18,7 @@ import (
 func newTestStore(t *testing.T) *users.Store {
 	t.Helper()
 	db := testdb.Open(t)
-	require.NoError(t, bootstrap.ApplySchema(t.Context(), db))
+	require.NoError(t, testkit.ApplySchema(t.Context(), db))
 	return users.New(db)
 }
 

--- a/server/identity/testkit/testkit.go
+++ b/server/identity/testkit/testkit.go
@@ -1,0 +1,33 @@
+// Package testkit is identity's coordinated test-fixture surface.
+//
+// Tests reach for testkit; production wiring (cmd/main, server/testdb/full,
+// test/integration) reaches for bootstrap. The two contracts are
+// deliberately separate: bootstrap is for standing up real wiring;
+// testkit is for tests that need just enough of identity to exercise
+// some other piece (the users table, a stub User existence check, etc.)
+// without spinning up the full Identity service.
+//
+// Today the package only exposes ApplySchema. As cross-context tests
+// grow, this is the right home for identity-specific seeders
+// (e.g. SeedUser) and fakes (e.g. UserExistsAlways) so each test file
+// stops re-implementing them.
+//
+// Constraint: this package must NOT import any other bounded context.
+// arch-go pins the rule. Cross-context fixture composition is
+// server/testdb/full's job, not testkit's.
+package testkit
+
+import (
+	"context"
+
+	"github.com/jmoiron/sqlx"
+
+	"github.com/fleetdm/edr/server/identity/bootstrap"
+)
+
+// ApplySchema runs identity's DDL + idempotent ALTERs against db.
+// Thin wrapper over bootstrap.ApplySchema so the test surface is
+// importable separately from the production wiring surface.
+func ApplySchema(ctx context.Context, db *sqlx.DB) error {
+	return bootstrap.ApplySchema(ctx, db)
+}

--- a/server/response/internal/mysql/store_test.go
+++ b/server/response/internal/mysql/store_test.go
@@ -8,19 +8,19 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/fleetdm/edr/server/response/api"
-	"github.com/fleetdm/edr/server/response/bootstrap"
 	"github.com/fleetdm/edr/server/response/internal/mysql"
+	"github.com/fleetdm/edr/server/response/testkit"
 	"github.com/fleetdm/edr/server/testdb"
 )
 
 // newTestStore opens an isolated DB and applies response's schema via
-// the canonical bootstrap.ApplySchema. Lives in the external test
+// the canonical testkit.ApplySchema. Lives in the external test
 // package so the testdb -> response/bootstrap -> response/internal/mysql
 // cycle doesn't bite when this file is in `package mysql`.
 func newTestStore(t *testing.T) *mysql.Store {
 	t.Helper()
 	db := testdb.Open(t)
-	require.NoError(t, bootstrap.ApplySchema(t.Context(), db))
+	require.NoError(t, testkit.ApplySchema(t.Context(), db))
 	return mysql.NewStore(db)
 }
 

--- a/server/response/testkit/testkit.go
+++ b/server/response/testkit/testkit.go
@@ -1,0 +1,29 @@
+// Package testkit is response's coordinated test-fixture surface.
+//
+// Tests reach for testkit; production wiring (cmd/main, server/testdb/full,
+// test/integration) reaches for bootstrap. The two contracts are
+// deliberately separate.
+//
+// Today the package only exposes ApplySchema. As cross-context tests
+// grow, this is the right home for response-specific seeders (e.g.
+// SeedCommand) and fakes (e.g. NoopHeartbeat) so each test file stops
+// re-implementing them.
+//
+// Constraint: this package must NOT import any other bounded context.
+// arch-go pins the rule.
+package testkit
+
+import (
+	"context"
+
+	"github.com/jmoiron/sqlx"
+
+	"github.com/fleetdm/edr/server/response/bootstrap"
+)
+
+// ApplySchema runs response's DDL against db. Thin wrapper over
+// bootstrap.ApplySchema so the test surface is importable separately
+// from the production wiring surface.
+func ApplySchema(ctx context.Context, db *sqlx.DB) error {
+	return bootstrap.ApplySchema(ctx, db)
+}

--- a/server/rules/internal/catalog/credential_keychain_dump_test.go
+++ b/server/rules/internal/catalog/credential_keychain_dump_test.go
@@ -5,15 +5,15 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/fleetdm/edr/server/detection/testharness"
+	detectiontestkit "github.com/fleetdm/edr/server/detection/testkit"
 )
 
 // TestCredentialKeychainDump_Fixtures runs every fixture case under
 // fixtures/credential_keychain_dump/ as its own sub-test. Add a new
 // case by dropping a *.json file in that directory — no Go edits
-// needed. See server/detection/testharness for the fixture schema.
+// needed. See server/detection/testkit for the fixture schema.
 func TestCredentialKeychainDump_Fixtures(t *testing.T) {
-	testharness.Replay(t, &CredentialKeychainDump{}, "fixtures/credential_keychain_dump")
+	detectiontestkit.Replay(t, &CredentialKeychainDump{}, "fixtures/credential_keychain_dump")
 }
 
 // TestCredentialKeychainDump_TechniquesMapping pins the MITRE ATT&CK

--- a/server/rules/internal/catalog/privilege_launchd_plist_write_test.go
+++ b/server/rules/internal/catalog/privilege_launchd_plist_write_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/fleetdm/edr/server/detection/testharness"
+	detectiontestkit "github.com/fleetdm/edr/server/detection/testkit"
 	"github.com/fleetdm/edr/server/rules/api"
 )
 
@@ -37,7 +37,7 @@ func TestPrivilegeLaunchdPlistWrite_Fixtures(t *testing.T) {
 			"FIXTURE-ALLOW": {},
 		},
 	}
-	testharness.Replay(t, r, "fixtures/privilege_launchd_plist_write")
+	detectiontestkit.Replay(t, r, "fixtures/privilege_launchd_plist_write")
 }
 
 // TestPrivilegeLaunchdPlistWrite_TechniquesMapping pins the MITRE ATT&CK
@@ -142,8 +142,8 @@ func TestPrivilegeLaunchdPlistWrite_OpenRaceWithoutProcess(t *testing.T) {
 	assert.Empty(t, findings, "race against process materialisation must skip silently")
 }
 
-// Compile-time check that testharness is referenced (other tests in
+// Compile-time check that detection/testkit is referenced (other tests in
 // this package use Replay; the import sits at file scope alongside
 // the api import so this declaration keeps the unused-import linter
 // happy without forcing a per-test refactor).
-var _ = testharness.Replay
+var _ = detectiontestkit.Replay

--- a/server/rules/internal/catalog/sudoers_tamper_test.go
+++ b/server/rules/internal/catalog/sudoers_tamper_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/fleetdm/edr/server/detection/testharness"
+	detectiontestkit "github.com/fleetdm/edr/server/detection/testkit"
 	"github.com/fleetdm/edr/server/rules/api"
 )
 
@@ -19,7 +19,7 @@ func TestSudoersTamper_Fixtures(t *testing.T) {
 			"/usr/local/bin/fixture-allowed-writer": {},
 		},
 	}
-	testharness.Replay(t, r, "fixtures/sudoers_tamper")
+	detectiontestkit.Replay(t, r, "fixtures/sudoers_tamper")
 }
 
 // TestSudoersTamper_TechniquesMapping pins the MITRE ATT&CK mapping.

--- a/server/rules/internal/catalog/testhelpers_test.go
+++ b/server/rules/internal/catalog/testhelpers_test.go
@@ -7,27 +7,26 @@ import (
 	"github.com/stretchr/testify/require"
 
 	detectionapi "github.com/fleetdm/edr/server/detection/api"
-	detectionbootstrap "github.com/fleetdm/edr/server/detection/bootstrap"
-	"github.com/fleetdm/edr/server/detection/testharness"
+	detectiontestkit "github.com/fleetdm/edr/server/detection/testkit"
 	"github.com/fleetdm/edr/server/testdb"
 )
 
 // catalogStore is a thin wrapper that exposes the limited
 // per-rule-test surface (insert events, materialise the process
 // graph, satisfy GraphReader). It hides the *mysql.Store +
-// *graph.Builder behind the testharness.Scenario type because
+// *graph.Builder behind the testkit.Scenario type because
 // catalog tests cannot import detection/internal/* directly.
 type catalogStore struct {
-	scenario *testharness.Scenario
+	scenario *detectiontestkit.Scenario
 }
 
 func openCatalogStore(t *testing.T) *catalogStore {
 	t.Helper()
 	db := testdb.Open(t)
 	ctx := t.Context()
-	require.NoError(t, detectionbootstrap.ApplySchema(ctx, db))
-	require.NoError(t, detectionbootstrap.MigrateSchema(ctx, db))
-	return &catalogStore{scenario: testharness.NewScenario(t, db)}
+	require.NoError(t, detectiontestkit.ApplySchema(ctx, db))
+	require.NoError(t, detectiontestkit.MigrateSchema(ctx, db))
+	return &catalogStore{scenario: detectiontestkit.NewScenario(t, db)}
 }
 
 // InsertEvents inserts a batch into the test DB.

--- a/server/rules/internal/policy/store_test.go
+++ b/server/rules/internal/policy/store_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/fleetdm/edr/server/rules/api"
-	"github.com/fleetdm/edr/server/rules/bootstrap"
 	"github.com/fleetdm/edr/server/rules/internal/policy"
+	"github.com/fleetdm/edr/server/rules/testkit"
 	"github.com/fleetdm/edr/server/testdb"
 )
 
@@ -21,7 +21,7 @@ import (
 func newTestStore(t *testing.T) *policy.Store {
 	t.Helper()
 	db := testdb.Open(t)
-	require.NoError(t, bootstrap.ApplySchema(t.Context(), db))
+	require.NoError(t, testkit.ApplySchema(t.Context(), db))
 	return policy.NewStore(db)
 }
 

--- a/server/rules/testkit/testkit.go
+++ b/server/rules/testkit/testkit.go
@@ -1,0 +1,28 @@
+// Package testkit is rules' coordinated test-fixture surface.
+//
+// Tests reach for testkit; production wiring (cmd/main, server/testdb/full,
+// test/integration) reaches for bootstrap. The two contracts are
+// deliberately separate.
+//
+// Today the package only exposes ApplySchema. As cross-context tests
+// grow, this is the right home for rules-specific seeders (e.g.
+// SeedPolicy) and fakes so each test file stops re-implementing them.
+//
+// Constraint: this package must NOT import any other bounded context.
+// arch-go pins the rule.
+package testkit
+
+import (
+	"context"
+
+	"github.com/jmoiron/sqlx"
+
+	"github.com/fleetdm/edr/server/rules/bootstrap"
+)
+
+// ApplySchema runs rules' DDL + seed-row inserts against db. Thin
+// wrapper over bootstrap.ApplySchema so the test surface is importable
+// separately from the production wiring surface.
+func ApplySchema(ctx context.Context, db *sqlx.DB) error {
+	return bootstrap.ApplySchema(ctx, db)
+}

--- a/server/testdb/full/full.go
+++ b/server/testdb/full/full.go
@@ -5,15 +5,21 @@
 // a single context's internal/ tree.
 //
 // Per-context unit tests inside `*/internal/X/` should use
-// server/testdb (the lightweight Open) plus the relevant context's
-// own ApplySchema directly, to avoid an import cycle of
+// server/testdb (the lightweight Open) plus their own context's
+// testkit.ApplySchema, to avoid the cycle
 // X → testdb/full → ctx/bootstrap → X.
 //
 // Schemas are applied in dependency order: identity first (owns
 // users + sessions), then endpoint, rules, response, detection. After
 // phase 5 dropped the cross-context fk_alerts_updated_by FK the
 // remaining four are independent; the order is preserved for
-// readability.
+// readability and so future cross-context FKs (e.g. an audit log
+// keyed by user_id) Just Work without re-shuffling the call sites.
+//
+// full imports each context's testkit rather than its bootstrap so
+// the rule "production wiring (bootstrap) and test fixtures (testkit)
+// are separate contracts" stays clean: cmd/main calls bootstrap, every
+// test surface goes through testkit.
 package full
 
 import (
@@ -21,11 +27,11 @@ import (
 
 	"github.com/jmoiron/sqlx"
 
-	detectionbootstrap "github.com/fleetdm/edr/server/detection/bootstrap"
-	endpointbootstrap "github.com/fleetdm/edr/server/endpoint/bootstrap"
-	identitybootstrap "github.com/fleetdm/edr/server/identity/bootstrap"
-	responsebootstrap "github.com/fleetdm/edr/server/response/bootstrap"
-	rulesbootstrap "github.com/fleetdm/edr/server/rules/bootstrap"
+	detectiontestkit "github.com/fleetdm/edr/server/detection/testkit"
+	endpointtestkit "github.com/fleetdm/edr/server/endpoint/testkit"
+	identitytestkit "github.com/fleetdm/edr/server/identity/testkit"
+	responsetestkit "github.com/fleetdm/edr/server/response/testkit"
+	rulestestkit "github.com/fleetdm/edr/server/rules/testkit"
 	"github.com/fleetdm/edr/server/testdb"
 )
 
@@ -36,22 +42,22 @@ func Open(t *testing.T) *sqlx.DB {
 	db := testdb.Open(t)
 	ctx := t.Context()
 
-	if err := identitybootstrap.ApplySchema(ctx, db); err != nil {
+	if err := identitytestkit.ApplySchema(ctx, db); err != nil {
 		t.Fatalf("apply identity schema: %v", err)
 	}
-	if err := endpointbootstrap.ApplySchema(ctx, db); err != nil {
+	if err := endpointtestkit.ApplySchema(ctx, db); err != nil {
 		t.Fatalf("apply endpoint schema: %v", err)
 	}
-	if err := rulesbootstrap.ApplySchema(ctx, db); err != nil {
+	if err := rulestestkit.ApplySchema(ctx, db); err != nil {
 		t.Fatalf("apply rules schema: %v", err)
 	}
-	if err := responsebootstrap.ApplySchema(ctx, db); err != nil {
+	if err := responsetestkit.ApplySchema(ctx, db); err != nil {
 		t.Fatalf("apply response schema: %v", err)
 	}
-	if err := detectionbootstrap.ApplySchema(ctx, db); err != nil {
+	if err := detectiontestkit.ApplySchema(ctx, db); err != nil {
 		t.Fatalf("apply detection schema: %v", err)
 	}
-	if err := detectionbootstrap.MigrateSchema(ctx, db); err != nil {
+	if err := detectiontestkit.MigrateSchema(ctx, db); err != nil {
 		t.Fatalf("apply detection migrations: %v", err)
 	}
 	return db


### PR DESCRIPTION
Introduces server/<X>/testkit/ for each of the five bounded contexts (identity, endpoint, rules, response, detection) as the curated test-fixture surface. Tests reach for testkit; production wiring (cmd/main, server/testdb/full) reaches for bootstrap.

Why: phase 6 left two non-API cross-context allowances in arch-go (**.detection.bootstrap and **.detection.testharness) so the catalog rule tests could apply detection schema and use testharness.Scenario. Both weakened the API-only bounded-context rule. Phase 7 collapses them into a single **.detection.testkit allowance, generalises the pattern across every context, and drops every test's direct dependency on its own context's bootstrap package.

Per-context surface:

- <X>/testkit/testkit.go: ApplySchema (and MigrateSchema for detection). Thin wrappers over bootstrap so the test contract is importable separately from the production wiring contract.
- detection/testkit/scenario.go + replay.go: lifted from detection/testharness/. Same code, new path. Replay also uses testkit's own Apply/Migrate so the runner doesn't reach for detection/bootstrap directly.

testdb/full now composes testkit.Apply across the five contexts (was calling bootstrap.ApplySchema). cmd/main is unchanged — production wiring still lives in bootstrap.

arch-go strict mode tightening:

- Each <X>/internal/* allow-list enumerates **.<X>.{api, internal.**, testkit} — drops the over-broad **.<X>.** that previously let internal code import its own bootstrap. Internal production code cannot call its own context's bootstrap; tests reach for testkit.
- New per-testkit rules pin each testkit to its own context, so cross-context test allowances (rules.internal -> detection.testkit) cannot be exploited as transitive sneak-in paths to a third context. Verified by transient violator files (one direct cross-context import in policy, one transitive sneak-in via testkit) before this commit.
- rules.internal allow-list drops **.detection.bootstrap and **.detection.testharness; gains **.detection.testkit. The non-API cross-context door is closed.

detection/testharness/ is deleted. Catalog rule fixture tests (credential_keychain_dump, privilege_launchd_plist_write, sudoers_tamper, testhelpers) and detection-internal tests all migrate to detection/testkit.

ADR-0004 updated with the testkit/bootstrap split.

go build ./..., task lint:go, task lint:arch, and full server test suite all clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized testing infrastructure across bounded contexts with dedicated testkit packages as the public testing surface
  * Enforced stricter module dependency boundaries

* **Tests**
  * Updated test suites to use new testkit infrastructure for database schema initialization

* **Documentation**
  * Updated architecture documentation to reflect module boundary changes and testing structure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->