### PR TITLE
Add comprehensive user-management capabilities to server identity module

### DIFF
--- a/openspec/changes/add-user-management/.openspec.yaml
+++ b/openspec/changes/add-user-management/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-03

--- a/openspec/changes/add-user-management/design.md
+++ b/openspec/changes/add-user-management/design.md
@@ -1,0 +1,301 @@
+## Context
+
+The user-management plan at `~/work/edr/ai/user-mgmt/plan.md` was authored before
+ADR-0004 carved `server/` into five bounded contexts (`identity`, `endpoint`, `rules`,
+`response`, `detection`). The original plan referenced flat-tree packages
+(`server/users`, `server/sessions`, `server/authn`, `server/authz`, `server/audit`,
+`server/auth/oidc`, `server/auth/breakglass`, `server/seed/admin.go`) that no longer
+exist in that shape. This design re-targets every load-bearing decision in the plan to
+the bounded-context layout while keeping the plan's product choices intact (Okta OIDC as
+the single SSO library, OPA / Rego as the authz engine, WebAuthn-mandatory break-glass,
+dual-emit audit log, single-default-tenant scaffolding).
+
+The current state, as of this proposal:
+
+- `identity` context owns `users`, `sessions`, login, and the seed-admin flow under
+  `server/identity/internal/{users,sessions,authn,seed}` (renamed during the modular-
+  monolith migration). The session capability is captured in
+  `openspec/specs/ui-authentication-session/spec.md`. Login is local-password only;
+  every authenticated user is functionally super-admin.
+- `endpoint`, `rules`, `response`, `detection` each own their own tables, schema migrations,
+  and admin-side handlers. Cross-context calls funnel through each context's `api/`
+  package; arch-go (`arch-go.yml` + `test/arch/arch_test.go`) hard-fails CI on a
+  disallowed import. There is one exception baked in by ADR-0004 phase 5: cross-context
+  FKs were removed and replaced with code-level validation; we will not reintroduce them.
+- The audit story today is "structured slog records emitted by individual handlers" with
+  no durable table, no read endpoint, and no central recorder.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Land wave 1 of the plan (Okta OIDC + break-glass + RBAC + audit + tenant scaffolding) as
+  one cohesive change inside the existing bounded-context architecture, with arch-go
+  passing at every PR boundary.
+- Expose the authz chokepoint and the audit recorder through `server/identity/api/` so that
+  every other context calls into identity through its public surface — no inversion of the
+  ADR-0004 import rules, no new "shared internal" package.
+- Keep the agent ↔ server protocol, the events schema, and the host-token middleware
+  unchanged. None of this work touches the agent.
+- Make the rollout safe via shadow mode: ship the chokepoint everywhere first with the
+  engine in "always allow but log the would-be decision" mode, then flip to enforcement
+  once every privileged handler has been converted and the deny dashboard is clean.
+
+**Non-Goals:**
+
+- Per-tenant SSO configuration; multi-IdP-per-deployment; SCIM; SAML. Wave 2 / wave 3.
+- Customer-authored Rego bundles. Engine supports it; not exposed.
+- Group → role mapping driven by Okta `groups` claim. Wave 2.
+- Forgot-password / self-service password reset for break-glass. Recovery is the
+  documented operator procedure.
+- API tokens (`identity.kind = 'api_token'`). Reserved schema slot; wave 2 deliverable.
+- Host-group / host-scoped read filtering ("show me only the alerts I can see"). The data
+  model is ready (`role_bindings.scope_type`, `scope_id`); MVP punts on the SQL filter
+  side and relies on tenant-scope `alert.read`.
+
+## Decisions
+
+### Single capability boundary: identity context owns authn, authz, and audit
+
+**Decision:** Keep all three new specs (`server-identity-authentication`,
+`server-identity-authorization`, `server-identity-audit-log`) inside the existing
+`identity` bounded context rather than creating a new context per concern.
+
+**Rationale:** Authn issues an `Actor`, authz consumes the `Actor`, audit records
+decisions made by authz. They share a session middleware, a request-context shape, a
+schema-migration boundary, and a deployment surface. Splitting them into separate
+contexts would force every other context's privileged handler to know about three
+upstream `api/` packages instead of one. ADR-0004 explicitly prefers a small number of
+cohesive contexts over per-table fragmentation; the same logic applies here. The three
+specs exist as separate documents so each can evolve independently (an audit-retention
+change, for example, should not require re-validating authz scenarios), but the
+runtime code lives under `server/identity/internal/`.
+
+**Alternatives considered:**
+
+- Separate `authz` context. Rejected — every other context would need to import both
+  `identity/api` (for the actor) and `authz/api` (for the chokepoint), doubling the
+  cross-context surface for no practical isolation benefit.
+- Audit as a cross-cutting "shared" package outside any context. Rejected — there is
+  no shared-package layer in the bounded-context layout; ADR-0004 is explicit that
+  cross-context calls go through `<other>/api`. A new shared layer would punch a hole
+  in arch-go's allow-list.
+
+### Public API surface
+
+`server/identity/api/` gains exactly four exports beyond what's there today:
+
+```go
+package api
+
+// Actor is built once by session middleware and threaded through context.Context.
+// Other contexts read it via api.ActorFromContext(ctx).
+type Actor struct {
+    UserID       int64
+    TenantID     string
+    IsBreakglass bool
+    AuthMethod   string                 // "oidc" | "local_password"
+    Roles        []RoleBinding
+    SessionFresh bool                   // last fresh auth event within the reauth window
+}
+
+// AuthZ is the chokepoint. Every privileged handler in detection/rules/response/endpoint
+// calls AuthZ.Allow before performing the side effect.
+type AuthZ interface {
+    Allow(ctx context.Context, action Action, resource Resource) (Decision, error)
+}
+
+// Audit is the recorder. authz.Allow calls it for every decision; handlers that want to
+// record state-changing actions distinct from authz decisions call it directly.
+type Audit interface {
+    Record(ctx context.Context, e Event) error
+}
+
+// Action constants live here, not as string literals at call sites. CI fails the build
+// if a string literal is used in an Allow call (vet rule + arch-go).
+const (
+    ActionHostRead       Action = "host.read"
+    ActionHostIsolate    Action = "host.isolate"
+    ActionHostKillProcess Action = "host.kill_process"
+    // ... full registry, mirrored in actions.json
+)
+```
+
+Identity's `bootstrap.New(deps)` returns concrete implementations (`AuthZ`, `Audit`,
+`SessionMiddleware`) wired to MySQL + the embedded OPA engine. `cmd/fleet-edr-server/main.go`
+constructs the identity bootstrap once and passes the resulting `AuthZ` and `Audit`
+handles into every other context's `bootstrap.New`. arch-go's allow-list already permits
+`detection / rules / response / endpoint → identity/api`; this change adds the new symbols
+to that surface, no rule edits needed.
+
+### Schema ownership across contexts
+
+Identity owns the new identity-side tables and their migrations. Every other context owns
+its own `tenant_id` column addition through its own `bootstrap.ApplySchema`. Concretely:
+
+- `server/identity/internal/store/schema.sql` — adds `tenants`, `identities`, `roles`,
+  `role_bindings`, `audit_events`, `bootstrap_tokens`, `webauthn_credentials`, plus the
+  additive columns on `users` and `sessions`. Existing migrations remain untouched;
+  follow the additive-only pattern documented for ADR-0004 phase 5.
+- `server/detection/internal/store/schema.sql` — adds `tenant_id` to `hosts` and `alerts`.
+- `server/rules/internal/store/schema.sql` — adds `tenant_id` to `policies`.
+- `server/response/internal/store/schema.sql` — adds `tenant_id` to `commands`.
+- `server/endpoint/internal/store/schema.sql` — adds `tenant_id` to `enrollments`.
+
+Apply order in `cmd/fleet-edr-server/main.go` is unchanged
+(`identity → endpoint → rules → response → detection`), which guarantees the `tenants`
+row exists before per-context tables that default `tenant_id` to `'default'` are created.
+
+No cross-context FKs. The `role_bindings.user_id → users.id` FK lives entirely inside
+identity. The plan's original `tenant_id` constraints are not enforced via FK across
+contexts; the contract is "every context defaults the column to `'default'` and never
+queries on it in wave 1." A future MSSP wave will introduce a tenant resolver in
+`identity/api` that other contexts call to translate session → tenant; arch-go already
+covers that path.
+
+### Authorization engine: embedded OPA / Rego
+
+The plan locks the engine choice to OPA/Rego with explicit revisit conditions; we
+preserve that decision verbatim. Engine wiring:
+
+- Policies live at `server/identity/internal/authz/policy/*.rego`, baked via `embed`.
+- The compiled `rego.PreparedEvalQuery` is constructed once in
+  `identity/internal/authz/engine.go` at boot.
+- Reload on `SIGHUP` is wired through the existing process-supervisor signal handler;
+  no new daemon goroutine.
+- Per-decision latency budget is <1ms p99 measured in `identity/internal/authz/bench_test.go`;
+  arch-go and golangci-lint allow the test target. A budget regression in CI is a
+  release blocker, not a warning.
+
+The action registry is dual-source-of-truth:
+
+- `server/identity/api/actions.go` exports `Action` typed constants. Non-test code MUST
+  import the constant; no string literals at call sites.
+- `server/identity/internal/authz/policy/data/actions.json` lists the same names. Boot
+  fails if the two diverge, and a Go test in `identity/internal/authz/tests/` enforces
+  parity.
+
+### Audit recording: dual-emit, deny-fail-soft
+
+Every `AuthZ.Allow` call ends in an `Audit.Record(...)` call before the response is
+written. The recorder:
+
+1. Inserts into `audit_events`. A failure here logs at ERROR and increments
+   `edr_audit_write_failures_total` (already wired through observability-instrumentation),
+   but does not fail the user request.
+2. Emits a structured slog record at INFO (allow) or WARN (deny / break-glass / error).
+3. Adds OTel span attributes (`edr.audit.action`, `edr.audit.decision`, `edr.audit.reason`)
+   on the active request span.
+
+Sampling for read-only decisions defaults to 0.0 in MVP and is config-tunable; break-glass
+actor forces sampling to 1.0 regardless of config.
+
+### Sessions: existing capability extends, does not split
+
+`ui-authentication-session` already owns the cookie + CSRF surface. We extend it rather
+than introducing a parallel session capability. The deltas are:
+
+- Two new columns on `sessions`: `identity_id BIGINT NULL`, `auth_method VARCHAR(32)`.
+- Idle (8h) / absolute (24h) / reauth-window (30m) replace the flat 12h expiry.
+- Break-glass sessions get tighter idle (15m) / absolute (1h) caps.
+- The login endpoint now accepts authentication originated from either OIDC callback or
+  break-glass; the cookie + CSRF mint is unchanged.
+
+The new authentication capability owns the OIDC callback handler that ends in a session
+mint; the session capability owns the cookie itself. The split is "who originates the
+authentication" (new capability) vs "what the cookie behaves like once minted" (existing
+capability). Both specs are updated in lockstep in this change.
+
+### Break-glass surface: SSO-only login UI, separate path for emergency
+
+`/login` no longer renders a password form. The break-glass surface lives at
+`/admin/break-glass` (login) and `/admin/break-glass/setup` (token redemption +
+WebAuthn registration). The optional reverse-proxy IP allowlist returns 404 for
+off-allowlist callers so the path is not even acknowledged. This matches the plan's
+resolved-decision section verbatim.
+
+The seed flow is the only behavior break for an upgrading operator. `seed.Admin`
+(now `server/identity/internal/seed/breakglass.go`) on first boot inserts a single-use
+bootstrap token row and prints the redemption URL banner. Migration of an existing
+`admin@fleet-edr.local` row sets `is_breakglass = 1`, nulls password fields, and
+auto-issues a token whose URL is printed once on first start after upgrade. Token
+redemption fully replaces the previous "lost the stderr password" recovery path
+documented in the existing session spec.
+
+## Risks / Trade-offs
+
+- **Shadow-mode → enforcement flip is a single-PR risk.** The plan's wave-1 phasing
+  converts handlers slice-by-slice with shadow mode active. Flipping `authz.shadow_mode`
+  to `false` is the moment ungated handlers stop being silently logged and start
+  returning 403. → Mitigation: shadow-mode dashboard (deny-decision count by handler)
+  must read zero deny decisions for the period covering the conversion before flipping;
+  tests gate on the absence of any handler that does not call `AuthZ.Allow` (a code-search
+  rule plus a fixture-handler audit).
+- **OPA dependency footprint.** `opa/rego` brings in a sizable transitive tree; binary
+  size and compile time grow noticeably. → Mitigation: documented in the plan;
+  dependency-review CI flags unexpected bumps; budget set against a baseline measured at
+  PR merge time.
+- **Per-decision latency regressions.** A poorly written Rego rule can do quadratic work.
+  → Mitigation: `opa test` + `opa eval --benchmark` in CI on every authz PR; the
+  `<1ms p99` budget is enforced via `bench_test.go` failing the build.
+- **Audit log volume during incidents.** A spike in deny decisions on a noisy handler
+  could saturate the DB writer. → Mitigation: bounded-buffer async writer with the same
+  back-pressure pattern as the event ingest queue (already proven under load in the
+  detection context); buffer-overflow drops are themselves emitted as a slog WARN +
+  OTel counter.
+- **JIT provisioning auto-creating accounts from any Okta tenant.** Default
+  `allow_jit_provisioning = true` for MVP per the plan; once a deployment ships, the
+  customer is expected to flip it to `false` and rely on an explicit allowlist. →
+  Mitigation: documented in the operator runbook; the audit row on JIT creation is at
+  WARN so a SigNoz alert can fire on unexpected tenants.
+- **Schema migration surface.** Five contexts run additive migrations in this change.
+  → Mitigation: each context's migration is independent and additive; rollback is a
+  redeploy of the prior binary, with the new tables / columns left harmlessly in place.
+- **`tenant_id` index churn on hot tables.** Adding the column to `hosts`, `alerts`,
+  `commands`, etc. creates an index in the plan as written. → Mitigation: ship without
+  the index in wave 1 (column only); add the index when MSSP wave 2 actually queries on
+  it. This deviates from the original plan, which over-specified on this point.
+
+## Migration Plan
+
+The plan lists seven phases inside the wave-1 PR sequence. We preserve those, retargeted
+to the bounded-context layout. Each phase is one PR; arch-go and golangci-lint pass at
+every phase boundary.
+
+1. **Schema + seeding (identity-only).** New identity tables, additive columns on
+   `users` / `sessions`, the role-seeder loop, the rewritten `seed.Admin` →
+   `seed.BreakGlassBootstrap`, and the cross-context `tenant_id` columns. Each context
+   ships its own additive migration in this PR; no behavior change yet.
+2. **Authz package shipped in shadow mode.** `server/identity/internal/authz` lands
+   compiled. `identity/api` exports `AuthZ`, `Audit`, `Actor`. Every existing
+   privileged handler is converted to call `AuthZ.Allow(...)` with the appropriate
+   action constant. Engine returns `{allow: true, reason: "shadow_mode"}` regardless of
+   the policy's verdict; the would-be decision is recorded in the audit log.
+3. **Audit recorder + dual-emit live.** `audit_events` writes start happening; the slog
+   / OTel emit path is wired through observability-instrumentation. Read endpoint
+   shipped behind `audit.read` with audit-of-audit on its own access.
+4. **OIDC + break-glass authn paths land.** OIDC discovery, callback, JIT, identity
+   model. Break-glass bootstrap-token + WebAuthn registration. UI changes
+   (`/login`, `/admin/break-glass`). Configurable but disabled by default
+   (`auth.oidc.enabled = false`).
+5. **Session middleware updates.** Idle / absolute / reauth timeouts; break-glass
+   tighter caps. Reauth-window enforcement on destructive actions.
+6. **Shadow-mode flip.** `authz.shadow_mode = false`. From this PR onward, deny
+   decisions return 403. Pilot-customer Okta wiring happens as a config push, not a
+   code change.
+7. **Documentation.** Operator runbook for break-glass redemption + WebAuthn registration.
+   Okta tenant setup guide. Role + permission matrix. SigNoz dashboard wiring for the
+   audit-decision stream.
+
+**Rollback strategy:** Every PR in this sequence is independently reversible. Phase 1
+through 5 are no-ops at the user level (shadow mode allows everything). Phase 6 (the
+flip) is the only PR where rollback might affect end-users; it is a one-line config
+revert, not a migration. The new identity tables remain in place across rollback —
+`bootstrap_tokens` and `webauthn_credentials` rows are harmless if the seed flow is
+reverted to printing a password.
+
+## Open Questions
+
+None. The plan's previously-open five questions were resolved before this change was
+proposed (see the proposal's "Resolved decisions" reference). No new open questions
+emerged from re-targeting to bounded contexts.

--- a/openspec/changes/add-user-management/design.md
+++ b/openspec/changes/add-user-management/design.md
@@ -1,7 +1,8 @@
 ## Context
 
-The user-management plan at `~/work/edr/ai/user-mgmt/plan.md` was authored before
-ADR-0004 carved `server/` into five bounded contexts (`identity`, `endpoint`, `rules`,
+The user-management plan tracked at
+`https://github.com/getvictor/fleet-edr/issues/66` was authored before ADR-0004 carved
+`server/` into five bounded contexts (`identity`, `endpoint`, `rules`,
 `response`, `detection`). The original plan referenced flat-tree packages
 (`server/users`, `server/sessions`, `server/authn`, `server/authz`, `server/audit`,
 `server/auth/oidc`, `server/auth/breakglass`, `server/seed/admin.go`) that no longer

--- a/openspec/changes/add-user-management/proposal.md
+++ b/openspec/changes/add-user-management/proposal.md
@@ -16,6 +16,11 @@ Rego authorization with five seeded roles, dual-emit audit log, and tenant scaff
 2 (API tokens, host-group scopes, MFA for non-break-glass, SSO group mapping) and wave 3
 (SAML, SCIM, customer-authored Rego) are explicitly deferred to follow-on plans.
 
+This OpenSpec change is the **spec-only** artifact: it adds the proposal, design, tasks,
+and delta specs that describe the eventual behavior. The implementation lands in the
+follow-up PRs enumerated in `tasks.md` (one phase per PR, each independently reviewable
+against the requirements pinned by this change).
+
 ## What Changes
 
 - Add Okta OIDC login at `/api/auth/login` and `/api/auth/callback` with PKCE S256, JIT

--- a/openspec/changes/add-user-management/proposal.md
+++ b/openspec/changes/add-user-management/proposal.md
@@ -1,0 +1,136 @@
+## Why
+
+Today every authenticated operator is functionally a super-admin: there is one seeded local
+account, no roles, no permissions, no SSO, and no audit log. The seed flow prints a
+generated password to stderr on first boot — fine for a laptop demo, untenable for the pilot
+deployments on the MVP roadmap and unworkable against the security-console competitive set
+(CrowdStrike Falcon, SentinelOne Singularity, Microsoft Defender for Endpoint), all of which
+ship SSO + RBAC + audit as table stakes. The product needs an identity boundary that an
+enterprise buyer can sign off on, that an MSSP can grow into, and that a SOC team can use to
+reconstruct who did what to which host.
+
+This change delivers wave 1 of the user-management plan tracked in
+`https://github.com/getvictor/fleet-edr/issues/66`: Okta OIDC SSO as the primary login,
+break-glass local account behind a separate URL with WebAuthn-mandatory bootstrap, embedded
+Rego authorization with five seeded roles, dual-emit audit log, and tenant scaffolding. Wave
+2 (API tokens, host-group scopes, MFA for non-break-glass, SSO group mapping) and wave 3
+(SAML, SCIM, customer-authored Rego) are explicitly deferred to follow-on plans.
+
+## What Changes
+
+- Add Okta OIDC login at `/api/auth/login` and `/api/auth/callback` with PKCE S256, JIT
+  provisioning to a seeded `analyst` role at the tenant scope, and ID-token verification
+  via discovery. Single global IdP per deployment; per-tenant IdP is a wave-2 feature.
+- **BREAKING** for the bootstrap flow: replace the existing "print a generated password to
+  stderr on first boot" seed with a single-use bootstrap token whose redemption URL is
+  printed instead. Operator visits `/admin/break-glass/setup?token=…` to set a password
+  (zxcvbn ≥14 chars) and register a WebAuthn credential before the break-glass account is
+  usable. Migration of an existing `admin@fleet-edr.local` row flips it to break-glass and
+  forces a token redemption before next login.
+- Move ongoing break-glass login to a separate `/admin/break-glass` URL that is not linked
+  from the SSO login page and that 404s for callers outside the optional reverse-proxy IP
+  allowlist. Per-IP and per-email rate limits, P1 audit on every successful break-glass
+  login.
+- Add five seeded roles (`super_admin`, `admin`, `senior_analyst`, `analyst`, `auditor`)
+  bound to users via a new `role_bindings` table with tenant / host-group / host scopes.
+  Host-group and host scopes ship as schema only; only tenant-wide scope is enforced in
+  wave 1.
+- Add a single authorization chokepoint that every UI/API handler calls before performing a
+  privileged action. The engine is embedded OPA / Rego with policies baked into the binary
+  and reloadable on SIGHUP. Roll out via a "shadow mode" config flag that always allows but
+  logs the would-be decision; flip off once every privileged handler is converted.
+- Add an append-only audit log written on every authn outcome and every authz decision on a
+  state-changing action. Dual-emit: durable row in MySQL + structured slog/OTel record on
+  the active request span so existing SigNoz dashboards can alert on patterns. Reads of the
+  audit log require `audit.read` and themselves write an audit-of-audit row.
+- Add a tenant scaffolding column (`tenant_id`, default `'default'`) to every table that
+  belongs to a tenant in the long run: identity tables (users, sessions, roles,
+  role_bindings, audit_events) plus the per-context tables that already exist
+  (hosts/alerts under detection, policies under rules, commands under response, enrollments
+  under endpoint). Wave 1 does not query on `tenant_id`; the goal is purely future-proofing
+  so MSSP work in wave 2 does not require backfill.
+- Tighten session timeouts to security-console norms: 8h idle / 24h absolute for normal
+  sessions, 15m idle / 1h absolute for break-glass. Destructive actions (host isolate,
+  host kill_process, host run_script, critical-severity alert dismiss) require a fresh auth
+  event within a 30-minute reauth window.
+- **BREAKING** for the `/login` UI surface: replace the email + password form with a single
+  "Continue with Okta" button. The local-password form now lives only at
+  `/admin/break-glass`; it is not linked or hinted at from `/login`. The existing
+  `POST /api/session` endpoint continues to work for break-glass authentication only.
+
+## Capabilities
+
+### New Capabilities
+
+- `server-identity-authentication`: Server-side authentication flows — Okta OIDC discovery,
+  authorize / callback, JIT provisioning, identity model (`users` ↔ `identities`),
+  break-glass bootstrap token + WebAuthn registration, ongoing break-glass login at a
+  separate path with IP allowlist + tighter rate limits, and the session augmentations
+  (`identity_id`, `auth_method`, idle / absolute / reauth windows) that record how a session
+  was authenticated. The session-cookie-and-CSRF surface itself stays in
+  `ui-authentication-session`.
+- `server-identity-authorization`: The RBAC engine plus the chokepoint every privileged
+  handler funnels through. Owns the action registry, the role / role-binding / scope
+  model, the seeded roles, the OPA-evaluated decision shape (`allow`, `reason`), the
+  shadow-mode rollout knob, and the tenant scaffolding (`tenants` table, `tenant_id`
+  discipline) that future MSSP work builds on.
+- `server-identity-audit-log`: The append-only audit-event store, the `audit.Record(...)`
+  surface every other capability calls into, the dual-emit to MySQL + slog / OTel, the
+  decision-driven sampling (writes / destructive at 100%, reads tunable at 0% in MVP,
+  break-glass actor forced to 100%), and the read endpoint behind `audit.read` that itself
+  emits an audit-of-audit row.
+
+### Modified Capabilities
+
+- `ui-authentication-session`: The "login mints a session cookie" requirement and the
+  argon2id password requirement now describe the break-glass-only path; OIDC sessions go
+  through the new authentication capability and reach the session layer with
+  `auth_method='oidc'`. The 12-hour expiry requirement is replaced by the new idle /
+  absolute / reauth windows. The seeded-bootstrap requirement is rewritten around the
+  single-use token + WebAuthn registration flow, so the recovery procedure changes.
+- `web-ui`: The "anonymous user lands on the login page" and "successful login routes to
+  the home view" scenarios change to describe the Okta-only `/login` page and the separate
+  `/admin/break-glass` surface. The account menu adds the current role and the auth method.
+- `server-admin-surface`: The "authenticated admin boundary" requirement is rewritten to
+  describe the authorization chokepoint replacing the implicit "any authenticated user is
+  admin" model; existing endpoints (enrollments, policy, attack-coverage, rules) gain
+  per-action authz checks instead of a uniform admin gate. Adds user-management,
+  role-binding, and audit-read endpoints under the same admin surface.
+
+## Impact
+
+**Tables added (identity context owns):** `tenants`, `identities`, `roles`, `role_bindings`,
+`audit_events`, `bootstrap_tokens`, `webauthn_credentials`. Plus additive columns on
+`users` (`tenant_id`, `display_name`, `status`, `is_breakglass`; `password_hash`/
+`password_salt` made nullable) and `sessions` (`identity_id`, `auth_method`).
+
+**Tables touched in other contexts (additive only):** `hosts` and `alerts` (detection),
+`policies` (rules), `commands` (response), `enrollments` (endpoint) each gain a
+`tenant_id VARCHAR(64) NOT NULL DEFAULT 'default'` column. Each context's
+`bootstrap.ApplySchema` runs the migration for its own tables; no cross-context FKs are
+introduced, in keeping with ADR-0004.
+
+**New cross-context API surface (`server/identity/api/`):** `AuthZ.Allow(ctx, action,
+resource) (Decision, error)`, `Audit.Record(ctx, event) error`, an `Actor` type populated
+by session middleware and carried in `context.Context`, and a public action-name registry
+so other contexts reference action constants instead of string literals. Every privileged
+handler in `detection`, `rules`, `response`, and `endpoint` swaps its ad-hoc role check for
+`identity.AuthZ.Allow(...)`.
+
+**New configuration:** `auth.oidc.*`, `auth.breakglass.*`, `auth.session.*`, `authz.*`,
+`audit.*` blocks plus two new env-derived secrets (`EDR_OIDC_CLIENT_SECRET`;
+`EDR_SESSION_SIGNING_KEY` is reused for the OAuth state cookie). All secrets validated at
+startup; missing values fail fast.
+
+**New dependencies:** `github.com/coreos/go-oidc/v3/oidc`, `golang.org/x/oauth2`,
+`github.com/open-policy-agent/opa/rego`, `github.com/go-webauthn/webauthn`. Argon2id and
+the existing cookie signer are reused. The OPA module pulls in a sizable transitive tree;
+flagged for dependency-review CI but accepted as a one-time cost.
+
+**Rollback:** Schema changes are additive; existing deployments retain a working session
+cookie + CSRF after the migration. The break-glass bootstrap-token flow is the only
+behavior change for an existing operator: the migration auto-issues a token whose URL is
+printed once on first start after upgrade, mirroring the current banner shape. Rollback to
+pre-change is migration-down + redeploy of the prior server binary; the new identity tables
+remain harmless if unused. The agent-server protocol and the events schema are
+unchanged, so no agent-side rollback steps are required.

--- a/openspec/changes/add-user-management/specs/server-admin-surface/spec.md
+++ b/openspec/changes/add-user-management/specs/server-admin-surface/spec.md
@@ -1,0 +1,140 @@
+## MODIFIED Requirements
+
+### Requirement: Authenticated admin boundary
+
+The server MUST gate every endpoint defined by this capability behind both the
+operator-session middleware AND the authorization chokepoint defined by the
+server-identity-authorization capability, so a caller that is not authenticated as an
+operator SHALL receive `401 Unauthorized` and a caller whose role does not grant the
+endpoint's required action SHALL receive `403 Forbidden`. The endpoints in this
+capability — `/api/enrollments`, `/api/enrollments/{host_id}/revoke`, `/api/policy`,
+`/api/attack-coverage`, `/api/rules`, `/api/users`, `/api/users/{id}`,
+`/api/users/{id}/role-bindings`, `/api/roles` — each MUST declare the action the
+chokepoint will be asked to authorize (for example, `host.read` for the enrollments
+listing, `host.revoke_enrollment` for revoke, `policy.read` for policy GET,
+`policy.write` for policy PUT, `user.read` for user listing, `user.invite` for user
+creation, `role.bind` for role bindings). The implicit "any authenticated operator is
+admin" model is no longer in effect; the chokepoint is the source of truth.
+
+#### Scenario: Unauthenticated request is rejected
+
+- **GIVEN** a client that has not authenticated
+- **WHEN** the client requests any endpoint defined by this capability
+- **THEN** the server returns `401 Unauthorized`
+- **AND** the response body uses the standard error shape `{"error": "..."}`
+
+#### Scenario: Authenticated operator without permission is rejected
+
+- **GIVEN** a client holding a valid session whose role does not grant the action
+  required by the endpoint
+- **WHEN** the client requests that endpoint
+- **THEN** the server returns `403 Forbidden`
+- **AND** an audit row is recorded with decision `deny` and the chokepoint's reason
+- **AND** the response body uses the standard error shape `{"error": "..."}`
+
+#### Scenario: Authorized operator request proceeds
+
+- **GIVEN** a client holding a valid session whose role grants the action required by
+  the endpoint at the requested resource's scope
+- **WHEN** the client requests the endpoint and satisfies any required CSRF check for
+  the HTTP method
+- **THEN** the request is dispatched to the corresponding admin handler
+- **AND** an audit row is recorded with decision `allow` (subject to read-sampling
+  rules for read endpoints)
+
+## ADDED Requirements
+
+### Requirement: List users
+
+The system SHALL expose `GET /api/users` returning the set of users known to the
+deployment. Each entry MUST identify the user (id, email, display name, status), the
+authentication methods they have bound (one or more identity rows summarized as a list
+of `{kind, provider}` pairs), the role bindings they hold (one or more role names with
+their scope), and the timestamp of their last successful authentication. The endpoint
+MUST require the `user.read` action.
+
+#### Scenario: Operator with `user.read` lists users
+
+- **GIVEN** at least one user exists and the caller's role grants `user.read`
+- **WHEN** the operator requests `GET /api/users`
+- **THEN** the server returns `200 OK` with a JSON array of user rows
+- **AND** every row identifies the user, their identity bindings, and their role bindings
+
+#### Scenario: Caller without `user.read` is forbidden
+
+- **GIVEN** a session whose role does not grant `user.read`
+- **WHEN** the operator requests `GET /api/users`
+- **THEN** the server returns `403 Forbidden`
+
+### Requirement: Disable a user
+
+The system SHALL expose `POST /api/users/{id}/disable` that flips a user's `status`
+column to `disabled` and revokes every active session bound to that user. The endpoint
+MUST require the `user.disable` action and MUST refuse to disable a user whose
+`is_breakglass=1` flag is set. A successful disable MUST emit an audit row with action
+`user.disabled` and the actor user id.
+
+#### Scenario: Disable a regular user
+
+- **GIVEN** an SSO-provisioned user with `is_breakglass=0` and an active session
+- **WHEN** an operator with `user.disable` POSTs to `/api/users/{id}/disable`
+- **THEN** the server returns `204 No Content`
+- **AND** the user's `status` is `disabled`
+- **AND** any active sessions bound to that user are removed
+- **AND** an audit row is recorded with action `user.disabled`
+
+#### Scenario: Disabling a break-glass account is refused
+
+- **GIVEN** the break-glass user with `is_breakglass=1`
+- **WHEN** an operator POSTs to `/api/users/{id}/disable` for that user
+- **THEN** the server returns a typed error (HTTP 4xx) and does not modify the user
+- **AND** the audit log records the rejection
+
+### Requirement: Bind and unbind a role
+
+The system SHALL expose `POST /api/users/{id}/role-bindings` to bind a role to a user
+and `DELETE /api/users/{id}/role-bindings/{binding_id}` to remove a binding. Both
+endpoints MUST require the `role.bind` action. The bind endpoint's request body MUST
+identify the role and MAY identify a `scope_type` and `scope_id`; in wave 1 the only
+honored `scope_type` is `tenant`, and a request specifying a non-tenant scope MUST be
+persisted (per the authorization spec) but MUST emit a warning in the response payload
+so the operator knows the binding will not yet take effect. Both bind and unbind MUST
+emit an audit row.
+
+#### Scenario: Operator binds an analyst role at tenant scope
+
+- **GIVEN** an operator with `role.bind`
+- **WHEN** the operator POSTs `/api/users/{id}/role-bindings` with `role='analyst'`
+  and `scope_type='tenant'`
+- **THEN** the server returns `201 Created` with the new binding's id
+- **AND** an audit row is recorded with action `role.bound`
+
+#### Scenario: Operator unbinds a role
+
+- **GIVEN** an existing role binding for a user
+- **WHEN** an operator with `role.bind` DELETEs
+  `/api/users/{id}/role-bindings/{binding_id}`
+- **THEN** the server returns `204 No Content`
+- **AND** an audit row is recorded with action `role.unbound`
+
+#### Scenario: Caller without `role.bind` is forbidden
+
+- **GIVEN** a session whose role does not grant `role.bind`
+- **WHEN** the operator attempts to bind or unbind a role
+- **THEN** the server returns `403 Forbidden`
+
+### Requirement: Read the role catalog
+
+The system SHALL expose `GET /api/roles` returning the role catalog. Each entry MUST
+include the role name, its description, the `is_builtin` flag, and the list of
+permissions it grants. The endpoint MUST require the `role.read` action and SHALL be
+available to roles that include role-binding work in their scope (`super_admin`,
+`admin`).
+
+#### Scenario: Admin reads the role catalog
+
+- **GIVEN** an operator with `role.read`
+- **WHEN** the operator requests `GET /api/roles`
+- **THEN** the server returns `200 OK` with the five seeded roles
+- **AND** each role entry carries its name, description, `is_builtin=true`, and
+  permission list

--- a/openspec/changes/add-user-management/specs/server-admin-surface/spec.md
+++ b/openspec/changes/add-user-management/specs/server-admin-surface/spec.md
@@ -6,15 +6,20 @@ The server MUST gate every endpoint defined by this capability behind both the
 operator-session middleware AND the authorization chokepoint defined by the
 server-identity-authorization capability, so a caller that is not authenticated as an
 operator SHALL receive `401 Unauthorized` and a caller whose role does not grant the
-endpoint's required action SHALL receive `403 Forbidden`. The endpoints in this
-capability — `/api/enrollments`, `/api/enrollments/{host_id}/revoke`, `/api/policy`,
-`/api/attack-coverage`, `/api/rules`, `/api/users`, `/api/users/{id}`,
-`/api/users/{id}/role-bindings`, `/api/roles` — each MUST declare the action the
-chokepoint will be asked to authorize (for example, `host.read` for the enrollments
-listing, `host.revoke_enrollment` for revoke, `policy.read` for policy GET,
-`policy.write` for policy PUT, `user.read` for user listing, `user.invite` for user
-creation, `role.bind` for role bindings). The implicit "any authenticated operator is
-admin" model is no longer in effect; the chokepoint is the source of truth.
+endpoint's required action SHALL receive `403 Forbidden`. Every endpoint introduced
+by this capability — including (non-exhaustively) `/api/enrollments`,
+`/api/enrollments/{host_id}/revoke`, `/api/policy`, `/api/attack-coverage`,
+`/api/rules`, `/api/users`, `/api/users/{id}`, `/api/users/{id}/disable`,
+`/api/users/{id}/role-bindings`, `/api/users/{id}/role-bindings/{binding_id}`, and
+`/api/roles` — MUST declare the action the chokepoint will be asked to authorize (for
+example, `host.read` for the enrollments listing, `host.revoke_enrollment` for revoke,
+`policy.read` for policy GET, `policy.write` for policy PUT, `user.read` for user
+listing, `user.disable` for disabling a user, `role.bind` for binding or unbinding a
+role, `role.read` for reading the role catalog). Any future endpoint added under this
+capability MUST follow the same pattern; the boundary applies to "every endpoint
+defined by this capability," not to a closed enumeration. The implicit "any
+authenticated operator is admin" model is no longer in effect; the chokepoint is the
+source of truth.
 
 #### Scenario: Unauthenticated request is rejected
 

--- a/openspec/changes/add-user-management/specs/server-identity-audit-log/spec.md
+++ b/openspec/changes/add-user-management/specs/server-identity-audit-log/spec.md
@@ -3,13 +3,17 @@
 ### Requirement: Authentication outcomes write an audit row
 
 The system SHALL record an audit row for every authentication outcome, success or
-failure, regardless of authentication method. The row MUST include the request
-timestamp, the source IP, the user agent, the request id, the action name (e.g.
-`auth.oidc.success`, `auth.breakglass.success`, `auth.local_password.failure`,
-`auth.oidc.callback.error`), the decision (`allow`, `deny`, or `error`), the reason,
-and (when known) the actor user id and identity id. Audit row writes MUST NOT block on
-the user response: a write failure SHALL be logged at ERROR and counted as a metric
-but the user request continues.
+failure, regardless of authentication method. Action names MUST follow the pattern
+`auth.<flow>.<outcome>` where `<flow>` is one of `oidc` or `breakglass` (named after
+the *flow* that produced the outcome, not the credential type — the break-glass flow
+combines a local password and a WebAuthn assertion under a single `breakglass` flow
+so dashboards stay cohesive). The action name MUST be one of `auth.oidc.success`,
+`auth.oidc.failure`, `auth.oidc.callback.error`, `auth.breakglass.success`, or
+`auth.breakglass.failure`. The row MUST include the request timestamp, the source IP,
+the user agent, the request id, the action name, the decision (`allow`, `deny`, or
+`error`), the reason, and (when known) the actor user id and identity id. Audit row
+writes MUST NOT block on the user response: a write failure SHALL be logged at ERROR
+and counted as a metric but the user request continues.
 
 #### Scenario: Successful SSO login is audited
 
@@ -18,13 +22,14 @@ but the user request continues.
 - **THEN** an audit row exists with `action='auth.oidc.success'`, `decision='allow'`,
   the actor's user id and identity id, and the request id
 
-#### Scenario: Failed local password is audited without leaking the failure mode to the client
+#### Scenario: Failed break-glass login is audited without leaking the failure mode to the client
 
 - **GIVEN** a break-glass login attempt with a wrong password
 - **WHEN** the server validates the submission
 - **THEN** the client receives a generic invalid-credentials response
-- **AND** the audit row records the precise failure reason
-  (`auth.local_password.password_mismatch`)
+- **AND** the audit row records `action='auth.breakglass.failure'` and the precise
+  failure reason in the row's `reason` field (e.g. `password_mismatch`,
+  `webauthn_assertion_invalid`)
 
 #### Scenario: Audit write failure does not fail the user request
 

--- a/openspec/changes/add-user-management/specs/server-identity-audit-log/spec.md
+++ b/openspec/changes/add-user-management/specs/server-identity-audit-log/spec.md
@@ -1,0 +1,128 @@
+## ADDED Requirements
+
+### Requirement: Authentication outcomes write an audit row
+
+The system SHALL record an audit row for every authentication outcome, success or
+failure, regardless of authentication method. The row MUST include the request
+timestamp, the source IP, the user agent, the request id, the action name (e.g.
+`auth.oidc.success`, `auth.breakglass.success`, `auth.local_password.failure`,
+`auth.oidc.callback.error`), the decision (`allow`, `deny`, or `error`), the reason,
+and (when known) the actor user id and identity id. Audit row writes MUST NOT block on
+the user response: a write failure SHALL be logged at ERROR and counted as a metric
+but the user request continues.
+
+#### Scenario: Successful SSO login is audited
+
+- **GIVEN** a successful Okta OIDC callback that mints a session
+- **WHEN** the response is sent
+- **THEN** an audit row exists with `action='auth.oidc.success'`, `decision='allow'`,
+  the actor's user id and identity id, and the request id
+
+#### Scenario: Failed local password is audited without leaking the failure mode to the client
+
+- **GIVEN** a break-glass login attempt with a wrong password
+- **WHEN** the server validates the submission
+- **THEN** the client receives a generic invalid-credentials response
+- **AND** the audit row records the precise failure reason
+  (`auth.local_password.password_mismatch`)
+
+#### Scenario: Audit write failure does not fail the user request
+
+- **GIVEN** a transient database failure when inserting the audit row for a successful
+  login
+- **WHEN** the recorder attempts the insert
+- **THEN** the user request still completes successfully (the session is still minted)
+- **AND** the failure is logged at ERROR with a unique structured key
+- **AND** the `edr_audit_write_failures_total` metric is incremented
+
+### Requirement: Authorization decisions on state-changing actions write an audit row
+
+The system SHALL record an audit row for every authorization decision on a
+state-changing action, including allow, deny, and error outcomes. Read-only actions
+SHALL be sampled at a configurable fraction (`audit.read_sampling`, default `0.0` in
+wave 1). When the actor is a break-glass account, the read-sampling fraction MUST be
+treated as `1.0` regardless of configuration so every break-glass action is auditable
+end-to-end.
+
+#### Scenario: State-changing allow is recorded
+
+- **GIVEN** an authorization decision of `allow` on a state-changing action (for
+  example, host isolate)
+- **WHEN** the chokepoint records the decision
+- **THEN** an audit row exists with `decision='allow'`, the action name, the resource
+  type and id, and the actor
+
+#### Scenario: Read sampling defaults skip non-break-glass reads
+
+- **GIVEN** `audit.read_sampling = 0.0` and a non-break-glass actor
+- **WHEN** the chokepoint records an allow decision on a read action
+- **THEN** no audit row is written
+
+#### Scenario: Break-glass reads are always recorded
+
+- **GIVEN** `audit.read_sampling = 0.0` and a break-glass actor
+- **WHEN** the chokepoint records an allow decision on a read action
+- **THEN** an audit row IS written despite the sampling configuration
+
+### Requirement: Audit rows are dual-emitted to slog and OTel
+
+The system SHALL emit a structured slog record and OTel span attributes for every
+audit row it inserts. The slog record MUST be at INFO when the decision is `allow`,
+WARN when the decision is `deny`, the action is a break-glass action, or the decision
+is `error`. The OTel span attributes MUST be set on the active request span and MUST
+include `edr.audit.action`, `edr.audit.decision`, and `edr.audit.reason`. The dual
+emit MUST happen even when the database insert fails so the observability pipeline
+sees a record.
+
+#### Scenario: Allow emits INFO
+
+- **GIVEN** an authorization allow on a state-changing action
+- **WHEN** the recorder emits
+- **THEN** a structured slog record at INFO is written with the audit fields
+- **AND** the active request span carries the three `edr.audit.*` attributes
+
+#### Scenario: Deny emits WARN
+
+- **GIVEN** an authorization deny on any action
+- **WHEN** the recorder emits
+- **THEN** a structured slog record at WARN is written with the audit fields
+
+### Requirement: Append-only persistence
+
+The system SHALL treat the audit table as append-only at the application layer: no
+production code path SHALL update or delete an existing audit row. Operator-driven
+retention pruning MAY happen via a documented out-of-band procedure but MUST NOT be
+exposed in the admin API in wave 1. The schema SHALL be designed so a future
+dual-database-user setup can revoke `UPDATE` and `DELETE` privileges on the audit
+table without code changes.
+
+#### Scenario: No code path updates an audit row
+
+- **GIVEN** any production code path that interacts with the audit recorder
+- **WHEN** static analysis (a build-time check) inspects the call sites
+- **THEN** no `UPDATE audit_events` or `DELETE FROM audit_events` statement is reachable
+  from production code
+
+### Requirement: Audit-log read endpoint requires `audit.read` and audits its own access
+
+The system SHALL expose `GET /api/audit-events` returning audit rows in reverse-chronological
+order with paging. The endpoint MUST require an authorization decision of `allow` for
+the action `audit.read` against a tenant resource. Every successful read of the audit
+log MUST itself record an audit row (`action='audit.read'`) so a future reviewer can
+reconstruct who inspected the audit trail and when.
+
+#### Scenario: Auditor reads the audit log
+
+- **GIVEN** an authenticated session bound to the `auditor` role
+- **WHEN** the operator issues `GET /api/audit-events?limit=50`
+- **THEN** the server returns `200 OK` with up to 50 rows in reverse-chronological order
+- **AND** the read itself produces an audit row with `action='audit.read'` and the
+  query parameters in the row's payload
+
+#### Scenario: Analyst is denied the audit log
+
+- **GIVEN** an authenticated session bound only to the `analyst` role
+- **WHEN** the operator issues `GET /api/audit-events`
+- **THEN** the server returns `403 Forbidden`
+- **AND** an audit row is recorded with decision `deny` and reason
+  `no_role_grants_action`

--- a/openspec/changes/add-user-management/specs/server-identity-authentication/spec.md
+++ b/openspec/changes/add-user-management/specs/server-identity-authentication/spec.md
@@ -1,0 +1,223 @@
+## ADDED Requirements
+
+### Requirement: Okta OIDC is the primary login path
+
+The system SHALL accept operator login via the configured Okta OpenID Connect (OIDC)
+issuer as the primary authentication path. The login flow MUST start at
+`GET /api/auth/login`, redirect the browser to the issuer's authorization endpoint with
+PKCE S256, accept the authorization-code callback at `GET /api/auth/callback`, verify the
+ID token's signature and standard claims (`iss`, `aud`, `exp`, `iat`, `nonce`), and
+exchange the resulting identity for a session cookie minted by the existing session
+capability. A successful callback MUST set the session cookie with `auth_method='oidc'`
+and redirect the browser to the application's home view.
+
+#### Scenario: Operator initiates SSO login
+
+- **GIVEN** OIDC is enabled for the deployment
+- **WHEN** the browser issues `GET /api/auth/login`
+- **THEN** the server responds with a 302 to the issuer's authorization endpoint
+- **AND** the redirect carries the configured `client_id`, the deployment's
+  `redirect_url`, the `openid profile email` scope set, a server-generated `state`
+  parameter, and a PKCE `code_challenge` with method `S256`
+
+#### Scenario: Successful callback mints a session
+
+- **GIVEN** the operator has authenticated at the IdP and the browser carries a fresh
+  authorization code
+- **WHEN** the IdP redirects the browser to `GET /api/auth/callback?code=...&state=...`
+  with a matching `state`
+- **THEN** the server exchanges the code, verifies the ID token, and creates a session
+- **AND** the session row records `auth_method='oidc'` and the matching identity row
+- **AND** the response sets the session cookie and redirects the browser to the
+  application's home view
+
+#### Scenario: Tampered or stale state is rejected
+
+- **GIVEN** the IdP returns a `state` value that does not match the server-issued state
+  cookie or whose associated state cookie has expired
+- **WHEN** the callback handler verifies the state
+- **THEN** the server returns a non-2xx error response without creating a session
+- **AND** an audit row is recorded with decision `error` and reason `oidc.state_mismatch`
+
+### Requirement: Just-in-time provisioning of unknown SSO users
+
+The system SHALL provision a user account on first successful Okta login when
+`auth.oidc.allow_jit_provisioning` is enabled and no identity row exists for the
+incoming `(provider, subject)` pair. The newly-created user SHALL be bound to the
+seeded `analyst` role at the deployment's tenant scope, MUST NOT inherit any other role
+from claims (group → role mapping is out of scope for wave 1), and the provisioning
+SHALL emit an audit row with action `user.created`. When `allow_jit_provisioning` is
+disabled, an unknown subject SHALL be denied with an audit row whose reason is
+`oidc.unknown_subject`.
+
+#### Scenario: First Okta login auto-provisions an analyst
+
+- **GIVEN** OIDC is enabled with `allow_jit_provisioning = true` and no identity row
+  for the incoming subject
+- **WHEN** the callback handler processes a verified ID token
+- **THEN** the server inserts a `users` row with `password_hash = NULL` and
+  `is_breakglass = 0`, an `identities` row keyed by `(provider, subject)`, and a
+  `role_bindings` row to the seeded `analyst` role at tenant scope
+- **AND** the audit log records `action='user.created'` with the actor identity and the
+  resulting user id
+
+#### Scenario: Unknown subject is rejected when JIT is disabled
+
+- **GIVEN** OIDC is enabled with `allow_jit_provisioning = false` and no identity row
+  for the incoming subject
+- **WHEN** the callback handler processes a verified ID token
+- **THEN** the server returns a non-2xx error response and does not create a user
+- **AND** the audit log records the decision with reason `oidc.unknown_subject`
+
+### Requirement: Break-glass account is bootstrapped via single-use token, not a printed password
+
+The system SHALL create at most one break-glass account through a single-use bootstrap
+token redemption flow rather than by printing a generated password. On first boot with
+no users in the system, or on operator-initiated reset, the server SHALL insert a
+`bootstrap_tokens` row whose token bytes are stored hashed, SHALL print the redemption
+URL (carrying the unhashed token) once on the standard error stream, and SHALL set the
+token's `expires_at` to the configured `bootstrap_token_ttl`. The token SHALL be
+single-use; consumption MUST be atomic with the user creation it triggers.
+
+#### Scenario: First boot with empty users prints the redemption URL
+
+- **GIVEN** the server starts with no users
+- **WHEN** initialization runs
+- **THEN** the server inserts exactly one `bootstrap_tokens` row with
+  `purpose='breakglass_setup'` and `expires_at = now + bootstrap_token_ttl`
+- **AND** a banner containing the redemption URL `/admin/break-glass/setup?token=<token>`
+  is written to the standard error stream as a single write
+- **AND** the unhashed token does not appear in any structured log; only the bootstrap
+  event with the token id and expiry is logged
+
+#### Scenario: Token redemption sets the password and registers WebAuthn
+
+- **GIVEN** the operator opens the redemption URL in a browser before the token expires
+- **WHEN** the operator submits a password whose strength meets the configured policy
+  (minimum 14 characters, scored by zxcvbn) AND completes WebAuthn registration of a
+  hardware key in the same request
+- **THEN** the server creates the break-glass `users` row with `is_breakglass=1`,
+  hashes the password with argon2id, persists the WebAuthn credential, marks the token
+  consumed, and writes an audit row with action `auth.breakglass.bootstrap`
+- **AND** the redemption response signs the operator in with a fresh break-glass session
+
+#### Scenario: Expired or already-consumed token cannot be redeemed
+
+- **GIVEN** a bootstrap token whose `expires_at` has passed or whose `consumed_at` is
+  already set
+- **WHEN** the operator submits the redemption form
+- **THEN** the server returns a non-2xx error and does not create a user or session
+- **AND** the audit log records the failed redemption with reason `bootstrap.expired`
+  or `bootstrap.consumed`
+
+### Requirement: Break-glass login lives at a separate path, not on the SSO login page
+
+The system SHALL serve the ongoing break-glass login UI at `/admin/break-glass`, which
+MUST NOT be linked from `/login`. The break-glass login MUST require both the local
+password and a successful WebAuthn assertion before minting a session. When the deployment
+configures an IP allowlist for the break-glass path, requests originating from
+non-allowlisted IPs (as determined by the configured forwarded-IP header) SHALL receive
+`404 Not Found` so the path's existence is not acknowledged.
+
+#### Scenario: Break-glass UI is reachable from an allowlisted IP
+
+- **GIVEN** the requester's IP is on the configured allowlist (or no allowlist is
+  configured)
+- **WHEN** the requester issues `GET /admin/break-glass`
+- **THEN** the server returns the break-glass login form (password + WebAuthn challenge)
+
+#### Scenario: Off-allowlist requester receives 404
+
+- **GIVEN** an IP allowlist is configured AND the requester's IP is not on it
+- **WHEN** the requester issues any request to `/admin/break-glass` or
+  `/admin/break-glass/setup`
+- **THEN** the server returns `404 Not Found` with a body indistinguishable from a
+  generic 404
+
+#### Scenario: Successful break-glass login requires both password and WebAuthn
+
+- **GIVEN** a requester who has supplied a correct break-glass password AND completed a
+  WebAuthn assertion against a registered credential
+- **WHEN** the server validates the submission
+- **THEN** the server creates a session with `auth_method='local_password'` (with WebAuthn
+  recorded as the second factor), sets the cookie with the break-glass tighter timeouts,
+  and writes an audit row at WARN with action `auth.breakglass.success`
+
+### Requirement: Break-glass authentication is rate-limited and audited at WARN
+
+The system MUST rate-limit break-glass attempts with tighter caps than SSO login: at
+most 5 attempts per 15 minutes per source IP and at most 10 attempts per hour per
+email. The bootstrap-setup endpoint MUST have its own rate bucket of at most 3 attempts
+per 5 minutes per IP. Every successful break-glass login MUST emit an audit row at WARN
+so a SigNoz alert can fire on any occurrence. Every failed break-glass authentication
+MUST emit an audit row recording the failure mode (unknown email, wrong password,
+WebAuthn failure) without leaking which fact caused the failure to the client.
+
+#### Scenario: Rate limit blocks excessive attempts
+
+- **GIVEN** a source IP has reached the per-IP cap on `/admin/break-glass`
+- **WHEN** the IP issues another login attempt
+- **THEN** the server returns `429 Too Many Requests` with `Retry-After`
+- **AND** the user store is not consulted for that request
+- **AND** the audit log records the rate-limit denial
+
+#### Scenario: Successful break-glass emits a WARN audit row
+
+- **GIVEN** a successful break-glass login
+- **WHEN** the response is sent
+- **THEN** an audit row is recorded at level WARN with `action='auth.breakglass.success'`
+- **AND** the structured slog record at WARN carries the user id, the source IP, and the
+  request id
+
+### Requirement: Reauthentication is required for destructive actions
+
+The system SHALL require a fresh authentication event within the configured reauth
+window (default 30 minutes for normal sessions; the same window applies to break-glass
+sessions) before authorizing a destructive action. The set of destructive actions in
+wave 1 MUST include host isolation, host process kill, host script run, and dismissing
+an alert whose severity is `critical`. A request whose session has not been
+re-authenticated within the window MUST be rejected with a typed error so the UI can
+prompt for re-authentication, and the rejection MUST be recorded in the audit log.
+
+#### Scenario: Fresh session executes a destructive action
+
+- **GIVEN** an authenticated session whose last fresh auth event is within the reauth
+  window
+- **WHEN** the operator invokes a destructive action that the policy would otherwise
+  allow
+- **THEN** the server proceeds with the action
+
+#### Scenario: Stale session is challenged before destructive action
+
+- **GIVEN** an authenticated session whose last fresh auth event is older than the
+  reauth window
+- **WHEN** the operator invokes a destructive action
+- **THEN** the server returns a typed `reauth_required` error with the action and the
+  reauth path
+- **AND** an audit row is recorded with decision `deny` and reason `reauth_required`
+- **AND** the action is not performed
+
+### Requirement: A user is the row, an identity is the way to authenticate
+
+The system SHALL distinguish a user (the person) from the identity binding(s) by which
+the user authenticates. Every user MUST have one or more identity rows; an identity row
+MUST belong to exactly one user. Identity kinds in wave 1 are `local_password` (used by
+the break-glass account) and `oidc` (used by SSO-provisioned accounts). The
+`(provider, subject)` pair on an identity MUST be globally unique so the same Okta
+account cannot bind to two users in the same deployment.
+
+#### Scenario: SSO user has exactly one OIDC identity
+
+- **GIVEN** a JIT-provisioned SSO user
+- **WHEN** the system queries the user's identities
+- **THEN** the result includes exactly one row with `kind='oidc'` keyed by the
+  configured provider and the IdP's subject claim
+- **AND** the user's `password_hash` and `password_salt` are NULL
+
+#### Scenario: Two SSO subjects cannot both bind to the same user
+
+- **GIVEN** a SSO callback for a subject that already has an identity bound to a
+  different user
+- **WHEN** the callback handler attempts to provision the new identity
+- **THEN** the unique constraint on `(provider, subject)` rejects the bind
+- **AND** the response is a non-2xx error and an audit row is recorded

