### PR TITLE
App Control demo cut step 2: set_application_control wire + snapshot

### DIFF
--- a/agent/cmd/fleet-edr-agent/main.go
+++ b/agent/cmd/fleet-edr-agent/main.go
@@ -7,10 +7,12 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"net/http"
 	"os"
 	"os/signal"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -144,14 +146,21 @@ func run() error {
 		MaxRetries: uploaderMaxRetries,
 	}, httpClient, logger)
 
+	// appControlDispatcher bridges the commander (which wants a stable
+	// ApplicationControlSender across receiver reconnects) and runReceiverLoop
+	// (which creates a new *receiver.Receiver on every connect). The ESF
+	// receiver loop publishes into this dispatcher on connect and clears it on
+	// disconnect.
+	esfAppControlDispatcher := &appControlDispatcher{}
+
 	pidTable := proctable.New()
-	go runReceiverLoop(ctx, logger, cfg.XPCService, q, pidTable, true)
+	go runReceiverLoop(ctx, logger, cfg.XPCService, q, pidTable, true, esfAppControlDispatcher)
 	if cfg.NetXPCService != "" {
-		go runReceiverLoop(ctx, logger, cfg.NetXPCService, q, pidTable, false)
+		go runReceiverLoop(ctx, logger, cfg.NetXPCService, q, pidTable, false, nil)
 	}
 	go runUploader(ctx, up, logger)
 
-	startCommander(ctx, hostID, cfg.ServerURL, tokenProvider, agentTransport, logger)
+	startCommander(ctx, hostID, cfg.ServerURL, tokenProvider, esfAppControlDispatcher, agentTransport, logger)
 	go pruneLoop(ctx, q, cfg.PruneAge, logger)
 	startProcessReconciler(ctx, cfg, pidTable, q, tokenProvider, logger)
 
