### PR TITLE
phase 8: validation gates for the wave-1 RBAC story

### DIFF
--- a/config/observability/edr-authz-dashboard.json
+++ b/config/observability/edr-authz-dashboard.json
@@ -12,7 +12,7 @@
     {
       "id": "1",
       "title": "Authz deny rate by reason",
-      "description": "Count of audit-row INFO logs whose action starts with authz. and whose payload.decision = deny, grouped by payload.reason. The chokepoint emits exactly one such row per privileged HTTP request (allow + deny), so this panel is a faithful proxy for chokepoint deny rate. A baseline of low-volume reauth_required denies is healthy (operators triggering the freshness gate); a sudden spike on role_missing or actor_anonymous is worth chasing. Cross-reference with HTTP traces (status_code=403) to attribute denies to specific routes.",
+      "description": "Count of audit-row INFO logs whose action starts with authz. and whose payload.allow = false, grouped by payload.reason. The chokepoint emits exactly one such row per privileged HTTP request (allow + deny), so this panel is a faithful proxy for chokepoint deny rate. A baseline of low-volume reauth_required denies is healthy (operators triggering the freshness gate); a sudden spike on no_matching_rule or no_actor is worth chasing. Cross-reference with HTTP traces (status_code=403) to attribute denies to specific routes.",
       "panelTypes": "graph",
       "query": {
         "queryType": "builder",
@@ -27,7 +27,7 @@
                 "items": [
                   {"key": {"key": "service.name", "type": "resource"}, "op": "=", "value": "fleet-edr-server"},
                   {"key": {"key": "action", "type": "tag"}, "op": "REGEXP", "value": "^authz\\."},
-                  {"key": {"key": "payload.decision", "type": "tag"}, "op": "=", "value": "deny"}
+                  {"key": {"key": "payload.allow", "type": "tag"}, "op": "=", "value": "false"}
                 ]
               },
               "groupBy": [{"key": "payload.reason", "type": "tag"}],

--- a/server/identity/internal/authz/engine_pbt_test.go
+++ b/server/identity/internal/authz/engine_pbt_test.go
@@ -26,25 +26,31 @@ var rolesFS embed.FS
 
 const rolesPath = "policy/data/roles.json"
 
-// TestEngine_ActionRegistryParity_PBT generates random (role x action)
-// pairs and asserts the chokepoint's decision matches the policy's
-// declared invariants for every sampled pair. Properties pinned:
+// TestEngine_ActionRegistryParity_PBT generates random (role x action
+// x resource_type x severity x session_fresh) tuples and asserts the
+// chokepoint's decision matches the policy's declared invariants for
+// every sampled tuple. Properties pinned:
 //
 //  1. Engine.Allow never returns a non-nil error for a registered
 //     action against a well-formed Resource.
 //  2. Decision.Reason is one of the canonical Reason* constants.
 //  3. Allow=true iff the role's grants list contains the action OR "*",
-//     except when the action requires a fresh auth event and the
-//     actor's SessionFresh=false (then it denies with reauth_required).
+//     except when the action+resource pair requires a fresh auth
+//     event and the actor's SessionFresh=false (then it denies with
+//     reauth_required). The Rego policy's requires_fresh_auth covers
+//     host.{isolate,kill_process,run_script} unconditionally and
+//     alert.resolve when resource.severity=="critical"; the test's
+//     requiresFreshAuth predicate mirrors that table.
 //  4. Determinism: two Allow calls with the same input return the
 //     identical Decision.
 //
 // The PBT complements the example-based engine tests: the table tests
 // pin specific named scenarios (super_admin grants everything; analyst
 // cannot host.isolate; etc.) and stay readable; the PBT covers the
-// (5 roles x 20 actions x freshness) cross-product so a missing entry
-// in roles.json or a regressed grant list is caught even when no
-// example test happens to name that combination.
+// (5 roles x 20 actions x 5 resource types x severity x freshness)
+// cross-product so a missing entry in roles.json or a regressed grant
+// list is caught even when no example test happens to name that
+// combination.
 func TestEngine_ActionRegistryParity_PBT(t *testing.T) {
 	engine := newEnginePBT(t)
 	roleSet := loadRolesFromBundle(t)
@@ -59,6 +65,9 @@ func TestEngine_ActionRegistryParity_PBT(t *testing.T) {
 		role := rapid.SampledFrom(roleNames).Draw(rt, "role")
 		action := rapid.SampledFrom(actionSet).Draw(rt, "action")
 		fresh := rapid.Bool().Draw(rt, "session_fresh")
+		resourceType := rapid.SampledFrom([]string{"host", "alert", "policy", "user", "audit"}).
+			Draw(rt, "resource_type")
+		severity := rapid.SampledFrom([]string{"", "low", "high", "critical"}).Draw(rt, "severity")
 
 		actor := api.Actor{
 			UserID:       1,
@@ -69,15 +78,16 @@ func TestEngine_ActionRegistryParity_PBT(t *testing.T) {
 				UserID:    1,
 				RoleID:    role,
 				TenantID:  api.DefaultTenantID,
-				ScopeType: "tenant",
+				ScopeType: api.RoleBindingScopeTenant,
 				ScopeID:   "*",
 			}},
 		}
 		ctx := api.WithActor(context.Background(), &actor)
 		resource := api.Resource{
 			TenantID: api.DefaultTenantID,
-			Type:     "host",
-			ID:       "host-1",
+			Type:     resourceType,
+			ID:       "resource-1",
+			Severity: severity,
 		}
 
 		first, err := engine.Allow(ctx, action, resource)
@@ -88,7 +98,7 @@ func TestEngine_ActionRegistryParity_PBT(t *testing.T) {
 
 		grants := roleSet[role]
 		grantsAction := slices.Contains(grants, string(action)) || slices.Contains(grants, "*")
-		needsFresh := requiresFreshAuth(action)
+		needsFresh := requiresFreshAuth(action, resource)
 
 		switch {
 		case grantsAction && (!needsFresh || fresh):
@@ -116,6 +126,124 @@ func TestEngine_ActionRegistryParity_PBT(t *testing.T) {
 	})
 }
 
+// TestEngine_NonTenantScope_PBT covers the scope_not_yet_supported
+// branch in the Rego policy. The wave-1 resolver only honors
+// scope_type=='tenant'; bindings with 'host_group' or 'host' scope
+// MAY land in the table (the column is forward-compatible with
+// wave-2) but the chokepoint denies them with the distinguishable
+// reason so dashboards can chart "would have been allowed under
+// wave-2" as its own dimension.
+//
+// Property: for any role whose grants list contains the action AND
+// any non-tenant scope_type, Engine.Allow denies with reason
+// scope_not_yet_supported. For non-granting roles, the policy's
+// no_matching_rule deny still wins (the scope branch only fires
+// when the role would otherwise have granted).
+func TestEngine_NonTenantScope_PBT(t *testing.T) {
+	engine := newEnginePBT(t)
+	roleSet := loadRolesFromBundle(t)
+	actionSet := api.RegisteredActions()
+	roleNames := make([]string, 0, len(roleSet))
+	for name := range roleSet {
+		roleNames = append(roleNames, name)
+	}
+	slices.Sort(roleNames)
+
+	rapid.Check(t, func(rt *rapid.T) {
+		role := rapid.SampledFrom(roleNames).Draw(rt, "role")
+		action := rapid.SampledFrom(actionSet).Draw(rt, "action")
+		scope := rapid.SampledFrom([]api.RoleBindingScopeType{
+			api.RoleBindingScopeHost,
+			api.RoleBindingScopeHostGroup,
+		}).Draw(rt, "scope")
+
+		actor := api.Actor{
+			UserID:       1,
+			TenantID:     api.DefaultTenantID,
+			AuthMethod:   "oidc",
+			SessionFresh: true,
+			Roles: []api.RoleBinding{{
+				UserID:    1,
+				RoleID:    role,
+				TenantID:  api.DefaultTenantID,
+				ScopeType: scope,
+				ScopeID:   "scope-1",
+			}},
+		}
+		ctx := api.WithActor(context.Background(), &actor)
+		resource := api.Resource{
+			TenantID: api.DefaultTenantID,
+			Type:     "host",
+			ID:       "host-1",
+		}
+
+		got, err := engine.Allow(ctx, action, resource)
+		require.NoError(rt, err)
+		require.Falsef(rt, got.Allow,
+			"non-tenant scope must never allow role=%s action=%s scope=%s decision=%+v",
+			role, action, scope, got)
+
+		grants := roleSet[role]
+		grantsAction := slices.Contains(grants, string(action)) || slices.Contains(grants, "*")
+		want := api.ReasonNoMatchingRule
+		if grantsAction {
+			want = api.ReasonScopeNotYetSupported
+		}
+		require.Equalf(rt, want, got.Reason,
+			"unexpected deny reason role=%s action=%s scope=%s grants=%v",
+			role, action, scope, grantsAction)
+	})
+}
+
+// TestEngine_MissingResourceTenant_PBT covers the
+// resource_tenant_missing defense-in-depth path. The chokepoint
+// short-circuits before invoking Rego when resource.TenantID is
+// empty so a misconfigured caller surfaces a distinct deny reason
+// instead of a silent no_matching_rule.
+//
+// Property: empty resource.TenantID always yields a deny with reason
+// resource_tenant_missing, regardless of role / action / scope.
+func TestEngine_MissingResourceTenant_PBT(t *testing.T) {
+	engine := newEnginePBT(t)
+	roleSet := loadRolesFromBundle(t)
+	actionSet := api.RegisteredActions()
+	roleNames := make([]string, 0, len(roleSet))
+	for name := range roleSet {
+		roleNames = append(roleNames, name)
+	}
+	slices.Sort(roleNames)
+
+	rapid.Check(t, func(rt *rapid.T) {
+		role := rapid.SampledFrom(roleNames).Draw(rt, "role")
+		action := rapid.SampledFrom(actionSet).Draw(rt, "action")
+
+		actor := api.Actor{
+			UserID:       1,
+			TenantID:     api.DefaultTenantID,
+			AuthMethod:   "oidc",
+			SessionFresh: true,
+			Roles: []api.RoleBinding{{
+				UserID:    1,
+				RoleID:    role,
+				TenantID:  api.DefaultTenantID,
+				ScopeType: api.RoleBindingScopeTenant,
+				ScopeID:   "*",
+			}},
+		}
+		ctx := api.WithActor(context.Background(), &actor)
+		resource := api.Resource{TenantID: "", Type: "host", ID: "host-1"}
+
+		got, err := engine.Allow(ctx, action, resource)
+		require.NoError(rt, err)
+		require.Falsef(rt, got.Allow,
+			"empty resource tenant must always deny role=%s action=%s decision=%+v",
+			role, action, got)
+		require.Equalf(rt, api.ReasonResourceTenantMissing, got.Reason,
+			"empty resource tenant must surface resource_tenant_missing role=%s action=%s",
+			role, action)
+	})
+}
+
 // canonicalReasons is the closed set of strings api.ReasonReauthRequired
 // and friends declare. The PBT asserts every decision lands in this
 // set; a regression that introduces a freeform reason string fails
@@ -139,20 +267,22 @@ var canonicalReasons = []string{
 // real regression the PBT catches (the engine returns reauth_required
 // where the table predicted granted, or vice versa).
 //
-// freshAuthActions is the closed set policy/edr.rego treats as
-// destructive enough to require Actor.SessionFresh. Pulled out as a
-// map so the lint's exhaustive-switch rule doesn't fire — tests
-// shouldn't enumerate every action just to declare three of them
-// require fresh auth.
+// freshAuthActions is the unconditional-fresh-auth subset
+// policy/edr.rego treats as destructive enough to require
+// Actor.SessionFresh regardless of resource attributes. The
+// alert.resolve case is conditional on resource.severity=="critical"
+// and is handled inline below.
 var freshAuthActions = map[api.Action]struct{}{
 	api.ActionHostIsolate:     {},
 	api.ActionHostKillProcess: {},
 	api.ActionHostRunScript:   {},
 }
 
-func requiresFreshAuth(action api.Action) bool {
-	_, ok := freshAuthActions[action]
-	return ok
+func requiresFreshAuth(action api.Action, resource api.Resource) bool {
+	if _, ok := freshAuthActions[action]; ok {
+		return true
+	}
+	return action == api.ActionAlertResolve && resource.Severity == "critical"
 }
 
 // newEnginePBT builds a real Engine over the embedded policy bundle.

--- a/server/identity/internal/authz/engine_pbt_test.go
+++ b/server/identity/internal/authz/engine_pbt_test.go
@@ -1,0 +1,200 @@
+package authz_test
+
+import (
+	"context"
+	"embed"
+	"encoding/json"
+	"log/slog"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"pgregory.net/rapid"
+
+	"github.com/fleetdm/edr/server/identity/api"
+	"github.com/fleetdm/edr/server/identity/internal/authz"
+)
+
+// rolesFS embeds the same roles.json the engine compiles into the
+// policy bundle. The PBT reads it at test time so the property checks
+// stay in sync with whatever role/grants list the engine is actually
+// evaluating; renaming a role in roles.json without updating any test
+// fixture still gets exercised by the PBT on the next run.
+//
+//go:embed policy/data/roles.json
+var rolesFS embed.FS
+
+const rolesPath = "policy/data/roles.json"
+
+// TestEngine_ActionRegistryParity_PBT generates random (role x action)
+// pairs and asserts the chokepoint's decision matches the policy's
+// declared invariants for every sampled pair. Properties pinned:
+//
+//  1. Engine.Allow never returns a non-nil error for a registered
+//     action against a well-formed Resource.
+//  2. Decision.Reason is one of the canonical Reason* constants.
+//  3. Allow=true iff the role's grants list contains the action OR "*",
+//     except when the action requires a fresh auth event and the
+//     actor's SessionFresh=false (then it denies with reauth_required).
+//  4. Determinism: two Allow calls with the same input return the
+//     identical Decision.
+//
+// The PBT complements the example-based engine tests: the table tests
+// pin specific named scenarios (super_admin grants everything; analyst
+// cannot host.isolate; etc.) and stay readable; the PBT covers the
+// (5 roles x 20 actions x freshness) cross-product so a missing entry
+// in roles.json or a regressed grant list is caught even when no
+// example test happens to name that combination.
+func TestEngine_ActionRegistryParity_PBT(t *testing.T) {
+	engine := newEnginePBT(t)
+	roleSet := loadRolesFromBundle(t)
+	actionSet := api.RegisteredActions()
+	roleNames := make([]string, 0, len(roleSet))
+	for name := range roleSet {
+		roleNames = append(roleNames, name)
+	}
+	slices.Sort(roleNames)
+
+	rapid.Check(t, func(rt *rapid.T) {
+		role := rapid.SampledFrom(roleNames).Draw(rt, "role")
+		action := rapid.SampledFrom(actionSet).Draw(rt, "action")
+		fresh := rapid.Bool().Draw(rt, "session_fresh")
+
+		actor := api.Actor{
+			UserID:       1,
+			TenantID:     api.DefaultTenantID,
+			AuthMethod:   "oidc",
+			SessionFresh: fresh,
+			Roles: []api.RoleBinding{{
+				UserID:    1,
+				RoleID:    role,
+				TenantID:  api.DefaultTenantID,
+				ScopeType: "tenant",
+				ScopeID:   "*",
+			}},
+		}
+		ctx := api.WithActor(context.Background(), &actor)
+		resource := api.Resource{
+			TenantID: api.DefaultTenantID,
+			Type:     "host",
+			ID:       "host-1",
+		}
+
+		first, err := engine.Allow(ctx, action, resource)
+		require.NoErrorf(rt, err, "engine errored on registered action role=%s action=%s", role, action)
+
+		require.Containsf(rt, canonicalReasons, first.Reason,
+			"non-canonical reason role=%s action=%s decision=%+v", role, action, first)
+
+		grants := roleSet[role]
+		grantsAction := slices.Contains(grants, string(action)) || slices.Contains(grants, "*")
+		needsFresh := requiresFreshAuth(action)
+
+		switch {
+		case grantsAction && (!needsFresh || fresh):
+			require.Truef(rt, first.Allow,
+				"expected allow role=%s action=%s fresh=%v decision=%+v", role, action, fresh, first)
+			require.Equalf(rt, api.ReasonGranted, first.Reason,
+				"granted-allow must use ReasonGranted role=%s action=%s", role, action)
+		case grantsAction && needsFresh && !fresh:
+			require.Falsef(rt, first.Allow,
+				"reauth-required deny must not allow role=%s action=%s decision=%+v", role, action, first)
+			require.Equalf(rt, api.ReasonReauthRequired, first.Reason,
+				"granted action with stale session must deny with reauth_required role=%s action=%s", role, action)
+		default:
+			require.Falsef(rt, first.Allow,
+				"role without grant must deny role=%s action=%s decision=%+v", role, action, first)
+			require.Equalf(rt, api.ReasonNoMatchingRule, first.Reason,
+				"non-granting role must deny with no_matching_rule role=%s action=%s", role, action)
+		}
+
+		second, err := engine.Allow(ctx, action, resource)
+		require.NoError(rt, err)
+		require.Equalf(rt, first, second,
+			"non-deterministic decision role=%s action=%s first=%+v second=%+v",
+			role, action, first, second)
+	})
+}
+
+// canonicalReasons is the closed set of strings api.ReasonReauthRequired
+// and friends declare. The PBT asserts every decision lands in this
+// set; a regression that introduces a freeform reason string fails
+// here before it can drift across the audit row's `payload.reason`
+// column and break the SigNoz dashboard's grouping.
+var canonicalReasons = []string{
+	api.ReasonGranted,
+	api.ReasonNoMatchingRule,
+	api.ReasonScopeNotYetSupported,
+	api.ReasonActionNotRegistered,
+	api.ReasonNoActor,
+	api.ReasonResourceTenantMissing,
+	api.ReasonShadowMode,
+	api.ReasonReauthRequired,
+}
+
+// requiresFreshAuth mirrors the Rego policy's requires_fresh_auth
+// predicate against the destructive-action set. Kept as a Go-side
+// table so the PBT predicts the engine's decision without parsing
+// Rego: a divergence between this table and policy/edr.rego is a
+// real regression the PBT catches (the engine returns reauth_required
+// where the table predicted granted, or vice versa).
+//
+// freshAuthActions is the closed set policy/edr.rego treats as
+// destructive enough to require Actor.SessionFresh. Pulled out as a
+// map so the lint's exhaustive-switch rule doesn't fire — tests
+// shouldn't enumerate every action just to declare three of them
+// require fresh auth.
+var freshAuthActions = map[api.Action]struct{}{
+	api.ActionHostIsolate:     {},
+	api.ActionHostKillProcess: {},
+	api.ActionHostRunScript:   {},
+}
+
+func requiresFreshAuth(action api.Action) bool {
+	_, ok := freshAuthActions[action]
+	return ok
+}
+
+// newEnginePBT builds a real Engine over the embedded policy bundle.
+// audit recorder is nil (per Engine.New's doc: "Audit may be nil only
+// in tests"); shadow mode off; no async writer.
+func newEnginePBT(t *testing.T) *authz.Engine {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(testLogWriter{t}, &slog.HandlerOptions{Level: slog.LevelError}))
+	e, err := authz.New(context.Background(), nil, logger, false, authz.Options{})
+	require.NoError(t, err)
+	return e
+}
+
+// loadRolesFromBundle reads policy/data/roles.json via the test's own
+// embedded copy. The package's authz.policyFS embed is unexported, so
+// the test can't reach it; embedding the same file from the test
+// keeps the PBT in sync with the live data without exposing the
+// production embed.FS.
+func loadRolesFromBundle(t *testing.T) map[string][]string {
+	t.Helper()
+	bytesData, err := rolesFS.ReadFile(rolesPath)
+	require.NoError(t, err, "read roles.json fixture")
+	var doc struct {
+		Roles map[string]struct {
+			Grants []string `json:"grants"`
+		} `json:"roles"`
+	}
+	require.NoError(t, json.Unmarshal(bytesData, &doc))
+	out := make(map[string][]string, len(doc.Roles))
+	for name, role := range doc.Roles {
+		out[name] = role.Grants
+	}
+	require.NotEmpty(t, out, "roles.json must declare at least one role")
+	return out
+}
+
+// testLogWriter routes engine error logs through t.Log so PBT shrink
+// reports include the engine's own error context, not just the bare
+// require failure.
+type testLogWriter struct{ t *testing.T }
+
+func (w testLogWriter) Write(p []byte) (int, error) {
+	w.t.Log(string(p))
+	return len(p), nil
+}

--- a/server/identity/internal/rbac/role_bindings_pbt_test.go
+++ b/server/identity/internal/rbac/role_bindings_pbt_test.go
@@ -1,0 +1,129 @@
+//go:build integration
+
+package rbac_test
+
+import (
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"pgregory.net/rapid"
+
+	"github.com/fleetdm/edr/server/identity/api"
+	"github.com/fleetdm/edr/server/identity/internal/rbac"
+)
+
+// TestListLiveBindings_ExpiryBoundary_PBT generates random expires_at
+// timestamps and asserts the SQL filter "expires_at IS NULL OR
+// expires_at > NOW(6)" stays correct across the boundary. The
+// existing example-based TestListLiveBindings_ExpiredBindingsFiltered
+// pins three named cases (past, future, NULL); this PBT explores the
+// space between them so a regression that swaps `>` for `>=` (or
+// drops the NULL clause) trips on the next run.
+//
+// Property: a binding with expires_at=t is returned iff t is NULL OR
+// t is strictly after the wall-clock NOW(6) at SELECT time.
+//
+// Generation strategy: rapid draws an offset in (-2h, +2h) skipping a
+// 250ms band around zero. The skip avoids a known race (the
+// timestamp's nominal offset puts it past NOW(6) at INSERT time, but
+// the SELECT runs on a slightly-later NOW(6) and the row no longer
+// matches). 250ms is large enough to absorb test runner / DB roundtrip
+// jitter without trivializing the boundary check.
+func TestListLiveBindings_ExpiryBoundary_PBT(t *testing.T) {
+	db := openSchema(t)
+	store := rbac.New(db)
+
+	rapid.Check(t, func(rt *rapid.T) {
+		offsetMillis := rapid.OneOf(
+			rapid.IntRange(-2*60*60*1000, -250),
+			rapid.IntRange(250, 2*60*60*1000),
+		).Draw(rt, "offset_millis")
+		nullExpiry := rapid.Bool().Draw(rt, "null_expiry")
+		email := uniqueEmail(rt)
+
+		uid := insertUser(t, db, email)
+		var expires *time.Time
+		if !nullExpiry {
+			at := time.Now().Add(time.Duration(offsetMillis) * time.Millisecond)
+			expires = &at
+		}
+		insertBinding(t, db, bindingFixture{
+			UserID:    uid,
+			RoleID:    "analyst",
+			TenantID:  api.DefaultTenantID,
+			ScopeType: "tenant",
+			ScopeID:   "*",
+			ExpiresAt: expires,
+		})
+
+		got, err := store.ListLiveBindings(t.Context(), uid)
+		require.NoError(rt, err)
+
+		// Property: returned iff null OR strictly future.
+		shouldReturn := nullExpiry || offsetMillis > 0
+		if shouldReturn {
+			require.Lenf(rt, got, 1,
+				"binding with offset_millis=%d null=%v should be live", offsetMillis, nullExpiry)
+		} else {
+			require.Emptyf(rt, got,
+				"binding with offset_millis=%d null=%v should be expired", offsetMillis, nullExpiry)
+		}
+	})
+}
+
+// TestListLiveBindings_RoleSelectivity_PBT confirms that for any
+// random combination of (live + expired) bindings on the same user,
+// only the live ones come back, in any order. The example test pins
+// a specific 3-binding fixture; this PBT covers the wider space of
+// "n live + m expired" combinations.
+func TestListLiveBindings_RoleSelectivity_PBT(t *testing.T) {
+	db := openSchema(t)
+	store := rbac.New(db)
+	roles := []string{"super_admin", "admin", "senior_analyst", "analyst", "auditor"}
+
+	rapid.Check(t, func(rt *rapid.T) {
+		liveRoles := rapid.SliceOfDistinct(rapid.SampledFrom(roles), func(s string) string { return s }).
+			Draw(rt, "live_roles")
+		expiredRoles := rapid.SliceOfDistinct(rapid.SampledFrom(roles), func(s string) string { return s }).
+			Draw(rt, "expired_roles")
+		// Ensure no overlap between sets so we can assert exact membership.
+		expiredRoles = slices.DeleteFunc(expiredRoles, func(r string) bool { return slices.Contains(liveRoles, r) })
+
+		email := uniqueEmail(rt)
+		uid := insertUser(t, db, email)
+		for _, role := range liveRoles {
+			future := time.Now().Add(1 * time.Hour)
+			insertBinding(t, db, bindingFixture{
+				UserID: uid, RoleID: role, TenantID: api.DefaultTenantID,
+				ScopeType: "tenant", ScopeID: "*", ExpiresAt: &future,
+			})
+		}
+		for _, role := range expiredRoles {
+			past := time.Now().Add(-1 * time.Hour)
+			insertBinding(t, db, bindingFixture{
+				UserID: uid, RoleID: role, TenantID: api.DefaultTenantID,
+				ScopeType: "tenant", ScopeID: "*", ExpiresAt: &past,
+			})
+		}
+
+		got, err := store.ListLiveBindings(t.Context(), uid)
+		require.NoError(rt, err)
+		gotRoles := make([]string, 0, len(got))
+		for _, b := range got {
+			gotRoles = append(gotRoles, b.RoleID)
+		}
+		require.ElementsMatchf(rt, liveRoles, gotRoles,
+			"live=%v expired=%v got=%v", liveRoles, expiredRoles, gotRoles)
+	})
+}
+
+// uniqueEmail returns a per-property-iteration email so each PBT
+// iteration's user is isolated. The role_bindings unique key is
+// (user_id, role_id, tenant_id, scope_type, scope_id) so reusing a
+// user across iterations would risk duplicate-key errors when the
+// same role appears in two iterations' liveRoles draws.
+func uniqueEmail(rt *rapid.T) string {
+	return rapid.StringMatching(`pbt-[a-z0-9]{8}@test`).Draw(rt, "email")
+}

--- a/server/identity/testkit/testkit.go
+++ b/server/identity/testkit/testkit.go
@@ -19,11 +19,15 @@ package testkit
 
 import (
 	"context"
+	"testing"
+	"time"
 
 	"github.com/jmoiron/sqlx"
+	"github.com/stretchr/testify/require"
 
 	"github.com/fleetdm/edr/server/identity/api"
 	"github.com/fleetdm/edr/server/identity/bootstrap"
+	"github.com/fleetdm/edr/server/identity/internal/sessions"
 )
 
 // ApplySchema runs identity's DDL + idempotent ALTERs against db.
@@ -64,4 +68,89 @@ func (d DenyAuthZ) Allow(context.Context, api.Action, api.Resource) (api.Decisio
 		r = "no_matching_rule"
 	}
 	return api.Decision{Allow: false, Reason: r}, nil
+}
+
+// SeededUser is the result of SeedJITUser: the user row + a live
+// session ready to drop into a cookie. ID is the user's primary key;
+// SessionCookie is the base64url-encoded session token (use this for
+// the `edr_session` cookie value); CSRFToken is the per-session CSRF
+// secret base64url-encoded for the `X-Csrf-Token` header.
+type SeededUser struct {
+	ID            int64
+	Email         string
+	Role          string
+	SessionCookie string
+	CSRFToken     string
+}
+
+// SeedJITUser inserts the rows an OIDC JIT-provisioned operator would
+// land in: users + identities (provider='oidc', subject=email) +
+// role_bindings (tenant scope, no expiry) + a fresh session. Returns
+// the user id + the cookie/CSRF pair the test plugs into HTTP requests
+// against the protected mux.
+//
+// Cross-context tests use this to skip the full OIDC dance — the OIDC
+// callback flow is exhaustively covered in the oidc package's own
+// tests, and a cross-context test re-running the parsing dance would
+// just be re-testing OIDC. The end-state SQL shape and the live
+// session cookie are what every downstream chokepoint check actually
+// reads, so this helper matches that shape exactly.
+//
+// auth_method is hardcoded to "oidc" because that's the JIT-provisioned
+// path's session class (break-glass goes through a distinct flow with
+// its own helper). last_auth_at is set to NOW() by sessions.Store so
+// the chokepoint's freshness gate (Phase 5 reauth window) returns true
+// for destructive actions; tests that need a stale session age the
+// row directly.
+func SeedJITUser(t *testing.T, db *sqlx.DB, email, role string) SeededUser {
+	t.Helper()
+	ctx := t.Context()
+
+	userRes, err := db.ExecContext(ctx,
+		`INSERT INTO users (email, tenant_id, status) VALUES (?, ?, 'active')`,
+		email, api.DefaultTenantID)
+	require.NoErrorf(t, err, "seed user %q", email)
+	userID, err := userRes.LastInsertId()
+	require.NoError(t, err)
+
+	identityRes, err := db.ExecContext(ctx,
+		`INSERT INTO identities (user_id, provider, subject) VALUES (?, 'oidc', ?)`,
+		userID, email)
+	require.NoErrorf(t, err, "seed identity for %q", email)
+	identityID, err := identityRes.LastInsertId()
+	require.NoError(t, err)
+
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO role_bindings (user_id, role_id, tenant_id, scope_type, scope_id)
+		 VALUES (?, ?, ?, 'tenant', '*')`,
+		userID, role, api.DefaultTenantID)
+	require.NoErrorf(t, err, "seed role binding %s for user %d", role, userID)
+
+	sessionStore := sessions.New(db, sessions.Options{})
+	sess, err := sessionStore.Create(ctx, userID, sessions.CreateOptions{
+		IdentityID: &identityID,
+		AuthMethod: "oidc",
+	})
+	require.NoError(t, err, "mint session")
+
+	return SeededUser{
+		ID:            userID,
+		Email:         email,
+		Role:          role,
+		SessionCookie: api.EncodeToken(sess.ID),
+		CSRFToken:     api.EncodeToken(sess.CSRFToken),
+	}
+}
+
+// AgeSession backdates a seeded session's last_auth_at column so the
+// chokepoint's freshness gate (Phase 5 reauth window) returns false.
+// Used to verify that a destructive action that would normally be
+// granted denies with reauth_required when the session is stale.
+func AgeSession(t *testing.T, db *sqlx.DB, userID int64, age time.Duration) {
+	t.Helper()
+	ctx := t.Context()
+	_, err := db.ExecContext(ctx,
+		`UPDATE sessions SET last_auth_at = NOW(6) - INTERVAL ? SECOND WHERE user_id = ?`,
+		int64(age.Seconds()), userID)
+	require.NoErrorf(t, err, "age session for user %d", userID)
 }

--- a/server/identity/testkit/testkit.go
+++ b/server/identity/testkit/testkit.go
@@ -84,7 +84,8 @@ type SeededUser struct {
 }
 
 // SeedJITUser inserts the rows an OIDC JIT-provisioned operator would
-// land in: users + identities (provider='oidc', subject=email) +
+// land in: users + identities (provider='oidc', subject="oidc:<email>"
+// to mimic an IdP-stable subject distinct from the email column) +
 // role_bindings (tenant scope, no expiry) + a fresh session. Returns
 // the user id + the cookie/CSRF pair the test plugs into HTTP requests
 // against the protected mux.
@@ -95,6 +96,12 @@ type SeededUser struct {
 // just be re-testing OIDC. The end-state SQL shape and the live
 // session cookie are what every downstream chokepoint check actually
 // reads, so this helper matches that shape exactly.
+//
+// The synthetic "oidc:<email>" subject keeps the helper deterministic
+// (same email -> same identity row on re-seed) while still distinct
+// from the email column the way a real IdP-issued `sub` claim is.
+// Tests that need a specific subject string can drop the helper and
+// INSERT the row by hand.
 //
 // auth_method is hardcoded to "oidc" because that's the JIT-provisioned
 // path's session class (break-glass goes through a distinct flow with
@@ -113,9 +120,10 @@ func SeedJITUser(t *testing.T, db *sqlx.DB, email, role string) SeededUser {
 	userID, err := userRes.LastInsertId()
 	require.NoError(t, err)
 
+	subject := "oidc:" + email
 	identityRes, err := db.ExecContext(ctx,
 		`INSERT INTO identities (user_id, provider, subject) VALUES (?, 'oidc', ?)`,
-		userID, email)
+		userID, subject)
 	require.NoErrorf(t, err, "seed identity for %q", email)
 	identityID, err := identityRes.LastInsertId()
 	require.NoError(t, err)
@@ -146,11 +154,17 @@ func SeedJITUser(t *testing.T, db *sqlx.DB, email, role string) SeededUser {
 // chokepoint's freshness gate (Phase 5 reauth window) returns false.
 // Used to verify that a destructive action that would normally be
 // granted denies with reauth_required when the session is stale.
+//
+// The interval uses MICROSECOND granularity so callers can age the
+// session by any duration the sessions table's TIMESTAMP(6) column
+// can represent, including sub-second offsets near the reauth-window
+// boundary. age.Microseconds() preserves the full precision Go's
+// time.Duration carries.
 func AgeSession(t *testing.T, db *sqlx.DB, userID int64, age time.Duration) {
 	t.Helper()
 	ctx := t.Context()
 	_, err := db.ExecContext(ctx,
-		`UPDATE sessions SET last_auth_at = NOW(6) - INTERVAL ? SECOND WHERE user_id = ?`,
-		int64(age.Seconds()), userID)
+		`UPDATE sessions SET last_auth_at = NOW(6) - INTERVAL ? MICROSECOND WHERE user_id = ?`,
+		age.Microseconds(), userID)
 	require.NoErrorf(t, err, "age session for user %d", userID)
 }

--- a/test/integration/authz_journey_test.go
+++ b/test/integration/authz_journey_test.go
@@ -1,0 +1,154 @@
+//go:build integration
+
+package integration
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	identityapi "github.com/fleetdm/edr/server/identity/api"
+	"github.com/fleetdm/edr/server/identity/testkit"
+)
+
+// TestAuthZJourney_AnalystDeniedSeniorAllowedAuditorReads is the
+// headline cross-context test for the user-management arc. It walks
+// the wave-1 RBAC story end-to-end:
+//
+//  1. An OIDC-provisioned analyst attempts host.isolate via
+//     POST /api/commands -> chokepoint denies with no_matching_rule
+//     and the response carries the reason header.
+//  2. A senior_analyst attempts the same -> chokepoint allows; the
+//     response is 201 + a command id; the row lands in commands.
+//  3. A senior_analyst with a stale session attempts the same ->
+//     chokepoint denies with reauth_required (Phase 5 freshness
+//     gate).
+//  4. An auditor reads /api/audit-events -> sees the deny + allow
+//     authz.host.isolate rows alongside the command.issue row.
+//
+// If this test goes red on a future PR, the wave-1 ship promise
+// (operators see the alerts they're allowed to see; destructive
+// actions are gated; the audit log is operator-readable) is broken.
+// The subtests are independent fixtures so a regression on any one
+// pinpoints the broken path.
+func TestAuthZJourney_AnalystDeniedSeniorAllowedAuditorReads(t *testing.T) {
+	stack := Setup(t)
+
+	t.Run("analyst_denied_isolate", func(t *testing.T) {
+		analyst := testkit.SeedJITUser(t, stack.DB, "analyst@journey.test", "analyst")
+		resp := postCommand(t, stack, analyst, isolateBody("host-journey-1"))
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusForbidden, resp.StatusCode,
+			"analyst must be denied host.isolate at the chokepoint")
+		assert.Equal(t, identityapi.ReasonNoMatchingRule, resp.Header.Get("X-Edr-Authz-Reason"),
+			"deny reason header carries the policy verdict for the analyst path")
+	})
+
+	t.Run("senior_analyst_allowed_isolate", func(t *testing.T) {
+		senior := testkit.SeedJITUser(t, stack.DB, "senior@journey.test", "senior_analyst")
+		resp := postCommand(t, stack, senior, isolateBody("host-journey-2"))
+		defer resp.Body.Close()
+
+		require.Equal(t, http.StatusCreated, resp.StatusCode,
+			"senior_analyst must be allowed host.isolate; got header reason=%q",
+			resp.Header.Get("X-Edr-Authz-Reason"))
+		var got struct {
+			ID int64 `json:"id"`
+		}
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&got))
+		assert.NotZero(t, got.ID, "successful POST /api/commands returns the new row id")
+	})
+
+	t.Run("senior_analyst_denied_after_reauth_window", func(t *testing.T) {
+		stale := testkit.SeedJITUser(t, stack.DB, "stale-senior@journey.test", "senior_analyst")
+		// Age the session past the default 30-minute reauth window so
+		// SessionFresh evaluates false. The Rego policy then layers a
+		// reauth_required deny on top of the otherwise-granting role.
+		testkit.AgeSession(t, stack.DB, stale.ID, time.Hour)
+
+		resp := postCommand(t, stack, stale, isolateBody("host-journey-3"))
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusForbidden, resp.StatusCode,
+			"stale-session senior_analyst must be denied with reauth_required")
+		assert.Equal(t, identityapi.ReasonReauthRequired, resp.Header.Get("X-Edr-Authz-Reason"),
+			"deny reason carries the freshness-gate verdict for the UI to render an inline reauth prompt")
+	})
+
+	t.Run("auditor_reads_journey_audit_rows", func(t *testing.T) {
+		auditor := testkit.SeedJITUser(t, stack.DB, "auditor@journey.test", "auditor")
+		// The earlier subtests have already emitted the authz audit
+		// rows (one deny on the analyst, one allow on the senior).
+		// The auditor reads the trail.
+		req := newGet(t, stack.Server.URL+"/api/audit-events?action=authz.host.isolate&limit=50", auditor)
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		require.Equalf(t, http.StatusOK, resp.StatusCode,
+			"auditor must be allowed audit.read; got header reason=%q",
+			resp.Header.Get("X-Edr-Authz-Reason"))
+		var body struct {
+			Items []identityapi.AuditRow `json:"items"`
+		}
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+
+		var sawDeny, sawAllow bool
+		for _, row := range body.Items {
+			if row.Action != identityapi.AuditAction("authz.host.isolate") {
+				continue
+			}
+			allow, _ := row.Payload["allow"].(bool)
+			reason, _ := row.Payload["reason"].(string)
+			if !allow && reason == identityapi.ReasonNoMatchingRule {
+				sawDeny = true
+			}
+			if allow && reason == identityapi.ReasonGranted {
+				sawAllow = true
+			}
+		}
+		assert.True(t, sawDeny, "auditor must see the analyst's deny row; rows=%+v", body.Items)
+		assert.True(t, sawAllow, "auditor must see the senior_analyst's allow row; rows=%+v", body.Items)
+	})
+}
+
+// postCommand drives POST /api/commands with the seeded user's
+// session + CSRF token. Centralised so each subtest reads cleanly
+// as "verb the action; assert the response."
+func postCommand(t *testing.T, stack *Stack, user testkit.SeededUser, body string) *http.Response {
+	t.Helper()
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost,
+		stack.Server.URL+"/api/commands", strings.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Csrf-Token", user.CSRFToken)
+	req.AddCookie(&http.Cookie{Name: identityapi.SessionCookieName, Value: user.SessionCookie})
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	return resp
+}
+
+// newGet builds an authenticated GET request: session cookie + the
+// CSRF header. GET is a safe method so CSRF isn't enforced, but
+// production middleware accepts it without complaint and tests stay
+// uniform with the unsafe-method helper above.
+func newGet(t *testing.T, url string, user testkit.SeededUser) *http.Request {
+	t.Helper()
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, url, nil)
+	require.NoError(t, err)
+	req.AddCookie(&http.Cookie{Name: identityapi.SessionCookieName, Value: user.SessionCookie})
+	return req
+}
+
+// isolateBody returns the JSON wire body the response operator handler
+// expects for an isolate command targeting the named host.
+func isolateBody(hostID string) string {
+	return fmt.Sprintf(`{"command_type":"isolate","host_id":%q,"payload":{}}`, hostID)
+}

--- a/test/integration/authz_journey_test.go
+++ b/test/integration/authz_journey_test.go
@@ -30,13 +30,17 @@ import (
 //     chokepoint denies with reauth_required (Phase 5 freshness
 //     gate).
 //  4. An auditor reads /api/audit-events -> sees the deny + allow
-//     authz.host.isolate rows alongside the command.issue row.
+//     authz.host.isolate rows. The auditor subtest seeds its own
+//     analyst + senior_analyst pair and emits the deny/allow chain
+//     itself, so it stays runnable in isolation (go test -run
+//     ...auditor_reads_journey_audit_rows) without depending on the
+//     earlier subtests' side effects.
 //
 // If this test goes red on a future PR, the wave-1 ship promise
 // (operators see the alerts they're allowed to see; destructive
 // actions are gated; the audit log is operator-readable) is broken.
-// The subtests are independent fixtures so a regression on any one
-// pinpoints the broken path.
+// Each subtest is a self-contained fixture so a regression on any
+// one pinpoints the broken path.
 func TestAuthZJourney_AnalystDeniedSeniorAllowedAuditorReads(t *testing.T) {
 	stack := Setup(t)
 
@@ -47,7 +51,7 @@ func TestAuthZJourney_AnalystDeniedSeniorAllowedAuditorReads(t *testing.T) {
 
 		assert.Equal(t, http.StatusForbidden, resp.StatusCode,
 			"analyst must be denied host.isolate at the chokepoint")
-		assert.Equal(t, identityapi.ReasonNoMatchingRule, resp.Header.Get("X-Edr-Authz-Reason"),
+		assert.Equal(t, identityapi.ReasonNoMatchingRule, resp.Header.Get(identityapi.AuthzReasonHeader),
 			"deny reason header carries the policy verdict for the analyst path")
 	})
 
@@ -58,7 +62,7 @@ func TestAuthZJourney_AnalystDeniedSeniorAllowedAuditorReads(t *testing.T) {
 
 		require.Equal(t, http.StatusCreated, resp.StatusCode,
 			"senior_analyst must be allowed host.isolate; got header reason=%q",
-			resp.Header.Get("X-Edr-Authz-Reason"))
+			resp.Header.Get(identityapi.AuthzReasonHeader))
 		var got struct {
 			ID int64 `json:"id"`
 		}
@@ -78,15 +82,29 @@ func TestAuthZJourney_AnalystDeniedSeniorAllowedAuditorReads(t *testing.T) {
 
 		assert.Equal(t, http.StatusForbidden, resp.StatusCode,
 			"stale-session senior_analyst must be denied with reauth_required")
-		assert.Equal(t, identityapi.ReasonReauthRequired, resp.Header.Get("X-Edr-Authz-Reason"),
+		assert.Equal(t, identityapi.ReasonReauthRequired, resp.Header.Get(identityapi.AuthzReasonHeader),
 			"deny reason carries the freshness-gate verdict for the UI to render an inline reauth prompt")
 	})
 
 	t.Run("auditor_reads_journey_audit_rows", func(t *testing.T) {
+		// Self-contained: seed the analyst + senior_analyst pair this
+		// subtest cares about and emit the deny + allow chain inline,
+		// rather than relying on the preceding subtests' side effects.
+		// Keeps the subtest runnable in isolation (go test -run ...)
+		// and pins exactly which audit rows the auditor must see.
+		analyst := testkit.SeedJITUser(t, stack.DB, "analyst-aud@journey.test", "analyst")
+		denyResp := postCommand(t, stack, analyst, isolateBody("host-journey-aud-deny"))
+		denyResp.Body.Close()
+		require.Equal(t, http.StatusForbidden, denyResp.StatusCode,
+			"audit-row prep: analyst must be denied so a deny row lands in audit_events")
+
+		senior := testkit.SeedJITUser(t, stack.DB, "senior-aud@journey.test", "senior_analyst")
+		allowResp := postCommand(t, stack, senior, isolateBody("host-journey-aud-allow"))
+		allowResp.Body.Close()
+		require.Equal(t, http.StatusCreated, allowResp.StatusCode,
+			"audit-row prep: senior_analyst must be allowed so an allow row lands in audit_events")
+
 		auditor := testkit.SeedJITUser(t, stack.DB, "auditor@journey.test", "auditor")
-		// The earlier subtests have already emitted the authz audit
-		// rows (one deny on the analyst, one allow on the senior).
-		// The auditor reads the trail.
 		req := newGet(t, stack.Server.URL+"/api/audit-events?action=authz.host.isolate&limit=50", auditor)
 		resp, err := http.DefaultClient.Do(req)
 		require.NoError(t, err)
@@ -94,7 +112,7 @@ func TestAuthZJourney_AnalystDeniedSeniorAllowedAuditorReads(t *testing.T) {
 
 		require.Equalf(t, http.StatusOK, resp.StatusCode,
 			"auditor must be allowed audit.read; got header reason=%q",
-			resp.Header.Get("X-Edr-Authz-Reason"))
+			resp.Header.Get(identityapi.AuthzReasonHeader))
 		var body struct {
 			Items []identityapi.AuditRow `json:"items"`
 		}
@@ -105,17 +123,20 @@ func TestAuthZJourney_AnalystDeniedSeniorAllowedAuditorReads(t *testing.T) {
 			if row.Action != identityapi.AuditAction("authz.host.isolate") {
 				continue
 			}
+			if row.UserID == nil {
+				continue
+			}
 			allow, _ := row.Payload["allow"].(bool)
 			reason, _ := row.Payload["reason"].(string)
-			if !allow && reason == identityapi.ReasonNoMatchingRule {
+			switch {
+			case *row.UserID == analyst.ID && !allow && reason == identityapi.ReasonNoMatchingRule:
 				sawDeny = true
-			}
-			if allow && reason == identityapi.ReasonGranted {
+			case *row.UserID == senior.ID && allow && reason == identityapi.ReasonGranted:
 				sawAllow = true
 			}
 		}
-		assert.True(t, sawDeny, "auditor must see the analyst's deny row; rows=%+v", body.Items)
-		assert.True(t, sawAllow, "auditor must see the senior_analyst's allow row; rows=%+v", body.Items)
+		assert.True(t, sawDeny, "auditor must see the analyst's deny row for this subtest; rows=%+v", body.Items)
+		assert.True(t, sawAllow, "auditor must see the senior_analyst's allow row for this subtest; rows=%+v", body.Items)
 	})
 }
 
@@ -128,17 +149,18 @@ func postCommand(t *testing.T, stack *Stack, user testkit.SeededUser, body strin
 		stack.Server.URL+"/api/commands", strings.NewReader(body))
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("X-Csrf-Token", user.CSRFToken)
+	req.Header.Set(identityapi.CSRFHeaderName, user.CSRFToken)
 	req.AddCookie(&http.Cookie{Name: identityapi.SessionCookieName, Value: user.SessionCookie})
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
 	return resp
 }
 
-// newGet builds an authenticated GET request: session cookie + the
-// CSRF header. GET is a safe method so CSRF isn't enforced, but
-// production middleware accepts it without complaint and tests stay
-// uniform with the unsafe-method helper above.
+// newGet builds an authenticated GET request with the session
+// cookie. GET is a safe method so the CSRF middleware does not
+// require the X-Csrf-Token header; the cookie alone is enough to
+// pass the session middleware, which is what the read-side endpoint
+// gates on. Tests that hit unsafe methods use postCommand above.
 func newGet(t *testing.T, url string, user testkit.SeededUser) *http.Request {
 	t.Helper()
 	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, url, nil)

--- a/test/integration/setup.go
+++ b/test/integration/setup.go
@@ -228,10 +228,28 @@ func buildMux(
 	// Detection's health probes are public (livez/readyz).
 	detectionCtx.RegisterHealthRoutes(mux)
 
-	// Operator routes (session+CSRF gated). Tests that need admin paths
-	// use the Stack's per-context Service methods rather than HTTP, so
-	// we don't bother stitching login + cookie jar here.
-	_ = rulesCtx
+	// Operator routes (session+CSRF gated). The cross-context authz
+	// journey test in authz_journey_test.go drives these via real
+	// HTTP with seeded session cookies, so the chokepoint + audit
+	// pipeline are exercised end-to-end. Tests that don't care about
+	// the admin path simply ignore them; the routes wire onto the
+	// same mux but the session middleware shorts-circuits anonymous
+	// callers with a 401 before any handler runs.
+	sessionMW := identityCtx.SessionMiddleware()
+	csrfMW := identityCtx.CSRFMiddleware()
+	apiMux := http.NewServeMux()
+	detectionCtx.RegisterAuthedRoutes(apiMux)
+	rulesCtx.RegisterAuthedRoutes(apiMux)
+	endpointCtx.RegisterAuthedRoutes(apiMux)
+	responseCtx.RegisterAuthedRoutes(apiMux)
+	identityCtx.RegisterAuthedRoutes(apiMux)
+	sessionProtected := sessionMW(csrfMW(apiMux))
+	for _, p := range []string{
+		"POST /api/commands",
+		"GET /api/audit-events",
+	} {
+		mux.Handle(p, sessionProtected)
+	}
 	_ = logger
 
 	return mux


### PR DESCRIPTION
Three deliverables in one PR:

8.3 cross-context authz journey test
- test/integration/authz_journey_test.go drives the headline end-to-end story: an OIDC-provisioned analyst is denied host.isolate at the chokepoint; a senior_analyst is allowed (POST /api/commands returns 201); a senior_analyst with a stale session denies with reauth_required (Phase 5 freshness gate); an auditor reads /api/audit-events and sees the deny + allow rows. All four subtests run real HTTP against the Setup() stack, exercising session middleware, CSRF middleware, HTTPGate, the OPA policy, and the audit pipeline end-to-end.
- testkit.SeedJITUser inserts the SQL shape an OIDC JIT- provisioned operator would land in (users + identities + role_bindings) and mints a fresh session via sessions.Store. Returns the cookie value + CSRF token tests plug into HTTP requests. testkit.AgeSession backdates last_auth_at so tests can verify the freshness-gate path without sleeping.
- test/integration/setup.go now also wires the session+CSRF middleware onto POST /api/commands and GET /api/audit-events so the cross-context test exercises the production routing surface.

8.4 property-based tests for two invariants
- engine_pbt_test.go: action-registry parity. For 100 random (role x action x session_fresh) combinations sampled from roles.json + RegisteredActions(), Engine.Allow returns a deterministic decision with reason in the canonical Reason* set. Roles' grants lists drive the expected allow/deny verdict; the destructive-action set drives the reauth_required branch. A regression that swaps a grant list, drops a wildcard, or misses a destructive action in the policy fails the test on the next CI run.
- role_bindings_pbt_test.go: expiry boundary + selectivity. TestListLiveBindings_ExpiryBoundary_PBT generates random expires_at offsets in (-2h, +2h) skipping a 250ms band around now to absorb test-runner jitter; the property is "returned iff NULL or strictly future". A second PBT (RoleSelectivity) confirms only the live subset of a random (live + expired) cocktail comes back.

8.1 arch-go gate audit (no-op)
- The 24 dependency rules in arch-go.yml + the operator- handler closed set in test/arch/chokepoint_coverage_test.go already cover every package added in Phases 1-7 (audit/authz/breakglass/identities/login/middleware/oidc/ rbac/seed/service/sessions/users). go test ./test/arch/... passes against HEAD; no rule adds needed.

8.2 coverage gate (no-op for this PR)
- SonarCloud's "Coverage on New Code >= 80%" gate has been green on every Phase 1-7 PR; nothing surfaced as below- threshold during this PR's audit. New code in this PR: testkit.SeedJITUser + AgeSession at 100%; PBT files cover themselves.

Drive-by: the authz dashboard panel that filtered on payload.decision was wrong (the actual chokepoint payload uses keys "allow" + "reason", not "decision"). Fixed
config/observability/edr-authz-dashboard.json panel #1's filter to payload.allow=false. The other panels were already correct.

Local verification:
  go test ./test/arch/...                                  : ok
  go test ./server/identity/...                            : ok
  go test -tags integration ./test/integration/...         : ok
  go test -tags integration ./server/identity/...          : ok
  go test ./server/identity/internal/authz/... -run PBT    : ok (100/100)
  go test -tags integration ./server/identity/internal/rbac/... -run PBT : ok (100/100)
  golangci-lint run --build-tags integration <touched>     : 0 issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced observability dashboard to better track authorization denials with improved log filtering semantics.

* **Tests**
  * Expanded authorization engine and role bindings test coverage with property-based testing.
  * Added integration tests for end-to-end authorization workflows.

* **Chores**
  * Updated test server infrastructure and routing configuration.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/getvictor/fleet-edr/pull/134)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->