--- a/openspec/changes/add-user-management/specs/server-identity-authentication/spec.md
+++ b/openspec/changes/add-user-management/specs/server-identity-authentication/spec.md
@@ -147,8 +147,12 @@ non-allowlisted IPs (as determined by the configured forwarded-IP header) SHALL 
 
 The system MUST rate-limit break-glass attempts with tighter caps than SSO login: at
 most 5 attempts per 15 minutes per source IP and at most 10 attempts per hour per
-email. The bootstrap-setup endpoint MUST have its own rate bucket of at most 3 attempts
-per 5 minutes per IP. Every successful break-glass login MUST emit an audit row at WARN
+*presented email*. The per-email limiter MUST key on the email exactly as presented in
+the request, regardless of whether an account exists for that email, so the response
+shape and timing for an unknown email are indistinguishable from those for a known
+email at the rate-limit layer (preventing account enumeration through differential
+limiter behavior). The bootstrap-setup endpoint MUST have its own rate bucket of at
+most 3 attempts per 5 minutes per IP. Every successful break-glass login MUST emit an audit row at WARN
 so a SigNoz alert can fire on any occurrence. Every failed break-glass authentication
 MUST emit an audit row recording the failure mode (unknown email, wrong password,
 WebAuthn failure) without leaking which fact caused the failure to the client.
