### PR TITLE
docs: drop broken edr.enroll.attempts metric reference (api.md)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -113,7 +113,8 @@ Over-limit requests return `429 Too Many Requests` with a
 `Retry-After` header.
 
 Ingestion (`POST /api/events`), command polling, and UI read
-endpoints are not rate limited.
+endpoints are not rate limited. If you proxy thousands of agents
+through a single IP (NAT), you may hit the enrollment rate limit.
 
 ## Errors
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -113,9 +113,7 @@ Over-limit requests return `429 Too Many Requests` with a
 `Retry-After` header.
 
 Ingestion (`POST /api/events`), command polling, and UI read
-endpoints are not rate limited. If you proxy thousands of agents
-through a single IP (NAT), monitor `edr.enroll.attempts` in OTel
-metrics to confirm you're not hitting the enroll cap.
+endpoints are not rate limited.
 
 ## Errors
 


### PR DESCRIPTION
Doc accuracy sweep, Broken category. The api.md rate-limits section suggested operators monitor `edr.enroll.attempts` in OTel metrics, but no such metric is registered (server/metrics/metrics.go ships edr.events.ingested, edr.alerts.created, edr.enrolled.hosts, edr.offline.hosts, edr.retention.rows_deleted, edr.processes.ttl_reconciled, edr.db.query.duration, edr.agent.queue.dropped, and that's the full set). Operators acting on that advice would search for a metric that will never appear.

Removing the broken sentence rather than substituting an alternative, per the sweep's "fix or remove" rule for Broken-category findings; adding new monitoring guidance is out of scope for this sweep.