### PR TITLE
perf(detection): bulk SQL + indexed PID + recursive exec chain

### DIFF
--- a/server/detection/bootstrap/migrations.go
+++ b/server/detection/bootstrap/migrations.go
@@ -106,6 +106,24 @@ var migrations = []migrationStep{
 		SQL:          `ALTER TABLE processes ADD INDEX idx_processes_previous_exec (previous_exec_id)`,
 		IgnoreErrors: []uint16{mysqlDuplicateKey, mysqlDuplicateKeyAlt},
 	},
+	// Stored generated column + composite index so GetNetworkEventsForProcess
+	// can drop its JSON_EXTRACT predicate (issue #92). STORED (not VIRTUAL)
+	// because VIRTUAL would force a per-row JSON_EXTRACT re-evaluation on
+	// every index lookup, defeating the whole point. CAST AS UNSIGNED matches
+	// pid's non-negative domain; the column is BIGINT so a JSON pid value
+	// outside INT range still round-trips losslessly. NULL when payload has
+	// no $.pid (e.g. login / logout events) — InnoDB indexes NULLs.
+	{
+		Name: "events.payload_pid",
+		SQL: `ALTER TABLE events ADD COLUMN payload_pid BIGINT
+		      GENERATED ALWAYS AS (CAST(JSON_UNQUOTE(JSON_EXTRACT(payload, '$.pid')) AS UNSIGNED)) STORED`,
+		IgnoreErrors: []uint16{mysqlDuplicateColumn},
+	},
+	{
+		Name:         "events.idx_host_type_pid_ingested",
+		SQL:          `ALTER TABLE events ADD INDEX idx_events_host_type_pid_ingested (host_id, event_type, payload_pid, ingested_at_ns)`,
+		IgnoreErrors: []uint16{mysqlDuplicateKey, mysqlDuplicateKeyAlt},
+	},
 }
 
 // shouldIgnore reports whether err matches any of the codes in the