@@ -174,8 +178,9 @@ WebAuthn failure) without leaking which fact caused the failure to the client.
 The system SHALL require a fresh authentication event within the configured reauth
 window (default 30 minutes for normal sessions; the same window applies to break-glass
 sessions) before authorizing a destructive action. The set of destructive actions in
-wave 1 MUST include host isolation, host process kill, host script run, and dismissing
-an alert whose severity is `critical`. A request whose session has not been
+wave 1 MUST include host isolation, host process kill, host script run, host enrollment
+revocation, and dismissing an alert whose severity is `critical`. A request whose session
+has not been
 re-authenticated within the window MUST be rejected with a typed error so the UI can
 prompt for re-authentication, and the rejection MUST be recorded in the audit log.
 
@@ -214,7 +219,7 @@ account cannot bind to two users in the same deployment.
   configured provider and the IdP's subject claim
 - **AND** the user's `password_hash` and `password_salt` are NULL
 
-#### Scenario: Two SSO subjects cannot both bind to the same user
+#### Scenario: A single SSO subject cannot be bound to multiple users
 
 - **GIVEN** a SSO callback for a subject that already has an identity bound to a
   different user

--- a/openspec/changes/add-user-management/specs/server-identity-authorization/spec.md
+++ b/openspec/changes/add-user-management/specs/server-identity-authorization/spec.md
@@ -42,7 +42,7 @@ The system SHALL seed five roles at startup and SHALL keep their `is_builtin` fl
 so they cannot be deleted via the admin API: `super_admin` (tenant + SSO config + every
 permission below), `admin` (day-to-day administration: user.read, user.invite, policy.*,
 host.*, alert.*), `senior_analyst` (investigate + take destructive action: host.read,
-host.isolate, host.kill_process, alert.*), `analyst` (investigate + comment + escalate:
+host.isolate, host.kill_process, host.run_script, alert.*), `analyst` (investigate + comment + escalate:
 host.read, process.read, alert.read, alert.comment), and `auditor` (read-only including
 audit.read). The break-glass user MUST be bound to `super_admin` at tenant scope.
 SSO-provisioned users MUST default to `analyst` at tenant scope; the system MUST NOT

