### PR TITLE
ci: gate PRs on zizmor findings at medium severity + medium confidence

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,5 +1,24 @@
 name: GitHub Actions security
 
+# zizmor audits .github/workflows/* for CI-supply-chain weaknesses
+# (excessive permissions, template injection, dangerous triggers, unpinned
+# actions, etc.). The job below is configured to FAIL CI on findings at
+# medium severity AND medium confidence or higher, so the gate catches the
+# meaningful issues without breaking on the auditor persona's speculative
+# low-confidence flags.
+#
+# Suppressing a false positive: add a trailing comment to the offending
+# line in the workflow file:
+#     # zizmor: ignore[<rule-id>] reason: <one-line>
+# (e.g. `# zizmor: ignore[excessive-permissions] reason: ...`)
+# The reason text is required by repo convention so the next reviewer can
+# tell why the suppression is correct.
+#
+# Bumping `zizmor-action`: every minor / major bump can introduce new
+# rules that fire on unchanged workflows. Budget 15-30 min of triage for
+# any pin update; resolve each new finding by either fixing the workflow
+# or adding a documented per-line ignore.
+
 on:
   push:
     branches: [main]
@@ -31,4 +50,13 @@ jobs:
 
       - uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
         with:
+          # auditor surfaces the broadest set of issues; min-confidence:
+          # medium filters out the auditor-extra speculative flags so they
+          # don't fail CI (they're still visible if you run zizmor locally
+          # without these knobs).
           persona: auditor
+          # Fail CI on findings at medium severity (zizmor's mapped warning
+          # level) or higher. Lower-severity advisory findings are not
+          # gated; surface them locally with `zizmor --persona=pedantic .`.
+          min-severity: medium
+          min-confidence: medium


### PR DESCRIPTION
zizmor was running today as report-only: SARIF flowed to the code-scanning tab and nothing failed CI, so workflow-supply-chain findings (excessive permissions, template injection, dangerous triggers) accumulated unread. Setting `min-severity: medium` plus `min-confidence: medium` on zizmor-action turns the workflow into a real gate without breaking on the auditor persona's lower-confidence speculation.

Threshold rationale (medium/medium):
- Below medium: stylistic / informational notes (e.g. undocumented-permissions). Not security-meaningful enough to block on.
- Auditor confidence below medium: the persona's broader sweep can flag patterns that look risky but turn out to be project conventions; we want them visible during a local run, not gating PRs.

Header comment also documents:
- The waiver path: `# zizmor: ignore[<rule-id>] reason: <one-line>` on the offending line. Reason text is required so the next reviewer can judge whether the suppression is correct.
- The triage tax of bumping zizmor-action: each minor / major bump can surface new rules on unchanged workflows; budget 15-30 min per pin update.

Prerequisite already landed: PR #106 (`gha-top-level-permissions-deny-all`) cleared the 18 existing zizmor alerts on main, so this gate kicks in against a clean slate.