### PR TITLE
ci: declare top-level permissions: {} on every workflow

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -10,6 +10,11 @@ on:
   pull_request:
   workflow_dispatch:
 
+# Top-level token has no permissions; each job grants the exact scopes it
+# needs (satisfies Scorecard Token-Permissions, Sonar githubactions:S8264,
+# zizmor excessive-permissions).
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/arch-go.yml
+++ b/.github/workflows/arch-go.yml
@@ -30,8 +30,8 @@ jobs:
     name: Detect Go changes
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
+      contents: read       # baseline; the detect step doesn't actually checkout
+      pull-requests: read  # gate job reads the PR's file list via gh api pulls/<n>/files
     outputs:
       relevant: ${{ steps.detect.outputs.relevant }}
     steps:

--- a/.github/workflows/arch-go.yml
+++ b/.github/workflows/arch-go.yml
@@ -16,6 +16,11 @@ on:
   pull_request:
   workflow_dispatch:
 
+# Top-level token has no permissions; each job grants the exact scopes it
+# needs (satisfies Scorecard Token-Permissions, Sonar githubactions:S8264,
+# zizmor excessive-permissions).
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/c-lint.yml
+++ b/.github/workflows/c-lint.yml
@@ -20,6 +20,11 @@ on:
       - ".github/workflows/c-lint.yml"
   workflow_dispatch:
 
+# Top-level token has no permissions; each job grants the exact scopes it
+# needs (satisfies Scorecard Token-Permissions, Sonar githubactions:S8264,
+# zizmor excessive-permissions).
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,6 +28,11 @@ on:
     - cron: "23 6 * * 1"  # Mon 06:23 UTC
   workflow_dispatch: {}
 
+# Top-level token has no permissions; each job grants the exact scopes it
+# needs (satisfies Scorecard Token-Permissions, Sonar githubactions:S8264,
+# zizmor excessive-permissions).
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -20,6 +20,11 @@ on:
   pull_request:
   workflow_dispatch:
 
+# Top-level token has no permissions; each job grants the exact scopes it
+# needs (satisfies Scorecard Token-Permissions, Sonar githubactions:S8264,
+# zizmor excessive-permissions).
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/go-nilaway.yml
+++ b/.github/workflows/go-nilaway.yml
@@ -14,6 +14,11 @@ on:
   pull_request:
   workflow_dispatch:
 
+# Top-level token has no permissions; each job grants the exact scopes it
+# needs (satisfies Scorecard Token-Permissions, Sonar githubactions:S8264,
+# zizmor excessive-permissions).
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/go-vulncheck.yml
+++ b/.github/workflows/go-vulncheck.yml
@@ -14,6 +14,11 @@ on:
   pull_request:
   workflow_dispatch:
 
+# Top-level token has no permissions; each job grants the exact scopes it
+# needs (satisfies Scorecard Token-Permissions, Sonar githubactions:S8264,
+# zizmor excessive-permissions).
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/openapi-lint.yml
+++ b/.github/workflows/openapi-lint.yml
@@ -12,6 +12,11 @@ on:
       - ".github/workflows/openapi-lint.yml"
   workflow_dispatch:
 
+# Top-level token has no permissions; each job grants the exact scopes it
+# needs (satisfies Scorecard Token-Permissions, Sonar githubactions:S8264,
+# zizmor excessive-permissions).
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -11,8 +11,11 @@ on:
 
 # SARIF upload requires security-events:write; granted only to the reusable
 # workflow invocation below so the default token (for checkouts etc.) stays
-# minimal. Permissions are declared per-job, not at workflow level (Sonar
-# githubactions:S8264).
+# minimal. The top-level `permissions: {}` grants nothing (does not trigger
+# Sonar githubactions:S8264, which forbids granting read scopes at workflow
+# level) while still satisfying Scorecard Token-Permissions, which wants
+# top-level permissions explicitly declared.
+permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/pkg-dryrun.yml
+++ b/.github/workflows/pkg-dryrun.yml
@@ -18,6 +18,11 @@ on:
   pull_request:
   workflow_dispatch: {}
 