--- a/openspec/changes/add-user-management/specs/server-identity-authorization/spec.md
+++ b/openspec/changes/add-user-management/specs/server-identity-authorization/spec.md
@@ -1,0 +1,168 @@
+## ADDED Requirements
+
+### Requirement: Every privileged action funnels through one authorization chokepoint
+
+The system SHALL evaluate every privileged action through a single authorization
+chokepoint that takes the calling actor (derived from the session), the action name,
+and the target resource and returns a decision (allow or deny) plus a machine-readable
+reason. No privileged handler MAY make its own role check; the chokepoint is the only
+sanctioned place where a permission decision is made. Action names MUST come from a
+registered enumeration; a request whose action is not registered SHALL be denied with
+reason `action_not_registered` (defense-in-depth against typos and ghost permissions).
+
+#### Scenario: Authorized action is allowed and recorded
+
+- **GIVEN** an authenticated actor whose role grants the requested action at the
+  resource's scope
+- **WHEN** the chokepoint evaluates the request
+- **THEN** the response is `{allow: true, reason: "granted"}`
+- **AND** an audit row is recorded with decision `allow`
+
+#### Scenario: Unauthorized action is denied with a reason
+
+- **GIVEN** an authenticated actor whose roles do not grant the requested action at the
+  resource's scope
+- **WHEN** the chokepoint evaluates the request
+- **THEN** the response is `{allow: false, reason: <policy-supplied reason>}`
+- **AND** the calling handler returns `403 Forbidden` to the client
+- **AND** an audit row is recorded with decision `deny` and the same reason
+
+#### Scenario: Unregistered action is denied as defense in depth
+
+- **GIVEN** a handler that calls the chokepoint with an action name not present in the
+  registered enumeration
+- **WHEN** the chokepoint evaluates the request
+- **THEN** the decision is `{allow: false, reason: "action_not_registered"}`
+- **AND** the build fails CI by way of a parity check between the action enumeration
+  and the policy bundle, so the production binary cannot ship with this state
+
+### Requirement: Five seeded roles bundle permissions for the deployment
+
+The system SHALL seed five roles at startup and SHALL keep their `is_builtin` flag set
+so they cannot be deleted via the admin API: `super_admin` (tenant + SSO config + every
+permission below), `admin` (day-to-day administration: user.read, user.invite, policy.*,
+host.*, alert.*), `senior_analyst` (investigate + take destructive action: host.read,
+host.isolate, host.kill_process, alert.*), `analyst` (investigate + comment + escalate:
+host.read, process.read, alert.read, alert.comment), and `auditor` (read-only including
+audit.read). The break-glass user MUST be bound to `super_admin` at tenant scope.
+SSO-provisioned users MUST default to `analyst` at tenant scope; the system MUST NOT
+auto-elevate any role from a SSO claim.
+
+#### Scenario: Roles are seeded on first boot
+
+- **GIVEN** an empty `roles` table
+- **WHEN** the server boots
+- **THEN** exactly the five seeded roles exist with `is_builtin=1`
+- **AND** the break-glass user (when present) is bound to `super_admin` at tenant scope
+
+#### Scenario: Built-in role cannot be deleted
+
+- **GIVEN** an authenticated `super_admin`
+- **WHEN** the operator attempts to delete a role with `is_builtin=1`
+- **THEN** the server returns a typed error and does not modify the role
+
+### Requirement: Role bindings carry a tenant + scope so future scoping is non-breaking
+
+Every role binding SHALL carry a `tenant_id`, a `scope_type` from the set
+`{'tenant', 'host_group', 'host'}`, and a `scope_id`. Wave 1 SHALL enforce only
+`scope_type='tenant'` (with `scope_id='*'`); a binding with a non-tenant scope_type
+MUST be persisted but MUST NOT be honored by the chokepoint until the corresponding
+scope resolver ships. A binding MAY carry an `expires_at`; an expired binding MUST be
+treated as if it did not exist when the chokepoint evaluates a request.
+
+#### Scenario: Tenant-scoped binding grants the action
+
+- **GIVEN** a role binding with `scope_type='tenant'`, `scope_id='*'`, and the role
+  granting the requested action
+- **WHEN** the chokepoint evaluates a request whose resource lives in the same tenant
+- **THEN** the decision is `{allow: true, reason: "granted"}`
+
+#### Scenario: Host-scoped binding does not grant the action in wave 1
+
+- **GIVEN** a role binding with `scope_type='host'` and `scope_id` matching the
+  resource host id
+- **WHEN** the chokepoint evaluates a request that would only be authorized via the
+  host scope
+- **THEN** the decision is `{allow: false, reason: "scope_not_yet_supported"}`
+- **AND** the audit row records the deny decision so the operator can see scopes are
+  not yet honored
+
+#### Scenario: Expired binding is ignored
+
+- **GIVEN** a role binding whose `expires_at` is in the past
+- **WHEN** the chokepoint loads the actor's bindings
+- **THEN** the expired binding is not part of the evaluation input
+- **AND** if no other binding grants the action, the decision is deny
+
+### Requirement: Tenant scaffolding column on every long-lived table
+
+Every table that belongs to a tenant in the long run SHALL carry a `tenant_id`
+column whose default value is the literal string `'default'`. Wave 1 MUST seed exactly
+one tenant (`id='default'`, `status='active'`) and MUST NOT use the column as a query
+filter. The column SHALL be present at minimum on every identity-context table
+(`users`, `sessions`, `roles`, `role_bindings`, `audit_events`) and on every
+non-identity table whose rows logically belong to a tenant in wave 2's MSSP shape:
+`hosts`, `alerts`, `policies`, `commands`, `enrollments`. The system MUST NOT enforce
+foreign keys between `tenants` and any non-identity table.
+
+#### Scenario: Default tenant exists at first boot
+
+- **GIVEN** a fresh deployment
+- **WHEN** the server boots
+- **THEN** the `tenants` table contains exactly one row with `id='default'` and
+  `status='active'`
+
+#### Scenario: New row inherits the default tenant
+
+- **GIVEN** a write to any tenant-scoped table that does not specify `tenant_id`
+- **WHEN** the row is inserted
+- **THEN** the row's `tenant_id` is `'default'`
+
+#### Scenario: Wave 1 does not query on tenant_id
+
+- **GIVEN** any read endpoint defined by an existing capability
+- **WHEN** the server processes the read
+- **THEN** the SQL filter does not include `tenant_id` (verified by query-builder
+  inspection in tests; the column is purely scaffolding)
+
+### Requirement: Authorization decisions sub-millisecond at p99
+
+The system SHALL evaluate the authorization chokepoint at p99 latency under 1
+millisecond on the deployment's production hardware. The benchmark harness MUST run on
+every authorization-touching pull request, and a regression that pushes p99 above
+1 ms SHALL fail the build. The benchmark MUST cover allow and deny paths and MUST use
+the seeded roles plus a representative role-binding fan-out.
+
+#### Scenario: Benchmark passes on the merge candidate
+
+- **GIVEN** a pull request that touches the authorization engine, the policy bundle, or
+  the action registry
+- **WHEN** continuous integration runs the authorization benchmark
+- **THEN** the recorded p99 over the standard input set is below 1 millisecond
+- **AND** the build passes
+
+#### Scenario: Benchmark regression blocks the build
+
+- **GIVEN** a pull request whose change pushes the benchmark p99 above 1 millisecond
+- **WHEN** continuous integration runs the benchmark
+- **THEN** the build fails and the PR cannot be merged until the regression is
+  addressed
+
+### Requirement: Shadow mode rolls authorization out without enforcing
+
+The system SHALL expose a configuration flag (`authz.shadow_mode`) that, when enabled,
+makes the chokepoint always return `{allow: true, reason: "shadow_mode"}` while still
+recording the would-be decision in the audit log. The flag MUST exist for the duration
+of the wave-1 rollout and MUST be removable in a follow-up change once enforcement is
+the steady state. The default for a fresh deployment SHALL be `shadow_mode=false`; an
+upgrade path MAY default it to `true` for a deployment whose policy verdict has not yet
+been validated against its handler set.
+
+#### Scenario: Shadow mode allows but logs the would-be decision
+
+- **GIVEN** `authz.shadow_mode=true` and a request whose policy decision would be deny
+- **WHEN** the chokepoint evaluates the request
+- **THEN** the response to the handler is `{allow: true, reason: "shadow_mode"}`
+- **AND** an audit row is recorded with decision `deny` and the policy-supplied reason
+- **AND** the audit row's payload notes that shadow mode was in effect so dashboards
+  can distinguish would-be denies from real denies

