### PR TITLE
#86 phase 1: schema + storage primitives for host-token rotation

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -283,12 +283,19 @@ tasks:
       service (MYSQL_ALLOW_EMPTY_PASSWORD=yes); a `root:toor@...` DSN will fail with
       access-denied. OTel exporter targets the local signoz-otel-collector on 4317; if
       no collector is running, exporter init logs warnings and request handling continues.
+
+      Host-token rotation defaults (issue #86): EDR_HOST_TOKEN_LIFETIME 24h,
+      EDR_HOST_TOKEN_GRACE 5m. Override either to a short value (e.g.
+      EDR_HOST_TOKEN_LIFETIME=30s) when QA-ing the rotation flow against a real VM agent
+      so you can observe a rotation cycle inside one minute rather than next-day.
     env:
       EDR_DSN: "root:@tcp(127.0.0.1:3316)/edr?parseTime=true"
       EDR_ENROLL_SECRET: dev-enroll-secret
       EDR_ALLOW_INSECURE_HTTP: "1"
       EDR_LISTEN_ADDR: "0.0.0.0:8088"
       EDR_LOG_FORMAT: text
+      EDR_HOST_TOKEN_LIFETIME: 24h
+      EDR_HOST_TOKEN_GRACE: 5m
       OTEL_EXPORTER_OTLP_ENDPOINT: http://127.0.0.1:4317
       OTEL_EXPORTER_OTLP_PROTOCOL: grpc
       OTEL_EXPORTER_OTLP_INSECURE: "true"

--- a/agent/cmd/fleet-edr-agent/main.go
+++ b/agent/cmd/fleet-edr-agent/main.go
@@ -262,12 +262,13 @@ func startCommander(
 		return
 	}
 	cmdr := commander.New(commander.Config{
-		ServerURL:    serverURL,
-		TokenFn:      tokenProvider.Token,
-		OnAuthFail:   tokenProvider.OnUnauthorized,
-		HostID:       hostID,
-		Interval:     5 * time.Second,
-		PolicySender: policySender,
+		ServerURL:     serverURL,
+		TokenFn:       tokenProvider.Token,
+		OnAuthFail:    tokenProvider.OnUnauthorized,
+		RotateTokenFn: tokenProvider.Rotate,
+		HostID:        hostID,
+		Interval:      5 * time.Second,
+		PolicySender:  policySender,
 	}, &http.Client{Transport: transport, Timeout: 10 * time.Second}, logger)
 	go func() {
 		if err := cmdr.Run(ctx); err != nil && ctx.Err() == nil {

--- a/agent/commander/commander.go
+++ b/agent/commander/commander.go
@@ -35,6 +35,12 @@ type Config struct {
 	// command handler; nil means "commander cannot apply policy updates" and the
 	// handler will report the command failed with a clear reason.
 	PolicySender PolicySender
+	// RotateTokenFn applies a rotate_token command's new bearer to the
+	// agent's persisted state (issue #86). Nil means rotate_token is
+	// reported as failed; this is the right behaviour for tests / dry-runs
+	// that don't carry a real enrollment provider. Production wires
+	// enrollment.TokenProvider.Rotate.
+	RotateTokenFn func(ctx context.Context, newToken string) error
 }
 
 // Commander polls the server for pending commands and dispatches them.
@@ -83,6 +89,15 @@ type setBlocklistPayload struct {
 	Version int64    `json:"version"`
 	Paths   []string `json:"paths"`
 	Hashes  []string `json:"hashes"`
+}
+
+// rotateTokenPayload mirrors the JSON the server emits when issuing a
+// rotate_token command (issue #86). The new bearer is in cleartext;
+// transport security is provided by TLS on the host-token-protected
+// command-poll endpoint, so receiving the new token here is no worse
+// than the original enrollment response.
+type rotateTokenPayload struct {
+	NewToken string `json:"new_token"`
 }
 
 type statusUpdate struct {
@@ -158,10 +173,44 @@ func (c *Commander) dispatch(ctx context.Context, cmd command) {
 		c.executeKill(ctx, cmd)
 	case "set_blocklist":
 		c.executeSetBlocklist(ctx, cmd)
+	case "rotate_token":
+		c.executeRotateToken(ctx, cmd)
 	default:
 		if err := c.updateStatus(ctx, cmd.ID, "failed", marshalResult("unknown command type: "+cmd.CommandType)); err != nil {
 			c.logger.ErrorContext(ctx, "commander fail", "cmd_id", cmd.ID, "err", err)
 		}
+	}
+}
+
+// executeRotateToken applies the server-issued new bearer to the agent's
+// persisted state, then acks the command. Ordering is load-bearing: the
+// ack PUT must happen AFTER the rotate succeeds, because the ack itself
+// is bearer-authenticated and the server has already pre-flipped its
+// active token to the new value (the old token only verifies during
+// the grace window). Acking with the old token still works for ~5
+// minutes; acking with the new token works indefinitely. So the
+// natural order -- rotate first, ack second -- is correct.
+func (c *Commander) executeRotateToken(ctx context.Context, cmd command) {
+	var payload rotateTokenPayload
+	if err := json.Unmarshal(cmd.Payload, &payload); err != nil {
+		_ = c.updateStatus(ctx, cmd.ID, "failed", marshalResult("invalid payload: "+err.Error()))
+		return
+	}
+	if payload.NewToken == "" {
+		_ = c.updateStatus(ctx, cmd.ID, "failed", marshalResult("payload missing new_token"))
+		return
+	}
+	if c.cfg.RotateTokenFn == nil {
+		_ = c.updateStatus(ctx, cmd.ID, "failed", marshalResult("rotate not configured"))
+		return
+	}
+	if err := c.cfg.RotateTokenFn(ctx, payload.NewToken); err != nil {
+		_ = c.updateStatus(ctx, cmd.ID, "failed", marshalResult("apply rotate: "+err.Error()))
+		return
+	}
+	c.logger.InfoContext(ctx, "commander rotate_token applied", "cmd_id", cmd.ID)
+	if err := c.updateStatus(ctx, cmd.ID, "completed", nil); err != nil {
+		c.logger.ErrorContext(ctx, "commander report rotate_token success", "cmd_id", cmd.ID, "err", err)
 	}
 }
 

--- a/agent/commander/rotate_test.go
+++ b/agent/commander/rotate_test.go
@@ -1,0 +1,190 @@
+package commander
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// rotateServerState models the minimal subset of the command-poll +
+// status-update server endpoints the commander hits for a rotate_token
+// dispatch: GET /api/commands once (returning the pending rotate_token
+// command) then PUT /api/commands/{id} twice (acked + completed). The
+// fields capture the status sequence so tests can assert "the
+// commander acked then completed" without diving into the HTTP shape.
+type rotateServerState struct {
+	mu             sync.Mutex
+	commandPolled  atomic.Int64
+	statusSequence []string
+	cmd            command
+}
+
+func newRotateServer(t *testing.T, cmd command) (*httptest.Server, *rotateServerState) {
+	t.Helper()
+	state := &rotateServerState{cmd: cmd}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/commands":
+			n := state.commandPolled.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			if n > 1 {
+				_, _ = w.Write([]byte("[]"))
+				return
+			}
+			_ = json.NewEncoder(w).Encode([]command{state.cmd})
+		case r.Method == http.MethodPut:
+			body, _ := io.ReadAll(r.Body)
+			var update statusUpdate
+			_ = json.Unmarshal(body, &update)
+			state.mu.Lock()
+			state.statusSequence = append(state.statusSequence, update.Status)
+			state.mu.Unlock()
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv, state
+}
+
+// Happy path: a pending rotate_token command produces (acked, completed)
+// status sequence and the RotateTokenFn closure receives the new token.
+func TestExecuteRotateToken_HappyPath(t *testing.T) {
+	const newToken = "rotated-token-43-chars-base64url-aaaaaaaaa"
+	cmd := command{
+		ID:          77,
+		HostID:      "host-1",
+		CommandType: "rotate_token",
+		Payload:     json.RawMessage(`{"new_token":"` + newToken + `"}`),
+		Status:      "pending",
+	}
+	srv, state := newRotateServer(t, cmd)
+
+	var got string
+	cmdr := New(Config{
+		ServerURL: srv.URL,
+		HostID:    "host-1",
+		RotateTokenFn: func(_ context.Context, tok string) error {
+			got = tok
+			return nil
+		},
+	}, nil, nil)
+
+	cmdr.pollAndDispatch(t.Context())
+
+	assert.Equal(t, newToken, got, "RotateTokenFn must receive the payload's new_token")
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	assert.Equal(t, []string{"acked", "completed"}, state.statusSequence,
+		"rotate_token must surface as acked then completed")
+}
+
+// A malformed payload (missing new_token) reports the command failed
+// without invoking RotateTokenFn. Defensive; a server that ships an
+// empty payload is broken, and the agent must not silently accept a
+// blank bearer.
+func TestExecuteRotateToken_PayloadValidation(t *testing.T) {
+	cases := []struct {
+		name    string
+		payload string
+		wantErr string
+	}{
+		{"missing field", `{}`, "payload missing new_token"},
+		{"empty string", `{"new_token":""}`, "payload missing new_token"},
+		{"wrong type for new_token", `{"new_token":123}`, "invalid payload"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := command{
+				ID:          1,
+				HostID:      "host-1",
+				CommandType: "rotate_token",
+				Payload:     json.RawMessage(tc.payload),
+				Status:      "pending",
+			}
+			srv, state := newRotateServer(t, cmd)
+
+			rotateCalled := false
+			cmdr := New(Config{
+				ServerURL: srv.URL,
+				HostID:    "host-1",
+				RotateTokenFn: func(context.Context, string) error {
+					rotateCalled = true
+					return nil
+				},
+			}, nil, nil)
+
+			cmdr.pollAndDispatch(t.Context())
+
+			assert.False(t, rotateCalled, "RotateTokenFn must not run with a malformed payload")
+			state.mu.Lock()
+			defer state.mu.Unlock()
+			require.Len(t, state.statusSequence, 2)
+			assert.Equal(t, "acked", state.statusSequence[0])
+			assert.Equal(t, "failed", state.statusSequence[1])
+		})
+	}
+}
+
+// A nil RotateTokenFn surfaces as a "rotate not configured" failure, not
+// a panic. Production wires enrollment.TokenProvider.Rotate; tests /
+// dry-runs that don't carry a real provider must still receive a clean
+// failure response.
+func TestExecuteRotateToken_NilFn(t *testing.T) {
+	cmd := command{
+		ID:          1,
+		HostID:      "host-1",
+		CommandType: "rotate_token",
+		Payload:     json.RawMessage(`{"new_token":"x"}`),
+		Status:      "pending",
+	}
+	srv, state := newRotateServer(t, cmd)
+
+	cmdr := New(Config{ServerURL: srv.URL, HostID: "host-1"}, nil, nil)
+	cmdr.pollAndDispatch(t.Context())
+
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	require.Len(t, state.statusSequence, 2)
+	assert.Equal(t, "failed", state.statusSequence[1])
+}
+
+// RotateTokenFn returning an error (e.g. on-disk write failure) must
+// surface as a "failed" status update, not as a silent success that
+// claims the rotation applied when in fact it did not. This is the
+// integrity property the audit trail relies on.
+func TestExecuteRotateToken_FnError(t *testing.T) {
+	cmd := command{
+		ID:          1,
+		HostID:      "host-1",
+		CommandType: "rotate_token",
+		Payload:     json.RawMessage(`{"new_token":"x"}`),
+		Status:      "pending",
+	}
+	srv, state := newRotateServer(t, cmd)
+
+	cmdr := New(Config{
+		ServerURL: srv.URL,
+		HostID:    "host-1",
+		RotateTokenFn: func(context.Context, string) error {
+			return errors.New("simulated disk full")
+		},
+	}, nil, nil)
+	cmdr.pollAndDispatch(t.Context())
+
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	require.Len(t, state.statusSequence, 2)
+	assert.Equal(t, "failed", state.statusSequence[1])
+}

--- a/agent/enrollment/enrollment.go
+++ b/agent/enrollment/enrollment.go
@@ -50,11 +50,15 @@ type Persisted struct {
 }
 
 // TokenProvider returns the current host token. Callers call Token() on every request and
-// OnUnauthorized() when they see an HTTP 401 from the server.
+// OnUnauthorized() when they see an HTTP 401 from the server. Rotate replaces the
+// in-memory + on-disk token atomically; the commander's rotate_token dispatch (issue #86)
+// is the only caller in production. A nil error means subsequent Token() calls observe
+// the new value, even if the agent crashes mid-write (writePersisted is atomic-via-rename).
 type TokenProvider interface {
 	Token() string
 	HostID() string
 	OnUnauthorized(ctx context.Context)
+	Rotate(ctx context.Context, newToken string) error
 }
 
 // Options bundle the inputs to Ensure. Populate from agent/config and env.
@@ -161,6 +165,33 @@ func (p *provider) HostID() string {
 		return ""
 	}
 	return s.p.HostID
+}
+
+// Rotate replaces the persisted bearer token with newToken atomically (write to a temp
+// file + rename). Subsequent Token() calls return the new value. The provider's same
+// reenrollMu serialises Rotate against any concurrent re-enroll so a 401-driven re-enroll
+// and a server-driven rotate cannot interleave their writes. Returns an error when
+// newToken is empty (a programmer error, surfaced loudly), when there is no persisted
+// state to rotate from (the agent never enrolled), or when the on-disk write fails.
+func (p *provider) Rotate(ctx context.Context, newToken string) error {
+	if newToken == "" {
+		return errors.New("enrollment.Rotate: empty token")
+	}
+	p.reenrollMu.Lock()
+	defer p.reenrollMu.Unlock()
+
+	cur := p.state.Load()
+	if cur == nil || cur.p == nil {
+		return errors.New("enrollment.Rotate: no persisted state to rotate from")
+	}
+	next := *cur.p
+	next.HostToken = newToken
+	if err := writePersisted(p.opts.TokenFile, &next); err != nil {
+		return fmt.Errorf("persist rotated token: %w", err)
+	}
+	p.state.Store(&persistedState{p: &next})
+	p.logger.InfoContext(ctx, "agent token rotated", "edr.host_id", next.HostID)
+	return nil
 }
 
 // OnUnauthorized is called by the uploader/commander when the server returns 401. We throttle

--- a/agent/enrollment/rotate_test.go
+++ b/agent/enrollment/rotate_test.go
@@ -1,0 +1,95 @@
+package enrollment
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// rotateTestServer stands up a minimal /api/enroll responder so the
+// initial enroll succeeds; Rotate is a pure-local op so rotateTestServer
+// is only consulted on the very first Ensure.
+func rotateTestServer(t *testing.T, hostID string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"host_id":"` + hostID + `","host_token":"original-token","enrolled_at":"2026-05-03T18:00:00Z"}`))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func newTestProvider(t *testing.T) (TokenProvider, string) {
+	t.Helper()
+	srv := rotateTestServer(t, "host-1")
+	tokenFile := filepath.Join(t.TempDir(), "enrolled.plist")
+	tp, err := Ensure(t.Context(), Options{
+		ServerURL:      srv.URL,
+		EnrollSecret:   "s",
+		TokenFile:      tokenFile,
+		AllowInsecure:  true,
+		HostIDOverride: "host-1",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "original-token", tp.Token())
+	return tp, tokenFile
+}
+
+// Happy path: Rotate replaces the in-memory + on-disk token, the next
+// Token() returns the new value, and the on-disk plist parses back to
+// the same shape (so a subsequent agent restart loads the rotated
+// token rather than the original).
+func TestRotate_HappyPath(t *testing.T) {
+	tp, tokenFile := newTestProvider(t)
+	const newTok = "rotated-token-43-chars-base64url-aaaaaaaaa"
+
+	require.NoError(t, tp.Rotate(t.Context(), newTok))
+	assert.Equal(t, newTok, tp.Token(), "in-memory token must reflect the rotation")
+
+	// Reload from disk: the persisted plist must carry the rotated token.
+	loaded, err := loadPersisted(tokenFile)
+	require.NoError(t, err)
+	assert.Equal(t, newTok, loaded.HostToken)
+	assert.Equal(t, "host-1", loaded.HostID, "rotation must not change host_id")
+}
+
+// Empty newToken is a programmer error; Rotate fails fast and leaves
+// the existing token in place. The on-disk file is also untouched.
+func TestRotate_EmptyTokenRejected(t *testing.T) {
+	tp, tokenFile := newTestProvider(t)
+	pre, err := loadPersisted(tokenFile)
+	require.NoError(t, err)
+
+	require.Error(t, tp.Rotate(t.Context(), ""))
+	assert.Equal(t, "original-token", tp.Token(), "in-memory token must be unchanged after a rejected rotate")
+	post, err := loadPersisted(tokenFile)
+	require.NoError(t, err)
+	assert.Equal(t, pre.HostToken, post.HostToken, "on-disk token must be unchanged after a rejected rotate")
+}
+
+// Rotate against a provider with no persisted state (e.g., a panic
+// path that constructed a provider without Ensure) must surface as an
+// error rather than a nil-pointer panic at write time.
+func TestRotate_NoStateRejected(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	p := &provider{opts: Options{Logger: logger}, logger: logger}
+	require.Error(t, p.Rotate(context.Background(), "anything"))
+}
+
+// File mode is preserved across rotations: the post-rotate plist is
+// 0600, matching the post-enroll write.
+func TestRotate_FileModePreserved(t *testing.T) {
+	tp, tokenFile := newTestProvider(t)
+	require.NoError(t, tp.Rotate(t.Context(), "next-token-43-chars-padding-aaaaaaaaaaaa"))
+	st, err := os.Stat(tokenFile)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), st.Mode().Perm())
+}

--- a/server/cmd/fleet-edr-server/main.go
+++ b/server/cmd/fleet-edr-server/main.go
@@ -294,6 +294,8 @@ func openEndpoint(
 		PolicyProvider:      policySvc,
 		CommandInserter:     cmdInserter,
 		Audit:               identityCtx.AuditRecorder(),
+		HostTokenLifetime:   cfg.HostTokenLifetime,
+		HostTokenGrace:      cfg.HostTokenGrace,
 	})
 	if err != nil {
 		logger.ErrorContext(ctx, "open endpoint", "err", err)
@@ -402,7 +404,7 @@ func registerSessionRoutes(mux *http.ServeMux, d muxDeps) {
 		"GET /api/hosts", "GET /api/hosts/{host_id}/tree", "GET /api/hosts/{host_id}/processes/{pid}",
 		"GET /api/alerts", "GET /api/alerts/{id}", "PUT /api/alerts/{id}",
 		"GET /api/commands/{id}", "POST /api/commands",
-		"GET /api/enrollments", "POST /api/enrollments/{host_id}/revoke",
+		"GET /api/enrollments", "POST /api/enrollments/{host_id}/revoke", "POST /api/enrollments/{host_id}/rotate",
 		"GET /api/policy", "PUT /api/policy",
 		"GET /api/attack-coverage",
 		"GET /api/rules",

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -172,9 +172,22 @@ func loadFrom(getenv func(string) string) (*Config, error) {
 	envparse.PositiveDuration(getenv, "EDR_STALE_PROCESS_INTERVAL", &c.StaleProcessInterval, &errs)
 	// #86 host-token rotation. Both must be positive; "disable rotation"
 	// is not a supported deployment mode (a never-rotating bearer token
-	// is the very thing this feature exists to fix).
+	// is the very thing this feature exists to fix). Grace must be
+	// strictly shorter than lifetime: with grace >= lifetime, two
+	// consecutive rotations would leave THREE valid tokens at once
+	// (current + previous still in grace + previous-previous's grace
+	// window stretching past the next rotation), which the
+	// previous_token_* schema columns can't represent. Verify-time
+	// rotation would happily overwrite the in-flight grace, leaving an
+	// agent with a token the server has discarded but whose grace had
+	// not yet expired. Reject the misconfiguration at boot.
 	envparse.PositiveDuration(getenv, "EDR_HOST_TOKEN_LIFETIME", &c.HostTokenLifetime, &errs)
 	envparse.PositiveDuration(getenv, "EDR_HOST_TOKEN_GRACE", &c.HostTokenGrace, &errs)
+	if c.HostTokenLifetime > 0 && c.HostTokenGrace > 0 && c.HostTokenGrace >= c.HostTokenLifetime {
+		errs = append(errs, fmt.Errorf(
+			"EDR_HOST_TOKEN_GRACE (%s) must be strictly shorter than EDR_HOST_TOKEN_LIFETIME (%s)",
+			c.HostTokenGrace, c.HostTokenLifetime))
+	}
 
 	if allowlist := envparse.Allowlist(getenv("EDR_LAUNCHAGENT_ALLOWLIST")); allowlist != nil {
 		c.LaunchAgentAllowlist = allowlist

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -84,6 +84,18 @@ type Config struct {
 	// servers where interactive SSH is unusual — the rule's "non-shell
 	// -> shell -> /tmp/" shape is then a clean attacker indicator.
 	SuspiciousExecParentAllowlist map[string]struct{}
+
+	// HostTokenLifetime is the maximum age of an agent's bearer token
+	// before the verify path triggers an automatic rotation (issue #86).
+	// Populated from EDR_HOST_TOKEN_LIFETIME. Default 24h: short enough
+	// that an exfiltrated token has bounded value, long enough that the
+	// per-host rotation traffic is negligible.
+	HostTokenLifetime time.Duration
+	// HostTokenGrace is the window during which a just-rotated previous
+	// token still verifies. Populated from EDR_HOST_TOKEN_GRACE.
+	// Default 5m: comfortably wider than an agent's poll interval so an
+	// in-flight request doesn't 401 mid-cycle.
+	HostTokenGrace time.Duration
 }
 
 // TLSEnabled reports whether TLS cert and key are both set.
@@ -105,6 +117,8 @@ func defaults() Config {
 		RetentionInterval:    time.Hour,
 		StaleProcessTTL:      6 * time.Hour,
 		StaleProcessInterval: 10 * time.Minute,
+		HostTokenLifetime:    24 * time.Hour,
+		HostTokenGrace:       5 * time.Minute,
 	}
 }
 
@@ -156,6 +170,11 @@ func loadFrom(getenv func(string) string) (*Config, error) {
 	// Phase 7 / issue #6: stale-process TTL. 0 disables the reconciler.
 	envparse.NonNegativeDuration(getenv, "EDR_STALE_PROCESS_TTL", &c.StaleProcessTTL, &errs)
 	envparse.PositiveDuration(getenv, "EDR_STALE_PROCESS_INTERVAL", &c.StaleProcessInterval, &errs)
+	// #86 host-token rotation. Both must be positive; "disable rotation"
+	// is not a supported deployment mode (a never-rotating bearer token
+	// is the very thing this feature exists to fix).
+	envparse.PositiveDuration(getenv, "EDR_HOST_TOKEN_LIFETIME", &c.HostTokenLifetime, &errs)
+	envparse.PositiveDuration(getenv, "EDR_HOST_TOKEN_GRACE", &c.HostTokenGrace, &errs)
 
 	if allowlist := envparse.Allowlist(getenv("EDR_LAUNCHAGENT_ALLOWLIST")); allowlist != nil {
 		c.LaunchAgentAllowlist = allowlist

--- a/server/endpoint/api/service.go
+++ b/server/endpoint/api/service.go
@@ -46,4 +46,18 @@ type Service interface {
 	// Used by admin's policy fan-out today; phase 3 may relocate the
 	// caller into the rules context.
 	ActiveHostIDs(ctx context.Context) ([]string, error)
+
+	// RotateToken atomically issues a fresh bearer token for hostID, moves
+	// the prior token into the grace-window slot (so an in-flight agent
+	// poll doesn't 401 mid-cycle), and queues a rotate_token command that
+	// delivers the new token to the agent on its next poll. Returns
+	// ErrNotFound when the host_id has no enrollment.
+	//
+	// trigger names who initiated the rotation; actor + reason are the
+	// operator-supplied attribution carried into the audit row when
+	// trigger == RotationTriggerOperator (both empty for auto). The raw
+	// new token is intentionally not in the response: the agent gets it
+	// via the rotate_token command, and exposing it via the operator API
+	// would invite copy-paste flows that bypass the command queue.
+	RotateToken(ctx context.Context, hostID string, trigger RotationTrigger, actor, reason string) (RotateResult, error)
 }

--- a/server/endpoint/api/types.go
+++ b/server/endpoint/api/types.go
@@ -49,6 +49,39 @@ type EnrollResponse struct {
 	EnrolledAt time.Time `json:"enrolled_at"`
 }
 
+// RotationTrigger describes who initiated a host-token rotation. Used by
+// the audit row payload so reviewers can distinguish a routine
+// scheduled rotation from a deliberate operator-driven one (incident
+// response, suspected token leak). Stored as a string so adding new
+// triggers (e.g. "scheduler" if a background sweep is added later) is a
+// constant-time addition rather than a wire-shape break.
+type RotationTrigger string
+
+const (
+	// RotationTriggerAuto is the verify-time trigger: an agent presented
+	// a token whose host_token_issued_at + lifetime is in the past.
+	RotationTriggerAuto RotationTrigger = "auto"
+	// RotationTriggerOperator is the explicit operator-driven trigger
+	// from POST /api/enrollments/{host_id}/rotate.
+	RotationTriggerOperator RotationTrigger = "operator"
+)
+
+// RotateResult is the operator-visible outcome of a host-token rotation.
+// The newly minted raw token is intentionally NOT in this struct: the
+// agent receives it via the rotate_token command on its next poll, and
+// surfacing it through the operator API would tempt copy-paste flows
+// that bypass the command queue. PreviousTokenIDPrefix is the hex of
+// the first 4 bytes of the rotated-out host_token_id, included on the
+// operator's UI confirmation + the audit row so a reviewer can pivot
+// from a rotation event to the verify request that triggered it
+// (audit + access-log share the X-Request-ID / trace_id correlation).
+// CommandID is the rotate_token command queued for the agent; useful
+// for an operator who wants to wait until the agent has acked.
+type RotateResult struct {
+	PreviousTokenIDPrefix string `json:"previous_token_id_prefix"`
+	CommandID             int64  `json:"command_id"`
+}
+
 // Errors returned across the api boundary. Callers compare with errors.Is.
 var (
 	// ErrInvalidSecret is returned when the agent's enroll_secret doesn't

--- a/server/endpoint/api/types.go
+++ b/server/endpoint/api/types.go
@@ -75,11 +75,19 @@ const (
 // operator's UI confirmation + the audit row so a reviewer can pivot
 // from a rotation event to the verify request that triggered it
 // (audit + access-log share the X-Request-ID / trace_id correlation).
-// CommandID is the rotate_token command queued for the agent; useful
-// for an operator who wants to wait until the agent has acked.
+//
+// CommandID is the rotate_token command queued for the agent. *int64
+// (not int64) so a rotation that committed in the DB but failed to
+// queue the agent command is observably distinct on the wire: nil ->
+// JSON omits command_id, telling the operator UI "rotation succeeded
+// but the agent will only pick up the new token via re-enroll after
+// the previous-token grace expires." A bare int64 zero would be
+// indistinguishable from a successful queue at id 0 (auto-increment
+// never returns 0, but a JSON consumer can't know that without
+// reading server source).
 type RotateResult struct {
 	PreviousTokenIDPrefix string `json:"previous_token_id_prefix"`
-	CommandID             int64  `json:"command_id"`
+	CommandID             *int64 `json:"command_id,omitempty"`
 }
 
 // Errors returned across the api boundary. Callers compare with errors.Is.

--- a/server/endpoint/bootstrap/bootstrap.go
+++ b/server/endpoint/bootstrap/bootstrap.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"time"
 
 	"github.com/jmoiron/sqlx"
 
@@ -48,9 +49,19 @@ type Deps struct {
 	CommandInserter CommandInserter
 
 	// Audit is the operator-action recorder. Optional: nil disables
-	// audit emission for enrollment.revoke. cmd/main wires
-	// identityCtx.AuditRecorder().
+	// audit emission for enrollment.revoke + enrollment.token_rotated.
+	// cmd/main wires identityCtx.AuditRecorder().
 	Audit identityapi.AuditRecorder
+
+	// HostTokenLifetime is how long a host bearer token may live before
+	// the verify path triggers an auto-rotation. Zero -> service
+	// default (24h). cmd/main reads EDR_HOST_TOKEN_LIFETIME.
+	HostTokenLifetime time.Duration
+	// HostTokenGrace is the window during which the just-superseded
+	// token still verifies after rotation, so an in-flight agent poll
+	// doesn't 401 mid-cycle. Zero -> service default (5m). cmd/main
+	// reads EDR_HOST_TOKEN_GRACE.
+	HostTokenGrace time.Duration
 }
 
 // Endpoint is the handle cmd/main holds for the endpoint bounded
@@ -76,12 +87,13 @@ func New(deps Deps) (*Endpoint, error) {
 	if deps.EnrollSecret == "" {
 		return nil, errors.New("endpoint bootstrap: EnrollSecret is required")
 	}
-	// PolicyProvider + CommandInserter are paired. Letting the mismatch
-	// fall through to service.New's panic would crash startup with no
-	// recoverable error; surface it as a config error instead so the
-	// caller's err-handling sees it.
-	if (deps.PolicyProvider == nil) != (deps.CommandInserter == nil) {
-		return nil, errors.New("endpoint bootstrap: PolicyProvider and CommandInserter must be set together (or both nil)")
+	// Policy without Commands is a config error (policy fan-out has nowhere
+	// to send commands); Commands without Policy is allowed since rotation
+	// uses Commands without consulting Policy. Surface this here as a
+	// recoverable error rather than letting it fall through to service.New's
+	// panic at boot.
+	if deps.PolicyProvider != nil && deps.CommandInserter == nil {
+		return nil, errors.New("endpoint bootstrap: PolicyProvider set but CommandInserter is nil; policy fan-out has nowhere to go")
 	}
 	logger := deps.Logger
 	if logger == nil {
@@ -89,7 +101,16 @@ func New(deps Deps) (*Endpoint, error) {
 	}
 
 	store := mysql.NewStore(deps.DB)
-	svc := service.New(store, deps.EnrollSecret, deps.PolicyProvider, deps.CommandInserter, logger)
+	svc := service.New(service.Options{
+		Store:    store,
+		Secret:   deps.EnrollSecret,
+		Policy:   deps.PolicyProvider,
+		Commands: deps.CommandInserter,
+		Audit:    deps.Audit,
+		Lifetime: deps.HostTokenLifetime,
+		Grace:    deps.HostTokenGrace,
+		Logger:   logger,
+	})
 
 	opH := operator.New(svc, logger)
 	opH.SetAudit(deps.Audit)

--- a/server/endpoint/bootstrap/bootstrap.go
+++ b/server/endpoint/bootstrap/bootstrap.go
@@ -47,7 +47,7 @@ type Deps struct {
 	CommandInserter CommandInserter
 
 	// Audit is the operator-action recorder. Optional: nil disables
-	// audit emission for enrollment.revoke + enrollment.token_rotated.
+	// audit emission for enrollment.revoke + enrollment.rotate_token.
 	// cmd/main wires identityCtx.AuditRecorder().
 	Audit identityapi.AuditRecorder
 

--- a/server/endpoint/bootstrap/bootstrap.go
+++ b/server/endpoint/bootstrap/bootstrap.go
@@ -117,6 +117,11 @@ func (e *Endpoint) ApplySchema(ctx context.Context) error {
 // against the given DB without requiring a fully constructed
 // *Endpoint. Used by server/testdb so tests can apply every context's
 // schema without faking out each bootstrap's service dependencies.
+//
+// Two passes: schemaStatements first (CREATE TABLE IF NOT EXISTS),
+// then schemaMigrations (idempotent ALTERs for upgrade paths).
+// Migration errors that signal "already applied" are swallowed so
+// re-running on a populated DB is a no-op.
 func ApplySchema(ctx context.Context, db *sqlx.DB) error {
 	if db == nil {
 		return errors.New("endpoint ApplySchema: db must not be nil")
@@ -124,6 +129,11 @@ func ApplySchema(ctx context.Context, db *sqlx.DB) error {
 	for _, stmt := range schemaStatements {
 		if _, err := db.ExecContext(ctx, stmt); err != nil {
 			return fmt.Errorf("endpoint schema create: %w", err)
+		}
+	}
+	for _, stmt := range schemaMigrations {
+		if _, err := db.ExecContext(ctx, stmt); err != nil && !isAlreadyAppliedMigration(err) {
+			return fmt.Errorf("endpoint schema migration: %w", err)
 		}
 	}
 	return nil

--- a/server/endpoint/bootstrap/schema.go
+++ b/server/endpoint/bootstrap/schema.go
@@ -1,5 +1,11 @@
 package bootstrap
 
+import (
+	"errors"
+
+	"github.com/go-sql-driver/mysql"
+)
+
 // schemaStatements are the CREATE TABLE statements endpoint owns.
 // Idempotent (IF NOT EXISTS); safe to re-run on a populated DB.
 var schemaStatements = []string{
@@ -10,20 +16,80 @@ var schemaStatements = []string{
 	// one-way, so leaking the column does not let an attacker recover
 	// the token. UNIQUE prevents accidental collisions from two hosts
 	// somehow winning the 2^-256 lottery.
+	//
+	// host_token_issued_at tracks per-token issuance (not per-enrollment).
+	// On enroll it equals enrolled_at; rotation bumps it to NOW() so the
+	// service can decide "this token has lived too long" without keeping
+	// a separate rotation-history row. previous_host_token_* + the
+	// expires_at peer column are the grace-window state: when rotation
+	// flips, the prior (id, hash, salt) is captured here so verify can
+	// fall through to it for a bounded window. Both rotation columns are
+	// NULL outside an active grace window. See #86 for the full rotation
+	// contract.
 	`CREATE TABLE IF NOT EXISTS enrollments (
-		host_id          VARCHAR(255) PRIMARY KEY,
-		host_token_id    VARBINARY(32)  NOT NULL,
-		host_token_hash  VARBINARY(255) NOT NULL,
-		host_token_salt  VARBINARY(32)  NOT NULL,
-		hostname         VARCHAR(255)   NOT NULL,
-		agent_version    VARCHAR(64)    NOT NULL,
-		os_version       VARCHAR(128)   NOT NULL,
-		source_ip        VARCHAR(45)    NOT NULL,
-		enrolled_at      TIMESTAMP(6)   NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
-		expires_at       TIMESTAMP(6)   NULL,
-		revoked_at       TIMESTAMP(6)   NULL,
-		revoke_reason    VARCHAR(128)   NULL,
-		revoked_by       VARCHAR(255)   NULL,
-		UNIQUE KEY uk_enrollments_token_id (host_token_id)
+		host_id                    VARCHAR(255)   PRIMARY KEY,
+		host_token_id              VARBINARY(32)  NOT NULL,
+		host_token_hash            VARBINARY(255) NOT NULL,
+		host_token_salt            VARBINARY(32)  NOT NULL,
+		host_token_issued_at       TIMESTAMP(6)   NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+		previous_host_token_id     VARBINARY(32)  NULL,
+		previous_host_token_hash   VARBINARY(255) NULL,
+		previous_host_token_salt   VARBINARY(32)  NULL,
+		previous_token_expires_at  TIMESTAMP(6)   NULL,
+		hostname                   VARCHAR(255)   NOT NULL,
+		agent_version              VARCHAR(64)    NOT NULL,
+		os_version                 VARCHAR(128)   NOT NULL,
+		source_ip                  VARCHAR(45)    NOT NULL,
+		enrolled_at                TIMESTAMP(6)   NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+		expires_at                 TIMESTAMP(6)   NULL,
+		revoked_at                 TIMESTAMP(6)   NULL,
+		revoke_reason              VARCHAR(128)   NULL,
+		revoked_by                 VARCHAR(255)   NULL,
+		UNIQUE KEY uk_enrollments_token_id (host_token_id),
+		INDEX idx_enrollments_prev_token (previous_host_token_id)
 	)`,
+}
+
+// schemaMigrations are idempotent ALTERs applied after the CREATE TABLEs
+// for upgrading databases that were created before the rotation columns
+// existed. Errors that mean "already applied" (duplicate column,
+// duplicate key) are swallowed by isAlreadyAppliedMigration so re-running
+// on a populated DB is a no-op.
+//
+// On a fresh DB the CREATE TABLE above already includes every column +
+// index this list adds, so every statement here returns "already applied"
+// and the loop is a no-op. The list exists for the upgrade path: an
+// operator running an older binary against the same MySQL gets the
+// rotation columns added in place.
+var schemaMigrations = []string{
+	`ALTER TABLE enrollments ADD COLUMN host_token_issued_at TIMESTAMP(6) NULL`,
+	// Backfill existing rows from enrolled_at so any host older than the
+	// rotation interval is flagged "rotation due" on its next verify, per
+	// #86's deploy contract. Idempotent: WHERE host_token_issued_at IS NULL
+	// excludes rows that already ran through this migration, and excludes
+	// rows born after the column went NOT NULL.
+	`UPDATE enrollments SET host_token_issued_at = enrolled_at WHERE host_token_issued_at IS NULL`,
+	`ALTER TABLE enrollments MODIFY COLUMN host_token_issued_at TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6)`,
+	`ALTER TABLE enrollments ADD COLUMN previous_host_token_id    VARBINARY(32)  NULL`,
+	`ALTER TABLE enrollments ADD COLUMN previous_host_token_hash  VARBINARY(255) NULL`,
+	`ALTER TABLE enrollments ADD COLUMN previous_host_token_salt  VARBINARY(32)  NULL`,
+	`ALTER TABLE enrollments ADD COLUMN previous_token_expires_at TIMESTAMP(6)   NULL`,
+	`ALTER TABLE enrollments ADD INDEX idx_enrollments_prev_token (previous_host_token_id)`,
+}
+
+// isAlreadyAppliedMigration returns true when err is one of the MySQL
+// "this ALTER is already applied" codes, so we can treat the re-run as a
+// no-op. Mirrors identity/bootstrap's helper.
+func isAlreadyAppliedMigration(err error) bool {
+	var mysqlErr *mysql.MySQLError
+	if !errors.As(err, &mysqlErr) {
+		return false
+	}
+	// 1060 duplicate column, 1061 duplicate key name, 1826 duplicate FK name,
+	// 1022 duplicate key on add (older MySQL code for FK name clash).
+	switch mysqlErr.Number {
+	case 1060, 1061, 1826, 1022:
+		return true
+	}
+	return false
 }

--- a/server/endpoint/internal/enroll/handler_test.go
+++ b/server/endpoint/internal/enroll/handler_test.go
@@ -47,6 +47,9 @@ func (f fakeService) CountActive(context.Context) (int, error) {
 func (f fakeService) ActiveHostIDs(context.Context) ([]string, error) {
 	panic("not implemented in fakeService")
 }
+func (f fakeService) RotateToken(context.Context, string, api.RotationTrigger, string, string) (api.RotateResult, error) {
+	panic("not implemented in fakeService")
+}
 
 func newServer(t *testing.T, svc api.Service, ratePerMinute int) *httptest.Server {
 	t.Helper()

--- a/server/endpoint/internal/middleware/hosttoken_test.go
+++ b/server/endpoint/internal/middleware/hosttoken_test.go
@@ -45,6 +45,9 @@ func (f fakeService) CountActive(context.Context) (int, error) {
 func (f fakeService) ActiveHostIDs(context.Context) ([]string, error) {
 	panic("not implemented in fakeService")
 }
+func (f fakeService) RotateToken(context.Context, string, api.RotationTrigger, string, string) (api.RotateResult, error) {
+	panic("not implemented in fakeService")
+}
 
 const testHostID = "93DFC6F5-763D-5075-B305-8AC145D12F96"
 const testToken = "abcdefghijklmnopqrstuvwxyz0123456789012345_"

--- a/server/endpoint/internal/mysql/hash.go
+++ b/server/endpoint/internal/mysql/hash.go
@@ -74,3 +74,10 @@ func verifyToken(token string, wantHash, salt []byte) bool {
 
 // ErrTokenMismatch is returned when a presented token does not match any enrolled host.
 var ErrTokenMismatch = errors.New("enrollment: token mismatch")
+
+// ErrRotateRaced is returned when RotateHostToken's optimistic-lock
+// UPDATE matched zero rows: another rotation for the same host has
+// already swapped the token between the caller's verify and the
+// rotate. Callers map this to a no-op (the other path's rotation
+// already produced a fresh token; nothing for this caller to do).
+var ErrRotateRaced = errors.New("enrollment: rotate raced with another rotation")

--- a/server/endpoint/internal/mysql/rotation_test.go
+++ b/server/endpoint/internal/mysql/rotation_test.go
@@ -1,0 +1,259 @@
+package mysql_test
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fleetdm/edr/server/endpoint/internal/mysql"
+)
+
+// rotationGrace is the grace window the tests use; long enough to cover
+// the test's own setup latency, short enough that the
+// "after-grace-rejection" branch is exercised in milliseconds.
+const rotationGrace = 500 * time.Millisecond
+
+// TestRotateHostToken_HappyPath asserts the contract: a successful
+// rotation returns a fresh raw token + a non-empty previous-token-id
+// prefix; the new token verifies; the old token still verifies during
+// grace; the rotation is recorded as MatchedPrevious=true on a
+// previous-token verify so the service layer's auto-rotate trigger
+// stays idle.
+func TestRotateHostToken_HappyPath(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+
+	reg, err := s.Register(ctx, mysql.RegisterRequest{
+		HostID: testUUID, Hostname: "h", AgentVersion: "v", OSVersion: "o", SourceIP: "127.0.0.1",
+	})
+	require.NoError(t, err)
+
+	// VerifyWithMeta on the freshly-issued token reports the current
+	// token, no previous match, and a fresh issued_at.
+	pre, err := s.VerifyWithMeta(ctx, reg.HostToken)
+	require.NoError(t, err)
+	assert.False(t, pre.MatchedPrevious)
+	assert.NotEmpty(t, pre.CurrentTokenID)
+	assert.WithinDuration(t, time.Now(), pre.TokenIssuedAt, 5*time.Second)
+
+	rot, err := s.RotateHostToken(ctx, testUUID, pre.CurrentTokenID, rotationGrace)
+	require.NoError(t, err)
+	assert.NotEmpty(t, rot.NewToken)
+	assert.NotEqual(t, reg.HostToken, rot.NewToken)
+	assert.Len(t, rot.PreviousTokenIDPrefix, 8) // 4 bytes hex == 8 chars
+
+	// The new token verifies as the current token; rotation is not in
+	// flight from this row's POV (we just committed it).
+	post, err := s.VerifyWithMeta(ctx, rot.NewToken)
+	require.NoError(t, err)
+	assert.Equal(t, testUUID, post.HostID)
+	assert.False(t, post.MatchedPrevious)
+	assert.WithinDuration(t, time.Now(), post.TokenIssuedAt, 2*time.Second,
+		"a freshly rotated token should bump host_token_issued_at to NOW()")
+
+	// The OLD token still verifies during grace, AND surfaces
+	// MatchedPrevious=true so the service layer knows another rotation
+	// is in flight and must not trigger a fresh one.
+	prev, err := s.VerifyWithMeta(ctx, reg.HostToken)
+	require.NoError(t, err)
+	assert.Equal(t, testUUID, prev.HostID)
+	assert.True(t, prev.MatchedPrevious)
+}
+
+// TestRotateHostToken_OldTokenRejectedAfterGrace validates the grace
+// boundary: as soon as previous_token_expires_at is in the past, the
+// old token must stop verifying. Without this, a leaked token would
+// stay valid forever even after rotation.
+func TestRotateHostToken_OldTokenRejectedAfterGrace(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+
+	reg, err := s.Register(ctx, mysql.RegisterRequest{
+		HostID: testUUID, Hostname: "h", AgentVersion: "v", OSVersion: "o", SourceIP: "127.0.0.1",
+	})
+	require.NoError(t, err)
+	pre, err := s.VerifyWithMeta(ctx, reg.HostToken)
+	require.NoError(t, err)
+
+	const tinyGrace = 50 * time.Millisecond
+	_, err = s.RotateHostToken(ctx, testUUID, pre.CurrentTokenID, tinyGrace)
+	require.NoError(t, err)
+
+	// Sleep past the grace boundary; the old token must now be rejected.
+	// Use a comfortable margin so the test doesn't flake on a slow CI
+	// runner.
+	time.Sleep(tinyGrace + 250*time.Millisecond)
+
+	_, err = s.Verify(ctx, reg.HostToken)
+	assert.ErrorIs(t, err, mysql.ErrTokenMismatch,
+		"old token must stop verifying once previous_token_expires_at is in the past")
+}
+
+// TestRotateHostToken_RaceLoses asserts that the optimistic-lock keyed
+// on currentTokenID rejects a stale rotate attempt: if rotation A
+// commits between caller B's VerifyWithMeta and caller B's
+// RotateHostToken, B's UPDATE matches zero rows and B gets
+// ErrRotateRaced. This is the contract the service layer relies on to
+// keep concurrent verifies from double-rotating.
+func TestRotateHostToken_RaceLoses(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+
+	reg, err := s.Register(ctx, mysql.RegisterRequest{
+		HostID: testUUID, Hostname: "h", AgentVersion: "v", OSVersion: "o", SourceIP: "127.0.0.1",
+	})
+	require.NoError(t, err)
+	pre, err := s.VerifyWithMeta(ctx, reg.HostToken)
+	require.NoError(t, err)
+
+	// First rotation succeeds.
+	_, err = s.RotateHostToken(ctx, testUUID, pre.CurrentTokenID, rotationGrace)
+	require.NoError(t, err)
+
+	// A second rotation using the SAME (now stale) currentTokenID must
+	// lose the race.
+	_, err = s.RotateHostToken(ctx, testUUID, pre.CurrentTokenID, rotationGrace)
+	assert.ErrorIs(t, err, mysql.ErrRotateRaced)
+}
+
+// TestRotateHostToken_ConcurrentVerifiesProduceOneRotation throws N
+// goroutines at RotateHostToken with the same currentTokenID. Exactly
+// one must commit; the rest must observe ErrRotateRaced. This is the
+// property the service-level "verify-time auto-rotate" relies on to
+// not produce a flurry of rotations under burst traffic.
+func TestRotateHostToken_ConcurrentVerifiesProduceOneRotation(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+
+	reg, err := s.Register(ctx, mysql.RegisterRequest{
+		HostID: testUUID, Hostname: "h", AgentVersion: "v", OSVersion: "o", SourceIP: "127.0.0.1",
+	})
+	require.NoError(t, err)
+	pre, err := s.VerifyWithMeta(ctx, reg.HostToken)
+	require.NoError(t, err)
+
+	const N = 16
+	var (
+		wg        sync.WaitGroup
+		successes int
+		races     int
+		mu        sync.Mutex
+	)
+	wg.Add(N)
+	for range N {
+		go func() {
+			defer wg.Done()
+			_, err := s.RotateHostToken(ctx, testUUID, pre.CurrentTokenID, rotationGrace)
+			mu.Lock()
+			defer mu.Unlock()
+			switch {
+			case err == nil:
+				successes++
+			case mysql.ErrRotateRaced.Error() == err.Error():
+				races++
+			default:
+				t.Errorf("unexpected error: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+	assert.Equal(t, 1, successes, "exactly one concurrent rotation must commit")
+	assert.Equal(t, N-1, races, "every other concurrent rotation must observe ErrRotateRaced")
+}
+
+// TestRotateHostToken_RejectsRevoked: revoking the enrollment must
+// prevent any further rotation. Otherwise an attacker who has the
+// (revoked) token could nudge the row back into a usable state.
+func TestRotateHostToken_RejectsRevoked(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+
+	reg, err := s.Register(ctx, mysql.RegisterRequest{
+		HostID: testUUID, Hostname: "h", AgentVersion: "v", OSVersion: "o", SourceIP: "127.0.0.1",
+	})
+	require.NoError(t, err)
+	pre, err := s.VerifyWithMeta(ctx, reg.HostToken)
+	require.NoError(t, err)
+
+	require.NoError(t, s.Revoke(ctx, testUUID, "compromised", "jane@example"))
+
+	_, err = s.RotateHostToken(ctx, testUUID, pre.CurrentTokenID, rotationGrace)
+	assert.ErrorIs(t, err, mysql.ErrRotateRaced,
+		"rotation against a revoked enrollment must surface as a race rather than silently bring it back")
+}
+
+// TestRotateHostToken_RejectsBadInputs covers the input-validation
+// contract: empty hostID / empty currentTokenID / non-positive grace
+// are programmer errors, surfaced loudly so they fail at the boundary
+// rather than leaking into the SQL.
+func TestRotateHostToken_RejectsBadInputs(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+
+	cases := []struct {
+		name    string
+		host    string
+		curID   []byte
+		grace   time.Duration
+		wantSub string
+	}{
+		{"empty hostID", "", []byte{1, 2, 3, 4}, time.Second, "hostID is required"},
+		{"empty currentTokenID", testUUID, nil, time.Second, "currentTokenID is required"},
+		{"zero grace", testUUID, []byte{1, 2, 3, 4}, 0, "grace must be > 0"},
+		{"negative grace", testUUID, []byte{1, 2, 3, 4}, -time.Second, "grace must be > 0"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := s.RotateHostToken(ctx, tc.host, tc.curID, tc.grace)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantSub)
+		})
+	}
+}
+
+// TestRotateHostToken_OverwritesPriorPrevious validates the rare double
+// rotation case: if rotation N+1 fires while a previous-token grace
+// from rotation N is still active, the previous slot is overwritten
+// with the just-superseded token. The oldest token (originally enrolled)
+// stops verifying immediately. Acceptable: a host that misses two
+// rotation windows has been offline / unreachable long enough that
+// re-enroll is the right recovery anyway.
+func TestRotateHostToken_OverwritesPriorPrevious(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+
+	reg, err := s.Register(ctx, mysql.RegisterRequest{
+		HostID: testUUID, Hostname: "h", AgentVersion: "v", OSVersion: "o", SourceIP: "127.0.0.1",
+	})
+	require.NoError(t, err)
+	v0, err := s.VerifyWithMeta(ctx, reg.HostToken)
+	require.NoError(t, err)
+
+	// First rotation: original token becomes "previous" in grace.
+	rot1, err := s.RotateHostToken(ctx, testUUID, v0.CurrentTokenID, rotationGrace)
+	require.NoError(t, err)
+	v1, err := s.VerifyWithMeta(ctx, rot1.NewToken)
+	require.NoError(t, err)
+
+	// Second rotation: rot1.NewToken becomes "previous"; the original
+	// reg.HostToken is no longer tracked.
+	rot2, err := s.RotateHostToken(ctx, testUUID, v1.CurrentTokenID, rotationGrace)
+	require.NoError(t, err)
+
+	// The original token: not in current, not in previous; rejected.
+	_, err = s.Verify(ctx, reg.HostToken)
+	require.ErrorIs(t, err, mysql.ErrTokenMismatch)
+
+	// rot1.NewToken: now the previous; verifies during grace.
+	r1, err := s.VerifyWithMeta(ctx, rot1.NewToken)
+	require.NoError(t, err)
+	assert.True(t, r1.MatchedPrevious)
+
+	// rot2.NewToken: current.
+	r2, err := s.VerifyWithMeta(ctx, rot2.NewToken)
+	require.NoError(t, err)
+	assert.False(t, r2.MatchedPrevious)
+}

--- a/server/endpoint/internal/mysql/rotation_test.go
+++ b/server/endpoint/internal/mysql/rotation_test.go
@@ -12,10 +12,14 @@ import (
 	"github.com/fleetdm/edr/server/endpoint/internal/mysql"
 )
 
-// rotationGrace is the grace window the tests use; long enough to cover
-// the test's own setup latency, short enough that the
-// "after-grace-rejection" branch is exercised in milliseconds.
-const rotationGrace = 500 * time.Millisecond
+// rotationGrace is the grace window the tests use for "verify-during-grace"
+// assertions. Sized to comfortably outlast the slowest plausible CI argon2id
+// sequence (5+ verify/rotate cycles at ~1.5s each on a slow GitHub runner)
+// so a test failure here means a real grace-window bug, not an elapsed clock.
+// The "after-grace-rejection" branch uses its own short tinyGrace + sleep
+// in TestRotateHostToken_OldTokenRejectedAfterGrace; that path is still
+// exercised in milliseconds.
+const rotationGrace = 30 * time.Second
 
 // TestRotateHostToken_HappyPath asserts the contract: a successful
 // rotation returns a fresh raw token + a non-empty previous-token-id

--- a/server/endpoint/internal/mysql/rotation_test.go
+++ b/server/endpoint/internal/mysql/rotation_test.go
@@ -1,6 +1,7 @@
 package mysql_test
 
 import (
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -152,7 +153,7 @@ func TestRotateHostToken_ConcurrentVerifiesProduceOneRotation(t *testing.T) {
 			switch {
 			case err == nil:
 				successes++
-			case mysql.ErrRotateRaced.Error() == err.Error():
+			case errors.Is(err, mysql.ErrRotateRaced):
 				races++
 			default:
 				t.Errorf("unexpected error: %v", err)

--- a/server/endpoint/internal/mysql/store.go
+++ b/server/endpoint/internal/mysql/store.go
@@ -310,6 +310,93 @@ func (s *Store) RotateHostToken(ctx context.Context, hostID string, currentToken
 	}, nil
 }
 
+// RotateHostTokenForce is the operator-driven counterpart to
+// RotateHostToken: it commits a rotation regardless of recent
+// rotations, gated only on (host exists AND not revoked). Used by the
+// POST /api/enrollments/{host_id}/rotate handler where the operator's
+// intent is "issue a fresh token NOW," not "rotate only if no other
+// rotation slipped in." Returns ErrNotFound when the host has no
+// non-revoked enrollment.
+//
+// Internally a SELECT FOR UPDATE inside a tx serialises concurrent
+// operator-clicks for the same host so the previous_* slot reflects
+// the most recently superseded token (not whichever one a non-locked
+// UPDATE happened to read mid-flip). The same SET-clause ordering rule
+// applies as RotateHostToken: previous_* assignments must come before
+// the host_* assignments since MySQL evaluates left-to-right.
+func (s *Store) RotateHostTokenForce(ctx context.Context, hostID string, grace time.Duration) (RotateResult, error) {
+	if hostID == "" {
+		return RotateResult{}, errors.New("RotateHostTokenForce: hostID is required")
+	}
+	if grace <= 0 {
+		return RotateResult{}, errors.New("RotateHostTokenForce: grace must be > 0")
+	}
+
+	newToken, err := generateToken()
+	if err != nil {
+		return RotateResult{}, err
+	}
+	newHash, newSalt, err := hashToken(newToken)
+	if err != nil {
+		return RotateResult{}, err
+	}
+	newID := tokenID(newToken)
+	expiresAt := time.Now().UTC().Add(grace)
+
+	tx, err := s.db.BeginTxx(ctx, &sql.TxOptions{})
+	if err != nil {
+		return RotateResult{}, fmt.Errorf("rotate force begin tx: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	var currentID []byte
+	err = tx.GetContext(ctx, &currentID, `
+		SELECT host_token_id FROM enrollments
+		WHERE host_id = ? AND revoked_at IS NULL
+		FOR UPDATE
+	`, hostID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return RotateResult{}, ErrNotFound
+	}
+	if err != nil {
+		return RotateResult{}, fmt.Errorf("rotate force lock: %w", err)
+	}
+
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE enrollments
+		SET previous_host_token_id    = host_token_id,
+		    previous_host_token_hash  = host_token_hash,
+		    previous_host_token_salt  = host_token_salt,
+		    previous_token_expires_at = ?,
+		    host_token_id             = ?,
+		    host_token_hash           = ?,
+		    host_token_salt           = ?,
+		    host_token_issued_at      = CURRENT_TIMESTAMP(6)
+		WHERE host_id = ? AND revoked_at IS NULL
+	`, expiresAt, newID, newHash, newSalt, hostID); err != nil {
+		return RotateResult{}, fmt.Errorf("rotate force update: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return RotateResult{}, fmt.Errorf("rotate force commit: %w", err)
+	}
+	committed = true
+
+	prefix := ""
+	if len(currentID) >= 4 {
+		prefix = hex.EncodeToString(currentID[:4])
+	}
+	return RotateResult{
+		NewToken:              newToken,
+		PreviousTokenIDPrefix: prefix,
+	}, nil
+}
+
 // CountActive returns how many non-revoked enrollments exist. Cheaper than
 // ActiveHostIDs when the caller only needs the count — Phase 4's OTel gauge
 // `edr.enrolled.hosts` is the primary caller.