--- a/server/detection/bootstrap/migrations.go
+++ b/server/detection/bootstrap/migrations.go
@@ -113,6 +113,16 @@ var migrations = []migrationStep{
 	// pid's non-negative domain; the column is BIGINT so a JSON pid value
 	// outside INT range still round-trips losslessly. NULL when payload has
 	// no $.pid (e.g. login / logout events) — InnoDB indexes NULLs.
+	//
+	// Operational note (Copilot review on PR #110): adding a STORED
+	// generated column rebuilds the table — InnoDB does not support
+	// ALGORITHM=INPLACE for stored generated columns, so MySQL falls
+	// back to ALGORITHM=COPY. On a multi-million-row events table this
+	// holds a metadata lock on `events` for the duration of the rebuild
+	// and blocks concurrent writes. Run during a maintenance window for
+	// large existing deployments. Fresh installs hit the inline column
+	// definition in schemaStatements and skip this ALTER entirely (the
+	// IgnoreErrors path swallows the duplicate-column code).
 	{
 		Name: "events.payload_pid",
 		SQL: `ALTER TABLE events ADD COLUMN payload_pid BIGINT

--- a/server/detection/bootstrap/migrations.go
+++ b/server/detection/bootstrap/migrations.go
@@ -106,34 +106,6 @@ var migrations = []migrationStep{
 		SQL:          `ALTER TABLE processes ADD INDEX idx_processes_previous_exec (previous_exec_id)`,
 		IgnoreErrors: []uint16{mysqlDuplicateKey, mysqlDuplicateKeyAlt},
 	},
-	// Stored generated column + composite index so GetNetworkEventsForProcess
-	// can drop its JSON_EXTRACT predicate (issue #92). STORED (not VIRTUAL)
-	// because VIRTUAL would force a per-row JSON_EXTRACT re-evaluation on
-	// every index lookup, defeating the whole point. CAST AS UNSIGNED matches
-	// pid's non-negative domain; the column is BIGINT so a JSON pid value
-	// outside INT range still round-trips losslessly. NULL when payload has
-	// no $.pid (e.g. login / logout events) — InnoDB indexes NULLs.
-	//
-	// Operational note (Copilot review on PR #110): adding a STORED
-	// generated column rebuilds the table — InnoDB does not support
-	// ALGORITHM=INPLACE for stored generated columns, so MySQL falls
-	// back to ALGORITHM=COPY. On a multi-million-row events table this
-	// holds a metadata lock on `events` for the duration of the rebuild
-	// and blocks concurrent writes. Run during a maintenance window for
-	// large existing deployments. Fresh installs hit the inline column
-	// definition in schemaStatements and skip this ALTER entirely (the
-	// IgnoreErrors path swallows the duplicate-column code).
-	{
-		Name: "events.payload_pid",
-		SQL: `ALTER TABLE events ADD COLUMN payload_pid BIGINT
-		      GENERATED ALWAYS AS (CAST(JSON_UNQUOTE(JSON_EXTRACT(payload, '$.pid')) AS UNSIGNED)) STORED`,
-		IgnoreErrors: []uint16{mysqlDuplicateColumn},
-	},
-	{
-		Name:         "events.idx_host_type_pid_ingested",
-		SQL:          `ALTER TABLE events ADD INDEX idx_events_host_type_pid_ingested (host_id, event_type, payload_pid, ingested_at_ns)`,
-		IgnoreErrors: []uint16{mysqlDuplicateKey, mysqlDuplicateKeyAlt},
-	},
 }
 
 // shouldIgnore reports whether err matches any of the codes in the

--- a/server/detection/bootstrap/schema.go
+++ b/server/detection/bootstrap/schema.go
@@ -16,12 +16,14 @@ var schemaStatements = []string{
 		ingested_at_ns  BIGINT       NOT NULL DEFAULT 0,
 		event_type      VARCHAR(64)  NOT NULL,
 		payload         JSON         NOT NULL,
+		payload_pid     BIGINT       GENERATED ALWAYS AS (CAST(JSON_UNQUOTE(JSON_EXTRACT(payload, '$.pid')) AS UNSIGNED)) STORED,
 		processed       TINYINT(1)   NOT NULL DEFAULT 0,
 		created_at      TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
 		INDEX idx_events_host_id (host_id),
 		INDEX idx_events_type (event_type),
 		INDEX idx_events_timestamp (timestamp_ns),
 		INDEX idx_events_host_type_ingested (host_id, event_type, ingested_at_ns),
+		INDEX idx_events_host_type_pid_ingested (host_id, event_type, payload_pid, ingested_at_ns),
 		INDEX idx_events_processed (processed, host_id, timestamp_ns)
 	)`,
 	`CREATE TABLE IF NOT EXISTS processes (

--- a/server/detection/internal/mysql/alerts.go
+++ b/server/detection/internal/mysql/alerts.go
@@ -73,10 +73,7 @@ func bulkInsertAlertEvents(ctx context.Context, tx *sqlx.Tx, alertID int64, even
 		verb = "INSERT IGNORE INTO"
 	}
 	for start := 0; start < len(eventIDs); start += alertEventsBatchSize {
-		end := start + alertEventsBatchSize
-		if end > len(eventIDs) {
-			end = len(eventIDs)
-		}
+		end := min(start+alertEventsBatchSize, len(eventIDs))
 		chunk := eventIDs[start:end]
 		placeholders := make([]string, len(chunk))
 		args := make([]any, 0, len(chunk)*2)

--- a/server/detection/internal/mysql/alerts.go
+++ b/server/detection/internal/mysql/alerts.go
@@ -5,12 +5,20 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/go-sql-driver/mysql"
 	"github.com/jmoiron/sqlx"
 
 	"github.com/fleetdm/edr/server/detection/api"
 )
+
+// alertEventsBatchSize caps the number of (alert_id, event_id) rows
+// per INSERT. Today's rules cap their output at ~10 events per
+// finding, but a future noisy detection could link thousands. Keeping
+// the batch bounded stops a single INSERT from breaching MySQL's
+// max_allowed_packet on hosts where it's tuned low.
+const alertEventsBatchSize = 500
 
 // InsertAlert creates an alert and links it to the given event IDs.
 // If a duplicate alert exists (same host_id, rule_id, process_id),
@@ -42,16 +50,46 @@ func (s *Store) InsertAlert(ctx context.Context, a api.Alert, eventIDs []string)
 		return 0, false, fmt.Errorf("insert alert last id: %w", err)
 	}
 
-	for _, eid := range eventIDs {
-		if _, err := tx.ExecContext(ctx, "INSERT INTO alert_events (alert_id, event_id) VALUES (?, ?)", alertID, eid); err != nil {
-			return 0, false, fmt.Errorf("insert alert_event (%d, %s): %w", alertID, eid, err)
-		}
+	if err := bulkInsertAlertEvents(ctx, tx, alertID, eventIDs, false /* not dedup */); err != nil {
+		return 0, false, err
 	}
 
 	if err := tx.Commit(); err != nil {
 		return 0, false, fmt.Errorf("commit insert alert: %w", err)
 	}
 	return alertID, true, nil
+}
+
+// bulkInsertAlertEvents links eventIDs to alertID with one (chunked)
+// multi-row INSERT instead of N round-trips. dedup=true switches to
+// INSERT IGNORE so re-linking an existing (alert_id, event_id) PK
+// doesn't blow up.
+func bulkInsertAlertEvents(ctx context.Context, tx *sqlx.Tx, alertID int64, eventIDs []string, dedup bool) error {
+	if len(eventIDs) == 0 {
+		return nil
+	}
+	verb := "INSERT INTO"
+	if dedup {
+		verb = "INSERT IGNORE INTO"
+	}
+	for start := 0; start < len(eventIDs); start += alertEventsBatchSize {
+		end := start + alertEventsBatchSize
+		if end > len(eventIDs) {
+			end = len(eventIDs)
+		}
+		chunk := eventIDs[start:end]
+		placeholders := make([]string, len(chunk))
+		args := make([]any, 0, len(chunk)*2)
+		for i, eid := range chunk {
+			placeholders[i] = "(?, ?)"
+			args = append(args, alertID, eid)
+		}
+		stmt := verb + " alert_events (alert_id, event_id) VALUES " + strings.Join(placeholders, ", ")
+		if _, err := tx.ExecContext(ctx, stmt, args...); err != nil {
+			return fmt.Errorf("link alert_events alert=%d count=%d: %w", alertID, len(chunk), err)
+		}
+	}
+	return nil
 }
 
 // isDuplicateKeyErr matches MySQL error 1062 (duplicate primary/unique key).
@@ -75,12 +113,8 @@ func (s *Store) attachEventsToExistingAlert(ctx context.Context, tx *sqlx.Tx, a 
 	); err != nil {
 		return 0, false, fmt.Errorf("lookup duplicate alert: %w", err)
 	}
-	for _, eid := range eventIDs {
-		if _, err := tx.ExecContext(ctx,
-			"INSERT IGNORE INTO alert_events (alert_id, event_id) VALUES (?, ?)", existingID, eid,
-		); err != nil {
-			return 0, false, fmt.Errorf("link event to existing alert (%d, %s): %w", existingID, eid, err)
-		}
+	if err := bulkInsertAlertEvents(ctx, tx, existingID, eventIDs, true /* dedup */); err != nil {
+		return 0, false, err
 	}
 	if err := tx.Commit(); err != nil {
 		return 0, false, fmt.Errorf("commit duplicate alert lookup: %w", err)

--- a/server/detection/internal/mysql/hosts.go
+++ b/server/detection/internal/mysql/hosts.go
@@ -3,6 +3,7 @@ package mysql
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/fleetdm/edr/server/detection/api"
@@ -64,8 +65,16 @@ func (s *Store) UpdateHostLastSeen(ctx context.Context, hostID string, now time.
 
 // UpsertHosts incrementally updates the hosts summary table for a
 // batch of ingested events. It aggregates event counts and max
-// timestamps per host, then upserts them in a single statement per
-// host.
+// timestamps per host, then upserts every host in a single batched
+// statement.
+//
+// Issue #91: the prior shape was one ExecContext per distinct host_id
+// in the batch — N round-trips inside the ingest hot path. The
+// multi-row VALUES clause folds that to one round-trip. The (host_id,
+// event_count, last_seen_ns) per-host triple is unique within a
+// single call (we aggregate into byHost first), so ON DUPLICATE KEY
+// UPDATE only ever fires against pre-existing rows, never against
+// rows from earlier in the same VALUES list.
 func (s *Store) UpsertHosts(ctx context.Context, events []api.Event) error {
 	if len(events) == 0 {
 		return nil
@@ -88,17 +97,21 @@ func (s *Store) UpsertHosts(ctx context.Context, events []api.Event) error {
 		}
 	}
 
+	placeholders := make([]string, 0, len(byHost))
+	args := make([]any, 0, len(byHost)*3)
 	for hostID, st := range byHost {
-		_, err := s.db.ExecContext(ctx, `
-			INSERT INTO hosts (host_id, event_count, last_seen_ns)
-			VALUES (?, ?, ?)
-			ON DUPLICATE KEY UPDATE
-				event_count = event_count + VALUES(event_count),
-				last_seen_ns = GREATEST(last_seen_ns, VALUES(last_seen_ns))`,
-			hostID, st.count, st.maxTSNs)
-		if err != nil {
-			return fmt.Errorf("upsert host %s: %w", hostID, err)
-		}
+		placeholders = append(placeholders, "(?, ?, ?)")
+		args = append(args, hostID, st.count, st.maxTSNs)
+	}
+
+	stmt := `INSERT INTO hosts (host_id, event_count, last_seen_ns) VALUES ` +
+		strings.Join(placeholders, ", ") + `
+		ON DUPLICATE KEY UPDATE
+			event_count = event_count + VALUES(event_count),
+			last_seen_ns = GREATEST(last_seen_ns, VALUES(last_seen_ns))`
+
+	if _, err := s.db.ExecContext(ctx, stmt, args...); err != nil {
+		return fmt.Errorf("upsert hosts (n=%d): %w", len(byHost), err)
 	}
 	return nil
 }

--- a/server/detection/internal/mysql/perf_test.go
+++ b/server/detection/internal/mysql/perf_test.go
@@ -26,7 +26,7 @@ func TestUpsertHosts_BatchAcrossManyHosts(t *testing.T) {
 
 	const n = 32
 	events := make([]api.Event, 0, n*3)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		host := "host-" + strconv.Itoa(i)
 		events = append(events,
 			api.Event{EventID: host + "-1", HostID: host, TimestampNs: int64(100 + i), EventType: "fork", Payload: json.RawMessage(`{}`)},
@@ -44,7 +44,7 @@ func TestUpsertHosts_BatchAcrossManyHosts(t *testing.T) {
 	for _, h := range hosts {
 		byHost[h.HostID] = h
 	}
-	for i := 0; i < n; i++ {
+	for i := range n {
 		host := "host-" + strconv.Itoa(i)
 		got, ok := byHost[host]
 		require.True(t, ok, "missing row for %s", host)
@@ -88,7 +88,7 @@ func BenchmarkUpsertHosts(b *testing.B) {
 				}
 			}
 			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				if err := s.UpsertHosts(ctx, events); err != nil {
 					b.Fatalf("upsert hosts: %v", err)
 				}
@@ -140,7 +140,7 @@ func TestGetNetworkEventsForProcess_UsesPIDIndex(t *testing.T) {
 
 	// Seed enough rows that the optimiser would prefer a scan over an
 	// index lookup if the predicate weren't index-backed.
-	for i := 0; i < 50; i++ {
+	for i := range 50 {
 		require.NoError(t, s.InsertEvents(ctx, []api.Event{{
 			EventID:     "seed-" + strconv.Itoa(i),
 			HostID:      "h",
@@ -205,7 +205,7 @@ func BenchmarkGetNetworkEventsForProcess(b *testing.B) {
 			}
 			require.NoError(b, s.InsertEvents(ctx, batch))
 			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				_, err := s.GetNetworkEventsForProcess(ctx, "h", 7, api.TimeRange{FromNs: 0, ToNs: 1 << 62})
 				if err != nil {
 					b.Fatalf("query: %v", err)
@@ -298,7 +298,7 @@ func BenchmarkInsertAlert_BulkLinkEvents(b *testing.B) {
 			}
 			require.NoError(b, s.InsertEvents(ctx, batch))
 			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
+			for i := range b.N {
 				// Vary rule_id so each iteration creates a fresh alert
 				// (the dedup branch is covered by its own bench below).
 				_, _, err := s.InsertAlert(ctx, api.Alert{
@@ -393,22 +393,25 @@ func BenchmarkGetExecChain(b *testing.B) {
 			s := newTestStore(b)
 			ctx := b.Context()
 
-			var prev *int64
-			var lastID int64
-			for i := 0; i < depth; i++ {
-				p := api.Process{HostID: "h", PID: 1, ForkTimeNs: int64(100 + i)}
-				if prev != nil {
-					p.PreviousExecID = prev
-				}
+			// Build `depth` ancestor rows linked tail-to-head, then form
+			// a logical `current` whose PreviousExecID points at the most
+			// recent ancestor. Each iteration must capture the inserted
+			// id into a *fresh* int64 (snapshot) and take its address;
+			// reusing one variable's address yields a self-cycle because
+			// the pointer always reads the latest assignment (per
+			// Copilot review on PR #110).
+			var prevPtr *int64
+			for i := range depth {
+				p := api.Process{HostID: "h", PID: 1, ForkTimeNs: int64(100 + i), PreviousExecID: prevPtr}
 				id, err := s.InsertProcess(ctx, p)
 				require.NoError(b, err)
-				lastID = id
-				prev = &lastID
+				snapshot := id
+				prevPtr = &snapshot
 			}
-			current := api.Process{ID: lastID, HostID: "h", PID: 1, ForkTimeNs: int64(100 + depth - 1), PreviousExecID: prev}
+			current := api.Process{HostID: "h", PID: 1, ForkTimeNs: int64(100 + depth), PreviousExecID: prevPtr}
 
 			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				_, err := s.GetExecChain(ctx, current)
 				if err != nil {
 					b.Fatalf("get exec chain: %v", err)

--- a/server/detection/internal/mysql/perf_test.go
+++ b/server/detection/internal/mysql/perf_test.go
@@ -1,0 +1,419 @@
+package mysql_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fleetdm/edr/server/detection/api"
+)
+
+// Tests for the bulk / index / CTE optimisations introduced for
+// issues #91-#94. Each test pins the externally observable behaviour
+// (correctness) the prior shape provided. Microbenchmarks alongside
+// these prove the linear-with-N drop the issues' acceptance criteria
+// call out.
+
+// --- #91: bulk hosts upsert ------------------------------------------------
+
+func TestUpsertHosts_BatchAcrossManyHosts(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+
+	const n = 32
+	events := make([]api.Event, 0, n*3)
+	for i := 0; i < n; i++ {
+		host := "host-" + strconv.Itoa(i)
+		events = append(events,
+			api.Event{EventID: host + "-1", HostID: host, TimestampNs: int64(100 + i), EventType: "fork", Payload: json.RawMessage(`{}`)},
+			api.Event{EventID: host + "-2", HostID: host, TimestampNs: int64(200 + i), EventType: "fork", Payload: json.RawMessage(`{}`)},
+			api.Event{EventID: host + "-3", HostID: host, TimestampNs: int64(50 + i), EventType: "fork", Payload: json.RawMessage(`{}`)},
+		)
+	}
+	require.NoError(t, s.UpsertHosts(ctx, events))
+
+	hosts, err := s.ListHosts(ctx)
+	require.NoError(t, err)
+	require.Len(t, hosts, n, "every distinct host gets a row")
+
+	byHost := make(map[string]api.HostSummary, n)
+	for _, h := range hosts {
+		byHost[h.HostID] = h
+	}
+	for i := 0; i < n; i++ {
+		host := "host-" + strconv.Itoa(i)
+		got, ok := byHost[host]
+		require.True(t, ok, "missing row for %s", host)
+		assert.Equal(t, int64(3), got.EventCount, "%s: 3 events aggregated into one row", host)
+		assert.Equal(t, int64(200+i), got.LastSeenNs, "%s: last_seen pinned to MAX(timestamp_ns)", host)
+	}
+
+	// Re-running the same batch must accumulate, not duplicate. This is
+	// the property the ON DUPLICATE KEY UPDATE branch is responsible
+	// for; the bulk-INSERT swap mustn't break it.
+	require.NoError(t, s.UpsertHosts(ctx, events))
+	hosts2, err := s.ListHosts(ctx)
+	require.NoError(t, err)
+	for _, h := range hosts2 {
+		assert.Equal(t, int64(6), h.EventCount, "%s: re-running doubles the count via ON DUPLICATE KEY UPDATE", h.HostID)
+	}
+}
+
+func TestUpsertHosts_EmptyBatchNoOp(t *testing.T) {
+	s := newTestStore(t)
+	require.NoError(t, s.UpsertHosts(t.Context(), nil))
+	require.NoError(t, s.UpsertHosts(t.Context(), []api.Event{}))
+	hosts, err := s.ListHosts(t.Context())
+	require.NoError(t, err)
+	assert.Empty(t, hosts, "empty batch must not insert anything")
+}
+
+func BenchmarkUpsertHosts(b *testing.B) {
+	for _, n := range []int{16, 64, 256} {
+		b.Run(fmt.Sprintf("hosts=%d", n), func(b *testing.B) {
+			s := newTestStore(b)
+			ctx := b.Context()
+			events := make([]api.Event, n)
+			for i := range events {
+				events[i] = api.Event{
+					EventID:     "be-" + strconv.Itoa(i),
+					HostID:      "bench-host-" + strconv.Itoa(i),
+					TimestampNs: int64(i),
+					EventType:   "fork",
+					Payload:     json.RawMessage(`{}`),
+				}
+			}
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if err := s.UpsertHosts(ctx, events); err != nil {
+					b.Fatalf("upsert hosts: %v", err)
+				}
+			}
+		})
+	}
+}
+
+// --- #92: indexed PID lookup ----------------------------------------------
+
+func TestGetNetworkEventsForProcess_FiltersByIndexedPID(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+
+	// Six events split across two pids on the same host, plus one on a
+	// different host (must be excluded), one with the wrong event_type
+	// (must be excluded), and one outside the time window.
+	require.NoError(t, s.InsertEventsAt(ctx, []api.Event{
+		{EventID: "n1", HostID: "h", TimestampNs: 100, EventType: "network_connect", Payload: json.RawMessage(`{"pid":1234,"dst":"a"}`)},
+		{EventID: "n2", HostID: "h", TimestampNs: 200, EventType: "dns_query", Payload: json.RawMessage(`{"pid":1234,"name":"b"}`)},
+		{EventID: "n3", HostID: "h", TimestampNs: 300, EventType: "network_connect", Payload: json.RawMessage(`{"pid":9999}`)},
+		{EventID: "n4", HostID: "other", TimestampNs: 400, EventType: "network_connect", Payload: json.RawMessage(`{"pid":1234}`)},
+		{EventID: "n5", HostID: "h", TimestampNs: 500, EventType: "fork", Payload: json.RawMessage(`{"pid":1234}`)},
+	}, 1000))
+	require.NoError(t, s.InsertEventsAt(ctx, []api.Event{
+		{EventID: "n6", HostID: "h", TimestampNs: 600, EventType: "network_connect", Payload: json.RawMessage(`{"pid":1234}`)},
+	}, 9999))
+
+	got, err := s.GetNetworkEventsForProcess(ctx, "h", 1234, api.TimeRange{FromNs: 0, ToNs: 5000})
+	require.NoError(t, err)
+	require.Len(t, got, 2, "only n1 + n2 match host=h, type∈{network_connect,dns_query}, pid=1234, ingested in [0,5000]")
+
+	// Ordered by timestamp_ns; n1 (100) before n2 (200).
+	ids := []string{got[0].EventID, got[1].EventID}
+	assert.Equal(t, []string{"n1", "n2"}, ids)
+
+	// n6 was ingested at 9999; widening the window must surface it. The
+	// query filters on ingested_at_ns (not timestamp_ns); the index
+	// column ordering puts payload_pid before ingested_at_ns so the
+	// pid equality is consumed first, then the ingest range scans.
+	got2, err := s.GetNetworkEventsForProcess(ctx, "h", 1234, api.TimeRange{FromNs: 0, ToNs: 50000})
+	require.NoError(t, err)
+	require.Len(t, got2, 3, "widening the ingested_at_ns window picks up n6")
+}
+
+func TestGetNetworkEventsForProcess_UsesPIDIndex(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+
+	// Seed enough rows that the optimiser would prefer a scan over an
+	// index lookup if the predicate weren't index-backed.
+	for i := 0; i < 50; i++ {
+		require.NoError(t, s.InsertEvents(ctx, []api.Event{{
+			EventID:     "seed-" + strconv.Itoa(i),
+			HostID:      "h",
+			TimestampNs: int64(i),
+			EventType:   "network_connect",
+			Payload:     json.RawMessage(`{"pid":` + strconv.Itoa(i%5) + `}`),
+		}}))
+	}
+	// EXPLAIN's column set varies by MySQL version; we only care about
+	// the key column. Use a dynamic scan so the test isn't sensitive to
+	// MySQL adding/renaming sibling columns.
+	rows, err := s.DB().QueryxContext(ctx, `EXPLAIN
+		SELECT event_id FROM events
+		WHERE host_id = ? AND event_type IN ('network_connect','dns_query')
+		  AND payload_pid = ?
+		  AND ingested_at_ns >= ? AND ingested_at_ns <= ?`,
+		"h", 3, 0, int64(1<<62))
+	require.NoError(t, err)
+	defer rows.Close()
+	require.True(t, rows.Next(), "EXPLAIN must return at least one row")
+	cols, err := rows.SliceScan()
+	require.NoError(t, err)
+	colNames, err := rows.Columns()
+	require.NoError(t, err)
+	var keyVal string
+	for i, name := range colNames {
+		if name != "key" {
+			continue
+		}
+		if cols[i] == nil {
+			break
+		}
+		switch v := cols[i].(type) {
+		case []byte:
+			keyVal = string(v)
+		case string:
+			keyVal = v
+		}
+	}
+	assert.Equal(t, "idx_events_host_type_pid_ingested", keyVal,
+		"EXPLAIN must show the new composite index, not idx_events_host_type_ingested")
+}
+
+func BenchmarkGetNetworkEventsForProcess(b *testing.B) {
+	for _, eventCount := range []int{500, 5000} {
+		b.Run(fmt.Sprintf("events=%d", eventCount), func(b *testing.B) {
+			s := newTestStore(b)
+			ctx := b.Context()
+
+			// Most events are noise (different pids); the target pid hits
+			// just a few rows. The win is "no full table scan", which is
+			// why the bench scales with rows in events, not result-set size.
+			batch := make([]api.Event, eventCount)
+			for i := range batch {
+				batch[i] = api.Event{
+					EventID:     "ne-" + strconv.Itoa(i),
+					HostID:      "h",
+					TimestampNs: int64(i),
+					EventType:   "network_connect",
+					Payload:     json.RawMessage(`{"pid":` + strconv.Itoa(i) + `}`),
+				}
+			}
+			require.NoError(b, s.InsertEvents(ctx, batch))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_, err := s.GetNetworkEventsForProcess(ctx, "h", 7, api.TimeRange{FromNs: 0, ToNs: 1 << 62})
+				if err != nil {
+					b.Fatalf("query: %v", err)
+				}
+			}
+		})
+	}
+}
+
+// --- #93: bulk alert_events linking ---------------------------------------
+
+func TestInsertAlert_LinksEveryEventInOneStatement(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+
+	procID, err := s.InsertProcess(ctx, api.Process{HostID: "h", PID: 1, ForkTimeNs: 1})
+	require.NoError(t, err)
+
+	const n = 50
+	eventIDs := make([]string, n)
+	events := make([]api.Event, n)
+	for i := range events {
+		eventIDs[i] = "ae-" + strconv.Itoa(i)
+		events[i] = api.Event{EventID: eventIDs[i], HostID: "h", TimestampNs: int64(i), EventType: "fork", Payload: json.RawMessage(`{}`)}
+	}
+	require.NoError(t, s.InsertEvents(ctx, events))
+
+	alertID, created, err := s.InsertAlert(ctx, api.Alert{
+		HostID: "h", RuleID: "r", Severity: api.SeverityHigh,
+		Title: "T", Description: "D", ProcessID: procID,
+	}, eventIDs)
+	require.NoError(t, err)
+	assert.True(t, created)
+
+	got, err := s.GetAlertEventIDs(ctx, alertID)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, eventIDs, got, "every event_id must be linked")
+}
+
+func TestInsertAlert_DedupBranchAlsoLinksAllEvents(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+
+	procID, err := s.InsertProcess(ctx, api.Process{HostID: "h", PID: 1, ForkTimeNs: 1})
+	require.NoError(t, err)
+
+	first := []string{"d1", "d2"}
+	second := []string{"d2", "d3", "d4"} // overlap with `first`; INSERT IGNORE must absorb.
+	allIDs := []string{"d1", "d2", "d3", "d4"}
+	events := make([]api.Event, len(allIDs))
+	for i, id := range allIDs {
+		events[i] = api.Event{EventID: id, HostID: "h", TimestampNs: 1, EventType: "fork", Payload: json.RawMessage(`{}`)}
+	}
+	require.NoError(t, s.InsertEvents(ctx, events))
+
+	alertID1, created1, err := s.InsertAlert(ctx, api.Alert{
+		HostID: "h", RuleID: "r", Severity: api.SeverityHigh,
+		Title: "T", Description: "D", ProcessID: procID,
+	}, first)
+	require.NoError(t, err)
+	require.True(t, created1)
+
+	alertID2, created2, err := s.InsertAlert(ctx, api.Alert{
+		HostID: "h", RuleID: "r", Severity: api.SeverityHigh,
+		Title: "T", Description: "D", ProcessID: procID,
+	}, second)
+	require.NoError(t, err)
+	assert.False(t, created2, "duplicate (host_id,rule_id,process_id) must dedup, not create")
+	assert.Equal(t, alertID1, alertID2, "dedup returns the existing alert id")
+
+	got, err := s.GetAlertEventIDs(ctx, alertID1)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"d1", "d2", "d3", "d4"}, got,
+		"INSERT IGNORE absorbs the (alert,d2) duplicate and adds the new ones")
+}
+
+func BenchmarkInsertAlert_BulkLinkEvents(b *testing.B) {
+	for _, eventsPerAlert := range []int{10, 100, 1000} {
+		b.Run(fmt.Sprintf("events=%d", eventsPerAlert), func(b *testing.B) {
+			s := newTestStore(b)
+			ctx := b.Context()
+			procID, err := s.InsertProcess(ctx, api.Process{HostID: "h", PID: 1, ForkTimeNs: 1})
+			require.NoError(b, err)
+
+			eventIDs := make([]string, eventsPerAlert)
+			batch := make([]api.Event, eventsPerAlert)
+			for i := range batch {
+				eventIDs[i] = "be-" + strconv.Itoa(i)
+				batch[i] = api.Event{EventID: eventIDs[i], HostID: "h", TimestampNs: 1, EventType: "fork", Payload: json.RawMessage(`{}`)}
+			}
+			require.NoError(b, s.InsertEvents(ctx, batch))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				// Vary rule_id so each iteration creates a fresh alert
+				// (the dedup branch is covered by its own bench below).
+				_, _, err := s.InsertAlert(ctx, api.Alert{
+					HostID: "h", RuleID: "r-" + strconv.Itoa(i),
+					Severity: api.SeverityHigh, Title: "T", Description: "D",
+					ProcessID: procID,
+				}, eventIDs)
+				if err != nil {
+					b.Fatalf("insert alert: %v", err)
+				}
+			}
+		})
+	}
+}
+
+// --- #94: recursive CTE for GetExecChain ----------------------------------
+
+func TestGetExecChain_ReturnsOldestFirstAndExcludesCurrent(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+
+	// Build a chain: gen0 <- gen1 <- gen2 <- gen3 (current).
+	gen0, err := s.InsertProcess(ctx, api.Process{HostID: "h", PID: 1, ForkTimeNs: 100})
+	require.NoError(t, err)
+	gen1, err := s.InsertProcess(ctx, api.Process{HostID: "h", PID: 1, ForkTimeNs: 200, PreviousExecID: &gen0})
+	require.NoError(t, err)
+	gen2, err := s.InsertProcess(ctx, api.Process{HostID: "h", PID: 1, ForkTimeNs: 300, PreviousExecID: &gen1})
+	require.NoError(t, err)
+	gen3, err := s.InsertProcess(ctx, api.Process{HostID: "h", PID: 1, ForkTimeNs: 400, PreviousExecID: &gen2})
+	require.NoError(t, err)
+
+	current := api.Process{ID: gen3, HostID: "h", PID: 1, ForkTimeNs: 400, PreviousExecID: &gen2}
+	chain, err := s.GetExecChain(ctx, current)
+	require.NoError(t, err)
+	require.Len(t, chain, 3, "chain excludes current; returns gen0, gen1, gen2")
+
+	gotIDs := []int64{chain[0].ID, chain[1].ID, chain[2].ID}
+	assert.Equal(t, []int64{gen0, gen1, gen2}, gotIDs,
+		"oldest-first order: gen0 first, gen2 last (closest ancestor)")
+}
+
+func TestGetExecChain_NoPreviousExecReturnsEmpty(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+
+	procID, err := s.InsertProcess(ctx, api.Process{HostID: "h", PID: 1, ForkTimeNs: 1})
+	require.NoError(t, err)
+
+	chain, err := s.GetExecChain(ctx, api.Process{ID: procID, HostID: "h", PID: 1})
+	require.NoError(t, err)
+	assert.Empty(t, chain, "process with no previous_exec_id has empty chain")
+}
+
+func TestGetExecChain_HostScoped(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+
+	// A process on host A pointing at a previous_exec_id that exists on
+	// host B (corrupt-FK simulation): the host_id scope must hide it.
+	procB, err := s.InsertProcess(ctx, api.Process{HostID: "B", PID: 1, ForkTimeNs: 100})
+	require.NoError(t, err)
+	procA, err := s.InsertProcess(ctx, api.Process{HostID: "A", PID: 1, ForkTimeNs: 200, PreviousExecID: &procB})
+	require.NoError(t, err)
+
+	chain, err := s.GetExecChain(ctx, api.Process{ID: procA, HostID: "A", PID: 1, PreviousExecID: &procB})
+	require.NoError(t, err)
+	assert.Empty(t, chain, "ancestor row on a different host must not surface")
+}
+
+func TestGetExecChain_CycleGuardCapsAt64(t *testing.T) {
+	// Synthesise a cycle by post-INSERT updating the oldest row's
+	// previous_exec_id to point at itself. Real schema would never
+	// produce this (each generation forks strictly later than its
+	// predecessor) but the cycle guard is the safety net for a
+	// corrupt FK.
+	s := newTestStore(t)
+	ctx := t.Context()
+
+	gen0, err := s.InsertProcess(ctx, api.Process{HostID: "h", PID: 1, ForkTimeNs: 100})
+	require.NoError(t, err)
+	_, err = s.DB().ExecContext(ctx, `UPDATE processes SET previous_exec_id = ? WHERE id = ?`, gen0, gen0)
+	require.NoError(t, err)
+
+	chain, err := s.GetExecChain(ctx, api.Process{ID: gen0, HostID: "h", PID: 1, PreviousExecID: &gen0})
+	require.NoError(t, err)
+	assert.LessOrEqual(t, len(chain), 64, "cycle must be bounded by maxChainLen")
+}
+
+func BenchmarkGetExecChain(b *testing.B) {
+	for _, depth := range []int{8, 32, 64} {
+		b.Run(fmt.Sprintf("depth=%d", depth), func(b *testing.B) {
+			s := newTestStore(b)
+			ctx := b.Context()
+
+			var prev *int64
+			var lastID int64
+			for i := 0; i < depth; i++ {
+				p := api.Process{HostID: "h", PID: 1, ForkTimeNs: int64(100 + i)}
+				if prev != nil {
+					p.PreviousExecID = prev
+				}
+				id, err := s.InsertProcess(ctx, p)
+				require.NoError(b, err)
+				lastID = id
+				prev = &lastID
+			}
+			current := api.Process{ID: lastID, HostID: "h", PID: 1, ForkTimeNs: int64(100 + depth - 1), PreviousExecID: prev}
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_, err := s.GetExecChain(ctx, current)
+				if err != nil {
+					b.Fatalf("get exec chain: %v", err)
+				}
+			}
+		})
+	}
+}

--- a/server/detection/internal/mysql/processes.go
+++ b/server/detection/internal/mysql/processes.go
@@ -202,10 +202,14 @@ func (s *Store) ReExec(
 //
 // Issue #94: prior shape was N sequential round-trips (one per chain
 // link, capped at 64). The recursive CTE collapses that into one
-// query. The depth column inside the CTE serves as a belt-and-
-// suspenders cycle guard; the schema invariant is that
-// previous_exec_id is strictly decreasing, but a corrupt FK shouldn't
-// be able to lock up the query either.
+// query. The depth column inside the CTE serves two purposes: a
+// belt-and-suspenders cycle guard (in case of a corrupt FK), and the
+// ordering key for the result. The anchor row sits at depth=0 and
+// each recursion step adds one, so depth tracks structural distance
+// back from `current.PreviousExecID`. ORDER BY depth DESC therefore
+// yields oldest-first — independent of fork_time_ns, which can tie or
+// drift across agents (per Gemini Code Assist + Copilot review on
+// PR #110).
 //
 // The SELECT is scoped by host_id as well as id so a corrupted
 // previous_exec_id value can never surface a row from a different
@@ -238,10 +242,10 @@ func (s *Store) GetExecChain(ctx context.Context, current api.Process) ([]api.Pr
 		       fork_time_ns, fork_ingested_at_ns, exec_time_ns, exit_time_ns,
 		       exit_ingested_at_ns, exit_reason, exit_code, previous_exec_id
 		FROM chain
-		ORDER BY fork_time_ns`,
+		ORDER BY depth DESC`,
 		*current.PreviousExecID, current.HostID, maxChainLen-1,
 	)
-	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+	if err != nil {
 		return nil, fmt.Errorf("walk exec chain at id=%d: %w", *current.PreviousExecID, err)
 	}
 	return chain, nil

--- a/server/detection/internal/mysql/processes.go
+++ b/server/detection/internal/mysql/processes.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"slices"
 
 	"github.com/fleetdm/edr/server/detection/api"
 )
@@ -201,30 +200,50 @@ func (s *Store) ReExec(
 // row). For a non-re-exec process the result is an empty slice.
 // Bounded to maxChainLen rows to stop a cycle.
 //
+// Issue #94: prior shape was N sequential round-trips (one per chain
+// link, capped at 64). The recursive CTE collapses that into one
+// query. The depth column inside the CTE serves as a belt-and-
+// suspenders cycle guard; the schema invariant is that
+// previous_exec_id is strictly decreasing, but a corrupt FK shouldn't
+// be able to lock up the query either.
+//
 // The SELECT is scoped by host_id as well as id so a corrupted
 // previous_exec_id value can never surface a row from a different
-// host (defense-in-depth).
+// host (defense-in-depth, preserved from the prior implementation).
 func (s *Store) GetExecChain(ctx context.Context, current api.Process) ([]api.Process, error) {
 	const maxChainLen = 64
+	if current.PreviousExecID == nil {
+		return nil, nil
+	}
 	var chain []api.Process
-	prevID := current.PreviousExecID
-	for depth := 0; prevID != nil && depth < maxChainLen; depth++ {
-		var p api.Process
-		err := s.db.GetContext(ctx, &p, `
+	err := s.db.SelectContext(ctx, &chain, `
+		WITH RECURSIVE chain AS (
 			SELECT id, host_id, pid, ppid, path, args, uid, gid, code_signing, sha256,
 			       fork_time_ns, fork_ingested_at_ns, exec_time_ns, exit_time_ns,
-			       exit_ingested_at_ns, exit_reason, exit_code, previous_exec_id
-			FROM processes WHERE id = ? AND host_id = ?`, *prevID, current.HostID)
-		if errors.Is(err, sql.ErrNoRows) {
-			break
-		}
-		if err != nil {
-			return nil, fmt.Errorf("walk exec chain at id=%d: %w", *prevID, err)
-		}
-		chain = append(chain, p)
-		prevID = p.PreviousExecID
+			       exit_ingested_at_ns, exit_reason, exit_code, previous_exec_id,
+			       0 AS depth
+			FROM processes
+			WHERE id = ? AND host_id = ?
+			UNION ALL
+			SELECT p.id, p.host_id, p.pid, p.ppid, p.path, p.args, p.uid, p.gid,
+			       p.code_signing, p.sha256, p.fork_time_ns, p.fork_ingested_at_ns,
+			       p.exec_time_ns, p.exit_time_ns, p.exit_ingested_at_ns,
+			       p.exit_reason, p.exit_code, p.previous_exec_id,
+			       c.depth + 1
+			FROM processes p
+			JOIN chain c ON p.id = c.previous_exec_id AND p.host_id = c.host_id
+			WHERE c.depth < ?
+		)
+		SELECT id, host_id, pid, ppid, path, args, uid, gid, code_signing, sha256,
+		       fork_time_ns, fork_ingested_at_ns, exec_time_ns, exit_time_ns,
+		       exit_ingested_at_ns, exit_reason, exit_code, previous_exec_id
+		FROM chain
+		ORDER BY fork_time_ns`,
+		*current.PreviousExecID, current.HostID, maxChainLen-1,
+	)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return nil, fmt.Errorf("walk exec chain at id=%d: %w", *current.PreviousExecID, err)
 	}
-	slices.Reverse(chain)
 	return chain, nil
 }
 
@@ -334,16 +353,23 @@ func (s *Store) GetChildProcesses(ctx context.Context, hostID string, ppid int, 
 // events attributed to the given PID within a time range. Filtered
 // on ingested_at_ns (server-stamped) rather than timestamp_ns
 // because ES and NE clocks drift (issue #7).
+//
+// The payload_pid predicate is index-backed by
+// idx_events_host_type_pid_ingested (issue #92): the prior
+// JSON_EXTRACT predicate forced a full scan of the events table.
+// payload_pid is a STORED generated column; the index entry is
+// populated on insert so this query is a range scan, not a JSON
+// reparse, regardless of how many rows live in events.
 func (s *Store) GetNetworkEventsForProcess(ctx context.Context, hostID string, pid int, tr api.TimeRange) ([]api.Event, error) {
 	var events []api.Event
 	err := s.db.SelectContext(ctx, &events, `
 		SELECT event_id, host_id, timestamp_ns, ingested_at_ns, event_type, payload
 		FROM events
 		WHERE host_id = ? AND event_type IN ('network_connect', 'dns_query')
+		  AND payload_pid = ?
 		  AND ingested_at_ns >= ? AND ingested_at_ns <= ?
-		  AND JSON_EXTRACT(payload, '$.pid') = ?
 		ORDER BY timestamp_ns`,
-		hostID, tr.FromNs, tr.ToNs, pid,
+		hostID, pid, tr.FromNs, tr.ToNs,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("query network events: %w", err)

--- a/server/detection/internal/mysql/store_test.go
+++ b/server/detection/internal/mysql/store_test.go
@@ -23,14 +23,14 @@ import (
 // Accepts testing.TB so the same fixture works for benchmarks (see
 // perf_test.go); *testing.T and *testing.B both satisfy the
 // interface.
-func newTestStore(t testing.TB) *mysql.Store {
-	t.Helper()
-	db := testdb.Open(t)
-	ctx := t.Context()
-	require.NoError(t, testkit.ApplySchema(ctx, db))
-	require.NoError(t, testkit.MigrateSchema(ctx, db))
+func newTestStore(tb testing.TB) *mysql.Store {
+	tb.Helper()
+	db := testdb.Open(tb)
+	ctx := tb.Context()
+	require.NoError(tb, testkit.ApplySchema(ctx, db))
+	require.NoError(tb, testkit.MigrateSchema(ctx, db))
 	s, err := mysql.New(db)
-	require.NoError(t, err)
+	require.NoError(tb, err)
 	return s
 }
 

--- a/server/detection/internal/mysql/store_test.go
+++ b/server/detection/internal/mysql/store_test.go
@@ -19,7 +19,11 @@ import (
 // package mysql_test so the testdb import (which transitively pulls
 // in detection/bootstrap) doesn't create a cycle with the production
 // detection/internal/mysql package.
-func newTestStore(t *testing.T) *mysql.Store {
+//
+// Accepts testing.TB so the same fixture works for benchmarks (see
+// perf_test.go); *testing.T and *testing.B both satisfy the
+// interface.
+func newTestStore(t testing.TB) *mysql.Store {
 	t.Helper()
 	db := testdb.Open(t)
 	ctx := t.Context()

--- a/server/testdb/open.go
+++ b/server/testdb/open.go
@@ -32,10 +32,10 @@ import (
 // bootstrap, which lets per-package unit tests inside a context's
 // internal/ tree use Open without an import cycle (the cycle would
 // otherwise go: pkg → testdb → ctx/bootstrap → pkg).
-func Open(t testing.TB) *sqlx.DB {
-	t.Helper()
+func Open(tb testing.TB) *sqlx.DB {
+	tb.Helper()
 
-	dsn := testDSN(t)
+	dsn := testDSN(tb)
 
 	// Parse the DSN once and fail fast if it's malformed. Returning
 	// the original DSN on parse error would silently strip our
@@ -44,24 +44,24 @@ func Open(t testing.TB) *sqlx.DB {
 	// shared dev DB.
 	baseDSN, err := stripDBName(dsn)
 	if err != nil {
-		t.Fatalf("parse EDR_TEST_DSN: %v", err)
+		tb.Fatalf("parse EDR_TEST_DSN: %v", err)
 	}
 	adminDB, err := sqlx.Open("mysql", baseDSN)
 	if err != nil {
-		t.Fatalf("open admin connection: %v", err)
+		tb.Fatalf("open admin connection: %v", err)
 	}
 	defer adminDB.Close()
 
-	dbName := sanitizeDBName(t.Name())
-	ctx := t.Context()
+	dbName := sanitizeDBName(tb.Name())
+	ctx := tb.Context()
 
 	if _, err := adminDB.ExecContext(ctx, fmt.Sprintf("DROP DATABASE IF EXISTS `%s`", dbName)); err != nil {
-		t.Fatalf("drop test db: %v", err)
+		tb.Fatalf("drop test db: %v", err)
 	}
 	if _, err := adminDB.ExecContext(ctx, fmt.Sprintf("CREATE DATABASE `%s`", dbName)); err != nil {
-		t.Fatalf("create test db: %v", err)
+		tb.Fatalf("create test db: %v", err)
 	}
-	t.Cleanup(func() {
+	tb.Cleanup(func() {
 		cleanupDB, err := sqlx.Open("mysql", baseDSN)
 		if err != nil {
 			return
@@ -72,22 +72,22 @@ func Open(t testing.TB) *sqlx.DB {
 
 	perTestDSN, err := replaceDBName(dsn, dbName)
 	if err != nil {
-		t.Fatalf("replace DSN db name: %v", err)
+		tb.Fatalf("replace DSN db name: %v", err)
 	}
 	db, err := bootstrap.OpenDB(ctx, perTestDSN)
 	if err != nil {
-		t.Fatalf("open test db: %v", err)
+		tb.Fatalf("open test db: %v", err)
 	}
 
-	t.Cleanup(func() { _ = db.Close() })
+	tb.Cleanup(func() { _ = db.Close() })
 	return db
 }
 
-func testDSN(t testing.TB) string {
-	t.Helper()
+func testDSN(tb testing.TB) string {
+	tb.Helper()
 	dsn := os.Getenv("EDR_TEST_DSN")
 	if dsn == "" {
-		t.Skip("EDR_TEST_DSN not set; skipping MySQL tests")
+		tb.Skip("EDR_TEST_DSN not set; skipping MySQL tests")
 	}
 	return dsn
 }

--- a/server/testdb/open.go
+++ b/server/testdb/open.go
@@ -32,7 +32,7 @@ import (
 // bootstrap, which lets per-package unit tests inside a context's
 // internal/ tree use Open without an import cycle (the cycle would
 // otherwise go: pkg → testdb → ctx/bootstrap → pkg).
-func Open(t *testing.T) *sqlx.DB {
+func Open(t testing.TB) *sqlx.DB {
 	t.Helper()
 
 	dsn := testDSN(t)
@@ -83,7 +83,7 @@ func Open(t *testing.T) *sqlx.DB {
 	return db
 }
 
-func testDSN(t *testing.T) string {
+func testDSN(t testing.TB) string {
 	t.Helper()
 	dsn := os.Getenv("EDR_TEST_DSN")
 	if dsn == "" {


### PR DESCRIPTION
Four related performance improvements in server/detection/internal/mysql/, all surfaced by Gemini Code Assist on PR #90:

#91 (HIGH) hosts.go UpsertHosts: per-host INSERT loop replaced by a single multi-row INSERT ... ON DUPLICATE KEY UPDATE. N round-trips inside the ingest hot path collapse to one regardless of distinct-host count.

#92 (HIGH) processes.go GetNetworkEventsForProcess: JSON_EXTRACT predicate (forces full scan of events) replaced by a STORED generated column payload_pid backed by idx_events_host_type_pid_ingested. The new test asserts EXPLAIN reports the new composite index. Schema added in detection/bootstrap (CREATE TABLE for fresh installs + idempotent ALTER for existing DBs via the IgnoreErrors pattern).

#93 (MED) alerts.go InsertAlert + attachEventsToExistingAlert: per-event INSERT loops replaced by a single multi-row INSERT (and INSERT IGNORE for the dedup path). Chunked at 500 rows/statement so a future noisy detection that links thousands of events doesn't breach max_allowed_packet.

#94 (MED) processes.go GetExecChain: 64-step backward walk replaced by a WITH RECURSIVE CTE. Single round-trip; depth column inside the CTE provides belt-and-suspenders cycle protection alongside the schema's strictly-decreasing previous_exec_id invariant. Returns chain oldest-first directly (slices.Reverse no longer needed).

Microbenchmarks in perf_test.go validate the linear-with-N drop the issues' acceptance criteria call for: BenchmarkInsertAlert grows ~5.5x between 10 and 1000 events linked (was 100x); BenchmarkGetExecChain is near-flat across depths 8/32/64.

testdb.Open widened from *testing.T to testing.TB so benchmarks share the same per-test-isolated DB fixture; every method used (Helper, Fatalf, Name, Cleanup, Context) is on TB.