--- a/openspec/changes/add-user-management/specs/ui-authentication-session/spec.md
+++ b/openspec/changes/add-user-management/specs/ui-authentication-session/spec.md
@@ -1,0 +1,188 @@
+## MODIFIED Requirements
+
+### Requirement: Login mints a session cookie and a CSRF token
+
+The system SHALL mint a session cookie and a per-session CSRF token whenever an
+authentication flow completes successfully, regardless of whether the originating flow
+is the OIDC callback (handled by the server-identity-authentication capability) or the
+break-glass login at `/admin/break-glass`. On success the response SHALL set the
+session cookie and return the CSRF token in the response body, so the UI can read the
+CSRF token client-side without exposing the session identifier to JavaScript. The
+session row MUST record the `auth_method` (`oidc` or `local_password`) and, when
+known, the `identity_id` of the identity that authenticated the session, so audit
+queries and the UI can surface "logged in via Okta" vs "logged in via break-glass."
+
+#### Scenario: Successful break-glass login mints a session
+
+- **GIVEN** a break-glass operator submits a correct password and a valid WebAuthn
+  assertion at `/admin/break-glass`
+- **WHEN** the request is processed
+- **THEN** the server responds 200 with a JSON body containing the user identity and a
+  CSRF token
+- **AND** the response sets the session cookie with HttpOnly, SameSite=Lax, and (when
+  TLS is enabled) Secure
+- **AND** the session row records `auth_method='local_password'` and the matching
+  `identity_id`
+- **AND** subsequent authenticated requests carrying that cookie are recognized as the
+  same session
+
+#### Scenario: Successful OIDC callback mints a session
+
+- **GIVEN** a successful Okta callback handled by the authentication capability
+- **WHEN** the callback ends
+- **THEN** the response sets the session cookie with the same security attributes
+- **AND** the session row records `auth_method='oidc'` and the matching `identity_id`
+
+#### Scenario: Login with empty fields at the break-glass surface
+
+- **GIVEN** the client posts an empty password to the break-glass login endpoint
+- **WHEN** the request is processed
+- **THEN** the server responds 400 with a typed error
+- **AND** no session is created and no cookie is set
+
+### Requirement: Login failures do not enumerate accounts
+
+The system MUST return the same generic error response for "no such email" and "wrong
+password" on the break-glass login surface so an attacker cannot tell from the
+response which emails correspond to real accounts, while still recording the
+distinction in the server-side audit log. The OIDC login surface does not face this
+risk because the IdP, not the EDR, validates credentials; failures originating from
+the IdP MUST surface as a generic OIDC error in the UI.
+
+#### Scenario: Email is unknown on the break-glass surface
+
+- **GIVEN** the client posts an email that does not correspond to any break-glass
+  account
+- **WHEN** the request is processed
+- **THEN** the server responds 401 with a generic invalid-credentials error
+- **AND** the audit log records that the email was unknown
+
+#### Scenario: Email is known but password is wrong on the break-glass surface
+
+- **GIVEN** the client posts an email that corresponds to a break-glass account but
+  with a wrong password
+- **WHEN** the request is processed
+- **THEN** the server responds 401 with the same generic invalid-credentials error as
+  for an unknown email
+- **AND** the audit log records that the password did not match
+
+### Requirement: Passwords are stored as argon2id hashes
+
+The system SHALL persist user passwords as argon2id hashes computed with time cost 3,
+memory cost 64 MiB, parallelism 4, and a 32-byte derived key, using a fresh 16-byte
+random salt per password. The system SHALL verify the presented password by recomputing
+argon2id with the stored salt under those same parameters and comparing the result to
+the stored hash with a constant-time equality check. The system SHALL NOT store
+plaintext passwords or reversibly encrypted passwords. SSO-authenticated users MAY
+have NULL `password_hash` and `password_salt` columns; the system MUST NOT attempt to
+verify a password against a NULL hash.
+
+#### Scenario: Password verification for a break-glass account
+
+- **GIVEN** a break-glass operator has an account with a stored argon2id hash and
+  16-byte salt
+- **WHEN** the operator logs in with the correct password
+- **THEN** argon2id is recomputed with the stored salt under the project's parameter
+  set
+- **AND** the result matches the stored hash under a constant-time equality check
+- **AND** the login succeeds
+
+#### Scenario: Wrong password takes the same CPU cost as a correct one
+
+- **GIVEN** a break-glass operator presents a known email with a wrong password
+- **WHEN** the verification path runs
+- **THEN** argon2id is computed under the same parameter set as a successful
+  verification
+- **AND** the per-request CPU cost is comparable to a successful login so that timing
+  does not leak whether the password was the cause of the failure
+
+#### Scenario: SSO user has no stored password
+
+- **GIVEN** a user provisioned via OIDC JIT
+- **WHEN** the user's row is inspected
+- **THEN** `password_hash` and `password_salt` are NULL
+- **AND** any code path that attempts password verification against this user errors
+  out before computing argon2id
+
+### Requirement: Initial break-glass account is bootstrapped via single-use token
+
+The system SHALL ensure exactly one break-glass account can be created at the
+deployment's first boot via a single-use bootstrap-token redemption flow, replacing
+the prior "print a generated password to stderr" flow. On first boot with no users in
+the system the server SHALL insert a `bootstrap_tokens` row, print the redemption URL
+once on the standard error stream, and refuse logins until the token is redeemed.
+Token redemption SHALL require the operator to set a password (whose strength meets
+the configured policy) AND register a WebAuthn credential before the break-glass
+account is created. The documented recovery path when the break-glass credentials are
+lost is to invoke an operator-side reset that issues a fresh bootstrap token; deleting
+a user row and restarting is no longer a valid recovery path.
+
+#### Scenario: First-startup prints the redemption URL
+
+- **GIVEN** the server starts and the users table is empty
+- **WHEN** initialization runs
+- **THEN** exactly one `bootstrap_tokens` row is inserted with
+  `purpose='breakglass_setup'`
+- **AND** a banner containing the redemption URL is written to the standard error
+  stream as a single write
+- **AND** no user row is created until the token is redeemed
+- **AND** the unhashed token does not appear in the structured log; only the
+  bootstrap event with the token id and expiry is logged
+
+#### Scenario: Restart with an existing operator does not reissue a token
+
+- **GIVEN** the users table already contains at least one row
+- **WHEN** the server starts
+- **THEN** no new bootstrap token is issued and no banner is emitted
+
+#### Scenario: Recovery after a lost break-glass credential
+
+- **GIVEN** the captured redemption URL has been lost or the WebAuthn key is
+  unavailable
+- **WHEN** an operator invokes the documented credential-reset procedure
+- **THEN** a fresh single-use bootstrap token is issued and its redemption URL is
+  printed to stderr
+- **AND** the existing break-glass user row remains in place; the next redemption
+  rotates its password and credential without inserting a duplicate row
+
+### Requirement: Sessions enforce idle, absolute, and reauthentication timeouts
+
+The system SHALL enforce three independent session lifetimes that together replace the
+prior 12-hour flat expiry. A normal session MUST expire after 8 hours of idle
+inactivity (sliding window) AND after 24 hours from issue (hard cap, regardless of
+activity). A break-glass session MUST use tighter caps of 15 minutes idle and 1 hour
+absolute. Destructive actions (host isolate, host process kill, host script run, and
+critical-severity alert dismiss) MUST require a fresh authentication event within a
+30-minute reauth window. The cookie's `Expires` and `Max-Age` MUST reflect the
+applicable absolute timeout so the browser stops sending the cookie after it elapses,
+and the server-side row MUST be treated as expired once any of the three windows has
+been crossed even if the browser does send the cookie.
+
+#### Scenario: Idle window expires a normal session
+
+- **GIVEN** a normal session whose last activity is more than 8 hours ago but whose
+  issue time is less than 24 hours ago
+- **WHEN** the client uses the session cookie
+- **THEN** the server treats the session as expired and returns 401
+
+#### Scenario: Absolute window expires a normal session even with continuous use
+
+- **GIVEN** a normal session whose issue time is more than 24 hours ago, regardless of
+  activity
+- **WHEN** the client uses the session cookie
+- **THEN** the server treats the session as expired and returns 401
+
+#### Scenario: Break-glass tighter caps
+
+- **GIVEN** a session minted by the break-glass flow
+- **WHEN** the cookie is set
+- **THEN** the cookie's `Max-Age` reflects the 1-hour absolute cap
+- **AND** the server-side row is treated as expired after 15 minutes of idle or 1 hour
+  from issue, whichever comes first
+
+#### Scenario: Reauth window challenges a destructive action
+
+- **GIVEN** a session whose last fresh authentication event is more than 30 minutes ago
+- **WHEN** the operator invokes a destructive action
+- **THEN** the server returns a typed `reauth_required` error and does not perform
+  the action

