### PR TITLE
docs: fix renamed-identifier references found in 2026-05-03 sweep

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,4 +84,4 @@ Layered on the global guide. Project-specific:
 - Line wrap at 140 characters.
 - Sentence case for headings.
 - No em-dashes (use `—` only when explicitly asked, otherwise `:` or `-` with surrounding spaces).
-- Don't run `make db-reset` without explicit user permission.
+- Don't run `task db:reset` without explicit user permission.

--- a/docs/api.md
+++ b/docs/api.md
@@ -82,8 +82,8 @@ X-CSRF-Token: <csrf_token>
 GET requests only need the cookie. Logout is `DELETE /api/session`.
 
 Endpoints that require the session cookie:
-- `GET /api/hosts`, `/api/hosts/{id}/tree`,
-  `/api/hosts/{id}/processes/{pid}`
+- `GET /api/hosts`, `/api/hosts/{host_id}/tree`,
+  `/api/hosts/{host_id}/processes/{pid}`
 - `GET /api/alerts`, `/api/alerts/{id}`; `PUT /api/alerts/{id}`
 - `GET /api/commands/{id}`, `POST /api/commands`
 - `GET /api/enrollments`,

--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -262,8 +262,7 @@ floor for any project that wants enterprise adoption.
 - [x] Unit tests with race detector (`go test -race -count=1`) for agent and server
 - [x] Integration tests against real MySQL 8.4 in CI
 - [x] React component tests with Vitest + Testing Library
-- [x] Test helpers and shared fixtures (`server/store/testhelper.go`,
-  `server/api/testhelpers_test.go`)
+- [x] Test helpers and shared fixtures (per-context `server/<context>/testkit/testkit.go`)
 - [x] **Three-layer test split** aligned with bounded contexts (per ADR-0004).
   Layer 1: per-package unit tests, default tag, co-located with the code; use
   `server/testdb.Open(t)` + the relevant context's `bootstrap.ApplySchema` (or
@@ -355,7 +354,7 @@ genuine differentiator versus most competitors.
   time so the policy is reviewable in `main.go`
 - [~] **OpenAPI 3.1 spec** committed at `docs/api/openapi.yaml`, prose overview at
   `docs/api.md`, AND hosted rendering at `/api/docs` via embedded Redoc (D1
-  deliverable: zero external network calls, served from `server/api/docs/embed`).
+  deliverable: zero external network calls, served from `server/apidocs/embed`).
   Still missing: handler/client codegen via `oapi-codegen` /
   `openapi-typescript`, so today the spec and the Go handlers can still drift
   without CI catching it

--- a/docs/maintenance/log.md
+++ b/docs/maintenance/log.md
@@ -15,3 +15,6 @@ or change the cadence - running tasks with no record is the same as not running 
 ---
 
 <!-- entries below, newest at the bottom -->
+
+2026-05-03  doc-accuracy-sweep  partial  scope: root-level READMEs + `docs/*.md` (subdirs deferred to next rotation)
+

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -133,7 +133,7 @@ restarts once mysql is ready (Compose healthcheck gates it).
 ## Backup and restore
 
 The entire EDR state is in the MySQL `edr` schema. The named volume
-`mysql-data` is the source of truth; nothing else is stateful.
+`edr-mysql-data` is the source of truth; nothing else is stateful.
 
 ### Logical backup
 
@@ -422,7 +422,7 @@ retention run. If that isn't enough, the events table is larger than
 your disk; you need either more disk or a shorter window. There is no
 online rebalance — expand storage and restart.
 
-**`docker compose up -d` fails with `volume mysql-data is in use`.**
+**`docker compose up -d` fails with `volume edr-mysql-data is in use`.**
 A previous server process didn't shut down cleanly. `docker compose
 down && docker compose up -d` usually clears it. Do NOT
-`docker volume rm mysql-data`; that wipes the database.
+`docker volume rm edr-mysql-data`; that wipes the database.

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -156,7 +156,7 @@ Trust assumptions:
 
 | Threat | Mitigation |
 | --- | --- |
-| A bad detection rule causes false-positive storm. | Per-rule unit tests; integration test in `server/rules/internal/tests/integration_test.go` exercises every shipped rule end-to-end; `tools/gen-rule-docs` ensures every rule has documented severity + false-positive sources. |
+| A bad detection rule causes false-positive storm. | Per-rule unit tests in `server/rules/internal/catalog/<rule>_test.go` cover Evaluate against real event fixtures; the rules-context integration test (`server/rules/internal/tests/integration_test.go`) iterates every shipped rule and locks catalog + doc-shape invariants; `tools/gen-rule-docs` ensures every rule has documented severity + false-positive sources. |
 | A missed detection allows attacker activity through. | Documented in `docs/detection-rules.md` as "Limitations" per rule; ATT&CK coverage page surfaces the gaps. Future work: Atomic Red Team / Caldera replays in CI. |
 | Inadvertent denial of service via inline blocking. | `set_blocklist` policy is operator-driven, version-bumped, audited; no automatic blocking based on rule output (alerts emit; blocks require explicit operator action). |
 

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -156,7 +156,7 @@ Trust assumptions:
 
 | Threat | Mitigation |
 | --- | --- |
-| A bad detection rule causes false-positive storm. | Per-rule unit tests; integration test in `all_rules_integration_test.go` exercises every shipped rule end-to-end; `tools/gen-rule-docs` ensures every rule has documented severity + false-positive sources. |
+| A bad detection rule causes false-positive storm. | Per-rule unit tests; integration test in `server/rules/internal/tests/integration_test.go` exercises every shipped rule end-to-end; `tools/gen-rule-docs` ensures every rule has documented severity + false-positive sources. |
 | A missed detection allows attacker activity through. | Documented in `docs/detection-rules.md` as "Limitations" per rule; ATT&CK coverage page surfaces the gaps. Future work: Atomic Red Team / Caldera replays in CI. |
 | Inadvertent denial of service via inline blocking. | `set_blocklist` policy is operator-driven, version-bumped, audited; no automatic blocking based on rule output (alerts emit; blocks require explicit operator action). |
 


### PR DESCRIPTION
Doc accuracy sweep, Renamed category. Each backticked identifier here points at a moved/renamed thing; the referent still exists, just under a different name.

- CLAUDE.md: `make db-reset` -> `task db:reset` (no Makefile, only Taskfile.yml)
- docs/api.md: `/api/hosts/{id}/...` -> `/api/hosts/{host_id}/...` to match handler.go path templates
- docs/operations.md: docker volume name `mysql-data` -> `edr-mysql-data` (compose file declares the volume as `edr-mysql-data`)
- docs/threat-model.md: `all_rules_integration_test.go` ->
  `server/rules/internal/tests/integration_test.go`
- docs/best-practices.md: stale per-package testhelper paths -> per-context `server/<context>/testkit/testkit.go`; `server/api/docs/embed` -> `server/apidocs/embed`
- docs/maintenance/log.md: dated sweep entry per the task's audit-trail rule