### PR TITLE
App Control demo cut step 4: block event -> alert (unified detection …

### DIFF
--- a/extension/edr/extension/ApplicationControlStore.swift
+++ b/extension/edr/extension/ApplicationControlStore.swift
@@ -36,7 +36,12 @@ struct ApplicationControlSnapshot {
 /// server's `server/rules/api.SetApplicationControlRule` JSON tags — a
 /// rename on either side is a contract break and the round-trip test on the
 /// server side is the gate.
+///
+/// ruleID is the stable string identifier (e.g. "app_control:42") the
+/// AUTH_EXEC handler echoes back in the `application_control_block` event
+/// so the server's alert mapping lands the alert under the same rule_id.
 struct ApplicationControlRule: Codable {
+    let ruleID: String
     let ruleType: String
     let identifier: String
     let action: String
@@ -46,6 +51,7 @@ struct ApplicationControlRule: Codable {
     let customURL: String?
 
     enum CodingKeys: String, CodingKey {
+        case ruleID = "rule_id"
         case ruleType = "rule_type"
         case identifier
         case action

--- a/extension/edr/extension/ESFSubscriber.swift
+++ b/extension/edr/extension/ESFSubscriber.swift
@@ -126,7 +126,16 @@ final class ESFSubscriber: Sendable {
                rule.action == ApplicationControlAction.block,
                rule.enforcement == ApplicationControlEnforcement.protect {
                 logger.warning("AUTH_EXEC DENIED by application control: \(path, privacy: .public) sha256=\(sha256, privacy: .public)")
+                // Deny FIRST so the kernel is unblocked before any
+                // userspace work. The block-event serialize + upload
+                // happens off the AUTH callback's deadline.
                 es_respond_auth_result(client, message, ES_AUTH_RESULT_DENY, false)
+                emitBlockEvent(
+                    target: target,
+                    rule: rule,
+                    matchedIdentifier: sha256,
+                    snapshot: snapshot
+                )
                 return
             }
         } else {
@@ -136,6 +145,36 @@ final class ESFSubscriber: Sendable {
             FileHashCache.shared.startLazyFill(path: path, stat: fileStat)
         }
         es_respond_auth_result(client, message, ES_AUTH_RESULT_ALLOW, false)
+    }
+
+    /// emitBlockEvent serializes an application_control_block event for the
+    /// just-denied AUTH_EXEC and hands it to the upload pipeline via
+    /// onEvent. Called after the DENY response so the kernel is already
+    /// unblocked; the JSON encode + XPC handoff happen off the callback's
+    /// deadline.
+    private func emitBlockEvent(
+        target: es_process_t,
+        rule: ApplicationControlRule,
+        matchedIdentifier: String,
+        snapshot: ApplicationControlSnapshot
+    ) {
+        let pid = audit_token_to_pid(target.audit_token)
+        let path = esTokenString(target.executable.pointee.path)
+        let payload = ApplicationControlBlockPayload(
+            pid: pid,
+            path: path,
+            ruleID: rule.ruleID,
+            ruleType: rule.ruleType,
+            identifier: matchedIdentifier,
+            severity: rule.severity,
+            customMsg: rule.customMsg,
+            customURL: rule.customURL,
+            policyID: snapshot.policyID,
+            policyVersion: snapshot.policyVersion
+        )
+        if let data = serializer.serialize(eventType: "application_control_block", payload: payload) {
+            onEvent?(data)
+        }
     }
 
     private func handleExec(_ msg: es_message_t) {

--- a/extension/edr/extension/EventSerializer.swift
+++ b/extension/edr/extension/EventSerializer.swift
@@ -68,6 +68,37 @@ struct OpenPayload: Codable, Sendable {
     }
 }
 
+/// ApplicationControlBlockPayload is the wire shape of the event the
+/// extension emits when AUTH_EXEC denies an exec. The server's
+/// `application_control_block` catalog rule decodes this payload and
+/// maps it to an alert with `source='application_control'`. Field
+/// names match the Go decode struct in
+/// `server/rules/internal/catalog/application_control_block.go`.
+struct ApplicationControlBlockPayload: Codable, Sendable {
+    let pid: pid_t
+    let path: String
+    let ruleID: String
+    let ruleType: String
+    let identifier: String
+    let severity: String
+    let customMsg: String?
+    let customURL: String?
+    let policyID: Int64
+    let policyVersion: Int64
+
+    enum CodingKeys: String, CodingKey {
+        case pid, path
+        case ruleID = "rule_id"
+        case ruleType = "rule_type"
+        case identifier
+        case severity
+        case customMsg = "custom_msg"
+        case customURL = "custom_url"
+        case policyID = "policy_id"
+        case policyVersion = "policy_version"
+    }
+}
+
 // MARK: - Event envelope
 
 struct EventEnvelope<P: Codable & Sendable>: Codable, Sendable {

--- a/schema/events.json
+++ b/schema/events.json
@@ -19,7 +19,7 @@
     },
     "event_type": {
       "type": "string",
-      "enum": ["exec", "fork", "exit", "open", "network_connect", "dns_query"],
+      "enum": ["exec", "fork", "exit", "open", "network_connect", "dns_query", "application_control_block"],
       "description": "Type of endpoint security event"
     },
     "payload": {
@@ -29,7 +29,8 @@
         { "$ref": "#/definitions/exit_payload" },
         { "$ref": "#/definitions/open_payload" },
         { "$ref": "#/definitions/network_connect_payload" },
-        { "$ref": "#/definitions/dns_query_payload" }
+        { "$ref": "#/definitions/dns_query_payload" },
+        { "$ref": "#/definitions/application_control_block_payload" }
       ]
     }
   },
@@ -126,6 +127,22 @@
           "items": { "type": "string" }
         },
         "protocol": { "type": "string", "enum": ["udp", "tcp"] }
+      }
+    },
+    "application_control_block_payload": {
+      "type": "object",
+      "required": ["pid", "path", "rule_id", "rule_type", "identifier", "severity", "policy_id", "policy_version"],
+      "properties": {
+        "pid": { "type": "integer" },
+        "path": { "type": "string" },
+        "rule_id": { "type": "string", "description": "Stable string identifier of the matched application-control rule (e.g. \"app_control:42\"). Echoed by the server as the alert's rule_id." },
+        "rule_type": { "type": "string", "enum": ["CDHASH", "BINARY", "SIGNINGID", "CERTIFICATE", "TEAMID", "PATH"] },
+        "identifier": { "type": "string", "description": "The matched identifier value (e.g. the SHA-256 the BINARY rule matched against)." },
+        "severity": { "type": "string", "enum": ["low", "medium", "high", "critical"] },
+        "custom_msg": { "type": "string" },
+        "custom_url": { "type": "string" },
+        "policy_id": { "type": "integer" },
+        "policy_version": { "type": "integer" }
       }
     }
   }

