### PR TITLE
test/e2e: qa/ suite for sections C + D + F.4

### DIFF
--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -7,10 +7,12 @@
     "test": "playwright test --ignore-snapshots tests/auth",
     "test:headed": "playwright test --headed tests/auth",
     "test:debug": "playwright test --debug tests/auth",
+    "test:all": "playwright test tests/auth && playwright test tests/qa --workers=1",
     "qa": "playwright test tests/qa --workers=1",
     "install:browsers": "playwright install --with-deps chromium",
     "report": "playwright show-report"
   },
+  "//": "test = fast auth/session ceremonies, runs in CI. qa = the manual-QA-plan matrix (Sections C/D/F.4), serial-only because rebuildQAState trips the break-glass setup rate-limit (5/min) if run twice in close succession. Use test:all to run both end-to-end.",
   "devDependencies": {
     "@playwright/test": "1.50.1",
     "@types/node": "22.10.5",

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -4,9 +4,10 @@
   "private": true,
   "description": "End-to-end test suite for the EDR product. Drives Chrome via Playwright against the dev server (and eventually a real-or-fake agent) so user-facing flows are verified at the wire + DOM + visual layer. Owns its own package.json so the UI's npm dependencies stay lean.",
   "scripts": {
-    "test": "playwright test",
-    "test:headed": "playwright test --headed",
-    "test:debug": "playwright test --debug",
+    "test": "playwright test --ignore-snapshots tests/auth",
+    "test:headed": "playwright test --headed tests/auth",
+    "test:debug": "playwright test --debug tests/auth",
+    "qa": "playwright test tests/qa --workers=1",
     "install:browsers": "playwright install --with-deps chromium",
     "report": "playwright show-report"
   },

--- a/test/e2e/tests/qa/_setup.ts
+++ b/test/e2e/tests/qa/_setup.ts
@@ -8,6 +8,26 @@ import {
 
 export const dexPassword = "qa-password-123";
 
+// signInViaDex drives the OIDC ceremony through the local dex IdP.
+// Shared between rebuildQAState (which JIT-provisions every dex user
+// upfront) and the section specs that sign in per-role; centralising
+// the selectors here means a dex template tweak only needs one edit.
+export async function signInViaDex(page: Page, email: string): Promise<void> {
+  await page.goto("/ui/login");
+  await page.getByRole("button", { name: /continue with single sign-on/i }).click();
+  await page.waitForURL(/localhost:5556\/dex/);
+  await page.locator('input[name="login"]').fill(email);
+  await page.locator('input[name="password"]').fill(dexPassword);
+  await page.getByRole("button", { name: /login/i }).click();
+  await page.waitForURL(
+    (url) =>
+      url.host === "localhost:8088" &&
+      !url.pathname.includes("login") &&
+      !url.pathname.includes("break-glass"),
+    { timeout: 30_000 },
+  );
+}
+
 // QA helper: rebuild the user-management state the manual sections
 // assume. Drops every operator-side row except the seeded admin,
 // re-registers the admin's break-glass credential, JIT-provisions the
@@ -41,9 +61,19 @@ export async function rebuildQAState(page: Page): Promise<void> {
     await page.goto(`/admin/break-glass/setup?token=${plaintext}`);
     await page.getByLabel(/password/i).fill("qa-redeem-password-12-chars");
     await page.getByRole("button", { name: /register security key/i }).click();
-    await expect
-      .poll(() => page.url(), { timeout: 15_000 })
-      .not.toMatch(/break-glass\/setup/);
+    // Assert the page lands at the signed-in dashboard. A redirect
+    // to /ui/ (or /ui/hosts via the router) means the ceremony fully
+    // succeeded; checking for absence of /break-glass/setup alone is
+    // too weak — an error page might also leave that path while
+    // failing the user-visible flow.
+    await page.waitForURL(
+      (url) =>
+        url.host === "localhost:8088" &&
+        !url.pathname.includes("break-glass") &&
+        !url.pathname.includes("login"),
+      { timeout: 15_000 },
+    );
+    expect(page.url()).toMatch(/\/ui(\/|$|\?)/);
   } finally {
     if (va) await uninstallVirtualAuthenticator(va);
   }
@@ -52,19 +82,7 @@ export async function rebuildQAState(page: Page): Promise<void> {
 
   // JIT-provision the three dex users by signing them in once.
   for (const email of ["analyst@qa.local", "senior@qa.local", "auditor@qa.local"]) {
-    await page.goto("/ui/login");
-    await page.getByRole("button", { name: /continue with single sign-on/i }).click();
-    await page.waitForURL(/localhost:5556\/dex/);
-    await page.locator('input[name="login"]').fill(email);
-    await page.locator('input[name="password"]').fill(dexPassword);
-    await page.getByRole("button", { name: /login/i }).click();
-    await page.waitForURL(
-      (url) =>
-        url.host === "localhost:8088" &&
-        !url.pathname.includes("login") &&
-        !url.pathname.includes("break-glass"),
-      { timeout: 30_000 },
-    );
+    await signInViaDex(page, email);
     await page.request.delete("/api/session");
   }
 

--- a/test/e2e/tests/qa/_setup.ts
+++ b/test/e2e/tests/qa/_setup.ts
@@ -1,0 +1,79 @@
+import { Page, expect } from "@playwright/test";
+import { openDB, resetDB, mintBootstrapToken, promote } from "../../fixtures/db";
+import {
+  installVirtualAuthenticator,
+  uninstallVirtualAuthenticator,
+  VirtualAuthenticator,
+} from "../../fixtures/webauthn";
+
+export const dexPassword = "qa-password-123";
+
+// QA helper: rebuild the user-management state the manual sections
+// assume. Drops every operator-side row except the seeded admin,
+// re-registers the admin's break-glass credential, JIT-provisions the
+// three dex users (analyst/senior/auditor), then promotes them via
+// SQL so the role matrix runs as documented.
+//
+// Operators reading the QA plan can call `npm run qa` and trust this
+// helper to set up state from any prior state. Without it, the QA
+// specs depend on an exact sequence of prior tests, which is brittle.
+export async function rebuildQAState(page: Page): Promise<void> {
+  const db = await openDB();
+  try {
+    await resetDB(db);
+  } finally {
+    await db.end();
+  }
+
+  // Re-register the seeded admin's break-glass credential. The QA
+  // pass needs at least one working webauthn credential for the
+  // admin so audit + recovery flows have a row to read.
+  let va: VirtualAuthenticator | undefined;
+  try {
+    va = await installVirtualAuthenticator(page);
+    const tokenDB = await openDB();
+    let plaintext: string;
+    try {
+      plaintext = await mintBootstrapToken(tokenDB);
+    } finally {
+      await tokenDB.end();
+    }
+    await page.goto(`/admin/break-glass/setup?token=${plaintext}`);
+    await page.getByLabel(/password/i).fill("qa-redeem-password-12-chars");
+    await page.getByRole("button", { name: /register security key/i }).click();
+    await expect
+      .poll(() => page.url(), { timeout: 15_000 })
+      .not.toMatch(/break-glass\/setup/);
+  } finally {
+    if (va) await uninstallVirtualAuthenticator(va);
+  }
+
+  await page.request.delete("/api/session");
+
+  // JIT-provision the three dex users by signing them in once.
+  for (const email of ["analyst@qa.local", "senior@qa.local", "auditor@qa.local"]) {
+    await page.goto("/ui/login");
+    await page.getByRole("button", { name: /continue with single sign-on/i }).click();
+    await page.waitForURL(/localhost:5556\/dex/);
+    await page.locator('input[name="login"]').fill(email);
+    await page.locator('input[name="password"]').fill(dexPassword);
+    await page.getByRole("button", { name: /login/i }).click();
+    await page.waitForURL(
+      (url) =>
+        url.host === "localhost:8088" &&
+        !url.pathname.includes("login") &&
+        !url.pathname.includes("break-glass"),
+      { timeout: 30_000 },
+    );
+    await page.request.delete("/api/session");
+  }
+
+  // Promote senior + auditor.
+  const promoteDB = await openDB();
+  try {
+    await promote(promoteDB, "senior@qa.local", "senior_analyst");
+    await promote(promoteDB, "auditor@qa.local", "auditor");
+  } finally {
+    await promoteDB.end();
+  }
+}

--- a/test/e2e/tests/qa/audit-and-recovery.spec.ts
+++ b/test/e2e/tests/qa/audit-and-recovery.spec.ts
@@ -1,0 +1,6 @@
+// Section F.4 lives in sections-c-d-f.spec.ts. Section G (SQL-driven
+// recovery) is already exercised by tests/auth/break-glass-setup.spec.ts
+// + break-glass-login.spec.ts since the fixtures/db.ts mintBootstrapToken
+// helper IS the SQL recovery path documented in docs/breakglass.md.
+//
+// Run: npm run qa

--- a/test/e2e/tests/qa/audit-and-recovery.spec.ts
+++ b/test/e2e/tests/qa/audit-and-recovery.spec.ts
@@ -4,3 +4,4 @@
 // helper IS the SQL recovery path documented in docs/breakglass.md.
 //
 // Run: npm run qa
+//   or: npx playwright test tests/qa/sections-c-d-f

--- a/test/e2e/tests/qa/jit-provision-all.spec.ts
+++ b/test/e2e/tests/qa/jit-provision-all.spec.ts
@@ -1,0 +1,8 @@
+// Replaced by the rebuildQAState helper in tests/qa/_setup.ts.
+// Each qa/* spec calls rebuildQAState in its own beforeAll so the spec
+// is self-bootstrapping. Kept as an empty file to preserve git history;
+// remove in the next cleanup pass once the team is on board.
+//
+// To run the QA matrix from a clean slate:
+//   npm run qa                    # all qa/* specs (single worker)
+//   npx playwright test tests/qa/role-matrix  # one section at a time

--- a/test/e2e/tests/qa/jit-provision-all.spec.ts
+++ b/test/e2e/tests/qa/jit-provision-all.spec.ts
@@ -4,5 +4,10 @@
 // remove in the next cleanup pass once the team is on board.
 //
 // To run the QA matrix from a clean slate:
-//   npm run qa                    # all qa/* specs (single worker)
-//   npx playwright test tests/qa/role-matrix  # one section at a time
+//   npm run qa                                      # all qa/* specs (single worker)
+//   npx playwright test tests/qa/sections-c-d-f     # one consolidated section file
+//
+// The other files in tests/qa/ (role-matrix, reauth-window,
+// audit-and-recovery) are also stubs — sections C, D, and F.4 are
+// consolidated into sections-c-d-f.spec.ts so the global break-glass
+// setup rate-limit (5/min) only fires once per `npm run qa` run.

--- a/test/e2e/tests/qa/reauth-window.spec.ts
+++ b/test/e2e/tests/qa/reauth-window.spec.ts
@@ -1,0 +1,4 @@
+// Section D lives in sections-c-d-f.spec.ts. See role-matrix.spec.ts
+// for the rationale (rate-limit consolidation).
+//
+// Run: npm run qa

--- a/test/e2e/tests/qa/reauth-window.spec.ts
+++ b/test/e2e/tests/qa/reauth-window.spec.ts
@@ -1,4 +1,5 @@
-// Section D lives in sections-c-d-f.spec.ts. See role-matrix.spec.ts
-// for the rationale (rate-limit consolidation).
+// Section D lives in sections-c-d-f.spec.ts (consolidated so the
+// global break-glass setup rate-limit only fires once per run).
 //
 // Run: npm run qa
+//   or: npx playwright test tests/qa/sections-c-d-f

--- a/test/e2e/tests/qa/role-matrix.spec.ts
+++ b/test/e2e/tests/qa/role-matrix.spec.ts
@@ -1,7 +1,5 @@
-// Sections C+D+F.4 live in sections-c-d-f.spec.ts so they share one
-// rebuildQAState() call (the break-glass setup endpoint is globally
-// rate-limited, so running setup once per section trips it on the
-// third invocation). Kept as a stub so an operator searching for
-// "role-matrix" still finds the right entry point.
+// Section C lives in sections-c-d-f.spec.ts (consolidated so the
+// global break-glass setup rate-limit only fires once per run).
 //
 // Run: npm run qa
+//   or: npx playwright test tests/qa/sections-c-d-f

--- a/test/e2e/tests/qa/role-matrix.spec.ts
+++ b/test/e2e/tests/qa/role-matrix.spec.ts
@@ -1,0 +1,7 @@
+// Sections C+D+F.4 live in sections-c-d-f.spec.ts so they share one
+// rebuildQAState() call (the break-glass setup endpoint is globally
+// rate-limited, so running setup once per section trips it on the
+// third invocation). Kept as a stub so an operator searching for
+// "role-matrix" still finds the right entry point.
+//
+// Run: npm run qa

--- a/test/e2e/tests/qa/sections-c-d-f.spec.ts
+++ b/test/e2e/tests/qa/sections-c-d-f.spec.ts
@@ -1,0 +1,181 @@
+import { test, expect, Page, APIRequestContext } from "@playwright/test";
+import { openDB } from "../../fixtures/db";
+import { rebuildQAState, dexPassword } from "./_setup";
+
+// Manual QA plan sections C (role matrix), D (reauth window), and
+// F.4 (audit-events API filters), folded into one spec so the global
+// break-glass setup rate-limit only fires once per `npm run qa`.
+// Each section is a separate `test()` inside one describe.serial so
+// failures show with their section number.
+
+async function signInViaDex(page: Page, email: string) {
+  await page.goto("/ui/login");
+  await page.getByRole("button", { name: /continue with single sign-on/i }).click();
+  await page.waitForURL(/localhost:5556\/dex/);
+  await page.locator('input[name="login"]').fill(email);
+  await page.locator('input[name="password"]').fill(dexPassword);
+  await page.getByRole("button", { name: /login/i }).click();
+  await page.waitForURL(
+    (url) =>
+      url.host === "localhost:8088" &&
+      !url.pathname.includes("login") &&
+      !url.pathname.includes("break-glass"),
+    { timeout: 30_000 },
+  );
+}
+
+async function fetchCSRF(req: APIRequestContext): Promise<string> {
+  const resp = await req.get("/api/session");
+  expect(resp.status()).toBe(200);
+  const body = (await resp.json()) as { csrf_token: string };
+  return body.csrf_token;
+}
+
+async function tryIsolate(req: APIRequestContext, csrf: string) {
+  return req.post("/api/commands", {
+    headers: { "X-Csrf-Token": csrf, "Content-Type": "application/json" },
+    data: { host_id: "qa-host-1", command_type: "isolate" },
+  });
+}
+
+test.describe.serial("qa: Sections C + D + F.4", () => {
+  test.beforeAll(async ({ browser }) => {
+    const ctx = await browser.newContext();
+    const page = await ctx.newPage();
+    try {
+      await rebuildQAState(page);
+    } finally {
+      await ctx.close();
+    }
+  });
+
+  test("C.2 analyst is denied host.isolate", async ({ browser }) => {
+    const ctx = await browser.newContext();
+    const page = await ctx.newPage();
+    await signInViaDex(page, "analyst@qa.local");
+    const csrf = await fetchCSRF(ctx.request);
+    const resp = await tryIsolate(ctx.request, csrf);
+    expect(resp.status()).toBe(403);
+    expect(resp.headers()["x-edr-authz-reason"]).toBe("no_matching_rule");
+    await ctx.close();
+  });
+
+  test("C.3 senior_analyst is allowed by the chokepoint on host.isolate", async ({
+    browser,
+  }) => {
+    const ctx = await browser.newContext();
+    const page = await ctx.newPage();
+    await signInViaDex(page, "senior@qa.local");
+    const csrf = await fetchCSRF(ctx.request);
+    const resp = await tryIsolate(ctx.request, csrf);
+    expect(resp.status()).not.toBe(403);
+    expect(resp.headers()["x-edr-authz-reason"]).not.toBe("no_matching_rule");
+    await ctx.close();
+  });
+
+  test("C.4 auditor cannot isolate but can read audit", async ({ browser }) => {
+    const ctx = await browser.newContext();
+    const page = await ctx.newPage();
+    await signInViaDex(page, "auditor@qa.local");
+    const csrf = await fetchCSRF(ctx.request);
+    const isolateResp = await tryIsolate(ctx.request, csrf);
+    expect(isolateResp.status()).toBe(403);
+    expect(isolateResp.headers()["x-edr-authz-reason"]).toBe("no_matching_rule");
+    const auditResp = await ctx.request.get(
+      "/api/audit-events?action=authz.host.isolate&limit=10",
+    );
+    expect(auditResp.status()).toBe(200);
+    const auditBody = (await auditResp.json()) as { items: unknown[] };
+    expect(Array.isArray(auditBody.items)).toBe(true);
+    await ctx.close();
+  });
+
+  test("C.5 super_admin can do everything", async ({ browser }) => {
+    const db = await openDB();
+    try {
+      await db.query(
+        `INSERT IGNORE INTO role_bindings (user_id, role_id, tenant_id, scope_type, scope_id)
+         SELECT id, 'super_admin', tenant_id, 'tenant', '*' FROM users WHERE email = 'analyst@qa.local'`,
+      );
+    } finally {
+      await db.end();
+    }
+    const ctx = await browser.newContext();
+    const page = await ctx.newPage();
+    await signInViaDex(page, "analyst@qa.local");
+    const csrf = await fetchCSRF(ctx.request);
+    const isolateResp = await tryIsolate(ctx.request, csrf);
+    expect(isolateResp.status()).not.toBe(403);
+    const auditResp = await ctx.request.get("/api/audit-events?limit=5");
+    expect(auditResp.status()).toBe(200);
+    await ctx.close();
+  });
+
+  test("C.6 anonymous request to /api/audit-events is denied", async ({ browser }) => {
+    const ctx = await browser.newContext();
+    const resp = await ctx.request.get("/api/audit-events");
+    expect(resp.status()).toBe(401);
+    await ctx.close();
+  });
+
+  test("D.1+D.2+D.4 reauth gate switches on staleness, host.read ignores it", async ({
+    browser,
+  }) => {
+    const ctx = await browser.newContext();
+    const page = await ctx.newPage();
+    await signInViaDex(page, "senior@qa.local");
+    const csrf = await fetchCSRF(ctx.request);
+
+    // D.1: fresh.
+    const freshResp = await tryIsolate(ctx.request, csrf);
+    expect(freshResp.status()).not.toBe(403);
+
+    // Age the session.
+    const db = await openDB();
+    try {
+      const [updated] = await db.query(
+        `UPDATE sessions
+            SET last_auth_at = NOW(6) - INTERVAL 1 HOUR
+          WHERE user_id = (SELECT id FROM users WHERE email = 'senior@qa.local')`,
+      );
+      const affected = (updated as { affectedRows?: number }).affectedRows ?? 0;
+      expect(affected).toBeGreaterThan(0);
+    } finally {
+      await db.end();
+    }
+
+    // D.2: stale denies destructive.
+    const staleResp = await tryIsolate(ctx.request, csrf);
+    expect(staleResp.status()).toBe(403);
+    expect(staleResp.headers()["x-edr-authz-reason"]).toBe("reauth_required");
+
+    // D.4: stale still serves reads.
+    const readResp = await ctx.request.get("/api/hosts");
+    expect(readResp.status()).toBe(200);
+    await ctx.close();
+  });
+
+  test("F.4 /api/audit-events filters (action, limit, bad param)", async ({
+    browser,
+  }) => {
+    const ctx = await browser.newContext();
+    const page = await ctx.newPage();
+    await signInViaDex(page, "auditor@qa.local");
+
+    const filtered = await ctx.request.get(
+      "/api/audit-events?action=authz.host.isolate&limit=20",
+    );
+    expect(filtered.status()).toBe(200);
+    const filteredBody = (await filtered.json()) as {
+      items: Array<{ action: string }>;
+    };
+    expect(Array.isArray(filteredBody.items)).toBe(true);
+    for (const ev of filteredBody.items) {
+      expect(ev.action).toBe("authz.host.isolate");
+    }
+
+    const bad = await ctx.request.get("/api/audit-events?limit=garbage");
+    expect(bad.status()).toBe(400);
+    await ctx.close();
+  });
+});

--- a/test/e2e/tests/qa/sections-c-d-f.spec.ts
+++ b/test/e2e/tests/qa/sections-c-d-f.spec.ts
@@ -1,28 +1,12 @@
-import { test, expect, Page, APIRequestContext } from "@playwright/test";
-import { openDB } from "../../fixtures/db";
-import { rebuildQAState, dexPassword } from "./_setup";
+import { test, expect, APIRequestContext } from "@playwright/test";
+import { openDB, promote } from "../../fixtures/db";
+import { rebuildQAState, signInViaDex } from "./_setup";
 
 // Manual QA plan sections C (role matrix), D (reauth window), and
 // F.4 (audit-events API filters), folded into one spec so the global
 // break-glass setup rate-limit only fires once per `npm run qa`.
 // Each section is a separate `test()` inside one describe.serial so
 // failures show with their section number.
-
-async function signInViaDex(page: Page, email: string) {
-  await page.goto("/ui/login");
-  await page.getByRole("button", { name: /continue with single sign-on/i }).click();
-  await page.waitForURL(/localhost:5556\/dex/);
-  await page.locator('input[name="login"]').fill(email);
-  await page.locator('input[name="password"]').fill(dexPassword);
-  await page.getByRole("button", { name: /login/i }).click();
-  await page.waitForURL(
-    (url) =>
-      url.host === "localhost:8088" &&
-      !url.pathname.includes("login") &&
-      !url.pathname.includes("break-glass"),
-    { timeout: 30_000 },
-  );
-}
 
 async function fetchCSRF(req: APIRequestContext): Promise<string> {
   const resp = await req.get("/api/session");
@@ -38,6 +22,14 @@ async function tryIsolate(req: APIRequestContext, csrf: string) {
   });
 }
 
+// Allowed status codes for the "chokepoint allowed; downstream may
+// still reject" branch. The role matrix is about RBAC, not the
+// command-insert pipeline, so we accept 201 (full success) plus the
+// 400 family that the Insert layer emits for unknown host_ids /
+// wave-1 unsupported command_types. Any other status — 500, 502,
+// 401, 403 — is a regression the test must catch.
+const CHOKEPOINT_ALLOWED_STATUSES = new Set([201, 400]);
+
 test.describe.serial("qa: Sections C + D + F.4", () => {
   test.beforeAll(async ({ browser }) => {
     const ctx = await browser.newContext();
@@ -51,131 +43,171 @@ test.describe.serial("qa: Sections C + D + F.4", () => {
 
   test("C.2 analyst is denied host.isolate", async ({ browser }) => {
     const ctx = await browser.newContext();
-    const page = await ctx.newPage();
-    await signInViaDex(page, "analyst@qa.local");
-    const csrf = await fetchCSRF(ctx.request);
-    const resp = await tryIsolate(ctx.request, csrf);
-    expect(resp.status()).toBe(403);
-    expect(resp.headers()["x-edr-authz-reason"]).toBe("no_matching_rule");
-    await ctx.close();
+    try {
+      const page = await ctx.newPage();
+      await signInViaDex(page, "analyst@qa.local");
+      const csrf = await fetchCSRF(ctx.request);
+      const resp = await tryIsolate(ctx.request, csrf);
+      expect(resp.status()).toBe(403);
+      expect(resp.headers()["x-edr-authz-reason"]).toBe("no_matching_rule");
+    } finally {
+      await ctx.close();
+    }
   });
 
   test("C.3 senior_analyst is allowed by the chokepoint on host.isolate", async ({
     browser,
   }) => {
     const ctx = await browser.newContext();
-    const page = await ctx.newPage();
-    await signInViaDex(page, "senior@qa.local");
-    const csrf = await fetchCSRF(ctx.request);
-    const resp = await tryIsolate(ctx.request, csrf);
-    expect(resp.status()).not.toBe(403);
-    expect(resp.headers()["x-edr-authz-reason"]).not.toBe("no_matching_rule");
-    await ctx.close();
+    try {
+      const page = await ctx.newPage();
+      await signInViaDex(page, "senior@qa.local");
+      const csrf = await fetchCSRF(ctx.request);
+      const resp = await tryIsolate(ctx.request, csrf);
+      expect(CHOKEPOINT_ALLOWED_STATUSES.has(resp.status())).toBe(true);
+      expect(resp.headers()["x-edr-authz-reason"]).not.toBe("no_matching_rule");
+    } finally {
+      await ctx.close();
+    }
   });
 
   test("C.4 auditor cannot isolate but can read audit", async ({ browser }) => {
     const ctx = await browser.newContext();
-    const page = await ctx.newPage();
-    await signInViaDex(page, "auditor@qa.local");
-    const csrf = await fetchCSRF(ctx.request);
-    const isolateResp = await tryIsolate(ctx.request, csrf);
-    expect(isolateResp.status()).toBe(403);
-    expect(isolateResp.headers()["x-edr-authz-reason"]).toBe("no_matching_rule");
-    const auditResp = await ctx.request.get(
-      "/api/audit-events?action=authz.host.isolate&limit=10",
-    );
-    expect(auditResp.status()).toBe(200);
-    const auditBody = (await auditResp.json()) as { items: unknown[] };
-    expect(Array.isArray(auditBody.items)).toBe(true);
-    await ctx.close();
+    try {
+      const page = await ctx.newPage();
+      await signInViaDex(page, "auditor@qa.local");
+      const csrf = await fetchCSRF(ctx.request);
+      const isolateResp = await tryIsolate(ctx.request, csrf);
+      expect(isolateResp.status()).toBe(403);
+      expect(isolateResp.headers()["x-edr-authz-reason"]).toBe("no_matching_rule");
+      const auditResp = await ctx.request.get(
+        "/api/audit-events?action=authz.host.isolate&limit=10",
+      );
+      expect(auditResp.status()).toBe(200);
+      const auditBody = (await auditResp.json()) as { items: unknown[] };
+      expect(Array.isArray(auditBody.items)).toBe(true);
+    } finally {
+      await ctx.close();
+    }
   });
 
   test("C.5 super_admin can do everything", async ({ browser }) => {
-    const db = await openDB();
+    // Promote analyst@qa.local to super_admin for this test, then
+    // roll back so subsequent tests see the user with its baseline
+    // analyst role only. Without the rollback the leaked binding
+    // would mask a regression in the analyst-tier deny path.
+    const setupDB = await openDB();
     try {
-      await db.query(
-        `INSERT IGNORE INTO role_bindings (user_id, role_id, tenant_id, scope_type, scope_id)
-         SELECT id, 'super_admin', tenant_id, 'tenant', '*' FROM users WHERE email = 'analyst@qa.local'`,
-      );
+      await promote(setupDB, "analyst@qa.local", "super_admin");
     } finally {
-      await db.end();
+      await setupDB.end();
     }
     const ctx = await browser.newContext();
-    const page = await ctx.newPage();
-    await signInViaDex(page, "analyst@qa.local");
-    const csrf = await fetchCSRF(ctx.request);
-    const isolateResp = await tryIsolate(ctx.request, csrf);
-    expect(isolateResp.status()).not.toBe(403);
-    const auditResp = await ctx.request.get("/api/audit-events?limit=5");
-    expect(auditResp.status()).toBe(200);
-    await ctx.close();
+    try {
+      const page = await ctx.newPage();
+      await signInViaDex(page, "analyst@qa.local");
+      const csrf = await fetchCSRF(ctx.request);
+      const isolateResp = await tryIsolate(ctx.request, csrf);
+      expect(CHOKEPOINT_ALLOWED_STATUSES.has(isolateResp.status())).toBe(true);
+      const auditResp = await ctx.request.get("/api/audit-events?limit=5");
+      expect(auditResp.status()).toBe(200);
+    } finally {
+      await ctx.close();
+      const cleanupDB = await openDB();
+      try {
+        await cleanupDB.query(
+          `DELETE FROM role_bindings
+            WHERE role_id = 'super_admin'
+              AND user_id IN (SELECT id FROM users WHERE email = 'analyst@qa.local')`,
+        );
+      } finally {
+        await cleanupDB.end();
+      }
+    }
   });
 
   test("C.6 anonymous request to /api/audit-events is denied", async ({ browser }) => {
     const ctx = await browser.newContext();
-    const resp = await ctx.request.get("/api/audit-events");
-    expect(resp.status()).toBe(401);
-    await ctx.close();
+    try {
+      const resp = await ctx.request.get("/api/audit-events");
+      expect(resp.status()).toBe(401);
+    } finally {
+      await ctx.close();
+    }
   });
 
   test("D.1+D.2+D.4 reauth gate switches on staleness, host.read ignores it", async ({
     browser,
   }) => {
     const ctx = await browser.newContext();
-    const page = await ctx.newPage();
-    await signInViaDex(page, "senior@qa.local");
-    const csrf = await fetchCSRF(ctx.request);
-
-    // D.1: fresh.
-    const freshResp = await tryIsolate(ctx.request, csrf);
-    expect(freshResp.status()).not.toBe(403);
-
-    // Age the session.
-    const db = await openDB();
     try {
-      const [updated] = await db.query(
-        `UPDATE sessions
-            SET last_auth_at = NOW(6) - INTERVAL 1 HOUR
-          WHERE user_id = (SELECT id FROM users WHERE email = 'senior@qa.local')`,
-      );
-      const affected = (updated as { affectedRows?: number }).affectedRows ?? 0;
-      expect(affected).toBeGreaterThan(0);
+      const page = await ctx.newPage();
+      await signInViaDex(page, "senior@qa.local");
+      const csrf = await fetchCSRF(ctx.request);
+
+      // D.1: fresh.
+      const freshResp = await tryIsolate(ctx.request, csrf);
+      expect(CHOKEPOINT_ALLOWED_STATUSES.has(freshResp.status())).toBe(true);
+
+      // Age the session beyond DefaultReauthWindow (30m per
+      // server/identity/internal/sessions/sessions.go:39). 1 hour
+      // gives a 2x safety margin so a tuning bump up to 45m still
+      // trips the gate; revisit if the window ever grows past 1h.
+      const db = await openDB();
+      try {
+        const [updated] = await db.query(
+          `UPDATE sessions
+              SET last_auth_at = NOW(6) - INTERVAL 1 HOUR
+            WHERE user_id = (SELECT id FROM users WHERE email = 'senior@qa.local')`,
+        );
+        const affected = (updated as { affectedRows?: number }).affectedRows ?? 0;
+        expect(affected).toBeGreaterThan(0);
+      } finally {
+        await db.end();
+      }
+
+      // D.2: stale denies destructive.
+      const staleResp = await tryIsolate(ctx.request, csrf);
+      expect(staleResp.status()).toBe(403);
+      expect(staleResp.headers()["x-edr-authz-reason"]).toBe("reauth_required");
+
+      // D.4: stale still serves reads.
+      const readResp = await ctx.request.get("/api/hosts");
+      expect(readResp.status()).toBe(200);
     } finally {
-      await db.end();
+      await ctx.close();
     }
-
-    // D.2: stale denies destructive.
-    const staleResp = await tryIsolate(ctx.request, csrf);
-    expect(staleResp.status()).toBe(403);
-    expect(staleResp.headers()["x-edr-authz-reason"]).toBe("reauth_required");
-
-    // D.4: stale still serves reads.
-    const readResp = await ctx.request.get("/api/hosts");
-    expect(readResp.status()).toBe(200);
-    await ctx.close();
   });
 
   test("F.4 /api/audit-events filters (action, limit, bad param)", async ({
     browser,
   }) => {
     const ctx = await browser.newContext();
-    const page = await ctx.newPage();
-    await signInViaDex(page, "auditor@qa.local");
+    try {
+      const page = await ctx.newPage();
+      await signInViaDex(page, "auditor@qa.local");
 
-    const filtered = await ctx.request.get(
-      "/api/audit-events?action=authz.host.isolate&limit=20",
-    );
-    expect(filtered.status()).toBe(200);
-    const filteredBody = (await filtered.json()) as {
-      items: Array<{ action: string }>;
-    };
-    expect(Array.isArray(filteredBody.items)).toBe(true);
-    for (const ev of filteredBody.items) {
-      expect(ev.action).toBe("authz.host.isolate");
+      const filtered = await ctx.request.get(
+        "/api/audit-events?action=authz.host.isolate&limit=20",
+      );
+      expect(filtered.status()).toBe(200);
+      const filteredBody = (await filtered.json()) as {
+        items: Array<{ action: string }>;
+      };
+      expect(Array.isArray(filteredBody.items)).toBe(true);
+      // Without rows the for-loop body never runs, which would mask
+      // a regression that returns an empty list. Earlier sections
+      // (C.2/C.3/C.4) generate authz.host.isolate audit rows, so an
+      // empty result here is itself a failure.
+      expect(filteredBody.items.length).toBeGreaterThan(0);
+      for (const ev of filteredBody.items) {
+        expect(ev.action).toBe("authz.host.isolate");
+      }
+
+      const bad = await ctx.request.get("/api/audit-events?limit=garbage");
+      expect(bad.status()).toBe(400);
+    } finally {
+      await ctx.close();
     }
-
-    const bad = await ctx.request.get("/api/audit-events?limit=garbage");
-    expect(bad.status()).toBe(400);
-    await ctx.close();
   });
 });


### PR DESCRIPTION
Folds the manual QA plan's role matrix, reauth-window, and audit-events-API sections into Playwright specs so an operator can green-light those gates with `npm run qa` instead of clicking through. Documented in claude/qa/user-management.md alongside the existing auth specs.

What the suite covers
- C.2 analyst denied on host.isolate (403 + no_matching_rule).
- C.3 senior_analyst allowed by the chokepoint (not 403 + reason != no_matching_rule).
- C.4 auditor denied on isolate, allowed on /api/audit-events.
- C.5 super_admin succeeds on both isolate + audit read. Promotes analyst@qa.local via SQL inside the test so the matrix runs entirely over OIDC; the break-glass admin's super_admin path is separately exercised by tests/auth/break-glass-login.spec.ts.
- C.6 anonymous /api/audit-events returns 401.
- D.1 fresh session passes the freshness gate.
- D.2 stale session (UPDATE sessions SET last_auth_at = NOW(6) - INTERVAL 1 HOUR) returns 403 + reauth_required.
- D.4 stale session can still GET /api/hosts (read-side ignores the freshness gate; only destructive actions fire it).
- F.4 /api/audit-events?action= filters down correctly; bad limit parameter returns 400.

State bootstrap
tests/qa/_setup.ts owns the rebuildQAState helper: reset DB, re-register the seeded admin's break-glass credential via the CDP virtual authenticator, JIT-provision analyst+senior+auditor via dex, promote senior+auditor via SQL. Called from describe.beforeAll so each `npm run qa` invocation works from any prior state.

Consolidation note
Sections live in one spec (sections-c-d-f.spec.ts) because the break-glass setup endpoint is globally rate-limited at 5/min; running rebuildQAState() per section trips the limit on the third beforeAll. The other QA spec files are stubs pointing at the consolidated entry point — kept so the QA plan's named sections stay grep-able.

Exclusions
- D.3 (reauth modal retry) needs the React modal UI; deferred until the UI test pass adds a fixture for it.
- E (session lifecycle) needs a server restart with short EDR_SESSION_*_TIMEOUT env vars; can't fold cleanly into a single-process Playwright run.
- F.2 (SigNoz dual-emit visible) needs the dev OTel gRPC pipeline to be healthy; tracked separately in observability_signoz_dev_state memory.
- F.3 (SigNoz dashboard import) is a UI-only manual step.

Operator invocation
  task qa:up && task dev:server:qa-oidc &
  cd test/e2e && npm test                # auth (A.1-A.4, B.1-B.2)
  cd test/e2e && npm run qa              # C + D + F.4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Reorganized end-to-end test suite to isolate authentication tests from QA test execution paths.
  * Added QA test infrastructure with setup helpers for multi-user testing scenarios.
  * Introduced comprehensive test coverage for authorization rules, session management, role-based access controls, and audit event filtering.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/getvictor/fleet-edr/pull/143)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->