### PR TITLE
App Control demo cut step 3: AUTH_EXEC BINARY decision + sha256 cache

### DIFF
--- a/extension/edr/extension/ApplicationControlStore.swift
+++ b/extension/edr/extension/ApplicationControlStore.swift
@@ -81,6 +81,22 @@ enum ApplicationControlRuleType {
     static let path = "PATH"
 }
 
+/// Rule-action tokens that match the server enum exactly. The demo cut
+/// only emits BLOCK; ALLOW and SILENT_BLOCK arrive with Phase B Lockdown.
+enum ApplicationControlAction {
+    static let block = "BLOCK"
+    static let allow = "ALLOW"
+    static let silentBlock = "SILENT_BLOCK"
+}
+
+/// Rule-enforcement tokens that match the server enum exactly. The demo
+/// cut only enforces PROTECT (deny-on-match); DETECT (log only) arrives
+/// with Phase B.
+enum ApplicationControlEnforcement {
+    static let protect = "PROTECT"
+    static let detect = "DETECT"
+}
+
 /// ApplicationControlStore holds the typed in-memory snapshot consulted by
 /// the AUTH_EXEC decision engine (Step 3). The snapshot also persists to
 /// disk so the extension's policy survives restarts. Updates from the agent

--- a/extension/edr/extension/ESFStringToken.swift
+++ b/extension/edr/extension/ESFStringToken.swift
@@ -8,12 +8,20 @@ import Foundation
 /// overread into adjacent memory in the worst case and produce garbage
 /// in the typical case. Use this helper everywhere a Swift String is
 /// derived from an es_string_token_t — paths, team IDs, signing IDs.
+///
 /// Returns the empty string when the token has no payload (data is
-/// nil or length is zero).
+/// nil or length is zero) OR when the bytes are not valid UTF-8. The
+/// failable `String(bytes:encoding:)` initializer is preferred over
+/// `String(decoding:as:)` per SwiftLint's optional_data_string_conversion
+/// rule: an invalid-UTF-8 byte run should surface as "unknown" (empty
+/// string) rather than as a path with U+FFFD replacement characters,
+/// which a downstream rule comparison might miscompare against the
+/// admin-provided canonical form.
 @inline(__always)
 func esTokenString(_ token: es_string_token_t) -> String {
     guard let buf = token.data, token.length > 0 else {
         return ""
     }
-    return String(decoding: UnsafeRawBufferPointer(start: buf, count: token.length), as: UTF8.self)
+    let bytes = UnsafeBufferPointer(start: buf, count: token.length)
+    return String(bytes: bytes, encoding: .utf8) ?? ""
 }

--- a/extension/edr/extension/ESFStringToken.swift
+++ b/extension/edr/extension/ESFStringToken.swift
@@ -17,11 +17,17 @@ import Foundation
 /// string) rather than as a path with U+FFFD replacement characters,
 /// which a downstream rule comparison might miscompare against the
 /// admin-provided canonical form.
+///
+/// Implementation note: es_string_token_t.data is UnsafePointer<CChar>
+/// (Int8), but String(bytes:encoding:) requires a sequence of UInt8.
+/// UnsafeRawBufferPointer reinterprets the same memory as raw bytes
+/// without an allocation or a copy; its Element is UInt8, which is
+/// what the failable initializer wants.
 @inline(__always)
 func esTokenString(_ token: es_string_token_t) -> String {
     guard let buf = token.data, token.length > 0 else {
         return ""
     }
-    let bytes = UnsafeBufferPointer(start: buf, count: token.length)
+    let bytes = UnsafeRawBufferPointer(start: buf, count: token.length)
     return String(bytes: bytes, encoding: .utf8) ?? ""
 }