--- a/server/detection/api/types.go
+++ b/server/detection/api/types.go
@@ -140,6 +140,7 @@ type Alert struct {
 	ID          int64           `db:"id" json:"id"`
 	HostID      string          `db:"host_id" json:"host_id"`
 	RuleID      string          `db:"rule_id" json:"rule_id"`
+	Source      string          `db:"source" json:"source"`
 	Severity    string          `db:"severity" json:"severity"`
 	Title       string          `db:"title" json:"title"`
 	Description string          `db:"description" json:"description"`
@@ -151,6 +152,22 @@ type Alert struct {
 	ResolvedAt  *time.Time      `db:"resolved_at" json:"resolved_at,omitempty"`
 	UpdatedBy   *int64          `db:"updated_by" json:"updated_by,omitempty"`
 }
+
+// AlertSource records what subsystem emitted an alert. The schema's
+// `source` ENUM mirrors this set. Including source in the alert dedup
+// key prevents a catalog rule and an application-control rule that
+// happen to share an identifier value from collapsing into one alert
+// row (see server-detection-rules-engine delta spec).
+const (
+	// AlertSourceDetection is the source for findings produced by
+	// catalog rules. The default for engine.persistFinding when a
+	// Finding leaves the field blank, since every catalog rule was
+	// "detection" before the source column was introduced.
+	AlertSourceDetection = "detection"
+	// AlertSourceApplicationControl is the source for alerts
+	// produced by an application_control_block ingest event.
+	AlertSourceApplicationControl = "application_control"
+)
 
 // AlertStatus enumerates the operator-driven alert lifecycle.
 // Schema-level ENUM('open','acknowledged','resolved'); the UI
@@ -176,9 +193,15 @@ const (
 // it as a type alias so catalog rule files implement
 // rulesapi.Rule.Evaluate without importing detection/api directly
 // (see arch-go.yml §api-purity for the alias rationale).
+//
+// Source is optional: when blank, engine.persistFinding defaults it
+// to AlertSourceDetection so existing catalog rules keep working
+// unchanged. The application-control block rule explicitly sets
+// AlertSourceApplicationControl.
 type Finding struct {
 	HostID      string
 	RuleID      string
+	Source      string
 	Severity    string
 	Title       string
 	Description string
@@ -203,6 +226,7 @@ type AlertFilter struct {
 	HostID    string
 	Status    AlertStatus
 	Severity  string
+	Source    string
 	ProcessID int64
 	Limit     int
 }

--- a/server/detection/bootstrap/schema.go
+++ b/server/detection/bootstrap/schema.go
@@ -55,6 +55,7 @@ var schemaStatements = []string{
 		id           BIGINT AUTO_INCREMENT PRIMARY KEY,
 		host_id      VARCHAR(255) NOT NULL,
 		rule_id      VARCHAR(64)  NOT NULL,
+		source       ENUM('detection', 'application_control') NOT NULL DEFAULT 'detection',
 		severity     ENUM('low', 'medium', 'high', 'critical') NOT NULL,
 		title        VARCHAR(512) NOT NULL,
 		description  TEXT         NOT NULL,
@@ -66,11 +67,12 @@ var schemaStatements = []string{
 		created_at   TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
 		updated_at   TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
 		resolved_at  TIMESTAMP(6) NULL,
-		UNIQUE KEY uk_alerts_dedup (host_id, rule_id, process_id),
+		UNIQUE KEY uk_alerts_dedup (source, host_id, rule_id, process_id),
 		INDEX idx_alerts_host (host_id),
 		INDEX idx_alerts_status_created (status, created_at),
 		INDEX idx_alerts_updated_by (updated_by),
 		INDEX idx_alerts_tenant_id (tenant_id),
+		INDEX idx_alerts_source_created (source, created_at),
 		CONSTRAINT fk_alerts_process FOREIGN KEY (process_id) REFERENCES processes(id)
 	)`,
 	`CREATE TABLE IF NOT EXISTS alert_events (

--- a/server/detection/internal/engine/engine.go
+++ b/server/detection/internal/engine/engine.go
@@ -102,13 +102,22 @@ func (e *Engine) Evaluate(ctx context.Context, events []api.Event) error {
 // line + metric only when the insert wasn't deduped away. Extracted
 // from Evaluate so that method stays under the project
 // cognitive-complexity cap.
+//
+// Finding.Source defaults to AlertSourceDetection when blank so
+// catalog rules don't need to set it; the application-control block
+// rule overrides it explicitly.
 func (e *Engine) persistFinding(ctx context.Context, f api.Finding, techniques []string) error {
 	if f.Techniques == nil {
 		f.Techniques = techniques
 	}
+	source := f.Source
+	if source == "" {
+		source = api.AlertSourceDetection
+	}
 	_, created, err := e.store.InsertAlert(ctx, api.Alert{
 		HostID:      f.HostID,
 		RuleID:      f.RuleID,
+		Source:      source,
 		Severity:    f.Severity,
 		Title:       f.Title,
 		Description: f.Description,

--- a/server/detection/internal/mysql/alerts.go
+++ b/server/detection/internal/mysql/alerts.go
@@ -25,9 +25,12 @@ const alertEventsBatchSize = 500
 // process_id), the insert is skipped and the existing alert ID is
 // returned. Returns the alert ID and whether it was newly created.
 //
-// Callers MUST set a.Source. The engine defaults blank to
-// AlertSourceDetection before this method sees the alert so existing
-// catalog rules keep working unchanged.
+// Callers SHOULD set a.Source; a blank Source defaults to
+// AlertSourceDetection so existing catalog-rule call sites that
+// predate the Source column keep working unchanged. The engine
+// already defaults blank Finding.Source on the way in, so this
+// fallback is belt-and-braces for any future caller that constructs
+// an Alert by hand.
 func (s *Store) InsertAlert(ctx context.Context, a api.Alert, eventIDs []string) (int64, bool, error) {
 	eventIDs = deduplicateStrings(eventIDs)
 	// Defense in depth: callers that forget to stamp Source land in

--- a/server/detection/internal/mysql/alerts.go
+++ b/server/detection/internal/mysql/alerts.go
@@ -21,11 +21,21 @@ import (
 const alertEventsBatchSize = 500
 
 // InsertAlert creates an alert and links it to the given event IDs.
-// If a duplicate alert exists (same host_id, rule_id, process_id),
-// the insert is skipped and the existing alert ID is returned.
-// Returns the alert ID and whether it was newly created.
+// If a duplicate alert exists (same source, host_id, rule_id,
+// process_id), the insert is skipped and the existing alert ID is
+// returned. Returns the alert ID and whether it was newly created.
+//
+// Callers MUST set a.Source. The engine defaults blank to
+// AlertSourceDetection before this method sees the alert so existing
+// catalog rules keep working unchanged.
 func (s *Store) InsertAlert(ctx context.Context, a api.Alert, eventIDs []string) (int64, bool, error) {
 	eventIDs = deduplicateStrings(eventIDs)
+	// Defense in depth: callers that forget to stamp Source land in
+	// the catalog-rule bucket. The ENUM column would otherwise reject
+	// an empty string with Error 1265 (Data truncated).
+	if a.Source == "" {
+		a.Source = api.AlertSourceDetection
+	}
 
 	tx, err := s.db.BeginTxx(ctx, nil)
 	if err != nil {
@@ -34,9 +44,9 @@ func (s *Store) InsertAlert(ctx context.Context, a api.Alert, eventIDs []string)
 	defer tx.Rollback() //nolint:errcheck
 
 	res, err := tx.ExecContext(ctx, `
-		INSERT INTO alerts (host_id, rule_id, severity, title, description, process_id, techniques)
-		VALUES (?, ?, ?, ?, ?, ?, ?)`,
-		a.HostID, a.RuleID, a.Severity, a.Title, a.Description, a.ProcessID, a.Techniques,
+		INSERT INTO alerts (host_id, rule_id, source, severity, title, description, process_id, techniques)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		a.HostID, a.RuleID, a.Source, a.Severity, a.Title, a.Description, a.ProcessID, a.Techniques,
 	)
 	if err != nil {
 		if isDuplicateKeyErr(err) {
@@ -102,14 +112,14 @@ func isDuplicateKeyErr(err error) bool {
 }
 
 // attachEventsToExistingAlert handles the dedup branch when
-// (host_id, rule_id, process_id) already has an alert row. Extracted
-// from InsertAlert to keep the main path under the cognitive
-// complexity limit.
+// (source, host_id, rule_id, process_id) already has an alert row.
+// Extracted from InsertAlert to keep the main path under the
+// cognitive complexity limit.
 func (s *Store) attachEventsToExistingAlert(ctx context.Context, tx *sqlx.Tx, a api.Alert, eventIDs []string) (int64, bool, error) {
 	var existingID int64
 	if err := tx.GetContext(ctx, &existingID,
-		"SELECT id FROM alerts WHERE host_id = ? AND rule_id = ? AND process_id = ?",
-		a.HostID, a.RuleID, a.ProcessID,
+		"SELECT id FROM alerts WHERE source = ? AND host_id = ? AND rule_id = ? AND process_id = ?",
+		a.Source, a.HostID, a.RuleID, a.ProcessID,
 	); err != nil {
 		return 0, false, fmt.Errorf("lookup duplicate alert: %w", err)
 	}
@@ -130,7 +140,7 @@ func (s *Store) ListAlerts(ctx context.Context, f api.AlertFilter) ([]api.Alert,
 		limit = 100
 	}
 
-	query := `SELECT id, host_id, rule_id, severity, title, description, process_id,
+	query := `SELECT id, host_id, rule_id, source, severity, title, description, process_id,
 	          techniques, status, created_at, updated_at, resolved_at, updated_by
 	          FROM alerts WHERE 1=1`
 	var args []any
@@ -146,6 +156,10 @@ func (s *Store) ListAlerts(ctx context.Context, f api.AlertFilter) ([]api.Alert,
 	if f.Severity != "" {
 		query += " AND severity = ?"
 		args = append(args, f.Severity)
+	}
+	if f.Source != "" {
+		query += " AND source = ?"
+		args = append(args, f.Source)
 	}
 	if f.ProcessID != 0 {
 		query += " AND process_id = ?"
@@ -167,7 +181,7 @@ func (s *Store) ListAlerts(ctx context.Context, f api.AlertFilter) ([]api.Alert,
 func (s *Store) GetAlert(ctx context.Context, id int64) (api.Alert, error) {
 	var a api.Alert
 	err := s.db.GetContext(ctx, &a,
-		`SELECT id, host_id, rule_id, severity, title, description, process_id,
+		`SELECT id, host_id, rule_id, source, severity, title, description, process_id,
 		        techniques, status, created_at, updated_at, resolved_at, updated_by
 		 FROM alerts WHERE id = ?`, id)
 	if errors.Is(err, sql.ErrNoRows) {
@@ -254,6 +268,10 @@ func (s *Store) CountAlerts(ctx context.Context, f api.AlertFilter) (int64, erro
 	if f.Severity != "" {
 		query += " AND severity = ?"
 		args = append(args, f.Severity)
+	}
+	if f.Source != "" {
+		query += " AND source = ?"
+		args = append(args, f.Source)
 	}
 	if f.ProcessID != 0 {
 		query += " AND process_id = ?"

--- a/server/rules/api/app_control_wire_test.go
+++ b/server/rules/api/app_control_wire_test.go
@@ -32,6 +32,7 @@ func TestMarshalSetApplicationControlPayload_RoundTrip(t *testing.T) {
 		},
 	}
 	policy := api.ApplicationControlPolicy{ID: 7, Version: 42}
+	rules[0].ID = 99
 
 	raw, err := api.MarshalSetApplicationControlPayload(policy, rules, time.Time{})
 	require.NoError(t, err)
@@ -43,6 +44,7 @@ func TestMarshalSetApplicationControlPayload_RoundTrip(t *testing.T) {
 	assert.Equal(t, int64(42), decoded.PolicyVersion)
 	require.Len(t, decoded.Rules, 1)
 	got := decoded.Rules[0]
+	assert.Equal(t, "app_control:99", got.RuleID)
 	assert.Equal(t, api.RuleTypeBinary, got.RuleType)
 	assert.Equal(t, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", got.Identifier)
 	assert.Equal(t, api.ActionBlock, got.Action)
@@ -134,7 +136,7 @@ func TestSetApplicationControlPayload_JSONKeys(t *testing.T) {
 	rulesAny, _ := got["rules"].([]any)
 	require.Len(t, rulesAny, 1)
 	rule, _ := rulesAny[0].(map[string]any)
-	for _, key := range []string{"rule_type", "identifier", "action", "enforcement", "severity", "custom_msg"} {
+	for _, key := range []string{"rule_id", "rule_type", "identifier", "action", "enforcement", "severity", "custom_msg"} {
 		assert.Contains(t, rule, key, "rule key %q missing", key)
 	}
 }
@@ -257,6 +259,7 @@ func TestMarshalSetApplicationControlPayload_RapidRoundTrip(t *testing.T) {
 				continue
 			}
 			expected = append(expected, api.SetApplicationControlRule{
+				RuleID:      api.ApplicationControlRuleID(r.ID),
 				RuleType:    r.RuleType,
 				Identifier:  r.Identifier,
 				Action:      r.Action,
@@ -269,6 +272,7 @@ func TestMarshalSetApplicationControlPayload_RapidRoundTrip(t *testing.T) {
 		require.Len(t, decoded.Rules, len(expected), "filtered rule count must match")
 		for i := range expected {
 			got := decoded.Rules[i]
+			assert.Equal(t, expected[i].RuleID, got.RuleID)
 			assert.Equal(t, expected[i].RuleType, got.RuleType)
 			assert.Equal(t, expected[i].Identifier, got.Identifier)
 			assert.Equal(t, expected[i].Action, got.Action)

--- a/server/rules/api/types.go
+++ b/server/rules/api/types.go
@@ -50,6 +50,16 @@ const (
 	SeverityCritical = detectionapi.SeverityCritical
 )
 
+// Alert source constants re-exported from detection/api so catalog
+// rules can stamp Finding.Source without importing detection/api
+// directly. The doc comment on rules/api (see doc.go) makes the
+// no-detection-import rule explicit; mirror constants here whenever a
+// rule needs one. Same values, same types, no behavior drift.
+const (
+	AlertSourceDetection          = detectionapi.AlertSourceDetection
+	AlertSourceApplicationControl = detectionapi.AlertSourceApplicationControl
+)
+
 // --- Catalog types -------------------------------------------------------------
 
 // Rule is a detection that the engine evaluates against a batch of

--- a/server/rules/api/types.go
+++ b/server/rules/api/types.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"time"
 
 	detectionapi "github.com/fleetdm/edr/server/detection/api"
@@ -398,7 +399,14 @@ type SetApplicationControlPayload struct {
 // the wire shape is stable across the demo cut and the rest of
 // Phase A. Disabled and expired rules are NOT included in the
 // payload — the fan-out filters them so the agent never sees them.
+//
+// RuleID is the stable string identifier (e.g. "app_control:42") that
+// the extension echoes back in the `application_control_block` event
+// so the server-side mapping lands the alert under the same rule_id.
+// Built by ApplicationControlRuleID(r.ID); the numeric row id alone
+// would risk collision with catalog rule ids in alert dedup.
 type SetApplicationControlRule struct {
+	RuleID      string      `json:"rule_id"`
 	RuleType    RuleType    `json:"rule_type"`
 	Identifier  string      `json:"identifier"`
 	Action      Action      `json:"action"`
@@ -406,6 +414,20 @@ type SetApplicationControlRule struct {
 	Severity    Severity    `json:"severity"`
 	CustomMsg   *string     `json:"custom_msg,omitempty"`
 	CustomURL   *string     `json:"custom_url,omitempty"`
+}
+
+// ApplicationControlRuleIDPrefix namespaces the rule_id that the
+// extension echoes in `application_control_block` events. Keeps the
+// alert dedup key collision-free against catalog rule ids even when
+// the alerts.source column is unavailable for filtering.
+const ApplicationControlRuleIDPrefix = "app_control:"
+
+// ApplicationControlRuleID renders the stable string rule_id for a
+// row in app_control_rules. The extension treats this value as
+// opaque; the server uses it for alert dedup and for mapping a
+// block-event back to its row.
+func ApplicationControlRuleID(id int64) string {
+	return fmt.Sprintf("%s%d", ApplicationControlRuleIDPrefix, id)
 }
 
 // MarshalSetApplicationControlPayload returns the JSON bytes the
@@ -425,6 +447,7 @@ func MarshalSetApplicationControlPayload(p ApplicationControlPolicy, rules []App
 			continue
 		}
 		entries = append(entries, SetApplicationControlRule{
+			RuleID:      ApplicationControlRuleID(r.ID),
 			RuleType:    r.RuleType,
 			Identifier:  r.Identifier,
 			Action:      r.Action,

--- a/server/rules/internal/catalog/application_control_block.go
+++ b/server/rules/internal/catalog/application_control_block.go
@@ -4,9 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"path/filepath"
+	"path"
 
-	detectionapi "github.com/fleetdm/edr/server/detection/api"
 	"github.com/fleetdm/edr/server/rules/api"
 )
 
@@ -96,7 +95,7 @@ func (r *ApplicationControlBlock) Evaluate(ctx context.Context, events []api.Eve
 		findings = append(findings, api.Finding{
 			HostID:      evt.HostID,
 			RuleID:      p.RuleID,
-			Source:      detectionapi.AlertSourceApplicationControl,
+			Source:      api.AlertSourceApplicationControl,
 			Severity:    p.Severity,
 			Title:       blockAlertTitle(p),
 			Description: blockAlertDescription(p),
@@ -111,8 +110,15 @@ func (r *ApplicationControlBlock) Evaluate(ctx context.Context, events []api.Eve
 // list. Prefers the binary basename so a row like
 // "Application blocked: Calculator" beats one that drowns the
 // column in a full path.
+//
+// Uses `path.Base` (Unix-only, forward-slash) rather than
+// `path/filepath.Base` (host-OS dependent). Agent paths are always
+// macOS Unix-style; if the server ever ran on Windows, filepath would
+// keep the full string under host=Windows because backslash is the
+// separator there. path.Base is the correct semantic for the
+// known-Unix input here, not just a cross-platform optimization.
 func blockAlertTitle(p applicationControlBlockPayload) string {
-	name := filepath.Base(p.Path)
+	name := path.Base(p.Path)
 	if name == "" || name == "." || name == "/" {
 		name = p.Path
 	}

--- a/server/rules/internal/catalog/application_control_block.go
+++ b/server/rules/internal/catalog/application_control_block.go
@@ -1,0 +1,135 @@
+package catalog
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+
+	detectionapi "github.com/fleetdm/edr/server/detection/api"
+	"github.com/fleetdm/edr/server/rules/api"
+)
+
+// ApplicationControlBlock is the built-in pass-through rule that
+// turns an `application_control_block` ingest event into an alert.
+// The extension's AUTH_EXEC decision walker already made the
+// blocking decision on the host; the rule's job here is to render
+// that decision as a row in the unified alerts view so admins see it
+// alongside catalog-rule findings.
+//
+// Unlike the catalog rules, this rule does not pattern-match over
+// events: every accepted block event becomes a finding, with the
+// rule_id and severity copied straight from the payload. Source is
+// stamped AlertSourceApplicationControl so the dedup key
+// (source, host_id, rule_id, process_id) keeps app-control alerts
+// distinct from any catalog-rule id collision.
+type ApplicationControlBlock struct{}
+
+// applicationControlBlockEventType is the well-known event_type the
+// extension emits when an AUTH_EXEC is denied. Stable wire-shape
+// string; mirrored on the Swift side in
+// `extension/edr/extension/EventSerializer.swift`.
+const applicationControlBlockEventType = "application_control_block"
+
+func (r *ApplicationControlBlock) ID() string { return "application_control_block" }
+
+// Techniques returns an empty slice. App-control blocks are not
+// mapped to MITRE ATT&CK because the framework's perspective is "the
+// adversary did something" — a successful block is the absence of
+// that. Operators who want ATT&CK badging on app-control alerts can
+// tag the originating rule downstream.
+func (r *ApplicationControlBlock) Techniques() []string { return []string{} }
+
+func (r *ApplicationControlBlock) Doc() api.Documentation {
+	return api.Documentation{
+		Title:   "Application control block",
+		Summary: "Surfaces every AUTH_EXEC denial from the extension as an alert in the unified view.",
+		Description: "The extension's AUTH_EXEC decision walker denies execs that match an admin-defined " +
+			"application-control rule. Every such denial emits an `application_control_block` event that this " +
+			"built-in rule maps to an alert with `source='application_control'`. The alert carries the matched " +
+			"rule's identifier, severity, and operator-supplied custom message. The dedup key " +
+			"(source, host_id, rule_id, process_id) means repeated blocks of the same binary by the same rule on " +
+			"the same process collapse into one alert row.",
+		Severity:   api.SeverityMedium,
+		EventTypes: []string{applicationControlBlockEventType},
+	}
+}
+
+type applicationControlBlockPayload struct {
+	PID           int     `json:"pid"`
+	Path          string  `json:"path"`
+	RuleID        string  `json:"rule_id"`
+	RuleType      string  `json:"rule_type"`
+	Identifier    string  `json:"identifier"`
+	Severity      string  `json:"severity"`
+	CustomMsg     *string `json:"custom_msg,omitempty"`
+	CustomURL     *string `json:"custom_url,omitempty"`
+	PolicyID      int64   `json:"policy_id"`
+	PolicyVersion int64   `json:"policy_version"`
+}
+
+// Evaluate maps each accepted block event to a Finding. Missing
+// process row → skip the event (the graph builder hasn't materialised
+// the exec yet; the next batch will see it after re-ingest). Missing
+// or malformed payload fields → skip; the validator at ingest is the
+// authoritative gate, this rule is best-effort over the residual.
+func (r *ApplicationControlBlock) Evaluate(ctx context.Context, events []api.Event, gr api.GraphReader) ([]api.Finding, error) {
+	var findings []api.Finding
+	for _, evt := range events {
+		if evt.EventType != applicationControlBlockEventType {
+			continue
+		}
+		var p applicationControlBlockPayload
+		if err := json.Unmarshal(evt.Payload, &p); err != nil {
+			continue
+		}
+		if p.RuleID == "" || p.Severity == "" {
+			continue
+		}
+		proc, err := gr.GetProcessByPID(ctx, evt.HostID, p.PID, evt.TimestampNs)
+		if err != nil {
+			return nil, fmt.Errorf("application control block: get process pid %d: %w", p.PID, err)
+		}
+		if proc == nil {
+			continue
+		}
+		findings = append(findings, api.Finding{
+			HostID:      evt.HostID,
+			RuleID:      p.RuleID,
+			Source:      detectionapi.AlertSourceApplicationControl,
+			Severity:    p.Severity,
+			Title:       blockAlertTitle(p),
+			Description: blockAlertDescription(p),
+			ProcessID:   proc.ID,
+			EventIDs:    []string{evt.EventID},
+		})
+	}
+	return findings, nil
+}
+
+// blockAlertTitle renders the alert headline shown in the alerts
+// list. Prefers the binary basename so a row like
+// "Application blocked: Calculator" beats one that drowns the
+// column in a full path.
+func blockAlertTitle(p applicationControlBlockPayload) string {
+	name := filepath.Base(p.Path)
+	if name == "" || name == "." || name == "/" {
+		name = p.Path
+	}
+	if name == "" {
+		return "Application blocked"
+	}
+	return "Application blocked: " + name
+}
+
+// blockAlertDescription prefers the operator's custom message (the
+// `custom_msg` the rule was created with) so admins can author the
+// exact text that lands in the alert. Falls back to a deterministic
+// default that names the rule type + identifier when no custom
+// message is set, per the server-detection-rules-engine delta spec.
+func blockAlertDescription(p applicationControlBlockPayload) string {
+	if p.CustomMsg != nil && *p.CustomMsg != "" {
+		return *p.CustomMsg
+	}
+	return fmt.Sprintf("Blocked %s rule for %s", p.RuleType, p.Identifier)
+}

--- a/server/rules/internal/catalog/application_control_block_test.go
+++ b/server/rules/internal/catalog/application_control_block_test.go
@@ -1,0 +1,227 @@
+package catalog
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	detectionapi "github.com/fleetdm/edr/server/detection/api"
+	"github.com/fleetdm/edr/server/rules/api"
+)
+
+// TestApplicationControlBlock_TableDriven covers every branch of the
+// block-event-to-finding mapping: happy path, missing fields, missing
+// process row, malformed payload, and the custom_msg default. Each
+// case names the property under test rather than the input; a failure
+// here pinpoints the exact mapping invariant that broke.
+func TestApplicationControlBlock_TableDriven(t *testing.T) {
+	customMsg := "Blocked: Calculator is not allowed"
+	cases := []struct {
+		name         string
+		payload      map[string]any
+		eventType    string
+		procExists   bool
+		wantFindings int
+		wantSeverity string
+		wantTitle    string
+		wantDesc     string
+		wantSource   string
+		wantRuleID   string
+	}{
+		{
+			name:      "happy path produces application_control finding",
+			eventType: "application_control_block",
+			payload: map[string]any{
+				"pid":            int64(100),
+				"path":           "/System/Applications/Calculator.app/Contents/MacOS/Calculator",
+				"rule_id":        "app_control:42",
+				"rule_type":      "BINARY",
+				"identifier":     "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+				"severity":       "high",
+				"custom_msg":     customMsg,
+				"policy_id":      int64(11),
+				"policy_version": int64(3),
+			},
+			procExists:   true,
+			wantFindings: 1,
+			wantSeverity: "high",
+			wantTitle:    "Application blocked: Calculator",
+			wantDesc:     customMsg,
+			wantSource:   detectionapi.AlertSourceApplicationControl,
+			wantRuleID:   "app_control:42",
+		},
+		{
+			name:      "missing custom_msg falls back to deterministic default",
+			eventType: "application_control_block",
+			payload: map[string]any{
+				"pid":            int64(100),
+				"path":           "/bin/ls",
+				"rule_id":        "app_control:7",
+				"rule_type":      "BINARY",
+				"identifier":     "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+				"severity":       "medium",
+				"policy_id":      int64(11),
+				"policy_version": int64(3),
+			},
+			procExists:   true,
+			wantFindings: 1,
+			wantSeverity: "medium",
+			wantTitle:    "Application blocked: ls",
+			wantDesc:     "Blocked BINARY rule for bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+			wantSource:   detectionapi.AlertSourceApplicationControl,
+			wantRuleID:   "app_control:7",
+		},
+		{
+			name:      "wrong event type is ignored",
+			eventType: "exec",
+			payload: map[string]any{
+				"pid":            int64(100),
+				"rule_id":        "app_control:1",
+				"severity":       "high",
+				"path":           "/bin/ls",
+				"rule_type":      "BINARY",
+				"identifier":     "x",
+				"policy_id":      int64(1),
+				"policy_version": int64(1),
+			},
+			procExists:   true,
+			wantFindings: 0,
+		},
+		{
+			name:      "missing rule_id skips event",
+			eventType: "application_control_block",
+			payload: map[string]any{
+				"pid":            int64(100),
+				"path":           "/bin/ls",
+				"rule_type":      "BINARY",
+				"identifier":     "x",
+				"severity":       "high",
+				"policy_id":      int64(1),
+				"policy_version": int64(1),
+			},
+			procExists:   true,
+			wantFindings: 0,
+		},
+		{
+			name:      "missing severity skips event",
+			eventType: "application_control_block",
+			payload: map[string]any{
+				"pid":            int64(100),
+				"path":           "/bin/ls",
+				"rule_id":        "app_control:1",
+				"rule_type":      "BINARY",
+				"identifier":     "x",
+				"policy_id":      int64(1),
+				"policy_version": int64(1),
+			},
+			procExists:   true,
+			wantFindings: 0,
+		},
+		{
+			name:      "missing process row skips event",
+			eventType: "application_control_block",
+			payload: map[string]any{
+				"pid":            int64(999),
+				"path":           "/bin/ls",
+				"rule_id":        "app_control:1",
+				"rule_type":      "BINARY",
+				"identifier":     "x",
+				"severity":       "high",
+				"policy_id":      int64(1),
+				"policy_version": int64(1),
+			},
+			procExists:   false,
+			wantFindings: 0,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rule := &ApplicationControlBlock{}
+			payload, err := json.Marshal(tc.payload)
+			require.NoError(t, err)
+			gr := &stubBlockGraphReader{exists: tc.procExists, procID: 99}
+
+			findings, err := rule.Evaluate(t.Context(), []api.Event{{
+				EventID:     "evt-1",
+				HostID:      "host-a",
+				TimestampNs: 1000,
+				EventType:   tc.eventType,
+				Payload:     payload,
+			}}, gr)
+			require.NoError(t, err)
+			require.Len(t, findings, tc.wantFindings)
+			if tc.wantFindings == 0 {
+				return
+			}
+			got := findings[0]
+			assert.Equal(t, tc.wantRuleID, got.RuleID)
+			assert.Equal(t, tc.wantSource, got.Source)
+			assert.Equal(t, tc.wantSeverity, got.Severity)
+			assert.Equal(t, tc.wantTitle, got.Title)
+			assert.Equal(t, tc.wantDesc, got.Description)
+			assert.Equal(t, int64(99), got.ProcessID)
+			assert.Equal(t, []string{"evt-1"}, got.EventIDs)
+		})
+	}
+}
+
+// TestApplicationControlBlock_GraphReaderError surfaces the
+// distinct failure mode where the GraphReader itself returns an
+// error (DB unreachable, query timeout). The rule must propagate
+// that error so the processor can unclaim + retry the batch instead
+// of silently dropping the block.
+func TestApplicationControlBlock_GraphReaderError(t *testing.T) {
+	rule := &ApplicationControlBlock{}
+	payload, _ := json.Marshal(map[string]any{
+		"pid":            100,
+		"path":           "/bin/ls",
+		"rule_id":        "app_control:1",
+		"rule_type":      "BINARY",
+		"identifier":     "x",
+		"severity":       "high",
+		"policy_id":      1,
+		"policy_version": 1,
+	})
+	wantErr := errors.New("graph reader unavailable")
+	gr := &stubBlockGraphReader{err: wantErr}
+	_, err := rule.Evaluate(t.Context(), []api.Event{{
+		EventID: "evt-1", HostID: "host-a", TimestampNs: 1000,
+		EventType: "application_control_block", Payload: payload,
+	}}, gr)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, wantErr)
+}
+
+// stubBlockGraphReader is the minimal GraphReader the rule needs:
+// only GetProcessByPID is exercised. Returning exists=false models
+// the "process not yet materialised" race the rule must skip
+// silently; returning err models a transient DB error the rule
+// must propagate.
+type stubBlockGraphReader struct {
+	exists bool
+	procID int64
+	err    error
+}
+
+func (s *stubBlockGraphReader) GetProcessByPID(_ context.Context, _ string, _ int, _ int64) (*detectionapi.Process, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	if !s.exists {
+		return nil, nil
+	}
+	return &detectionapi.Process{ID: s.procID}, nil
+}
+
+func (s *stubBlockGraphReader) GetChildProcesses(_ context.Context, _ string, _ int, _ detectionapi.TimeRange) ([]detectionapi.Process, error) {
+	return nil, nil
+}
+
+func (s *stubBlockGraphReader) GetExecChain(_ context.Context, current detectionapi.Process) ([]detectionapi.Process, error) {
+	return []detectionapi.Process{current}, nil
+}

--- a/server/rules/internal/catalog/application_control_block_test.go
+++ b/server/rules/internal/catalog/application_control_block_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	detectionapi "github.com/fleetdm/edr/server/detection/api"
 	"github.com/fleetdm/edr/server/rules/api"
 )
 
@@ -51,7 +50,7 @@ func TestApplicationControlBlock_TableDriven(t *testing.T) {
 			wantSeverity: "high",
 			wantTitle:    "Application blocked: Calculator",
 			wantDesc:     customMsg,
-			wantSource:   detectionapi.AlertSourceApplicationControl,
+			wantSource:   api.AlertSourceApplicationControl,
 			wantRuleID:   "app_control:42",
 		},
 		{
@@ -72,7 +71,7 @@ func TestApplicationControlBlock_TableDriven(t *testing.T) {
 			wantSeverity: "medium",
 			wantTitle:    "Application blocked: ls",
 			wantDesc:     "Blocked BINARY rule for bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-			wantSource:   detectionapi.AlertSourceApplicationControl,
+			wantSource:   api.AlertSourceApplicationControl,
 			wantRuleID:   "app_control:7",
 		},
 		{
@@ -177,7 +176,7 @@ func TestApplicationControlBlock_TableDriven(t *testing.T) {
 // of silently dropping the block.
 func TestApplicationControlBlock_GraphReaderError(t *testing.T) {
 	rule := &ApplicationControlBlock{}
-	payload, _ := json.Marshal(map[string]any{
+	payload, err := json.Marshal(map[string]any{
 		"pid":            100,
 		"path":           "/bin/ls",
 		"rule_id":        "app_control:1",
@@ -187,9 +186,10 @@ func TestApplicationControlBlock_GraphReaderError(t *testing.T) {
 		"policy_id":      1,
 		"policy_version": 1,
 	})
+	require.NoError(t, err)
 	wantErr := errors.New("graph reader unavailable")
 	gr := &stubBlockGraphReader{err: wantErr}
-	_, err := rule.Evaluate(t.Context(), []api.Event{{
+	_, err = rule.Evaluate(t.Context(), []api.Event{{
 		EventID: "evt-1", HostID: "host-a", TimestampNs: 1000,
 		EventType: "application_control_block", Payload: payload,
 	}}, gr)
@@ -208,20 +208,20 @@ type stubBlockGraphReader struct {
 	err    error
 }
 
-func (s *stubBlockGraphReader) GetProcessByPID(_ context.Context, _ string, _ int, _ int64) (*detectionapi.Process, error) {
+func (s *stubBlockGraphReader) GetProcessByPID(_ context.Context, _ string, _ int, _ int64) (*api.Process, error) {
 	if s.err != nil {
 		return nil, s.err
 	}
 	if !s.exists {
 		return nil, nil
 	}
-	return &detectionapi.Process{ID: s.procID}, nil
+	return &api.Process{ID: s.procID}, nil
 }
 
-func (s *stubBlockGraphReader) GetChildProcesses(_ context.Context, _ string, _ int, _ detectionapi.TimeRange) ([]detectionapi.Process, error) {
+func (s *stubBlockGraphReader) GetChildProcesses(_ context.Context, _ string, _ int, _ api.TimeRange) ([]api.Process, error) {
 	return nil, nil
 }
 
-func (s *stubBlockGraphReader) GetExecChain(_ context.Context, current detectionapi.Process) ([]detectionapi.Process, error) {
-	return []detectionapi.Process{current}, nil
+func (s *stubBlockGraphReader) GetExecChain(_ context.Context, current api.Process) ([]api.Process, error) {
+	return []api.Process{current}, nil
 }

--- a/server/rules/internal/catalog/registry.go
+++ b/server/rules/internal/catalog/registry.go
@@ -21,5 +21,6 @@ func New(opts api.RegistryOptions) []api.Rule {
 		&CredentialKeychainDump{},
 		&PrivilegeLaunchdPlistWrite{AllowedTeamIDs: opts.LaunchDaemonTeamIDAllowlist},
 		&SudoersTamper{AllowedWriters: opts.SudoersWriterAllowlist},
+		&ApplicationControlBlock{},
 	}
 }

--- a/server/rules/internal/catalog/registry_test.go
+++ b/server/rules/internal/catalog/registry_test.go
@@ -26,6 +26,7 @@ func TestAll_RegisterEveryShippedRule(t *testing.T) {
 		"credential_keychain_dump",
 		"privilege_launchd_plist_write",
 		"sudoers_tamper",
+		"application_control_block",
 	}
 	require.Len(t, got, len(wantIDs))
 	for i, want := range wantIDs {

--- a/server/rules/internal/tests/integration_test.go
+++ b/server/rules/internal/tests/integration_test.go
@@ -56,7 +56,6 @@ func newRules(t *testing.T) *rulesbootstrap.Rules {
 func TestCatalog_ListShape(t *testing.T) {
 	r := newRules(t)
 	catalog := r.Catalog().List()
-	require.Len(t, catalog, 8)
 	wantIDs := []string{
 		"suspicious_exec",
 		"persistence_launchagent",
@@ -66,7 +65,9 @@ func TestCatalog_ListShape(t *testing.T) {
 		"credential_keychain_dump",
 		"privilege_launchd_plist_write",
 		"sudoers_tamper",
+		"application_control_block",
 	}
+	require.Len(t, catalog, len(wantIDs))
 	for i, want := range wantIDs {
 		assert.Equal(t, want, catalog[i].ID, "rule at index %d", i)
 		assert.NotEmpty(t, catalog[i].Doc.Title, "rule %s missing Doc.Title", catalog[i].ID)
@@ -74,12 +75,14 @@ func TestCatalog_ListShape(t *testing.T) {
 	}
 }
 
-// TestContentService_ActiveRules surfaces the same eight rules through
-// the engine-facing interface.
+// TestContentService_ActiveRules surfaces every shipped rule through
+// the engine-facing interface. The exact roster lives in
+// TestCatalog_ListShape; this test just confirms the count is in
+// lockstep and every rule has a non-empty descriptor.
 func TestContentService_ActiveRules(t *testing.T) {
 	r := newRules(t)
 	rules := r.ContentService().ActiveRules()
-	require.Len(t, rules, 8)
+	require.Len(t, rules, len(r.Catalog().List()))
 	for _, rule := range rules {
 		assert.NotEmpty(t, rule.ID())
 		assert.NotEmpty(t, rule.Doc().Title)
@@ -112,7 +115,7 @@ func TestOperator_GetRules(t *testing.T) {
 		} `json:"rules"`
 	}
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
-	require.Len(t, body.Rules, 8)
+	require.Len(t, body.Rules, len(r.Catalog().List()))
 	assert.Equal(t, "suspicious_exec", body.Rules[0].ID)
 	assert.NotEmpty(t, body.Rules[0].Doc.Title)
 }

--- a/test/integration/app_control_block_test.go
+++ b/test/integration/app_control_block_test.go
@@ -74,7 +74,7 @@ func TestAppControlBlock_EventBecomesAlert(t *testing.T) {
 		HostID:      hostID,
 		TimestampNs: now + 2,
 		EventType:   "application_control_block",
-		Payload: blockPayload(blockPayloadInput{
+		Payload: blockPayload(t, blockPayloadInput{
 			PID:           blockPID,
 			Path:          "/System/Applications/Calculator.app/Contents/MacOS/Calculator",
 			RuleID:        ruleID,
@@ -114,7 +114,7 @@ func TestAppControlBlock_EventBecomesAlert(t *testing.T) {
 		HostID:      hostID,
 		TimestampNs: now + 3,
 		EventType:   "application_control_block",
-		Payload: blockPayload(blockPayloadInput{
+		Payload: blockPayload(t, blockPayloadInput{
 			PID:           blockPID,
 			Path:          "/System/Applications/Calculator.app/Contents/MacOS/Calculator",
 			RuleID:        ruleID,
@@ -169,7 +169,7 @@ func TestAppControlBlock_DefaultDescriptionWhenCustomMsgAbsent(t *testing.T) {
 		HostID:      hostID,
 		TimestampNs: now + 2,
 		EventType:   "application_control_block",
-		Payload: blockPayload(blockPayloadInput{
+		Payload: blockPayload(t, blockPayloadInput{
 			PID:           blockPID,
 			Path:          "/bin/ls",
 			RuleID:        "app_control:12",
@@ -214,8 +214,12 @@ type blockPayloadInput struct {
 // blockPayload renders the JSON shape the extension emits for an
 // application_control_block event. Kept as a local helper so the
 // wire-tag contract is exercised by the test rather than imported
-// from production code.
-func blockPayload(in blockPayloadInput) json.RawMessage {
+// from production code. Takes *testing.T so a marshal failure fails
+// the test loudly instead of slipping a corrupt payload into the
+// event post (would surface downstream as an opaque mismatch
+// otherwise).
+func blockPayload(t *testing.T, in blockPayloadInput) json.RawMessage {
+	t.Helper()
 	type wire struct {
 		PID           int     `json:"pid"`
 		Path          string  `json:"path"`
@@ -228,12 +232,13 @@ func blockPayload(in blockPayloadInput) json.RawMessage {
 		PolicyID      int64   `json:"policy_id"`
 		PolicyVersion int64   `json:"policy_version"`
 	}
-	b, _ := json.Marshal(wire{
+	b, err := json.Marshal(wire{
 		PID: in.PID, Path: in.Path,
 		RuleID: in.RuleID, RuleType: in.RuleType, Identifier: in.Identifier,
 		Severity: in.Severity, CustomMsg: in.CustomMsg, CustomURL: in.CustomURL,
 		PolicyID: in.PolicyID, PolicyVersion: in.PolicyVersion,
 	})
+	require.NoError(t, err)
 	return b
 }
 

--- a/test/integration/app_control_block_test.go
+++ b/test/integration/app_control_block_test.go
@@ -1,0 +1,261 @@
+//go:build integration
+
+package integration
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	detectionapi "github.com/fleetdm/edr/server/detection/api"
+)
+
+// TestAppControlBlock_EventBecomesAlert is the cross-context smoke
+// for the Application Control demo cut's beat #8: a denied AUTH_EXEC
+// on the host ends up as a row in the alerts view that the admin
+// can scroll to.
+//
+// The wiring under test:
+//
+//   - The agent posts an `application_control_block` event to
+//     /api/events (gated by the same host-token middleware as every
+//     other event upload).
+//   - The detection processor materialises the linked process and
+//     evaluates the built-in `application_control_block` catalog rule
+//     against the batch.
+//   - The rule emits a Finding with Source=application_control.
+//   - The engine persists it as an alert; dedup key is
+//     (source, host_id, rule_id, process_id) so a repeat block of
+//     the same binary by the same rule on the same process collapses
+//     into one row.
+//
+// A regression in any of those steps breaks the demo recording; the
+// test exists to catch the regression in CI before the demo dry-run
+// catches it on camera.
+func TestAppControlBlock_EventBecomesAlert(t *testing.T) {
+	stack := Setup(t)
+
+	const hostID = "BBBB1111-2222-3333-4444-555566667777"
+	const blockPID = 5151
+	hostToken := stepEnroll(t, stack, hostID)
+
+	// Seed a process row the block-event's pid can resolve against.
+	// The rule skips events whose pid doesn't materialise into a
+	// process row (the graph builder hadn't seen the exec yet), so
+	// without the fork/exec pair the block event would land as no-op.
+	now := time.Now().UnixNano()
+	seedEvents := []detectionapi.Event{
+		{
+			EventID: "ac-fork", HostID: hostID, TimestampNs: now, EventType: "fork",
+			Payload: json.RawMessage(fmt.Sprintf(`{"child_pid":%d,"parent_pid":1}`, blockPID)),
+		},
+		{
+			EventID: "ac-exec", HostID: hostID, TimestampNs: now + 1, EventType: "exec",
+			Payload: json.RawMessage(fmt.Sprintf(
+				`{"pid":%d,"ppid":1,"path":"/System/Applications/Calculator.app/Contents/MacOS/Calculator","args":["Calculator"]}`,
+				blockPID)),
+		},
+	}
+	postEvents(t, stack, hostToken, seedEvents)
+	waitForProcess(t, stack, hostID, blockPID)
+
+	// First block event: should produce an alert with
+	// source=application_control.
+	const ruleID = "app_control:7"
+	customMsg := "Blocked: Calculator is not allowed by policy"
+	blockEvent := detectionapi.Event{
+		EventID:     "ac-block-1",
+		HostID:      hostID,
+		TimestampNs: now + 2,
+		EventType:   "application_control_block",
+		Payload: blockPayload(blockPayloadInput{
+			PID:           blockPID,
+			Path:          "/System/Applications/Calculator.app/Contents/MacOS/Calculator",
+			RuleID:        ruleID,
+			RuleType:      "BINARY",
+			Identifier:    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			Severity:      "high",
+			CustomMsg:     &customMsg,
+			PolicyID:      11,
+			PolicyVersion: 3,
+		}),
+	}
+	postEvents(t, stack, hostToken, []detectionapi.Event{blockEvent})
+
+	var alert detectionapi.Alert
+	require.Eventually(t, func() bool {
+		alerts, err := stack.DetectionService().ListAlerts(t.Context(), detectionapi.AlertFilter{
+			HostID: hostID,
+			Source: detectionapi.AlertSourceApplicationControl,
+		})
+		if err != nil || len(alerts) == 0 {
+			return false
+		}
+		alert = alerts[0]
+		return true
+	}, 5*time.Second, 50*time.Millisecond, "application control block event must surface as an alert")
+
+	assert.Equal(t, detectionapi.AlertSourceApplicationControl, alert.Source)
+	assert.Equal(t, ruleID, alert.RuleID)
+	assert.Equal(t, "high", alert.Severity)
+	assert.Equal(t, customMsg, alert.Description, "operator's custom_msg is the alert description")
+	assert.Contains(t, alert.Title, "Calculator", "alert title should name the blocked binary")
+
+	// Re-post the same block (fresh event_id, same rule+host+process):
+	// the alert dedup gate should keep the row count at 1.
+	repeat := detectionapi.Event{
+		EventID:     "ac-block-2",
+		HostID:      hostID,
+		TimestampNs: now + 3,
+		EventType:   "application_control_block",
+		Payload: blockPayload(blockPayloadInput{
+			PID:           blockPID,
+			Path:          "/System/Applications/Calculator.app/Contents/MacOS/Calculator",
+			RuleID:        ruleID,
+			RuleType:      "BINARY",
+			Identifier:    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			Severity:      "high",
+			CustomMsg:     &customMsg,
+			PolicyID:      11,
+			PolicyVersion: 3,
+		}),
+	}
+	postEvents(t, stack, hostToken, []detectionapi.Event{repeat})
+
+	// Wait long enough for the processor to have observed the second
+	// event, then assert dedup held.
+	require.Eventually(t, func() bool {
+		count, err := stack.DetectionService().ListAlerts(t.Context(), detectionapi.AlertFilter{
+			HostID: hostID,
+			Source: detectionapi.AlertSourceApplicationControl,
+		})
+		return err == nil && len(count) == 1
+	}, 2*time.Second, 50*time.Millisecond, "repeat block on same (rule, process) must dedup into one alert row")
+}
+
+// TestAppControlBlock_DefaultDescriptionWhenCustomMsgAbsent verifies
+// the server-detection-rules-engine spec's default summary contract:
+// when the operator did not author a custom_msg, the alert description
+// falls back to "Blocked <rule_type> rule for <identifier>".
+func TestAppControlBlock_DefaultDescriptionWhenCustomMsgAbsent(t *testing.T) {
+	stack := Setup(t)
+
+	const hostID = "CCCC1111-2222-3333-4444-555566667777"
+	const blockPID = 6262
+	hostToken := stepEnroll(t, stack, hostID)
+
+	now := time.Now().UnixNano()
+	postEvents(t, stack, hostToken, []detectionapi.Event{
+		{
+			EventID: "ac-fork-default", HostID: hostID, TimestampNs: now, EventType: "fork",
+			Payload: json.RawMessage(fmt.Sprintf(`{"child_pid":%d,"parent_pid":1}`, blockPID)),
+		},
+		{
+			EventID: "ac-exec-default", HostID: hostID, TimestampNs: now + 1, EventType: "exec",
+			Payload: json.RawMessage(fmt.Sprintf(`{"pid":%d,"ppid":1,"path":"/bin/ls","args":["ls"]}`, blockPID)),
+		},
+	})
+	waitForProcess(t, stack, hostID, blockPID)
+
+	const sha = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	postEvents(t, stack, hostToken, []detectionapi.Event{{
+		EventID:     "ac-block-default",
+		HostID:      hostID,
+		TimestampNs: now + 2,
+		EventType:   "application_control_block",
+		Payload: blockPayload(blockPayloadInput{
+			PID:           blockPID,
+			Path:          "/bin/ls",
+			RuleID:        "app_control:12",
+			RuleType:      "BINARY",
+			Identifier:    sha,
+			Severity:      "medium",
+			PolicyID:      11,
+			PolicyVersion: 4,
+		}),
+	}})
+
+	var alert detectionapi.Alert
+	require.Eventually(t, func() bool {
+		alerts, err := stack.DetectionService().ListAlerts(t.Context(), detectionapi.AlertFilter{
+			HostID: hostID,
+			Source: detectionapi.AlertSourceApplicationControl,
+		})
+		if err != nil || len(alerts) == 0 {
+			return false
+		}
+		alert = alerts[0]
+		return true
+	}, 5*time.Second, 50*time.Millisecond)
+
+	assert.Equal(t, "Blocked BINARY rule for "+sha, alert.Description,
+		"missing custom_msg must fall back to the deterministic default")
+}
+
+type blockPayloadInput struct {
+	PID           int
+	Path          string
+	RuleID        string
+	RuleType      string
+	Identifier    string
+	Severity      string
+	CustomMsg     *string
+	CustomURL     *string
+	PolicyID      int64
+	PolicyVersion int64
+}
+
+// blockPayload renders the JSON shape the extension emits for an
+// application_control_block event. Kept as a local helper so the
+// wire-tag contract is exercised by the test rather than imported
+// from production code.
+func blockPayload(in blockPayloadInput) json.RawMessage {
+	type wire struct {
+		PID           int     `json:"pid"`
+		Path          string  `json:"path"`
+		RuleID        string  `json:"rule_id"`
+		RuleType      string  `json:"rule_type"`
+		Identifier    string  `json:"identifier"`
+		Severity      string  `json:"severity"`
+		CustomMsg     *string `json:"custom_msg,omitempty"`
+		CustomURL     *string `json:"custom_url,omitempty"`
+		PolicyID      int64   `json:"policy_id"`
+		PolicyVersion int64   `json:"policy_version"`
+	}
+	b, _ := json.Marshal(wire{
+		PID: in.PID, Path: in.Path,
+		RuleID: in.RuleID, RuleType: in.RuleType, Identifier: in.Identifier,
+		Severity: in.Severity, CustomMsg: in.CustomMsg, CustomURL: in.CustomURL,
+		PolicyID: in.PolicyID, PolicyVersion: in.PolicyVersion,
+	})
+	return b
+}
+
+func postEvents(t *testing.T, stack *Stack, hostToken string, events []detectionapi.Event) {
+	t.Helper()
+	body, err := json.Marshal(events)
+	require.NoError(t, err)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost,
+		stack.Server.URL+"/api/events", bytes.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+hostToken)
+	resp, err := stack.Server.Client().Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode, "POST /api/events status")
+}
+
+func waitForProcess(t *testing.T, stack *Stack, hostID string, pid int) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		p, err := stack.DetectionService().GetProcessDetail(t.Context(), hostID, pid, time.Now().UnixNano())
+		return err == nil && p != nil
+	}, 5*time.Second, 50*time.Millisecond, "processor must materialise the seed process row")
+}

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -102,6 +102,11 @@ export interface Alert {
   id: number;
   host_id: string;
   rule_id: string;
+  // source is "detection" for catalog-rule findings and
+  // "application_control" for blocks emitted by the extension's
+  // AUTH_EXEC decision walker. Surfaced so the UI can chip / filter
+  // alerts by origin without re-parsing rule_id.
+  source: string;
   severity: string;
   title: string;
   description: string;


### PR DESCRIPTION
…view)

Closes demo beat #8: an AUTH_EXEC denial on the host produces a row in the alerts view alongside catalog-rule findings.

Server side
- detection/api/types.go: new AlertSourceDetection / AlertSourceApplicationControl constants; Source field on Alert, Finding, and AlertFilter.
- detection/bootstrap/schema.go: source ENUM('detection', 'application_control') column on alerts (default 'detection'); the unique dedup key promotes to (source, host_id, rule_id, process_id) so a catalog rule and an app-control rule that happen to share an identifier never collapse into one row.
- detection/internal/mysql/alerts.go: source threaded through every insert / select / count / dedup lookup; defense-in-depth defaults blank Source to 'detection' so callers that forget the field land in the catalog-rule bucket instead of hitting MySQL's truncated- ENUM error.
- detection/internal/engine/engine.go: persistFinding stamps the Finding's Source onto the alert, defaulting to AlertSourceDetection when blank (catalog rules don't need to set it).

Rule
- rules/internal/catalog/application_control_block.go: built-in catalog rule that maps every application_control_block ingest event to a Finding with Source=application_control. Description prefers the operator's custom_msg, falling back to "Blocked <rule_type> rule for <identifier>" per spec.
- rules/internal/catalog/registry.go: register the rule alongside the catalog detection rules so it loads via the existing rulesCtx.ContentService() -> detectionCtx.LoadActive() path.

Wire
- rules/api/types.go: new RuleID string field on SetApplicationControlRule + ApplicationControlRuleID() helper that renders "app_control:<numeric_id>" so the extension echoes a stable string identifier in the block event; alert dedup never collides with catalog rule ids.
- schema/events.json: register application_control_block event_type and the matching payload schema.

Extension
- ApplicationControlStore.swift: ruleID on the Codable rule struct; decodes the new rule_id wire field.
- EventSerializer.swift: ApplicationControlBlockPayload Codable matching the Go decode struct field-for-field.
- ESFSubscriber.swift: emitBlockEvent() builds the payload and hands it to onEvent after the DENY response so the JSON encode + XPC handoff happen off the AUTH callback's kernel deadline.

UI
- types.ts: Alert.source field so the alerts page can chip / filter by origin without re-parsing rule_id (the filter chip itself is step 9 polish; this lands the field so step-5 / step-9 don't have to retroactively widen the type).

Tests
- rules/internal/catalog/application_control_block_test.go: table- driven unit test for every branch of the rule (happy path, missing rule_id / severity, missing process row, custom_msg default), plus the GraphReader-error propagation case.
- rules/internal/catalog/registry_test.go + rules/internal/tests/ integration_test.go: count + roster updated to include the new rule.
- rules/api/app_control_wire_test.go: rule_id round-trip pinned in both the example-based and rapid PBT round-trip tests.
- test/integration/app_control_block_test.go: cross-context test exercising the demo path end-to-end -- agent posts a block event, it surfaces as an alert with source=application_control; re-post the same block dedups into one row; missing custom_msg lands the spec's deterministic default description.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Application control blocking now generates tracked alerts when execution attempts are denied
  * Alerts include a source field to distinguish between detection-based and application control-based origins
  * Application control block events support optional custom messages and URLs for operator context

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/getvictor/fleet-edr/pull/155)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->