### PR TITLE
phase 6: lock chokepoint coverage + ship-v1 operator runbook

### DIFF
--- a/docs/authz.md
+++ b/docs/authz.md
@@ -16,12 +16,13 @@ enforcement on.
 
 The boot log announces the posture explicitly:
 
-```
-INFO authz enforcement posture=ENABLED env_var=EDR_AUTHZ_SHADOW_MODE
+```text
+INFO authz enforcement posture=ENABLED mode_description=enforcing env_var=EDR_AUTHZ_SHADOW_MODE
 ```
 
-(or `posture="SHADOW (denies audited but allowed)"` when the env
-var is set). Grep `posture=ENABLED` in your log shipper to confirm
+(or `posture=SHADOW mode_description="denies audited but allowed"`
+when the env var is set). The `posture` field is a stable enum —
+filter on `posture=ENABLED` in your log shipper to confirm
 production deployments are enforcing.
 
 ## Seeded role matrix
@@ -51,7 +52,7 @@ them from accidental delete via a future admin endpoint.
 
 When the chokepoint denies, the response is:
 
-```
+```http
 HTTP/1.1 403 Forbidden
 X-Edr-Authz-Reason: <reason>
 Content-Type: application/json
@@ -64,7 +65,7 @@ When the deny is `reauth_required` (Phase 5: destructive action on a
 session past the freshness window), the body is structured so the
 UI can prompt for re-authentication inline:
 
-```
+```http
 HTTP/1.1 403 Forbidden
 X-Edr-Authz-Reason: reauth_required
 Content-Type: application/json
@@ -93,11 +94,18 @@ diagnosis flow.
 | `action_not_registered` | The handler called `Allow` with an action string outside `RegisteredActions`. | Server bug. File a ticket; the offending handler likely passed a string literal instead of a typed `api.Action` constant. |
 | `no_actor` | The chokepoint was reached without an authenticated session on context. | Server bug — the session middleware is misconfigured for the route. Check the route's middleware chain. |
 | `resource_tenant_missing` | The handler built a `Resource` with an empty `TenantID`. | Server bug. The handler should call `api.ActorTenantID(ctx)` to populate the field. |
-| `shadow_mode` | The deployment is running with `EDR_AUTHZ_SHADOW_MODE=1`. The deny was audited, but the wire response is allow. | Inspect the audit row to see which deny was masked, then unset the env var. |
 
-The audit-log row carries `payload.reason` matching the header, plus
-`payload.role` (the seeded role that would have granted, if any) and
-`payload.shadow_mode=true` when shadow mode is on.
+`shadow_mode` is NOT a wire-shape reason — when the deployment runs
+with `EDR_AUTHZ_SHADOW_MODE=1`, the engine forces `Allow=true` and
+HTTPGate emits no 403 / no reason header. The audit-only mode shows
+up in the audit log as `payload.shadow_mode=true` on the row that
+records the would-be-deny verdict. To find masked denies, query
+`audit_events WHERE payload->'$.shadow_mode' IS NOT NULL`.
+
+The audit-log row's `payload` carries `reason` matching the header
+plus `shadow_mode=true` when audit-only mode is on. The granting
+role is not on the payload today — derive it by joining
+`role_bindings` for the actor's `user_id` if needed.
 
 ## Binding a role to a user (wave 1)
 
@@ -116,8 +124,10 @@ VALUES (
 ```
 
 The `(user_id, role_id, tenant_id, scope_type, scope_id)` tuple is
-the primary key — re-running the same statement is a duplicate-key
-error rather than a silent no-op, which is the safer direction.
+the `uk_role_bindings` UNIQUE key (the row's primary key is an
+auto-increment `id`). Re-running the same INSERT raises a
+duplicate-key error rather than a silent no-op, which is the safer
+direction. To upsert deliberately, add `ON DUPLICATE KEY UPDATE`.
 
 To revoke: `DELETE FROM role_bindings WHERE user_id = <user_id>
 AND role_id = 'admin'`. Sessions don't get bounced automatically;
@@ -141,14 +151,14 @@ matrix matches the operators-and-roles you expect.
 
 The boot log line for shadow mode reads:
 