--- a/extension/edr/extension/ESFStringToken.swift
+++ b/extension/edr/extension/ESFStringToken.swift
@@ -1,0 +1,19 @@
+import EndpointSecurity
+import Foundation
+
+/// Read an es_string_token_t into a Swift String using the token's
+/// explicit length rather than scanning for a NUL terminator. The
+/// Endpoint Security API does NOT guarantee that the underlying byte
+/// buffer is NUL-terminated, so `String(cString: token.data)` can
+/// overread into adjacent memory in the worst case and produce garbage
+/// in the typical case. Use this helper everywhere a Swift String is
+/// derived from an es_string_token_t — paths, team IDs, signing IDs.
+/// Returns the empty string when the token has no payload (data is
+/// nil or length is zero).
+@inline(__always)
+func esTokenString(_ token: es_string_token_t) -> String {
+    guard let buf = token.data, token.length > 0 else {
+        return ""
+    }
+    return String(decoding: UnsafeRawBufferPointer(start: buf, count: token.length), as: UTF8.self)
+}

--- a/extension/edr/extension/ESFSubscriber.swift
+++ b/extension/edr/extension/ESFSubscriber.swift
@@ -4,9 +4,13 @@ import os.log
 
 private let logger = Logger(subsystem: "com.fleetdm.edr.securityextension", category: "ESFSubscriber")
 
-// Application Control phase 1 removes the legacy blocklist; AUTH_EXEC currently
-// allows every exec. The decision engine and rule snapshot land in phase 4 of
-// the add-application-control change.
+/// Our Apple Developer Team ID. Any binary signed with this team_id is
+/// allowed through AUTH_EXEC regardless of rule match — the failsafe that
+/// prevents a misconfigured rule from blocking the agent, extension, or
+/// host app itself. Hardcoded for the application-control demo cut; Phase B
+/// of the broader change replaces this with a server-pushed failsafe list
+/// so operators can extend it without an agent re-release.
+private let extensionTeamID = "FDG8Q7N4CC"
 
 /// ESFSubscriber manages the Endpoint Security client and subscribes to
 /// process lifecycle events (exec, fork, exit, open).
@@ -47,11 +51,12 @@ final class ESFSubscriber: Sendable {
         }
 
         logger.info("Subscribed to \(events.count) event types (including AUTH_EXEC)")
-        // Phase 1 of add-application-control deletes the legacy blocklist and leaves
-        // AUTH_EXEC as an unconditional allow. Surface this loudly at startup so
-        // operators monitoring logs during rollout are never confused about why
-        // nothing is being blocked. The decision engine lands in phase 4.
-        logger.warning("Application Control disabled (phase 1 temporary state) — AUTH_EXEC returns ES_AUTH_RESULT_ALLOW")
+        // Application Control demo cut: AUTH_EXEC consults the
+        // ApplicationControlStore snapshot and denies BINARY-matched execs.
+        // Cache misses on the lazy file-hash cache return ALLOW silently;
+        // the cache fills off the callback so the next exec of the same
+        // binary catches. See FileHashCache + ApplicationControlStore.
+        logger.info("Application Control active: AUTH_EXEC consults BINARY rule snapshot")
     }
 
     func stop() {
@@ -78,11 +83,56 @@ final class ESFSubscriber: Sendable {
         }
     }
 