+# Top-level token has no permissions; each job grants the exact scopes it
+# needs (satisfies Scorecard Token-Permissions, Sonar githubactions:S8264,
+# zizmor excessive-permissions).
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/release-secrets-check.yml
+++ b/.github/workflows/release-secrets-check.yml
@@ -20,6 +20,11 @@ name: release secrets check
 on:
   workflow_dispatch: {}
 
+# Top-level token has no permissions; each job grants the exact scopes it
+# needs (satisfies Scorecard Token-Permissions, Sonar githubactions:S8264,
+# zizmor excessive-permissions).
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,13 +22,16 @@ on:
   # release-signing environment secrets.
   workflow_dispatch: {}
 
+# Top-level `permissions: {}` grants nothing (does not trigger Sonar
+# githubactions:S8264, which forbids granting read scopes at workflow level)
+# while still satisfying Scorecard Token-Permissions. Each job below
+# escalates for its specific needs; there is deliberately no read-only
+# default to fall back to.
+permissions: {}
+
 concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: false
-
-# Permissions are declared per-job below (Sonar githubactions:S8264). The
-# macos-pkg and docker-server jobs each escalate for their specific needs;
-# there's no read-only default to fall back to.
 
 jobs:
   macos-pkg:

--- a/.github/workflows/rulesets-drift.yml
+++ b/.github/workflows/rulesets-drift.yml
@@ -45,6 +45,11 @@ on:
     - cron: "37 4 * * 1"
   workflow_dispatch:
 
+# Top-level token has no permissions; each job grants the exact scopes it
+# needs (satisfies Scorecard Token-Permissions, Sonar githubactions:S8264,
+# zizmor excessive-permissions).
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -10,6 +10,11 @@ on:
   # Lets us re-run after fixing a finding without pushing an empty commit.
   workflow_dispatch:
 
+# Top-level token has no permissions; each job grants the exact scopes it
+# needs (satisfies Scorecard Token-Permissions, Sonar githubactions:S8264,
+# zizmor excessive-permissions).
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/swift-lint.yml
+++ b/.github/workflows/swift-lint.yml
@@ -16,6 +16,11 @@ on:
       - ".github/workflows/swift-lint.yml"
   workflow_dispatch:
 
+# Top-level token has no permissions; each job grants the exact scopes it
+# needs (satisfies Scorecard Token-Permissions, Sonar githubactions:S8264,
+# zizmor excessive-permissions).
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
   workflow_dispatch:
 
+# Top-level token has no permissions; each job grants the exact scopes it
+# needs (satisfies Scorecard Token-Permissions, Sonar githubactions:S8264,
+# zizmor excessive-permissions).
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/ts-lint.yml
+++ b/.github/workflows/ts-lint.yml
@@ -17,6 +17,11 @@ on:
   pull_request:
   workflow_dispatch:
 
+# Top-level token has no permissions; each job grants the exact scopes it
+# needs (satisfies Scorecard Token-Permissions, Sonar githubactions:S8264,
+# zizmor excessive-permissions).
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
GitHub code-scanning has 36 alerts that all stem from the same root: 17 of 18 workflow files lack a top-level `permissions:` block, even though every job already declares its own. Affected:

- Scorecard `TokenPermissionsID` (high) x 19 alerts: penalises workflows whose token defaults are implicit instead of explicit. Highest score requires top-level read-only with required writes at the run level.
- zizmor `excessive-permissions` (warning) x 17 alerts: same root cause.
- zizmor `undocumented-permissions` (note) x 1 alert on arch-go.yml: a permissions block with no comment explaining why.

The straightforward fix (top-level `contents: read`) would clear those but trigger Sonar `githubactions:S8264` (MAJOR), which forbids granting read scopes at workflow level on the principle of least privilege.

`permissions: {}` (empty -- deny all) threads both: Scorecard sees an explicit top-level declaration, Sonar S8264 has nothing to flag because no read scope is granted at workflow level, zizmor sees the empty block plus the explanatory comment. Per-job permissions blocks are unchanged and continue to grant the exact scopes each job needs.

Comments on osv-scanner.yml and release.yml that referenced the old "per-job only because S8264" rationale are updated to describe the new pattern.

zizmor.yml already used this pattern (top-level `permissions: {}` plus per-job grants); this commit extends it to the rest.

Verified: `actionlint .github/workflows/*.yml` passes.