-```
-INFO authz enforcement posture="SHADOW (denies audited but allowed)" env_var=EDR_AUTHZ_SHADOW_MODE
+```text
+INFO authz enforcement posture=SHADOW mode_description="denies audited but allowed" env_var=EDR_AUTHZ_SHADOW_MODE
 ```
 
 This is the canonical signal that audit-only mode is active. A
-production log shipper should alert on this line — if shadow mode
-landed in production accidentally, you want to know within minutes,
-not by the time the next deploy runs.
+production log shipper should alert on `posture=SHADOW` — if
+audit-only mode landed in production accidentally, you want to know
+within minutes, not by the time the next deploy runs.
 
 ## Behind the chokepoint
 

--- a/docs/authz.md
+++ b/docs/authz.md
@@ -1,0 +1,185 @@
+# Authorization
+
+Every privileged operator action in the EDR server passes through a
+single chokepoint that decides allow / deny based on the calling
+operator's role bindings and the action being attempted. A deny
+becomes a `403` on the wire with an `X-Edr-Authz-Reason` header
+naming the policy's verdict; the same row lands in the audit log
+with the actor + the resource attached.
+
+The chokepoint enforces by default. The
+`EDR_AUTHZ_SHADOW_MODE=1` environment variable flips it into
+audit-only mode (the policy still evaluates and the audit row is
+still written, but the wire response is always allow); use that knob
+when verifying role bindings against the audit log without flipping
+enforcement on.
+
+The boot log announces the posture explicitly:
+
+```
+INFO authz enforcement posture=ENABLED env_var=EDR_AUTHZ_SHADOW_MODE
+```
+
+(or `posture="SHADOW (denies audited but allowed)"` when the env
+var is set). Grep `posture=ENABLED` in your log shipper to confirm
+production deployments are enforcing.
+
+## Seeded role matrix
+
+Five built-in roles ship with the server. Their grants are the
+source of truth in `server/identity/internal/authz/policy/data/roles.json`;
+this section is a human-readable mirror.
+
+| Role | Reads | Writes / Destructive |
+|---|---|---|
+| `super_admin` | everything | everything (`*` wildcard) |
+| `admin` | host, process, alert, policy, enrollment, user | host.{isolate, kill_process, run_script}, alert lifecycle (acknowledge, resolve, reopen, comment), policy CRUD, enrollment.{revoke, rotate_token}, user.invite |
+| `senior_analyst` | host, process, alert | host.{isolate, kill_process, run_script}, alert lifecycle (acknowledge, resolve, reopen, comment) |
+| `analyst` | host, process, alert | alert.comment |
+| `auditor` | host, process, alert, audit | — |
+
+`super_admin` is the break-glass account's role at first boot. SSO
+operators provisioned via JIT default to `analyst`; promote via the
+SQL pattern below.
+
+The five-role layout is wave-1; wave-2 will add an admin API for
+role management. For wave-1 the `INSERT IGNORE` seed at boot
+guarantees the rows exist, and the `is_builtin=1` column protects
+them from accidental delete via a future admin endpoint.
+
+## How a 403 reads on the wire
+
+When the chokepoint denies, the response is:
+
+```
+HTTP/1.1 403 Forbidden
+X-Edr-Authz-Reason: <reason>
+Content-Type: application/json
+Cache-Control: no-store
+
+{"error": "forbidden"}
+```
+
+When the deny is `reauth_required` (Phase 5: destructive action on a
+session past the freshness window), the body is structured so the
+UI can prompt for re-authentication inline:
+
+```
+HTTP/1.1 403 Forbidden
+X-Edr-Authz-Reason: reauth_required
+Content-Type: application/json
+
+{
+  "error": "reauth_required",
+  "challenge": {
+    "auth_method": "oidc",
+    "reauth_url": "/api/auth/login?reauth=1"
+  }
+}
+```
+
+Reading the `X-Edr-Authz-Reason` header (or the matching
+`audit_events` row's `payload.reason`) is the entry point for any
+diagnosis flow.
+
+### Reason codes
+
+| `X-Edr-Authz-Reason` | What it means | What to do |
+|---|---|---|
+| `granted` | Decision was Allow. Never appears on a 403; documented for completeness because the audit row uses the same field. | — |
+| `no_matching_rule` | The actor's role bindings don't grant the action. | Bind the appropriate role via SQL (see below). |
+| `reauth_required` | The actor's session is past the reauth window (default 30m). The role grants the action; the operator just needs to re-prove possession of credentials. | UI handles this automatically via the reauth modal. If a non-UI client hits it, follow `challenge.reauth_url` and retry. |
+| `scope_not_yet_supported` | The actor has a `host_group` or `host` scoped role binding. Wave-1 only honours `tenant` scopes. | Persist a `tenant`-scoped binding instead — `host_group`/`host` scopes are wave-2. |
+| `action_not_registered` | The handler called `Allow` with an action string outside `RegisteredActions`. | Server bug. File a ticket; the offending handler likely passed a string literal instead of a typed `api.Action` constant. |
+| `no_actor` | The chokepoint was reached without an authenticated session on context. | Server bug — the session middleware is misconfigured for the route. Check the route's middleware chain. |
+| `resource_tenant_missing` | The handler built a `Resource` with an empty `TenantID`. | Server bug. The handler should call `api.ActorTenantID(ctx)` to populate the field. |
+| `shadow_mode` | The deployment is running with `EDR_AUTHZ_SHADOW_MODE=1`. The deny was audited, but the wire response is allow. | Inspect the audit row to see which deny was masked, then unset the env var. |
+
+The audit-log row carries `payload.reason` matching the header, plus
+`payload.role` (the seeded role that would have granted, if any) and
+`payload.shadow_mode=true` when shadow mode is on.
+
+## Binding a role to a user (wave 1)
+
+There is no admin API in wave 1; bindings go in via SQL. The shape
+mirrors `server/identity/bootstrap/schema.go`:
+
+```sql
+INSERT INTO role_bindings (user_id, role_id, tenant_id, scope_type, scope_id)
+VALUES (
+  <user_id>,           -- users.id
+  'admin',             -- one of: super_admin, admin, senior_analyst, analyst, auditor
+  'default',           -- wave-1 deployments use a single tenant
+  'tenant',            -- wave-1 honours only tenant scope
+  '*'                  -- wildcard for the tenant scope
+);
+```
+
+The `(user_id, role_id, tenant_id, scope_type, scope_id)` tuple is
+the primary key — re-running the same statement is a duplicate-key
+error rather than a silent no-op, which is the safer direction.
+
+To revoke: `DELETE FROM role_bindings WHERE user_id = <user_id>
+AND role_id = 'admin'`. Sessions don't get bounced automatically;
+the next chokepoint call reads fresh bindings via
+`Service.LoadActor`, so the change takes effect on the next request.
+
+## `EDR_AUTHZ_SHADOW_MODE=1` (audit-only mode)
+
+Set `EDR_AUTHZ_SHADOW_MODE=1` and restart to flip the chokepoint
+into audit-only mode. Every `Allow` call still:
+
+- evaluates the policy,
+- writes the audit row with `payload.reason` set to what the verdict
+  WOULD have been, and
+- adds `payload.shadow_mode=true` to the row.
+
+The wire response is always allow. Use this knob to verify role
+bindings against the audit log without flipping enforcement on —
+e.g. when standing up a fresh deployment and confirming the seeded
+matrix matches the operators-and-roles you expect.
+
+The boot log line for shadow mode reads:
+
+```
+INFO authz enforcement posture="SHADOW (denies audited but allowed)" env_var=EDR_AUTHZ_SHADOW_MODE
+```
+
+This is the canonical signal that audit-only mode is active. A
+production log shipper should alert on this line — if shadow mode
+landed in production accidentally, you want to know within minutes,
+not by the time the next deploy runs.
+
+## Behind the chokepoint
+
+The implementation lives in `server/identity/internal/authz/`.
+`Engine.Allow` evaluates a single `data.edr.authz.decision` query
+against an embedded OPA / Rego module
+(`server/identity/internal/authz/policy/edr.rego`); the role-grant
+table is `policy/data/roles.json`. Every call also threads through
+`AuditRecorder.Record` so the deny dashboard reads from the same
+table the chokepoint writes to.
+
+See `docs/architecture.md` for the bounded-context split and
+`docs/adr/0004-modular-monolith-bounded-contexts.md` for why the
+chokepoint sits inside the `identity` context but exposes a public
+`api.AuthZ` interface every other context calls.
+
+## Test coverage
+
+Three test layers protect the chokepoint contract:
+
+- `server/identity/internal/authz/engine_test.go` —
+  `TestAllow_RoleActionMatrix` pins every (role, action) verdict at
+  the engine level; `TestAllow_EveryRegisteredActionGrantedSomewhere`
+  asserts every `RegisteredActions` constant is granted by at least
+  one seeded role (so an action added without a matching grant in
+  `roles.json` doesn't ship as a permanent `no_matching_rule`).
+- `server/identity/internal/authz/policy_test.go` —
+  `TestPolicy_ActionsParity` keeps `RegisteredActions`, the embedded
+  `actions.json` bundle, and the role grants in `roles.json` in sync.
+- `test/arch/chokepoint_coverage_test.go` —
+  `TestEveryPrivilegedHandlerCallsHTTPGate` walks every operator
+  handler file and asserts each references `HTTPGate`. A new
+  privileged route added without the chokepoint call fails the
+  build with a directed message.

--- a/server/cmd/fleet-edr-server/main.go
+++ b/server/cmd/fleet-edr-server/main.go
@@ -98,13 +98,18 @@ func run() error {
 	// confused 403 — or worse, a silently-allowed request — hours
 	// later. Log it as a separate event so the deny dashboard /
 	// SigNoz query that pivots on `posture` doesn't have to parse it
-	// out of the noisier "starting" event.
+	// out of the noisier "starting" event. `posture` is a stable
+	// enum (ENABLED | SHADOW) for log filters / dashboard groupings;
+	// `mode_description` carries the operator-facing prose.
 	authzPosture := "ENABLED"
+	authzDescription := "enforcing"
 	if cfg.AuthzShadowMode {
-		authzPosture = "SHADOW (denies audited but allowed)"
+		authzPosture = "SHADOW"
+		authzDescription = "denies audited but allowed"
 	}
 	logger.InfoContext(ctx, "authz enforcement",
 		"posture", authzPosture,
+		"mode_description", authzDescription,
 		"env_var", "EDR_AUTHZ_SHADOW_MODE",
 	)
 	if !cfg.TLSEnabled() {

--- a/server/cmd/fleet-edr-server/main.go
+++ b/server/cmd/fleet-edr-server/main.go
@@ -93,6 +93,20 @@ func run() error {
 		"tls", cfg.TLSEnabled(),
 		"tls12_allowed", cfg.AllowTLS12,
 	)
+	// AuthZ posture is announced on its own line so a typo on
+	// EDR_AUTHZ_SHADOW_MODE surfaces at boot rather than via a
+	// confused 403 — or worse, a silently-allowed request — hours
+	// later. Log it as a separate event so the deny dashboard /
+	// SigNoz query that pivots on `posture` doesn't have to parse it
+	// out of the noisier "starting" event.
+	authzPosture := "ENABLED"
+	if cfg.AuthzShadowMode {
+		authzPosture = "SHADOW (denies audited but allowed)"
+	}
+	logger.InfoContext(ctx, "authz enforcement",
+		"posture", authzPosture,
+		"env_var", "EDR_AUTHZ_SHADOW_MODE",
+	)
 	if !cfg.TLSEnabled() {
 		logger.WarnContext(ctx, "EDR_ALLOW_INSECURE_HTTP=1 set; TLS disabled — do not run in production")
 	}

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -145,16 +145,17 @@ type Config struct {
 	// out everyone behind the proxy.
 	TrustedProxies []string
 
-	// AuthzShadowMode is the wave-1 rollout knob for the authorization
+	// AuthzShadowMode is the audit-only knob for the authorization
 	// chokepoint. When true, every Allow call evaluates the policy and
-	// audits the would-be decision but ALWAYS returns Allow=true so
-	// pilot deployments observe the deny dashboard before enforcement
-	// flips on. Populated from EDR_AUTHZ_SHADOW_MODE; default false
-	// (enforcement on) for fresh deployments. The flag is read at
-	// boot only — flipping it in production is a restart in wave 1
-	// (a future admin endpoint or file-watch can call
-	// Identity.SetAuthzShadowMode atomically; the in-memory engine
-	// flag is already hot-swap-safe via atomic.Bool).
+	// audits the would-be decision but ALWAYS returns Allow=true. The
+	// default is false: a fresh deployment enforces from boot. Set
+	// EDR_AUTHZ_SHADOW_MODE=1 to flip the chokepoint into audit-only
+	// mode while verifying role-binding coverage against the audit
+	// log; never leave it on for routine operation. The flag is read
+	// at boot only — a restart picks up the change. The in-memory
+	// engine flag is already hot-swap-safe via atomic.Bool, so a
+	// future admin endpoint or file-watch can call
+	// Identity.SetAuthzShadowMode atomically without a restart.
 	AuthzShadowMode bool
 
 	// AuditReadSampling is the inclusion probability (0.0-1.0) the

--- a/server/detection/internal/tests/integration_test.go
+++ b/server/detection/internal/tests/integration_test.go
@@ -14,6 +14,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -625,22 +626,36 @@ func TestGraph_BuildsTreeFromExecBatch(t *testing.T) {
 	}
 	insertEventsViaIngest(ctx, t, d, "h", events)
 
+	// Wait until the LAST exec has been applied — not just until 3 rows
+	// exist. A fork creates a row with the parent's path inherited; the
+	// exec that follows rewrites that row's path. If we polled on
+	// countNodes >= 3 we'd race the window where row 200's path is
+	// still the inherited "/bin/sh" because exec-pl hasn't been
+	// processed yet (CI surfaced exactly that as
+	// `["/usr/bin/python3", "/bin/sh", "/bin/sh"]`).
 	require.Eventually(t, func() bool {
 		tree, err := d.Service().BuildTree(ctx, "h",
 			api.TimeRange{FromNs: now - int64(time.Hour), ToNs: now + int64(time.Hour)}, 100)
 		if err != nil {
 			return false
 		}
-		return countNodes(tree) >= 3
-	}, 5*time.Second, 50*time.Millisecond, "expected 3 process rows materialised")
+		paths := flattenPaths(tree)
+		// All three exec'd paths must be present; the third one is the
+		// last event in the batch, so its presence implies every prior
+		// fork + exec has materialised.
+		return slices.Contains(paths, "/usr/bin/python3") &&
+			slices.Contains(paths, "/bin/sh") &&
+			slices.Contains(paths, "/tmp/payload")
+	}, 5*time.Second, 50*time.Millisecond, "expected /usr/bin/python3 -> /bin/sh -> /tmp/payload chain to materialise")
 
 	tree, err := d.Service().BuildTree(ctx, "h",
 		api.TimeRange{FromNs: now - int64(time.Hour), ToNs: now + int64(time.Hour)}, 100)
 	require.NoError(t, err)
 	assert.NotEmpty(t, tree, "BuildTree must return at least one root")
 
-	// At least one process must have a non-empty path that points at
-	// /usr/bin/python3 (the chain root).
+	// Final post-condition mirrors what Eventually waited on; kept as
+	// explicit asserts so a failure points at the missing path
+	// directly rather than at the polling timeout.
 	paths := flattenPaths(tree)
 	assert.Contains(t, paths, "/usr/bin/python3")
 	assert.Contains(t, paths, "/bin/sh")

--- a/server/identity/internal/authz/engine_test.go
+++ b/server/identity/internal/authz/engine_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/fleetdm/edr/server/identity/api"
 	"github.com/fleetdm/edr/server/identity/internal/authz"
+	"github.com/fleetdm/edr/server/identity/internal/seed"
 )
 
 // recordingAudit collects every AuditEvent the engine writes so tests
@@ -127,25 +128,43 @@ func TestAllow_RoleActionMatrix(t *testing.T) {
 }
 
 // TestAllow_EveryRegisteredActionGrantedSomewhere asserts the seeded
-// role matrix grants each Action constant to at least one role.
-// Catches an action being added to RegisteredActions without a
-// matching grant in roles.json — that action would silently produce
-// no_matching_rule for every caller forever, which would land as a
-// 403 the first time a real user invoked it with no obvious
-// diagnosis path. The Rego-side parity check in
-// TestPolicy_ActionsParity covers symbol drift; this test covers the
-// "registered but unreachable" gap on top.
+// role matrix grants each Action constant to at least one role
+// OTHER than super_admin. Catches an action being added to
+// RegisteredActions without a matching grant in roles.json — that
+// action would silently produce no_matching_rule for every caller
+// forever, which would land as a 403 the first time a real user
+// invoked it with no obvious diagnosis path. The Rego-side parity
+// check in TestPolicy_ActionsParity covers symbol drift; this test
+// covers the "registered but unreachable for real operators" gap on
+// top.
+//
+// super_admin is excluded from the probe because its `*` wildcard
+// would silently mask a new action that's only reachable by
+// break-glass — break-glass is for incident response, not routine
+// operator workflows. The wildcard is exercised separately by
+// TestAllow_RoleActionMatrix; here we want to know that every
+// action has a non-wildcard role that can do it.
+//
+// The seeded role list is derived from seed.BuiltinRoles to stay in
+// sync with the seeder: a future PR that introduces a new role
+// picks it up automatically (and the test keeps holding the line
+// "every action must reach a non-wildcard role").
 func TestAllow_EveryRegisteredActionGrantedSomewhere(t *testing.T) {
 	e, _ := newEngine(t, false)
-	// Mirror the seed/roles.go set; super_admin is the wildcard so any
-	// action it doesn't grant under * would point at a parser bug. The
-	// per-Action loop short-circuits on the first allow, so a wildcard
-	// hit usually wins instantly.
-	seededRoles := []string{"super_admin", "admin", "senior_analyst", "analyst", "auditor"}
+	var roles []string
+	for _, r := range seed.BuiltinRoles {
+		if r.ID == "super_admin" {
+			continue
+		}
+		roles = append(roles, r.ID)
+	}
+	require.NotEmptyf(t, roles,
+		"seed.BuiltinRoles produced no non-wildcard roles; the seeded "+
+			"matrix has changed shape and this test needs a fresh look")
 	for _, action := range api.RegisteredActions() {
 		t.Run(string(action), func(t *testing.T) {
 			granted := false
-			for _, role := range seededRoles {
+			for _, role := range roles {
 				actor := actorWithRoles(1, "default", tenantBinding(role, "default"))
 				ctx := api.WithActor(t.Context(), actor)
 				d, err := e.Allow(ctx, action, api.Resource{TenantID: "default"})
@@ -156,9 +175,11 @@ func TestAllow_EveryRegisteredActionGrantedSomewhere(t *testing.T) {
 				}
 			}
 			assert.Truef(t, granted,
-				"action %q is registered in api.RegisteredActions but no seeded "+
-					"role grants it; either add a grant in policy/data/roles.json "+
-					"or remove the constant from api.RegisteredActions", action)
+				"action %q is registered in api.RegisteredActions but no "+
+					"non-wildcard seeded role grants it; either add a grant in "+
+					"policy/data/roles.json (admin / senior_analyst / analyst / "+
+					"auditor) or remove the constant from api.RegisteredActions",
+				action)
 		})
 	}
 }

--- a/server/identity/internal/authz/engine_test.go
+++ b/server/identity/internal/authz/engine_test.go
@@ -126,6 +126,43 @@ func TestAllow_RoleActionMatrix(t *testing.T) {
 	}
 }
 
+// TestAllow_EveryRegisteredActionGrantedSomewhere asserts the seeded
+// role matrix grants each Action constant to at least one role.
+// Catches an action being added to RegisteredActions without a
+// matching grant in roles.json — that action would silently produce
+// no_matching_rule for every caller forever, which would land as a
+// 403 the first time a real user invoked it with no obvious
+// diagnosis path. The Rego-side parity check in
+// TestPolicy_ActionsParity covers symbol drift; this test covers the
+// "registered but unreachable" gap on top.
+func TestAllow_EveryRegisteredActionGrantedSomewhere(t *testing.T) {
+	e, _ := newEngine(t, false)
+	// Mirror the seed/roles.go set; super_admin is the wildcard so any
+	// action it doesn't grant under * would point at a parser bug. The
+	// per-Action loop short-circuits on the first allow, so a wildcard
+	// hit usually wins instantly.
+	seededRoles := []string{"super_admin", "admin", "senior_analyst", "analyst", "auditor"}
+	for _, action := range api.RegisteredActions() {
+		t.Run(string(action), func(t *testing.T) {
+			granted := false
+			for _, role := range seededRoles {
+				actor := actorWithRoles(1, "default", tenantBinding(role, "default"))
+				ctx := api.WithActor(t.Context(), actor)
+				d, err := e.Allow(ctx, action, api.Resource{TenantID: "default"})
+				require.NoError(t, err)
+				if d.Allow {
+					granted = true
+					break
+				}
+			}
+			assert.Truef(t, granted,
+				"action %q is registered in api.RegisteredActions but no seeded "+
+					"role grants it; either add a grant in policy/data/roles.json "+
+					"or remove the constant from api.RegisteredActions", action)
+		})
+	}
+}
+
 // TestAllow_UnregisteredAction_Denied verifies the defense-in-depth
 // gate: a caller passing an action string outside RegisteredActions
 // is denied with reason action_not_registered before Rego sees it.

--- a/test/arch/chokepoint_coverage_test.go
+++ b/test/arch/chokepoint_coverage_test.go
@@ -9,7 +9,6 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
-	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -53,15 +52,19 @@ var gateExceptions = map[string]bool{
 // TestEveryPrivilegedHandlerCallsHTTPGate walks each operator-surface
 // directory, parses every non-test Go file with go/parser, and fails
 // the test if the file declares an HTTP handler function but never
-// references HTTPGate.
+// makes a real call to HTTPGate. The check is per-file (any handler
+// in the file is "covered" if anywhere in the same file emits an
+// HTTPGate call expression), not per-handler-function — handlers in
+// these files share the same Handler struct and the same gating
+// pattern, so file-level coverage matches the convention.
 //
-// The check is loose by design: a handler could call HTTPGate from
-// a helper in the same file (still counted) or in a sibling file
-// (also counted because we check at the directory level when looser
-// matching is needed). The regression we care about is "someone
-// added a new privileged route and forgot the gate" — that almost
-// always lands as a new file with handler funcs but no HTTPGate
-// reference. False positives are addressed via gateExceptions.
+// Detection is AST-based: we look for ast.CallExpr nodes whose
+// function expression resolves to an identifier named HTTPGate
+// (matching api.HTTPGate, identityapi.HTTPGate, or any future
+// import alias). String-matching the source would let a file pass
+// by mentioning HTTPGate in a comment or a string literal — that
+// would weaken the architectural lock the test exists to enforce.
+// False positives are addressed via gateExceptions.
 func TestEveryPrivilegedHandlerCallsHTTPGate(t *testing.T) {
 	repoRoot := repoRootFromTest(t)
 	var offenders []string
@@ -178,17 +181,48 @@ func isRequestPtr(e ast.Expr) bool {
 	return ok && pkg.Name == "http" && sel.Sel.Name == "Request"
 }
 
-// fileReferencesHTTPGate returns true if the file's source mentions
-// HTTPGate anywhere. We use the source bytes (not the AST) because
-// the call may be qualified (api.HTTPGate, identityapi.HTTPGate) and
-// the ast.SelectorExpr walk would have to expand both spellings;
-// substring-matching is robust against future-rename without losing
-// fidelity (the helper is exported with that exact name).
+// fileReferencesHTTPGate returns true if the file makes a real call
+// to a function named HTTPGate (matching api.HTTPGate,
+// identityapi.HTTPGate, or any other import-alias spelling). We walk
+// the AST and look for ast.CallExpr nodes whose function expression
+// resolves to that identifier — string-matching the raw source would
+// let comments, doc strings, or unrelated names trip the check and
+// silently weaken the architectural lock.
 func fileReferencesHTTPGate(t *testing.T, path string) bool {
 	t.Helper()
-	src, err := os.ReadFile(path) //nolint:gosec // path comes from filepath.Join under a test-fixed prefix
-	require.NoErrorf(t, err, "read %s", path)
-	return strings.Contains(string(src), "HTTPGate")
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
+	require.NoErrorf(t, err, "parse %s", path)
+	found := false
+	ast.Inspect(f, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if calleeName(call.Fun) == "HTTPGate" {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
+}
+
+// calleeName returns the rightmost identifier of a call's function
+// expression: for `api.HTTPGate(…)` the SelectorExpr resolves to
+// "HTTPGate"; for a bare `HTTPGate(…)` (same-package) the Ident
+// itself resolves to "HTTPGate". Any other shape (dynamic dispatch
+// via interface, function literal, etc.) returns "" — operator
+// handlers don't use those, and matching them would risk false
+// positives on unrelated calls.
+func calleeName(fn ast.Expr) string {
+	switch v := fn.(type) {
+	case *ast.SelectorExpr:
+		return v.Sel.Name
+	case *ast.Ident:
+		return v.Name
+	}
+	return ""
 }
 
 // repoRootFromTest resolves the repo root by walking up from the
@@ -213,10 +247,3 @@ func repoRootFromTest(t *testing.T) string {
 	t.Fatalf("could not find go.mod walking up from %s", wd)
 	return ""
 }
-
-// Compile-time assertion that the `net/http` import is exercised.
-// The actual ResponseWriter / Request usage is via
-// AST-comparison-by-name above, so without this anchor the import
-// would be flagged unused by the linter. Anchor returns nil to keep
-// the helper inert; var _ = ensures it's evaluated.
-var _ = func() http.HandlerFunc { return nil }

--- a/test/arch/chokepoint_coverage_test.go
+++ b/test/arch/chokepoint_coverage_test.go
@@ -1,0 +1,222 @@
+// Package arch_test gates the architectural invariants every PR must
+// preserve. chokepoint_coverage_test asserts every operator-handler
+// file references the api.HTTPGate chokepoint helper, so a future PR
+// that adds a privileged route can't ship a handler that silently
+// bypasses the authorization gate.
+package arch_test
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// operatorHandlerDirs is the closed set of directories whose Go files
+// implement privileged HTTP handlers. Every non-test file in these
+// dirs that declares a function with the
+// `(http.ResponseWriter, *http.Request)` signature must reference
+// HTTPGate (api.HTTPGate or identityapi.HTTPGate). Adding a new
+// operator-surface package is a deliberate act: drop it in here at
+// the same time, with PR review on the gate coverage of every
+// handler in the new package.
+//
+// Pre-auth surfaces (oidc, breakglass, login) are intentionally out:
+// their routes don't gate on operator role bindings — they're the
+// authentication flows themselves. Reauth endpoints under
+// breakglass/handler.go gate on session AuthMethod, which is a
+// session-level check rather than the role-based chokepoint.
+var operatorHandlerDirs = []string{
+	"server/detection/internal/operator",
+	"server/rules/internal/operator",
+	"server/response/internal/operator",
+	"server/endpoint/internal/operator",
+	"server/identity/internal/audit",
+}
+
+// gateExceptions is the per-file allowlist for handler files that
+// legitimately don't call HTTPGate. Empty today; reserved for future
+// public-info / health / metric routes that might land in operator/
+// without authz gating. Adding an entry here is a deliberate act
+// that should ride alongside a PR comment explaining why.
+var gateExceptions = map[string]bool{
+	// Format: filepath relative to repo root, e.g.
+	// "server/detection/internal/operator/healthz.go".
+}
+
+// TestEveryPrivilegedHandlerCallsHTTPGate walks each operator-surface
+// directory, parses every non-test Go file with go/parser, and fails
+// the test if the file declares an HTTP handler function but never
+// references HTTPGate.
+//
+// The check is loose by design: a handler could call HTTPGate from
+// a helper in the same file (still counted) or in a sibling file
+// (also counted because we check at the directory level when looser
+// matching is needed). The regression we care about is "someone
+// added a new privileged route and forgot the gate" — that almost
+// always lands as a new file with handler funcs but no HTTPGate
+// reference. False positives are addressed via gateExceptions.
+func TestEveryPrivilegedHandlerCallsHTTPGate(t *testing.T) {
+	repoRoot := repoRootFromTest(t)
+	var offenders []string
+	handlerFilesScanned := 0
+	for _, relDir := range operatorHandlerDirs {
+		dir := filepath.Join(repoRoot, relDir)
+		entries, err := os.ReadDir(dir)
+		require.NoErrorf(t, err, "read operator dir %s", dir)
+		for _, e := range entries {
+			if e.IsDir() || !strings.HasSuffix(e.Name(), ".go") || strings.HasSuffix(e.Name(), "_test.go") {
+				continue
+			}
+			rel := filepath.Join(relDir, e.Name())
+			if gateExceptions[rel] {
+				continue
+			}
+			full := filepath.Join(dir, e.Name())
+			if !fileHasHandlerFunc(t, full) {
+				continue
+			}
+			handlerFilesScanned++
+			if !fileReferencesHTTPGate(t, full) {
+				offenders = append(offenders, rel)
+			}
+		}
+	}
+	// Defensive: a refactor that broke the parser would otherwise turn
+	// the test into a silent no-op. Pin a floor under the count of
+	// handler files we actually walked. Today there are 5 (one per
+	// operator-handler directory); the floor is 4 to give one
+	// directory the room to be temporarily restructured.
+	require.GreaterOrEqualf(t, handlerFilesScanned, 4,
+		"expected to walk at least 4 handler files across operatorHandlerDirs but "+
+			"only walked %d — the parser likely missed an HTTP handler signature, "+
+			"check fileHasHandlerFunc / paramTypeIdents",
+		handlerFilesScanned)
+	require.Emptyf(t, offenders,
+		"the following operator-handler files declare an http.ResponseWriter "+
+			"function but never reference HTTPGate; either add a chokepoint call "+
+			"or add the file to gateExceptions with a justification:\n  %s",
+		strings.Join(offenders, "\n  "))
+}
+
+// fileHasHandlerFunc returns true if any function in the file has a
+// signature matching `(http.ResponseWriter, *http.Request)`. Method
+// receivers + free functions both qualify; the parameter shape is
+// what matters.
+func fileHasHandlerFunc(t *testing.T, path string) bool {
+	t.Helper()
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
+	require.NoErrorf(t, err, "parse %s", path)
+	found := false
+	ast.Inspect(f, func(n ast.Node) bool {
+		fn, ok := n.(*ast.FuncDecl)
+		if !ok || fn.Type.Params == nil {
+			return true
+		}
+		params := fn.Type.Params.List
+		// Need at least two distinct parameter types: ResponseWriter
+		// then *Request. Param lists can group same-typed names in one
+		// Field, so flatten by counting types-at-positions.
+		types := paramTypeIdents(params)
+		if len(types) < 2 {
+			return true
+		}
+		if isResponseWriter(types[0]) && isRequestPtr(types[1]) {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
+}
+
+// paramTypeIdents returns the type expression at each parameter
+// position, expanding grouped Field entries (`a, b T`) into one entry
+// per name. The return is positional so caller can check param[0]
+// against ResponseWriter and param[1] against *Request without
+// re-walking.
+func paramTypeIdents(params []*ast.Field) []ast.Expr {
+	var out []ast.Expr
+	for _, p := range params {
+		if len(p.Names) == 0 {
+			out = append(out, p.Type)
+			continue
+		}
+		for range p.Names {
+			out = append(out, p.Type)
+		}
+	}
+	return out
+}
+
+func isResponseWriter(e ast.Expr) bool {
+	sel, ok := e.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	pkg, ok := sel.X.(*ast.Ident)
+	return ok && pkg.Name == "http" && sel.Sel.Name == "ResponseWriter"
+}
+
+func isRequestPtr(e ast.Expr) bool {
+	star, ok := e.(*ast.StarExpr)
+	if !ok {
+		return false
+	}
+	sel, ok := star.X.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	pkg, ok := sel.X.(*ast.Ident)
+	return ok && pkg.Name == "http" && sel.Sel.Name == "Request"
+}
+
+// fileReferencesHTTPGate returns true if the file's source mentions
+// HTTPGate anywhere. We use the source bytes (not the AST) because
+// the call may be qualified (api.HTTPGate, identityapi.HTTPGate) and
+// the ast.SelectorExpr walk would have to expand both spellings;
+// substring-matching is robust against future-rename without losing
+// fidelity (the helper is exported with that exact name).
+func fileReferencesHTTPGate(t *testing.T, path string) bool {
+	t.Helper()
+	src, err := os.ReadFile(path) //nolint:gosec // path comes from filepath.Join under a test-fixed prefix
+	require.NoErrorf(t, err, "read %s", path)
+	return strings.Contains(string(src), "HTTPGate")
+}
+
+// repoRootFromTest resolves the repo root by walking up from the
+// test's working directory looking for go.mod. The arch_test runs
+// from test/arch/ but other test bins might invoke it differently;
+// resolving go.mod up the tree is more robust than hardcoding "../..".
+func repoRootFromTest(t *testing.T) string {
+	t.Helper()
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+	cur := wd
+	for range 8 { // depth cap: any sane repo finds go.mod within 8 hops
+		if _, err := os.Stat(filepath.Join(cur, "go.mod")); err == nil {
+			return cur
+		}
+		parent := filepath.Dir(cur)
+		if parent == cur {
+			break
+		}
+		cur = parent
+	}
+	t.Fatalf("could not find go.mod walking up from %s", wd)
+	return ""
+}
+
+// Compile-time assertion that the `net/http` import is exercised.
+// The actual ResponseWriter / Request usage is via
+// AST-comparison-by-name above, so without this anchor the import
+// would be flagged unused by the linter. Anchor returns nil to keep
+// the helper inert; var _ = ensures it's evaluated.
+var _ = func() http.HandlerFunc { return nil }


### PR DESCRIPTION
The spec frames Phase 6 as a single-PR flip of authz.shadow_mode from true to false. In this codebase that flip already happened in Phase 2 wiring — server/config/config.go reads
EDR_AUTHZ_SHADOW_MODE as opt-in, default false. Phase 6 here is ship-v1 readiness instead: lock coverage so a v1 tag can't carry a privileged handler that silently bypasses the chokepoint, and write the doc the first-deploying operator reads when a 403 lands.

Tests:
- TestAllow_EveryRegisteredActionGrantedSomewhere (server/identity/internal/authz/engine_test.go) iterates RegisteredActions() and asserts each is granted by at least one seeded role. Catches an action added to the registry without a matching grant in roles.json — that action would otherwise ship as a permanent no_matching_rule deny for every caller.
- TestEveryPrivilegedHandlerCallsHTTPGate (test/arch/chokepoint_coverage_test.go) parses every operator handler file under {detection,rules,response,endpoint}/internal/operator/
  + identity/internal/audit/, finds functions with the (http.ResponseWriter, *http.Request) signature, and asserts the file references HTTPGate. Path-based gateExceptions allowlist for files that legitimately don't gate (empty today). Defensive handlerFilesScanned floor catches a parser regression that would otherwise turn the test into a silent no-op.

Boot log:
- main.go now logs `authz enforcement posture=ENABLED|SHADOW` on startup. A typo on EDR_AUTHZ_SHADOW_MODE surfaces immediately rather than via a confused 403 hours later. Separate event from the broader "fleet-edr-server starting" line so a SigNoz / log- shipper alert pivoting on the posture field doesn't have to parse it out of noisier multi-field events.

Comment cleanup:
- config.go's AuthzShadowMode comment dropped the "wave-1 rollout knob" framing — wave 1 IS what v1 ships. Documents the field as the audit-only knob and the boot-only read semantics.

Operator runbook:
- New docs/authz.md. Covers the seeded role matrix (mirroring policy/data/roles.json), the wire shape of a chokepoint deny including the reauth_required structured body, the seven reason codes with one-line guidance per code, the wave-1 SQL pattern for binding a role, the EDR_AUTHZ_SHADOW_MODE knob, and a cross-reference to the three test layers that protect the contract going forward. First-deploy guidance, not incident response.

The HTTP-end role-matrix integration test (originally proposed in the plan) is dropped: the engine matrix in
TestAllow_RoleActionMatrix already pins (role, action) verdicts, and the new handler-coverage test catches handlers that forgot the gate entirely. The narrow remaining gap (handler calls HTTPGate with the wrong Action constant) is small enough to defer past v1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added detailed authorization enforcement documentation covering configuration, role matrices, audit logging, and operational procedures including role binding management.

* **Logging & Observability**
  * Authorization enforcement posture is now logged during startup for operational visibility and troubleshooting.

* **Tests**
  * Added architectural tests to ensure authorization enforcement mechanisms are consistently applied across all operator actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->