-    /// AUTH_EXEC handler: phase-1 demolition leaves this as an unconditional allow.
-    /// The application-control decision engine (target identifier tuple, precedence
-    /// walk over the rule snapshot, lazy signing-info cache) lands in phase 4 of the
-    /// add-application-control change.
+    /// AUTH_EXEC handler: application-control decision walk.
+    ///
+    /// The demo cut enforces only the BINARY rule type. Walk:
+    ///   1. Failsafe — if the exec target's `team_id` is our own, ALLOW.
+    ///      Prevents a misconfigured rule from blocking the agent /
+    ///      extension / host app. The Phase B server-pushed failsafe list
+    ///      will widen this to include platform binaries (`launchd`,
+    ///      `systemextensionsd`, etc.) and additional admin-defined
+    ///      carve-outs.
+    ///   2. Lazy file SHA-256 cache lookup by `(inode, mtime)`. Cache
+    ///      misses do NOT block the AUTH callback — the BINARY rule type
+    ///      silently misses for this exec, the cache fills off-thread,
+    ///      and the next exec of the same binary catches. This is the
+    ///      "first launch allowed, second launch blocked" behavior the
+    ///      demo plan documents and the recording exercises.
+    ///   3. Snapshot lookup — if the cached hash matches a BINARY rule
+    ///      with `action=BLOCK` and `enforcement=PROTECT`, DENY.
+    ///      Otherwise ALLOW.
+    ///
+    /// The decision is reached inside the AUTH_EXEC deadline because every
+    /// step is a constant-time map lookup; signing-info fetch + file read
+    /// happen on the lazy-fill background path, never on the callback.
     private func handleAuthExec(_ message: UnsafePointer<es_message_t>) {
+        let msg = message.pointee
+        let target = msg.event.exec.target.pointee
+        let path = String(cString: target.executable.pointee.path.data)
+        let teamID = target.team_id.data.map { String(cString: $0) } ?? ""
+        let fileStat = target.executable.pointee.stat
+
+        // Failsafe carve-out.
+        if teamID == extensionTeamID {
+            es_respond_auth_result(client, message, ES_AUTH_RESULT_ALLOW, false)
+            return
+        }
+
+        let snapshot = ApplicationControlStore.shared.currentSnapshot()
+        if let sha256 = FileHashCache.shared.lookup(stat: fileStat) {
+            if let rule = snapshot.binaryRules[sha256],
+               rule.action == "BLOCK",
+               rule.enforcement == "PROTECT" {
+                logger.warning("AUTH_EXEC DENIED by application control: \(path, privacy: .public) sha256=\(sha256, privacy: .public)")
+                es_respond_auth_result(client, message, ES_AUTH_RESULT_DENY, false)
+                return
+            }
+        } else {
+            // Cache miss: kick the async fill so the next exec of this
+            // binary hits the cache. Documented behavior — never block
+            // the AUTH callback on a file read.
+            FileHashCache.shared.startLazyFill(path: path, stat: fileStat)
+        }
         es_respond_auth_result(client, message, ES_AUTH_RESULT_ALLOW, false)
     }
 