--- a/server/endpoint/internal/mysql/store.go
+++ b/server/endpoint/internal/mysql/store.go
@@ -3,6 +3,7 @@ package mysql
 import (
 	"context"
 	"database/sql"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"time"
@@ -96,45 +97,217 @@ func (s *Store) Register(ctx context.Context, req RegisterRequest) (*RegisterRes
 	}, nil
 }
 
-// Verify returns the host_id associated with token, or an error. Returns ErrTokenMismatch
-// when the token does not match any active enrollment — callers should map that to 401.
-//
-// Implementation: look up the single candidate row by host_token_id (SHA-256 of the token),
-// then run argon2id verify against that row's hash+salt. This is O(1) regardless of fleet
-// size, and the argon2id step is still run on every auth so DB theft doesn't yield usable
-// tokens.
+// VerifyResult is the rotation-aware shape returned by VerifyWithMeta:
+// HostID identifies the matched enrollment, CurrentTokenID is the
+// SHA-256 of the matched token (used by the service layer as the
+// optimistic-lock key for RotateHostToken), TokenIssuedAt is the
+// current token's issue timestamp (the rotation-eligibility input),
+// and MatchedPrevious tells the caller whether the verify succeeded
+// against the grace-window previous token (in which case rotation is
+// already in flight and the caller must NOT trigger another).
+type VerifyResult struct {
+	HostID          string
+	CurrentTokenID  []byte
+	TokenIssuedAt   time.Time
+	MatchedPrevious bool
+}
+
+// Verify is the thin wrapper that callers who only need the host_id keep
+// using; new callers (the service-level rotation trigger) reach for
+// VerifyWithMeta below.
 func (s *Store) Verify(ctx context.Context, token string) (string, error) {
+	r, err := s.VerifyWithMeta(ctx, token)
+	if err != nil {
+		return "", err
+	}
+	return r.HostID, nil
+}
+
+// VerifyWithMeta returns the host_id + rotation metadata for a presented
+// token, or ErrTokenMismatch on any kind of mismatch (unknown token,
+// revoked enrollment, expired previous-token grace, hash mismatch).
+//
+// Implementation: try the current token first by host_token_id (SHA-256
+// O(1) lookup, then argon2id verify). On miss, fall back to the previous
+// token via previous_host_token_id WHERE previous_token_expires_at >
+// NOW(): this is the grace window the rotation flow opens. Both lookups
+// pay one argon2id evaluation on a hit; a miss against the current path
+// still pays one argon2id on the previous path before declaring
+// mismatch, which is intentional rate-limiting against guessing.
+func (s *Store) VerifyWithMeta(ctx context.Context, token string) (VerifyResult, error) {
 	if token == "" {
-		return "", ErrTokenMismatch
+		return VerifyResult{}, ErrTokenMismatch
 	}
 	// Bearer tokens have 32 bytes of entropy (43 base64url chars); short-circuit obviously bad
 	// lengths before paying the argon2 price.
 	if len(token) != 43 {
-		return "", ErrTokenMismatch
+		return VerifyResult{}, ErrTokenMismatch
 	}
+	tid := tokenID(token)
 
+	if r, ok, err := s.verifyAgainstCurrent(ctx, token, tid); err != nil {
+		return VerifyResult{}, err
+	} else if ok {
+		return r, nil
+	}
+	return s.verifyAgainstPrevious(ctx, token, tid)
+}
+
+// verifyAgainstCurrent does the host_token_id lookup. ok=false means the
+// row was not found (caller should fall through to previous-token path);
+// any other error is surfaced as-is. ok=true with err=nil is the happy
+// path; ok=true with ErrTokenMismatch means the row was found but the
+// argon2id verify failed (treat as mismatch, do NOT fall through to
+// previous since that would be redundant computation against the same
+// host).
+func (s *Store) verifyAgainstCurrent(ctx context.Context, token string, tid []byte) (VerifyResult, bool, error) {
 	var row struct {
-		HostID string `db:"host_id"`
-		Hash   []byte `db:"host_token_hash"`
-		Salt   []byte `db:"host_token_salt"`
+		HostID   string    `db:"host_id"`
+		Hash     []byte    `db:"host_token_hash"`
+		Salt     []byte    `db:"host_token_salt"`
+		IssuedAt time.Time `db:"host_token_issued_at"`
 	}
 	err := s.db.GetContext(ctx, &row, `
-		SELECT host_id, host_token_hash, host_token_salt
+		SELECT host_id, host_token_hash, host_token_salt, host_token_issued_at
 		FROM enrollments
 		WHERE host_token_id = ? AND revoked_at IS NULL
-	`, tokenID(token))
+	`, tid)
 	if errors.Is(err, sql.ErrNoRows) {
-		return "", ErrTokenMismatch
+		return VerifyResult{}, false, nil
 	}
 	if err != nil {
-		return "", fmt.Errorf("query enrollment by token id: %w", err)
+		return VerifyResult{}, false, fmt.Errorf("query enrollment by token id: %w", err)
 	}
 	if !verifyToken(token, row.Hash, row.Salt) {
-		// Token_id match but hash mismatch would require a SHA-256 collision — treat as
-		// mismatch rather than internal error.
-		return "", ErrTokenMismatch
+		// Token_id match but hash mismatch would require a SHA-256 collision; treat as
+		// mismatch rather than internal error and do not fall through to previous-token
+		// lookup (which is for a different token entirely, by id).
+		return VerifyResult{}, true, ErrTokenMismatch
 	}
-	return row.HostID, nil
+	return VerifyResult{
+		HostID:         row.HostID,
+		CurrentTokenID: tid,
+		TokenIssuedAt:  row.IssuedAt,
+	}, true, nil
+}
+
+// verifyAgainstPrevious does the previous_host_token_id lookup, gated on
+// previous_token_expires_at > NOW. Returns the same VerifyResult shape
+// with MatchedPrevious=true so the service layer skips the rotation
+// trigger (rotation is already in flight; another would be wasteful).
+func (s *Store) verifyAgainstPrevious(ctx context.Context, token string, tid []byte) (VerifyResult, error) {
+	var row struct {
+		HostID   string    `db:"host_id"`
+		Hash     []byte    `db:"previous_host_token_hash"`
+		Salt     []byte    `db:"previous_host_token_salt"`
+		IssuedAt time.Time `db:"host_token_issued_at"`
+	}
+	err := s.db.GetContext(ctx, &row, `
+		SELECT host_id, previous_host_token_hash, previous_host_token_salt, host_token_issued_at
+		FROM enrollments
+		WHERE previous_host_token_id = ?
+		  AND revoked_at IS NULL
+		  AND previous_token_expires_at IS NOT NULL
+		  AND previous_token_expires_at > ?
+	`, tid, time.Now().UTC())
+	if errors.Is(err, sql.ErrNoRows) {
+		return VerifyResult{}, ErrTokenMismatch
+	}
+	if err != nil {
+		return VerifyResult{}, fmt.Errorf("query enrollment by previous token id: %w", err)
+	}
+	if !verifyToken(token, row.Hash, row.Salt) {
+		return VerifyResult{}, ErrTokenMismatch
+	}
+	return VerifyResult{
+		HostID:          row.HostID,
+		CurrentTokenID:  nil, // intentionally nil: caller must not trigger rotation against a previous-token match
+		TokenIssuedAt:   row.IssuedAt,
+		MatchedPrevious: true,
+	}, nil
+}
+
+// RotateResult carries the freshly minted token + audit-friendly metadata
+// back to the caller. NewToken is the raw bearer the service layer
+// queues into a rotate_token command for the agent. PreviousTokenIDPrefix
+// is the first 8 hex chars of the prior host_token_id, included on the
+// audit row so reviewers can correlate a rotation to the verify request
+// that triggered it without storing the full token id (which is
+// preimage-resistant but still a per-host identifier).
+type RotateResult struct {
+	NewToken              string
+	PreviousTokenIDPrefix string
+}
+
+// RotateHostToken atomically swaps a host's bearer token: generates a
+// fresh (id, hash, salt), captures the existing values into previous_*,
+// sets previous_token_expires_at = NOW + grace, and updates
+// host_token_issued_at to NOW. The atomic UPDATE is keyed on the
+// currentTokenID the caller asserts (typically the value returned from
+// a recent VerifyWithMeta), so two concurrent rotations serialise:
+// only the one whose currentTokenID matches the row's host_token_id
+// commits; the loser's UPDATE affects 0 rows and returns
+// ErrRotateRaced. Callers map ErrRotateRaced to a "no-op, the other
+// rotation already swapped the token" branch.
+//
+// The UPDATE uses LEFT-side ordering carefully (previous_* before
+// host_*) because MySQL evaluates SET assignments left-to-right and
+// uses the new value for subsequent right-side reads. Reversing the
+// order would copy the NEW host_token_id into previous_host_token_id,
+// not the old one.
+func (s *Store) RotateHostToken(ctx context.Context, hostID string, currentTokenID []byte, grace time.Duration) (RotateResult, error) {
+	if hostID == "" {
+		return RotateResult{}, errors.New("RotateHostToken: hostID is required")
+	}
+	if len(currentTokenID) == 0 {
+		return RotateResult{}, errors.New("RotateHostToken: currentTokenID is required")
+	}
+	if grace <= 0 {
+		return RotateResult{}, errors.New("RotateHostToken: grace must be > 0")
+	}
+
+	newToken, err := generateToken()
+	if err != nil {
+		return RotateResult{}, err
+	}
+	newHash, newSalt, err := hashToken(newToken)
+	if err != nil {
+		return RotateResult{}, err
+	}
+	newID := tokenID(newToken)
+	expiresAt := time.Now().UTC().Add(grace)
+
+	res, err := s.db.ExecContext(ctx, `
+		UPDATE enrollments
+		SET previous_host_token_id    = host_token_id,
+		    previous_host_token_hash  = host_token_hash,
+		    previous_host_token_salt  = host_token_salt,
+		    previous_token_expires_at = ?,
+		    host_token_id             = ?,
+		    host_token_hash           = ?,
+		    host_token_salt           = ?,
+		    host_token_issued_at      = CURRENT_TIMESTAMP(6)
+		WHERE host_id = ? AND host_token_id = ? AND revoked_at IS NULL
+	`, expiresAt, newID, newHash, newSalt, hostID, currentTokenID)
+	if err != nil {
+		return RotateResult{}, fmt.Errorf("rotate host token: %w", err)
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return RotateResult{}, fmt.Errorf("rotate rows affected: %w", err)
+	}
+	if affected == 0 {
+		return RotateResult{}, ErrRotateRaced
+	}
+
+	prefix := ""
+	if len(currentTokenID) >= 4 {
+		prefix = hex.EncodeToString(currentTokenID[:4])
+	}
+	return RotateResult{
+		NewToken:              newToken,
+		PreviousTokenIDPrefix: prefix,
+	}, nil
 }
 
 // CountActive returns how many non-revoked enrollments exist. Cheaper than

--- a/server/endpoint/internal/operator/audit_test.go
+++ b/server/endpoint/internal/operator/audit_test.go
@@ -38,6 +38,9 @@ func (f fakeRevokeService) Revoke(ctx context.Context, hostID, reason, actor str
 }
 func (f fakeRevokeService) CountActive(context.Context) (int, error)        { panic("not used") }
 func (f fakeRevokeService) ActiveHostIDs(context.Context) ([]string, error) { panic("not used") }
+func (f fakeRevokeService) RotateToken(context.Context, string, api.RotationTrigger, string, string) (api.RotateResult, error) {
+	panic("not used")
+}
 
 type captureRecorder struct {
 	last   identityapi.AuditEvent

--- a/server/endpoint/internal/operator/audit_test.go
+++ b/server/endpoint/internal/operator/audit_test.go
@@ -120,7 +120,8 @@ func TestHandler_Rotate_HappyPath(t *testing.T) {
 		captured.trigger = trigger
 		captured.actor = actor
 		captured.reason = reason
-		return api.RotateResult{PreviousTokenIDPrefix: "deadbeef", CommandID: 7}, nil
+		id := int64(7)
+		return api.RotateResult{PreviousTokenIDPrefix: "deadbeef", CommandID: &id}, nil
 	}}
 	h := New(svc, nil)
 
@@ -141,7 +142,8 @@ func TestHandler_Rotate_HappyPath(t *testing.T) {
 	var got api.RotateResult
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&got))
 	assert.Equal(t, "deadbeef", got.PreviousTokenIDPrefix)
-	assert.Equal(t, int64(7), got.CommandID)
+	require.NotNil(t, got.CommandID)
+	assert.Equal(t, int64(7), *got.CommandID)
 	// The handler tags the trigger as Operator so the service emits the
 	// right audit row payload (verified at the service layer).
 	assert.Equal(t, "H-1", captured.hostID)

--- a/server/endpoint/internal/operator/audit_test.go
+++ b/server/endpoint/internal/operator/audit_test.go
@@ -15,11 +15,12 @@ import (
 	identityapi "github.com/fleetdm/edr/server/identity/api"
 )
 
-// fakeRevokeService stubs api.Service. Only Revoke + List are exercised
-// by these tests; other methods panic so a regression that wires this
-// fake into a different path surfaces immediately.
+// fakeRevokeService stubs api.Service. Only Revoke + List + RotateToken
+// are exercised by these tests; other methods panic so a regression
+// that wires this fake into a different path surfaces immediately.
 type fakeRevokeService struct {
 	revoke func(ctx context.Context, hostID, reason, actor string) error
+	rotate func(ctx context.Context, hostID string, trigger api.RotationTrigger, actor, reason string) (api.RotateResult, error)
 }
 
 func (f fakeRevokeService) Enroll(context.Context, api.EnrollRequest, string) (api.EnrollResponse, error) {
@@ -38,8 +39,11 @@ func (f fakeRevokeService) Revoke(ctx context.Context, hostID, reason, actor str
 }
 func (f fakeRevokeService) CountActive(context.Context) (int, error)        { panic("not used") }
 func (f fakeRevokeService) ActiveHostIDs(context.Context) ([]string, error) { panic("not used") }
-func (f fakeRevokeService) RotateToken(context.Context, string, api.RotationTrigger, string, string) (api.RotateResult, error) {
-	panic("not used")
+func (f fakeRevokeService) RotateToken(ctx context.Context, hostID string, trigger api.RotationTrigger, actor, reason string) (api.RotateResult, error) {
+	if f.rotate == nil {
+		panic("fake.RotateToken not set")
+	}
+	return f.rotate(ctx, hostID, trigger, actor, reason)
 }
 
 type captureRecorder struct {
@@ -99,4 +103,111 @@ func TestHandler_Revoke_NilAuditOK(t *testing.T) {
 	require.NoError(t, err)
 	resp.Body.Close()
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+}
+
+// Successful POST .../rotate returns 200 with a JSON body carrying the
+// CommandID + PreviousTokenIDPrefix the operator can pivot from to
+// audit / SigNoz traces.
+func TestHandler_Rotate_HappyPath(t *testing.T) {
+	captured := struct {
+		hostID  string
+		trigger api.RotationTrigger
+		actor   string
+		reason  string
+	}{}
+	svc := fakeRevokeService{rotate: func(_ context.Context, hostID string, trigger api.RotationTrigger, actor, reason string) (api.RotateResult, error) {
+		captured.hostID = hostID
+		captured.trigger = trigger
+		captured.actor = actor
+		captured.reason = reason
+		return api.RotateResult{PreviousTokenIDPrefix: "deadbeef", CommandID: 7}, nil
+	}}
+	h := New(svc, nil)
+
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	body, _ := json.Marshal(map[string]any{"actor": "victor@example", "reason": "incident-2026-Q2"})
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, srv.URL+"/api/enrollments/H-1/rotate", bytes.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := srv.Client().Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	var got api.RotateResult
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&got))
+	assert.Equal(t, "deadbeef", got.PreviousTokenIDPrefix)
+	assert.Equal(t, int64(7), got.CommandID)
+	// The handler tags the trigger as Operator so the service emits the
+	// right audit row payload (verified at the service layer).
+	assert.Equal(t, "H-1", captured.hostID)
+	assert.Equal(t, api.RotationTriggerOperator, captured.trigger)
+	assert.Equal(t, "victor@example", captured.actor)
+	assert.Equal(t, "incident-2026-Q2", captured.reason)
+}
+
+// Missing actor or reason returns 400; rotation is operator-attributed
+// audit material, so silent rotations without attribution would
+// undermine the audit story #87 just shipped.
+func TestHandler_Rotate_RequiresActorAndReason(t *testing.T) {
+	cases := []struct {
+		name string
+		body map[string]any
+	}{
+		{"missing actor", map[string]any{"reason": "x"}},
+		{"missing reason", map[string]any{"actor": "x"}},
+		{"both empty", map[string]any{}},
+		{"whitespace actor", map[string]any{"actor": "   ", "reason": "y"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := fakeRevokeService{rotate: func(context.Context, string, api.RotationTrigger, string, string) (api.RotateResult, error) {
+				t.Fatal("RotateToken must not be called when actor/reason validation fails")
+				return api.RotateResult{}, nil
+			}}
+			h := New(svc, nil)
+			mux := http.NewServeMux()
+			h.RegisterRoutes(mux)
+			srv := httptest.NewServer(mux)
+			t.Cleanup(srv.Close)
+
+			body, _ := json.Marshal(tc.body)
+			req, err := http.NewRequestWithContext(t.Context(), http.MethodPost,
+				srv.URL+"/api/enrollments/H-1/rotate", bytes.NewReader(body))
+			require.NoError(t, err)
+			req.Header.Set("Content-Type", "application/json")
+			resp, err := srv.Client().Do(req)
+			require.NoError(t, err)
+			resp.Body.Close()
+			assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		})
+	}
+}
+
+// Missing host returns 404, not 500; the handler must surface
+// api.ErrNotFound from the service as the operator-facing
+// "not_found" code.
+func TestHandler_Rotate_NotFound(t *testing.T) {
+	svc := fakeRevokeService{rotate: func(context.Context, string, api.RotationTrigger, string, string) (api.RotateResult, error) {
+		return api.RotateResult{}, api.ErrNotFound
+	}}
+	h := New(svc, nil)
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	body, _ := json.Marshal(map[string]any{"actor": "op", "reason": "x"})
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost,
+		srv.URL+"/api/enrollments/missing/rotate", bytes.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := srv.Client().Do(req)
+	require.NoError(t, err)
+	resp.Body.Close()
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
 }

--- a/server/endpoint/internal/operator/handler.go
+++ b/server/endpoint/internal/operator/handler.go
@@ -214,7 +214,7 @@ func (h *Handler) handleRotate(w http.ResponseWriter, r *http.Request) {
 		attrkeys.AdminActor, body.Actor,
 		attrkeys.AdminReason, body.Reason,
 		attrkeys.HostID, hostID,
-		"edr.command.id", res.CommandID,
+		"edr.command.id", commandIDForLog(res.CommandID),
 		"edr.previous_token_id_prefix", res.PreviousTokenIDPrefix,
 	)
 	writeJSON(ctx, h.logger, w, http.StatusOK, res)
@@ -226,4 +226,16 @@ func writeJSON(ctx context.Context, logger *slog.Logger, w http.ResponseWriter, 
 
 func writeErr(ctx context.Context, logger *slog.Logger, w http.ResponseWriter, status int, code string) {
 	httpserver.NoStoreJSON(ctx, logger, w, status, map[string]string{"error": code})
+}
+
+// commandIDForLog dereferences a *int64 for slog attribute output, returning
+// 0 when the rotation committed but no rotate_token command was queued (the
+// nil case carries that signal explicitly on the wire via the omitempty JSON
+// shape; the access log uses 0 to keep the attribute monomorphic int64
+// rather than mixing int64 and "absent").
+func commandIDForLog(p *int64) int64 {
+	if p == nil {
+		return 0
+	}
+	return *p
 }

--- a/server/endpoint/internal/operator/handler.go
+++ b/server/endpoint/internal/operator/handler.go
@@ -54,10 +54,11 @@ func New(svc api.Service, logger *slog.Logger) *Handler {
 // set, revoke still applies but no audit row is written.
 func (h *Handler) SetAudit(rec identityapi.AuditRecorder) { h.audit = rec }
 
-// RegisterRoutes wires the two operator routes on the given mux.
+// RegisterRoutes wires the operator routes on the given mux.
 func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/enrollments", h.handleList)
 	mux.HandleFunc("POST /api/enrollments/{host_id}/revoke", h.handleRevoke)
+	mux.HandleFunc("POST /api/enrollments/{host_id}/rotate", h.handleRotate)
 }
 
 func (h *Handler) handleList(w http.ResponseWriter, r *http.Request) {
@@ -158,6 +159,65 @@ func (h *Handler) recordRevokeAudit(r *http.Request, hostID string, body revokeR
 			attrkeys.HostID, hostID,
 		)
 	}
+}
+
+// rotateRequest is the body shape accepted by POST
+// /api/enrollments/{host_id}/rotate. Actor + Reason are required so
+// the audit row records the operator who triggered the rotation and
+// why; making both required avoids silent rotations that audit
+// reviewers can't attribute later.
+type rotateRequest struct {
+	Actor  string `json:"actor"`
+	Reason string `json:"reason"`
+}
+
+func (h *Handler) handleRotate(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	hostID := r.PathValue("host_id")
+	if hostID == "" {
+		writeErr(ctx, h.logger, w, http.StatusBadRequest, "missing host_id")
+		return
+	}
+
+	var body rotateRequest
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, revokeBodyCap)).Decode(&body); err != nil {
+		writeErr(ctx, h.logger, w, http.StatusBadRequest, "bad_body")
+		return
+	}
+	body.Actor = strings.TrimSpace(body.Actor)
+	body.Reason = strings.TrimSpace(body.Reason)
+	if body.Actor == "" || body.Reason == "" {
+		writeErr(ctx, h.logger, w, http.StatusBadRequest, "actor and reason are required")
+		return
+	}
+
+	res, err := h.svc.RotateToken(ctx, hostID, api.RotationTriggerOperator, body.Actor, body.Reason)
+	switch {
+	case errors.Is(err, api.ErrNotFound):
+		writeErr(ctx, h.logger, w, http.StatusNotFound, "not_found")
+		return
+	case err != nil:
+		h.logger.ErrorContext(ctx, "rotate enrollment", "err", err)
+		writeErr(ctx, h.logger, w, http.StatusInternalServerError, "internal")
+		return
+	}
+
+	// Span attributes mirror the audit row payload so SigNoz dashboards
+	// can pivot from the trace to the audit event by trace_id.
+	trace.SpanFromContext(ctx).SetAttributes(
+		attribute.String(attrkeys.AdminAction, "rotate_token"),
+		attribute.String(attrkeys.AdminActor, body.Actor),
+		attribute.String(attrkeys.HostID, hostID),
+	)
+	h.logger.InfoContext(ctx, "host token rotated",
+		attrkeys.AdminAction, "rotate_token",
+		attrkeys.AdminActor, body.Actor,
+		attrkeys.AdminReason, body.Reason,
+		attrkeys.HostID, hostID,
+		"edr.command.id", res.CommandID,
+		"edr.previous_token_id_prefix", res.PreviousTokenIDPrefix,
+	)
+	writeJSON(ctx, h.logger, w, http.StatusOK, res)
 }
 
 func writeJSON(ctx context.Context, logger *slog.Logger, w http.ResponseWriter, status int, body any) {

--- a/server/endpoint/internal/service/rotation_test.go
+++ b/server/endpoint/internal/service/rotation_test.go
@@ -3,6 +3,7 @@ package service_test
 import (
 	"context"
 	"log/slog"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -24,16 +25,32 @@ const (
 	testSecret = "test-enroll-secret"
 )
 
-// fakeRecorder captures audit events for assertion. Must be safe to
-// invoke from any goroutine; the verify-time auto-rotate path is
-// synchronous today but a future scheduler may run it concurrently.
+// fakeRecorder captures audit events for assertion. Goroutine-safe so
+// future moves of the verify-time auto-rotate trigger to a background
+// scheduler do not silently introduce data races; today the path is
+// synchronous, but the contract is the safer side of the change.
+// Tests read events via Snapshot so the slice copy is taken under the
+// same mutex.
 type fakeRecorder struct {
+	mu     sync.Mutex
 	events []identityapi.AuditEvent
 }
 
 func (f *fakeRecorder) Record(_ context.Context, e identityapi.AuditEvent) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.events = append(f.events, e)
 	return nil
+}
+
+// Snapshot returns a copy of the captured events so tests assert on a
+// stable view independent of concurrent Record calls.
+func (f *fakeRecorder) Snapshot() []identityapi.AuditEvent {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]identityapi.AuditEvent, len(f.events))
+	copy(out, f.events)
+	return out
 }
 
 // commandCapture records (host_id, command_type, payload) tuples so
@@ -119,7 +136,7 @@ func TestVerifyToken_FreshTokenDoesNotRotate(t *testing.T) {
 	hostID, err := svc.VerifyToken(t.Context(), tok)
 	require.NoError(t, err)
 	assert.Equal(t, testHostID, hostID)
-	assert.Empty(t, audit.events, "fresh token must not emit any audit row")
+	assert.Empty(t, audit.Snapshot(), "fresh token must not emit any audit row")
 	assert.Zero(t, cmds.calls.Load(), "fresh token must not queue any rotate_token command")
 }
 
@@ -135,9 +152,9 @@ func TestVerifyToken_StaleTokenAutoRotates(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, testHostID, hostID)
 
-	require.Len(t, audit.events, 1, "stale-token verify must emit exactly one audit row")
-	got := audit.events[0]
-	assert.Equal(t, identityapi.AuditEnrollmentTokenRotated, got.Action)
+	require.Len(t, audit.Snapshot(), 1, "stale-token verify must emit exactly one audit row")
+	got := audit.Snapshot()[0]
+	assert.Equal(t, identityapi.AuditEnrollmentRotateToken, got.Action)
 	assert.Equal(t, "host", got.TargetType)
 	assert.Equal(t, testHostID, got.TargetID)
 	assert.Equal(t, "auto", got.Payload["trigger"])
@@ -161,14 +178,14 @@ func TestVerifyToken_GraceTokenDoesNotReRotate(t *testing.T) {
 	ageToken(t, db, testHostID, 2*time.Hour)
 	_, err := svc.VerifyToken(t.Context(), oldTok)
 	require.NoError(t, err)
-	require.Len(t, audit.events, 1)
+	require.Len(t, audit.Snapshot(), 1)
 	require.Equal(t, int64(1), cmds.calls.Load())
 
 	// Second verify with the OLD token: matches the previous-token grace
 	// path. Service must NOT trigger another rotation.
 	_, err = svc.VerifyToken(t.Context(), oldTok)
 	require.NoError(t, err)
-	assert.Len(t, audit.events, 1, "grace-path verify must not emit another audit row")
+	assert.Len(t, audit.Snapshot(), 1, "grace-path verify must not emit another audit row")
 	assert.Equal(t, int64(1), cmds.calls.Load(), "grace-path verify must not queue another rotate_token command")
 }
 
@@ -183,10 +200,11 @@ func TestRotateToken_OperatorPath(t *testing.T) {
 		"victor@example", "incident-2026-Q2")
 	require.NoError(t, err)
 	assert.NotEmpty(t, res.PreviousTokenIDPrefix)
-	assert.Positive(t, res.CommandID, "operator path must report the queued command_id")
+	require.NotNil(t, res.CommandID, "operator path must surface the queued command_id")
+	assert.Positive(t, *res.CommandID)
 
-	require.Len(t, audit.events, 1)
-	got := audit.events[0]
+	require.Len(t, audit.Snapshot(), 1)
+	got := audit.Snapshot()[0]
 	assert.Equal(t, "operator", got.Payload["trigger"])
 	assert.Equal(t, "victor@example", got.Payload["actor"])
 	assert.Equal(t, "incident-2026-Q2", got.Payload["reason"])
@@ -200,7 +218,7 @@ func TestRotateToken_MissingHost(t *testing.T) {
 	_, err := svc.RotateToken(t.Context(), "AAAA1111-2222-3333-4444-555566667777",
 		api.RotationTriggerOperator, "operator", "test")
 	require.ErrorIs(t, err, api.ErrNotFound)
-	assert.Empty(t, audit.events)
+	assert.Empty(t, audit.Snapshot())
 	assert.Zero(t, cmds.calls.Load())
 }
 
@@ -215,7 +233,7 @@ func TestRotateToken_RevokedHost(t *testing.T) {
 
 	_, err := svc.RotateToken(t.Context(), testHostID, api.RotationTriggerOperator, "op", "test")
 	require.ErrorIs(t, err, api.ErrNotFound)
-	assert.Empty(t, audit.events)
+	assert.Empty(t, audit.Snapshot())
 	assert.Zero(t, cmds.calls.Load())
 }
 
@@ -240,6 +258,6 @@ func TestRotateToken_NilDepsOK(t *testing.T) {
 
 	res, err := svc.RotateToken(t.Context(), testHostID, api.RotationTriggerOperator, "", "")
 	require.NoError(t, err)
-	assert.Zero(t, res.CommandID, "nil CommandInserter -> command_id 0")
+	assert.Nil(t, res.CommandID, "nil CommandInserter -> CommandID nil so the wire shape omits command_id")
 	assert.NotEmpty(t, res.PreviousTokenIDPrefix)
 }

--- a/server/endpoint/internal/service/rotation_test.go
+++ b/server/endpoint/internal/service/rotation_test.go
@@ -1,0 +1,245 @@
+package service_test
+
+import (
+	"context"
+	"log/slog"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fleetdm/edr/server/endpoint/api"
+	"github.com/fleetdm/edr/server/endpoint/internal/mysql"
+	"github.com/fleetdm/edr/server/endpoint/internal/service"
+	"github.com/fleetdm/edr/server/endpoint/testkit"
+	identityapi "github.com/fleetdm/edr/server/identity/api"
+	"github.com/fleetdm/edr/server/testdb"
+)
+
+const (
+	testHostID = "93DFC6F5-763D-5075-B305-8AC145D12F96"
+	testSecret = "test-enroll-secret"
+)
+
+// fakeRecorder captures audit events for assertion. Must be safe to
+// invoke from any goroutine; the verify-time auto-rotate path is
+// synchronous today but a future scheduler may run it concurrently.
+type fakeRecorder struct {
+	events []identityapi.AuditEvent
+}
+
+func (f *fakeRecorder) Record(_ context.Context, e identityapi.AuditEvent) error {
+	f.events = append(f.events, e)
+	return nil
+}
+
+// commandCapture records (host_id, command_type, payload) tuples so
+// tests can assert which commands the service queued. Returns a fake
+// command_id sequence (1, 2, ...) so the operator path can verify the
+// CommandID field of the api.RotateResult.
+type commandCapture struct {
+	calls atomic.Int64
+	last  struct {
+		hostID      string
+		commandType string
+		payload     []byte
+	}
+}
+
+func (c *commandCapture) Insert(_ context.Context, hostID, commandType string, payload []byte) (int64, error) {
+	id := c.calls.Add(1)
+	c.last.hostID = hostID
+	c.last.commandType = commandType
+	c.last.payload = payload
+	return id, nil
+}
+
+// newServiceForTest stands up an endpoint Service backed by a real
+// MySQL test DB, with a captured CommandInserter + audit recorder so
+// each test can inspect the side effects of rotation.
+func newServiceForTest(t *testing.T, lifetime, grace time.Duration) (svc api.Service, store *mysql.Store, db *sqlx.DB, audit *fakeRecorder, cmds *commandCapture) {
+	t.Helper()
+	db = testdb.Open(t)
+	require.NoError(t, testkit.ApplySchema(t.Context(), db))
+	store = mysql.NewStore(db)
+	audit = &fakeRecorder{}
+	cmds = &commandCapture{}
+	svc = service.New(service.Options{
+		Store:    store,
+		Secret:   testSecret,
+		Audit:    audit,
+		Commands: cmds.Insert,
+		Policy:   nil, // not exercised in these tests; paired-nil with Commands is OK because the enroll fan-out is the only consumer of the pair.
+		Lifetime: lifetime,
+		Grace:    grace,
+		Logger:   slog.Default(),
+	})
+	return svc, store, db, audit, cmds
+}
+
+// enrollOne issues a fresh enrollment via the public Service.Enroll
+// path and returns the bearer token + the row's current host_token_id
+// (lifted out of the DB for tests that need to assert "this rotation
+// changed the underlying id").
+func enrollOne(t *testing.T, svc api.Service, hostID string) string {
+	t.Helper()
+	res, err := svc.Enroll(t.Context(), api.EnrollRequest{
+		EnrollSecret: testSecret,
+		HardwareUUID: hostID,
+		Hostname:     "qa",
+		AgentVersion: "v",
+		OSVersion:    "o",
+	}, "127.0.0.1")
+	require.NoError(t, err)
+	return res.HostToken
+}
+
+// ageToken backdates the host's host_token_issued_at by the given
+// duration so the next VerifyToken sees the token as past lifetime
+// without making the test wait. The schema column is NOT NULL with a
+// CURRENT_TIMESTAMP default; a direct UPDATE is the cheap test-only
+// way to forge token age.
+func ageToken(t *testing.T, db *sqlx.DB, hostID string, age time.Duration) {
+	t.Helper()
+	_, err := db.ExecContext(t.Context(),
+		`UPDATE enrollments SET host_token_issued_at = ? WHERE host_id = ?`,
+		time.Now().UTC().Add(-age), hostID)
+	require.NoError(t, err)
+}
+
+// A fresh token does not trigger rotation: the agent's normal poll
+// shouldn't pay an extra UPDATE + INSERT + audit cost on every request.
+func TestVerifyToken_FreshTokenDoesNotRotate(t *testing.T) {
+	svc, _, _, audit, cmds := newServiceForTest(t, time.Hour, time.Minute)
+	tok := enrollOne(t, svc, testHostID)
+
+	hostID, err := svc.VerifyToken(t.Context(), tok)
+	require.NoError(t, err)
+	assert.Equal(t, testHostID, hostID)
+	assert.Empty(t, audit.events, "fresh token must not emit any audit row")
+	assert.Zero(t, cmds.calls.Load(), "fresh token must not queue any rotate_token command")
+}
+
+// A token past lifetime triggers rotation on the next verify, queues a
+// rotate_token command for the agent, and emits exactly one audit row
+// tagged with trigger=auto.
+func TestVerifyToken_StaleTokenAutoRotates(t *testing.T) {
+	svc, _, db, audit, cmds := newServiceForTest(t, time.Hour, time.Minute)
+	tok := enrollOne(t, svc, testHostID)
+	ageToken(t, db, testHostID, 2*time.Hour) // well past 1h lifetime
+
+	hostID, err := svc.VerifyToken(t.Context(), tok)
+	require.NoError(t, err)
+	assert.Equal(t, testHostID, hostID)
+
+	require.Len(t, audit.events, 1, "stale-token verify must emit exactly one audit row")
+	got := audit.events[0]
+	assert.Equal(t, identityapi.AuditEnrollmentTokenRotated, got.Action)
+	assert.Equal(t, "host", got.TargetType)
+	assert.Equal(t, testHostID, got.TargetID)
+	assert.Equal(t, "auto", got.Payload["trigger"])
+	assert.NotEmpty(t, got.Payload["previous_token_id_prefix"])
+
+	assert.Equal(t, int64(1), cmds.calls.Load(), "exactly one rotate_token command must be queued")
+	assert.Equal(t, testHostID, cmds.last.hostID)
+	assert.Equal(t, "rotate_token", cmds.last.commandType)
+	assert.Contains(t, string(cmds.last.payload), "new_token", "rotate_token payload must carry the new bearer")
+}
+
+// A verify against the previous-token grace path must NOT trigger a
+// rotation: rotation is already in flight (the new token has been
+// issued; the agent just hasn't picked it up yet). Triggering another
+// would discard the in-flight rotation prematurely.
+func TestVerifyToken_GraceTokenDoesNotReRotate(t *testing.T) {
+	svc, _, db, audit, cmds := newServiceForTest(t, time.Hour, time.Minute)
+	oldTok := enrollOne(t, svc, testHostID)
+
+	// First verify: stale -> rotation triggers, new token queued.
+	ageToken(t, db, testHostID, 2*time.Hour)
+	_, err := svc.VerifyToken(t.Context(), oldTok)
+	require.NoError(t, err)
+	require.Len(t, audit.events, 1)
+	require.Equal(t, int64(1), cmds.calls.Load())
+
+	// Second verify with the OLD token: matches the previous-token grace
+	// path. Service must NOT trigger another rotation.
+	_, err = svc.VerifyToken(t.Context(), oldTok)
+	require.NoError(t, err)
+	assert.Len(t, audit.events, 1, "grace-path verify must not emit another audit row")
+	assert.Equal(t, int64(1), cmds.calls.Load(), "grace-path verify must not queue another rotate_token command")
+}
+
+// RotateToken (operator path) force-rotates regardless of the token's
+// age and emits an audit row tagged with trigger=operator + the
+// supplied actor + reason fields.
+func TestRotateToken_OperatorPath(t *testing.T) {
+	svc, _, _, audit, cmds := newServiceForTest(t, 24*time.Hour, time.Minute)
+	enrollOne(t, svc, testHostID) // intentionally fresh; operator override should still rotate
+
+	res, err := svc.RotateToken(t.Context(), testHostID, api.RotationTriggerOperator,
+		"victor@example", "incident-2026-Q2")
+	require.NoError(t, err)
+	assert.NotEmpty(t, res.PreviousTokenIDPrefix)
+	assert.Positive(t, res.CommandID, "operator path must report the queued command_id")
+
+	require.Len(t, audit.events, 1)
+	got := audit.events[0]
+	assert.Equal(t, "operator", got.Payload["trigger"])
+	assert.Equal(t, "victor@example", got.Payload["actor"])
+	assert.Equal(t, "incident-2026-Q2", got.Payload["reason"])
+	assert.Equal(t, int64(1), cmds.calls.Load())
+}
+
+// Rotate on a missing host returns ErrNotFound (no audit, no command).
+func TestRotateToken_MissingHost(t *testing.T) {
+	svc, _, _, audit, cmds := newServiceForTest(t, 24*time.Hour, time.Minute)
+
+	_, err := svc.RotateToken(t.Context(), "AAAA1111-2222-3333-4444-555566667777",
+		api.RotationTriggerOperator, "operator", "test")
+	require.ErrorIs(t, err, api.ErrNotFound)
+	assert.Empty(t, audit.events)
+	assert.Zero(t, cmds.calls.Load())
+}
+
+// Rotate against a revoked enrollment also surfaces as ErrNotFound:
+// the row exists but is no longer eligible for rotation. Otherwise an
+// attacker who has the (revoked) token could nudge the row back into
+// a usable state.
+func TestRotateToken_RevokedHost(t *testing.T) {
+	svc, store, _, audit, cmds := newServiceForTest(t, 24*time.Hour, time.Minute)
+	enrollOne(t, svc, testHostID)
+	require.NoError(t, store.Revoke(t.Context(), testHostID, "compromised", "operator"))
+
+	_, err := svc.RotateToken(t.Context(), testHostID, api.RotationTriggerOperator, "op", "test")
+	require.ErrorIs(t, err, api.ErrNotFound)
+	assert.Empty(t, audit.events)
+	assert.Zero(t, cmds.calls.Load())
+}
+
+// RotateToken with both Audit and Commands nil must not panic; the
+// service degrades gracefully (DB rotation still happens, audit + command
+// emission no-op). This is the "tests / ingest binary" mode.
+func TestRotateToken_NilDepsOK(t *testing.T) {
+	db := testdb.Open(t)
+	require.NoError(t, testkit.ApplySchema(t.Context(), db))
+	svc := service.New(service.Options{
+		Store:    mysql.NewStore(db),
+		Secret:   testSecret,
+		Lifetime: 24 * time.Hour,
+		Grace:    time.Minute,
+		Logger:   slog.Default(),
+	})
+	_, err := svc.Enroll(t.Context(), api.EnrollRequest{
+		EnrollSecret: testSecret, HardwareUUID: testHostID,
+		Hostname: "h", AgentVersion: "v", OSVersion: "o",
+	}, "127.0.0.1")
+	require.NoError(t, err)
+
+	res, err := svc.RotateToken(t.Context(), testHostID, api.RotationTriggerOperator, "", "")
+	require.NoError(t, err)
+	assert.Zero(t, res.CommandID, "nil CommandInserter -> command_id 0")
+	assert.NotEmpty(t, res.PreviousTokenIDPrefix)
+}

--- a/server/endpoint/internal/service/service.go
+++ b/server/endpoint/internal/service/service.go
@@ -252,10 +252,9 @@ func (s *service) RotateToken(ctx context.Context, hostID string, trigger api.Ro
 	if err != nil {
 		return api.RotateResult{}, fmt.Errorf("rotate token: %w", err)
 	}
-	cmdID := s.deliverRotation(ctx, hostID, trigger, actor, reason, rot)
 	return api.RotateResult{
 		PreviousTokenIDPrefix: rot.PreviousTokenIDPrefix,
-		CommandID:             cmdID,
+		CommandID:             s.deliverRotation(ctx, hostID, trigger, actor, reason, rot),
 	}, nil
 }
 
@@ -263,9 +262,12 @@ func (s *service) RotateToken(ctx context.Context, hostID string, trigger api.Ro
 // emits the audit row. Shared between the verify-time auto path and
 // the operator-driven RotateToken path so both audit row shapes are
 // byte-identical except for the trigger / actor / reason payload
-// fields. Returns the command_id (or 0 if the queue insert failed) so
-// the operator endpoint can include it in its 200 body for clients
-// that want to wait until the agent has acked.
+// fields. Returns *int64: a non-nil pointer carries the freshly-queued
+// command id, nil signals "rotation committed in the DB but the agent
+// command queue did not receive the new bearer." The operator UI uses
+// the nil case to surface "agent will recover via re-enroll once the
+// previous-token grace expires" rather than waiting indefinitely for
+// an ack.
 //
 // Best-effort on the command insert: rotation already committed in
 // the DB. If we can't queue the rotate_token command, the agent's
@@ -275,20 +277,22 @@ func (s *service) RotateToken(ctx context.Context, hostID string, trigger api.Ro
 // Best-effort on the audit emit too: a missed audit row is a follow-up
 // incident, not a reason to fail an HTTP response that already
 // returned 200/204.
-func (s *service) deliverRotation(ctx context.Context, hostID string, trigger api.RotationTrigger, actor, reason string, rot mysql.RotateResult) int64 {
-	cmdID := int64(0)
+func (s *service) deliverRotation(ctx context.Context, hostID string, trigger api.RotationTrigger, actor, reason string, rot mysql.RotateResult) *int64 {
+	var cmdID *int64
 	if s.commands != nil {
 		payload, err := json.Marshal(map[string]string{"new_token": rot.NewToken})
-		if err == nil {
-			cmdID, err = s.commands(ctx, hostID, commandTypeRotateToken, payload)
+		switch {
+		case err != nil:
+			s.logger.WarnContext(ctx, "rotate_token marshal failed",
+				attrkeys.HostID, hostID, "err", err)
+		default:
+			id, err := s.commands(ctx, hostID, commandTypeRotateToken, payload)
 			if err != nil {
 				s.logger.WarnContext(ctx, "rotate_token enqueue failed",
 					attrkeys.HostID, hostID, "err", err)
-				cmdID = 0
+			} else {
+				cmdID = &id
 			}
-		} else {
-			s.logger.WarnContext(ctx, "rotate_token marshal failed",
-				attrkeys.HostID, hostID, "err", err)
 		}
 	}
 
@@ -303,18 +307,18 @@ func (s *service) deliverRotation(ctx context.Context, hostID string, trigger ap
 		if reason != "" {
 			payload["reason"] = reason
 		}
-		if cmdID > 0 {
-			payload["command_id"] = cmdID
+		if cmdID != nil {
+			payload["command_id"] = *cmdID
 		}
 		if err := s.audit.Record(ctx, identityapi.AuditEvent{
-			Action:     identityapi.AuditEnrollmentTokenRotated,
+			Action:     identityapi.AuditEnrollmentRotateToken,
 			TargetType: "host",
 			TargetID:   hostID,
 			Payload:    payload,
 		}); err != nil {
 			s.logger.WarnContext(ctx, "audit record failed",
 				attrkeys.HostID, hostID,
-				"action", string(identityapi.AuditEnrollmentTokenRotated),
+				"action", string(identityapi.AuditEnrollmentRotateToken),
 				"err", err)
 		}
 	}

--- a/server/endpoint/internal/service/service.go
+++ b/server/endpoint/internal/service/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/subtle"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -13,12 +14,24 @@ import (
 	"github.com/fleetdm/edr/server/attrkeys"
 	"github.com/fleetdm/edr/server/endpoint/api"
 	"github.com/fleetdm/edr/server/endpoint/internal/mysql"
+	identityapi "github.com/fleetdm/edr/server/identity/api"
 )
 
-// commandTypeSetBlocklist is the only command-type endpoint emits at
-// enroll time today. Exposed as a constant rather than scattered string
-// literals so future renames are mechanical.
-const commandTypeSetBlocklist = "set_blocklist"
+// Command-type constants for endpoint-emitted commands. Exposed as
+// constants so future renames are mechanical.
+const (
+	commandTypeSetBlocklist = "set_blocklist"
+	commandTypeRotateToken  = "rotate_token"
+)
+
+// Default rotation parameters, applied by the service when bootstrap
+// passes zero values. Lifetime = 24 hours matches #86's specified
+// default; grace = 5 minutes matches the issue body's "in-flight poll
+// must not 401" target.
+const (
+	defaultHostTokenLifetime = 24 * time.Hour
+	defaultHostTokenGrace    = 5 * time.Minute
+)
 
 // hardwareUUIDPattern accepts the canonical hyphenated UUID form in
 // either case. macOS IOPlatformUUID is uppercase-hyphenated. Future
@@ -33,34 +46,80 @@ var hardwareUUIDPattern = regexp.MustCompile(`^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-
 // for symmetry with rules's existing closure pattern.
 type CommandInserter func(ctx context.Context, hostID, commandType string, payload []byte) (int64, error)
 
+// Options bundles every dependency the endpoint service needs. Replaces
+// the previous positional-arg constructor: rotation added Audit,
+// Lifetime, and Grace to the dep set, and an 8-arg positional
+// signature reads like a registry rather than a contract.
+type Options struct {
+	// Store, Secret, Logger are required.
+	Store  *mysql.Store
+	Secret string
+	Logger *slog.Logger
+
+	// Policy + Commands are an all-or-nothing pair (handler precondition).
+	// Both nil disables the post-enroll policy fan-out AND the
+	// rotate_token command emission; the rotation will still flip the DB
+	// row, but the agent won't get a command to apply the new token, so
+	// it'll re-enroll once the grace window expires. Acceptable in tests
+	// and the ingest binary; production wires both.
+	Policy   api.PolicyProvider
+	Commands CommandInserter
+
+	// Audit is the operator-action audit recorder. Nil disables audit
+	// emission for token rotations; tests that don't care can pass nil.
+	Audit identityapi.AuditRecorder
+
+	// Lifetime is the maximum age of a current token before the verify
+	// path triggers an auto-rotation. Zero -> defaultHostTokenLifetime.
+	Lifetime time.Duration
+	// Grace is the window during which the just-superseded token still
+	// verifies after rotation. Zero -> defaultHostTokenGrace.
+	Grace time.Duration
+}
+
 // service implements api.Service by composing the mysql.Store with
-// the optional PolicyProvider (today: rules.api.PolicyService;
-// phase 3) and CommandInserter closure (today:
-// response.api.Service.Insert; phase 4) that cmd/main supplies.
+// the optional PolicyProvider, CommandInserter closure, and audit
+// recorder that cmd/main supplies.
 type service struct {
 	store    *mysql.Store
 	secret   string
 	policy   api.PolicyProvider // nil-safe: handler skips fan-out
 	commands CommandInserter
+	audit    identityapi.AuditRecorder
+	lifetime time.Duration
+	grace    time.Duration
 	logger   *slog.Logger
 }
 
-// New constructs a Service. All inputs (other than the optional policy/
-// commands pair) are required to be non-nil; bootstrap.New is the only
-// caller in production and validates them upfront.
-//
-// PolicyProvider and CommandInserter are an all-or-nothing pair: if one
-// is set the other must be too (panic otherwise). This matches the
-// existing enrollment.NewHandler precondition.
-func New(s *mysql.Store, secret string, policy api.PolicyProvider, cmds CommandInserter, logger *slog.Logger) api.Service {
-	if (policy != nil) != (cmds != nil) {
-		panic("endpoint service: PolicyProvider and CommandInserter must be set together or both nil")
+// New constructs a Service. Policy without Commands panics: a
+// PolicyProvider that can't queue any command is a config error (the
+// enroll handler's post-enroll fan-out has nowhere to send the
+// resulting set_blocklist). Commands without Policy is allowed, since
+// rotation queues commands without consulting Policy.
+func New(opts Options) api.Service {
+	if opts.Policy != nil && opts.Commands == nil {
+		panic("endpoint service: PolicyProvider set but CommandInserter is nil; policy fan-out has nowhere to go")
+	}
+	logger := opts.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	lifetime := opts.Lifetime
+	if lifetime <= 0 {
+		lifetime = defaultHostTokenLifetime
+	}
+	grace := opts.Grace
+	if grace <= 0 {
+		grace = defaultHostTokenGrace
 	}
 	return &service{
-		store:    s,
-		secret:   secret,
-		policy:   policy,
-		commands: cmds,
+		store:    opts.Store,
+		secret:   opts.Secret,
+		policy:   opts.Policy,
+		commands: opts.Commands,
+		audit:    opts.Audit,
+		lifetime: lifetime,
+		grace:    grace,
 		logger:   logger,
 	}
 }
@@ -139,14 +198,126 @@ func (s *service) enqueueInitialPolicy(ctx context.Context, hostID string) {
 }
 
 func (s *service) VerifyToken(ctx context.Context, token string) (string, error) {
-	hostID, err := s.store.Verify(ctx, token)
+	res, err := s.store.VerifyWithMeta(ctx, token)
 	if errors.Is(err, mysql.ErrTokenMismatch) {
 		return "", api.ErrInvalidToken
 	}
 	if err != nil {
 		return "", fmt.Errorf("verify token: %w", err)
 	}
-	return hostID, nil
+
+	// Verify-time auto-rotation trigger. Conditions:
+	//   - The verify hit the CURRENT token (not the previous-token
+	//     grace path; if it hit previous, a rotation is already in
+	//     flight and another would be wasteful).
+	//   - The current token is past its lifetime.
+	// Best-effort: failures are warn-logged but do not fail the verify.
+	// The verify already succeeded; the agent's next poll will re-trigger
+	// any rotation we couldn't queue this time.
+	if !res.MatchedPrevious && time.Since(res.TokenIssuedAt) > s.lifetime {
+		s.maybeAutoRotate(ctx, res.HostID, res.CurrentTokenID)
+	}
+
+	return res.HostID, nil
+}
+
+// maybeAutoRotate is the verify-time auto-rotation path. Optimistic-
+// locked on currentTokenID so concurrent verifies for the same host
+// don't double-rotate: only the verify whose currentTokenID still
+// matches the row's host_token_id commits, the rest race-lose with
+// ErrRotateRaced (silently swallowed -- the other verify already did
+// the work).
+func (s *service) maybeAutoRotate(ctx context.Context, hostID string, currentTokenID []byte) {
+	rot, err := s.store.RotateHostToken(ctx, hostID, currentTokenID, s.grace)
+	if errors.Is(err, mysql.ErrRotateRaced) {
+		return
+	}
+	if err != nil {
+		s.logger.WarnContext(ctx, "auto-rotate failed",
+			attrkeys.HostID, hostID, "err", err)
+		return
+	}
+	s.deliverRotation(ctx, hostID, api.RotationTriggerAuto, "", "", rot)
+}
+
+func (s *service) RotateToken(ctx context.Context, hostID string, trigger api.RotationTrigger, actor, reason string) (api.RotateResult, error) {
+	if hostID == "" {
+		return api.RotateResult{}, fmt.Errorf("rotate token: %w", api.ErrNotFound)
+	}
+	rot, err := s.store.RotateHostTokenForce(ctx, hostID, s.grace)
+	if errors.Is(err, mysql.ErrNotFound) {
+		return api.RotateResult{}, api.ErrNotFound
+	}
+	if err != nil {
+		return api.RotateResult{}, fmt.Errorf("rotate token: %w", err)
+	}
+	cmdID := s.deliverRotation(ctx, hostID, trigger, actor, reason, rot)
+	return api.RotateResult{
+		PreviousTokenIDPrefix: rot.PreviousTokenIDPrefix,
+		CommandID:             cmdID,
+	}, nil
+}
+
+// deliverRotation queues the rotate_token command for the agent and
+// emits the audit row. Shared between the verify-time auto path and
+// the operator-driven RotateToken path so both audit row shapes are
+// byte-identical except for the trigger / actor / reason payload
+// fields. Returns the command_id (or 0 if the queue insert failed) so
+// the operator endpoint can include it in its 200 body for clients
+// that want to wait until the agent has acked.
+//
+// Best-effort on the command insert: rotation already committed in
+// the DB. If we can't queue the rotate_token command, the agent's
+// previous token still works during grace; once grace expires it'll
+// 401 and re-enroll. Acceptable failure mode for a queue hiccup.
+//
+// Best-effort on the audit emit too: a missed audit row is a follow-up
+// incident, not a reason to fail an HTTP response that already
+// returned 200/204.
+func (s *service) deliverRotation(ctx context.Context, hostID string, trigger api.RotationTrigger, actor, reason string, rot mysql.RotateResult) int64 {
+	cmdID := int64(0)
+	if s.commands != nil {
+		payload, err := json.Marshal(map[string]string{"new_token": rot.NewToken})
+		if err == nil {
+			cmdID, err = s.commands(ctx, hostID, commandTypeRotateToken, payload)
+			if err != nil {
+				s.logger.WarnContext(ctx, "rotate_token enqueue failed",
+					attrkeys.HostID, hostID, "err", err)
+				cmdID = 0
+			}
+		} else {
+			s.logger.WarnContext(ctx, "rotate_token marshal failed",
+				attrkeys.HostID, hostID, "err", err)
+		}
+	}
+
+	if s.audit != nil {
+		payload := map[string]any{
+			"trigger":                  string(trigger),
+			"previous_token_id_prefix": rot.PreviousTokenIDPrefix,
+		}
+		if actor != "" {
+			payload["actor"] = actor
+		}
+		if reason != "" {
+			payload["reason"] = reason
+		}
+		if cmdID > 0 {
+			payload["command_id"] = cmdID
+		}
+		if err := s.audit.Record(ctx, identityapi.AuditEvent{
+			Action:     identityapi.AuditEnrollmentTokenRotated,
+			TargetType: "host",
+			TargetID:   hostID,
+			Payload:    payload,
+		}); err != nil {
+			s.logger.WarnContext(ctx, "audit record failed",
+				attrkeys.HostID, hostID,
+				"action", string(identityapi.AuditEnrollmentTokenRotated),
+				"err", err)
+		}
+	}
+	return cmdID
 }
 
 func (s *service) List(ctx context.Context) ([]api.Enrollment, error) {

--- a/server/endpoint/internal/tests/integration_test.go
+++ b/server/endpoint/internal/tests/integration_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jmoiron/sqlx"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -90,8 +91,20 @@ func (r *recordingCommandInserter) snapshot() []recordedCommand {
 
 // newEndpoint wires endpoint.bootstrap.New against a fresh test DB.
 // Returns the *Endpoint handle so tests can hit Service() directly or
-// register routes onto a test mux.
+// register routes onto a test mux. Tests that need direct DB access
+// (e.g. rotation_test.go's ageToken) reach for newEndpointWithDB.
 func newEndpoint(t *testing.T, opts ...func(*bootstrap.Deps)) *bootstrap.Endpoint {
+	t.Helper()
+	ep, _ := newEndpointWithDB(t, opts...)
+	return ep
+}
+
+// newEndpointWithDB exposes the underlying *sqlx.DB alongside the
+// Endpoint so tests that need to manipulate row state directly (e.g.
+// backdating host_token_issued_at to forge a stale token without
+// waiting an hour) can do so without leaking through the public
+// bootstrap.Endpoint surface.
+func newEndpointWithDB(t *testing.T, opts ...func(*bootstrap.Deps)) (*bootstrap.Endpoint, *sqlx.DB) {
 	t.Helper()
 	s := full.Open(t)
 	deps := bootstrap.Deps{
@@ -106,7 +119,7 @@ func newEndpoint(t *testing.T, opts ...func(*bootstrap.Deps)) *bootstrap.Endpoin
 	ep, err := bootstrap.New(deps)
 	require.NoError(t, err)
 	require.NoError(t, ep.ApplySchema(t.Context()))
-	return ep
+	return ep, s
 }
 
 // TestEnrollVerifyListRevoke walks the full operator + agent flow:

--- a/server/endpoint/internal/tests/rotation_test.go
+++ b/server/endpoint/internal/tests/rotation_test.go
@@ -1,0 +1,198 @@
+//go:build integration
+
+package tests
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fleetdm/edr/server/endpoint/api"
+	"github.com/fleetdm/edr/server/endpoint/bootstrap"
+	identityapi "github.com/fleetdm/edr/server/identity/api"
+)
+
+// recordingAudit captures emitted AuditEvents so the integration tests
+// can assert "the rotation produced exactly the audit row a SIEM
+// reviewer will pivot from."
+type recordingAudit struct {
+	mu     sync.Mutex
+	events []identityapi.AuditEvent
+}
+
+func (r *recordingAudit) Record(_ context.Context, e identityapi.AuditEvent) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.events = append(r.events, e)
+	return nil
+}
+
+func (r *recordingAudit) snapshot() []identityapi.AuditEvent {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]identityapi.AuditEvent, len(r.events))
+	copy(out, r.events)
+	return out
+}
+
+// withRotation builds the bootstrap.Deps overlay that wires
+// HostTokenLifetime / Grace + the recording audit + command inserter
+// for rotation tests. Returned helpers expose the captured commands +
+// audit rows after each test action; the *sqlx.DB lets the test
+// backdate host_token_issued_at to forge stale tokens.
+func withRotation(t *testing.T, lifetime, grace time.Duration) (*bootstrap.Endpoint, *sqlx.DB, *recordingCommandInserter, *recordingAudit) {
+	t.Helper()
+	cmds := &recordingCommandInserter{}
+	audit := &recordingAudit{}
+	ep, db := newEndpointWithDB(t, func(d *bootstrap.Deps) {
+		d.PolicyProvider = nil
+		d.CommandInserter = cmds.Insert
+		d.Audit = audit
+		d.HostTokenLifetime = lifetime
+		d.HostTokenGrace = grace
+	})
+	return ep, db, cmds, audit
+}
+
+// ageToken backdates host_token_issued_at via a direct UPDATE so the
+// next VerifyToken sees the token as past lifetime without making the
+// test wait. The same pattern is used in the unit-level rotation tests
+// in endpoint/internal/service/rotation_test.go.
+func ageToken(t *testing.T, db *sqlx.DB, hostID string, age time.Duration) {
+	t.Helper()
+	_, err := db.ExecContext(t.Context(),
+		`UPDATE enrollments SET host_token_issued_at = ? WHERE host_id = ?`,
+		time.Now().UTC().Add(-age), hostID)
+	require.NoError(t, err)
+}
+
+// TestRotation_AutoTriggerOnStaleToken: enroll, age the token past
+// lifetime, verify -> rotation auto-triggers. A rotate_token command
+// queues with the new bearer in the payload; an audit row records
+// trigger=auto. The new token verifies; the old token still verifies
+// during grace and reports MatchedPrevious-equivalent behaviour by NOT
+// triggering a second rotation.
+func TestRotation_AutoTriggerOnStaleToken(t *testing.T) {
+	ep, db, cmds, audit := withRotation(t, time.Hour, 5*time.Minute)
+	ctx := t.Context()
+
+	res, err := ep.Service().Enroll(ctx, api.EnrollRequest{
+		EnrollSecret: testEnrollSecret,
+		HardwareUUID: testHardwareUUID,
+		Hostname:     "h", OSVersion: "x", AgentVersion: "0.1.0",
+	}, "192.0.2.1")
+	require.NoError(t, err)
+	oldToken := res.HostToken
+
+	// Age past lifetime + first verify triggers rotation.
+	ageToken(t, db, testHardwareUUID, 2*time.Hour)
+	hostID, err := ep.Service().VerifyToken(ctx, oldToken)
+	require.NoError(t, err)
+	assert.Equal(t, testHardwareUUID, hostID)
+
+	// Exactly one audit row + one rotate_token command emitted.
+	events := audit.snapshot()
+	require.Len(t, events, 1)
+	assert.Equal(t, identityapi.AuditEnrollmentTokenRotated, events[0].Action)
+	assert.Equal(t, "auto", events[0].Payload["trigger"])
+	assert.NotEmpty(t, events[0].Payload["previous_token_id_prefix"])
+
+	calls := cmds.snapshot()
+	require.Len(t, calls, 1)
+	assert.Equal(t, "rotate_token", calls[0].CommandType)
+	assert.Equal(t, testHardwareUUID, calls[0].HostID)
+	assert.Contains(t, string(calls[0].Payload), "new_token")
+
+	// The OLD token still verifies during grace AND must NOT trigger
+	// another rotation -- the in-flight rotation is the source of truth.
+	_, err = ep.Service().VerifyToken(ctx, oldToken)
+	require.NoError(t, err)
+	assert.Len(t, audit.snapshot(), 1, "grace verify must not emit another audit row")
+	assert.Len(t, cmds.snapshot(), 1, "grace verify must not queue another rotate_token command")
+}
+
+// TestRotation_OldTokenRejectedAfterGrace: same setup, but a 100ms
+// grace + sleep past it proves the previous-token grace boundary is
+// the actual cutoff. Without this, a leaked token would stay valid
+// forever even after rotation.
+func TestRotation_OldTokenRejectedAfterGrace(t *testing.T) {
+	ep, db, _, _ := withRotation(t, time.Hour, 100*time.Millisecond)
+	ctx := t.Context()
+
+	res, err := ep.Service().Enroll(ctx, api.EnrollRequest{
+		EnrollSecret: testEnrollSecret,
+		HardwareUUID: testHardwareUUID,
+		Hostname:     "h", OSVersion: "x", AgentVersion: "0.1.0",
+	}, "192.0.2.1")
+	require.NoError(t, err)
+	oldToken := res.HostToken
+
+	ageToken(t, db, testHardwareUUID, 2*time.Hour)
+	_, err = ep.Service().VerifyToken(ctx, oldToken)
+	require.NoError(t, err)
+
+	// Sleep past the grace window and reverify with the old token.
+	time.Sleep(300 * time.Millisecond)
+	_, err = ep.Service().VerifyToken(ctx, oldToken)
+	require.ErrorIs(t, err, api.ErrInvalidToken)
+}
+
+// TestRotation_OperatorPath: explicit Service.RotateToken bypasses the
+// lifetime check (operator wants a fresh token NOW). Audit row carries
+// trigger=operator + actor + reason. CommandID is non-zero so a UI
+// can wait for the agent to ack via /api/commands/{id}.
+func TestRotation_OperatorPath(t *testing.T) {
+	ep, _, cmds, audit := withRotation(t, 24*time.Hour, 5*time.Minute)
+	ctx := t.Context()
+
+	_, err := ep.Service().Enroll(ctx, api.EnrollRequest{
+		EnrollSecret: testEnrollSecret,
+		HardwareUUID: testHardwareUUID,
+		Hostname:     "h", OSVersion: "x", AgentVersion: "0.1.0",
+	}, "192.0.2.1")
+	require.NoError(t, err)
+
+	rot, err := ep.Service().RotateToken(ctx, testHardwareUUID,
+		api.RotationTriggerOperator, "victor@example", "incident-2026-Q2")
+	require.NoError(t, err)
+	assert.Positive(t, rot.CommandID)
+	assert.NotEmpty(t, rot.PreviousTokenIDPrefix)
+
+	events := audit.snapshot()
+	require.Len(t, events, 1)
+	assert.Equal(t, "operator", events[0].Payload["trigger"])
+	assert.Equal(t, "victor@example", events[0].Payload["actor"])
+	assert.Equal(t, "incident-2026-Q2", events[0].Payload["reason"])
+
+	calls := cmds.snapshot()
+	require.Len(t, calls, 1)
+	assert.Equal(t, "rotate_token", calls[0].CommandType)
+}
+
+// TestRotation_RevokedHostNotRotatable: revoke + rotate must surface
+// ErrNotFound rather than silently rehydrating the row. The audit
+// reviewer's mental model is "revoke is terminal"; a back-door
+// rotation would defeat that.
+func TestRotation_RevokedHostNotRotatable(t *testing.T) {
+	ep, _, cmds, audit := withRotation(t, 24*time.Hour, time.Minute)
+	ctx := t.Context()
+
+	_, err := ep.Service().Enroll(ctx, api.EnrollRequest{
+		EnrollSecret: testEnrollSecret,
+		HardwareUUID: testHardwareUUID,
+		Hostname:     "h", OSVersion: "x", AgentVersion: "0.1.0",
+	}, "192.0.2.1")
+	require.NoError(t, err)
+	require.NoError(t, ep.Service().Revoke(ctx, testHardwareUUID, "compromised", "operator"))
+
+	_, err = ep.Service().RotateToken(ctx, testHardwareUUID,
+		api.RotationTriggerOperator, "operator", "test")
+	require.ErrorIs(t, err, api.ErrNotFound)
+	assert.Empty(t, audit.snapshot())
+	assert.Empty(t, cmds.snapshot())
+}

--- a/server/endpoint/internal/tests/rotation_test.go
+++ b/server/endpoint/internal/tests/rotation_test.go
@@ -98,7 +98,7 @@ func TestRotation_AutoTriggerOnStaleToken(t *testing.T) {
 	// Exactly one audit row + one rotate_token command emitted.
 	events := audit.snapshot()
 	require.Len(t, events, 1)
-	assert.Equal(t, identityapi.AuditEnrollmentTokenRotated, events[0].Action)
+	assert.Equal(t, identityapi.AuditEnrollmentRotateToken, events[0].Action)
 	assert.Equal(t, "auto", events[0].Payload["trigger"])
 	assert.NotEmpty(t, events[0].Payload["previous_token_id_prefix"])
 
@@ -160,7 +160,8 @@ func TestRotation_OperatorPath(t *testing.T) {
 	rot, err := ep.Service().RotateToken(ctx, testHardwareUUID,
 		api.RotationTriggerOperator, "victor@example", "incident-2026-Q2")
 	require.NoError(t, err)
-	assert.Positive(t, rot.CommandID)
+	require.NotNil(t, rot.CommandID, "operator path must surface the queued command_id")
+	assert.Positive(t, *rot.CommandID)
 	assert.NotEmpty(t, rot.PreviousTokenIDPrefix)
 
 	events := audit.snapshot()

--- a/server/identity/api/audit.go
+++ b/server/identity/api/audit.go
@@ -47,9 +47,12 @@ const (
 	// Command issuance (response context).
 	AuditCommandIssue AuditAction = "command.issue"
 
-	// Enrollment lifecycle (endpoint context).
-	AuditEnrollmentRevoke       AuditAction = "enrollment.revoke"
-	AuditEnrollmentTokenRotated AuditAction = "enrollment.token_rotated"
+	// Enrollment lifecycle (endpoint context). Constants follow the
+	// <resource>.<verb> convention documented at the top of this file:
+	// rotate_token reads as "rotate the host token of the enrollment,"
+	// matching the wire-shape command_type the agent dispatches on.
+	AuditEnrollmentRevoke      AuditAction = "enrollment.revoke"
+	AuditEnrollmentRotateToken AuditAction = "enrollment.rotate_token"
 )
 
 // AuditEvent is the value passed to AuditRecorder.Record. Caller fills

--- a/server/identity/api/audit.go
+++ b/server/identity/api/audit.go
@@ -48,7 +48,8 @@ const (
 	AuditCommandIssue AuditAction = "command.issue"
 
 	// Enrollment lifecycle (endpoint context).
-	AuditEnrollmentRevoke AuditAction = "enrollment.revoke"
+	AuditEnrollmentRevoke       AuditAction = "enrollment.revoke"
+	AuditEnrollmentTokenRotated AuditAction = "enrollment.token_rotated"
 )
 
 // AuditEvent is the value passed to AuditRecorder.Record. Caller fills


### PR DESCRIPTION
Lays the storage groundwork for host-token rotation without changing the public api.Service surface yet, so this commit can land + soak through CI before the service-layer / operator-endpoint / agent changes pile on. The endpoint context's Verify still returns the same (string, error) shape; new metadata-returning + rotation-committing methods sit alongside it for phase-2 callers.

Schema (additive, idempotent):
- enrollments.host_token_issued_at TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6). Tracks per-token issuance separately from the per-enrollment enrolled_at, so rotation eligibility is a function of the active token's age, not the host's age.
- enrollments.previous_host_token_id / _hash / _salt (all NULLABLE). When rotation flips, the prior (id, hash, salt) is captured here so the verify path can fall through to the previous token during the grace window.
- enrollments.previous_token_expires_at TIMESTAMP(6) NULL. Bounds the grace window per #86's contract (~5 min default, set by the rotate call site).
- INDEX idx_enrollments_prev_token (previous_host_token_id) so the fall-through verify is also O(1).
- A schemaMigrations array (mirroring identity/bootstrap's pattern) + isAlreadyAppliedMigration helper for the upgrade path: an existing enrollments table gets the same columns ALTERed in, with a backfill UPDATE that copies enrolled_at into host_token_issued_at so any pre-rotation host gets flagged "rotation due" on its next verify rather than starting fresh from the moment of deploy.

Storage (server/endpoint/internal/mysql/store.go):
- VerifyResult struct: HostID, CurrentTokenID (the SHA-256 the caller used; phase-2's RotateToken needs it as the optimistic-lock key), TokenIssuedAt (rotation-eligibility input), and MatchedPrevious (true when the verify hit the previous-token grace path so phase-2 knows another rotation is in flight and must not trigger a fresh one).
- VerifyWithMeta returns the full struct; Verify is now a thin wrapper preserving the existing (hostID, error) return so phase-1 doesn't ripple through identity / detection callers.
- Verify path is split into verifyAgainstCurrent + verifyAgainstPrevious helpers so the grace fallback is a separate, individually-testable branch. Two SQL round-trips on a miss (current then previous), one on a hit; argon2id only runs against the row that was actually found.
- RotateHostToken does the atomic flip in one SQL statement. SET clause ordered previous_* before host_* because MySQL evaluates assignments left-to-right and uses the new value for subsequent reads; reversed order would copy the new id into previous_host_token_id. The UPDATE is gated on host_token_id = currentTokenID so two concurrent rotations serialise: only the one whose currentTokenID still matches commits, the rest get RowsAffected=0 -> ErrRotateRaced.
- ErrRotateRaced sentinel for the lost-race branch; ErrTokenMismatch unchanged.

Tests (server/endpoint/internal/mysql/rotation_test.go):
- TestRotateHostToken_HappyPath: rotation returns a fresh raw token + non-empty previous-id prefix; new token verifies as current; old token still verifies during grace and surfaces MatchedPrevious=true (the contract phase-2's verify-time trigger relies on).
- TestRotateHostToken_OldTokenRejectedAfterGrace: 50ms grace + 300ms sleep proves previous_token_expires_at is the binding cutoff; without this a leaked token would stay valid forever.
- TestRotateHostToken_RaceLoses: a stale currentTokenID surfaces ErrRotateRaced via the optimistic lock.
- TestRotateHostToken_ConcurrentVerifiesProduceOneRotation: 16 goroutines, exactly one commits, the rest race-lose. This is the property the verify-time auto-rotate will rely on under burst poll traffic.
- TestRotateHostToken_RejectsRevoked: rotation against a revoked enrollment must surface as ErrRotateRaced rather than silently rehydrating the row.
- TestRotateHostToken_RejectsBadInputs: empty hostID / empty currentTokenID / non-positive grace fail at the boundary, not inside the SQL.
- TestRotateHostToken_OverwritesPriorPrevious: double rotation while a prior grace is still active discards the original token; the oldest-token-rejected outcome is documented in the test as the acceptable failure mode for a host that missed two rotation windows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic and operator-initiated host token rotation with configurable grace periods for token transition
  * Tokens can now be renewed with a grace window allowing verification of both current and previous tokens

* **Chores**
  * Added configuration parameters `EDR_HOST_TOKEN_LIFETIME` (default 24h) and `EDR_HOST_TOKEN_GRACE` (default 5m) for token rotation management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->