### PR TITLE
feat(httpserver): trusted-proxy X-Forwarded-For (#81)

### DIFF
--- a/server/cmd/fleet-edr-server/main.go
+++ b/server/cmd/fleet-edr-server/main.go
@@ -150,7 +150,16 @@ func run() error {
 	go runDetection(ctx, detectionCtx, logger)
 	go runIdentity(ctx, identityCtx, logger)
 
-	srv := newHTTPServer(cfg, mux, logger)
+	clientIPResolver, err := httpserver.NewClientIPResolver(cfg.TrustedProxies)
+	if err != nil {
+		logger.ErrorContext(ctx, "EDR_TRUSTED_PROXIES invalid", "err", err)
+		return err
+	}
+	if len(cfg.TrustedProxies) > 0 {
+		logger.InfoContext(ctx, "trusting X-Forwarded-For from proxies", "trusted", cfg.TrustedProxies)
+	}
+
+	srv := newHTTPServer(cfg, mux, logger, clientIPResolver)
 	if err := configureTLSIfEnabled(ctx, logger, srv, cfg); err != nil {
 		return err
 	}
@@ -337,11 +346,12 @@ func runIdentity(ctx context.Context, identityCtx *identitybootstrap.Identity, l
 	}
 }
 
-func newHTTPServer(cfg *config.Config, mux *http.ServeMux, logger *slog.Logger) *http.Server {
+func newHTTPServer(cfg *config.Config, mux *http.ServeMux, logger *slog.Logger, clientIPResolver *httpserver.ClientIPResolver) *http.Server {
 	handler := httpserver.Build(mux, httpserver.Options{
-		Logger:      logger,
-		ServiceName: serviceName,
-		TLSEnabled:  cfg.TLSEnabled(),
+		Logger:           logger,
+		ServiceName:      serviceName,
+		TLSEnabled:       cfg.TLSEnabled(),
+		ClientIPResolver: clientIPResolver,
 	})
 	return &http.Server{
 		Addr:         cfg.ListenAddr,

--- a/server/cmd/fleet-edr-server/main.go
+++ b/server/cmd/fleet-edr-server/main.go
@@ -150,12 +150,19 @@ func run() error {
 	go runDetection(ctx, detectionCtx, logger)
 	go runIdentity(ctx, identityCtx, logger)
 
-	clientIPResolver, err := httpserver.NewClientIPResolver(cfg.TrustedProxies)
-	if err != nil {
-		logger.ErrorContext(ctx, "EDR_TRUSTED_PROXIES invalid", "err", err)
-		return err
-	}
+	// Only construct the resolver when EDR_TRUSTED_PROXIES is non-empty.
+	// httpserver.Build skips installing the middleware on a nil resolver,
+	// and httpserver.ClientIP's fallback returns the same peer IP the
+	// resolver's empty-list path would return — so this saves one
+	// per-request middleware hop in the default deployment (per Copilot
+	// review on PR #113).
+	var clientIPResolver *httpserver.ClientIPResolver
 	if len(cfg.TrustedProxies) > 0 {
+		clientIPResolver, err = httpserver.NewClientIPResolver(cfg.TrustedProxies)
+		if err != nil {
+			logger.ErrorContext(ctx, "EDR_TRUSTED_PROXIES invalid", "err", err)
+			return err
+		}
 		logger.InfoContext(ctx, "trusting X-Forwarded-For from proxies", "trusted", cfg.TrustedProxies)
 	}
 

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -84,6 +84,16 @@ type Config struct {
 	// servers where interactive SSH is unusual — the rule's "non-shell
 	// -> shell -> /tmp/" shape is then a clean attacker indicator.
 	SuspiciousExecParentAllowlist map[string]struct{}
+
+	// TrustedProxies is the set of CIDRs (or bare IPs) the server will
+	// trust X-Forwarded-For from. Populated from EDR_TRUSTED_PROXIES
+	// (comma-separated). Empty by default — XFF is ignored and the
+	// per-IP rate limiter + audit log see the direct TCP peer (issue
+	// #81). Set this to your reverse proxy / load-balancer pool the
+	// moment you put an ALB / nginx / Cloudflare in front of
+	// fleet-edr-server, or one user hitting the rate limit will lock
+	// out everyone behind the proxy.
+	TrustedProxies []string
 }
 
 // TLSEnabled reports whether TLS cert and key are both set.
@@ -170,6 +180,10 @@ func loadFrom(getenv func(string) string) (*Config, error) {
 		c.SuspiciousExecParentAllowlist = allowlist
 	}
 
+	if v := getenv("EDR_TRUSTED_PROXIES"); v != "" {
+		c.TrustedProxies = splitCSV(v)
+	}
+
 	if v := getenv("EDR_LOG_LEVEL"); v != "" {
 		// Normalize to the canonical lowercase form so downstream slog handlers see one of the
 		// documented values regardless of how the operator spelled it (e.g. "INFO", "Warn").
@@ -209,6 +223,23 @@ func optionalStr(dst *string, key string, getenv func(string) string) {
 	if v := getenv(key); v != "" {
 		*dst = v
 	}
+}
+
+// splitCSV trims and drops empty tokens from a comma-separated value.
+// CIDR validation is deferred to httpserver.NewClientIPResolver so a
+// bad token errors with a uniform message at startup.
+func splitCSV(v string) []string {
+	parts := strings.Split(v, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if t := strings.TrimSpace(p); t != "" {
+			out = append(out, t)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 func validLogLevel(lvl string) bool {

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -234,6 +234,42 @@ func TestLoad(t *testing.T) {
 			wantErr: "EDR_LOGIN_RATE_PER_MIN",
 		},
 		{
+			name: "EDR_TRUSTED_PROXIES populates and trims",
+			env: withExtra(minEnv, map[string]string{
+				// Mixed CIDR forms + whitespace + an empty entry. CIDR
+				// validation is deferred to httpserver.NewClientIPResolver,
+				// so config-level parsing only trims and drops empties.
+				"EDR_TRUSTED_PROXIES": " 10.0.0.0/8 , 192.168.1.5,, fd00::/8",
+			}),
+			validate: func(t *testing.T, c *Config) {
+				t.Helper()
+				assert.Equal(t,
+					[]string{"10.0.0.0/8", "192.168.1.5", "fd00::/8"},
+					c.TrustedProxies,
+					"split must trim entries and drop the empty token")
+			},
+		},
+		{
+			name: "EDR_TRUSTED_PROXIES unset leaves nil slice",
+			env:  minEnv,
+			validate: func(t *testing.T, c *Config) {
+				t.Helper()
+				assert.Nil(t, c.TrustedProxies,
+					"unset env keeps the secure default — XFF ignored, peer IP used")
+			},
+		},
+		{
+			name: "EDR_TRUSTED_PROXIES with only whitespace yields nil",
+			env: withExtra(minEnv, map[string]string{
+				"EDR_TRUSTED_PROXIES": " , , ",
+			}),
+			validate: func(t *testing.T, c *Config) {
+				t.Helper()
+				assert.Nil(t, c.TrustedProxies,
+					"all-empty input must collapse to nil rather than an empty slice")
+			},
+		},
+		{
 			name: "zero login rate rejected",
 			env: withExtra(minEnv, map[string]string{
 				"EDR_LOGIN_RATE_PER_MIN": "0",

--- a/server/detection/internal/operator/handler.go
+++ b/server/detection/internal/operator/handler.go
@@ -263,7 +263,7 @@ func (h *Handler) recordAlertStatusAudit(r *http.Request, alertID int64, newStat
 		Action:     action,
 		TargetType: "alert",
 		TargetID:   strconv.FormatInt(alertID, 10),
-		RemoteAddr: r.RemoteAddr,
+		RemoteAddr: httpserver.ClientIP(r),
 		Payload:    map[string]any{"new_status": newStatus},
 	}); err != nil {
 		h.logger.WarnContext(r.Context(), "audit record",

--- a/server/endpoint/internal/enroll/handler.go
+++ b/server/endpoint/internal/enroll/handler.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"errors"
 	"log/slog"
-	"net"
 	"net/http"
 	"time"
 
@@ -31,10 +30,9 @@ const (
 // Handler serves POST /api/enroll. Unauthenticated; rate-limited per
 // source IP. Audit log + OTel span attributes on every attempt.
 type Handler struct {
-	svc      api.Service
-	logger   *slog.Logger
-	limiter  *httpserver.IPLimiter
-	trimHost bool // net.SplitHostPort applied in remoteIP; toggleable for tests
+	svc     api.Service
+	logger  *slog.Logger
+	limiter *httpserver.IPLimiter
 }
 
 // Options control handler behaviour.
@@ -60,10 +58,9 @@ func New(svc api.Service, opts Options) *Handler {
 		logger = slog.Default()
 	}
 	return &Handler{
-		svc:      svc,
-		logger:   logger,
-		limiter:  httpserver.NewIPLimiter(rate.Every(time.Minute/time.Duration(opts.RatePerMinute)), opts.RatePerMinute),
-		trimHost: true,
+		svc:     svc,
+		logger:  logger,
+		limiter: httpserver.NewIPLimiter(rate.Every(time.Minute/time.Duration(opts.RatePerMinute)), opts.RatePerMinute),
 	}
 }
 
@@ -112,7 +109,7 @@ const maxEnrollBodyBytes = 4 << 10
 func (h *Handler) handleEnroll(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	span := trace.SpanFromContext(ctx)
-	ip := remoteIP(r, h.trimHost)
+	ip := httpserver.ClientIP(r)
 	span.SetAttributes(attribute.String(attrkeys.RemoteAddr, ip))
 
 	if !h.limiter.Allow(ip) {
@@ -220,18 +217,4 @@ func (h *Handler) failf(ctx context.Context, w http.ResponseWriter, status int, 
 	w.Header().Set("Cache-Control", "no-store")
 	w.WriteHeader(status)
 	_ = json.NewEncoder(w).Encode(errBody{Error: code})
-}
-
-// remoteIP extracts a stable IP string from r.RemoteAddr. trimHost is
-// always true in production; tests that pass "127.0.0.1" directly skip
-// the split.
-func remoteIP(r *http.Request, trimHost bool) string {
-	if !trimHost {
-		return r.RemoteAddr
-	}
-	host, _, err := net.SplitHostPort(r.RemoteAddr)
-	if err != nil {
-		return r.RemoteAddr
-	}
-	return host
 }

--- a/server/endpoint/internal/operator/handler.go
+++ b/server/endpoint/internal/operator/handler.go
@@ -147,7 +147,7 @@ func (h *Handler) recordRevokeAudit(r *http.Request, hostID string, body revokeR
 		Action:     identityapi.AuditEnrollmentRevoke,
 		TargetType: "host",
 		TargetID:   hostID,
-		RemoteAddr: r.RemoteAddr,
+		RemoteAddr: httpserver.ClientIP(r),
 		Payload: map[string]any{
 			"actor":  body.Actor,
 			"reason": body.Reason,

--- a/server/httpserver/clientip.go
+++ b/server/httpserver/clientip.go
@@ -99,10 +99,22 @@ func (c *ClientIPResolver) ClientIP(r *http.Request) string {
 	if !ok || !c.isTrusted(peerAddr) {
 		return peer
 	}
-	// Peer is trusted: walk the XFF chain right-to-left, skipping
-	// trusted hops. r.Header.Values returns one entry per header (some
-	// proxies emit multiple); each entry may itself contain a
-	// comma-separated chain.
+	if client := c.firstUntrustedXFFEntry(r); client != "" {
+		return client
+	}
+	// Every XFF entry was trusted (or the chain was empty / malformed).
+	// The peer is the most reliable thing left.
+	return peer
+}
+
+// firstUntrustedXFFEntry walks the X-Forwarded-For header(s) on r
+// from right to left and returns the first entry that is NOT in any
+// trusted CIDR. Returns "" when the chain is empty, every entry is
+// trusted, or every entry is malformed. r.Header.Values returns one
+// element per header; each element may itself contain a
+// comma-separated chain. Extracted from ClientIP to keep the
+// caller's cognitive complexity below the project lint cap.
+func (c *ClientIPResolver) firstUntrustedXFFEntry(r *http.Request) string {
 	values := r.Header.Values("X-Forwarded-For")
 	for i := len(values) - 1; i >= 0; i-- {
 		parts := strings.Split(values[i], ",")
@@ -112,18 +124,13 @@ func (c *ClientIPResolver) ClientIP(r *http.Request) string {
 				continue
 			}
 			addr, ok := parseAddr(entry)
-			if !ok {
-				continue
-			}
-			if c.isTrusted(addr) {
+			if !ok || c.isTrusted(addr) {
 				continue
 			}
 			return addr.String()
 		}
 	}
-	// Every XFF entry was trusted (or the chain was empty / malformed).
-	// The peer is the most reliable thing left.
-	return peer
+	return ""
 }
 
 func (c *ClientIPResolver) isTrusted(addr netip.Addr) bool {
@@ -147,8 +154,12 @@ func remoteHost(remoteAddr string) string {
 	return host
 }
 
+// parseAddr parses a single XFF entry. Strips a trailing :port via
+// remoteHost first — non-standard but seen in some proxy / NLB setups
+// (per Gemini Code Assist review on PR #113). Unmaps IPv4-mapped IPv6
+// so a "::ffff:10.0.0.1" entry compares against an IPv4 trusted CIDR.
 func parseAddr(s string) (netip.Addr, bool) {
-	addr, err := netip.ParseAddr(s)
+	addr, err := netip.ParseAddr(remoteHost(s))
 	if err != nil {
 		return netip.Addr{}, false
 	}
@@ -175,9 +186,11 @@ type clientIPCtxKey struct{}
 // resolver is wired (returns peer IP).
 //
 // Production code should always call this rather than
-// httpserver.RemoteIP or r.RemoteAddr directly: the test harness sets
-// it via middleware, prod sets it via middleware, and the fallback
-// keeps tests that don't go through the middleware chain working.
+// httpserver.RemoteIP or r.RemoteAddr directly: prod sets the value
+// via middleware, and the fallback keeps tests that don't go through
+// the middleware chain working. The fallback NEVER honours XFF — a
+// forgotten middleware wire-up degrades to the secure default rather
+// than letting spoofed XFF through.
 func ClientIP(r *http.Request) string {
 	if r == nil {
 		return ""
@@ -187,5 +200,5 @@ func ClientIP(r *http.Request) string {
 			return s
 		}
 	}
-	return RemoteIP(r)
+	return remoteHost(r.RemoteAddr)
 }

--- a/server/httpserver/clientip.go
+++ b/server/httpserver/clientip.go
@@ -1,0 +1,191 @@
+package httpserver
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/netip"
+	"strings"
+)
+
+// ClientIPResolver resolves the trustworthy client IP from an
+// *http.Request when fleet-edr-server is deployed behind one or more
+// reverse proxies / load balancers.
+//
+// Issue #81. Default behaviour (zero or empty trusted list) is the
+// pre-existing "ignore X-Forwarded-For, return the direct peer IP"
+// stance: trusting XFF from any caller lets a client spoof its logged
+// source IP and collapses the per-IP rate limiter into a single
+// shared bucket. The resolver only honours XFF when the immediate TCP
+// peer (r.RemoteAddr) is itself a configured trusted proxy.
+//
+// Resolution rules:
+//
+//   - r.RemoteAddr is NOT in any trusted CIDR -> return its host
+//     portion. XFF is ignored regardless of contents.
+//   - r.RemoteAddr IS in a trusted CIDR -> walk the X-Forwarded-For
+//     chain right-to-left, skip entries that themselves match a
+//     trusted CIDR, and return the first non-trusted entry. If every
+//     entry is trusted (or the chain is empty / malformed) fall back
+//     to the peer IP.
+//
+// The right-to-left walk handles chained proxies (alb -> nginx ->
+// fleet-edr-server) safely: each hop appends to XFF, so the rightmost
+// non-trusted entry is the closest hop the trusted infrastructure
+// vouches for. The leftmost entry is whatever the client originally
+// claimed and is never inherently trustworthy.
+type ClientIPResolver struct {
+	trusted []netip.Prefix
+}
+
+// NewClientIPResolver parses cidrs into trusted prefixes. Each entry
+// may be either a CIDR ("10.0.0.0/8") or a bare IP ("192.168.1.5"),
+// in which case it is treated as /32 (IPv4) or /128 (IPv6). nil or
+// empty input yields a resolver that returns the direct peer IP for
+// every call (the secure default).
+//
+// Returns an error naming the offending entry on the first bad token
+// so an operator can fix the env var without playing whack-a-mole.
+func NewClientIPResolver(cidrs []string) (*ClientIPResolver, error) {
+	r := &ClientIPResolver{}
+	for _, raw := range cidrs {
+		token := strings.TrimSpace(raw)
+		if token == "" {
+			continue
+		}
+		prefix, err := parseTrustedPrefix(token)
+		if err != nil {
+			return nil, fmt.Errorf("trusted proxy %q: %w", raw, err)
+		}
+		r.trusted = append(r.trusted, prefix)
+	}
+	return r, nil
+}
+
+func parseTrustedPrefix(token string) (netip.Prefix, error) {
+	if strings.Contains(token, "/") {
+		p, err := netip.ParsePrefix(token)
+		if err != nil {
+			return netip.Prefix{}, err
+		}
+		return p.Masked(), nil
+	}
+	addr, err := netip.ParseAddr(token)
+	if err != nil {
+		return netip.Prefix{}, err
+	}
+	addr = addr.Unmap()
+	bits := 32
+	if addr.Is6() {
+		bits = 128
+	}
+	return netip.PrefixFrom(addr, bits), nil
+}
+
+// ClientIP resolves the trustworthy client IP for r per the rules in
+// the type doc. Returns "" when r is nil. A nil receiver is treated
+// as an empty trusted list — useful for tests and for the boot path
+// before the resolver is constructed.
+func (c *ClientIPResolver) ClientIP(r *http.Request) string {
+	if r == nil {
+		return ""
+	}
+	peer := remoteHost(r.RemoteAddr)
+	if c == nil || len(c.trusted) == 0 {
+		return peer
+	}
+	peerAddr, ok := parseAddr(peer)
+	if !ok || !c.isTrusted(peerAddr) {
+		return peer
+	}
+	// Peer is trusted: walk the XFF chain right-to-left, skipping
+	// trusted hops. r.Header.Values returns one entry per header (some
+	// proxies emit multiple); each entry may itself contain a
+	// comma-separated chain.
+	values := r.Header.Values("X-Forwarded-For")
+	for i := len(values) - 1; i >= 0; i-- {
+		parts := strings.Split(values[i], ",")
+		for j := len(parts) - 1; j >= 0; j-- {
+			entry := strings.TrimSpace(parts[j])
+			if entry == "" {
+				continue
+			}
+			addr, ok := parseAddr(entry)
+			if !ok {
+				continue
+			}
+			if c.isTrusted(addr) {
+				continue
+			}
+			return addr.String()
+		}
+	}
+	// Every XFF entry was trusted (or the chain was empty / malformed).
+	// The peer is the most reliable thing left.
+	return peer
+}
+
+func (c *ClientIPResolver) isTrusted(addr netip.Addr) bool {
+	addr = addr.Unmap()
+	for _, p := range c.trusted {
+		if p.Contains(addr) {
+			return true
+		}
+	}
+	return false
+}
+
+// remoteHost strips the port from a "host:port" string. Falls back to
+// the trimmed input when SplitHostPort fails (e.g. Unix socket peer
+// or a test that passed an already-stripped IP).
+func remoteHost(remoteAddr string) string {
+	host, _, err := net.SplitHostPort(remoteAddr)
+	if err != nil {
+		return strings.TrimSpace(remoteAddr)
+	}
+	return host
+}
+
+func parseAddr(s string) (netip.Addr, bool) {
+	addr, err := netip.ParseAddr(s)
+	if err != nil {
+		return netip.Addr{}, false
+	}
+	return addr.Unmap(), true
+}
+
+// Middleware returns an http.Handler middleware that resolves the
+// client IP once per request and stashes it on ctx so downstream
+// handlers (rate limiter, audit recorders, access log) read the same
+// value. Idempotent if installed more than once on a request.
+func (c *ClientIPResolver) Middleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ip := c.ClientIP(r)
+		ctx := context.WithValue(r.Context(), clientIPCtxKey{}, ip)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+type clientIPCtxKey struct{}
+
+// ClientIP returns the resolved client IP for r. When the resolver
+// middleware ran on r the value comes from ctx; otherwise the direct
+// peer IP (port stripped) is returned. Safe to call before any
+// resolver is wired (returns peer IP).
+//
+// Production code should always call this rather than
+// httpserver.RemoteIP or r.RemoteAddr directly: the test harness sets
+// it via middleware, prod sets it via middleware, and the fallback
+// keeps tests that don't go through the middleware chain working.
+func ClientIP(r *http.Request) string {
+	if r == nil {
+		return ""
+	}
+	if v := r.Context().Value(clientIPCtxKey{}); v != nil {
+		if s, ok := v.(string); ok && s != "" {
+			return s
+		}
+	}
+	return RemoteIP(r)
+}

--- a/server/httpserver/clientip_test.go
+++ b/server/httpserver/clientip_test.go
@@ -1,0 +1,229 @@
+package httpserver_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fleetdm/edr/server/httpserver"
+)
+
+func TestNewClientIPResolver_Validation(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   []string
+		wantErr bool
+	}{
+		{"nil input is the secure default", nil, false},
+		{"empty input is the secure default", []string{}, false},
+		{"whitespace-only entries are dropped", []string{" ", "\t"}, false},
+		{"bare IPv4", []string{"192.168.1.5"}, false},
+		{"bare IPv6", []string{"::1"}, false},
+		{"IPv4 CIDR", []string{"10.0.0.0/8"}, false},
+		{"IPv6 CIDR", []string{"fd00::/8"}, false},
+		{"mixed forms", []string{"10.0.0.0/8", "192.168.1.1", "fd00::/8"}, false},
+		{"garbage rejected", []string{"not-an-ip"}, true},
+		{"bad CIDR rejected", []string{"10.0.0.0/99"}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r, err := httpserver.NewClientIPResolver(tc.input)
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.Nil(t, r)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, r)
+		})
+	}
+}
+
+func TestClientIPResolver_ResolutionRules(t *testing.T) {
+	const trustedHop = "10.0.0.5"
+	const trustedHopAlt = "10.0.0.6"
+	const untrustedHop = "203.0.113.99"
+	const realClient = "198.51.100.7"
+
+	mustResolver := func(t *testing.T, cidrs []string) *httpserver.ClientIPResolver {
+		t.Helper()
+		r, err := httpserver.NewClientIPResolver(cidrs)
+		require.NoError(t, err)
+		return r
+	}
+
+	cases := []struct {
+		name        string
+		trusted     []string
+		remoteAddr  string
+		xff         []string // multiple header instances; each may itself be comma-separated
+		want        string
+		description string
+	}{
+		{
+			name:        "no trusted proxies returns peer regardless of XFF",
+			trusted:     nil,
+			remoteAddr:  trustedHop + ":5555",
+			xff:         []string{realClient},
+			want:        trustedHop,
+			description: "secure default: untouched by spoofed XFF",
+		},
+		{
+			name:        "untrusted peer ignores XFF",
+			trusted:     []string{"10.0.0.0/8"},
+			remoteAddr:  untrustedHop + ":5555",
+			xff:         []string{"1.2.3.4, " + realClient},
+			want:        untrustedHop,
+			description: "spoofed XFF from a non-trusted peer must not move the resolved IP",
+		},
+		{
+			name:       "trusted peer with single XFF returns leftmost untrusted",
+			trusted:    []string{"10.0.0.0/8"},
+			remoteAddr: trustedHop + ":5555",
+			xff:        []string{realClient},
+			want:       realClient,
+		},
+		{
+			name:       "trusted peer with chain of trusted hops walks past them",
+			trusted:    []string{"10.0.0.0/8"},
+			remoteAddr: trustedHop + ":5555",
+			xff:        []string{realClient + ", " + trustedHopAlt + ", " + trustedHop},
+			want:       realClient,
+		},
+		{
+			name:       "all-trusted XFF falls back to peer",
+			trusted:    []string{"10.0.0.0/8"},
+			remoteAddr: trustedHop + ":5555",
+			xff:        []string{trustedHopAlt + ", " + trustedHop},
+			want:       trustedHop,
+		},
+		{
+			name:        "missing XFF + trusted peer returns peer",
+			trusted:     []string{"10.0.0.0/8"},
+			remoteAddr:  trustedHop + ":5555",
+			xff:         nil,
+			want:        trustedHop,
+			description: "happy path when traffic comes through the proxy without an XFF stamp",
+		},
+		{
+			name:       "multiple XFF header instances combine right-to-left",
+			trusted:    []string{"10.0.0.0/8"},
+			remoteAddr: trustedHop + ":5555",
+			xff:        []string{realClient, trustedHopAlt + ", " + trustedHop},
+			want:       realClient,
+		},
+		{
+			name:        "malformed XFF entry is skipped",
+			trusted:     []string{"10.0.0.0/8"},
+			remoteAddr:  trustedHop + ":5555",
+			xff:         []string{realClient + ", garbage, " + trustedHop},
+			want:        realClient,
+			description: "garbage entries don't stop the right-to-left walk",
+		},
+		{
+			name:        "empty entries from extra commas are skipped",
+			trusted:     []string{"10.0.0.0/8"},
+			remoteAddr:  trustedHop + ":5555",
+			xff:         []string{",, " + realClient + " , ,"},
+			want:        realClient,
+			description: "tolerant of proxy formatting quirks",
+		},
+		{
+			name:       "IPv6 trusted peer + IPv6 XFF",
+			trusted:    []string{"fd00::/8"},
+			remoteAddr: "[fd00::1]:5555",
+			xff:        []string{"2001:db8::1, fd00::2"},
+			want:       "2001:db8::1",
+		},
+		{
+			name:        "IPv4-mapped IPv6 in XFF compares against IPv4 CIDR",
+			trusted:     []string{"10.0.0.0/8"},
+			remoteAddr:  trustedHop + ":5555",
+			xff:         []string{realClient + ", ::ffff:10.0.0.6"},
+			want:        realClient,
+			description: "::ffff:10.0.0.6 must be recognised as the same as 10.0.0.6 and skipped",
+		},
+		{
+			name:        "bare-IP trusted entry treated as /32",
+			trusted:     []string{"203.0.113.10"},
+			remoteAddr:  "203.0.113.10:5555",
+			xff:         []string{realClient},
+			want:        realClient,
+			description: "exact-host match without writing /32",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resolver := mustResolver(t, tc.trusted)
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/x", nil)
+			req.RemoteAddr = tc.remoteAddr
+			for _, v := range tc.xff {
+				req.Header.Add("X-Forwarded-For", v)
+			}
+			got := resolver.ClientIP(req)
+			assert.Equal(t, tc.want, got, "%s", tc.description)
+		})
+	}
+}
+
+func TestClientIPResolver_NilSafety(t *testing.T) {
+	var nilResolver *httpserver.ClientIPResolver
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/x", nil)
+	req.RemoteAddr = "192.168.1.1:5555"
+	req.Header.Set("X-Forwarded-For", "1.2.3.4")
+	assert.Equal(t, "192.168.1.1", nilResolver.ClientIP(req),
+		"nil resolver behaves like an empty trusted list (peer IP, XFF ignored)")
+
+	assert.Empty(t, nilResolver.ClientIP(nil), "nil request returns empty")
+}
+
+func TestClientIP_FallsBackToRemoteAddrWithoutMiddleware(t *testing.T) {
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/x", nil)
+	req.RemoteAddr = "203.0.113.1:5555"
+	req.Header.Set("X-Forwarded-For", "1.2.3.4")
+	// No middleware ran -> ctx has no resolved IP -> fall back to peer.
+	// XFF is NOT honoured on this fallback path (the fallback is
+	// httpserver.RemoteIP, not the resolver) so a forgotten middleware
+	// wire-up degrades safely instead of letting XFF spoofing through.
+	assert.Equal(t, "203.0.113.1", httpserver.ClientIP(req))
+}
+
+func TestClientIP_NilRequest(t *testing.T) {
+	assert.Empty(t, httpserver.ClientIP(nil))
+}
+
+func TestClientIPResolver_MiddlewareStashesIPOnContext(t *testing.T) {
+	resolver, err := httpserver.NewClientIPResolver([]string{"10.0.0.0/8"})
+	require.NoError(t, err)
+
+	var observed string
+	terminal := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		observed = httpserver.ClientIP(r)
+	})
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/x", nil)
+	req.RemoteAddr = "10.0.0.5:1234"
+	req.Header.Set("X-Forwarded-For", "198.51.100.7")
+	rr := httptest.NewRecorder()
+	resolver.Middleware(terminal).ServeHTTP(rr, req)
+
+	assert.Equal(t, "198.51.100.7", observed,
+		"downstream handler reads the resolver's verdict via ClientIP")
+}
+
+func TestClientIPResolver_MiddlewareSurvivesNilRequestContext(t *testing.T) {
+	// Defensive: pathological middleware ordering could pass an
+	// *http.Request with a nil ctx. r.Context() never returns nil per
+	// Go's contract, but exercise the code path anyway.
+	resolver, err := httpserver.NewClientIPResolver(nil)
+	require.NoError(t, err)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/x", nil)
+	req.RemoteAddr = "127.0.0.1:9000"
+	rr := httptest.NewRecorder()
+	resolver.Middleware(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {})).ServeHTTP(rr, req)
+	// No assertion: the test passes if the middleware doesn't panic.
+}

--- a/server/httpserver/httpserver.go
+++ b/server/httpserver/httpserver.go
@@ -41,6 +41,12 @@ type Options struct {
 	// speaks TLS; emitting HSTS over plain HTTP is a footgun that can make users unreachable if
 	// they accidentally deploy the next process without TLS.
 	TLSEnabled bool
+	// ClientIPResolver, when set, runs as middleware that resolves the
+	// trusted client IP once per request and stashes it on ctx so
+	// downstream rate-limit + audit code reads the same value (issue
+	// #81). nil disables the middleware: handlers fall back to the
+	// direct TCP peer via httpserver.ClientIP.
+	ClientIPResolver *ClientIPResolver
 }
 
 // Build wraps the provided handler with the full middleware chain.
@@ -62,6 +68,12 @@ func Build(handler http.Handler, opts Options) http.Handler {
 		h = hstsHeader()(h)
 	}
 	h = xRequestIDEcho()(h)
+	// Client-IP resolution sits outside the access log so the resolved
+	// IP is on ctx by the time accessLog logs (and downstream handlers
+	// run). Wrap before xRequestIDEcho so trace correlation is unchanged.
+	if opts.ClientIPResolver != nil {
+		h = opts.ClientIPResolver.Middleware(h)
+	}
 	h = otelhttp.NewHandler(h, opts.ServiceName,
 		otelhttp.WithSpanNameFormatter(func(_ string, r *http.Request) string {
 			// otelhttp calls the formatter inside its own handler, so r.Pattern may be empty.

--- a/server/httpserver/httpserver.go
+++ b/server/httpserver/httpserver.go
@@ -68,9 +68,13 @@ func Build(handler http.Handler, opts Options) http.Handler {
 		h = hstsHeader()(h)
 	}
 	h = xRequestIDEcho()(h)
-	// Client-IP resolution sits outside the access log so the resolved
-	// IP is on ctx by the time accessLog logs (and downstream handlers
-	// run). Wrap before xRequestIDEcho so trace correlation is unchanged.
+	// Client-IP resolution wraps xRequestIDEcho so the resolver runs
+	// outermost in the application layer (still inside otelhttp's
+	// span). The resolved IP is therefore on ctx by the time accessLog
+	// + downstream handlers read it via ClientIP(r). Skipped entirely
+	// when no proxies are configured: the empty trusted list yields
+	// the same value httpserver.ClientIP's fallback does, with one
+	// fewer per-request allocation.
 	if opts.ClientIPResolver != nil {
 		h = opts.ClientIPResolver.Middleware(h)
 	}
@@ -156,7 +160,7 @@ func accessLog(logger *slog.Logger, slowThreshold time.Duration) func(http.Handl
 				"status", rw.status,
 				"bytes", rw.bytes,
 				"duration_ms", dur.Milliseconds(),
-				"remote_addr", remoteAddr(r),
+				"remote_addr", ClientIP(r),
 			}
 
 			ctx := r.Context()
@@ -202,15 +206,6 @@ func (s *statusCapture) Flush() {
 	if f, ok := s.ResponseWriter.(http.Flusher); ok {
 		f.Flush()
 	}
-}
-
-// remoteAddr returns the peer address for access logging. We intentionally do NOT consult
-// `X-Forwarded-For`: that header is client-settable and trusting it without a trusted-proxy
-// allowlist lets any caller spoof their logged source IP. When the server moves behind a
-// real reverse proxy (Phase 5 packaging), revisit this with an explicit trusted-proxies
-// config knob; until then, r.RemoteAddr is the only trustworthy source.
-func remoteAddr(r *http.Request) string {
-	return r.RemoteAddr
 }
 
 // NoStoreJSON is a small helper for health handlers: writes JSON with no-store cache headers.

--- a/server/identity/internal/login/handler.go
+++ b/server/identity/internal/login/handler.go
@@ -116,7 +116,7 @@ const loginBodyCap = 4 << 10 // 4 KiB
 func (h *Handler) handleLogin(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	span := trace.SpanFromContext(ctx)
-	ip := httpserver.RemoteIP(r)
+	ip := httpserver.ClientIP(r)
 	span.SetAttributes(attribute.String(attrkeys.RemoteAddr, ip))
 
 	if !h.limiter.Allow(ip) {
@@ -211,7 +211,7 @@ func (h *Handler) handleGet(w http.ResponseWriter, r *http.Request) {
 // through to the cookie clear.
 func (h *Handler) handleLogout(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	ip := httpserver.RemoteIP(r)
+	ip := httpserver.ClientIP(r)
 
 	raw := h.decodeLogoutToken(r)
 	if raw != nil {

--- a/server/response/internal/operator/handler.go
+++ b/server/response/internal/operator/handler.go
@@ -121,7 +121,7 @@ func (h *Handler) recordCommandAudit(r *http.Request, hostID, commandType string
 		Action:     identityapi.AuditCommandIssue,
 		TargetType: "host",
 		TargetID:   hostID,
-		RemoteAddr: r.RemoteAddr,
+		RemoteAddr: httpserver.ClientIP(r),
 		Payload: map[string]any{
 			"command_type": commandType,
 			"command_id":   commandID,

--- a/server/rules/internal/operator/handler.go
+++ b/server/rules/internal/operator/handler.go
@@ -201,7 +201,7 @@ func (h *Handler) recordPolicyAudit(r *http.Request, body putPolicyRequest, vers
 		Action:     identityapi.AuditPolicyUpdate,
 		TargetType: "policy",
 		TargetID:   api.DefaultPolicyName,
-		RemoteAddr: r.RemoteAddr,
+		RemoteAddr: httpserver.ClientIP(r),
 		Payload:    payload,
 	}); err != nil {
 		h.logger.WarnContext(ctx, "audit record",


### PR DESCRIPTION
Adds a ClientIPResolver that honours X-Forwarded-For only when the direct TCP peer (r.RemoteAddr) is itself a configured trusted proxy. The default — empty trusted list — matches the prior secure stance: XFF is ignored and every IP-keyed surface (rate limiter, audit log) sees the direct peer. Configure via EDR_TRUSTED_PROXIES (CSV of CIDRs or bare IPs) the moment fleet-edr-server runs behind an ALB / nginx / Cloudflare; without it, one user hitting the rate limit locks out everyone behind the proxy.

Resolution semantics (issue #81 spec + OWASP guidance):
  - r.RemoteAddr untrusted -> ignore XFF, return peer IP.
  - r.RemoteAddr trusted   -> walk XFF right-to-left, skip trusted
                              hops, return the first non-trusted entry;
                              fall back to peer if every entry is
                              trusted or the chain is empty.
The right-to-left walk handles chained proxies (ALB -> nginx ->
fleet-edr-server) safely. The leftmost entry — what the original
client claimed — is never treated as inherently trustworthy.

Wire-up:
  - server/httpserver/clientip.go: ClientIPResolver, Middleware that stashes the resolved IP on ctx, and ClientIP(r) helper that reads it (falls back to RemoteIP when the middleware didn't run, so a forgotten wire-up degrades to today's behaviour rather than silently honouring spoofed XFF).
  - server/httpserver/httpserver.go: Options.ClientIPResolver opt-in, middleware installed inside the otelhttp span and outside the access log.
  - server/config: EDR_TRUSTED_PROXIES env var (CSV; bare IPs auto- promoted to /32 or /128 by the resolver).
  - server/cmd/fleet-edr-server/main.go: build resolver from config, pass into httpserver.Build, log the trusted set on startup.

Consumer call-site swaps (RemoteAddr / RemoteIP / local remoteIP -> httpserver.ClientIP):
  - identity/internal/login/handler.go: rate-limit bucket key + audit.
  - endpoint/internal/enroll/handler.go: rate-limit bucket key + audit. Drops the local remoteIP helper and trimHost field — the central helper handles the host-port-stripping cases the old flag toggled.
  - detection/internal/operator/handler.go: alert audit RemoteAddr.
  - endpoint/internal/operator/handler.go: enrollment-revoke audit.
  - response/internal/operator/handler.go: command-issue audit.
  - rules/internal/operator/handler.go: policy-update audit.

Tests:
  - clientip_test.go covers the matrix in the issue spec: no XFF, untrusted-peer ignore, trusted-peer single + multi-hop chain, all-trusted fallback, multiple XFF header instances, malformed + empty entries, IPv6, ::ffff:IPv4-mapped IPv6, bare-IP CIDR. Plus nil-resolver and middleware-ctx wiring.
  - Existing rate-limit tests in login + enroll continue to pass; the httpserver.ClientIP fallback path keeps tests working without rewiring middleware.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added trusted proxy configuration support to accurately detect client IP addresses when the server operates behind reverse proxies or load balancers. Supports comma-separated IP addresses and CIDR network blocks.

## Refactor
* Updated client IP detection across request handlers to use a unified, proxy-aware resolution mechanism, ensuring consistent client identification in audit logs and rate limiting throughout the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->