@@ -100,8 +150,17 @@ final class ESFSubscriber: Sendable {
         let args = extractArgs(from: &exec)
         let uid = audit_token_to_euid(target.audit_token)
         let gid = audit_token_to_egid(target.audit_token)
+        let fileStat = target.executable.pointee.stat
 
         let codeSigning = extractCodeSigning(from: target)
+        // NOTIFY_EXEC has no kernel deadline, so the sync compute is the
+        // right call here — every event carries a real hash for downstream
+        // telemetry. The AUTH callback (which has a deadline) already
+        // started a lazy fill for the same (inode, mtime), so the common
+        // case is a cache hit. lookupOrCompute returns nil when the file
+        // is gone or unreadable (deleted-between-AUTH-and-NOTIFY race);
+        // the event still fires with the rest of the metadata.
+        let sha256 = FileHashCache.shared.lookupOrCompute(path: path, stat: fileStat)
 
         let payload = ExecPayload(
             pid: pid,
@@ -112,7 +171,7 @@ final class ESFSubscriber: Sendable {
             uid: uid,
             gid: gid,
             codeSigning: codeSigning,
-            sha256: nil
+            sha256: sha256
         )
 
         if let data = serializer.serialize(eventType: "exec", payload: payload) {

--- a/extension/edr/extension/ESFSubscriber.swift
+++ b/extension/edr/extension/ESFSubscriber.swift
@@ -92,7 +92,7 @@ final class ESFSubscriber: Sendable {
     ///      will widen this to include platform binaries (`launchd`,
     ///      `systemextensionsd`, etc.) and additional admin-defined
     ///      carve-outs.
-    ///   2. Lazy file SHA-256 cache lookup by `(inode, mtime)`. Cache
+    ///   2. Lazy file SHA-256 cache lookup by `(dev, inode, mtime)`. Cache
     ///      misses do NOT block the AUTH callback — the BINARY rule type
     ///      silently misses for this exec, the cache fills off-thread,
     ///      and the next exec of the same binary catches. This is the
@@ -108,8 +108,10 @@ final class ESFSubscriber: Sendable {
     private func handleAuthExec(_ message: UnsafePointer<es_message_t>) {
         let msg = message.pointee
         let target = msg.event.exec.target.pointee
-        let path = String(cString: target.executable.pointee.path.data)
-        let teamID = target.team_id.data.map { String(cString: $0) } ?? ""
+        // esTokenString uses the token's explicit length; es_string_token_t
+        // is NOT NUL-guaranteed and String(cString:) can overread.
+        let path = esTokenString(target.executable.pointee.path)
+        let teamID = esTokenString(target.team_id)
         let fileStat = target.executable.pointee.stat
 
         // Failsafe carve-out.
@@ -121,8 +123,8 @@ final class ESFSubscriber: Sendable {
         let snapshot = ApplicationControlStore.shared.currentSnapshot()
         if let sha256 = FileHashCache.shared.lookup(stat: fileStat) {
             if let rule = snapshot.binaryRules[sha256],
-               rule.action == "BLOCK",
-               rule.enforcement == "PROTECT" {
+               rule.action == ApplicationControlAction.block,
+               rule.enforcement == ApplicationControlEnforcement.protect {
                 logger.warning("AUTH_EXEC DENIED by application control: \(path, privacy: .public) sha256=\(sha256, privacy: .public)")
                 es_respond_auth_result(client, message, ES_AUTH_RESULT_DENY, false)
                 return

--- a/extension/edr/extension/FileHashCache.swift
+++ b/extension/edr/extension/FileHashCache.swift
@@ -28,6 +28,7 @@ final class FileHashCache {
     static let shared = FileHashCache()
 
     private struct Key: Hashable {
+        let device: Int32
         let inode: UInt64
         let mtimeSec: Int64
         let mtimeNsec: Int64
@@ -65,7 +66,7 @@ final class FileHashCache {
         if let cached = lock.withLock({ $0[key] }) {
             return cached
         }
-        guard let hash = Self.computeSHA256(path: path) else {
+        guard let hash = Self.computeSHA256(path: path, expected: fileStat) else {
             return nil
         }
         lock.withLock { $0[key] = hash }
@@ -84,6 +85,7 @@ final class FileHashCache {
             return
         }
         let capturedPath = path
+        let capturedStat = fileStat
         computeQueue.async {
             // Recheck under the lock after the queue resumes so we don't
             // race against a synchronous lookupOrCompute that may have
@@ -93,7 +95,7 @@ final class FileHashCache {
             if !stillEmpty {
                 return
             }
-            guard let hash = Self.computeSHA256(path: capturedPath) else {
+            guard let hash = Self.computeSHA256(path: capturedPath, expected: capturedStat) else {
                 return
             }
             self.lock.withLock { $0[key] = hash }
@@ -102,19 +104,41 @@ final class FileHashCache {
 
     private static func makeKey(from fileStat: stat) -> Key {
         Key(
+            device: fileStat.st_dev,
             inode: UInt64(fileStat.st_ino),
             mtimeSec: Int64(fileStat.st_mtimespec.tv_sec),
             mtimeNsec: Int64(fileStat.st_mtimespec.tv_nsec)
         )
     }
 
-    private static func computeSHA256(path: String) -> String? {
+    /// computeSHA256 hashes the file at path, but only after re-stating
+    /// the open file handle and confirming its (dev, inode, mtime) tuple
+    /// still matches the expected stat from the originating ES event.
+    /// Without this TOCTOU guard a replace-between-AUTH-and-read can
+    /// associate a different file's hash with the original cache key,
+    /// poisoning future decisions. Mismatch → nil; the caller's cache
+    /// entry stays empty and the next exec re-stats.
+    private static func computeSHA256(path: String, expected: stat) -> String? {
         let url = URL(fileURLWithPath: path)
         guard let handle = try? FileHandle(forReadingFrom: url) else {
             logger.warning("could not open file for hashing: \(path, privacy: .public)")
             return nil
         }
         defer { try? handle.close() }
+        // Verify the opened handle still points at the file the ES event
+        // told us about. If the file was atomically replaced between AUTH
+        // and our read, the underlying inode (or device, or mtime) will
+        // differ; abort and let the caller fall back to "no hash yet".
+        var openedStat = stat()
+        let fd = handle.fileDescriptor
+        guard fstat(fd, &openedStat) == 0 else {
+            logger.warning("fstat failed on \(path, privacy: .public)")
+            return nil
+        }
+        if !Self.statMatches(expected: expected, actual: openedStat) {
+            logger.warning("file replaced between AUTH and hash read: \(path, privacy: .public)")
+            return nil
+        }
         var hasher = SHA256()
         let chunkSize = 64 * 1024
         while true {
@@ -130,5 +154,12 @@ final class FileHashCache {
         }
         let digest = hasher.finalize()
         return digest.map { String(format: "%02x", $0) }.joined()
+    }
+
+    private static func statMatches(expected: stat, actual: stat) -> Bool {
+        expected.st_dev == actual.st_dev
+            && expected.st_ino == actual.st_ino
+            && expected.st_mtimespec.tv_sec == actual.st_mtimespec.tv_sec
+            && expected.st_mtimespec.tv_nsec == actual.st_mtimespec.tv_nsec
     }
 }

--- a/extension/edr/extension/FileHashCache.swift
+++ b/extension/edr/extension/FileHashCache.swift
@@ -1,0 +1,134 @@
+import CryptoKit
+import Darwin
+import Foundation
+import os
+
+private let logger = Logger(subsystem: "com.fleetdm.edr.securityextension", category: "FileHashCache")
+
+/// FileHashCache memoises SHA-256 digests of executable Mach-O files keyed
+/// by their on-disk identity tuple `(inode, mtimeSec, mtimeNsec)`. The
+/// AUTH_EXEC decision engine consults the cache on every exec; cache misses
+/// trigger a non-blocking async fill so the AUTH callback never waits on
+/// disk I/O. Cache hits on the regular NOTIFY_EXEC path also save a redundant
+/// hash compute when the binary has already been hashed once.
+///
+/// Cache key choice. macOS `es_file_t.stat` is available on every AUTH_EXEC
+/// without an extra `stat()` syscall, and inode+mtime is the canonical
+/// "same file" fingerprint on a POSIX filesystem: a different inode means
+/// a different file (e.g. atomic-replace updates), and a different mtime
+/// means the same inode has been modified in place. We deliberately do NOT
+/// key on path: the same Mach-O file can be reached via multiple paths
+/// (hard links, symlinks resolved upstream), and keying on path would miss
+/// the cache for legitimate "same file" execs.
+///
+/// Streaming hash. SHA-256 runs over 64 KiB chunks read through a
+/// FileHandle so a multi-gigabyte binary doesn't have to fit in memory.
+/// CryptoKit.SHA256's update/finalize API supports incremental hashing.
+final class FileHashCache {
+    static let shared = FileHashCache()
+
+    private struct Key: Hashable {
+        let inode: UInt64
+        let mtimeSec: Int64
+        let mtimeNsec: Int64
+    }
+
+    private let lock = OSAllocatedUnfairLock(initialState: [Key: String]())
+    // Concurrent dispatch queue is fine here because every write to the
+    // cache goes through the OSAllocatedUnfairLock and every reader either
+    // sees the full hex string or "not yet cached". The queue's only job
+    // is to keep the fill work off the AUTH_EXEC callback thread.
+    private let computeQueue = DispatchQueue(
+        label: "com.fleetdm.edr.filehashcache.compute",
+        qos: .userInitiated,
+        attributes: .concurrent
+    )
+
+    /// lookup returns the cached SHA-256 hex string for the file identified
+    /// by stat, or nil if no entry exists yet. Pure cache read; never
+    /// blocks. The AUTH_EXEC handler is the only intended caller on the
+    /// hot path.
+    func lookup(stat fileStat: stat) -> String? {
+        let key = Self.makeKey(from: fileStat)
+        return lock.withLock { $0[key] }
+    }
+
+    /// lookupOrCompute returns the cached hash if present, otherwise reads
+    /// the file synchronously and stores the result. Intended for the
+    /// NOTIFY_EXEC path, which has no kernel deadline and where every
+    /// event has a chance to carry a real hash for downstream telemetry.
+    /// Returns nil if the file cannot be read (deleted between AUTH and
+    /// NOTIFY, permissions, etc.); the caller emits the event without the
+    /// hash rather than dropping it entirely.
+    func lookupOrCompute(path: String, stat fileStat: stat) -> String? {
+        let key = Self.makeKey(from: fileStat)
+        if let cached = lock.withLock({ $0[key] }) {
+            return cached
+        }
+        guard let hash = Self.computeSHA256(path: path) else {
+            return nil
+        }
+        lock.withLock { $0[key] = hash }
+        return hash
+    }
+
+    /// startLazyFill triggers an asynchronous hash compute IF the cache
+    /// does not already have an entry. Used by the AUTH_EXEC handler on
+    /// cache miss so the next exec of the same binary hits the cache. Safe
+    /// to call repeatedly; concurrent fills for the same key compute the
+    /// same value and the last write wins.
+    func startLazyFill(path: String, stat fileStat: stat) {
+        let key = Self.makeKey(from: fileStat)
+        let alreadyCached = lock.withLock { $0[key] != nil }
+        if alreadyCached {
+            return
+        }
+        let capturedPath = path
+        computeQueue.async {
+            // Recheck under the lock after the queue resumes so we don't
+            // race against a synchronous lookupOrCompute that may have
+            // populated the cache between the alreadyCached check and the
+            // async dispatch.
+            let stillEmpty = self.lock.withLock { $0[key] == nil }
+            if !stillEmpty {
+                return
+            }
+            guard let hash = Self.computeSHA256(path: capturedPath) else {
+                return
+            }
+            self.lock.withLock { $0[key] = hash }
+        }
+    }
+
+    private static func makeKey(from fileStat: stat) -> Key {
+        Key(
+            inode: UInt64(fileStat.st_ino),
+            mtimeSec: Int64(fileStat.st_mtimespec.tv_sec),
+            mtimeNsec: Int64(fileStat.st_mtimespec.tv_nsec)
+        )
+    }
+
+    private static func computeSHA256(path: String) -> String? {
+        let url = URL(fileURLWithPath: path)
+        guard let handle = try? FileHandle(forReadingFrom: url) else {
+            logger.warning("could not open file for hashing: \(path, privacy: .public)")
+            return nil
+        }
+        defer { try? handle.close() }
+        var hasher = SHA256()
+        let chunkSize = 64 * 1024
+        while true {
+            do {
+                guard let chunk = try handle.read(upToCount: chunkSize), !chunk.isEmpty else {
+                    break
+                }
+                hasher.update(data: chunk)
+            } catch {
+                logger.warning("hash read failed: \(error.localizedDescription, privacy: .public)")
+                return nil
+            }
+        }
+        let digest = hasher.finalize()
+        return digest.map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/extension/edr/extension/FileHashCache.swift
+++ b/extension/edr/extension/FileHashCache.swift
@@ -25,6 +25,12 @@ private let logger = Logger(subsystem: "com.fleetdm.edr.securityextension", cate
 /// FileHandle so a multi-gigabyte binary doesn't have to fit in memory.
 /// CryptoKit.SHA256's update/finalize API supports incremental hashing.
 final class FileHashCache {
+    /// 64 KiB chunks balance memory pressure against syscall count for streaming
+    /// SHA-256 over Mach-O binaries: large enough that hashing a typical
+    /// multi-MB executable does only ~tens of reads, small enough that a
+    /// concurrent run on a gigabyte-class binary doesn't bloat resident set.
+    private static let hashReadChunkBytes = 65_536
+
     static let shared = FileHashCache()
 
     private struct Key: Hashable {
@@ -140,10 +146,9 @@ final class FileHashCache {
             return nil
         }
         var hasher = SHA256()
-        let chunkSize = 64 * 1024
         while true {
             do {
-                guard let chunk = try handle.read(upToCount: chunkSize), !chunk.isEmpty else {
+                guard let chunk = try handle.read(upToCount: Self.hashReadChunkBytes), !chunk.isEmpty else {
                     break
                 }
                 hasher.update(data: chunk)


### PR DESCRIPTION
Third step of the demo cut at ai/policy/demo-plan.md. The extension now actually blocks execs against the snapshot. Demo beat #6 (modal pop-up after a denied exec) is reachable end-to-end pending the host- app modal that Step 6 adds.

FileHashCache (extension/edr/extension/FileHashCache.swift):
- New singleton FileHashCache. SHA-256 hex strings indexed by (inode, mtimeSec, mtimeNsec) tuple from es_file_t.stat. Keying on the inode triple rather than the path catches "same file, different path" cases (hard links, symlinks resolved upstream) that a path key would miss.
- Three call paths:
  * lookup(stat:) — pure read, used on AUTH (deadline-sensitive).
  * lookupOrCompute(path:stat:) — sync compute, used on NOTIFY (no deadline). Every event carries a real hash when the file is readable.
  * startLazyFill(path:stat:) — async compute on AUTH cache miss. Recheck-under-lock guard avoids double-compute when a concurrent sync compute races the async dispatch.
- Streaming SHA-256 via CryptoKit's incremental SHA256 over 64 KiB FileHandle chunks so multi-gigabyte binaries don't have to fit in memory.
- OSAllocatedUnfairLock around the dictionary; concurrent compute queue (qos: .userInitiated) so async fills can run in parallel across distinct binaries.

AUTH_EXEC decision walk (extension/edr/extension/ESFSubscriber.swift):
- handleAuthExec now consults the ApplicationControlStore snapshot:
  1. Failsafe — exec target's team_id matches extensionTeamID ("FDG8Q7N4CC") → ALLOW unconditionally. Prevents a misconfigured rule from blocking the agent / extension / host app. Hardcoded for the demo; the Phase B server-pushed failsafe list widens this to launchd, systemextensionsd, and admin carve-outs.
  2. FileHashCache.lookup(stat:) cache miss → ALLOW + startLazyFill. Documented "first exec misses, second exec catches" behavior the demo recording exercises (warm the cache once, then push the rule, then re-launch — the second launch hits the block).
  3. Cache hit + BINARY rule with action=BLOCK + enforcement=PROTECT → ES_AUTH_RESULT_DENY. Logged at WARN with the matched hash so post-mortem inspection in `log show` is straightforward.
  4. Otherwise → ALLOW.
- Decision is reached inside the AUTH_EXEC deadline because every step is a constant-time map lookup; file read + signing-info fetch happen off the callback on the lazy-fill background queue.

Exec event hash population (handleExec):
- The existing `sha256` field on ExecPayload was previously hard- coded to nil. Now reads from FileHashCache.lookupOrCompute on every NOTIFY_EXEC. Common case is a cache hit because AUTH preceded NOTIFY for the same exec and triggered the lazy fill; cold cache computes synchronously on this path (no deadline) so every event emitted carries a real hash for the alerts pipeline + UI.
- nil is still possible if the file disappears between AUTH and NOTIFY (rare race); the event still fires with the rest of the metadata rather than dropping entirely.

Startup log (start()):
- Switched the "Application Control disabled (phase 1)" warning to an info-level "Application Control active" line so operators monitoring logs during the demo see the right state.

Demo readiness:
- Beat #5 (launch Calculator on edr-dev) now produces a real AUTH_EXEC → snapshot lookup → DENY when the SHA-256 is in the snapshot. Beat #6 (modal pop-up) still depends on Step 6.
- Beat #8 (alert in the UI) depends on Step 4 wiring the block event through the detection pipeline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added application control rules with action types (block, allow, silent block) and enforcement modes (protect, detect)
  * Implemented executable hash-based verification for enhanced security control enforcement with caching to optimize performance
  * Updated application control decision logic to evaluate cached file signatures against configured rules

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/getvictor/fleet-edr/pull/154)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->