--- a/openspec/changes/add-user-management/specs/web-ui/spec.md
+++ b/openspec/changes/add-user-management/specs/web-ui/spec.md
@@ -54,8 +54,11 @@ The UI SHALL render the current operator's role and authentication method in the
 account menu so an operator can tell at a glance whether they are signed in via Okta
 or via the break-glass account, and what permissions their session carries. The role
 label MUST be one of the seeded role names (or a custom role name if non-built-in
-roles ship in a later wave). The authentication method MUST be one of `oidc` or
-`local_password`. The role and authentication method MUST be visible without
+roles ship in a later wave). The authentication-method indicator is derived from the
+session's `auth_method` value (`oidc` or `local_password`) but the UI MUST present a
+human-friendly label rather than the raw enum: `oidc` SHALL render as `Okta` and
+`local_password` (when the session was minted at the break-glass surface) SHALL
+render as `break-glass`. The role and authentication method MUST be visible without
 navigating to a settings page; they are first-class affordances of the menu.
 
 #### Scenario: Account menu shows Okta + analyst

--- a/openspec/changes/add-user-management/specs/web-ui/spec.md
+++ b/openspec/changes/add-user-management/specs/web-ui/spec.md
@@ -1,0 +1,74 @@
+## MODIFIED Requirements
+
+### Requirement: Authenticated entry to the application
+
+The UI SHALL probe the server's session endpoint on application load and SHALL render
+the SSO login page when the probe indicates no active session. The SSO login page MUST
+present exactly one primary action — "Continue with Okta" — and MUST NOT render an
+email-and-password form, MUST NOT link to the break-glass surface, and MUST NOT hint
+that local login exists. Activating the SSO action MUST navigate the browser to the
+server's SSO entry endpoint, which redirects to the configured Okta issuer. A
+successful authentication (round-tripped through Okta and the server's callback) MUST
+establish a session and route the user to the application's home view; a failed
+authentication MUST surface a generic error without revealing whether the IdP rejected
+the user, the EDR's JIT policy denied the user, or the callback verification failed.
+The break-glass login UI lives at `/admin/break-glass` and is reachable only by
+operators who know the URL out-of-band.
+
+#### Scenario: Anonymous user lands on the SSO login page
+
+- **GIVEN** a browser with no active session cookie
+- **WHEN** the user navigates to the application
+- **THEN** the UI renders the SSO login page with a single "Continue with Okta" action
+- **AND** the page does not show an email or password field
+- **AND** the page does not link to the break-glass surface
+
+#### Scenario: Continue with Okta initiates the SSO flow
+
+- **GIVEN** the SSO login page is displayed
+- **WHEN** the user activates the "Continue with Okta" action
+- **THEN** the browser navigates to the server's SSO entry endpoint, which redirects
+  to the configured Okta issuer
+
+#### Scenario: Successful SSO callback routes to the home view
+
+- **GIVEN** the SSO flow has completed at the IdP and the browser has been redirected
+  back to the EDR's callback endpoint with a valid authorization code
+- **WHEN** the server completes its callback handling and sets the session cookie
+- **THEN** the UI re-renders into the host list as the home view
+
+#### Scenario: Failed SSO surfaces a non-revealing error
+
+- **GIVEN** the SSO callback fails for any reason (IdP rejection, JIT policy denied
+  the unknown subject, callback verification failed, network error)
+- **WHEN** the UI re-renders
+- **THEN** the UI shows a single generic error such as "sign-in failed; contact your
+  administrator"
+- **AND** the UI does not distinguish between failure modes
+
+## ADDED Requirements
+
+### Requirement: Account menu surfaces role and authentication method
+
+The UI SHALL render the current operator's role and authentication method in the
+account menu so an operator can tell at a glance whether they are signed in via Okta
+or via the break-glass account, and what permissions their session carries. The role
+label MUST be one of the seeded role names (or a custom role name if non-built-in
+roles ship in a later wave). The authentication method MUST be one of `oidc` or
+`local_password`. The role and authentication method MUST be visible without
+navigating to a settings page; they are first-class affordances of the menu.
+
+#### Scenario: Account menu shows Okta + analyst
+
+- **GIVEN** an operator whose session was minted by the SSO flow and whose role
+  binding is `analyst`
+- **WHEN** the operator opens the account menu
+- **THEN** the menu shows the operator's display name, the role label `analyst`, and
+  an authentication-method indicator labelled `Okta`
+
+#### Scenario: Account menu shows break-glass + super_admin
+
+- **GIVEN** an operator whose session was minted via `/admin/break-glass`
+- **WHEN** the operator opens the account menu
+- **THEN** the menu shows the operator's display name, the role label `super_admin`,
+  and an authentication-method indicator labelled `break-glass`

--- a/openspec/changes/add-user-management/tasks.md
+++ b/openspec/changes/add-user-management/tasks.md
@@ -1,0 +1,149 @@
+## Phase 1: schema + seeding (one PR per context, additive only)
+
+- [ ] **1.1** Add identity-context tables to `server/identity/internal/store/schema.sql`:
+  `tenants`, `identities`, `roles`, `role_bindings`, `audit_events`, `bootstrap_tokens`,
+  `webauthn_credentials`. Plus additive columns on `users`
+  (`tenant_id`, `display_name`, `status`, `is_breakglass`; nullable `password_hash`,
+  `password_salt`) and `sessions` (`identity_id`, `auth_method`).
+- [ ] **1.2** Add `tenant_id VARCHAR(64) NOT NULL DEFAULT 'default'` to detection's
+  `hosts` and `alerts` via `server/detection/internal/store/schema.sql`.
+- [ ] **1.3** Add `tenant_id` to rules' `policies` via
+  `server/rules/internal/store/schema.sql`.
+- [ ] **1.4** Add `tenant_id` to response's `commands` via
+  `server/response/internal/store/schema.sql`.
+- [ ] **1.5** Add `tenant_id` to endpoint's `enrollments` via
+  `server/endpoint/internal/store/schema.sql`.
+- [ ] **1.6** Seed `tenants` with one row (`id='default'`, `status='active'`) on identity
+  bootstrap; idempotent.
+- [ ] **1.7** Seed the five built-in roles (`super_admin`, `admin`, `senior_analyst`,
+  `analyst`, `auditor`) via `server/identity/internal/seed/roles.go`; idempotent.
+- [ ] **1.8** Rewrite `server/identity/internal/seed/admin.go` →
+  `seed/breakglass.go`: replace the printed-password flow with a single-use
+  `bootstrap_tokens` row whose redemption URL is printed once on stderr. Migrate any
+  existing `admin@fleet-edr.local` row to `is_breakglass=1` with NULL password fields
+  and auto-issue a token.
+- [ ] **1.9** Per-context integration tests at
+  `server/identity/internal/tests/schema_test.go` and the parallel test file in each
+  other context that touched its `tenant_id` column. Verify defaults, NULL allowance,
+  and that wave-1 reads do not query on `tenant_id`.
+- [ ] **1.10** Cross-context integration test at
+  `test/integration/tenant_scaffolding_test.go` — boot the full server, exercise
+  every existing read endpoint, assert the rendered SQL never contains `tenant_id` in
+  a WHERE clause.
+
+## Phase 2: authorization chokepoint shipped in shadow mode
+
+- [ ] **2.1** New package `server/identity/internal/authz/` with the OPA engine wiring
+  (compiled `PreparedEvalQuery`, `embed`-baked `*.rego` files at
+  `internal/authz/policy/*.rego`, SIGHUP reload).
+- [ ] **2.2** Action registry at `server/identity/api/actions.go` (typed `Action`
+  constants) and `server/identity/internal/authz/policy/data/actions.json`. Build-time
+  parity check that the two lists agree.
+- [ ] **2.3** Public surface exports on `server/identity/api/`: `Actor`,
+  `RoleBinding`, `Resource`, `Decision`, `AuthZ` interface, `ActorFromContext(ctx)`.
+- [ ] **2.4** Session middleware in `server/identity/internal/sessions/` builds the
+  `Actor` from the session row + role bindings + tenant id; threads it into request
+  context.
+- [ ] **2.5** Bench harness at `server/identity/internal/authz/bench_test.go` covering
+  allow + deny paths over the seeded roles. Wire into CI; fail at p99 ≥ 1ms.
+- [ ] **2.6** Add `authz.shadow_mode` config flag (default `false` for fresh deployments,
+  `true` for upgrades). Engine returns `{allow:true, reason:"shadow_mode"}` when set;
+  audit row records the would-be decision and notes shadow mode in payload.
+- [ ] **2.7** Convert every privileged handler in detection / rules / response /
+  endpoint / identity to call `authz.Allow(ctx, action, resource)`. One PR per context.
+  Remove any ad-hoc role checks the call replaces. arch-go must continue to pass.
+- [ ] **2.8** Code-search rule: privileged-route registration that does not call
+  `authz.Allow` fails the build. Add to lefthook + CI.
+
+## Phase 3: audit recorder + dual-emit
+
+- [ ] **3.1** New package `server/identity/internal/audit/` with `Recorder` (DB
+  insert + slog + OTel span attributes). Public `Audit` interface on
+  `server/identity/api/`.
+- [ ] **3.2** Async writer with a bounded buffer; back-pressure logs to slog/OTel only.
+  Pattern mirrors detection's event-ingest queue.
+- [ ] **3.3** Wire `audit.Record` into the authz chokepoint so every decision lands an
+  audit row (subject to read-sampling). Wire it into authentication outcomes.
+- [ ] **3.4** Add `audit.read_sampling` config (default 0.0); break-glass actor forces
+  1.0 regardless.
+- [ ] **3.5** New endpoint `GET /api/audit-events` in identity's admin handlers; gated
+  on `audit.read`; itself emits an audit-of-audit row. Pagination via cursor.
+- [ ] **3.6** Static-analysis check: no production code path may emit
+  `UPDATE audit_events` or `DELETE FROM audit_events`. Add to lefthook.
+
+## Phase 4: OIDC + break-glass authentication
+
+- [ ] **4.1** New package `server/identity/internal/oidc/` using
+  `github.com/coreos/go-oidc/v3/oidc` + `golang.org/x/oauth2`. Discovery, JWKS refresh,
+  PKCE S256, ID-token verification (issuer, audience, expiry, nonce), ±2-minute clock
+  skew tolerance.
+- [ ] **4.2** New routes in identity's bootstrap: `GET /api/auth/login`,
+  `GET /api/auth/callback`. State stored in a short-lived signed cookie reusing
+  `EDR_SESSION_SIGNING_KEY`.
+- [ ] **4.3** JIT provisioning: insert `users` (NULL password) + `identities`
+  (provider, subject), bind to `analyst` at tenant scope, audit `user.created`. Honors
+  `auth.oidc.allow_jit_provisioning`.
+- [ ] **4.4** New package `server/identity/internal/breakglass/` covering bootstrap
+  token issuance + redemption, password validation (zxcvbn ≥ 14), WebAuthn registration
+  via `github.com/go-webauthn/webauthn`. Atomic redemption + user creation +
+  credential persistence.
+- [ ] **4.5** New routes: `GET /admin/break-glass`, `POST /admin/break-glass` (login
+  with password + WebAuthn assertion), `GET /admin/break-glass/setup`,
+  `POST /admin/break-glass/setup`. IP allowlist 404 enforcement when configured.
+- [ ] **4.6** Tighter rate limits on the break-glass surface (per-IP + per-email +
+  bootstrap-setup bucket). Existing rate-limiter middleware extended.
+- [ ] **4.7** UI: replace the `/login` form with the "Continue with Okta" page; add the
+  `/admin/break-glass` and `/admin/break-glass/setup` views. Wire account-menu to
+  surface role + auth method.
+- [ ] **4.8** Per-context integration tests for OIDC happy path, JIT provisioning,
+  unknown-subject deny, expired state, bootstrap-token redemption, expired token,
+  consumed token, IP allowlist 404, rate-limit responses.
+
+## Phase 5: session middleware updates
+
+- [ ] **5.1** Replace flat 12-hour expiry with idle (8h) + absolute (24h) for normal
+  sessions; idle (15m) + absolute (1h) for break-glass.
+- [ ] **5.2** Reauth window (30m) enforcement on the action set (host.isolate,
+  host.kill_process, host.run_script, alert.dismiss with severity=critical). Typed
+  `reauth_required` error.
+- [ ] **5.3** UI: handle `reauth_required` by prompting the operator to re-authenticate
+  inline, then retrying the original action.
+- [ ] **5.4** Per-context integration tests for each timeout window and the reauth
+  challenge.
+
+## Phase 6: shadow-mode flip
+
+- [ ] **6.1** Operator playbook: review the shadow-mode dashboard for one full week of
+  production traffic on the pilot deployment; deny-decision count must read zero on
+  every privileged handler. Resolve any outliers.
+- [ ] **6.2** Single-PR change: flip `authz.shadow_mode` default to `false` for fresh
+  deployments and provide a release note advising upgrade-path operators to flip the
+  same flag once their dashboard is clean.
+- [ ] **6.3** Remove the upgrade-default branch from the config loader once all
+  customer deployments have flipped (tracked separately, not blocking this change).
+
+## Phase 7: documentation
+
+- [ ] **7.1** Operator runbook: break-glass redemption + WebAuthn registration,
+  break-glass credential rotation, lost-credential recovery procedure.
+- [ ] **7.2** Okta tenant setup guide: app type (web), redirect URLs, scope set,
+  group claim posture (group → role mapping deferred to wave 2).
+- [ ] **7.3** Role + permission matrix: machine-readable copy under
+  `server/identity/internal/authz/policy/data/actions.json` plus a human-readable
+  rendering in `docs/`.
+- [ ] **7.4** SigNoz dashboard wiring: deny-decision rate by handler, break-glass
+  login rate, bootstrap-token issuance count, audit-write-failure count.
+- [ ] **7.5** Update `docs/threat-model.md` to reflect the new identity boundary,
+  the chokepoint, the audit log, and the WebAuthn-mandatory break-glass control.
+
+## Phase 8: validation gates (run continuously, not a separate phase)
+
+- [ ] **8.1** arch-go (`arch-go.yml` + `test/arch/arch_test.go`) passes at every PR
+  boundary.
+- [ ] **8.2** Coverage on new code remains ≥ 80% on the SonarCloud gate (per
+  CLAUDE.md).
+- [ ] **8.3** Cross-context integration tests at `test/integration/` cover at least
+  one end-to-end scenario per phase: SSO login → host.isolate (denied for analyst,
+  allowed for senior_analyst) → audit row visible to auditor.
+- [ ] **8.4** Property-based tests where the shape fits: scope-resolution invariants,
+  role-binding expiry behavior, action-registry parity.


### PR DESCRIPTION
- Implement role-based access control (RBAC) with seeded roles (analyst, admin, etc.).
- Introduce Okta OIDC SSO login with just-in-time (JIT) user provisioning.
- Replace local admin bootstrap flow with secure, token-based break-glass setup.
- Enable reusable authorization chokepoint for privileged actions across contexts.
- Incorporate dual-emit audit logging for authentication and authorization events.
- Add tenant scaffolding for future multi-tenancy support (`tenant_id` columns).
- Update `/login` and admin UI to support new auth flow and stricter session policies.
- Schema changes include new identity tables and updates to existing session structures.