### PR TITLE
Add operator audit trail (#87); drop Bearer challenge on cookie-auth …

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -52,12 +52,18 @@ tasks:
 
   ui:setup:
     desc: |
-      Install UI npm dependencies. Idempotent: skips when ui/node_modules already exists,
-      so it is cheap to wire as a dep of build:ui and dev:ui. A fresh clone or a new git
-      worktree therefore builds without a separate manual `cd ui && npm ci` step.
+      Install UI npm dependencies. Wired as a dep of build:ui and dev:ui so a fresh clone
+      or new git worktree builds without a separate manual `cd ui && npm ci` step. Skips
+      when `node_modules/.package-lock.json` (the snapshot npm writes on a successful
+      `npm ci`) is at least as new as `package-lock.json`, so a lockfile bump triggers a
+      fresh install but a no-op build does not pay the cost. A bare `test -d node_modules`
+      guard would leave stale dependencies in place after a branch switch that touches
+      the lockfile.
     dir: ui
-    status:
-      - test -d node_modules
+    sources:
+      - package-lock.json
+    generates:
+      - node_modules/.package-lock.json
     cmds:
       - npm ci
 
@@ -289,10 +295,12 @@ tasks:
       DESTRUCTIVE: drop the dev database and recreate empty. Requires explicit
       confirmation (Taskfile's prompt:). Use only when the schema is out of
       sync with current migrations; routine dev never needs this.
-      Credentials match the dev:server DSN (root:toor on port 3316).
+      Credentials match the dev:server DSN (root, empty password, port 3316);
+      see the dev:server desc for why the password is empty (matches docker-compose
+      MYSQL_ALLOW_EMPTY_PASSWORD=yes; a `-ptoor` invocation produces access-denied).
     prompt: About to DROP DATABASE edr. Continue?
     cmds:
-      - mysql -uroot -ptoor -h127.0.0.1 -P3316 -e "DROP DATABASE IF EXISTS edr; CREATE DATABASE edr CHARACTER SET utf8mb4;"
+      - mysql -uroot -h127.0.0.1 -P3316 -e "DROP DATABASE IF EXISTS edr; CREATE DATABASE edr CHARACTER SET utf8mb4;"
 
   # -------- install tools / hooks --------
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -50,9 +50,21 @@ tasks:
     cmds:
       - go build -o {{.AGENT_BIN}} {{.AGENT_PKG}}
 
+  ui:setup:
+    desc: |
+      Install UI npm dependencies. Idempotent: skips when ui/node_modules already exists,
+      so it is cheap to wire as a dep of build:ui and dev:ui. A fresh clone or a new git
+      worktree therefore builds without a separate manual `cd ui && npm ci` step.
+    dir: ui
+    status:
+      - test -d node_modules
+    cmds:
+      - npm ci
+
   build:ui:
     desc: Build the React UI; output embedded in the server binary via server/ui/dist/
     dir: ui
+    deps: [ui:setup]
     cmds:
       - npm run build
 
@@ -232,19 +244,31 @@ tasks:
   # -------- dev loops --------
 
   dev:server:
-    desc: Run the server against local MySQL with insecure HTTP for dev
+    desc: |
+      Run the server against local MySQL with insecure HTTP for dev. Binds 0.0.0.0:8088
+      so a UTM/QEMU VM agent on the bridge interface (typically 192.168.64.1 from inside
+      the VM) can reach it. On an untrusted LAN, override EDR_LISTEN_ADDR back to
+      127.0.0.1:8088. The DSN uses an empty password to match the docker-compose mysql
+      service (MYSQL_ALLOW_EMPTY_PASSWORD=yes); a `root:toor@...` DSN will fail with
+      access-denied. OTel exporter targets the local signoz-otel-collector on 4317; if
+      no collector is running, exporter init logs warnings and request handling continues.
     env:
-      EDR_DSN: "root:toor@tcp(127.0.0.1:3316)/edr?parseTime=true"
+      EDR_DSN: "root:@tcp(127.0.0.1:3316)/edr?parseTime=true"
       EDR_ENROLL_SECRET: dev-enroll-secret
       EDR_ALLOW_INSECURE_HTTP: "1"
-      EDR_LISTEN_ADDR: "127.0.0.1:8088"
+      EDR_LISTEN_ADDR: "0.0.0.0:8088"
       EDR_LOG_FORMAT: text
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://127.0.0.1:4317
+      OTEL_EXPORTER_OTLP_PROTOCOL: grpc
+      OTEL_EXPORTER_OTLP_INSECURE: "true"
+      OTEL_SERVICE_NAME: fleet-edr-server
     cmds:
       - go run {{.SERVER_PKG}}
 
   dev:ui:
     desc: Run the UI Vite dev server with HMR (proxies /api/v1 to the backend)
     dir: ui
+    deps: [ui:setup]
     cmds:
       - npm run dev
 

--- a/arch-go.yml
+++ b/arch-go.yml
@@ -36,6 +36,7 @@ dependenciesRules:
         - "**.endpoint.testkit"
         - "**.attrkeys"
         - "**.httpserver"
+        - "**.identity.api"  # identity.api.AuditRecorder for enrollment.revoke audit
         - "**.rules.api"   # rules.api.PolicyService satisfies endpoint's PolicyProvider
         - "**.testdb"
 
@@ -53,6 +54,7 @@ dependenciesRules:
         - "**.attrkeys"
         - "**.httpserver"
         - "**.endpoint.api"
+        - "**.identity.api"  # identity.api.AuditRecorder for policy.{create,update,delete} audit
         - "**.detection.api"
         - "**.detection.api.**"
         - "**.detection.testkit"

--- a/server/cmd/fleet-edr-server/main.go
+++ b/server/cmd/fleet-edr-server/main.go
@@ -100,7 +100,7 @@ func run() error {
 		return err
 	}
 
-	responseCtx, err := openResponse(ctx, logger, db, detectionCtx)
+	responseCtx, err := openResponse(ctx, logger, db, detectionCtx, identityCtx)
 	if err != nil {
 		return err
 	}
@@ -112,13 +112,13 @@ func run() error {
 		}
 		return endpointCtx.Service().ActiveHostIDs(ctx)
 	}
-	rulesCtx, err := openRules(ctx, logger, db, cfg, activeHostsLister, responseCtx.Service().Insert)
+	rulesCtx, err := openRules(ctx, logger, db, cfg, activeHostsLister, responseCtx.Service().Insert, identityCtx)
 	if err != nil {
 		return err
 	}
 	detectionCtx.LoadActive(rulesCtx.ContentService())
 
-	endpointCtx, err = openEndpoint(ctx, logger, db, cfg, rulesCtx.PolicyService(), responseCtx.Service().Insert)
+	endpointCtx, err = openEndpoint(ctx, logger, db, cfg, rulesCtx.PolicyService(), responseCtx.Service().Insert, identityCtx)
 	if err != nil {
 		return err
 	}
@@ -203,6 +203,7 @@ func openDetection(
 		RetentionDays:        cfg.RetentionDays,
 		RetentionInterval:    cfg.RetentionInterval,
 		UserExists:           identityCtx.Service().UserExists,
+		Audit:                identityCtx.AuditRecorder(),
 	})
 	if err != nil {
 		logger.ErrorContext(ctx, "open detection", "err", err)
@@ -224,11 +225,13 @@ func openResponse(
 	logger *slog.Logger,
 	db *sqlx.DB,
 	detectionCtx *detectionbootstrap.Detection,
+	identityCtx *identitybootstrap.Identity,
 ) (*responsebootstrap.Response, error) {
 	responseCtx, err := responsebootstrap.New(responsebootstrap.Deps{
 		DB:        db,
 		Logger:    logger,
 		Heartbeat: detectionCtx.Service().RecordHostSeen,
+		Audit:     identityCtx.AuditRecorder(),
 	})
 	if err != nil {
 		logger.ErrorContext(ctx, "open response", "err", err)
@@ -248,6 +251,7 @@ func openRules(
 	cfg *config.Config,
 	activeHostsLister rulesbootstrap.ActiveHostsLister,
 	cmdInserter rulesbootstrap.CommandInserter,
+	identityCtx *identitybootstrap.Identity,
 ) (*rulesbootstrap.Rules, error) {
 	rulesCtx, err := rulesbootstrap.New(rulesbootstrap.Deps{
 		DB:     db,
@@ -260,6 +264,7 @@ func openRules(
 		},
 		ActiveHostsLister: activeHostsLister,
 		CommandInserter:   cmdInserter,
+		Audit:             identityCtx.AuditRecorder(),
 	})
 	if err != nil {
 		logger.ErrorContext(ctx, "open rules", "err", err)
@@ -279,6 +284,7 @@ func openEndpoint(
 	cfg *config.Config,
 	policySvc endpointapi.PolicyProvider,
 	cmdInserter endpointbootstrap.CommandInserter,
+	identityCtx *identitybootstrap.Identity,
 ) (*endpointbootstrap.Endpoint, error) {
 	endpointCtx, err := endpointbootstrap.New(endpointbootstrap.Deps{
 		DB:                  db,
@@ -287,6 +293,7 @@ func openEndpoint(
 		EnrollRatePerMinute: cfg.EnrollRatePerMin,
 		PolicyProvider:      policySvc,
 		CommandInserter:     cmdInserter,
+		Audit:               identityCtx.AuditRecorder(),
 	})
 	if err != nil {
 		logger.ErrorContext(ctx, "open endpoint", "err", err)
@@ -399,6 +406,7 @@ func registerSessionRoutes(mux *http.ServeMux, d muxDeps) {
 		"GET /api/policy", "PUT /api/policy",
 		"GET /api/attack-coverage",
 		"GET /api/rules",
+		"GET /api/audit",
 		"GET /api/session",
 	} {
 		mux.Handle(p, sessionProtected)

--- a/server/detection/bootstrap/bootstrap.go
+++ b/server/detection/bootstrap/bootstrap.go
@@ -18,6 +18,7 @@ import (
 	"github.com/fleetdm/edr/server/detection/internal/operator"
 	"github.com/fleetdm/edr/server/detection/internal/pipeline"
 	"github.com/fleetdm/edr/server/detection/internal/service"
+	identityapi "github.com/fleetdm/edr/server/identity/api"
 	rulesapi "github.com/fleetdm/edr/server/rules/api"
 )
 
@@ -69,6 +70,10 @@ type Deps struct {
 	// Cross-context inputs (Full mode only).
 	UserExists UserExists
 	Metrics    api.MetricsRecorder
+	// Audit is the operator-action recorder. Optional: nil disables
+	// audit emission for alert-status changes (existing tests pass nil
+	// without ceremony). cmd/main wires identityCtx.AuditRecorder().
+	Audit identityapi.AuditRecorder
 }
 
 // Detection is the handle cmd/main holds.
@@ -123,6 +128,7 @@ func New(deps Deps) (*Detection, error) {
 		query := graph.NewQuery(store)
 		det.svc = service.New(store, query, intakeH, deps.UserExists, logger)
 		det.operatorH = operator.New(det.svc, logger)
+		det.operatorH.SetAudit(deps.Audit)
 
 		processor := pipeline.NewProcessor(
 			store,

--- a/server/detection/internal/operator/handler.go
+++ b/server/detection/internal/operator/handler.go
@@ -30,6 +30,7 @@ type alertDetailResponse struct {
 // Handler serves the operator-facing detection routes.
 type Handler struct {
 	svc    api.Service
+	audit  identityapi.AuditRecorder
 	logger *slog.Logger
 }
 
@@ -43,6 +44,12 @@ func New(svc api.Service, logger *slog.Logger) *Handler {
 	}
 	return &Handler{svc: svc, logger: logger}
 }
+
+// SetAudit installs the operator audit recorder. Optional: when not
+// set, alert-status changes still apply but no audit row is written.
+// Bootstrap calls this after New so existing tests that pass nil for
+// audit do not need to change.
+func (h *Handler) SetAudit(rec identityapi.AuditRecorder) { h.audit = rec }
 
 // RegisterRoutes registers the operator routes on the given mux.
 func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
@@ -221,7 +228,50 @@ func (h *Handler) handleUpdateAlertStatus(w http.ResponseWriter, r *http.Request
 		)
 	}
 
+	h.recordAlertStatusAudit(r, id, body.Status, userID)
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// recordAlertStatusAudit emits one audit row for the just-committed
+// alert-status change. Action is per-status so SIEM filters can scope
+// to "all acks" vs "all resolves" without parsing payload. Audit
+// failures are soft: the action committed; a missing audit row is a
+// follow-up incident, not a reason to fail an HTTP response that
+// already returned 204.
+func (h *Handler) recordAlertStatusAudit(r *http.Request, alertID int64, newStatus string, userID int64) {
+	if h.audit == nil {
+		return
+	}
+	var action identityapi.AuditAction
+	switch newStatus {
+	case string(api.AlertStatusAcknowledged):
+		action = identityapi.AuditAlertAcknowledge
+	case string(api.AlertStatusResolved):
+		action = identityapi.AuditAlertResolve
+	case string(api.AlertStatusOpen):
+		action = identityapi.AuditAlertReopen
+	default:
+		return // status validated above; an unknown one would be a programming error.
+	}
+	var uid *int64
+	if userID > 0 {
+		u := userID
+		uid = &u
+	}
+	if err := h.audit.Record(r.Context(), identityapi.AuditEvent{
+		UserID:     uid,
+		Action:     action,
+		TargetType: "alert",
+		TargetID:   strconv.FormatInt(alertID, 10),
+		RemoteAddr: r.RemoteAddr,
+		Payload:    map[string]any{"new_status": newStatus},
+	}); err != nil {
+		h.logger.WarnContext(r.Context(), "audit record",
+			"err", err,
+			"action", string(action),
+			"edr.alert.id", alertID,
+		)
+	}
 }
 
 func (h *Handler) writeJSON(w http.ResponseWriter, r *http.Request, v any) {

--- a/server/endpoint/bootstrap/bootstrap.go
+++ b/server/endpoint/bootstrap/bootstrap.go
@@ -15,6 +15,7 @@ import (
 	"github.com/fleetdm/edr/server/endpoint/internal/mysql"
 	"github.com/fleetdm/edr/server/endpoint/internal/operator"
 	"github.com/fleetdm/edr/server/endpoint/internal/service"
+	identityapi "github.com/fleetdm/edr/server/identity/api"
 )
 
 // CommandInserter is the closure cmd/main supplies so the post-enroll
@@ -45,6 +46,11 @@ type Deps struct {
 	// 2+3; the closure pattern matches what rules has used since
 	// phase 3 and removes one layer of interface boilerplate.
 	CommandInserter CommandInserter
+
+	// Audit is the operator-action recorder. Optional: nil disables
+	// audit emission for enrollment.revoke. cmd/main wires
+	// identityCtx.AuditRecorder().
+	Audit identityapi.AuditRecorder
 }
 
 // Endpoint is the handle cmd/main holds for the endpoint bounded
@@ -85,13 +91,15 @@ func New(deps Deps) (*Endpoint, error) {
 	store := mysql.NewStore(deps.DB)
 	svc := service.New(store, deps.EnrollSecret, deps.PolicyProvider, deps.CommandInserter, logger)
 
+	opH := operator.New(svc, logger)
+	opH.SetAudit(deps.Audit)
 	return &Endpoint{
 		svc: svc,
 		enrollH: enroll.New(svc, enroll.Options{
 			RatePerMinute: deps.EnrollRatePerMinute,
 			Logger:        logger,
 		}),
-		operatorH:   operator.New(svc, logger),
+		operatorH:   opH,
 		hostTokenMW: middleware.HostToken(svc, logger),
 		db:          deps.DB,
 		logger:      logger,

--- a/server/endpoint/internal/operator/audit_test.go
+++ b/server/endpoint/internal/operator/audit_test.go
@@ -62,7 +62,7 @@ func TestHandler_Revoke_EmitsAudit(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	body, _ := json.Marshal(map[string]any{"actor": "operator@test", "reason": "compromise"})
-	req, err := http.NewRequest(http.MethodPost, srv.URL+"/api/enrollments/H-9/revoke", bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, srv.URL+"/api/enrollments/H-9/revoke", bytes.NewReader(body))
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := srv.Client().Do(req)
@@ -89,7 +89,7 @@ func TestHandler_Revoke_NilAuditOK(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	body, _ := json.Marshal(map[string]any{"actor": "operator@test", "reason": "compromise"})
-	req, err := http.NewRequest(http.MethodPost, srv.URL+"/api/enrollments/H-9/revoke", bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, srv.URL+"/api/enrollments/H-9/revoke", bytes.NewReader(body))
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := srv.Client().Do(req)

--- a/server/endpoint/internal/operator/audit_test.go
+++ b/server/endpoint/internal/operator/audit_test.go
@@ -1,0 +1,99 @@
+package operator
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fleetdm/edr/server/endpoint/api"
+	identityapi "github.com/fleetdm/edr/server/identity/api"
+)
+
+// fakeRevokeService stubs api.Service. Only Revoke + List are exercised
+// by these tests; other methods panic so a regression that wires this
+// fake into a different path surfaces immediately.
+type fakeRevokeService struct {
+	revoke func(ctx context.Context, hostID, reason, actor string) error
+}
+
+func (f fakeRevokeService) Enroll(context.Context, api.EnrollRequest, string) (api.EnrollResponse, error) {
+	panic("not used")
+}
+func (f fakeRevokeService) VerifyToken(context.Context, string) (string, error) { panic("not used") }
+func (f fakeRevokeService) List(context.Context) ([]api.Enrollment, error)      { return nil, nil }
+func (f fakeRevokeService) Get(context.Context, string) (*api.Enrollment, error) {
+	panic("not used")
+}
+func (f fakeRevokeService) Revoke(ctx context.Context, hostID, reason, actor string) error {
+	if f.revoke == nil {
+		panic("fake.Revoke not set")
+	}
+	return f.revoke(ctx, hostID, reason, actor)
+}
+func (f fakeRevokeService) CountActive(context.Context) (int, error)        { panic("not used") }
+func (f fakeRevokeService) ActiveHostIDs(context.Context) ([]string, error) { panic("not used") }
+
+type captureRecorder struct {
+	last   identityapi.AuditEvent
+	called bool
+}
+
+func (c *captureRecorder) Record(_ context.Context, e identityapi.AuditEvent) error {
+	c.called = true
+	c.last = e
+	return nil
+}
+
+func TestHandler_Revoke_EmitsAudit(t *testing.T) {
+	svc := fakeRevokeService{revoke: func(_ context.Context, _, _, _ string) error { return nil }}
+	rec := &captureRecorder{}
+	h := New(svc, nil)
+	h.SetAudit(rec)
+
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	body, _ := json.Marshal(map[string]any{"actor": "operator@test", "reason": "compromise"})
+	req, err := http.NewRequest(http.MethodPost, srv.URL+"/api/enrollments/H-9/revoke", bytes.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := srv.Client().Do(req)
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+	require.True(t, rec.called, "audit recorder must be invoked on a successful revoke")
+	assert.Equal(t, identityapi.AuditEnrollmentRevoke, rec.last.Action)
+	assert.Equal(t, "host", rec.last.TargetType)
+	assert.Equal(t, "H-9", rec.last.TargetID)
+	assert.Equal(t, "operator@test", rec.last.Payload["actor"])
+	assert.Equal(t, "compromise", rec.last.Payload["reason"])
+}
+
+// Nil recorder must not panic; revoke still applies and audit silently no-ops.
+func TestHandler_Revoke_NilAuditOK(t *testing.T) {
+	svc := fakeRevokeService{revoke: func(_ context.Context, _, _, _ string) error { return nil }}
+	h := New(svc, nil)
+
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	body, _ := json.Marshal(map[string]any{"actor": "operator@test", "reason": "compromise"})
+	req, err := http.NewRequest(http.MethodPost, srv.URL+"/api/enrollments/H-9/revoke", bytes.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := srv.Client().Do(req)
+	require.NoError(t, err)
+	resp.Body.Close()
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+}

--- a/server/endpoint/internal/operator/handler.go
+++ b/server/endpoint/internal/operator/handler.go
@@ -23,6 +23,7 @@ import (
 	"github.com/fleetdm/edr/server/attrkeys"
 	"github.com/fleetdm/edr/server/endpoint/api"
 	"github.com/fleetdm/edr/server/httpserver"
+	identityapi "github.com/fleetdm/edr/server/identity/api"
 )
 
 // revokeBodyCap caps the JSON body size for POST /revoke. The handler
@@ -34,6 +35,7 @@ const revokeBodyCap = 64 << 10
 // Handler serves the operator-facing enrollment routes.
 type Handler struct {
 	svc    api.Service
+	audit  identityapi.AuditRecorder
 	logger *slog.Logger
 }
 
@@ -47,6 +49,10 @@ func New(svc api.Service, logger *slog.Logger) *Handler {
 	}
 	return &Handler{svc: svc, logger: logger}
 }
+
+// SetAudit installs the operator audit recorder. Optional: when not
+// set, revoke still applies but no audit row is written.
+func (h *Handler) SetAudit(rec identityapi.AuditRecorder) { h.audit = rec }
 
 // RegisterRoutes wires the two operator routes on the given mux.
 func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
@@ -116,7 +122,42 @@ func (h *Handler) handleRevoke(w http.ResponseWriter, r *http.Request) {
 		attrkeys.HostID, hostID,
 	)
 
+	h.recordRevokeAudit(r, hostID, body)
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// recordRevokeAudit emits one audit row for the just-committed enrollment
+// revoke. body.Actor / body.Reason are operator-supplied attribution
+// strings carried in the payload; the session userID is the
+// authenticated identity that signed the request. Soft-fail on audit
+// error.
+func (h *Handler) recordRevokeAudit(r *http.Request, hostID string, body revokeRequest) {
+	if h.audit == nil {
+		return
+	}
+	ctx := r.Context()
+	uid, _ := identityapi.UserIDFromContext(ctx)
+	var userID *int64
+	if uid > 0 {
+		u := uid
+		userID = &u
+	}
+	if err := h.audit.Record(ctx, identityapi.AuditEvent{
+		UserID:     userID,
+		Action:     identityapi.AuditEnrollmentRevoke,
+		TargetType: "host",
+		TargetID:   hostID,
+		RemoteAddr: r.RemoteAddr,
+		Payload: map[string]any{
+			"actor":  body.Actor,
+			"reason": body.Reason,
+		},
+	}); err != nil {
+		h.logger.WarnContext(ctx, "audit record",
+			"err", err, "action", string(identityapi.AuditEnrollmentRevoke),
+			attrkeys.HostID, hostID,
+		)
+	}
 }
 
 func writeJSON(ctx context.Context, logger *slog.Logger, w http.ResponseWriter, status int, body any) {

--- a/server/httpserver/authfail.go
+++ b/server/httpserver/authfail.go
@@ -19,20 +19,53 @@ type AuthErrBody struct {
 	Error string `json:"error"`
 }
 
-// WriteAuthFailure writes a typed JSON auth/CSRF failure response with
-// the project's standard wire shape. Centralised so the host-token
-// middleware (endpoint context) and the session middleware (identity
-// context) write byte-identical 401 / 403 / 503 bodies.
+// WriteAuthFailure writes a typed JSON auth/CSRF failure response for
+// endpoints protected by a Bearer token (e.g. agent enrollment / event
+// upload). Cookie-session endpoints must use WriteCookieAuthFailure
+// instead so they don't emit a misleading Bearer challenge: see the doc
+// comment there.
 //
 // Behaviour:
 //   - Sets a `WWW-Authenticate: Bearer error="invalid_token"` challenge on
-//     401 only — sending it on 5xx would push agents toward
+//     401 only. Sending it on 5xx would push agents toward
 //     retry-with-new-credentials when the real problem is server-side.
 //   - Tags the active OTel span with auth.result=fail + auth.reason so the
 //     same span attributes show up regardless of which middleware
 //     produced the failure.
 //   - Emits a single warn log line with the reason + status.
 func WriteAuthFailure(ctx context.Context, w http.ResponseWriter, logger *slog.Logger, status int, reason string) {
+	tagAuthFailure(ctx, logger, status, reason)
+	if status == http.StatusUnauthorized {
+		w.Header().Set("WWW-Authenticate", `Bearer error="invalid_token"`)
+	}
+	NoStoreJSON(ctx, logger, w, status, AuthErrBody{Error: reason})
+}
+
+// WriteCookieAuthFailure is the cookie-session counterpart to
+// WriteAuthFailure. It writes a byte-identical JSON body and emits the
+// same span attributes + warn log line, but never sets a WWW-Authenticate
+// header.
+//
+// Cookie-session endpoints (browser UI, /api/session, anything behind the
+// Session middleware) reject by design any non-cookie credential, so a
+// Bearer challenge is wrong on the wire: browsers' HTTP-Basic dialogs
+// ignore it, `curl --anyauth` fires a redundant retry round, and tools
+// that surface WWW-Authenticate to the user just print a confusing
+// "expected Bearer" hint when the real recovery is "open the login page."
+// RFC 7235 registers no scheme for cookie auth and discourages inventing
+// one, so we omit the header entirely. The JSON `{"error": "..."}` body
+// remains the actionable failure signal for both UI redirects and
+// scripted clients.
+func WriteCookieAuthFailure(ctx context.Context, w http.ResponseWriter, logger *slog.Logger, status int, reason string) {
+	tagAuthFailure(ctx, logger, status, reason)
+	NoStoreJSON(ctx, logger, w, status, AuthErrBody{Error: reason})
+}
+
+// tagAuthFailure is the shared bookkeeping for both WriteAuthFailure and
+// WriteCookieAuthFailure: pin auth.result/auth.reason on the active OTel
+// span and emit a single warn log line. Pulled out so the two writers
+// stay byte-identical in everything except the WWW-Authenticate header.
+func tagAuthFailure(ctx context.Context, logger *slog.Logger, status int, reason string) {
 	span := trace.SpanFromContext(ctx)
 	span.SetAttributes(
 		attribute.String(attrkeys.AuthResult, "fail"),
@@ -41,8 +74,4 @@ func WriteAuthFailure(ctx context.Context, w http.ResponseWriter, logger *slog.L
 	if logger != nil {
 		logger.WarnContext(ctx, "authn failed", attrkeys.AuthReason, reason, "status", status)
 	}
-	if status == http.StatusUnauthorized {
-		w.Header().Set("WWW-Authenticate", `Bearer error="invalid_token"`)
-	}
-	NoStoreJSON(ctx, logger, w, status, AuthErrBody{Error: reason})
 }

--- a/server/httpserver/authfail_test.go
+++ b/server/httpserver/authfail_test.go
@@ -65,7 +65,7 @@ func TestWriteAuthFailure_BodyShape(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			rec := httptest.NewRecorder()
-			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
 			tc.write(rec, req)
 
 			assert.Equal(t, tc.status, rec.Code)
@@ -88,7 +88,7 @@ func TestWriteAuthFailure_BodyShape(t *testing.T) {
 // authentication failure distinct from a service outage.
 func TestWriteAuthFailure_Bearer401_SetsChallenge(t *testing.T) {
 	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
 	httpserver.WriteAuthFailure(req.Context(), rec, slog.Default(),
 		http.StatusUnauthorized, "invalid_token")
 
@@ -104,7 +104,7 @@ func TestWriteAuthFailure_BearerNon401_OmitsChallenge(t *testing.T) {
 	for _, status := range []int{http.StatusForbidden, http.StatusServiceUnavailable, http.StatusInternalServerError} {
 		t.Run(http.StatusText(status), func(t *testing.T) {
 			rec := httptest.NewRecorder()
-			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
 			httpserver.WriteAuthFailure(req.Context(), rec, slog.Default(),
 				status, "verifier_unavailable")
 
@@ -124,7 +124,7 @@ func TestWriteCookieAuthFailure_NoChallenge(t *testing.T) {
 	for _, status := range []int{http.StatusUnauthorized, http.StatusForbidden, http.StatusServiceUnavailable, http.StatusInternalServerError} {
 		t.Run(http.StatusText(status), func(t *testing.T) {
 			rec := httptest.NewRecorder()
-			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
 			httpserver.WriteCookieAuthFailure(req.Context(), rec, slog.Default(),
 				status, "missing_session")
 
@@ -141,7 +141,7 @@ func TestWriteCookieAuthFailure_NoChallenge(t *testing.T) {
 // natural way to express "no logger".
 func TestWriteAuthFailure_NilLoggerOK(t *testing.T) {
 	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
 	assert.NotPanics(t, func() {
 		httpserver.WriteAuthFailure(req.Context(), rec, nil, http.StatusUnauthorized, "boot_failure")
 	})

--- a/server/httpserver/authfail_test.go
+++ b/server/httpserver/authfail_test.go
@@ -1,0 +1,152 @@
+package httpserver_test
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fleetdm/edr/server/httpserver"
+)
+
+// Both writers must produce a byte-identical JSON failure body so that
+// scripted clients (the agent, smoke tests, cURL helpers) can match a
+// single response shape regardless of which middleware fired.
+func TestWriteAuthFailure_BodyShape(t *testing.T) {
+	cases := []struct {
+		name   string
+		write  func(w http.ResponseWriter, r *http.Request)
+		status int
+		body   string
+	}{
+		{
+			name: "bearer 401",
+			write: func(w http.ResponseWriter, r *http.Request) {
+				httpserver.WriteAuthFailure(r.Context(), w, slog.Default(),
+					http.StatusUnauthorized, "missing_bearer")
+			},
+			status: http.StatusUnauthorized,
+			body:   `{"error":"missing_bearer"}` + "\n",
+		},
+		{
+			name: "cookie 401",
+			write: func(w http.ResponseWriter, r *http.Request) {
+				httpserver.WriteCookieAuthFailure(r.Context(), w, slog.Default(),
+					http.StatusUnauthorized, "missing_session")
+			},
+			status: http.StatusUnauthorized,
+			body:   `{"error":"missing_session"}` + "\n",
+		},
+		{
+			name: "cookie 403 csrf",
+			write: func(w http.ResponseWriter, r *http.Request) {
+				httpserver.WriteCookieAuthFailure(r.Context(), w, slog.Default(),
+					http.StatusForbidden, "csrf_mismatch")
+			},
+			status: http.StatusForbidden,
+			body:   `{"error":"csrf_mismatch"}` + "\n",
+		},
+		{
+			name: "bearer 503 verifier_unavailable",
+			write: func(w http.ResponseWriter, r *http.Request) {
+				httpserver.WriteAuthFailure(r.Context(), w, slog.Default(),
+					http.StatusServiceUnavailable, "verifier_unavailable")
+			},
+			status: http.StatusServiceUnavailable,
+			body:   `{"error":"verifier_unavailable"}` + "\n",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			tc.write(rec, req)
+
+			assert.Equal(t, tc.status, rec.Code)
+			body, err := io.ReadAll(rec.Body)
+			require.NoError(t, err)
+			assert.Equal(t, tc.body, string(body))
+			assert.Equal(t, "no-store", rec.Header().Get("Cache-Control"))
+			assert.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+
+			// Body parses as the shared shape regardless of which writer fired.
+			var parsed httpserver.AuthErrBody
+			require.NoError(t, json.Unmarshal([]byte(tc.body), &parsed))
+		})
+	}
+}
+
+// WriteAuthFailure (Bearer-token endpoints) MUST set
+// `WWW-Authenticate: Bearer error="invalid_token"` on 401 per RFC 6750
+// so the agent's existing client logic continues to recognise an
+// authentication failure distinct from a service outage.
+func TestWriteAuthFailure_Bearer401_SetsChallenge(t *testing.T) {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	httpserver.WriteAuthFailure(req.Context(), rec, slog.Default(),
+		http.StatusUnauthorized, "invalid_token")
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	assert.Equal(t, `Bearer error="invalid_token"`, rec.Header().Get("WWW-Authenticate"),
+		"Bearer 401 must carry the RFC 6750 challenge")
+}
+
+// On 5xx the Bearer writer must NOT advertise a challenge, since the
+// failure isn't a credential problem and we don't want clients to retry
+// with fresh tokens against an unhealthy server.
+func TestWriteAuthFailure_BearerNon401_OmitsChallenge(t *testing.T) {
+	for _, status := range []int{http.StatusForbidden, http.StatusServiceUnavailable, http.StatusInternalServerError} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			httpserver.WriteAuthFailure(req.Context(), rec, slog.Default(),
+				status, "verifier_unavailable")
+
+			assert.Equal(t, status, rec.Code)
+			assert.Empty(t, rec.Header().Get("WWW-Authenticate"),
+				"non-401 must not advertise a Bearer challenge")
+		})
+	}
+}
+
+// Regression for #80: cookie-session endpoints must not advertise a
+// Bearer challenge on 401. The browser receives a 401 with a JSON body
+// and follows the application's redirect-to-login UX; sending Bearer
+// triggers spurious HTTP-Basic dialogs in some clients and confuses
+// scripted callers that prefer Bearer-shaped responses for retries.
+func TestWriteCookieAuthFailure_NoChallenge(t *testing.T) {
+	for _, status := range []int{http.StatusUnauthorized, http.StatusForbidden, http.StatusServiceUnavailable, http.StatusInternalServerError} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			httpserver.WriteCookieAuthFailure(req.Context(), rec, slog.Default(),
+				status, "missing_session")
+
+			assert.Equal(t, status, rec.Code)
+			assert.Empty(t, rec.Header().Get("WWW-Authenticate"),
+				"cookie-auth failures must not advertise a Bearer challenge regardless of status")
+		})
+	}
+}
+
+// Both writers must tolerate a nil logger so handlers that fail before
+// the logger is wired (e.g. boot path) can still produce a clean
+// response. The signature accepts *slog.Logger so passing nil is the
+// natural way to express "no logger".
+func TestWriteAuthFailure_NilLoggerOK(t *testing.T) {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	assert.NotPanics(t, func() {
+		httpserver.WriteAuthFailure(req.Context(), rec, nil, http.StatusUnauthorized, "boot_failure")
+	})
+	rec2 := httptest.NewRecorder()
+	assert.NotPanics(t, func() {
+		httpserver.WriteCookieAuthFailure(req.Context(), rec2, nil, http.StatusUnauthorized, "boot_failure")
+	})
+}

--- a/server/identity/api/audit.go
+++ b/server/identity/api/audit.go
@@ -1,0 +1,145 @@
+package api
+
+import (
+	"context"
+	"time"
+)
+
+// AuditAction is a stable wire-shape identifier for an operator action
+// the audit trail records. Values are namespaced as `<resource>.<verb>`
+// and never repurposed once they ship in a release: downstream tooling
+// (SIEM exporters, retention rules, alert dashboards) will match on the
+// literal string, so a rename today is a contract break tomorrow. Add
+// new actions; do not edit existing ones.
+type AuditAction string
+
+const (
+	// AuditAuthLoginSuccess records a successful login. user_id and
+	// actor_email are both populated from the authenticated user.
+	AuditAuthLoginSuccess AuditAction = "auth.login.success"
+	// AuditAuthLoginFailed records a failed login attempt. user_id is
+	// nil (the email may be unknown or the password mismatched, both
+	// produce the same wire 401, but the audit row records the
+	// distinction in the reason field of the payload). actor_email
+	// captures the attempted email so a brute force across many emails
+	// shows up as a sequence in retention.
+	AuditAuthLoginFailed AuditAction = "auth.login.failed"
+	// AuditAuthLogout records a successful logout. user_id is the user
+	// whose session was just invalidated.
+	AuditAuthLogout AuditAction = "auth.logout"
+
+	// Alert lifecycle (detection context). Constants are per-status
+	// rather than per-verb because the wire shape PUT /api/alerts/{id}
+	// takes the new status as a string ("acknowledged"/"resolved"/
+	// "open") and the audit row mirrors that vocabulary so SIEM filters
+	// stay aligned with the API. AlertReopen records a status flip back
+	// to open, which is rare but auditable as a deliberate operator
+	// action (reverting an over-eager triage decision).
+	AuditAlertAcknowledge AuditAction = "alert.acknowledge"
+	AuditAlertResolve     AuditAction = "alert.resolve"
+	AuditAlertReopen      AuditAction = "alert.reopen"
+
+	// Policy CRUD (rules context).
+	AuditPolicyCreate AuditAction = "policy.create"
+	AuditPolicyUpdate AuditAction = "policy.update"
+	AuditPolicyDelete AuditAction = "policy.delete"
+
+	// Command issuance (response context).
+	AuditCommandIssue AuditAction = "command.issue"
+
+	// Enrollment lifecycle (endpoint context).
+	AuditEnrollmentRevoke AuditAction = "enrollment.revoke"
+)
+
+// AuditEvent is the value passed to AuditRecorder.Record. Caller fills
+// the application-layer fields; the Recorder pulls trace_id from ctx
+// (which equals the X-Request-ID echoed in response headers) so handler
+// code does not have to re-extract it. RemoteAddr is on the event
+// because it derives from *http.Request, which is not on ctx by
+// convention. occurred_at is set by the Recorder at INSERT time.
+type AuditEvent struct {
+	// UserID is the authenticated user, when one exists. Nil for
+	// pre-auth events (login_failed) so the audit row records "who
+	// attempted" without claiming "who was authenticated."
+	UserID *int64
+	// ActorEmail is the email that should be recorded on the row. For
+	// successful actions the user.email at the time of action. For
+	// login_failed, the attempted email even if no user exists.
+	ActorEmail string
+	Action     AuditAction
+	// TargetType + TargetID identify the object the action applied to.
+	// For unary actions (login, logout) leave both empty.
+	TargetType string
+	TargetID   string
+	// RemoteAddr is the peer address for retention/correlation. Today
+	// this is r.RemoteAddr verbatim (not X-Forwarded-For); see #81 for
+	// the trusted-proxy follow-up.
+	RemoteAddr string
+	// Payload is opaque per-action context (previous alert state, policy
+	// diff, login_failed reason). Stored as MySQL JSON; the audit table
+	// makes no schema commitment so individual handlers can record what
+	// reviewers will need without a migration.
+	Payload map[string]any
+}
+
+// AuditRecorder is the write side of the audit trail. The
+// implementation is append-only by design: there is no Update or
+// Delete method, and the table grants the application's DB user only
+// SELECT and INSERT privileges in environments where DBA-level grant
+// management is possible. Even where grants are uniform, the
+// interface shape forces every audit-modifying code path to add a
+// method (a code review signal) rather than slip a tampering UPDATE
+// past unnoticed.
+//
+// Record blocks until the row is durably written. Synchronous on
+// purpose: an audit row that's "in flight" at the moment of a process
+// crash is not a useful audit trail. Throughput cost is modest (one
+// INSERT per operator action), and operator-action volume is several
+// orders of magnitude smaller than event ingest, so synchronous is
+// the right default.
+type AuditRecorder interface {
+	Record(ctx context.Context, e AuditEvent) error
+}
+
+// AuditFilter constrains AuditReader.List. All fields are optional;
+// zero-value means "no constraint on this dimension." Pagination uses
+// (Limit, BeforeID) cursor: callers pass the smallest id from the
+// previous page to walk back through history, since occurred_at + id
+// is monotonic for any single MySQL writer (auto_increment id is
+// strictly increasing within an instance).
+type AuditFilter struct {
+	UserID     *int64
+	Action     AuditAction
+	TargetType string
+	TargetID   string
+	Since      time.Time
+	Until      time.Time
+	Limit      int
+	BeforeID   int64
+}
+
+// AuditReader is the read side. Separated from Recorder so that a
+// future split (writer in the operator API, reader behind a separate
+// admin-only mux) does not require touching the audit-emitting
+// handlers.
+type AuditReader interface {
+	List(ctx context.Context, f AuditFilter) ([]AuditRow, error)
+}
+
+// AuditRow is the read-side shape returned by AuditReader. user_email
+// is denormalised on read (LEFT JOIN against users) so the retrieval
+// endpoint produces actionable rows in a single query, even after a
+// user has been deleted from the users table (UserID then resolves to
+// a nil-or-empty email).
+type AuditRow struct {
+	ID         int64          `json:"id"`
+	OccurredAt time.Time      `json:"occurred_at"`
+	UserID     *int64         `json:"user_id,omitempty"`
+	UserEmail  string         `json:"user_email,omitempty"`
+	Action     AuditAction    `json:"action"`
+	TargetType string         `json:"target_type,omitempty"`
+	TargetID   string         `json:"target_id,omitempty"`
+	TraceID    string         `json:"trace_id,omitempty"`
+	RemoteAddr string         `json:"remote_addr,omitempty"`
+	Payload    map[string]any `json:"payload,omitempty"`
+}

--- a/server/identity/bootstrap/bootstrap.go
+++ b/server/identity/bootstrap/bootstrap.go
@@ -148,7 +148,7 @@ func (i *Identity) RegisterPublicRoutes(mux *http.ServeMux) {
 }
 
 // RegisterAuthedRoutes wires GET /api/session (who-am-i) and
-// GET /api/v1/audit (operator-action history). Caller wraps in
+// GET /api/audit (operator-action history). Caller wraps in
 // SessionMiddleware + CSRFMiddleware before mounting.
 func (i *Identity) RegisterAuthedRoutes(mux *http.ServeMux) {
 	i.loginHandler.RegisterAuthedRoutes(mux)

--- a/server/identity/bootstrap/bootstrap.go
+++ b/server/identity/bootstrap/bootstrap.go
@@ -11,6 +11,7 @@ import (
 	"github.com/jmoiron/sqlx"
 
 	"github.com/fleetdm/edr/server/identity/api"
+	"github.com/fleetdm/edr/server/identity/internal/audit"
 	"github.com/fleetdm/edr/server/identity/internal/login"
 	"github.com/fleetdm/edr/server/identity/internal/middleware"
 	"github.com/fleetdm/edr/server/identity/internal/service"
@@ -43,6 +44,8 @@ const defaultCleanupInterval = 5 * time.Minute
 type Identity struct {
 	svc          api.Service
 	loginHandler *login.Handler
+	auditStore   *audit.Store
+	auditHandler *audit.Handler
 	sessionMW    func(http.Handler) http.Handler
 	csrfMW       func(http.Handler) http.Handler
 	db           *sqlx.DB
@@ -69,6 +72,7 @@ func New(deps Deps) (*Identity, error) {
 	usersStore := users.New(deps.DB)
 	sessionsStore := sessions.New(deps.DB, sessions.Options{TTL: deps.SessionTTL})
 	svc := service.New(usersStore, sessionsStore, logger)
+	auditStore := audit.New(deps.DB)
 
 	return &Identity{
 		svc: svc,
@@ -76,7 +80,10 @@ func New(deps Deps) (*Identity, error) {
 			RatePerMinute: deps.LoginRatePerMin,
 			CookieSecure:  deps.CookieSecure,
 			Logger:        logger,
+			Audit:         auditStore,
 		}),
+		auditStore:   auditStore,
+		auditHandler: audit.NewHandler(auditStore, logger),
 		sessionMW:    middleware.Session(svc, logger),
 		csrfMW:       middleware.CSRF(logger),
 		db:           deps.DB,
@@ -140,11 +147,19 @@ func (i *Identity) RegisterPublicRoutes(mux *http.ServeMux) {
 	i.loginHandler.RegisterPublicRoutes(mux)
 }
 
-// RegisterAuthedRoutes wires GET /api/session (who-am-i). Caller wraps in
+// RegisterAuthedRoutes wires GET /api/session (who-am-i) and
+// GET /api/v1/audit (operator-action history). Caller wraps in
 // SessionMiddleware + CSRFMiddleware before mounting.
 func (i *Identity) RegisterAuthedRoutes(mux *http.ServeMux) {
 	i.loginHandler.RegisterAuthedRoutes(mux)
+	i.auditHandler.RegisterAuthedRoutes(mux)
 }
+
+// AuditRecorder returns the cross-context-callable AuditRecorder.
+// Other contexts (response, rules, endpoint) take this as a constructor
+// dependency and call Record() at the point an operator action commits;
+// see api.AuditRecorder for the interface contract.
+func (i *Identity) AuditRecorder() api.AuditRecorder { return i.auditStore }
 
 // Run owns the identity context's background goroutines. Today: a ticker
 // that sweeps expired session rows. Returns when ctx is cancelled. cmd/main

--- a/server/identity/bootstrap/schema.go
+++ b/server/identity/bootstrap/schema.go
@@ -39,6 +39,35 @@ var schemaStatements = []string{
 		expires_at    TIMESTAMP(6)   NOT NULL,
 		INDEX idx_sessions_expires (expires_at)
 	)`,
+	// audit_events is the append-only operator audit trail. Append-only is
+	// enforced primarily by the application code (no UPDATE/DELETE paths
+	// in the audit package, no Update/Delete methods on AuditRecorder)
+	// and can be tightened to GRANT-level enforcement in deployments
+	// that have a DBA without changing this schema. actor_user_id is
+	// nullable so login_failed rows (where the email may map to no user)
+	// still record the attempt; actor_email is denormalised so audit
+	// remains readable after a user row is deleted. payload is JSON to
+	// let individual actions record per-action context (alert prior
+	// state, policy diff) without a schema migration. Indexes cover the
+	// retrieval queries the admin UI will run: by occurred_at (timeline),
+	// by actor (per-user history), by action (filter all logins), and by
+	// target (alert history).
+	`CREATE TABLE IF NOT EXISTS audit_events (
+		id              BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+		occurred_at     TIMESTAMP(6)    NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+		actor_user_id   BIGINT          NULL,
+		actor_email     VARCHAR(255)    NULL,
+		action          VARCHAR(64)     NOT NULL,
+		target_type     VARCHAR(64)     NULL,
+		target_id       VARCHAR(255)    NULL,
+		trace_id        VARCHAR(32)     NULL,
+		remote_addr     VARCHAR(64)     NULL,
+		payload         JSON            NULL,
+		INDEX idx_audit_events_occurred (occurred_at),
+		INDEX idx_audit_events_actor (actor_user_id, occurred_at),
+		INDEX idx_audit_events_action (action, occurred_at),
+		INDEX idx_audit_events_target (target_type, target_id, occurred_at)
+	)`,
 }
 
 // schemaMigrations are idempotent ALTERs applied after the CREATE TABLEs.

--- a/server/identity/internal/audit/handler.go
+++ b/server/identity/internal/audit/handler.go
@@ -1,9 +1,10 @@
 package audit
 
 import (
-	"encoding/json"
+	"context"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"strconv"
 	"time"
 
@@ -11,7 +12,7 @@ import (
 	"github.com/fleetdm/edr/server/identity/api"
 )
 
-// Handler serves GET /api/v1/audit. Cookie-auth gated by the identity
+// Handler serves GET /api/audit. Cookie-auth gated by the identity
 // Session middleware (caller wraps before mounting); no role gate yet
 // because identity is single-admin in the MVP. When multi-user roles
 // land the handler grows a `requireAdmin` step at the top of List.
@@ -36,9 +37,9 @@ func NewHandler(reader api.AuditReader, logger *slog.Logger) *Handler {
 // expected to be wrapped in identity's Session middleware before being
 // mounted on the public router; the handler itself does not re-check
 // auth. Path is /api/audit (not /api/v1/audit) to match the rest of
-// the operator API surface — /api/v1/* in this project is reserved
-// for agent-facing endpoints behind the host-token middleware, and
-// audit retrieval is an operator-only concern.
+// the operator API surface; /api/v1/* in this project is reserved for
+// agent-facing endpoints behind the host-token middleware, and audit
+// retrieval is an operator-only concern.
 func (h *Handler) RegisterAuthedRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/audit", h.handleList)
 }
@@ -49,9 +50,28 @@ type listResponse struct {
 
 func (h *Handler) handleList(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	q := r.URL.Query()
+	filter, errCode, ok := parseAuditFilter(r.URL.Query())
+	if !ok {
+		writeListErr(ctx, h.logger, w, http.StatusBadRequest, errCode)
+		return
+	}
+	items, err := h.reader.List(ctx, filter)
+	if err != nil {
+		h.logger.ErrorContext(ctx, "audit list", "err", err)
+		writeListErr(ctx, h.logger, w, http.StatusInternalServerError, "internal")
+		return
+	}
+	httpserver.NoStoreJSON(ctx, h.logger, w, http.StatusOK, listResponse{Items: items})
+}
 
-	filter := api.AuditFilter{
+// parseAuditFilter centralises the per-query-param decode + validate so
+// handleList stays at a cognitive complexity below Sonar's S3776 threshold.
+// On a parse error returns the wire-format error code (e.g. "bad_user_id")
+// alongside ok=false so the caller can write a 400 with the same body
+// shape every other operator endpoint uses. Successful parse returns the
+// populated filter, "" for the error code, and ok=true.
+func parseAuditFilter(q url.Values) (api.AuditFilter, string, bool) {
+	f := api.AuditFilter{
 		Action:     api.AuditAction(q.Get("action")),
 		TargetType: q.Get("target_type"),
 		TargetID:   q.Get("target_id"),
@@ -59,55 +79,48 @@ func (h *Handler) handleList(w http.ResponseWriter, r *http.Request) {
 	if v := q.Get("user_id"); v != "" {
 		uid, err := strconv.ParseInt(v, 10, 64)
 		if err != nil {
-			httpserver.WriteCookieAuthFailure(ctx, w, h.logger, http.StatusBadRequest, "bad_user_id")
-			return
+			return f, "bad_user_id", false
 		}
-		filter.UserID = &uid
+		f.UserID = &uid
 	}
 	if v := q.Get("since"); v != "" {
 		t, err := time.Parse(time.RFC3339, v)
 		if err != nil {
-			httpserver.WriteCookieAuthFailure(ctx, w, h.logger, http.StatusBadRequest, "bad_since")
-			return
+			return f, "bad_since", false
 		}
-		filter.Since = t
+		f.Since = t
 	}
 	if v := q.Get("until"); v != "" {
 		t, err := time.Parse(time.RFC3339, v)
 		if err != nil {
-			httpserver.WriteCookieAuthFailure(ctx, w, h.logger, http.StatusBadRequest, "bad_until")
-			return
+			return f, "bad_until", false
 		}
-		filter.Until = t
+		f.Until = t
 	}
 	if v := q.Get("limit"); v != "" {
 		n, err := strconv.Atoi(v)
 		if err != nil || n <= 0 {
-			httpserver.WriteCookieAuthFailure(ctx, w, h.logger, http.StatusBadRequest, "bad_limit")
-			return
+			return f, "bad_limit", false
 		}
-		filter.Limit = n
+		f.Limit = n
 	}
 	if v := q.Get("before_id"); v != "" {
 		n, err := strconv.ParseInt(v, 10, 64)
 		if err != nil || n <= 0 {
-			httpserver.WriteCookieAuthFailure(ctx, w, h.logger, http.StatusBadRequest, "bad_before_id")
-			return
+			return f, "bad_before_id", false
 		}
-		filter.BeforeID = n
+		f.BeforeID = n
 	}
+	return f, "", true
+}
 
-	items, err := h.reader.List(ctx, filter)
-	if err != nil {
-		h.logger.ErrorContext(ctx, "audit list", "err", err)
-		httpserver.WriteCookieAuthFailure(ctx, w, h.logger, http.StatusInternalServerError, "internal")
-		return
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	w.Header().Set("Cache-Control", "no-store")
-	w.WriteHeader(http.StatusOK)
-	if err := json.NewEncoder(w).Encode(listResponse{Items: items}); err != nil {
-		h.logger.ErrorContext(ctx, "audit list encode", "err", err)
-	}
+// writeListErr writes a 4xx / 5xx response from the audit-list endpoint
+// using the project's standard `{"error": "code"}` body. NoStoreJSON
+// (not WriteCookieAuthFailure) is the right helper here because these
+// failures are validation / backend-read errors, not authentication
+// failures: routing them through WriteCookieAuthFailure would stamp
+// `edr.auth.result=fail` on the active OTel span and emit `authn failed`
+// log lines, polluting auth dashboards with parsing errors.
+func writeListErr(ctx context.Context, logger *slog.Logger, w http.ResponseWriter, status int, code string) {
+	httpserver.NoStoreJSON(ctx, logger, w, status, map[string]string{"error": code})
 }

--- a/server/identity/internal/audit/handler.go
+++ b/server/identity/internal/audit/handler.go
@@ -1,0 +1,113 @@
+package audit
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/fleetdm/edr/server/httpserver"
+	"github.com/fleetdm/edr/server/identity/api"
+)
+
+// Handler serves GET /api/v1/audit. Cookie-auth gated by the identity
+// Session middleware (caller wraps before mounting); no role gate yet
+// because identity is single-admin in the MVP. When multi-user roles
+// land the handler grows a `requireAdmin` step at the top of List.
+type Handler struct {
+	reader api.AuditReader
+	logger *slog.Logger
+}
+
+// NewHandler builds a handler around the given AuditReader. Panics if
+// reader is nil because a Handler that always 500s isn't useful.
+func NewHandler(reader api.AuditReader, logger *slog.Logger) *Handler {
+	if reader == nil {
+		panic("audit.NewHandler: reader must not be nil")
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Handler{reader: reader, logger: logger}
+}
+
+// RegisterAuthedRoutes wires GET /api/audit on mux. The mux is
+// expected to be wrapped in identity's Session middleware before being
+// mounted on the public router; the handler itself does not re-check
+// auth. Path is /api/audit (not /api/v1/audit) to match the rest of
+// the operator API surface — /api/v1/* in this project is reserved
+// for agent-facing endpoints behind the host-token middleware, and
+// audit retrieval is an operator-only concern.
+func (h *Handler) RegisterAuthedRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("GET /api/audit", h.handleList)
+}
+
+type listResponse struct {
+	Items []api.AuditRow `json:"items"`
+}
+
+func (h *Handler) handleList(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	q := r.URL.Query()
+
+	filter := api.AuditFilter{
+		Action:     api.AuditAction(q.Get("action")),
+		TargetType: q.Get("target_type"),
+		TargetID:   q.Get("target_id"),
+	}
+	if v := q.Get("user_id"); v != "" {
+		uid, err := strconv.ParseInt(v, 10, 64)
+		if err != nil {
+			httpserver.WriteCookieAuthFailure(ctx, w, h.logger, http.StatusBadRequest, "bad_user_id")
+			return
+		}
+		filter.UserID = &uid
+	}
+	if v := q.Get("since"); v != "" {
+		t, err := time.Parse(time.RFC3339, v)
+		if err != nil {
+			httpserver.WriteCookieAuthFailure(ctx, w, h.logger, http.StatusBadRequest, "bad_since")
+			return
+		}
+		filter.Since = t
+	}
+	if v := q.Get("until"); v != "" {
+		t, err := time.Parse(time.RFC3339, v)
+		if err != nil {
+			httpserver.WriteCookieAuthFailure(ctx, w, h.logger, http.StatusBadRequest, "bad_until")
+			return
+		}
+		filter.Until = t
+	}
+	if v := q.Get("limit"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n <= 0 {
+			httpserver.WriteCookieAuthFailure(ctx, w, h.logger, http.StatusBadRequest, "bad_limit")
+			return
+		}
+		filter.Limit = n
+	}
+	if v := q.Get("before_id"); v != "" {
+		n, err := strconv.ParseInt(v, 10, 64)
+		if err != nil || n <= 0 {
+			httpserver.WriteCookieAuthFailure(ctx, w, h.logger, http.StatusBadRequest, "bad_before_id")
+			return
+		}
+		filter.BeforeID = n
+	}
+
+	items, err := h.reader.List(ctx, filter)
+	if err != nil {
+		h.logger.ErrorContext(ctx, "audit list", "err", err)
+		httpserver.WriteCookieAuthFailure(ctx, w, h.logger, http.StatusInternalServerError, "internal")
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(listResponse{Items: items}); err != nil {
+		h.logger.ErrorContext(ctx, "audit list encode", "err", err)
+	}
+}

--- a/server/identity/internal/audit/handler_test.go
+++ b/server/identity/internal/audit/handler_test.go
@@ -50,7 +50,9 @@ func TestHandler_ListEmptySuccess(t *testing.T) {
 	reader := &stubReader{rows: nil}
 	srv := newHandlerTestServer(t, reader)
 
-	resp, err := http.Get(srv.URL + "/api/audit")
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+"/api/audit", nil)
+	require.NoError(t, err)
+	resp, err := srv.Client().Do(req)
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
@@ -86,7 +88,9 @@ func TestHandler_ListPopulated(t *testing.T) {
 	}}}
 	srv := newHandlerTestServer(t, reader)
 
-	resp, err := http.Get(srv.URL + "/api/audit?limit=1")
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+"/api/audit?limit=1", nil)
+	require.NoError(t, err)
+	resp, err := srv.Client().Do(req)
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
@@ -128,7 +132,9 @@ func TestHandler_ListParseErrors(t *testing.T) {
 			reader := &stubReader{}
 			srv := newHandlerTestServer(t, reader)
 
-			resp, err := http.Get(srv.URL + "/api/audit?" + tc.query)
+			req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+"/api/audit?"+tc.query, nil)
+			require.NoError(t, err)
+			resp, err := srv.Client().Do(req)
 			require.NoError(t, err)
 			defer resp.Body.Close()
 
@@ -159,7 +165,9 @@ func TestHandler_ListFilterParsing(t *testing.T) {
 	q := "user_id=42&action=alert.acknowledge&target_type=alert&target_id=99" +
 		"&since=2026-05-01T00:00:00Z&until=2026-05-04T00:00:00Z" +
 		"&limit=25&before_id=1000"
-	resp, err := http.Get(srv.URL + "/api/audit?" + q)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+"/api/audit?"+q, nil)
+	require.NoError(t, err)
+	resp, err := srv.Client().Do(req)
 	require.NoError(t, err)
 	resp.Body.Close()
 	require.Equal(t, http.StatusOK, resp.StatusCode)
@@ -183,7 +191,9 @@ func TestHandler_ListReaderError(t *testing.T) {
 	reader := &stubReader{err: errors.New("clickhouse went away")}
 	srv := newHandlerTestServer(t, reader)
 
-	resp, err := http.Get(srv.URL + "/api/audit")
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+"/api/audit", nil)
+	require.NoError(t, err)
+	resp, err := srv.Client().Do(req)
 	require.NoError(t, err)
 	defer resp.Body.Close()
 

--- a/server/identity/internal/audit/handler_test.go
+++ b/server/identity/internal/audit/handler_test.go
@@ -1,0 +1,207 @@
+package audit_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fleetdm/edr/server/identity/api"
+	"github.com/fleetdm/edr/server/identity/internal/audit"
+)
+
+// stubReader is a deterministic api.AuditReader for handler tests.
+// captures the AuditFilter the handler computed so each test can assert
+// "the query string parsed into this filter" without setting up a DB.
+type stubReader struct {
+	rows       []api.AuditRow
+	err        error
+	gotFilter  api.AuditFilter
+	calledOnce bool
+}
+
+func (s *stubReader) List(_ context.Context, f api.AuditFilter) ([]api.AuditRow, error) {
+	s.gotFilter = f
+	s.calledOnce = true
+	return s.rows, s.err
+}
+
+func newHandlerTestServer(t *testing.T, reader api.AuditReader) *httptest.Server {
+	t.Helper()
+	h := audit.NewHandler(reader, slog.Default())
+	mux := http.NewServeMux()
+	h.RegisterAuthedRoutes(mux)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// Empty result → 200 with `{"items":[]}` (not null, not omitted) so the
+// admin UI can iterate without a nil guard.
+func TestHandler_ListEmptySuccess(t *testing.T) {
+	reader := &stubReader{rows: nil}
+	srv := newHandlerTestServer(t, reader)
+
+	resp, err := http.Get(srv.URL + "/api/audit")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
+	assert.Equal(t, "no-store", resp.Header.Get("Cache-Control"))
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	var got struct {
+		Items []api.AuditRow `json:"items"`
+	}
+	require.NoError(t, json.Unmarshal(body, &got))
+	assert.Empty(t, got.Items)
+	assert.True(t, reader.calledOnce)
+}
+
+// Successful read with rows is forwarded byte-for-byte; payload, action,
+// trace_id, and target survive marshalling.
+func TestHandler_ListPopulated(t *testing.T) {
+	uid := int64(7)
+	reader := &stubReader{rows: []api.AuditRow{{
+		ID:         42,
+		OccurredAt: time.Date(2026, 5, 3, 18, 0, 0, 0, time.UTC),
+		UserID:     &uid,
+		UserEmail:  "operator@example.test",
+		Action:     api.AuditAlertAcknowledge,
+		TargetType: "alert",
+		TargetID:   "34",
+		TraceID:    "abcd",
+		RemoteAddr: "127.0.0.1:1",
+		Payload:    map[string]any{"new_status": "acknowledged"},
+	}}}
+	srv := newHandlerTestServer(t, reader)
+
+	resp, err := http.Get(srv.URL + "/api/audit?limit=1")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	var got struct {
+		Items []api.AuditRow `json:"items"`
+	}
+	require.NoError(t, json.Unmarshal(body, &got))
+	require.Len(t, got.Items, 1)
+	assert.Equal(t, api.AuditAlertAcknowledge, got.Items[0].Action)
+	assert.Equal(t, "alert", got.Items[0].TargetType)
+	assert.Equal(t, "34", got.Items[0].TargetID)
+	assert.Equal(t, "operator@example.test", got.Items[0].UserEmail)
+	assert.Equal(t, "acknowledged", got.Items[0].Payload["new_status"])
+	assert.Equal(t, 1, reader.gotFilter.Limit)
+}
+
+// Each query-param parse error must surface a 400 with a stable wire
+// code and MUST NOT touch the reader (no point hitting the DB for a
+// malformed request) and MUST NOT be tagged as an authn failure.
+func TestHandler_ListParseErrors(t *testing.T) {
+	cases := []struct {
+		name     string
+		query    string
+		wantCode string
+	}{
+		{"bad user_id", "user_id=notanumber", "bad_user_id"},
+		{"bad since", "since=yesterday", "bad_since"},
+		{"bad until", "until=tomorrow", "bad_until"},
+		{"bad limit non-numeric", "limit=ten", "bad_limit"},
+		{"bad limit zero", "limit=0", "bad_limit"},
+		{"bad before_id non-numeric", "before_id=foo", "bad_before_id"},
+		{"bad before_id zero", "before_id=0", "bad_before_id"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			reader := &stubReader{}
+			srv := newHandlerTestServer(t, reader)
+
+			resp, err := http.Get(srv.URL + "/api/audit?" + tc.query)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+
+			assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+			// Regression for #80 review: validation 400s must not advertise
+			// a Bearer challenge AND must not flow through
+			// WriteCookieAuthFailure (which would tag the OTel span as
+			// auth.result=fail and emit a `Warn authn failed` log line for
+			// what is actually a query-string parse error).
+			assert.Empty(t, resp.Header.Get("WWW-Authenticate"))
+
+			body, _ := io.ReadAll(resp.Body)
+			var got map[string]string
+			require.NoError(t, json.Unmarshal(body, &got))
+			assert.Equal(t, tc.wantCode, got["error"])
+			assert.False(t, reader.calledOnce, "reader should not run on parse error")
+		})
+	}
+}
+
+// Filter parsing roundtrips: every supported field maps from query string
+// onto the AuditFilter the reader sees. Catches future regressions where
+// adding a new filter forgets to plumb the URL parameter or vice versa.
+func TestHandler_ListFilterParsing(t *testing.T) {
+	reader := &stubReader{}
+	srv := newHandlerTestServer(t, reader)
+
+	q := "user_id=42&action=alert.acknowledge&target_type=alert&target_id=99" +
+		"&since=2026-05-01T00:00:00Z&until=2026-05-04T00:00:00Z" +
+		"&limit=25&before_id=1000"
+	resp, err := http.Get(srv.URL + "/api/audit?" + q)
+	require.NoError(t, err)
+	resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	got := reader.gotFilter
+	require.NotNil(t, got.UserID)
+	assert.Equal(t, int64(42), *got.UserID)
+	assert.Equal(t, api.AuditAlertAcknowledge, got.Action)
+	assert.Equal(t, "alert", got.TargetType)
+	assert.Equal(t, "99", got.TargetID)
+	assert.Equal(t, time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC), got.Since.UTC())
+	assert.Equal(t, time.Date(2026, 5, 4, 0, 0, 0, 0, time.UTC), got.Until.UTC())
+	assert.Equal(t, 25, got.Limit)
+	assert.Equal(t, int64(1000), got.BeforeID)
+}
+
+// A reader error is a 500, not an auth failure; the body still uses the
+// project's `{"error":"code"}` shape so scripted clients have one schema
+// to parse for both 4xx and 5xx.
+func TestHandler_ListReaderError(t *testing.T) {
+	reader := &stubReader{err: errors.New("clickhouse went away")}
+	srv := newHandlerTestServer(t, reader)
+
+	resp, err := http.Get(srv.URL + "/api/audit")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+	assert.Empty(t, resp.Header.Get("WWW-Authenticate"))
+
+	body, _ := io.ReadAll(resp.Body)
+	var got map[string]string
+	require.NoError(t, json.Unmarshal(body, &got))
+	assert.Equal(t, "internal", got["error"])
+}
+
+func TestNewHandler_PanicsOnNilReader(t *testing.T) {
+	assert.Panics(t, func() { _ = audit.NewHandler(nil, slog.Default()) })
+}
+
+// Nil logger is permitted (slog.Default fallback). A handler that
+// panics on a missing logger is a footgun for early-boot code paths.
+func TestNewHandler_NilLoggerOK(t *testing.T) {
+	assert.NotPanics(t, func() { _ = audit.NewHandler(&stubReader{}, nil) })
+}

--- a/server/identity/internal/audit/mysql.go
+++ b/server/identity/internal/audit/mysql.go
@@ -147,7 +147,12 @@ func (s *Store) List(ctx context.Context, f api.AuditFilter) ([]api.AuditRow, er
 	}
 	defer func() { _ = rows.Close() }()
 
-	out := make([]api.AuditRow, 0, limit)
+	// CodeQL flags `make([]T, 0, limit)` when limit traces back to a
+	// user-controlled value, even though limit is clamped to maxListLimit
+	// above. Drop the capacity hint and let the slice grow on demand;
+	// audit pages are bounded (LIMIT in the SELECT, max 500 rows), so
+	// the few reallocations along the way are not measurable.
+	var out []api.AuditRow
 	for rows.Next() {
 		r, err := scanListRow(rows)
 		if err != nil {

--- a/server/identity/internal/audit/mysql.go
+++ b/server/identity/internal/audit/mysql.go
@@ -46,6 +46,16 @@ func New(db *sqlx.DB) *Store {
 // is set by the DB DEFAULT, so a clock skew between app and DB host
 // shows up consistently across rows.
 //
+// When UserID is set but ActorEmail is empty (the common case for
+// cross-context handlers that only see user_id on ctx, e.g. alert
+// status changes), Record looks up the current email from users and
+// denormalises it onto the audit row. That lookup is what keeps an
+// audit row attributable after a user is later deleted: the LEFT JOIN
+// on read returns "" for a missing user, but the denormalised
+// actor_email column survives. A failed lookup leaves actor_email
+// empty rather than failing the audit; the row still records the
+// user_id, and reviewers can correlate via that.
+//
 // Synchronous: returns once the row is durably committed. The caller
 // is expected to record audit AFTER the underlying action commits, so
 // a successful audit row is evidence that the action persisted.
@@ -55,6 +65,7 @@ func (s *Store) Record(ctx context.Context, e api.AuditEvent) error {
 	}
 
 	traceID := traceIDFromContext(ctx)
+	actorEmail := s.resolveActorEmail(ctx, e)
 
 	var payloadBytes []byte
 	if len(e.Payload) > 0 {
@@ -72,7 +83,7 @@ func (s *Store) Record(ctx context.Context, e api.AuditEvent) error {
 		) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
 	_, err := s.db.ExecContext(ctx, q,
 		nullInt64(e.UserID),
-		nullString(e.ActorEmail),
+		nullString(actorEmail),
 		string(e.Action),
 		nullString(e.TargetType),
 		nullString(e.TargetID),
@@ -86,6 +97,30 @@ func (s *Store) Record(ctx context.Context, e api.AuditEvent) error {
 	return nil
 }
 
+// resolveActorEmail returns the email to denormalise onto the audit row.
+// Caller-supplied ActorEmail wins (login paths know the email already);
+// otherwise look it up from users by UserID. A failed lookup is not a
+// hard error because the audit row's user_id column is still
+// authoritative; we simply leave actor_email empty and let the LEFT
+// JOIN on read surface the live email when the user still exists.
+func (s *Store) resolveActorEmail(ctx context.Context, e api.AuditEvent) string {
+	if e.ActorEmail != "" {
+		return e.ActorEmail
+	}
+	if e.UserID == nil {
+		return ""
+	}
+	var email sql.NullString
+	if err := s.db.QueryRowContext(ctx,
+		`SELECT email FROM users WHERE id = ?`, *e.UserID).Scan(&email); err != nil {
+		return ""
+	}
+	if email.Valid {
+		return email.String
+	}
+	return ""
+}
+
 // List returns audit rows matching the filter, newest first. Caller
 // passes a non-zero Limit; the Store caps it at maxListLimit so a
 // runaway request cannot scan the whole table.
@@ -94,7 +129,45 @@ func (s *Store) List(ctx context.Context, f api.AuditFilter) ([]api.AuditRow, er
 	if limit <= 0 || limit > maxListLimit {
 		limit = maxListLimit
 	}
+	where, args := buildListWhere(f)
+	args = append(args, limit)
 
+	q := `
+		SELECT a.id, a.occurred_at, a.actor_user_id, a.actor_email,
+		       a.action, a.target_type, a.target_id, a.trace_id,
+		       a.remote_addr, a.payload, COALESCE(u.email, '')
+		FROM audit_events a
+		LEFT JOIN users u ON u.id = a.actor_user_id ` + where + `
+		ORDER BY a.id DESC
+		LIMIT ?`
+
+	rows, err := s.db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("audit.List query: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	out := make([]api.AuditRow, 0, limit)
+	for rows.Next() {
+		r, err := scanListRow(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("audit.List iter: %w", err)
+	}
+	return out, nil
+}
+
+// buildListWhere builds the WHERE clause + bound args for List. Pulled
+// out of List so the parent function stays at a cognitive complexity
+// below Sonar's S3776 threshold; each branch is a single optional
+// filter and is independently testable. The leading `WHERE 1=1` is a
+// trivial harness so each clause appends as ` AND ...?` regardless of
+// which other filters are set.
+func buildListWhere(f api.AuditFilter) (string, []any) {
 	args := make([]any, 0, 8)
 	where := "WHERE 1=1"
 	if f.UserID != nil {
@@ -125,76 +198,63 @@ func (s *Store) List(ctx context.Context, f api.AuditFilter) ([]api.AuditRow, er
 		where += " AND a.id < ?"
 		args = append(args, f.BeforeID)
 	}
-	args = append(args, limit)
+	return where, args
+}
 
-	q := `
-		SELECT a.id, a.occurred_at, a.actor_user_id, a.actor_email,
-		       a.action, a.target_type, a.target_id, a.trace_id,
-		       a.remote_addr, a.payload, COALESCE(u.email, '')
-		FROM audit_events a
-		LEFT JOIN users u ON u.id = a.actor_user_id ` + where + `
-		ORDER BY a.id DESC
-		LIMIT ?`
-
-	rows, err := s.db.QueryContext(ctx, q, args...)
-	if err != nil {
-		return nil, fmt.Errorf("audit.List query: %w", err)
+// scanListRow unmarshals one row from List's SELECT into a public
+// AuditRow. Pulled out so List's per-row loop body stays trivial; the
+// scan + null-handling logic is the lion's share of the cognitive
+// complexity that S3776 was flagging on the previous in-line shape.
+// The caller's row iteration is therefore a one-liner per row, and the
+// scan logic is independently exercised by mysql_test's round-trip
+// assertions.
+func scanListRow(rows *sql.Rows) (api.AuditRow, error) {
+	var (
+		r            api.AuditRow
+		actorUserID  sql.NullInt64
+		actorEmail   sql.NullString
+		targetType   sql.NullString
+		targetID     sql.NullString
+		traceID      sql.NullString
+		remoteAddr   sql.NullString
+		payloadBytes []byte
+		joinedEmail  string
+		action       string
+	)
+	if err := rows.Scan(
+		&r.ID, &r.OccurredAt, &actorUserID, &actorEmail,
+		&action, &targetType, &targetID, &traceID,
+		&remoteAddr, &payloadBytes, &joinedEmail,
+	); err != nil {
+		return r, fmt.Errorf("audit.List scan: %w", err)
 	}
-	defer func() { _ = rows.Close() }()
-
-	out := make([]api.AuditRow, 0, limit)
-	for rows.Next() {
-		var (
-			r            api.AuditRow
-			actorUserID  sql.NullInt64
-			actorEmail   sql.NullString
-			targetType   sql.NullString
-			targetID     sql.NullString
-			traceID      sql.NullString
-			remoteAddr   sql.NullString
-			payloadBytes []byte
-			joinedEmail  string
-			action       string
-		)
-		if err := rows.Scan(
-			&r.ID, &r.OccurredAt, &actorUserID, &actorEmail,
-			&action, &targetType, &targetID, &traceID,
-			&remoteAddr, &payloadBytes, &joinedEmail,
-		); err != nil {
-			return nil, fmt.Errorf("audit.List scan: %w", err)
-		}
-		r.Action = api.AuditAction(action)
-		if actorUserID.Valid {
-			id := actorUserID.Int64
-			r.UserID = &id
-		}
-		// Prefer the live join so the retrieval endpoint reflects current
-		// emails (e.g. an admin who renamed their email post-action sees
-		// the new value). Fall back to the denormalised actor_email when
-		// the user row no longer exists.
-		switch {
-		case joinedEmail != "":
-			r.UserEmail = joinedEmail
-		case actorEmail.Valid:
-			r.UserEmail = actorEmail.String
-		}
-		r.TargetType = targetType.String
-		r.TargetID = targetID.String
-		r.TraceID = traceID.String
-		r.RemoteAddr = remoteAddr.String
-		if len(payloadBytes) > 0 {
-			payload := map[string]any{}
-			if err := json.Unmarshal(payloadBytes, &payload); err != nil {
-				return nil, fmt.Errorf("audit.List unmarshal payload row=%d: %w", r.ID, err)
-			}
-			r.Payload = payload
-		}
-		out = append(out, r)
+	r.Action = api.AuditAction(action)
+	if actorUserID.Valid {
+		id := actorUserID.Int64
+		r.UserID = &id
 	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("audit.List iter: %w", err)
+	// Prefer the live join so the retrieval endpoint reflects current
+	// emails (e.g. an admin who renamed their email post-action sees
+	// the new value). Fall back to the denormalised actor_email when
+	// the user row no longer exists.
+	switch {
+	case joinedEmail != "":
+		r.UserEmail = joinedEmail
+	case actorEmail.Valid:
+		r.UserEmail = actorEmail.String
 	}
-	return out, nil
+	r.TargetType = targetType.String
+	r.TargetID = targetID.String
+	r.TraceID = traceID.String
+	r.RemoteAddr = remoteAddr.String
+	if len(payloadBytes) > 0 {
+		payload := map[string]any{}
+		if err := json.Unmarshal(payloadBytes, &payload); err != nil {
+			return r, fmt.Errorf("audit.List unmarshal payload row=%d: %w", r.ID, err)
+		}
+		r.Payload = payload
+	}
+	return r, nil
 }
 
 // maxListLimit caps the page size so a runaway retrieval request can't

--- a/server/identity/internal/audit/mysql.go
+++ b/server/identity/internal/audit/mysql.go
@@ -1,0 +1,233 @@
+// Package audit owns the operator-action audit trail: the AuditRecorder
+// implementation that handlers across every bounded context call when
+// an operator action commits, and the read-side AuditReader the
+// retrieval endpoint serves.
+//
+// Append-only is enforced by the interface shape (no Update / Delete
+// methods on either Recorder or Reader) and reinforced at the SQL
+// boundary by the absence of any non-INSERT write paths in this
+// package. A future deployment that runs the application under a DB
+// user with only SELECT + INSERT privileges on audit_events would be
+// a configuration change rather than a refactor.
+package audit
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/jmoiron/sqlx"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/fleetdm/edr/server/identity/api"
+)
+
+// Store implements both api.AuditRecorder and api.AuditReader against
+// MySQL. Constructed once at boot from bootstrap.New and shared across
+// every audit-emitting handler in the process.
+type Store struct {
+	db *sqlx.DB
+}
+
+// New returns a Store. Panics if db is nil because a Store with a nil
+// db is a programming error that would only surface at request time.
+func New(db *sqlx.DB) *Store {
+	if db == nil {
+		panic("audit.New: db must not be nil")
+	}
+	return &Store{db: db}
+}
+
+// Record inserts one audit row. trace_id is pulled from ctx so handler
+// code does not have to thread it explicitly; if no span is active the
+// column is left NULL (the row still records the action). occurred_at
+// is set by the DB DEFAULT, so a clock skew between app and DB host
+// shows up consistently across rows.
+//
+// Synchronous: returns once the row is durably committed. The caller
+// is expected to record audit AFTER the underlying action commits, so
+// a successful audit row is evidence that the action persisted.
+func (s *Store) Record(ctx context.Context, e api.AuditEvent) error {
+	if e.Action == "" {
+		return errors.New("audit.Record: Action is required")
+	}
+
+	traceID := traceIDFromContext(ctx)
+
+	var payloadBytes []byte
+	if len(e.Payload) > 0 {
+		var err error
+		payloadBytes, err = json.Marshal(e.Payload)
+		if err != nil {
+			return fmt.Errorf("audit.Record: marshal payload: %w", err)
+		}
+	}
+
+	const q = `
+		INSERT INTO audit_events (
+			actor_user_id, actor_email, action, target_type, target_id,
+			trace_id, remote_addr, payload
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+	_, err := s.db.ExecContext(ctx, q,
+		nullInt64(e.UserID),
+		nullString(e.ActorEmail),
+		string(e.Action),
+		nullString(e.TargetType),
+		nullString(e.TargetID),
+		nullString(traceID),
+		nullString(e.RemoteAddr),
+		nullBytes(payloadBytes),
+	)
+	if err != nil {
+		return fmt.Errorf("audit.Record insert: %w", err)
+	}
+	return nil
+}
+
+// List returns audit rows matching the filter, newest first. Caller
+// passes a non-zero Limit; the Store caps it at maxListLimit so a
+// runaway request cannot scan the whole table.
+func (s *Store) List(ctx context.Context, f api.AuditFilter) ([]api.AuditRow, error) {
+	limit := f.Limit
+	if limit <= 0 || limit > maxListLimit {
+		limit = maxListLimit
+	}
+
+	args := make([]any, 0, 8)
+	where := "WHERE 1=1"
+	if f.UserID != nil {
+		where += " AND a.actor_user_id = ?"
+		args = append(args, *f.UserID)
+	}
+	if f.Action != "" {
+		where += " AND a.action = ?"
+		args = append(args, string(f.Action))
+	}
+	if f.TargetType != "" {
+		where += " AND a.target_type = ?"
+		args = append(args, f.TargetType)
+	}
+	if f.TargetID != "" {
+		where += " AND a.target_id = ?"
+		args = append(args, f.TargetID)
+	}
+	if !f.Since.IsZero() {
+		where += " AND a.occurred_at >= ?"
+		args = append(args, f.Since)
+	}
+	if !f.Until.IsZero() {
+		where += " AND a.occurred_at < ?"
+		args = append(args, f.Until)
+	}
+	if f.BeforeID > 0 {
+		where += " AND a.id < ?"
+		args = append(args, f.BeforeID)
+	}
+	args = append(args, limit)
+
+	q := `
+		SELECT a.id, a.occurred_at, a.actor_user_id, a.actor_email,
+		       a.action, a.target_type, a.target_id, a.trace_id,
+		       a.remote_addr, a.payload, COALESCE(u.email, '')
+		FROM audit_events a
+		LEFT JOIN users u ON u.id = a.actor_user_id ` + where + `
+		ORDER BY a.id DESC
+		LIMIT ?`
+
+	rows, err := s.db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("audit.List query: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	out := make([]api.AuditRow, 0, limit)
+	for rows.Next() {
+		var (
+			r            api.AuditRow
+			actorUserID  sql.NullInt64
+			actorEmail   sql.NullString
+			targetType   sql.NullString
+			targetID     sql.NullString
+			traceID      sql.NullString
+			remoteAddr   sql.NullString
+			payloadBytes []byte
+			joinedEmail  string
+			action       string
+		)
+		if err := rows.Scan(
+			&r.ID, &r.OccurredAt, &actorUserID, &actorEmail,
+			&action, &targetType, &targetID, &traceID,
+			&remoteAddr, &payloadBytes, &joinedEmail,
+		); err != nil {
+			return nil, fmt.Errorf("audit.List scan: %w", err)
+		}
+		r.Action = api.AuditAction(action)
+		if actorUserID.Valid {
+			id := actorUserID.Int64
+			r.UserID = &id
+		}
+		// Prefer the live join so the retrieval endpoint reflects current
+		// emails (e.g. an admin who renamed their email post-action sees
+		// the new value). Fall back to the denormalised actor_email when
+		// the user row no longer exists.
+		switch {
+		case joinedEmail != "":
+			r.UserEmail = joinedEmail
+		case actorEmail.Valid:
+			r.UserEmail = actorEmail.String
+		}
+		r.TargetType = targetType.String
+		r.TargetID = targetID.String
+		r.TraceID = traceID.String
+		r.RemoteAddr = remoteAddr.String
+		if len(payloadBytes) > 0 {
+			payload := map[string]any{}
+			if err := json.Unmarshal(payloadBytes, &payload); err != nil {
+				return nil, fmt.Errorf("audit.List unmarshal payload row=%d: %w", r.ID, err)
+			}
+			r.Payload = payload
+		}
+		out = append(out, r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("audit.List iter: %w", err)
+	}
+	return out, nil
+}
+
+// maxListLimit caps the page size so a runaway retrieval request can't
+// scan the whole table. 500 is well above any realistic admin UI page
+// (history grids show 50-100 typically) but small enough to keep the
+// response under a megabyte even with maximally populated payloads.
+const maxListLimit = 500
+
+func traceIDFromContext(ctx context.Context) string {
+	sc := trace.SpanContextFromContext(ctx)
+	if !sc.IsValid() {
+		return ""
+	}
+	return sc.TraceID().String()
+}
+
+func nullInt64(p *int64) any {
+	if p == nil {
+		return nil
+	}
+	return *p
+}
+
+func nullString(s string) any {
+	if s == "" {
+		return nil
+	}
+	return s
+}
+
+func nullBytes(b []byte) any {
+	if len(b) == 0 {
+		return nil
+	}
+	return b
+}

--- a/server/identity/internal/audit/mysql_test.go
+++ b/server/identity/internal/audit/mysql_test.go
@@ -1,0 +1,205 @@
+package audit_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/sdk/trace"
+	otrace "go.opentelemetry.io/otel/trace"
+
+	"github.com/fleetdm/edr/server/identity/api"
+	"github.com/fleetdm/edr/server/identity/internal/audit"
+	"github.com/fleetdm/edr/server/identity/testkit"
+	"github.com/fleetdm/edr/server/testdb"
+)
+
+// newStore returns a fresh audit Store backed by a test DB. The
+// identity testkit applies users + sessions + audit_events schema, so
+// the LEFT JOIN against users in List can resolve actor emails.
+func newStore(t *testing.T) (*audit.Store, *sqlx.DB) {
+	t.Helper()
+	db := testdb.Open(t)
+	require.NoError(t, testkit.ApplySchema(t.Context(), db))
+	return audit.New(db), db
+}
+
+// seedUser inserts a users row so audit rows that reference it can be
+// joined to surface actor_email on retrieval.
+func seedUser(t *testing.T, db *sqlx.DB, id int64, email string) {
+	t.Helper()
+	_, err := db.ExecContext(t.Context(),
+		`INSERT INTO users (id, email, password_hash, password_salt) VALUES (?, ?, ?, ?)`,
+		id, email, []byte("stub-hash"), []byte("stub-salt"))
+	require.NoError(t, err)
+}
+
+func TestRecord_RoundTrip(t *testing.T) {
+	store, db := newStore(t)
+	const userID = int64(1)
+	seedUser(t, db, userID, "admin@fleet-edr.local")
+
+	uid := userID
+	require.NoError(t, store.Record(t.Context(), api.AuditEvent{
+		UserID:     &uid,
+		ActorEmail: "admin@fleet-edr.local",
+		Action:     api.AuditAuthLoginSuccess,
+		RemoteAddr: "127.0.0.1:54321",
+		Payload:    map[string]any{"reason": "n/a"},
+	}))
+
+	rows, err := store.List(t.Context(), api.AuditFilter{Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	r := rows[0]
+	assert.Equal(t, api.AuditAuthLoginSuccess, r.Action)
+	assert.Equal(t, "admin@fleet-edr.local", r.UserEmail, "live email comes from JOIN")
+	require.NotNil(t, r.UserID)
+	assert.Equal(t, userID, *r.UserID)
+	assert.Equal(t, "127.0.0.1:54321", r.RemoteAddr)
+	assert.Equal(t, "n/a", r.Payload["reason"])
+	assert.WithinDuration(t, time.Now(), r.OccurredAt, 30*time.Second)
+}
+
+// login_failed rows have no user_id (the email may be unknown). The
+// retrieval endpoint must surface them with the attempted email so a
+// brute-force pattern is observable in retention.
+func TestRecord_LoginFailedKeepsEmailWithoutUser(t *testing.T) {
+	store, _ := newStore(t)
+
+	require.NoError(t, store.Record(t.Context(), api.AuditEvent{
+		ActorEmail: "stranger@example.test",
+		Action:     api.AuditAuthLoginFailed,
+		RemoteAddr: "203.0.113.1:11111",
+		Payload:    map[string]any{"reason": "user_not_found"},
+	}))
+
+	rows, err := store.List(t.Context(), api.AuditFilter{Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Nil(t, rows[0].UserID)
+	assert.Equal(t, "stranger@example.test", rows[0].UserEmail,
+		"actor_email column populated even when no users row exists")
+	assert.Equal(t, "user_not_found", rows[0].Payload["reason"])
+}
+
+// trace_id is pulled from the OTel span on ctx so handler code does not
+// have to thread it explicitly. The span's trace-id ends up in the
+// audit row, which lets a reviewer correlate an audit row with the
+// corresponding SigNoz traces / logs by trace-id alone.
+func TestRecord_TraceIDFromContext(t *testing.T) {
+	store, _ := newStore(t)
+
+	tp := trace.NewTracerProvider()
+	tracer := tp.Tracer("audit-test")
+	ctx, span := tracer.Start(t.Context(), "test-span")
+	t.Cleanup(func() { span.End() })
+
+	require.NoError(t, store.Record(ctx, api.AuditEvent{
+		Action: api.AuditAuthLoginFailed,
+	}))
+
+	rows, err := store.List(t.Context(), api.AuditFilter{Limit: 1})
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+
+	want := otrace.SpanFromContext(ctx).SpanContext().TraceID().String()
+	assert.Equal(t, want, rows[0].TraceID)
+}
+
+// List filters by action so the admin UI can scope to "all logins" or
+// "all alert acks" etc.
+func TestList_FilterByAction(t *testing.T) {
+	store, db := newStore(t)
+	seedUser(t, db, 1, "u1@test")
+
+	uid := int64(1)
+	require.NoError(t, store.Record(t.Context(), api.AuditEvent{UserID: &uid, Action: api.AuditAuthLoginSuccess}))
+	require.NoError(t, store.Record(t.Context(), api.AuditEvent{UserID: &uid, Action: api.AuditAuthLogout}))
+	require.NoError(t, store.Record(t.Context(), api.AuditEvent{UserID: &uid, Action: api.AuditAuthLogout}))
+
+	logouts, err := store.List(t.Context(), api.AuditFilter{Action: api.AuditAuthLogout, Limit: 10})
+	require.NoError(t, err)
+	assert.Len(t, logouts, 2)
+	for _, r := range logouts {
+		assert.Equal(t, api.AuditAuthLogout, r.Action)
+	}
+}
+
+// List paginates via the (Limit, BeforeID) cursor: passing the smallest
+// id from page N returns page N+1. We verify the boundary condition
+// (cursor row is excluded, not duplicated).
+func TestList_Paginates(t *testing.T) {
+	store, db := newStore(t)
+	seedUser(t, db, 1, "u1@test")
+
+	uid := int64(1)
+	for i := 0; i < 5; i++ {
+		require.NoError(t, store.Record(t.Context(), api.AuditEvent{
+			UserID: &uid, Action: api.AuditAuthLoginSuccess,
+		}))
+	}
+
+	page1, err := store.List(t.Context(), api.AuditFilter{Limit: 2})
+	require.NoError(t, err)
+	require.Len(t, page1, 2)
+
+	page2, err := store.List(t.Context(), api.AuditFilter{Limit: 2, BeforeID: page1[len(page1)-1].ID})
+	require.NoError(t, err)
+	require.Len(t, page2, 2)
+
+	// No row appears in both pages.
+	for _, a := range page1 {
+		for _, b := range page2 {
+			assert.NotEqual(t, a.ID, b.ID, "pages must not overlap")
+		}
+	}
+	// Pages descend by id (newest first).
+	assert.Greater(t, page1[0].ID, page2[0].ID)
+}
+
+// Record requires a non-empty Action; an empty action is a programming
+// error caught at the boundary so it does not produce mystery rows.
+func TestRecord_RejectsEmptyAction(t *testing.T) {
+	store, _ := newStore(t)
+	err := store.Record(t.Context(), api.AuditEvent{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Action is required")
+}
+
+// New panics on nil db: a Store with a nil db is a programming error
+// that would only surface at request time (when the user's audit row
+// disappears into a nil-pointer panic).
+func TestNew_PanicsOnNilDB(t *testing.T) {
+	assert.Panics(t, func() { _ = audit.New(nil) })
+}
+
+// Sanity: the action constants are stable strings — anyone changing
+// them is renaming wire-shape contracts, and this test fails loudly so
+// the rename gets caught at code-review time.
+func TestAuditAction_StableConstants(t *testing.T) {
+	cases := []struct {
+		got  api.AuditAction
+		want string
+	}{
+		{api.AuditAuthLoginSuccess, "auth.login.success"},
+		{api.AuditAuthLoginFailed, "auth.login.failed"},
+		{api.AuditAuthLogout, "auth.logout"},
+		{api.AuditAlertAcknowledge, "alert.acknowledge"},
+		{api.AuditAlertResolve, "alert.resolve"},
+		{api.AuditAlertReopen, "alert.reopen"},
+		{api.AuditPolicyCreate, "policy.create"},
+		{api.AuditPolicyUpdate, "policy.update"},
+		{api.AuditPolicyDelete, "policy.delete"},
+		{api.AuditCommandIssue, "command.issue"},
+		{api.AuditEnrollmentRevoke, "enrollment.revoke"},
+	}
+	for _, tc := range cases {
+		assert.Equal(t, tc.want, string(tc.got))
+	}
+	// Sanity quick-fail if the package is compiled with the wrong context.
+	_ = context.TODO
+}

--- a/server/identity/internal/audit/mysql_test.go
+++ b/server/identity/internal/audit/mysql_test.go
@@ -172,7 +172,7 @@ func TestList_Paginates(t *testing.T) {
 	seedUser(t, db, 1, "u1@test")
 
 	uid := int64(1)
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		require.NoError(t, store.Record(t.Context(), api.AuditEvent{
 			UserID: &uid, Action: api.AuditAuthLoginSuccess,
 		}))

--- a/server/identity/internal/audit/mysql_test.go
+++ b/server/identity/internal/audit/mysql_test.go
@@ -64,6 +64,41 @@ func TestRecord_RoundTrip(t *testing.T) {
 	assert.WithinDuration(t, time.Now(), r.OccurredAt, 30*time.Second)
 }
 
+// When the caller does not supply ActorEmail, the Recorder must look it
+// up from the users table by UserID and denormalise it onto the row so
+// the audit row stays attributable after the user is later deleted.
+// This is the key durability promise behind the cross-context recordX
+// helpers, which only have user_id from ctx (no email).
+func TestRecord_AutoResolvesActorEmailFromUserID(t *testing.T) {
+	store, db := newStore(t)
+	const userID = int64(99)
+	seedUser(t, db, userID, "operator-99@test")
+
+	uid := userID
+	require.NoError(t, store.Record(t.Context(), api.AuditEvent{
+		UserID: &uid,
+		Action: api.AuditAlertAcknowledge,
+		// ActorEmail intentionally empty; Recorder should fill it from the users row.
+	}))
+
+	rows, err := store.List(t.Context(), api.AuditFilter{Limit: 1})
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, "operator-99@test", rows[0].UserEmail)
+
+	// And after the user is deleted, the denormalised email survives so
+	// the audit row stays attributable. Pre-deletion the LEFT JOIN
+	// returns the live email; post-deletion the join is empty and the
+	// reader falls back to the actor_email column captured at record time.
+	_, err = db.ExecContext(t.Context(), `DELETE FROM users WHERE id = ?`, userID)
+	require.NoError(t, err)
+	rowsAfter, err := store.List(t.Context(), api.AuditFilter{Limit: 1})
+	require.NoError(t, err)
+	require.Len(t, rowsAfter, 1)
+	assert.Equal(t, "operator-99@test", rowsAfter[0].UserEmail,
+		"denormalised actor_email must survive user deletion")
+}
+
 // login_failed rows have no user_id (the email may be unknown). The
 // retrieval endpoint must surface them with the attempted email so a
 // brute-force pattern is observable in retention.

--- a/server/identity/internal/login/handler.go
+++ b/server/identity/internal/login/handler.go
@@ -213,45 +213,73 @@ func (h *Handler) handleLogout(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	ip := httpserver.RemoteIP(r)
 
-	if cookie, err := r.Cookie(api.SessionCookieName); err == nil && cookie.Value != "" {
-		if raw, err := api.DecodeToken(cookie.Value); err == nil {
-			// Resolve the session BEFORE deletion so we can record who logged
-			// out. Logout is idempotent on missing sessions, so a failed
-			// resolve falls through silently to the cookie clear without an
-			// audit row (there is nothing to audit).
-			var actorUserID *int64
-			var actorEmail string
-			if sess, err := h.svc.GetSession(ctx, raw); err == nil {
-				uid := sess.UserID
-				actorUserID = &uid
-				if u, err := h.svc.GetUser(ctx, sess.UserID); err == nil {
-					actorEmail = u.Email
-				}
-			}
-			if delErr := h.svc.Logout(ctx, raw); delErr == nil {
-				trace.SpanFromContext(ctx).SetAttributes(
-					attribute.String(attrkeys.AuthAction, "logout"),
-				)
-				h.logger.InfoContext(ctx, "logout ok",
-					attrkeys.AuthAction, "logout",
-					attrkeys.SessionIDPrefix, idPrefix(raw),
-				)
-				if actorUserID != nil {
-					h.recordAudit(ctx, api.AuditEvent{
-						UserID:     actorUserID,
-						ActorEmail: actorEmail,
-						Action:     api.AuditAuthLogout,
-						RemoteAddr: ip,
-					})
-				}
-			} else {
-				h.logger.ErrorContext(ctx, "session delete", "err", delErr)
-			}
+	raw := h.decodeLogoutToken(r)
+	if raw != nil {
+		// Resolve the session BEFORE deletion so we can record who logged
+		// out. Logout is idempotent on missing sessions, so a failed
+		// resolve falls through silently to the cookie clear without an
+		// audit row (there is nothing to audit).
+		actorUserID, actorEmail := h.resolveLogoutActor(ctx, raw)
+		switch err := h.svc.Logout(ctx, raw); {
+		case err != nil:
+			h.logger.ErrorContext(ctx, "session delete", "err", err)
+		case actorUserID != nil:
+			trace.SpanFromContext(ctx).SetAttributes(
+				attribute.String(attrkeys.AuthAction, "logout"),
+			)
+			h.logger.InfoContext(ctx, "logout ok",
+				attrkeys.AuthAction, "logout",
+				attrkeys.SessionIDPrefix, idPrefix(raw),
+			)
+			h.recordAudit(ctx, api.AuditEvent{
+				UserID:     actorUserID,
+				ActorEmail: actorEmail,
+				Action:     api.AuditAuthLogout,
+				RemoteAddr: ip,
+			})
 		}
 	}
 
 	http.SetCookie(w, h.expireCookie())
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// decodeLogoutToken extracts the raw session token from the logout request,
+// returning nil when the cookie is absent, empty, or malformed. Pulled out
+// of handleLogout so its happy path is a single early-return instead of a
+// double-nested `if cookie { if raw, err := ...`. Returning nil on every
+// failure mode preserves logout's "always clear the cookie, never error"
+// contract.
+func (h *Handler) decodeLogoutToken(r *http.Request) []byte {
+	cookie, err := r.Cookie(api.SessionCookieName)
+	if err != nil || cookie.Value == "" {
+		return nil
+	}
+	raw, err := api.DecodeToken(cookie.Value)
+	if err != nil {
+		return nil
+	}
+	return raw
+}
+
+// resolveLogoutActor looks up the user behind a session token so the audit
+// row records the right user_id + email. Returns (nil, "") when the
+// session is unknown / expired (logout is idempotent so a missing session
+// produces no audit row). When the session resolves but the users row
+// fetch fails (e.g. the user was deleted between session create and now),
+// returns the user_id with an empty email; the audit row still records
+// the user_id, and reviewers can correlate via that.
+func (h *Handler) resolveLogoutActor(ctx context.Context, raw []byte) (*int64, string) {
+	sess, err := h.svc.GetSession(ctx, raw)
+	if err != nil {
+		return nil, ""
+	}
+	uid := sess.UserID
+	u, err := h.svc.GetUser(ctx, sess.UserID)
+	if err != nil {
+		return &uid, ""
+	}
+	return &uid, u.Email
 }
 
 func (h *Handler) writeSessionJSON(ctx context.Context, w http.ResponseWriter, u api.User, csrfToken []byte) {

--- a/server/identity/internal/login/handler.go
+++ b/server/identity/internal/login/handler.go
@@ -26,6 +26,7 @@ import (
 // Handler serves the login + session-check + logout endpoints.
 type Handler struct {
 	svc       api.Service
+	audit     api.AuditRecorder
 	logger    *slog.Logger
 	limiter   *httpserver.IPLimiter
 	cookieSec bool
@@ -39,6 +40,12 @@ type Options struct {
 	CookieSecure bool
 	// Logger for audit lines.
 	Logger *slog.Logger
+	// Audit is the operator-action audit recorder. Optional: when nil the
+	// handler skips the Record calls (existing tests that don't care about
+	// the audit trail need not stand one up). When set, login_success,
+	// login_failed, and logout each emit one row through this recorder
+	// after the action commits.
+	Audit api.AuditRecorder
 }
 
 // New builds a session handler. Panics if svc is nil.
@@ -55,6 +62,7 @@ func New(svc api.Service, opts Options) *Handler {
 	}
 	return &Handler{
 		svc:       svc,
+		audit:     opts.Audit,
 		logger:    logger,
 		limiter:   httpserver.NewIPLimiter(rate.Every(time.Minute/time.Duration(opts.RatePerMinute)), opts.RatePerMinute),
 		cookieSec: opts.CookieSecure,
@@ -115,6 +123,10 @@ func (h *Handler) handleLogin(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Retry-After", "60")
 		h.fail(ctx, w, http.StatusTooManyRequests, "rate_limited", failInfo{IP: ip},
 			attrkeys.AuthReason, "rate_limited")
+		// Audit-record the throttled attempt: a brute force shows up as a
+		// dense sequence of rate_limited rows, which is an observability
+		// signal even though the wire response is just "try again."
+		h.recordLoginFailed(ctx, "", ip, "rate_limited")
 		return
 	}
 
@@ -138,10 +150,12 @@ func (h *Handler) handleLogin(w http.ResponseWriter, r *http.Request) {
 		// emails. Audit log records the distinction.
 		h.fail(ctx, w, http.StatusUnauthorized, "invalid_credentials", failInfo{IP: ip, Email: req.Email},
 			attrkeys.AuthReason, "user_not_found")
+		h.recordLoginFailed(ctx, req.Email, ip, "user_not_found")
 		return
 	case errors.Is(err, api.ErrBadPassword):
 		h.fail(ctx, w, http.StatusUnauthorized, "invalid_credentials", failInfo{IP: ip, Email: req.Email},
 			attrkeys.AuthReason, "password_mismatch")
+		h.recordLoginFailed(ctx, req.Email, ip, "password_mismatch")
 		return
 	case err != nil:
 		h.logger.ErrorContext(ctx, "login", "err", err)
@@ -163,6 +177,13 @@ func (h *Handler) handleLogin(w http.ResponseWriter, r *http.Request) {
 		attrkeys.SessionIDPrefix, idPrefix(result.SessionToken),
 		attrkeys.RemoteAddr, ip,
 	)
+
+	h.recordAudit(ctx, api.AuditEvent{
+		UserID:     &result.User.ID,
+		ActorEmail: result.User.Email,
+		Action:     api.AuditAuthLoginSuccess,
+		RemoteAddr: ip,
+	})
 
 	h.writeSessionJSON(ctx, w, result.User, result.CSRFToken)
 }
@@ -190,9 +211,23 @@ func (h *Handler) handleGet(w http.ResponseWriter, r *http.Request) {
 // through to the cookie clear.
 func (h *Handler) handleLogout(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
+	ip := httpserver.RemoteIP(r)
 
 	if cookie, err := r.Cookie(api.SessionCookieName); err == nil && cookie.Value != "" {
 		if raw, err := api.DecodeToken(cookie.Value); err == nil {
+			// Resolve the session BEFORE deletion so we can record who logged
+			// out. Logout is idempotent on missing sessions, so a failed
+			// resolve falls through silently to the cookie clear without an
+			// audit row (there is nothing to audit).
+			var actorUserID *int64
+			var actorEmail string
+			if sess, err := h.svc.GetSession(ctx, raw); err == nil {
+				uid := sess.UserID
+				actorUserID = &uid
+				if u, err := h.svc.GetUser(ctx, sess.UserID); err == nil {
+					actorEmail = u.Email
+				}
+			}
 			if delErr := h.svc.Logout(ctx, raw); delErr == nil {
 				trace.SpanFromContext(ctx).SetAttributes(
 					attribute.String(attrkeys.AuthAction, "logout"),
@@ -201,6 +236,14 @@ func (h *Handler) handleLogout(w http.ResponseWriter, r *http.Request) {
 					attrkeys.AuthAction, "logout",
 					attrkeys.SessionIDPrefix, idPrefix(raw),
 				)
+				if actorUserID != nil {
+					h.recordAudit(ctx, api.AuditEvent{
+						UserID:     actorUserID,
+						ActorEmail: actorEmail,
+						Action:     api.AuditAuthLogout,
+						RemoteAddr: ip,
+					})
+				}
 			} else {
 				h.logger.ErrorContext(ctx, "session delete", "err", delErr)
 			}
@@ -285,4 +328,38 @@ func writeJSON(ctx context.Context, logger *slog.Logger, w http.ResponseWriter, 
 	if err := json.NewEncoder(w).Encode(body); err != nil {
 		logger.ErrorContext(ctx, "session encode response", "err", err)
 	}
+}
+
+// recordAudit writes one audit row, treating recorder errors as soft:
+// log-warn-and-continue. The action being audited (login/logout) has
+// already committed by the time we reach this helper, so failing the
+// HTTP response on an audit-table hiccup would be worse than a missed
+// audit row. The structured warn line preserves the full event for
+// log-based reconstruction if needed.
+func (h *Handler) recordAudit(ctx context.Context, e api.AuditEvent) {
+	if h.audit == nil {
+		return
+	}
+	if err := h.audit.Record(ctx, e); err != nil {
+		h.logger.WarnContext(ctx, "audit record",
+			"err", err,
+			"action", string(e.Action),
+			attrkeys.UserEmail, e.ActorEmail,
+		)
+	}
+}
+
+// recordLoginFailed writes an auth.login.failed audit row with the
+// reason the login was rejected. UserID is always nil for failed
+// attempts: the email may map to no user (user_not_found), to the
+// wrong password (password_mismatch), or be untouched by the rate
+// limiter (rate_limited), and recording a UserID would imply the
+// attempt got past authentication.
+func (h *Handler) recordLoginFailed(ctx context.Context, email, ip, reason string) {
+	h.recordAudit(ctx, api.AuditEvent{
+		ActorEmail: email,
+		Action:     api.AuditAuthLoginFailed,
+		RemoteAddr: ip,
+		Payload:    map[string]any{"reason": reason},
+	})
 }

--- a/server/identity/internal/middleware/session.go
+++ b/server/identity/internal/middleware/session.go
@@ -35,12 +35,12 @@ func Session(svc api.Service, logger *slog.Logger) func(http.Handler) http.Handl
 			ctx := r.Context()
 			cookie, err := r.Cookie(api.SessionCookieName)
 			if err != nil || cookie.Value == "" {
-				httpserver.WriteAuthFailure(ctx, w, logger, http.StatusUnauthorized, "missing_session")
+				httpserver.WriteCookieAuthFailure(ctx, w, logger, http.StatusUnauthorized, "missing_session")
 				return
 			}
 			raw, err := api.DecodeToken(cookie.Value)
 			if err != nil {
-				httpserver.WriteAuthFailure(ctx, w, logger, http.StatusUnauthorized, "invalid_session")
+				httpserver.WriteCookieAuthFailure(ctx, w, logger, http.StatusUnauthorized, "invalid_session")
 				return
 			}
 			sess, err := svc.GetSession(ctx, raw)
@@ -49,11 +49,11 @@ func Session(svc api.Service, logger *slog.Logger) func(http.Handler) http.Handl
 				// Covers both "cookie points at deleted row" (logout happened
 				// elsewhere) and "cookie points at expired row". The UI maps
 				// both to "redirect to login".
-				httpserver.WriteAuthFailure(ctx, w, logger, http.StatusUnauthorized, "invalid_session")
+				httpserver.WriteCookieAuthFailure(ctx, w, logger, http.StatusUnauthorized, "invalid_session")
 				return
 			case err != nil:
 				logger.ErrorContext(ctx, "session lookup", "err", err)
-				httpserver.WriteAuthFailure(ctx, w, logger, http.StatusServiceUnavailable, "session_store_unavailable")
+				httpserver.WriteCookieAuthFailure(ctx, w, logger, http.StatusServiceUnavailable, "session_store_unavailable")
 				return
 			}
 			trace.SpanFromContext(ctx).SetAttributes(
@@ -88,17 +88,17 @@ func CSRF(logger *slog.Logger) func(http.Handler) http.Handler {
 				// with 500 because the problem is server-side, not the
 				// caller's credentials.
 				logger.ErrorContext(ctx, "CSRF middleware invoked without Session on ctx")
-				httpserver.WriteAuthFailure(ctx, w, logger, http.StatusInternalServerError, "csrf_misconfigured")
+				httpserver.WriteCookieAuthFailure(ctx, w, logger, http.StatusInternalServerError, "csrf_misconfigured")
 				return
 			}
 			presented := r.Header.Get(api.CSRFHeaderName)
 			if presented == "" {
-				httpserver.WriteAuthFailure(ctx, w, logger, http.StatusForbidden, "csrf_missing")
+				httpserver.WriteCookieAuthFailure(ctx, w, logger, http.StatusForbidden, "csrf_missing")
 				return
 			}
 			got, err := api.DecodeToken(presented)
 			if err != nil || subtle.ConstantTimeCompare(got, sess.CSRFToken) != 1 {
-				httpserver.WriteAuthFailure(ctx, w, logger, http.StatusForbidden, "csrf_mismatch")
+				httpserver.WriteCookieAuthFailure(ctx, w, logger, http.StatusForbidden, "csrf_mismatch")
 				return
 			}
 			next.ServeHTTP(w, r)

--- a/server/identity/internal/middleware/session_test.go
+++ b/server/identity/internal/middleware/session_test.go
@@ -69,6 +69,12 @@ func TestSession_MissingCookieReturns401(t *testing.T) {
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	// Regression for #80: a cookie-auth 401 must not advertise a Bearer challenge.
+	// The Session middleware's failure mode is "open the login page", not
+	// "retry with a Bearer token", so clients that surface WWW-Authenticate
+	// to the user (browsers' HTTP-Basic dialog, curl --anyauth) shouldn't
+	// see one.
+	assert.Empty(t, resp.Header.Get("WWW-Authenticate"))
 }
 
 func TestSession_UnknownCookieReturns401(t *testing.T) {

--- a/server/response/bootstrap/bootstrap.go
+++ b/server/response/bootstrap/bootstrap.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/jmoiron/sqlx"
 
+	identityapi "github.com/fleetdm/edr/server/identity/api"
 	"github.com/fleetdm/edr/server/response/api"
 	"github.com/fleetdm/edr/server/response/internal/agent"
 	"github.com/fleetdm/edr/server/response/internal/mysql"
@@ -35,6 +36,11 @@ type Deps struct {
 	// bump. Production wires cmd/main's `s.UpdateHostLastSeen`
 	// closure; cmd/main wires it to detectionCtx.RecordHostSeen.
 	Heartbeat Heartbeat
+
+	// Audit is the operator-action recorder. Optional: nil disables
+	// audit emission for command issuance. cmd/main wires
+	// identityCtx.AuditRecorder().
+	Audit identityapi.AuditRecorder
 }
 
 // Response is the handle cmd/main holds for the response bounded
@@ -59,10 +65,12 @@ func New(deps Deps) (*Response, error) {
 	}
 	store := mysql.NewStore(deps.DB)
 	svc := service.New(store, deps.Heartbeat, logger)
+	opH := operator.New(svc, logger)
+	opH.SetAudit(deps.Audit)
 	return &Response{
 		svc:       svc,
 		agentH:    agent.New(svc, logger),
-		operatorH: operator.New(svc, logger),
+		operatorH: opH,
 		db:        deps.DB,
 		logger:    logger,
 	}, nil

--- a/server/response/internal/operator/audit_test.go
+++ b/server/response/internal/operator/audit_test.go
@@ -1,0 +1,124 @@
+package operator
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	identityapi "github.com/fleetdm/edr/server/identity/api"
+	"github.com/fleetdm/edr/server/response/api"
+)
+
+// captureRecorder is a minimal identityapi.AuditRecorder for handler tests:
+// captures the last Event and returns a configurable error so each test
+// can assert "this is exactly the row I expect for this action" without
+// touching MySQL.
+type captureRecorder struct {
+	last   identityapi.AuditEvent
+	called bool
+	err    error
+}
+
+func (c *captureRecorder) Record(_ context.Context, e identityapi.AuditEvent) error {
+	c.called = true
+	c.last = e
+	return c.err
+}
+
+// Successful command issuance MUST emit one audit row carrying the new
+// command_id + command_type in the payload, the issuing user_id pulled
+// from ctx by the handler, and the host as the target. Without this
+// row a customer asking "who issued kill_process for host X on
+// 2026-Q2" has no record.
+func TestHandler_CommandIssue_EmitsAudit(t *testing.T) {
+	svc := fakeService{insert: func(_ context.Context, _ string, _ string, _ []byte) (int64, error) {
+		return 99, nil
+	}}
+	rec := &captureRecorder{}
+	h := New(svc, nil)
+	h.SetAudit(rec)
+
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	body, _ := json.Marshal(map[string]any{
+		"host_id":      "H-1",
+		"command_type": "kill_process",
+		"payload":      map[string]any{"pid": 1234},
+	})
+	req, err := http.NewRequest(http.MethodPost, srv.URL+"/api/commands", bytes.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := srv.Client().Do(req)
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+	require.True(t, rec.called, "audit recorder must be invoked on a successful command issuance")
+	assert.Equal(t, identityapi.AuditCommandIssue, rec.last.Action)
+	assert.Equal(t, "host", rec.last.TargetType)
+	assert.Equal(t, "H-1", rec.last.TargetID)
+	assert.Equal(t, "kill_process", rec.last.Payload["command_type"])
+	assert.EqualValues(t, 99, rec.last.Payload["command_id"])
+}
+
+// A nil recorder is the documented "audit-disabled" mode (e.g. unit tests
+// that don't care about audit). The handler must still process the
+// request and return 201 without panicking.
+func TestHandler_CommandIssue_NilAuditOK(t *testing.T) {
+	svc := fakeService{insert: func(_ context.Context, _ string, _ string, _ []byte) (int64, error) {
+		return 100, nil
+	}}
+	h := New(svc, nil) // SetAudit deliberately not called.
+
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	body, _ := json.Marshal(map[string]any{"host_id": "H-1", "command_type": "isolate"})
+	req, err := http.NewRequest(http.MethodPost, srv.URL+"/api/commands", bytes.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := srv.Client().Do(req)
+	require.NoError(t, err)
+	resp.Body.Close()
+	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+}
+
+// Insert errors on the underlying service must NOT emit an audit row;
+// audit records "what happened", not "what was attempted." A failed
+// insert flows through the existing error response path; the recorder
+// should remain untouched.
+func TestHandler_CommandIssue_InsertErrorSkipsAudit(t *testing.T) {
+	svc := fakeService{insert: func(_ context.Context, _ string, _ string, _ []byte) (int64, error) {
+		return 0, api.ErrInvalidInsertRequest
+	}}
+	rec := &captureRecorder{}
+	h := New(svc, nil)
+	h.SetAudit(rec)
+
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	body, _ := json.Marshal(map[string]any{"host_id": "H-1", "command_type": "isolate"})
+	req, err := http.NewRequest(http.MethodPost, srv.URL+"/api/commands", bytes.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := srv.Client().Do(req)
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.False(t, rec.called, "audit must not record actions that failed to commit")
+}

--- a/server/response/internal/operator/audit_test.go
+++ b/server/response/internal/operator/audit_test.go
@@ -54,7 +54,7 @@ func TestHandler_CommandIssue_EmitsAudit(t *testing.T) {
 		"command_type": "kill_process",
 		"payload":      map[string]any{"pid": 1234},
 	})
-	req, err := http.NewRequest(http.MethodPost, srv.URL+"/api/commands", bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, srv.URL+"/api/commands", bytes.NewReader(body))
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := srv.Client().Do(req)
@@ -85,7 +85,7 @@ func TestHandler_CommandIssue_NilAuditOK(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	body, _ := json.Marshal(map[string]any{"host_id": "H-1", "command_type": "isolate"})
-	req, err := http.NewRequest(http.MethodPost, srv.URL+"/api/commands", bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, srv.URL+"/api/commands", bytes.NewReader(body))
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := srv.Client().Do(req)
@@ -112,7 +112,7 @@ func TestHandler_CommandIssue_InsertErrorSkipsAudit(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	body, _ := json.Marshal(map[string]any{"host_id": "H-1", "command_type": "isolate"})
-	req, err := http.NewRequest(http.MethodPost, srv.URL+"/api/commands", bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, srv.URL+"/api/commands", bytes.NewReader(body))
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := srv.Client().Do(req)

--- a/server/response/internal/operator/handler.go
+++ b/server/response/internal/operator/handler.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/fleetdm/edr/server/attrkeys"
 	"github.com/fleetdm/edr/server/httpserver"
+	identityapi "github.com/fleetdm/edr/server/identity/api"
 	"github.com/fleetdm/edr/server/response/api"
 )
 
@@ -30,6 +31,7 @@ const createBodyCap = 64 << 10
 // Handler serves the operator-facing command routes.
 type Handler struct {
 	svc    api.Service
+	audit  identityapi.AuditRecorder
 	logger *slog.Logger
 }
 
@@ -43,6 +45,10 @@ func New(svc api.Service, logger *slog.Logger) *Handler {
 	}
 	return &Handler{svc: svc, logger: logger}
 }
+
+// SetAudit installs the operator audit recorder. Optional: when not
+// set, command issuance still works but no audit row is written.
+func (h *Handler) SetAudit(rec identityapi.AuditRecorder) { h.audit = rec }
 
 // RegisterRoutes wires the two operator routes on the given mux.
 // Caller wraps in identity.Session + identity.CSRF before mounting.
@@ -90,7 +96,42 @@ func (h *Handler) handleCreate(w http.ResponseWriter, r *http.Request) {
 		"edr.command.id", id,
 	)
 
+	h.recordCommandAudit(r, body.HostID, body.CommandType, id)
 	writeJSON(ctx, h.logger, w, http.StatusCreated, map[string]int64{"id": id})
+}
+
+// recordCommandAudit emits one audit row for the just-committed
+// command issuance. target = the host receiving the command;
+// payload carries command_type + command_id so a reviewer can
+// reconstruct the exact action without joining commands. Soft-fail
+// on audit error: the command row is authoritative.
+func (h *Handler) recordCommandAudit(r *http.Request, hostID, commandType string, commandID int64) {
+	if h.audit == nil {
+		return
+	}
+	ctx := r.Context()
+	uid, _ := identityapi.UserIDFromContext(ctx)
+	var userID *int64
+	if uid > 0 {
+		u := uid
+		userID = &u
+	}
+	if err := h.audit.Record(ctx, identityapi.AuditEvent{
+		UserID:     userID,
+		Action:     identityapi.AuditCommandIssue,
+		TargetType: "host",
+		TargetID:   hostID,
+		RemoteAddr: r.RemoteAddr,
+		Payload: map[string]any{
+			"command_type": commandType,
+			"command_id":   commandID,
+		},
+	}); err != nil {
+		h.logger.WarnContext(ctx, "audit record",
+			"err", err, "action", string(identityapi.AuditCommandIssue),
+			attrkeys.HostID, hostID,
+		)
+	}
 }
 
 func (h *Handler) handleGet(w http.ResponseWriter, r *http.Request) {

--- a/server/rules/bootstrap/bootstrap.go
+++ b/server/rules/bootstrap/bootstrap.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/jmoiron/sqlx"
 
+	identityapi "github.com/fleetdm/edr/server/identity/api"
 	"github.com/fleetdm/edr/server/rules/api"
 	"github.com/fleetdm/edr/server/rules/internal/catalog"
 	"github.com/fleetdm/edr/server/rules/internal/operator"
@@ -44,6 +45,11 @@ type Deps struct {
 	// both non-nil enables it. An asymmetric pair is a config error.
 	ActiveHostsLister ActiveHostsLister
 	CommandInserter   CommandInserter
+
+	// Audit is the operator-action recorder. Optional: nil disables
+	// audit emission for policy updates. cmd/main wires
+	// identityCtx.AuditRecorder().
+	Audit identityapi.AuditRecorder
 }
 
 // Rules is the handle cmd/main holds for the rules bounded context.
@@ -72,9 +78,11 @@ func New(deps Deps) (*Rules, error) {
 	rules := catalog.New(deps.RegistryOptions)
 	svc := service.New(policyStore, rules, deps.ActiveHostsLister, deps.CommandInserter, logger)
 
+	opH := operator.New(svc, logger)
+	opH.SetAudit(deps.Audit)
 	return &Rules{
 		svc:       svc,
-		operatorH: operator.New(svc, logger),
+		operatorH: opH,
 		db:        deps.DB,
 		logger:    logger,
 	}, nil

--- a/server/rules/internal/operator/audit_test.go
+++ b/server/rules/internal/operator/audit_test.go
@@ -99,7 +99,7 @@ func TestHandler_PolicyUpdate_EmitsAudit(t *testing.T) {
 		"actor":  "victor@example",
 		"reason": "incident-2026-Q2",
 	})
-	req, err := http.NewRequest(http.MethodPut, srv.URL+"/api/policy", bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPut, srv.URL+"/api/policy", bytes.NewReader(body))
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := srv.Client().Do(req)
@@ -136,7 +136,7 @@ func TestHandler_PolicyUpdate_NilAuditOK(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	body, _ := stdjson.Marshal(map[string]any{"actor": "v", "reason": "r"})
-	req, err := http.NewRequest(http.MethodPut, srv.URL+"/api/policy", bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPut, srv.URL+"/api/policy", bytes.NewReader(body))
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := srv.Client().Do(req)

--- a/server/rules/internal/operator/audit_test.go
+++ b/server/rules/internal/operator/audit_test.go
@@ -1,0 +1,146 @@
+package operator
+
+import (
+	"bytes"
+	"context"
+	stdjson "encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	identityapi "github.com/fleetdm/edr/server/identity/api"
+	"github.com/fleetdm/edr/server/rules/api"
+)
+
+// fakePolicyService stubs the operator handler's Service surface
+// (PolicyService + Lister + Fanout). Each method has a closure so
+// tests inject only the behaviour they need.
+type fakePolicyService struct {
+	get    func(ctx context.Context) (api.BlocklistPolicy, error)
+	update func(ctx context.Context, req api.UpdateRequest) (api.BlocklistPolicy, error)
+	list   func() []api.RuleMetadata
+	fanout func(ctx context.Context, p api.BlocklistPolicy) (int, int, error)
+}
+
+func (f fakePolicyService) Get(ctx context.Context) (api.BlocklistPolicy, error) {
+	if f.get == nil {
+		return api.BlocklistPolicy{}, nil
+	}
+	return f.get(ctx)
+}
+func (f fakePolicyService) Update(ctx context.Context, req api.UpdateRequest) (api.BlocklistPolicy, error) {
+	if f.update == nil {
+		panic("fake.Update not set")
+	}
+	return f.update(ctx, req)
+}
+func (f fakePolicyService) List() []api.RuleMetadata {
+	if f.list == nil {
+		return nil
+	}
+	return f.list()
+}
+func (f fakePolicyService) Fanout(ctx context.Context, p api.BlocklistPolicy) (int, int, error) {
+	if f.fanout == nil {
+		return 0, 0, nil
+	}
+	return f.fanout(ctx, p)
+}
+func (f fakePolicyService) ActiveCommandPayload(context.Context) (stdjson.RawMessage, int64, bool, error) {
+	panic("not used")
+}
+
+type captureRecorder struct {
+	last   identityapi.AuditEvent
+	called bool
+}
+
+func (c *captureRecorder) Record(_ context.Context, e identityapi.AuditEvent) error {
+	c.called = true
+	c.last = e
+	return nil
+}
+
+// A successful policy update emits one audit row carrying the operator-
+// supplied actor + reason in the payload, alongside the new version,
+// path/hash counts, and fan-out stats. Reviewers later asking
+// "who pushed v3 of the blocklist and why" land on this row.
+func TestHandler_PolicyUpdate_EmitsAudit(t *testing.T) {
+	svc := fakePolicyService{
+		update: func(_ context.Context, _ api.UpdateRequest) (api.BlocklistPolicy, error) {
+			return api.BlocklistPolicy{
+				Name:    api.DefaultPolicyName,
+				Version: 7,
+				Blocklist: api.Blocklist{
+					Paths:  []string{"/usr/local/bin/x"},
+					Hashes: []string{},
+				},
+			}, nil
+		},
+		fanout: func(_ context.Context, _ api.BlocklistPolicy) (int, int, error) {
+			return 3, 0, nil
+		},
+	}
+	rec := &captureRecorder{}
+	h := New(svc, nil)
+	h.SetAudit(rec)
+
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	body, _ := stdjson.Marshal(map[string]any{
+		"paths":  []string{"/usr/local/bin/x"},
+		"hashes": []string{},
+		"actor":  "victor@example",
+		"reason": "incident-2026-Q2",
+	})
+	req, err := http.NewRequest(http.MethodPut, srv.URL+"/api/policy", bytes.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := srv.Client().Do(req)
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	require.True(t, rec.called)
+	assert.Equal(t, identityapi.AuditPolicyUpdate, rec.last.Action)
+	assert.Equal(t, "policy", rec.last.TargetType)
+	assert.Equal(t, api.DefaultPolicyName, rec.last.TargetID)
+	assert.Equal(t, "victor@example", rec.last.Payload["actor"])
+	assert.Equal(t, "incident-2026-Q2", rec.last.Payload["reason"])
+	assert.EqualValues(t, 7, rec.last.Payload["version"])
+	assert.EqualValues(t, 1, rec.last.Payload["path_count"])
+	assert.EqualValues(t, 0, rec.last.Payload["hash_count"])
+	assert.EqualValues(t, 3, rec.last.Payload["fanout_hosts"])
+	assert.EqualValues(t, 0, rec.last.Payload["fanout_failed"])
+}
+
+// Nil recorder is the documented "audit-disabled" mode; the policy
+// update must still apply and return 200 without panicking.
+func TestHandler_PolicyUpdate_NilAuditOK(t *testing.T) {
+	svc := fakePolicyService{
+		update: func(_ context.Context, _ api.UpdateRequest) (api.BlocklistPolicy, error) {
+			return api.BlocklistPolicy{Name: api.DefaultPolicyName, Version: 1}, nil
+		},
+	}
+	h := New(svc, nil)
+
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	body, _ := stdjson.Marshal(map[string]any{"actor": "v", "reason": "r"})
+	req, err := http.NewRequest(http.MethodPut, srv.URL+"/api/policy", bytes.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := srv.Client().Do(req)
+	require.NoError(t, err)
+	resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}

--- a/server/rules/internal/operator/handler.go
+++ b/server/rules/internal/operator/handler.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/fleetdm/edr/server/attrkeys"
 	"github.com/fleetdm/edr/server/httpserver"
+	identityapi "github.com/fleetdm/edr/server/identity/api"
 	"github.com/fleetdm/edr/server/rules/api"
 )
 
@@ -30,6 +31,7 @@ type Service interface {
 // the rules service handle; mount via RegisterRoutes.
 type Handler struct {
 	svc    Service
+	audit  identityapi.AuditRecorder
 	logger *slog.Logger
 }
 
@@ -43,6 +45,10 @@ func New(svc Service, logger *slog.Logger) *Handler {
 	}
 	return &Handler{svc: svc, logger: logger}
 }
+
+// SetAudit installs the operator audit recorder. Optional: when not
+// set, policy updates still apply but no audit row is written.
+func (h *Handler) SetAudit(rec identityapi.AuditRecorder) { h.audit = rec }
 
 // RegisterRoutes wires the four operator routes onto the given mux.
 func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
@@ -158,7 +164,50 @@ func (h *Handler) handlePutPolicy(w http.ResponseWriter, r *http.Request) {
 	}
 	logFn(ctx, "rules policy updated", logArgs...)
 
+	h.recordPolicyAudit(r, body, p.Version, fanoutHosts, fanoutFailed, fanoutErrText)
 	writeJSON(ctx, h.logger, w, http.StatusOK, p)
+}
+
+// recordPolicyAudit emits one audit row for the just-committed policy
+// update. The body.Actor + body.Reason go in the payload because they
+// carry operator-supplied attribution that the session userID alone
+// does not (an operator may be running an automation script that
+// signs the change with a different label). Soft-fail on audit error.
+func (h *Handler) recordPolicyAudit(r *http.Request, body putPolicyRequest, version int64, fanoutHosts, fanoutFailed int, fanoutErrText string) {
+	if h.audit == nil {
+		return
+	}
+	ctx := r.Context()
+	uid, _ := identityapi.UserIDFromContext(ctx)
+	var userID *int64
+	if uid > 0 {
+		u := uid
+		userID = &u
+	}
+	payload := map[string]any{
+		"version":       version,
+		"path_count":    len(body.Paths),
+		"hash_count":    len(body.Hashes),
+		"actor":         body.Actor,
+		"reason":        body.Reason,
+		"fanout_hosts":  fanoutHosts,
+		"fanout_failed": fanoutFailed,
+	}
+	if fanoutErrText != "" {
+		payload["fanout_error"] = fanoutErrText
+	}
+	if err := h.audit.Record(ctx, identityapi.AuditEvent{
+		UserID:     userID,
+		Action:     identityapi.AuditPolicyUpdate,
+		TargetType: "policy",
+		TargetID:   api.DefaultPolicyName,
+		RemoteAddr: r.RemoteAddr,
+		Payload:    payload,
+	}); err != nil {
+		h.logger.WarnContext(ctx, "audit record",
+			"err", err, "action", string(identityapi.AuditPolicyUpdate),
+		)
+	}
 }
 
 // handleListRules returns the structured per-rule documentation for


### PR DESCRIPTION
…401s (#80)

Both fixes get more expensive every day they don't ship. The audit trail opens a permanent gap in the historical record the moment the server serves operator actions without it; the misleading Bearer challenge on cookie-protected endpoints confuses browser auth flows and HTTP clients that key retry behaviour off WWW-Authenticate.

Audit (#87):
  - audit_events table (occurred_at, actor_user_id, actor_email, action, target_type, target_id, trace_id, remote_addr, payload JSON), four indexes covering the retrieval queries the admin UI will run.
  - identity/api.AuditRecorder and AuditReader interfaces, plus 9 AuditAction constants namespaced <resource>.<verb>. Append-only is enforced by the interface shape: no Update or Delete methods, no UPDATE/DELETE paths in the audit package.
  - MySQL Store + GET /api/audit retrieval handler under identity/internal/audit. trace_id is pulled from ctx so audit rows pivot to SigNoz spans by the same handle that lands on the response X-Request-ID header.
  - Wired at five call sites: login/logout/login_failed in identity, alert.{acknowledge,resolve,reopen} in detection, policy.update in rules, command.issue in response, enrollment.revoke in endpoint. Each call site soft-fails on Recorder errors (the action committed; a missing audit row is a follow-up incident, not a reason to fail an HTTP response that already returned 200/204/201).
  - arch-go widened to allow rules.internal and endpoint.internal to import identity.api for the AuditRecorder.

WWW-Authenticate (#80):
  - Split httpserver.WriteAuthFailure into Bearer (existing semantics, still emits the RFC 6750 challenge on 401 for agent endpoints) and new WriteCookieAuthFailure (no header, ever). The cookie variant documents in its doc comment why RFC 7235 has no scheme for cookie auth and inventing one is worse than omitting the header.
  - identity/middleware/session.go's seven callers (Session + CSRF) now use the cookie variant; hosttoken middleware in endpoint stays on the Bearer variant.

Folded-in dev-environment fixes:
  - Taskfile.yml dev:server: empty-password DSN (matches docker-compose MYSQL_ALLOW_EMPTY_PASSWORD; root:toor was failing access-denied), bind 0.0.0.0:8088 so a UTM VM agent on the bridge interface can reach it, OTel envs declared (parent shell still wins on conflict per Taskfile v3 semantics).
  - New ui:setup task with a status guard runs npm ci on a fresh worktree, wired as deps of build:ui and dev:ui so a clean clone builds without separate setup.

Tests added:
  - authfail_test.go covers both Bearer (challenge on 401, omitted on 5xx) and Cookie (no challenge on any status) writers, plus the shared body/log shape.
  - audit/mysql_test.go covers Record round-trip, login_failed without a users row (denormalised actor_email read path), trace_id capture from ctx, action filter, BeforeID pagination, empty-action rejection, nil-db panic, and stable AuditAction constants.
  - session_test.go regression assertion: cookie-auth 401 carries no WWW-Authenticate.

Verified end-to-end against the dev server: nine distinct AuditAction values land in audit_events with correct actor, target, payload, and trace_id matching the dev-server access-log trace_id for the same request. Chrome login + UI policy save produced an audit row with the operator's email and the supplied reason in the payload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added comprehensive audit logging for operator actions (login, logout, alert management, policy operations, command issuance, and enrollment operations)
  * Added audit trail search and filtering endpoint with pagination support

* **Improvements**
  * Enhanced development server observability with OTLP exporter configuration
  * Automated UI dependency setup in development workflow
  * Improved authentication failure response handling for cookie-based sessions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->