@@ -272,6 +281,7 @@ func startCommander(
 	ctx context.Context,
 	hostID, serverURL string,
 	tokenProvider enrollment.TokenProvider,
+	appControlSender commander.ApplicationControlSender,
 	transport http.RoundTripper,
 	logger *slog.Logger,
 ) {
@@ -280,12 +290,13 @@ func startCommander(
 		return
 	}
 	cmdr := commander.New(commander.Config{
-		ServerURL:     serverURL,
-		TokenFn:       tokenProvider.Token,
-		OnAuthFail:    tokenProvider.OnUnauthorized,
-		RotateTokenFn: tokenProvider.Rotate,
-		HostID:        hostID,
-		Interval:      commanderPollInterval,
+		ServerURL:                serverURL,
+		TokenFn:                  tokenProvider.Token,
+		OnAuthFail:               tokenProvider.OnUnauthorized,
+		RotateTokenFn:            tokenProvider.Rotate,
+		HostID:                   hostID,
+		Interval:                 commanderPollInterval,
+		ApplicationControlSender: appControlSender,
 	}, &http.Client{Transport: transport, Timeout: 10 * time.Second}, logger)
 	go func() {
 		if err := cmdr.Run(ctx); err != nil && ctx.Err() == nil {
@@ -340,7 +351,10 @@ func pruneLoop(ctx context.Context, q *queue.Queue, pruneAge time.Duration, logg
 }
 
 // runReceiverLoop connects to an XPC service and reconnects with exponential backoff,
-// piping every event the receiver yields into the agent's queue.
+// piping every event the receiver yields into the agent's queue. When dispatcher is
+// non-nil, every successful connection publishes the current *Receiver into it so
+// outbound callers (commander set_application_control) can send messages to the
+// peer; disconnects clear the dispatcher to prevent sending on a dead handle.
 func runReceiverLoop(
 	ctx context.Context,
 	logger *slog.Logger,
@@ -348,6 +362,7 @@ func runReceiverLoop(
 	q *queue.Queue,
 	pt *proctable.Table,
 	updateTable bool,
+	dispatcher *appControlDispatcher,
 ) {
 	const (
 		initialBackoff = time.Second
@@ -356,7 +371,7 @@ func runReceiverLoop(
 
 	backoff := initialBackoff
 	for ctx.Err() == nil {
-		reconnect, connected := runReceiverOnce(ctx, logger, xpcService, q, pt, updateTable)
+		reconnect, connected := runReceiverOnce(ctx, logger, xpcService, q, pt, updateTable, dispatcher)
 		if connected {
 			// Successful session; reset the backoff so the next reconnect is fast.
 			backoff = initialBackoff
@@ -390,6 +405,7 @@ func runReceiverOnce(
 	q *queue.Queue,
 	pt *proctable.Table,
 	updateTable bool,
+	dispatcher *appControlDispatcher,
 ) (reconnect, connected bool) {
 	recv := receiver.New(xpcService, receiverEventBuffer)
 	if err := recv.Connect(); err != nil {
@@ -398,7 +414,13 @@ func runReceiverOnce(
 	}
 	logger.InfoContext(ctx, "receiver connected", "service", xpcService)
 
+	if dispatcher != nil {
+		dispatcher.set(recv)
+	}
 	reconnect = pipeEvents(ctx, logger, recv, q, pt, updateTable)
+	if dispatcher != nil {
+		dispatcher.clear()
+	}
 	recv.Disconnect()
 	return reconnect, true
 }
@@ -481,4 +503,41 @@ func sleepCtx(ctx context.Context, d time.Duration) bool {
 	case <-t.C:
 		return true
 	}
+}
+
+// appControlDispatcher satisfies commander.ApplicationControlSender across the
+// lifecycle of the ESF receiver: runReceiverLoop publishes the current
+// *Receiver on connect and clears it on disconnect. Between clear() and the
+// next set(), SendApplicationControl returns an error so the command gets
+// reported as `failed` and the server's next policy fan-out re-queues the
+// update. Using atomic.Pointer keeps the hot path
+// (SendApplicationControl from commander) lock-free.
+type appControlDispatcher struct {
+	cur atomic.Pointer[receiver.Receiver]
+}
+
+func (d *appControlDispatcher) set(r *receiver.Receiver) { d.cur.Store(r) }
+
+// clear unconditionally clears the published receiver pointer. This is safe
+// under the current runReceiverLoop lifecycle, which serialises set/clear for
+// a single service — there is only one goroutine calling set() and clear() in
+// sequence per connect cycle, so there is no window where a later set() can
+// be wiped by an earlier clear(). If this dispatcher is ever extended to
+// handle overlapping receiver lifecycles (multiple services or concurrent
+// reconnects), clear() would need receiver-aware CompareAndSwap semantics to
+// avoid nulling out a freshly-published pointer from a later set().
+func (d *appControlDispatcher) clear() {
+	d.cur.Store(nil)
+}
+
+// SendApplicationControl satisfies commander.ApplicationControlSender. Returns
+// an error when no receiver is published (between disconnect and the next
+// successful reconnect) so the commander treats the command as failed and the
+// server's next push reconverges the agent.
+func (d *appControlDispatcher) SendApplicationControl(payload []byte) error {
+	r := d.cur.Load()
+	if r == nil {
+		return errors.New("app control dispatcher: no receiver connected")
+	}
+	return r.SendApplicationControl(payload)
 }

--- a/agent/commander/commander.go
+++ b/agent/commander/commander.go
@@ -23,6 +23,16 @@ const defaultPollInterval = 5 * time.Second
 // shape stays stable across handlers.
 const invalidPayloadPrefix = "invalid payload: "
 
+// ApplicationControlSender forwards a raw application-control snapshot
+// JSON payload to the ESF extension over XPC. The commander stays
+// decoupled from the concrete receiver so tests can supply a recording
+// double. Nil is allowed (set_application_control commands are then
+// reported as `failed` with a clear reason), matching the pre-step-1
+// commander shape.
+type ApplicationControlSender interface {
+	SendApplicationControl(payload []byte) error
+}
+
 // Config holds commander settings.
 type Config struct {
 	ServerURL string
@@ -32,6 +42,11 @@ type Config struct {
 	OnAuthFail func(ctx context.Context)
 	HostID     string
 	Interval   time.Duration
+	// ApplicationControlSender is the XPC bridge to the ESF extension. Used by the
+	// set_application_control command handler; nil means "commander cannot apply
+	// snapshot updates" and the handler will report the command failed with a
+	// clear reason.
+	ApplicationControlSender ApplicationControlSender
 	// RotateTokenFn applies a rotate_token command's new bearer to the
 	// agent's persisted state (issue #86). Nil means rotate_token is
 	// reported as failed; this is the right behaviour for tests / dry-runs
@@ -77,6 +92,22 @@ type command struct {
 
 type killPayload struct {
 	PID int `json:"pid"`
+}
+
+// setApplicationControlPayload mirrors server/rules/api.SetApplicationControlPayload.
+// Field names + json tags are load-bearing: the extension parses the same
+// JSON bytes and the byte-shape must match across all three sides. The
+// commander's only job is to verify the envelope (policy_id present, version
+// positive) before handing the raw bytes off to the extension; the per-rule
+// decode happens on the extension side, which is the only consumer that
+// actually walks the rules list.
+type setApplicationControlPayload struct {
+	PolicyID      int64 `json:"policy_id"`
+	PolicyVersion int64 `json:"policy_version"`
+	// Rules is decoded as json.RawMessage so the commander doesn't need to
+	// know the rule shape; the extension is the source of truth for the
+	// per-rule schema and the commander only forwards the bytes it received.
+	Rules json.RawMessage `json:"rules"`
 }
 
 // rotateTokenPayload mirrors the JSON the server emits when issuing a
@@ -159,12 +190,75 @@ func (c *Commander) dispatch(ctx context.Context, cmd command) {
 	switch cmd.CommandType {
 	case "kill_process":
 		c.executeKill(ctx, cmd)
+	case "set_application_control":
+		c.executeSetApplicationControl(ctx, cmd)
 	case "rotate_token":
 		c.executeRotateToken(ctx, cmd)
 	default:
 		if err := c.updateStatus(ctx, cmd.ID, "failed", marshalResult("unknown command type: "+cmd.CommandType)); err != nil {
 			c.logger.ErrorContext(ctx, "commander fail", "cmd_id", cmd.ID, "err", err)
 		}
+	}
+}
+
+// executeSetApplicationControl forwards the raw command payload to the ESF
+// extension over XPC. Result shape on success:
+// {"policy_id": P, "policy_version": V} so operators can confirm via
+// `GET /commands/{id}` that the agent applied the snapshot it was meant to.
+//
+// Envelope validation only: the per-rule shape is the extension's
+// responsibility. Forwarding the raw bytes (rather than re-marshalling)
+// keeps the wire shape byte-identical across server → agent → extension so
+// a future schema tightening that fails on one side surfaces on the same
+// commit.
+func (c *Commander) executeSetApplicationControl(ctx context.Context, cmd command) {
+	var payload setApplicationControlPayload
+	if err := json.Unmarshal(cmd.Payload, &payload); err != nil {
+		_ = c.updateStatus(ctx, cmd.ID, "failed", marshalResult(invalidPayloadPrefix+err.Error()))
+		return
+	}
+	if payload.PolicyID <= 0 {
+		_ = c.updateStatus(ctx, cmd.ID, "failed", marshalResult("payload missing or invalid policy_id"))
+		return
+	}
+	if payload.PolicyVersion <= 0 {
+		// Versioning is the ordering guard for snapshot state on the extension; a
+		// zero/negative version would either mask an out-of-order delivery or reflect a
+		// hand-queued test command that shouldn't be acted on. Fail fast so the server-
+		// side audit trail attributes the error to its source rather than to the XPC
+		// layer returning opaque decode errors from the extension.
+		_ = c.updateStatus(ctx, cmd.ID, "failed", marshalResult("invalid policy_version"))
+		return
+	}
+	if c.cfg.ApplicationControlSender == nil {
+		_ = c.updateStatus(ctx, cmd.ID, "failed", marshalResult("application control sender not configured"))
+		return
+	}
+
+	c.logger.InfoContext(ctx, "commander set_application_control",
+		"cmd_id", cmd.ID,
+		"edr.app_control.policy_id", payload.PolicyID,
+		"edr.app_control.policy_version", payload.PolicyVersion,
+	)
+
+	// Forward the raw JSON bytes so the extension parses the same shape the server wrote.
+	// Re-marshalling would introduce drift in field ordering / casing that a future schema
+	// tightening could catch on one side but not the other.
+	if err := c.cfg.ApplicationControlSender.SendApplicationControl([]byte(cmd.Payload)); err != nil {
+		_ = c.updateStatus(ctx, cmd.ID, "failed", marshalResult("xpc send: "+err.Error()))
+		return
+	}
+
+	// The send is async — completing the command here does NOT mean the extension has
+	// successfully applied the snapshot. The demo cut intentionally stops short of an
+	// extension-side ack; the audit trail of "command completed on agent" is sufficient
+	// for now. A future revision can add a round-trip ack with the actually-applied version.
+	result, _ := json.Marshal(map[string]any{
+		"policy_id":      payload.PolicyID,
+		"policy_version": payload.PolicyVersion,
+	})
+	if err := c.updateStatus(ctx, cmd.ID, "completed", result); err != nil {
+		c.logger.ErrorContext(ctx, "commander report set_application_control success", "cmd_id", cmd.ID, "err", err)
 	}
 }
 

--- a/agent/commander/commander.go
+++ b/agent/commander/commander.go
@@ -97,10 +97,12 @@ type killPayload struct {
 // setApplicationControlPayload mirrors server/rules/api.SetApplicationControlPayload.
 // Field names + json tags are load-bearing: the extension parses the same
 // JSON bytes and the byte-shape must match across all three sides. The
-// commander's only job is to verify the envelope (policy_id present, version
-// positive) before handing the raw bytes off to the extension; the per-rule
-// decode happens on the extension side, which is the only consumer that
-// actually walks the rules list.
+// commander's job is envelope validation (policy_id present, version
+// positive, rules is a JSON array) before handing the raw bytes off to the
+// extension; the per-rule decode happens on the extension side, which is the
+// only consumer that actually walks the rules list. Gating on the rules-is-an-
+// array check here prevents reporting `completed` for a payload the extension
+// will silently fail to decode.
 type setApplicationControlPayload struct {
 	PolicyID      int64 `json:"policy_id"`
 	PolicyVersion int64 `json:"policy_version"`
@@ -230,6 +232,16 @@ func (c *Commander) executeSetApplicationControl(ctx context.Context, cmd comman
 		_ = c.updateStatus(ctx, cmd.ID, "failed", marshalResult("invalid policy_version"))
 		return
 	}
+	// Validate that rules is present AND a JSON array (empty array allowed).
+	// Without this gate, payloads with missing/null/non-array rules slip past
+	// the envelope check because the json.RawMessage decode accepts any
+	// well-formed JSON value, the extension then fails to decode silently,
+	// and the server sees `completed` for a snapshot the extension never
+	// applied.
+	if !isJSONArray(payload.Rules) {
+		_ = c.updateStatus(ctx, cmd.ID, "failed", marshalResult("payload missing or invalid rules array"))
+		return
+	}
 	if c.cfg.ApplicationControlSender == nil {
 		_ = c.updateStatus(ctx, cmd.ID, "failed", marshalResult("application control sender not configured"))
 		return
@@ -325,6 +337,25 @@ func (c *Commander) executeKill(ctx context.Context, cmd command) {
 func marshalResult(errMsg string) json.RawMessage {
 	b, _ := json.Marshal(map[string]string{"error": errMsg})
 	return b
+}
+
+// isJSONArray reports whether raw is a JSON array (including the empty
+// array). Used by the set_application_control envelope check to reject
+// payloads with missing or null `rules` fields, which would otherwise slip
+// through json.Unmarshal-into-json.RawMessage and only fail at extension
+// decode time after the server has already seen `completed`.
+func isJSONArray(raw json.RawMessage) bool {
+	for _, b := range raw {
+		switch b {
+		case ' ', '\t', '\r', '\n':
+			continue
+		case '[':
+			return true
+		default:
+			return false
+		}
+	}
+	return false
 }
 
 func (c *Commander) updateStatus(ctx context.Context, cmdID int64, status string, result json.RawMessage) error {

--- a/agent/commander/commander_test.go
+++ b/agent/commander/commander_test.go
@@ -74,6 +74,180 @@ func TestFetchPending401_CallsOnAuthFail(t *testing.T) {
 	assert.Equal(t, int64(1), called.Load(), "401 on fetchPending must trigger OnAuthFail exactly once")
 }
 
+// recordingApplicationControlSender captures application_control snapshot payloads so
+// tests can inspect them without cgo / real XPC. Mimics the production sender's
+// contract: return nil on success, a non-nil error on failure so the commander
+// reports the command as `failed`.
+type recordingApplicationControlSender struct {
+	sent    [][]byte
+	sendErr error
+}
+
+func (r *recordingApplicationControlSender) SendApplicationControl(payload []byte) error {
+	if r.sendErr != nil {
+		return r.sendErr
+	}
+	r.sent = append(r.sent, append([]byte(nil), payload...))
+	return nil
+}
+
+// TestExecuteSetApplicationControl_HappyPath covers the set_application_control
+// command path: server enqueues the command, commander forwards it to the
+// extension, and reports `completed` with policy_id + policy_version.
+func TestExecuteSetApplicationControl_HappyPath(t *testing.T) {
+	var gotStatus string
+	var gotResult []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		var body statusUpdate
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		gotStatus = body.Status
+		gotResult = body.Result
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	sender := &recordingApplicationControlSender{}
+	c := New(Config{
+		ServerURL:                srv.URL,
+		HostID:                   "host-a",
+		ApplicationControlSender: sender,
+	}, nil, nil)
+
+	rawPayload := `{"policy_id":7,"policy_version":42,"rules":[{"rule_type":"BINARY","identifier":"aaa","action":"BLOCK","enforcement":"PROTECT","severity":"medium"}]}`
+	cmd := command{
+		ID:          11,
+		CommandType: "set_application_control",
+		Payload:     json.RawMessage(rawPayload),
+	}
+	c.executeSetApplicationControl(t.Context(), cmd)
+
+	require.Len(t, sender.sent, 1)
+	// Byte equality, not JSONEq — the commander's contract with the extension is
+	// "forward the exact payload bytes the server sent", not "forward some JSON
+	// equivalent". Re-marshalling could change field ordering or whitespace and the
+	// test must catch that.
+	assert.Equal(t, []byte(rawPayload), sender.sent[0],
+		"commander must forward the raw payload bytes, not a re-marshalled copy")
+
+	assert.Equal(t, "completed", gotStatus)
+	var result map[string]any
+	require.NoError(t, json.Unmarshal(gotResult, &result))
+	assert.EqualValues(t, 7, result["policy_id"])
+	assert.EqualValues(t, 42, result["policy_version"])
+}
+
+// TestExecuteSetApplicationControl_InvalidPayload covers the malformed-JSON
+// path: the commander must report `failed` BEFORE handing off to XPC so a
+// future schema tightening on the extension side never sees garbage bytes.
+func TestExecuteSetApplicationControl_InvalidPayload(t *testing.T) {
+	var gotStatus string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body statusUpdate
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		gotStatus = body.Status
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	sender := &recordingApplicationControlSender{}
+	c := New(Config{ServerURL: srv.URL, HostID: "host-a", ApplicationControlSender: sender}, nil, nil)
+
+	c.executeSetApplicationControl(t.Context(), command{
+		ID:          12,
+		CommandType: "set_application_control",
+		Payload:     json.RawMessage(`{`), // malformed
+	})
+	assert.Equal(t, "failed", gotStatus)
+	assert.Empty(t, sender.sent, "malformed payload must not reach the extension")
+}
+
+// TestExecuteSetApplicationControl_InvalidVersion covers the version
+// validation guard: real server versions start at 1, so a zero or negative
+// payload version is either a hand-queued test command or an out-of-order
+// delivery and the extension must never see it.
+func TestExecuteSetApplicationControl_InvalidVersion(t *testing.T) {
+	var gotStatus, gotErr string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body statusUpdate
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		gotStatus = body.Status
+		var result map[string]string
+		_ = json.Unmarshal(body.Result, &result)
+		gotErr = result["error"]
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	sender := &recordingApplicationControlSender{}
+	c := New(Config{ServerURL: srv.URL, HostID: "host-a", ApplicationControlSender: sender}, nil, nil)
+
+	c.executeSetApplicationControl(t.Context(), command{
+		ID:          13,
+		CommandType: "set_application_control",
+		Payload:     json.RawMessage(`{"policy_id":7,"policy_version":0,"rules":[]}`),
+	})
+	assert.Equal(t, "failed", gotStatus)
+	assert.Equal(t, "invalid policy_version", gotErr)
+	assert.Empty(t, sender.sent, "payload with invalid version must not reach the extension")
+}
+
+// TestExecuteSetApplicationControl_MissingPolicyID covers the symmetric
+// envelope check for policy_id. Zero policy_id never comes from a healthy
+// server fan-out; fail explicitly rather than hand garbage to the extension.
+func TestExecuteSetApplicationControl_MissingPolicyID(t *testing.T) {
+	var gotStatus, gotErr string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body statusUpdate
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		gotStatus = body.Status
+		var result map[string]string
+		_ = json.Unmarshal(body.Result, &result)
+		gotErr = result["error"]
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	sender := &recordingApplicationControlSender{}
+	c := New(Config{ServerURL: srv.URL, HostID: "host-a", ApplicationControlSender: sender}, nil, nil)
+
+	c.executeSetApplicationControl(t.Context(), command{
+		ID:          14,
+		CommandType: "set_application_control",
+		Payload:     json.RawMessage(`{"policy_id":0,"policy_version":1,"rules":[]}`),
+	})
+	assert.Equal(t, "failed", gotStatus)
+	assert.Contains(t, gotErr, "policy_id")
+	assert.Empty(t, sender.sent)
+}
+
+// TestExecuteSetApplicationControl_NoSenderConfigured covers the agent
+// startup case where the XPC bridge has not been wired yet (or has
+// disconnected). The command must fail with a clear reason so the
+// operator's audit log surfaces "no extension" rather than a silent
+// success.
+func TestExecuteSetApplicationControl_NoSenderConfigured(t *testing.T) {
+	var gotStatus string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body statusUpdate
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		gotStatus = body.Status
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	c := New(Config{ServerURL: srv.URL, HostID: "host-a"}, nil, nil)
+	c.executeSetApplicationControl(t.Context(), command{
+		ID:          15,
+		CommandType: "set_application_control",
+		Payload:     json.RawMessage(`{"policy_id":7,"policy_version":1,"rules":[]}`),
+	})
+	assert.Equal(t, "failed", gotStatus)
+}
+
 // TestUpdateStatus401_CallsOnAuthFail covers the PUT /commands/{id} path — a token can be
 // revoked between fetchPending and the following ack/complete, and the hook must fire there
 // too or recovery waits for the next poll tick.

--- a/agent/commander/commander_test.go
+++ b/agent/commander/commander_test.go
@@ -224,6 +224,70 @@ func TestExecuteSetApplicationControl_MissingPolicyID(t *testing.T) {
 	assert.Empty(t, sender.sent)
 }
 
+// TestExecuteSetApplicationControl_RulesMissingOrInvalid covers the
+// envelope check on `rules`. Without this gate, a payload with missing
+// or null rules slips past json.Unmarshal-into-json.RawMessage and only
+// fails on the extension's typed decode — but by then the commander has
+// already reported `completed`, so the server is wrong about per-host
+// convergence. The commander must reject those shapes BEFORE forwarding.
+func TestExecuteSetApplicationControl_RulesMissingOrInvalid(t *testing.T) {
+	cases := []struct {
+		name    string
+		payload string
+	}{
+		{"missing rules", `{"policy_id":7,"policy_version":1}`},
+		{"null rules", `{"policy_id":7,"policy_version":1,"rules":null}`},
+		{"rules is object", `{"policy_id":7,"policy_version":1,"rules":{}}`},
+		{"rules is string", `{"policy_id":7,"policy_version":1,"rules":"oops"}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotStatus, gotErr string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var body statusUpdate
+				_ = json.NewDecoder(r.Body).Decode(&body)
+				gotStatus = body.Status
+				var result map[string]string
+				_ = json.Unmarshal(body.Result, &result)
+				gotErr = result["error"]
+				w.WriteHeader(http.StatusNoContent)
+			}))
+			defer srv.Close()
+
+			sender := &recordingApplicationControlSender{}
+			c := New(Config{ServerURL: srv.URL, HostID: "host-a", ApplicationControlSender: sender}, nil, nil)
+			c.executeSetApplicationControl(t.Context(), command{
+				ID:          16,
+				CommandType: "set_application_control",
+				Payload:     json.RawMessage(tc.payload),
+			})
+			assert.Equal(t, "failed", gotStatus)
+			assert.Contains(t, gotErr, "rules")
+			assert.Empty(t, sender.sent, "non-array rules payload must not reach the extension")
+		})
+	}
+}
+
+// TestExecuteSetApplicationControl_EmptyRulesAccepted covers the
+// converse: an empty rules array is a legal state (just-after-policy
+// creation, or after every rule is deleted) and the commander must
+// forward it cleanly.
+func TestExecuteSetApplicationControl_EmptyRulesAccepted(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	sender := &recordingApplicationControlSender{}
+	c := New(Config{ServerURL: srv.URL, HostID: "host-a", ApplicationControlSender: sender}, nil, nil)
+	c.executeSetApplicationControl(t.Context(), command{
+		ID:          17,
+		CommandType: "set_application_control",
+		Payload:     json.RawMessage(`{"policy_id":7,"policy_version":1,"rules":[]}`),
+	})
+	require.Len(t, sender.sent, 1, "empty rules array is a valid snapshot push")
+}
+
 // TestExecuteSetApplicationControl_NoSenderConfigured covers the agent
 // startup case where the XPC bridge has not been wired yet (or has
 // disconnected). The command must fail with a clear reason so the

--- a/agent/receiver/receiver.go
+++ b/agent/receiver/receiver.go
@@ -130,6 +130,36 @@ func (r *Receiver) Connect() error {
 	return nil
 }
 
+// SendApplicationControl delivers an `application_control.update` XPC message
+// to the peer. Returns an error if the connection is not established or the
+// send call rejected the payload. The send is asynchronous; a nil error means
+// the message was handed off to XPC, not that the peer has acknowledged it —
+// an ack is not part of the current wire protocol.
+//
+// We hold r.mu across the C bridge call so a concurrent Disconnect() cannot
+// tear the slot down while C is still using the handle. Without the extended
+// lock, the small integer handle could be reused by another Receiver's
+// Connect between our snapshot and the xpc_bridge_send_application_control
+// call, and we'd end up sending this host's payload on a different peer's
+// connection.
+func (r *Receiver) SendApplicationControl(payload []byte) error {
+	if len(payload) == 0 {
+		return errors.New("empty application_control payload")
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if !r.connected || r.handle < 0 {
+		return errors.New("receiver not connected")
+	}
+	rc := int(C.xpc_bridge_send_application_control(C.int(r.handle), (*C.uint8_t)(unsafe.Pointer(&payload[0])), C.size_t(len(payload))))
+	if rc != 0 {
+		return fmt.Errorf("xpc_bridge_send_application_control returned %d", rc)
+	}
+	return nil
+}
+
 // Disconnect tears down the XPC connection.
 func (r *Receiver) Disconnect() {
 	r.mu.Lock()

--- a/agent/xpcbridge/xpc_bridge.c
+++ b/agent/xpcbridge/xpc_bridge.c
@@ -114,6 +114,31 @@ int xpc_bridge_connect(const char *service_name, const void *context, xpc_bridge
     return handle;
 }
 
+int xpc_bridge_send_application_control(int handle, const uint8_t *data, size_t len) {
+    if (handle < 0 || handle >= XPC_BRIDGE_MAX_CONNECTIONS || data == NULL || len == 0) {
+        return -1;
+    }
+
+    pthread_mutex_lock(&g_slots_mutex);
+    if (!g_slots[handle].in_use) {
+        pthread_mutex_unlock(&g_slots_mutex);
+        return -1;
+    }
+    xpc_connection_t conn = g_slots[handle].connection;
+    // Retain so the connection survives even if the caller tears the slot down between
+    // our unlock and the async send. XPC itself refcounts the object; we mirror that.
+    xpc_retain(conn);
+    pthread_mutex_unlock(&g_slots_mutex);
+
+    xpc_object_t msg = xpc_dictionary_create_empty();
+    xpc_dictionary_set_string(msg, "type", "application_control.update");
+    xpc_dictionary_set_data(msg, "data", data, len);
+    xpc_connection_send_message(conn, msg);
+    xpc_release(msg);
+    xpc_release(conn);
+    return 0;
+}
+
 void xpc_bridge_disconnect(int handle) {
     if (handle < 0 || handle >= XPC_BRIDGE_MAX_CONNECTIONS) {
         return;

--- a/agent/xpcbridge/xpc_bridge.c
+++ b/agent/xpcbridge/xpc_bridge.c
@@ -108,8 +108,15 @@ int xpc_bridge_connect(const char *service_name, const void *context, xpc_bridge
     xpc_connection_send_message(conn, hello);
     xpc_release(hello);
 
+    // Publish the conn + queue under the slots mutex so a concurrent
+    // xpc_bridge_send_application_control cannot observe (in_use=1, connection=NULL).
+    // The earlier reservation marked in_use=1 outside this critical section
+    // for liveness; this second critical section commits the actual handles
+    // atomically with respect to send/disconnect.
+    pthread_mutex_lock(&g_slots_mutex);
     g_slots[handle].connection = conn;
     g_slots[handle].queue = queue;
+    pthread_mutex_unlock(&g_slots_mutex);
 
     return handle;
 }
@@ -125,6 +132,13 @@ int xpc_bridge_send_application_control(int handle, const uint8_t *data, size_t 
         return -1;
     }
     xpc_connection_t conn = g_slots[handle].connection;
+    if (conn == NULL) {
+        // Slot is reserved (in_use=1) but xpc_bridge_connect has not yet
+        // committed the connection handle. Treat as "not yet ready" and let
+        // the caller retry on the next poll cycle.
+        pthread_mutex_unlock(&g_slots_mutex);
+        return -1;
+    }
     // Retain so the connection survives even if the caller tears the slot down between
     // our unlock and the async send. XPC itself refcounts the object; we mirror that.
     xpc_retain(conn);

--- a/agent/xpcbridge/xpc_bridge.h
+++ b/agent/xpcbridge/xpc_bridge.h
@@ -28,4 +28,12 @@ int xpc_bridge_connect(const char *service_name, const void *context, xpc_bridge
 // Disconnect and clean up a specific connection.
 void xpc_bridge_disconnect(int handle);
 
+// Send an "application_control.update" message to the peer on the given handle.
+// The payload is copied into an XPC dictionary under the "data" key alongside
+// "type"="application_control.update". Returns 0 on success, -1 if the handle
+// is invalid or the connection is gone. XPC send is asynchronous — success
+// here means the message was enqueued on the connection, not that the peer
+// received it.
+int xpc_bridge_send_application_control(int handle, const uint8_t *data, size_t len);
+
 #endif

--- a/extension/edr/extension/ApplicationControlStore.swift
+++ b/extension/edr/extension/ApplicationControlStore.swift
@@ -125,11 +125,15 @@ final class ApplicationControlStore {
         }
         let snapshot = makeSnapshot(from: document)
         lock.withLock { $0 = snapshot }
-        logger.info(
-            "loaded application control snapshot: policy=\(snapshot.policyID, privacy: .public) "
-            + "version=\(snapshot.policyVersion, privacy: .public) "
-            + "rules=\(document.rules.count, privacy: .public)"
-        )
+        // Build the summary as a plain Swift String first, then interpolate it
+        // as a single OSLogMessage placeholder. Going via String avoids the
+        // SwiftLint line_length cap (the full interpolated form is >200 chars)
+        // AND keeps the log statement a single Logger call, which is what
+        // os.log's OSLogMessage type accepts (it has no `+` operator across
+        // interpolation segments).
+        let summary = "loaded app control snapshot: " +
+            "policy=\(snapshot.policyID) version=\(snapshot.policyVersion) rules=\(document.rules.count)"
+        logger.info("\(summary, privacy: .public)")
     }
 
     /// apply decodes the raw JSON from an `application_control.update` XPC
@@ -161,11 +165,11 @@ final class ApplicationControlStore {
             logger.info("application_control.update version \(snapshot.policyVersion, privacy: .public) <= current; ignoring")
             return
         }
-        logger.info(
-            "applied application control snapshot: policy=\(snapshot.policyID, privacy: .public) "
-            + "version=\(snapshot.policyVersion, privacy: .public) "
-            + "rules=\(document.rules.count, privacy: .public)"
-        )
+        // Same OSLogMessage / line_length pattern as in loadFromDisk above:
+        // build the message as a plain String, then interpolate once.
+        let summary = "applied app control snapshot: " +
+            "policy=\(snapshot.policyID) version=\(snapshot.policyVersion) rules=\(document.rules.count)"
+        logger.info("\(summary, privacy: .public)")
         persistQueue.async { [data] in
             self.persist(rawJSON: data)
         }

--- a/extension/edr/extension/ApplicationControlStore.swift
+++ b/extension/edr/extension/ApplicationControlStore.swift
@@ -1,0 +1,239 @@
+import Foundation
+import os.log
+
+private let logger = Logger(subsystem: "com.fleetdm.edr.securityextension", category: "ApplicationControlStore")
+
+// ApplicationControlSnapshot is the typed in-memory shape the AUTH_EXEC decision
+// engine (Step 3) consults on every exec. Rules are indexed by (rule_type,
+// identifier) so the precedence walk is O(1) per type. Phase 1 of the demo cut
+// only populates the BINARY map; the others are reserved for the follow-on
+// types (CDHASH, SIGNINGID, CERTIFICATE, TEAMID, PATH) coming later.
+struct ApplicationControlSnapshot {
+    let policyID: Int64
+    let policyVersion: Int64
+    let binaryRules: [String: ApplicationControlRule]      // identifier (file SHA-256) -> rule
+    let cdhashRules: [String: ApplicationControlRule]      // 40 hex
+    let signingIDRules: [String: ApplicationControlRule]   // "<TeamID>:<bundle.id>" or "platform:<bundle.id>"
+    let certificateRules: [String: ApplicationControlRule] // 64 hex (leaf cert sha256)
+    let teamIDRules: [String: ApplicationControlRule]      // 10 char TeamID
+    let pathRules: [String: ApplicationControlRule]        // canonical absolute path
+
+    static let empty = ApplicationControlSnapshot(
+        policyID: 0,
+        policyVersion: 0,
+        binaryRules: [:],
+        cdhashRules: [:],
+        signingIDRules: [:],
+        certificateRules: [:],
+        teamIDRules: [:],
+        pathRules: [:]
+    )
+}
+
+/// ApplicationControlRule mirrors one entry in the wire payload. Codable so
+/// the same struct decodes both an incoming XPC payload and the persisted
+/// snapshot file on disk. Field names use snake_case in JSON to match the
+/// server's `server/rules/api.SetApplicationControlRule` JSON tags — a
+/// rename on either side is a contract break and the round-trip test on the
+/// server side is the gate.
+struct ApplicationControlRule: Codable {
+    let ruleType: String
+    let identifier: String
+    let action: String
+    let enforcement: String
+    let severity: String
+    let customMsg: String?
+    let customURL: String?
+
+    enum CodingKeys: String, CodingKey {
+        case ruleType = "rule_type"
+        case identifier
+        case action
+        case enforcement
+        case severity
+        case customMsg = "custom_msg"
+        case customURL = "custom_url"
+    }
+}
+
+/// ApplicationControlDocument is the on-the-wire shape of the snapshot.
+/// Identical to server/rules/api.SetApplicationControlPayload.
+struct ApplicationControlDocument: Codable {
+    let policyID: Int64
+    let policyVersion: Int64
+    let rules: [ApplicationControlRule]
+
+    enum CodingKeys: String, CodingKey {
+        case policyID = "policy_id"
+        case policyVersion = "policy_version"
+        case rules
+    }
+}
+
+/// Rule-type tokens that match the server enum exactly. Stable across the
+/// wire; renaming any constant is a contract break.
+enum ApplicationControlRuleType {
+    static let binary = "BINARY"
+    static let cdhash = "CDHASH"
+    static let signingID = "SIGNINGID"
+    static let certificate = "CERTIFICATE"
+    static let teamID = "TEAMID"
+    static let path = "PATH"
+}
+
+/// ApplicationControlStore holds the typed in-memory snapshot consulted by
+/// the AUTH_EXEC decision engine (Step 3). The snapshot also persists to
+/// disk so the extension's policy survives restarts. Updates from the agent
+/// come in via XPC and route through `apply(rawJSON:)`.
+///
+/// Concurrency:
+///  - Reads of `currentSnapshot()` are lock-free via OSAllocatedUnfairLock.
+///  - Writes (apply, persist) happen on a serial queue.
+///  - The disk write uses write-temp-then-rename so a crash mid-write cannot
+///    leave the file partially written.
+final class ApplicationControlStore {
+    static let shared = ApplicationControlStore()
+
+    private let lock = OSAllocatedUnfairLock(initialState: ApplicationControlSnapshot.empty)
+    private let persistQueue = DispatchQueue(label: "com.fleetdm.edr.appcontrol.persist", qos: .utility)
+    private let storagePath = "/var/db/com.fleetdm.edr/application-control.json"
+
+    /// currentSnapshot returns the active snapshot. Lock-free fast path: the
+    /// AUTH_EXEC handler will call this on every exec, so it must be O(1)
+    /// and never block.
+    func currentSnapshot() -> ApplicationControlSnapshot {
+        return lock.withLock { $0 }
+    }
+
+    /// loadFromDisk reads the persisted snapshot at startup. Missing file or
+    /// decode error fails open (empty snapshot) — the agent will push the
+    /// current snapshot on its next command poll cycle. Never fatal.
+    func loadFromDisk() {
+        let url = URL(fileURLWithPath: storagePath)
+        guard let data = try? Data(contentsOf: url) else {
+            logger.info("no persisted application control snapshot at startup")
+            return
+        }
+        guard let document = decodeDocument(data) else {
+            logger.warning("failed to decode persisted application control snapshot; starting empty")
+            return
+        }
+        let snapshot = makeSnapshot(from: document)
+        lock.withLock { $0 = snapshot }
+        logger.info("loaded application control snapshot: policy=\(snapshot.policyID, privacy: .public) version=\(snapshot.policyVersion, privacy: .public) rules=\(document.rules.count, privacy: .public)")
+    }
+
+    /// apply decodes the raw JSON from an `application_control.update` XPC
+    /// message, validates version monotonicity (the server bumps version on
+    /// every mutation; an equal or smaller version is either a duplicate
+    /// delivery or an out-of-order replay and must not regress the active
+    /// snapshot), atomically swaps the in-memory state, and persists the
+    /// new snapshot to disk.
+    func apply(rawJSON data: Data) {
+        guard let document = decodeDocument(data) else {
+            logger.error("application_control.update missing or malformed; ignoring")
+            return
+        }
+        let snapshot = makeSnapshot(from: document)
+
+        var applied = false
+        lock.withLock { current in
+            // Monotonic-version gate. A duplicate delivery (same version) is
+            // not an error — the agent retries on its next poll if the
+            // previous cycle's ack failed — but we still skip the swap so
+            // the disk write doesn't fire for a no-op.
+            if snapshot.policyID == current.policyID && snapshot.policyVersion <= current.policyVersion {
+                return
+            }
+            current = snapshot
+            applied = true
+        }
+        if !applied {
+            logger.info("application_control.update version \(snapshot.policyVersion, privacy: .public) <= current; ignoring")
+            return
+        }
+        logger.info("applied application control snapshot: policy=\(snapshot.policyID, privacy: .public) version=\(snapshot.policyVersion, privacy: .public) rules=\(document.rules.count, privacy: .public)")
+        persistQueue.async { [data] in
+            self.persist(rawJSON: data)
+        }
+    }
+
+    private func decodeDocument(_ data: Data) -> ApplicationControlDocument? {
+        let decoder = JSONDecoder()
+        return try? decoder.decode(ApplicationControlDocument.self, from: data)
+    }
+
+    private func makeSnapshot(from document: ApplicationControlDocument) -> ApplicationControlSnapshot {
+        var binary: [String: ApplicationControlRule] = [:]
+        var cdhash: [String: ApplicationControlRule] = [:]
+        var signingID: [String: ApplicationControlRule] = [:]
+        var certificate: [String: ApplicationControlRule] = [:]
+        var teamID: [String: ApplicationControlRule] = [:]
+        var path: [String: ApplicationControlRule] = [:]
+        for rule in document.rules {
+            switch rule.ruleType {
+            case ApplicationControlRuleType.binary:
+                binary[rule.identifier] = rule
+            case ApplicationControlRuleType.cdhash:
+                cdhash[rule.identifier] = rule
+            case ApplicationControlRuleType.signingID:
+                signingID[rule.identifier] = rule
+            case ApplicationControlRuleType.certificate:
+                certificate[rule.identifier] = rule
+            case ApplicationControlRuleType.teamID:
+                teamID[rule.identifier] = rule
+            case ApplicationControlRuleType.path:
+                path[rule.identifier] = rule
+            default:
+                // The server validator already gates rule_type, so an unknown
+                // value here is a contract break the operator audit log will
+                // surface upstream. Skip the entry rather than dropping the
+                // whole snapshot.
+                logger.warning("application_control.update unknown rule_type; skipping entry")
+            }
+        }
+        return ApplicationControlSnapshot(
+            policyID: document.policyID,
+            policyVersion: document.policyVersion,
+            binaryRules: binary,
+            cdhashRules: cdhash,
+            signingIDRules: signingID,
+            certificateRules: certificate,
+            teamIDRules: teamID,
+            pathRules: path
+        )
+    }
+
+    /// persist writes the raw payload to disk via write-temp-then-rename so a
+    /// crash mid-write cannot leave the file partially written. Creates the
+    /// parent directory if missing.
+    private func persist(rawJSON data: Data) {
+        let directory = (storagePath as NSString).deletingLastPathComponent
+        do {
+            try FileManager.default.createDirectory(atPath: directory, withIntermediateDirectories: true, attributes: nil)
+        } catch {
+            logger.error("application control persist mkdir failed: \(error.localizedDescription, privacy: .public)")
+            return
+        }
+        let tmpPath = storagePath + ".tmp"
+        do {
+            try data.write(to: URL(fileURLWithPath: tmpPath), options: .atomic)
+        } catch {
+            logger.error("application control persist write failed: \(error.localizedDescription, privacy: .public)")
+            return
+        }
+        do {
+            try FileManager.default.moveItem(atPath: tmpPath, toPath: storagePath)
+        } catch {
+            // moveItem fails if the destination exists. Remove and retry.
+            do {
+                try FileManager.default.removeItem(atPath: storagePath)
+                try FileManager.default.moveItem(atPath: tmpPath, toPath: storagePath)
+            } catch {
+                logger.error("application control persist rename failed: \(error.localizedDescription, privacy: .public)")
+                try? FileManager.default.removeItem(atPath: tmpPath)
+                return
+            }
+        }
+    }
+}

--- a/extension/edr/extension/ApplicationControlStore.swift
+++ b/extension/edr/extension/ApplicationControlStore.swift
@@ -1,6 +1,5 @@
 import Foundation
 import os
-import os.log
 
 private let logger = Logger(subsystem: "com.fleetdm.edr.securityextension", category: "ApplicationControlStore")
 
@@ -126,7 +125,11 @@ final class ApplicationControlStore {
         }
         let snapshot = makeSnapshot(from: document)
         lock.withLock { $0 = snapshot }
-        logger.info("loaded application control snapshot: policy=\(snapshot.policyID, privacy: .public) version=\(snapshot.policyVersion, privacy: .public) rules=\(document.rules.count, privacy: .public)")
+        logger.info(
+            "loaded application control snapshot: policy=\(snapshot.policyID, privacy: .public) "
+            + "version=\(snapshot.policyVersion, privacy: .public) "
+            + "rules=\(document.rules.count, privacy: .public)"
+        )
     }
 
     /// apply decodes the raw JSON from an `application_control.update` XPC
@@ -158,7 +161,11 @@ final class ApplicationControlStore {
             logger.info("application_control.update version \(snapshot.policyVersion, privacy: .public) <= current; ignoring")
             return
         }
-        logger.info("applied application control snapshot: policy=\(snapshot.policyID, privacy: .public) version=\(snapshot.policyVersion, privacy: .public) rules=\(document.rules.count, privacy: .public)")
+        logger.info(
+            "applied application control snapshot: policy=\(snapshot.policyID, privacy: .public) "
+            + "version=\(snapshot.policyVersion, privacy: .public) "
+            + "rules=\(document.rules.count, privacy: .public)"
+        )
         persistQueue.async { [data] in
             self.persist(rawJSON: data)
         }

--- a/extension/edr/extension/ApplicationControlStore.swift
+++ b/extension/edr/extension/ApplicationControlStore.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 import os.log
 
 private let logger = Logger(subsystem: "com.fleetdm.edr.securityextension", category: "ApplicationControlStore")
@@ -87,10 +88,13 @@ enum ApplicationControlRuleType {
 /// come in via XPC and route through `apply(rawJSON:)`.
 ///
 /// Concurrency:
-///  - Reads of `currentSnapshot()` are lock-free via OSAllocatedUnfairLock.
-///  - Writes (apply, persist) happen on a serial queue.
-///  - The disk write uses write-temp-then-rename so a crash mid-write cannot
-///    leave the file partially written.
+///  - Reads of `currentSnapshot()` take the OSAllocatedUnfairLock for a
+///    constant-time critical section. This is not literally lock-free; the
+///    OS-level primitive is an inline-storage unfair lock optimised for
+///    uncontended fast paths.
+///  - Writes (apply, persist) happen on a serial dispatch queue.
+///  - The disk write uses Data.write(to:options:.atomic), which writes a
+///    temporary file and renames it atomically.
 final class ApplicationControlStore {
     static let shared = ApplicationControlStore()
 
@@ -98,9 +102,11 @@ final class ApplicationControlStore {
     private let persistQueue = DispatchQueue(label: "com.fleetdm.edr.appcontrol.persist", qos: .utility)
     private let storagePath = "/var/db/com.fleetdm.edr/application-control.json"
 
-    /// currentSnapshot returns the active snapshot. Lock-free fast path: the
-    /// AUTH_EXEC handler will call this on every exec, so it must be O(1)
-    /// and never block.
+    /// currentSnapshot returns the active snapshot. The AUTH_EXEC handler
+    /// calls this on every exec, so the critical section is constant time
+    /// (a copy of the small ApplicationControlSnapshot struct) and the
+    /// underlying lock is an OSAllocatedUnfairLock tuned for uncontended
+    /// fast paths.
     func currentSnapshot() -> ApplicationControlSnapshot {
         return lock.withLock { $0 }
     }
@@ -204,36 +210,19 @@ final class ApplicationControlStore {
         )
     }
 
-    /// persist writes the raw payload to disk via write-temp-then-rename so a
-    /// crash mid-write cannot leave the file partially written. Creates the
-    /// parent directory if missing.
+    /// persist writes the raw payload to disk atomically. Data.write(to:options:.atomic)
+    /// is implemented as write-temp-then-rename internally — Foundation manages
+    /// the temp file and the rename in a single atomic swap that handles the
+    /// destination-already-exists case correctly. No manual mv dance and no
+    /// non-atomic window where the destination is missing.
     private func persist(rawJSON data: Data) {
-        let directory = (storagePath as NSString).deletingLastPathComponent
+        let url = URL(fileURLWithPath: storagePath)
+        let directory = url.deletingLastPathComponent()
         do {
-            try FileManager.default.createDirectory(atPath: directory, withIntermediateDirectories: true, attributes: nil)
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true, attributes: nil)
+            try data.write(to: url, options: .atomic)
         } catch {
-            logger.error("application control persist mkdir failed: \(error.localizedDescription, privacy: .public)")
-            return
-        }
-        let tmpPath = storagePath + ".tmp"
-        do {
-            try data.write(to: URL(fileURLWithPath: tmpPath), options: .atomic)
-        } catch {
-            logger.error("application control persist write failed: \(error.localizedDescription, privacy: .public)")
-            return
-        }
-        do {
-            try FileManager.default.moveItem(atPath: tmpPath, toPath: storagePath)
-        } catch {
-            // moveItem fails if the destination exists. Remove and retry.
-            do {
-                try FileManager.default.removeItem(atPath: storagePath)
-                try FileManager.default.moveItem(atPath: tmpPath, toPath: storagePath)
-            } catch {
-                logger.error("application control persist rename failed: \(error.localizedDescription, privacy: .public)")
-                try? FileManager.default.removeItem(atPath: tmpPath)
-                return
-            }
+            logger.error("application control persist failed: \(error.localizedDescription, privacy: .public)")
         }
     }
 }

--- a/extension/edr/extension/XPCServer.swift
+++ b/extension/edr/extension/XPCServer.swift
@@ -53,21 +53,30 @@ final class XPCServer {
     /// agent). The protocol is tiny: a "type" string tells us what kind of message it is.
     ///
     ///   - "hello" : the handshake the agent uses to trigger the Mach port bind.
+    ///   - "application_control.update" : a typed snapshot push from the
+    ///     server's fan-out. The "data" key holds raw JSON bytes that
+    ///     ApplicationControlStore decodes + persists.
     ///
     /// Unknown types are logged and ignored — future protocol evolutions should be
     /// additive, and a forward-compat agent must still work against this server.
-    /// The application-control message type is added back in phase 4 of the
-    /// add-application-control change once the new decision engine lands.
     private func handlePeerMessage(_ event: xpc_object_t) {
         guard let typeCStr = xpc_dictionary_get_string(event, "type") else {
             return
         }
         let type = String(cString: typeCStr)
         // "hello" is a no-op: the mere receipt of the message triggered the lazy Mach
-        // port connection; there's nothing to do server-side. Switched to an if/else
-        // chain so adding the phase-4 application-control inbound message type is a
-        // single new branch rather than a switch reshape.
+        // port connection; there's nothing to do server-side.
         if type == "hello" {
+            return
+        }
+        if type == "application_control.update" {
+            var dataLen: Int = 0
+            guard let rawPtr = xpc_dictionary_get_data(event, "data", &dataLen), dataLen > 0 else {
+                logger.error("application_control.update missing 'data'")
+                return
+            }
+            let data = Data(bytes: rawPtr, count: dataLen)
+            ApplicationControlStore.shared.apply(rawJSON: data)
             return
         }
         // type is peer-supplied; redact in the unified log so a compromised peer

--- a/extension/edr/extension/main.swift
+++ b/extension/edr/extension/main.swift
@@ -1,9 +1,12 @@
 import Foundation
 import EndpointSecurity
 
-// Application Control phase 1 removes the legacy blocklist; AUTH_EXEC currently
-// allows every exec. The phase-4 decision engine will reintroduce a persisted
-// snapshot load here.
+// Load the persisted application control snapshot BEFORE ESF starts subscribing.
+// Startup order matters here — if we subscribed first, a racing exec of a blocked
+// hash between subscribe and loadFromDisk would not yet see the snapshot. The
+// Phase 3 decision engine plugs into ESFSubscriber's AUTH_EXEC handler; this
+// step (Phase 2) wires the snapshot lifecycle so it's ready when Phase 3 lands.
+ApplicationControlStore.shared.loadFromDisk()
 
 let server = XPCServer(serviceName: "FDG8Q7N4CC.com.fleetdm.edr.securityextension.xpc")
 server.start()

--- a/server/rules/api/app_control_wire_test.go
+++ b/server/rules/api/app_control_wire_test.go
@@ -1,0 +1,139 @@
+package api_test
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fleetdm/edr/server/rules/api"
+)
+
+// TestMarshalSetApplicationControlPayload_RoundTrip pins the wire
+// shape every agent sees. The byte-exact form is the contract the
+// extension's Swift decoder parses; field rename / reorder here
+// breaks every deployed agent at the same instant.
+func TestMarshalSetApplicationControlPayload_RoundTrip(t *testing.T) {
+	msg := "Blocked: corporate policy"
+	url := "https://help.example.com/blocked"
+	rules := []api.ApplicationControlRule{
+		{
+			RuleType:    api.RuleTypeBinary,
+			Identifier:  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			Action:      api.ActionBlock,
+			Enforcement: api.EnforcementProtect,
+			Enabled:     true,
+			Severity:    api.SeverityRuleMedium,
+			CustomMsg:   &msg,
+			CustomURL:   &url,
+		},
+	}
+	policy := api.ApplicationControlPolicy{ID: 7, Version: 42}
+
+	raw, err := api.MarshalSetApplicationControlPayload(policy, rules, time.Time{})
+	require.NoError(t, err)
+
+	var decoded api.SetApplicationControlPayload
+	require.NoError(t, json.Unmarshal(raw, &decoded))
+
+	assert.Equal(t, int64(7), decoded.PolicyID)
+	assert.Equal(t, int64(42), decoded.PolicyVersion)
+	require.Len(t, decoded.Rules, 1)
+	got := decoded.Rules[0]
+	assert.Equal(t, api.RuleTypeBinary, got.RuleType)
+	assert.Equal(t, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", got.Identifier)
+	assert.Equal(t, api.ActionBlock, got.Action)
+	assert.Equal(t, api.EnforcementProtect, got.Enforcement)
+	assert.Equal(t, api.SeverityRuleMedium, got.Severity)
+	if assert.NotNil(t, got.CustomMsg) {
+		assert.Equal(t, msg, *got.CustomMsg)
+	}
+	if assert.NotNil(t, got.CustomURL) {
+		assert.Equal(t, url, *got.CustomURL)
+	}
+}
+
+// TestMarshalSetApplicationControlPayload_FiltersDisabled covers the
+// payload's filtering contract: disabled rules MUST NOT reach the
+// agent. The fan-out path lifts this gate so the extension never
+// allocates snapshot entries for rules an admin has paused.
+func TestMarshalSetApplicationControlPayload_FiltersDisabled(t *testing.T) {
+	rules := []api.ApplicationControlRule{
+		{RuleType: api.RuleTypeBinary, Identifier: "a", Enabled: true},
+		{RuleType: api.RuleTypeBinary, Identifier: "b", Enabled: false},
+		{RuleType: api.RuleTypeBinary, Identifier: "c", Enabled: true},
+	}
+	raw, err := api.MarshalSetApplicationControlPayload(api.ApplicationControlPolicy{ID: 1, Version: 1}, rules, time.Time{})
+	require.NoError(t, err)
+	var decoded api.SetApplicationControlPayload
+	require.NoError(t, json.Unmarshal(raw, &decoded))
+	require.Len(t, decoded.Rules, 2)
+	assert.Equal(t, "a", decoded.Rules[0].Identifier)
+	assert.Equal(t, "c", decoded.Rules[1].Identifier)
+}
+
+// TestMarshalSetApplicationControlPayload_FiltersExpired covers the
+// expires_at filter when the caller passes a non-zero `now`. The
+// agent should never see rules whose TTL has passed.
+func TestMarshalSetApplicationControlPayload_FiltersExpired(t *testing.T) {
+	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	past := now.Add(-time.Hour)
+	future := now.Add(time.Hour)
+	rules := []api.ApplicationControlRule{
+		{RuleType: api.RuleTypeBinary, Identifier: "live-no-expiry", Enabled: true},
+		{RuleType: api.RuleTypeBinary, Identifier: "expired", Enabled: true, ExpiresAt: &past},
+		{RuleType: api.RuleTypeBinary, Identifier: "live-future-expiry", Enabled: true, ExpiresAt: &future},
+	}
+	raw, err := api.MarshalSetApplicationControlPayload(api.ApplicationControlPolicy{ID: 1, Version: 1}, rules, now)
+	require.NoError(t, err)
+	var decoded api.SetApplicationControlPayload
+	require.NoError(t, json.Unmarshal(raw, &decoded))
+	require.Len(t, decoded.Rules, 2)
+	assert.Equal(t, "live-no-expiry", decoded.Rules[0].Identifier)
+	assert.Equal(t, "live-future-expiry", decoded.Rules[1].Identifier)
+}
+
+// TestMarshalSetApplicationControlPayload_EmptyRules confirms the
+// empty-rules case round-trips cleanly. An empty payload is a valid
+// state (just-after-policy-creation, or after every rule is deleted)
+// and the agent + extension must handle it without erroring.
+func TestMarshalSetApplicationControlPayload_EmptyRules(t *testing.T) {
+	raw, err := api.MarshalSetApplicationControlPayload(api.ApplicationControlPolicy{ID: 1, Version: 1}, nil, time.Time{})
+	require.NoError(t, err)
+	var decoded api.SetApplicationControlPayload
+	require.NoError(t, json.Unmarshal(raw, &decoded))
+	assert.Equal(t, int64(1), decoded.PolicyID)
+	assert.Equal(t, int64(1), decoded.PolicyVersion)
+	assert.Empty(t, decoded.Rules)
+}
+
+// TestSetApplicationControlPayload_JSONKeys pins the JSON field
+// names that the extension's Swift Decodable reads. Renames here
+// silently break the extension at decode time; this test fails
+// loudly when a rename happens.
+func TestSetApplicationControlPayload_JSONKeys(t *testing.T) {
+	msg := "blocked"
+	raw, err := api.MarshalSetApplicationControlPayload(
+		api.ApplicationControlPolicy{ID: 1, Version: 2},
+		[]api.ApplicationControlRule{{
+			RuleType: api.RuleTypeBinary, Identifier: "x",
+			Action: api.ActionBlock, Enforcement: api.EnforcementProtect,
+			Enabled: true, Severity: api.SeverityRuleHigh, CustomMsg: &msg,
+		}},
+		time.Time{},
+	)
+	require.NoError(t, err)
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(raw, &got))
+	for _, key := range []string{"policy_id", "policy_version", "rules"} {
+		assert.Contains(t, got, key, "top-level key %q missing", key)
+	}
+	rulesAny, _ := got["rules"].([]any)
+	require.Len(t, rulesAny, 1)
+	rule, _ := rulesAny[0].(map[string]any)
+	for _, key := range []string{"rule_type", "identifier", "action", "enforcement", "severity", "custom_msg"} {
+		assert.Contains(t, rule, key, "rule key %q missing", key)
+	}
+}

--- a/server/rules/api/app_control_wire_test.go
+++ b/server/rules/api/app_control_wire_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"pgregory.net/rapid"
 
 	"github.com/fleetdm/edr/server/rules/api"
 )
@@ -136,4 +137,153 @@ func TestSetApplicationControlPayload_JSONKeys(t *testing.T) {
 	for _, key := range []string{"rule_type", "identifier", "action", "enforcement", "severity", "custom_msg"} {
 		assert.Contains(t, rule, key, "rule key %q missing", key)
 	}
+}
+
+// ruleTypes is the universe of RuleType values the wire payload can carry.
+// The marshal helper does not gate on rule_type (the server's validator
+// does, before the rule lands in the database), so for the round-trip
+// property test we sample the full enum and assert each value survives
+// Marshal ∘ Unmarshal unchanged.
+var ruleTypes = []api.RuleType{
+	api.RuleTypeBinary,
+	api.RuleTypeCDHash,
+	api.RuleTypeSigningID,
+	api.RuleTypeCertificate,
+	api.RuleTypeTeamID,
+	api.RuleTypePath,
+}
+
+var severities = []api.Severity{
+	api.SeverityRuleLow,
+	api.SeverityRuleMedium,
+	api.SeverityRuleHigh,
+	api.SeverityRuleCritical,
+}
+
+// genRule produces a random rule shape. Identifier is opaque to the
+// payload codec (the per-rule_type identifier validator runs server-
+// side, not in the marshal helper), so we use a printable-ASCII string
+// generator to exercise the JSON encoding path without dragging in
+// per-type format gymnastics.
+func genRule(t *rapid.T, idx int) api.ApplicationControlRule {
+	identifier := rapid.StringMatching(`[a-zA-Z0-9._:-]{1,64}`).Draw(t, "identifier")
+	enabled := rapid.Bool().Draw(t, "enabled")
+	rt := rapid.SampledFrom(ruleTypes).Draw(t, "rule_type")
+	sev := rapid.SampledFrom(severities).Draw(t, "severity")
+
+	var customMsg *string
+	if rapid.Bool().Draw(t, "has_custom_msg") {
+		s := rapid.StringMatching(`[a-zA-Z0-9 .,:!?-]{0,140}`).Draw(t, "custom_msg")
+		customMsg = &s
+	}
+	var customURL *string
+	if rapid.Bool().Draw(t, "has_custom_url") {
+		s := "https://example.invalid/" + rapid.StringMatching(`[a-z0-9-]{1,32}`).Draw(t, "url_path")
+		customURL = &s
+	}
+
+	var expiresAt *time.Time
+	if rapid.Bool().Draw(t, "has_expires_at") {
+		secs := rapid.Int64Range(-86_400_000, 86_400_000).Draw(t, "expires_at_seconds_from_now")
+		exp := time.Unix(secs, 0).UTC()
+		expiresAt = &exp
+	}
+
+	return api.ApplicationControlRule{
+		ID:          int64(idx),
+		PolicyID:    1,
+		RuleType:    rt,
+		Identifier:  identifier,
+		Action:      api.ActionBlock,
+		Enforcement: api.EnforcementProtect,
+		Enabled:     enabled,
+		Severity:    sev,
+		Source:      api.SourceAdmin,
+		CustomMsg:   customMsg,
+		CustomURL:   customURL,
+		ExpiresAt:   expiresAt,
+	}
+}
+
+// TestMarshalSetApplicationControlPayload_RapidRoundTrip is the PBT
+// counterpart to the example-based round-trip tests above. For any
+// random policy + rule list + clock, Marshal then Unmarshal must
+// reproduce exactly the policy version, the policy id, and every
+// rule that survives the filter (enabled + (no expires_at OR
+// expires_at > now OR now is zero)). Catches a regression where a
+// future field add forgets a json tag, where the filter loses a rule
+// it should keep, or where the JSON shape becomes ambiguous on
+// optional fields.
+//
+// Bounded rule-list size: rapid.SliceOfN caps each generated batch
+// so each property iteration stays under a few milliseconds.
+func TestMarshalSetApplicationControlPayload_RapidRoundTrip(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		policyID := rapid.Int64Range(1, 1_000_000).Draw(t, "policy_id")
+		policyVersion := rapid.Int64Range(1, 1_000_000).Draw(t, "policy_version")
+		nRules := rapid.IntRange(0, 20).Draw(t, "n_rules")
+
+		rules := make([]api.ApplicationControlRule, 0, nRules)
+		for i := range nRules {
+			rules = append(rules, genRule(t, i))
+		}
+
+		// "now" is either zero (filter disabled) or a fixed epoch the
+		// genRule random expires_at values straddle.
+		var now time.Time
+		if rapid.Bool().Draw(t, "filter_enabled") {
+			now = time.Unix(0, 0).UTC()
+		}
+
+		policy := api.ApplicationControlPolicy{ID: policyID, Version: policyVersion}
+		raw, err := api.MarshalSetApplicationControlPayload(policy, rules, now)
+		require.NoError(t, err)
+
+		var decoded api.SetApplicationControlPayload
+		require.NoError(t, json.Unmarshal(raw, &decoded))
+		assert.Equal(t, policyID, decoded.PolicyID)
+		assert.Equal(t, policyVersion, decoded.PolicyVersion)
+
+		// Build the expected post-filter view from the inputs and
+		// compare element-wise. The filter contract: drop disabled
+		// rules; drop rules whose expires_at is in the past relative
+		// to a non-zero `now`.
+		expected := make([]api.SetApplicationControlRule, 0, len(rules))
+		for _, r := range rules {
+			if !r.Enabled {
+				continue
+			}
+			if !now.IsZero() && r.ExpiresAt != nil && !r.ExpiresAt.After(now) {
+				continue
+			}
+			expected = append(expected, api.SetApplicationControlRule{
+				RuleType:    r.RuleType,
+				Identifier:  r.Identifier,
+				Action:      r.Action,
+				Enforcement: r.Enforcement,
+				Severity:    r.Severity,
+				CustomMsg:   r.CustomMsg,
+				CustomURL:   r.CustomURL,
+			})
+		}
+		require.Len(t, decoded.Rules, len(expected), "filtered rule count must match")
+		for i := range expected {
+			got := decoded.Rules[i]
+			assert.Equal(t, expected[i].RuleType, got.RuleType)
+			assert.Equal(t, expected[i].Identifier, got.Identifier)
+			assert.Equal(t, expected[i].Action, got.Action)
+			assert.Equal(t, expected[i].Enforcement, got.Enforcement)
+			assert.Equal(t, expected[i].Severity, got.Severity)
+			if expected[i].CustomMsg == nil {
+				assert.Nil(t, got.CustomMsg)
+			} else if assert.NotNil(t, got.CustomMsg) {
+				assert.Equal(t, *expected[i].CustomMsg, *got.CustomMsg)
+			}
+			if expected[i].CustomURL == nil {
+				assert.Nil(t, got.CustomURL)
+			} else if assert.NotNil(t, got.CustomURL) {
+				assert.Equal(t, *expected[i].CustomURL, *got.CustomURL)
+			}
+		}
+	})
 }

--- a/server/rules/api/types.go
+++ b/server/rules/api/types.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"time"
 
@@ -366,4 +367,76 @@ type ApplicationControlStore interface {
 	ListPolicies(ctx context.Context, tenantID string) ([]ApplicationControlPolicy, error)
 	ListRulesByPolicy(ctx context.Context, policyID int64) ([]ApplicationControlRule, error)
 	CreateRule(ctx context.Context, req CreateRuleRequest) (ApplicationControlRule, error)
+}
+
+// CommandTypeSetApplicationControl is the well-known command type the
+// agent reads on every poll and routes to its application-control
+// snapshot dispatcher. Stable wire-shape string; renaming is a
+// contract break for every deployed agent.
+const CommandTypeSetApplicationControl = "set_application_control"
+
+// SetApplicationControlPayload is the wire shape the server writes
+// into a `set_application_control` command and the agent + extension
+// decode end-to-end. Field tags are load-bearing: the extension
+// (Swift) Decodable derives the JSON keys from these tags. A change
+// here MUST land in lockstep with the matching change in
+// ApplicationControlStore.swift.
+//
+// Lives in api/ so cmd/main and the REST handler can construct it
+// without importing rules internals; the agent commander decodes the
+// same shape with its own private struct to avoid pulling
+// server/rules/api into the agent module graph.
+type SetApplicationControlPayload struct {
+	PolicyID      int64                       `json:"policy_id"`
+	PolicyVersion int64                       `json:"policy_version"`
+	Rules         []SetApplicationControlRule `json:"rules"`
+}
+
+// SetApplicationControlRule is one row in the payload's rules array.
+// Every field that the extension's decision walker (Step 3), block
+// notification (Step 4), or block event (Step 4) needs lands here so
+// the wire shape is stable across the demo cut and the rest of
+// Phase A. Disabled and expired rules are NOT included in the
+// payload — the fan-out filters them so the agent never sees them.
+type SetApplicationControlRule struct {
+	RuleType    RuleType    `json:"rule_type"`
+	Identifier  string      `json:"identifier"`
+	Action      Action      `json:"action"`
+	Enforcement Enforcement `json:"enforcement"`
+	Severity    Severity    `json:"severity"`
+	CustomMsg   *string     `json:"custom_msg,omitempty"`
+	CustomURL   *string     `json:"custom_url,omitempty"`
+}
+
+// MarshalSetApplicationControlPayload returns the JSON bytes the
+// agent's commander forwards to the extension. Filters disabled rules
+// and rules whose expires_at is in the past so the agent + extension
+// never see them. now is provided by the caller (cmd/main passes
+// time.Now()) so tests can pin a deterministic clock; passing the
+// zero value disables the expires_at filter (treat every rule as
+// non-expired).
+func MarshalSetApplicationControlPayload(p ApplicationControlPolicy, rules []ApplicationControlRule, now time.Time) (json.RawMessage, error) {
+	entries := make([]SetApplicationControlRule, 0, len(rules))
+	for _, r := range rules {
+		if !r.Enabled {
+			continue
+		}
+		if !now.IsZero() && r.ExpiresAt != nil && !r.ExpiresAt.After(now) {
+			continue
+		}
+		entries = append(entries, SetApplicationControlRule{
+			RuleType:    r.RuleType,
+			Identifier:  r.Identifier,
+			Action:      r.Action,
+			Enforcement: r.Enforcement,
+			Severity:    r.Severity,
+			CustomMsg:   r.CustomMsg,
+			CustomURL:   r.CustomURL,
+		})
+	}
+	return json.Marshal(SetApplicationControlPayload{
+		PolicyID:      p.ID,
+		PolicyVersion: p.Version,
+		Rules:         entries,
+	})
 }


### PR DESCRIPTION
Second step of the demo cut at ai/policy/demo-plan.md. Unlocks the server's ability to push a snapshot to a host even when no rules are present yet. The Phase 3 decision engine plugs into the snapshot in the next commit.

Wire shape (server/rules/api/types.go + app_control_wire_test.go):
- CommandTypeSetApplicationControl = "set_application_control" string constant.
- SetApplicationControlPayload struct: policy_id, policy_version, rules[]. Field tags are load-bearing and Swift-decoder-binding.
- SetApplicationControlRule per-row struct: rule_type, identifier, action, enforcement, severity, custom_msg, custom_url. Disabled rules and (when now is non-zero) expired rules are filtered out by the marshal helper so the agent + extension never see them.
- MarshalSetApplicationControlPayload helper exported so the future fan-out path (Step 5) constructs the same bytes the test pins.
- Round-trip tests pin byte-shape and JSON keys; rename here breaks every deployed agent at the same instant.

Agent command (agent/commander/commander.go +
agent/commander/commander_test.go):
- New ApplicationControlSender interface — XPC bridge to the ESF extension. Mirrors the deleted-in-Phase-1 PolicySender shape but scoped to the new typed snapshot.
- Config.ApplicationControlSender field; nil means "no extension bridge" and the executor reports the command failed.
- executeSetApplicationControl decodes the envelope (policy_id > 0, policy_version > 0), forwards the raw bytes byte-identical to the extension (no re-marshal so the wire stays stable), and reports completed with {policy_id, policy_version} so operators can confirm per-host convergence via GET /commands/{id}.
- Tests: happy path (byte-equal forward), malformed payload, invalid version, missing policy_id, no sender configured.

C bridge (agent/xpcbridge/xpc_bridge.[ch]):
- xpc_bridge_send_application_control: sends "application_control.update" XPC dictionary with "data" key carrying the raw JSON. Symmetric retain/release with the existing xpc_bridge_connect contract so concurrent Disconnect during async send stays safe.

Receiver (agent/receiver/receiver.go):
- Receiver.SendApplicationControl method calls into the C bridge with the same mu-held contract the old SendPolicy used. Empty payload rejected at the Go boundary so the C side never sees an empty pointer.

Agent wiring (agent/cmd/fleet-edr-agent/main.go):
- Reintroduce the dispatcher pattern (lock-free atomic.Pointer) that bridges the per-connect *Receiver to the long-lived commander. Between disconnect and reconnect, SendApplicationControl returns an error so the command gets reported failed and the server's next fan-out re-queues the update. runReceiverLoop / runReceiverOnce regain the dispatcher arg; startCommander regains the appControlSender arg.

Extension snapshot (extension/edr/extension/ApplicationControlStore.swift):
- New singleton ApplicationControlStore with:
  * In-memory snapshot indexed by (rule_type, identifier) — six maps, one per rule_type, so the Phase 3 precedence walk is O(1) per type. The demo cut only populates BINARY; the others are zero-cost until the corresponding identifier extractors come online.
  * Lock-free reads via OSAllocatedUnfairLock so AUTH_EXEC never blocks on the snapshot.
  * Version-monotonic apply: same-or-lower version is skipped (handles duplicate XPC deliveries cleanly).
  * Atomic persist to /var/db/com.fleetdm.edr/application-control.json via write-temp-then-rename so a crash mid-write can't leave a partial file.
  * loadFromDisk on startup; missing-file fails open and the agent's next push restores state.
- ApplicationControlRule + ApplicationControlDocument Codable structs match the Go-side JSON tags exactly (rule_type, custom_msg, etc.). A rename on either side breaks the round-trip; the Go-side test pins the keys.

Extension XPC (extension/edr/extension/XPCServer.swift):
- Handler for application_control.update message type. Reads the "data" payload and hands it to ApplicationControlStore.shared.apply.

Extension startup (extension/edr/extension/main.swift):
- Call ApplicationControlStore.shared.loadFromDisk() BEFORE ESF subscribes so a racing AUTH_EXEC after process start sees the persisted snapshot, not an empty one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * End-to-end application control: server→agent→extension forwarding, dispatch only while a live receiver is connected, and extension applies incoming updates.
  * Extension persists and loads policy snapshots on startup; updates are applied and saved atomically with monotonic version enforcement.

* **Bug Fixes & Validation**
  * Stronger payload validation, explicit failure reporting for malformed/missing fields, and prevention of policy regressions.

* **Tests**
  * Comprehensive unit and wire-format tests covering happy paths, failures, and round-trip marshaling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/getvictor/fleet-edr/pull/153)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->