### PR TITLE
App Control demo cut step 6: host-app notification modal (Phase B pul…

### DIFF
--- a/extension/edr/com.fleetdm.edr.notify.plist
+++ b/extension/edr/com.fleetdm.edr.notify.plist
@@ -51,9 +51,24 @@
 	<key>ProcessType</key>
 	<string>Interactive</string>
 
-	<key>StandardOutPath</key>
-	<string>/tmp/fleet-edr-notify.log</string>
-	<key>StandardErrorPath</key>
-	<string>/tmp/fleet-edr-notify.log</string>
+	<!--
+	    No StandardOutPath / StandardErrorPath: the host app routes
+	    its output through os_log (Logger(subsystem: "com.fleetdm.edr"))
+	    so anything worth keeping shows up in the unified log and is
+	    queryable via `log show --predicate 'subsystem == "com.fleetdm.edr"'`.
+	    A shared file path under /tmp would race across users on a
+	    multi-user install (the first user's launchd creates the file
+	    with permissions that lock out later sessions) — caught by
+	    Gemini + Copilot on PR #157.
+
+	    Packaging note: the dist/pkg path does NOT yet copy this
+	    plist into /Library/LaunchAgents. The demo dry-run runs the
+	    host app manually in a Terminal session
+	    (`sudo /Applications/Fleet\ EDR.app/Contents/MacOS/edr notify`)
+	    so the daemon's Mach lookup lands in the same bootstrap
+	    namespace as the user's process. Production packaging hooks
+	    are a follow-up tracked alongside the LaunchAgent installer
+	    work.
+	-->
 </dict>
 </plist>

--- a/extension/edr/com.fleetdm.edr.notify.plist
+++ b/extension/edr/com.fleetdm.edr.notify.plist
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!--
+	    Fleet EDR per-user notification surface (LaunchAgent).
+	    Run by launchd in each user's session, this plist starts
+	    the host app in `notify` mode so the system extension's
+	    NotificationClient can post AUTH_EXEC-denial modals.
+
+	    Install path (per user): ~/Library/LaunchAgents/com.fleetdm.edr.notify.plist
+	    System-wide alternative: /Library/LaunchAgents/com.fleetdm.edr.notify.plist
+	    The system-wide path requires a logout/login cycle on first install.
+	-->
+	<key>Label</key>
+	<string>com.fleetdm.edr.notify</string>
+
+	<key>ProgramArguments</key>
+	<array>
+		<string>/Applications/Fleet EDR.app/Contents/MacOS/edr</string>
+		<string>notify</string>
+	</array>
+
+	<!--
+	    MachServices binds the XPC name the extension connects to.
+	    launchd routes the first connection to this Mach service to
+	    spawning the host app, so the notify surface is on-demand
+	    rather than always-resident. The name matches the
+	    blockNotificationServiceName constant baked into both
+	    extension/NotificationClient.swift and edr/BlockNotification.swift.
+	-->
+	<key>MachServices</key>
+	<dict>
+		<key>FDG8Q7N4CC.com.fleetdm.edr.notifications</key>
+		<true/>
+	</dict>
+
+	<key>RunAtLoad</key>
+	<false/>
+
+	<!--
+	    KeepAlive=false: the agent re-spawns the process on demand
+	    via the Mach service binding. A crashed host app stays down
+	    until the next AUTH_EXEC denial, which is the desired
+	    behaviour — we don't want a CPU-burning crashloop on the
+	    user's desktop. The next denial spawns a fresh instance.
+	-->
+	<key>KeepAlive</key>
+	<false/>
+
+	<key>ProcessType</key>
+	<string>Interactive</string>
+
+	<key>StandardOutPath</key>
+	<string>/tmp/fleet-edr-notify.log</string>
+	<key>StandardErrorPath</key>
+	<string>/tmp/fleet-edr-notify.log</string>
+</dict>
+</plist>

--- a/extension/edr/edr/BlockAlert.swift
+++ b/extension/edr/edr/BlockAlert.swift
@@ -45,10 +45,12 @@ final class BlockAlertPresenterAppKit: NSObject, BlockAlertPresenter {
     func present(_ notification: BlockNotificationPayload) {
         queue.async { [weak self] in
             guard let self else { return }
-            if self.shouldDedup(notification) {
-                logger.info("suppressed duplicate block alert within dedup window")
-                return
-            }
+            // Dedup is re-checked synchronously on the main queue
+            // right before the modal is shown — see showAlert.
+            // Checking here too would only suppress arrivals while
+            // the queue is idle; a long-open modal can wait minutes,
+            // during which more duplicates accumulate and would
+            // pass an early-stage dedup with a stale timestamp.
             DispatchQueue.main.sync {
                 self.showAlert(notification)
             }
@@ -57,7 +59,11 @@ final class BlockAlertPresenterAppKit: NSObject, BlockAlertPresenter {
 
     /// shouldDedup returns true when we've shown an alert with the
     /// same `(rule_id, binary_path)` tuple within `dedupWindow`.
-    /// Called on `queue`; no lock needed.
+    /// Called from showAlert on the main queue — the synchronous
+    /// hop in present() guarantees we re-check at presentation time
+    /// rather than enqueue time, so a 60s-open modal followed by 10
+    /// queued duplicates produces one new alert (the first that
+    /// arrives past the window), not all 10 in succession.
     private func shouldDedup(_ notification: BlockNotificationPayload) -> Bool {
         let key = notification.ruleID + "|" + notification.binaryPath
         let now = Date()
@@ -71,6 +77,10 @@ final class BlockAlertPresenterAppKit: NSObject, BlockAlertPresenter {
     }
 
     private func showAlert(_ notification: BlockNotificationPayload) {
+        if shouldDedup(notification) {
+            logger.info("suppressed duplicate block alert within dedup window")
+            return
+        }
         let alert = NSAlert()
         alert.alertStyle = .warning
         alert.messageText = "Application blocked: \(binaryDisplayName(notification.binaryPath))"
@@ -79,22 +89,27 @@ final class BlockAlertPresenterAppKit: NSObject, BlockAlertPresenter {
         let dismissButton = alert.addButton(withTitle: "Dismiss")
         dismissButton.tag = NSApplication.ModalResponse.alertFirstButtonReturn.rawValue
 
+        // moreURL is non-nil iff the operator authored a "More info"
+        // link AND it parsed to an http/https URL. Other schemes
+        // (file://, custom URI handlers) are rejected so a hostile
+        // rule author can't trigger arbitrary URL handlers from a
+        // single click on the alert.
+        var moreURL: URL?
         if let urlString = notification.customURL,
            let url = URL(string: urlString),
            url.scheme == "https" || url.scheme == "http" {
             let moreButton = alert.addButton(withTitle: "More info")
             moreButton.tag = NSApplication.ModalResponse.alertSecondButtonReturn.rawValue
-            // Bring the host app forward so the modal lands on top
-            // of whatever window the user was looking at.
-            NSApp.activate(ignoringOtherApps: true)
-            let response = alert.runModal()
-            if response == .alertSecondButtonReturn {
-                NSWorkspace.shared.open(url)
-            }
-            return
+            moreURL = url
         }
+
+        // Bring the host app forward so the modal lands on top of
+        // whatever window the user was looking at.
         NSApp.activate(ignoringOtherApps: true)
-        _ = alert.runModal()
+        let response = alert.runModal()
+        if response == .alertSecondButtonReturn, let url = moreURL {
+            NSWorkspace.shared.open(url)
+        }
     }
 
     /// body picks the alert's informativeText: prefers the

--- a/extension/edr/edr/BlockAlert.swift
+++ b/extension/edr/edr/BlockAlert.swift
@@ -1,0 +1,124 @@
+import AppKit
+import Foundation
+import os.log
+
+private let logger = Logger(subsystem: "com.fleetdm.edr", category: "BlockAlert")
+
+/// BlockAlertPresenter is the protocol the XPC listener calls into.
+/// Real life uses BlockAlertPresenterAppKit; tests use a fake.
+protocol BlockAlertPresenter {
+    func present(_ notification: BlockNotificationPayload)
+}
+
+/// BlockAlertPresenterAppKit renders one NSAlert per accepted
+/// block-notification. The visual is intentionally Santa-shaped:
+/// an icon-bearing modal with the rule's `custom_msg` in the body
+/// and a "More info" / "Dismiss" button pair. The host app runs as
+/// an NSApplication with accessory activation policy so the alert
+/// appears as a floating modal without putting an icon in the Dock.
+///
+/// Serialisation: NSAlert.runModal blocks the calling thread, so we
+/// process notifications on a dedicated serial queue and hop to the
+/// main queue with `DispatchQueue.main.sync` to show each alert.
+/// The queue's serial nature means two blocked execs back-to-back
+/// produce two modals shown one after the other — never overlapping
+/// — and the receive ordering matches the AUTH_EXEC denial ordering.
+///
+/// Dedup: a (rule_id, binary_path) tuple seen within the last
+/// `dedupWindow` is suppressed. The extension's AUTH_EXEC handler
+/// fires on every exec attempt, and a misbehaving caller might
+/// retry many times in a tight loop; we don't want to bury the
+/// user's screen in modals.
+final class BlockAlertPresenterAppKit: NSObject, BlockAlertPresenter {
+    private let queue = DispatchQueue(label: "com.fleetdm.edr.block-alert")
+    private let dedupWindow: TimeInterval
+    private var recent: [String: Date] = [:]
+
+    /// dedupWindow defaults to 30 seconds. Long enough that the
+    /// human at the keyboard pressing Cmd-Click → Open repeatedly on
+    /// the same app doesn't paper their screen, short enough that a
+    /// later genuine re-exec attempt still surfaces visibly.
+    init(dedupWindow: TimeInterval = 30) {
+        self.dedupWindow = dedupWindow
+    }
+
+    func present(_ notification: BlockNotificationPayload) {
+        queue.async { [weak self] in
+            guard let self else { return }
+            if self.shouldDedup(notification) {
+                logger.info("suppressed duplicate block alert within dedup window")
+                return
+            }
+            DispatchQueue.main.sync {
+                self.showAlert(notification)
+            }
+        }
+    }
+
+    /// shouldDedup returns true when we've shown an alert with the
+    /// same `(rule_id, binary_path)` tuple within `dedupWindow`.
+    /// Called on `queue`; no lock needed.
+    private func shouldDedup(_ notification: BlockNotificationPayload) -> Bool {
+        let key = notification.ruleID + "|" + notification.binaryPath
+        let now = Date()
+        // Purge entries older than the window to keep the map bounded.
+        recent = recent.filter { $0.value.addingTimeInterval(dedupWindow) > now }
+        if let last = recent[key], last.addingTimeInterval(dedupWindow) > now {
+            return true
+        }
+        recent[key] = now
+        return false
+    }
+
+    private func showAlert(_ notification: BlockNotificationPayload) {
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        alert.messageText = "Application blocked: \(binaryDisplayName(notification.binaryPath))"
+        alert.informativeText = body(notification)
+
+        let dismissButton = alert.addButton(withTitle: "Dismiss")
+        dismissButton.tag = NSApplication.ModalResponse.alertFirstButtonReturn.rawValue
+
+        if let urlString = notification.customURL,
+           let url = URL(string: urlString),
+           url.scheme == "https" || url.scheme == "http" {
+            let moreButton = alert.addButton(withTitle: "More info")
+            moreButton.tag = NSApplication.ModalResponse.alertSecondButtonReturn.rawValue
+            // Bring the host app forward so the modal lands on top
+            // of whatever window the user was looking at.
+            NSApp.activate(ignoringOtherApps: true)
+            let response = alert.runModal()
+            if response == .alertSecondButtonReturn {
+                NSWorkspace.shared.open(url)
+            }
+            return
+        }
+        NSApp.activate(ignoringOtherApps: true)
+        _ = alert.runModal()
+    }
+
+    /// body picks the alert's informativeText: prefers the
+    /// operator-authored custom message when set, otherwise renders
+    /// a deterministic default (Santa-shaped: "<binary> was blocked
+    /// by your organization's security policy").
+    private func body(_ notification: BlockNotificationPayload) -> String {
+        if let custom = notification.customMsg, !custom.isEmpty {
+            return custom
+        }
+        let name = binaryDisplayName(notification.binaryPath)
+        return "\(name) was blocked by your organization's security policy."
+    }
+
+    /// binaryDisplayName picks the last path component when it's
+    /// useful, otherwise falls back to the full path. The hash
+    /// path-component cases (".", "/", "") shouldn't happen with
+    /// real ESF input but the guard keeps the alert text sane in
+    /// the synthetic-fixture regression-test path.
+    private func binaryDisplayName(_ path: String) -> String {
+        let name = (path as NSString).lastPathComponent
+        if name.isEmpty || name == "." || name == "/" {
+            return path
+        }
+        return name
+    }
+}

--- a/extension/edr/edr/BlockNotification.swift
+++ b/extension/edr/edr/BlockNotification.swift
@@ -35,21 +35,26 @@ let blockNotificationPeerRequirement =
 /// future analytics ping without re-querying the server.
 struct BlockNotificationPayload: Codable, Sendable {
     /// Stable rule identifier (e.g. "app_control:42") that the
-    /// server alert mapping uses. The host app surfaces it in the
-    /// alert text only when no custom_msg is set.
+    /// server alert mapping uses. Travels for forensic correlation
+    /// only — today's host-app UI doesn't render it; the operator
+    /// inspects the server alerts view to see which rule fired.
     let ruleID: String
     /// Rule type token (BINARY today; the others come post-demo).
     let ruleType: String
     /// Matched identifier value — the file SHA-256 for a BINARY
-    /// rule. The host app shows the first 12 hex chars so the
-    /// alert text doesn't sprawl across the screen.
+    /// rule. Travels for forensic correlation; the host-app UI
+    /// does not currently render it.
     let identifier: String
     /// Operator-authored custom message. When set, this is the
-    /// alert's main body verbatim.
+    /// alert's body verbatim. When unset / empty, the presenter
+    /// falls back to "<binary> was blocked by your organization's
+    /// security policy."
     let customMsg: String?
-    /// Operator-authored "More info" URL. When set + parsable,
-    /// the alert renders a "More info" button that opens the URL
-    /// in the user's default browser.
+    /// Operator-authored "More info" URL. When set + parsable as
+    /// an http or https URL, the alert renders a "More info"
+    /// button that opens the link in the user's default browser.
+    /// Other schemes are rejected so a hostile rule author can't
+    /// trigger arbitrary URL handlers from a single click.
     let customURL: String?
     /// Absolute path of the binary the extension denied. The host
     /// app shows the binary's basename in the alert headline so a

--- a/extension/edr/edr/BlockNotification.swift
+++ b/extension/edr/edr/BlockNotification.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+/// Mach service name the host app vends so the system extension can
+/// push a desktop notification on every AUTH_EXEC denial. The
+/// team-id prefix matches the convention the agent ↔ extension XPC
+/// channel already uses (`FDG8Q7N4CC.com.fleetdm.edr.securityextension.xpc`).
+///
+/// Visibility: declared in `edr/edr/Info.plist`'s `MachServices` so
+/// launchd registers the name when the host app is launched via the
+/// LaunchAgent plist shipped alongside this file. For the demo dry-
+/// run on the SIP-disabled VM the host app can also be started
+/// manually with `edr notify`; the listener self-registers the name
+/// in that case too.
+let blockNotificationServiceName = "FDG8Q7N4CC.com.fleetdm.edr.notifications"
+
+/// Stable wire-shape identifier for the block-notification message.
+/// Mirrors the `type` key convention the extension's existing XPC
+/// peer protocol uses (`application_control.update`, `hello`).
+let blockNotificationMessageType = "application_control.block_notification"
+
+/// Code-signing requirement both ends apply to the peer. Same team
+/// ID as the agent ↔ extension channel: any binary signed by Fleet
+/// Device Management can speak the protocol. Phase B extends this
+/// with notarization checks for production deployments.
+let blockNotificationPeerRequirement =
+    "anchor apple generic and certificate leaf[subject.OU] = \"FDG8Q7N4CC\""
+
+/// BlockNotificationPayload is the JSON shape the extension serialises
+/// into the XPC message's `data` field. Field tags match the
+/// snake_case wire convention used elsewhere in the project (see
+/// schema/events.json). The host app decodes via Codable.
+///
+/// Both ruleID and policyID/policyVersion travel in the payload so the
+/// host app can include them in any "More info" deep-link path or
+/// future analytics ping without re-querying the server.
+struct BlockNotificationPayload: Codable, Sendable {
+    /// Stable rule identifier (e.g. "app_control:42") that the
+    /// server alert mapping uses. The host app surfaces it in the
+    /// alert text only when no custom_msg is set.
+    let ruleID: String
+    /// Rule type token (BINARY today; the others come post-demo).
+    let ruleType: String
+    /// Matched identifier value — the file SHA-256 for a BINARY
+    /// rule. The host app shows the first 12 hex chars so the
+    /// alert text doesn't sprawl across the screen.
+    let identifier: String
+    /// Operator-authored custom message. When set, this is the
+    /// alert's main body verbatim.
+    let customMsg: String?
+    /// Operator-authored "More info" URL. When set + parsable,
+    /// the alert renders a "More info" button that opens the URL
+    /// in the user's default browser.
+    let customURL: String?
+    /// Absolute path of the binary the extension denied. The host
+    /// app shows the binary's basename in the alert headline so a
+    /// row reads "Application blocked: Calculator" rather than
+    /// drowning the column in a full path.
+    let binaryPath: String
+    /// Policy id from the snapshot the extension was holding at
+    /// decision time. Travels for forensic correlation only —
+    /// today's host-app UI doesn't render it.
+    let policyID: Int64
+    /// Policy version from the same snapshot. Same forensic-only
+    /// rationale.
+    let policyVersion: Int64
+
+    enum CodingKeys: String, CodingKey {
+        case ruleID = "rule_id"
+        case ruleType = "rule_type"
+        case identifier
+        case customMsg = "custom_msg"
+        case customURL = "custom_url"
+        case binaryPath = "binary_path"
+        case policyID = "policy_id"
+        case policyVersion = "policy_version"
+    }
+}

--- a/extension/edr/edr/Info.plist
+++ b/extension/edr/edr/Info.plist
@@ -16,5 +16,19 @@
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>LSBackgroundOnly</key>
 	<true/>
+	<!--
+	    MachServices declares the XPC service name the host app
+	    vends in `notify` mode. launchd registers the name when the
+	    LaunchAgent (Library/LaunchAgents/com.fleetdm.edr.notify.plist)
+	    starts the host app under a user session, so the system
+	    extension's NotificationClient can connect by name without
+	    bootstrap_check_in plumbing. The team-id prefix matches the
+	    convention the agent ↔ extension XPC channel already uses.
+	-->
+	<key>MachServices</key>
+	<dict>
+		<key>FDG8Q7N4CC.com.fleetdm.edr.notifications</key>
+		<true/>
+	</dict>
 </dict>
 </plist>

--- a/extension/edr/edr/Info.plist
+++ b/extension/edr/edr/Info.plist
@@ -14,7 +14,18 @@
 	<string>APPL</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
-	<key>LSBackgroundOnly</key>
+	<!--
+	    LSUIElement (not LSBackgroundOnly): the bundle has to be able
+	    to present an NSAlert modal in `notify` mode, but it should
+	    NOT claim a Dock icon for the other CLI modes (activate /
+	    enable-filter / disable-filter etc.) which run, print, and
+	    exit. LSUIElement gives us both: AppKit can show UI when we
+	    ask it to, and the app stays invisible in the Dock and Cmd-
+	    Tab switcher otherwise. LSBackgroundOnly was the wrong key —
+	    it would have silently suppressed NSAlert presentation on
+	    every block, as Copilot flagged on PR #157.
+	-->
+	<key>LSUIElement</key>
 	<true/>
 	<!--
 	    MachServices declares the XPC service name the host app

--- a/extension/edr/edr/NotificationListener.swift
+++ b/extension/edr/edr/NotificationListener.swift
@@ -1,0 +1,115 @@
+import Foundation
+import os.log
+
+private let logger = Logger(subsystem: "com.fleetdm.edr", category: "NotificationListener")
+
+/// NotificationListener is the host-app's inbound XPC surface. It
+/// vends the Mach service the extension's NotificationClient
+/// connects to, validates the peer is signed by Fleet, decodes the
+/// block-notification payload, and dispatches each accepted message
+/// to the BlockAlert presenter.
+///
+/// Mirrors the extension's existing XPCServer shape on purpose: same
+/// listener model, same per-peer event handler, same code-signing
+/// requirement string. Keeping the two surfaces structurally similar
+/// means a fix in one (a CodeRabbit-flagged race, a missing nil
+/// check) is easy to port to the other.
+final class NotificationListener {
+    private let serviceName: String
+    private let presenter: BlockAlertPresenter
+    private let queue = DispatchQueue(label: "com.fleetdm.edr.notification-listener")
+    private var listener: xpc_connection_t?
+    private var peers: Set<NotificationPeer> = []
+
+    init(serviceName: String = blockNotificationServiceName, presenter: BlockAlertPresenter) {
+        self.serviceName = serviceName
+        self.presenter = presenter
+    }
+
+    func start() {
+        let conn = xpc_connection_create_mach_service(
+            serviceName, queue,
+            UInt64(XPC_CONNECTION_MACH_SERVICE_LISTENER)
+        )
+        xpc_connection_set_event_handler(conn) { [weak self] event in
+            self?.handleListenerEvent(event)
+        }
+        xpc_connection_activate(conn)
+        listener = conn
+        logger.info("notification listener started on \(self.serviceName, privacy: .public)")
+    }
+
+    private func handleListenerEvent(_ event: xpc_object_t) {
+        let type = xpc_get_type(event)
+        if type == XPC_TYPE_CONNECTION {
+            let result = xpc_connection_set_peer_code_signing_requirement(event, blockNotificationPeerRequirement)
+            if result != 0 {
+                logger.error("set peer code signing on notification listener: \(result, privacy: .public)")
+                xpc_connection_cancel(event)
+                return
+            }
+            let peer = NotificationPeer(connection: event)
+            peers.insert(peer)
+            logger.info("notification peer connected (total: \(self.peers.count, privacy: .public))")
+            xpc_connection_set_event_handler(event) { [weak self] peerEvent in
+                let peerType = xpc_get_type(peerEvent)
+                if peerType == XPC_TYPE_ERROR {
+                    self?.queue.async {
+                        self?.peers.remove(peer)
+                        logger.info("notification peer disconnected (total: \(self?.peers.count ?? 0, privacy: .public))")
+                    }
+                    return
+                }
+                if peerType == XPC_TYPE_DICTIONARY {
+                    self?.handlePeerMessage(peerEvent)
+                }
+            }
+            xpc_connection_activate(event)
+        } else if type == XPC_TYPE_ERROR {
+            logger.error("notification listener error")
+        }
+    }
+
+    private func handlePeerMessage(_ event: xpc_object_t) {
+        guard let typeCStr = xpc_dictionary_get_string(event, "type") else {
+            return
+        }
+        let kind = String(cString: typeCStr)
+        guard kind == blockNotificationMessageType else {
+            // type is peer-supplied; redact in the unified log so a
+            // compromised peer cannot inject arbitrary strings.
+            logger.info("ignored XPC message of unknown type: \(kind, privacy: .private)")
+            return
+        }
+        var dataLen = 0
+        guard let rawPtr = xpc_dictionary_get_data(event, "data", &dataLen), dataLen > 0 else {
+            logger.error("block notification missing 'data'")
+            return
+        }
+        let data = Data(bytes: rawPtr, count: dataLen)
+        let decoder = JSONDecoder()
+        let payload: BlockNotificationPayload
+        do {
+            payload = try decoder.decode(BlockNotificationPayload.self, from: data)
+        } catch {
+            logger.error("decode block notification: \(error.localizedDescription, privacy: .public)")
+            return
+        }
+        presenter.present(payload)
+    }
+}
+
+/// NotificationPeer wraps an xpc_connection_t so we can store it in
+/// a Set. Same shape as the agent ↔ extension XPCServer's XPCPeer.
+private final class NotificationPeer: Hashable {
+    let connection: xpc_connection_t
+    init(connection: xpc_connection_t) {
+        self.connection = connection
+    }
+    static func == (lhs: NotificationPeer, rhs: NotificationPeer) -> Bool {
+        lhs.connection === rhs.connection
+    }
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(ObjectIdentifier(connection as AnyObject))
+    }
+}

--- a/extension/edr/edr/NotificationListener.swift
+++ b/extension/edr/edr/NotificationListener.swift
@@ -72,6 +72,12 @@ final class NotificationListener {
 
     private func handlePeerMessage(_ event: xpc_object_t) {
         guard let typeCStr = xpc_dictionary_get_string(event, "type") else {
+            // Logged at error level so a forensic trail captures any
+            // malformed messages — a missing "type" key would
+            // otherwise vanish silently and a protocol-version drift
+            // between the extension's send and the host app's decode
+            // would be invisible to operators.
+            logger.error("received XPC message missing 'type' key")
             return
         }
         let kind = String(cString: typeCStr)

--- a/extension/edr/edr/main.swift
+++ b/extension/edr/edr/main.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import NetworkExtension
 import os.log
@@ -174,6 +175,30 @@ private func disableDNSProxy() {
     }
 }
 
+/// runNotifyMode keeps the host app alive as a long-running
+/// accessory NSApplication, vending the block-notification XPC
+/// service and presenting NSAlert modals on every accepted
+/// AUTH_EXEC-denied notification. Distinct from the other CLI
+/// modes (one-shot extension activation, filter toggles) which run
+/// dispatchMain and exit on completion — the notify surface has no
+/// terminal state by design.
+///
+/// Runs as `.accessory` so a modal can appear without the app
+/// claiming a Dock icon. `app.run()` (not dispatchMain()) is what
+/// AppKit needs to dispatch input events that NSAlert depends on.
+private func runNotifyMode() {
+    let app = NSApplication.shared
+    app.setActivationPolicy(.accessory)
+    let presenter = BlockAlertPresenterAppKit()
+    let listener = NotificationListener(presenter: presenter)
+    listener.start()
+    logger.info("Application Control notification surface running on \(blockNotificationServiceName, privacy: .public)")
+    // Hold a strong reference so ARC doesn't tear listener down once
+    // main returns from its enclosing scope.
+    _ = listener
+    app.run()
+}
+
 let action = CommandLine.arguments.count > 1 ? CommandLine.arguments[1] : "activate"
 
 switch action {
@@ -193,6 +218,9 @@ case "disable-dns-proxy":
     print("Disabling DNS proxy...")
     disableDNSProxy()
     dispatchMain()
+case "notify":
+    print("Starting Fleet EDR notification surface...")
+    runNotifyMode()
 default:
     let manager = ExtensionManager(action: action)
     manager.run()

--- a/extension/edr/edr/main.swift
+++ b/extension/edr/edr/main.swift
@@ -193,10 +193,14 @@ private func runNotifyMode() {
     let listener = NotificationListener(presenter: presenter)
     listener.start()
     logger.info("Application Control notification surface running on \(blockNotificationServiceName, privacy: .public)")
-    // Hold a strong reference so ARC doesn't tear listener down once
-    // main returns from its enclosing scope.
-    _ = listener
-    app.run()
+    // withExtendedLifetime keeps the listener alive for the duration
+    // of the AppKit run loop. ARC is otherwise free to drop a local
+    // whose only remaining "uses" are inside [weak self] event
+    // handlers, which would silently take the XPC surface offline in
+    // optimised builds — caught by Gemini and Copilot on PR #157.
+    withExtendedLifetime(listener) {
+        app.run()
+    }
 }
 
 let action = CommandLine.arguments.count > 1 ? CommandLine.arguments[1] : "activate"

--- a/extension/edr/extension/BlockNotification.swift
+++ b/extension/edr/extension/BlockNotification.swift
@@ -25,6 +25,13 @@ let blockNotificationPeerRequirement =
 /// BlockNotificationPayload mirrors the host app's Codable shape.
 /// JSON tags are load-bearing — they have to stay in lockstep with
 /// the host-app copy.
+/// See edr/edr/BlockNotification.swift for full field documentation.
+/// In particular:
+///   - ruleID and identifier travel for forensic correlation only.
+///   - customMsg becomes the alert body verbatim when set; the
+///     presenter falls back to a deterministic default otherwise.
+///   - customURL is rendered as a "More info" button only when the
+///     value parses as an http or https URL.
 struct BlockNotificationPayload: Codable, Sendable {
     let ruleID: String
     let ruleType: String

--- a/extension/edr/extension/BlockNotification.swift
+++ b/extension/edr/extension/BlockNotification.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+/// Mirror of edr/edr/BlockNotification.swift for the extension side
+/// of the same XPC channel. Both files have to ship identical
+/// constants + payload shape; the alternative is a shared framework
+/// target, which the current Xcode project deliberately doesn't have
+/// (each binary is a thin slice with its own entitlements set).
+///
+/// Renaming any of these strings is a wire-shape contract break —
+/// the host app's NotificationListener and this NotificationClient
+/// would drift apart and the next AUTH_EXEC denial would silently
+/// fail to surface a user-visible alert.
+
+/// Mach service name vended by the host app. See edr/edr's
+/// MachServices declaration for the launchd registration.
+let blockNotificationServiceName = "FDG8Q7N4CC.com.fleetdm.edr.notifications"
+
+/// Stable wire-shape identifier for the block-notification message.
+let blockNotificationMessageType = "application_control.block_notification"
+
+/// Code-signing requirement both ends apply to the peer.
+let blockNotificationPeerRequirement =
+    "anchor apple generic and certificate leaf[subject.OU] = \"FDG8Q7N4CC\""
+
+/// BlockNotificationPayload mirrors the host app's Codable shape.
+/// JSON tags are load-bearing — they have to stay in lockstep with
+/// the host-app copy.
+struct BlockNotificationPayload: Codable, Sendable {
+    let ruleID: String
+    let ruleType: String
+    let identifier: String
+    let customMsg: String?
+    let customURL: String?
+    let binaryPath: String
+    let policyID: Int64
+    let policyVersion: Int64
+
+    enum CodingKeys: String, CodingKey {
+        case ruleID = "rule_id"
+        case ruleType = "rule_type"
+        case identifier
+        case customMsg = "custom_msg"
+        case customURL = "custom_url"
+        case binaryPath = "binary_path"
+        case policyID = "policy_id"
+        case policyVersion = "policy_version"
+    }
+}

--- a/extension/edr/extension/ESFSubscriber.swift
+++ b/extension/edr/extension/ESFSubscriber.swift
@@ -136,6 +136,12 @@ final class ESFSubscriber: Sendable {
                     matchedIdentifier: sha256,
                     snapshot: snapshot
                 )
+                emitBlockNotification(
+                    target: target,
+                    rule: rule,
+                    matchedIdentifier: sha256,
+                    snapshot: snapshot
+                )
                 return
             }
         } else {
@@ -175,6 +181,33 @@ final class ESFSubscriber: Sendable {
         if let data = serializer.serialize(eventType: "application_control_block", payload: payload) {
             onEvent?(data)
         }
+    }
+
+    /// emitBlockNotification fires the desktop-notification XPC
+    /// message to the host app's listener. Called after the DENY
+    /// response so the kernel is already unblocked; the alert is
+    /// post-hoc UX. Fire-and-forget — NotificationClient swallows
+    /// errors so a missing host app (the LaunchAgent hasn't
+    /// started yet, or the user logged out) doesn't slow the
+    /// AUTH_EXEC handler down.
+    private func emitBlockNotification(
+        target: es_process_t,
+        rule: ApplicationControlRule,
+        matchedIdentifier: String,
+        snapshot: ApplicationControlSnapshot
+    ) {
+        let path = esTokenString(target.executable.pointee.path)
+        let payload = BlockNotificationPayload(
+            ruleID: rule.ruleID,
+            ruleType: rule.ruleType,
+            identifier: matchedIdentifier,
+            customMsg: rule.customMsg,
+            customURL: rule.customURL,
+            binaryPath: path,
+            policyID: snapshot.policyID,
+            policyVersion: snapshot.policyVersion
+        )
+        NotificationClient.shared.notify(payload)
     }
 
     private func handleExec(_ msg: es_message_t) {

--- a/extension/edr/extension/NotificationClient.swift
+++ b/extension/edr/extension/NotificationClient.swift
@@ -25,10 +25,10 @@ final class NotificationClient {
     static let shared = NotificationClient()
 
     private let queue = DispatchQueue(label: "com.fleetdm.edr.securityextension.notification-client")
-    // Encoder is configured once. Sorted keys keeps the wire bytes
-    // byte-identical across runs, which the host-app side relies on
-    // for the existing-alert dedup (two block notifications for the
-    // exact same rule+process collapse into one modal).
+    // Encoder is configured once. Sorted keys makes a captured wire
+    // sample diffable across runs — useful for the unified-log
+    // forensic trail, not for behavior. The host-app side dedups on
+    // (rule_id, binary_path), not on byte-identical JSON.
     private let encoder: JSONEncoder = {
         let e = JSONEncoder()
         e.outputFormatting = .sortedKeys
@@ -47,7 +47,13 @@ final class NotificationClient {
         queue.async { [weak self] in
             guard let self else { return }
             guard let data = self.encodePayload(payload) else { return }
-            let conn = self.acquireConnection()
+            guard let conn = self.acquireConnection() else {
+                // Code-signing install failed; the connection was
+                // cancelled in acquireConnection. Drop the message —
+                // the call site already returned DENY to the kernel,
+                // so swallowing the alert is the safe direction.
+                return
+            }
             let msg = xpc_dictionary_create_empty()
             xpc_dictionary_set_string(msg, "type", blockNotificationMessageType)
             data.withUnsafeBytes { buf in
@@ -76,7 +82,24 @@ final class NotificationClient {
     /// fresh one. Called only from `queue`, so the assignment
     /// doesn't need locking. The event handler resets `connection`
     /// to nil on invalidation so the next call reopens.
-    private func acquireConnection() -> xpc_connection_t {
+    ///
+    /// Returns nil when the peer code-signing requirement fails to
+    /// install. We fail closed in that case rather than send to an
+    /// unvalidated peer — a spoofed notification surface could
+    /// otherwise present arbitrary modal text to the user.
+    ///
+    /// Bootstrap-domain note (Copilot, PR #157): the extension is a
+    /// LaunchDaemon and its Mach lookups land in the system
+    /// bootstrap namespace, while a per-user LaunchAgent registers
+    /// the notification service in the GUI bootstrap. The demo
+    /// dry-run runs the host app inside the same Terminal session
+    /// the operator opens, so the two namespaces overlap and the
+    /// connect succeeds. Production deployment with the LaunchAgent
+    /// installed at /Library/LaunchAgents needs a session-bridging
+    /// helper or sysext-side `xpc_connection_set_target_uid`
+    /// pinning; tracked as Phase B follow-up alongside the
+    /// notification-center integration work.
+    private func acquireConnection() -> xpc_connection_t? {
         if let existing = connection {
             return existing
         }
@@ -88,7 +111,9 @@ final class NotificationClient {
         // posture as the agent ↔ extension channel.
         let req = xpc_connection_set_peer_code_signing_requirement(conn, blockNotificationPeerRequirement)
         if req != 0 {
-            logger.error("set peer code signing on notification client: \(req, privacy: .public)")
+            logger.error("notification client peer code-signing install failed; failing closed: \(req, privacy: .public)")
+            xpc_connection_cancel(conn)
+            return nil
         }
         xpc_connection_set_event_handler(conn) { [weak self] event in
             self?.handleConnectionEvent(event)
@@ -103,12 +128,15 @@ final class NotificationClient {
     /// reopen on the next notify. The expected error path is the
     /// host app exiting (user logged out, the LaunchAgent stopped);
     /// reopening on the next notify covers re-login automatically.
+    ///
+    /// The event handler is dispatched on `queue` by XPC, so
+    /// `connection = nil` is a direct in-handler write rather than a
+    /// queue.async hop — no concurrent reader can observe a torn
+    /// state and the next queued notify sees the nil and reopens.
     private func handleConnectionEvent(_ event: xpc_object_t) {
         let type = xpc_get_type(event)
         if type == XPC_TYPE_ERROR {
-            queue.async { [weak self] in
-                self?.connection = nil
-            }
+            connection = nil
             logger.info("notification client connection invalidated; will reopen on next notify")
         }
     }

--- a/extension/edr/extension/NotificationClient.swift
+++ b/extension/edr/extension/NotificationClient.swift
@@ -1,0 +1,115 @@
+import Foundation
+import os.log
+
+private let logger = Logger(subsystem: "com.fleetdm.edr.securityextension", category: "NotificationClient")
+
+/// NotificationClient is the extension's outbound XPC channel to the
+/// host app's block-notification listener. The decision engine fires
+/// `notify(_:)` after returning DENY to the kernel, so the modal pops
+/// on the user's desktop without ever blocking the AUTH_EXEC callback.
+///
+/// Concurrency: every method routes through a dedicated serial queue.
+/// xpc_connection_t is otherwise free-threaded but using a single
+/// queue gives us a predictable ordering (the second blocked exec's
+/// notification can't beat the first one's), and keeps the host-app
+/// listener from receiving overlapping messages on the same
+/// connection.
+///
+/// Lifecycle: the connection is lazy. We open it on the first
+/// `notify` and keep it for subsequent calls so the steady-state path
+/// is a single xpc_connection_send_message. Reconnection on peer
+/// disconnect is delegated to the next `notify` — XPC's
+/// activate-after-cancel pattern doesn't apply once a connection
+/// hits the invalid state.
+final class NotificationClient {
+    static let shared = NotificationClient()
+
+    private let queue = DispatchQueue(label: "com.fleetdm.edr.securityextension.notification-client")
+    // Encoder is configured once. Sorted keys keeps the wire bytes
+    // byte-identical across runs, which the host-app side relies on
+    // for the existing-alert dedup (two block notifications for the
+    // exact same rule+process collapse into one modal).
+    private let encoder: JSONEncoder = {
+        let e = JSONEncoder()
+        e.outputFormatting = .sortedKeys
+        return e
+    }()
+    private var connection: xpc_connection_t?
+
+    private init() {}
+
+    /// notify enqueues the block-notification message on the
+    /// outbound XPC connection. Fire-and-forget by design: the
+    /// extension already returned DENY to the kernel and the alert
+    /// is post-hoc UX, so a missing host app shouldn't error out
+    /// the call site. Failures are logged and swallowed.
+    func notify(_ payload: BlockNotificationPayload) {
+        queue.async { [weak self] in
+            guard let self else { return }
+            guard let data = self.encodePayload(payload) else { return }
+            let conn = self.acquireConnection()
+            let msg = xpc_dictionary_create_empty()
+            xpc_dictionary_set_string(msg, "type", blockNotificationMessageType)
+            data.withUnsafeBytes { buf in
+                guard let baseAddress = buf.baseAddress else { return }
+                xpc_dictionary_set_data(msg, "data", baseAddress, buf.count)
+            }
+            xpc_connection_send_message(conn, msg)
+        }
+    }
+
+    /// encodePayload renders the JSON bytes the host app's
+    /// JSONDecoder consumes. Failure here is a programmer error
+    /// (the payload is a fixed struct with no failable
+    /// initializers) — log and bail so the call site doesn't get
+    /// noisier handling a case that shouldn't happen.
+    private func encodePayload(_ payload: BlockNotificationPayload) -> Data? {
+        do {
+            return try encoder.encode(payload)
+        } catch {
+            logger.error("encode block notification: \(error.localizedDescription, privacy: .public)")
+            return nil
+        }
+    }
+
+    /// acquireConnection returns the cached connection or opens a
+    /// fresh one. Called only from `queue`, so the assignment
+    /// doesn't need locking. The event handler resets `connection`
+    /// to nil on invalidation so the next call reopens.
+    private func acquireConnection() -> xpc_connection_t {
+        if let existing = connection {
+            return existing
+        }
+        let conn = xpc_connection_create_mach_service(
+            blockNotificationServiceName, queue, 0
+        )
+        // Validate the host app's code signature so a non-Fleet
+        // process can't impersonate the notification surface. Same
+        // posture as the agent ↔ extension channel.
+        let req = xpc_connection_set_peer_code_signing_requirement(conn, blockNotificationPeerRequirement)
+        if req != 0 {
+            logger.error("set peer code signing on notification client: \(req, privacy: .public)")
+        }
+        xpc_connection_set_event_handler(conn) { [weak self] event in
+            self?.handleConnectionEvent(event)
+        }
+        xpc_connection_activate(conn)
+        connection = conn
+        return conn
+    }
+
+    /// handleConnectionEvent observes XPC error events so we can
+    /// drop the cached connection and let `acquireConnection`
+    /// reopen on the next notify. The expected error path is the
+    /// host app exiting (user logged out, the LaunchAgent stopped);
+    /// reopening on the next notify covers re-login automatically.
+    private func handleConnectionEvent(_ event: xpc_object_t) {
+        let type = xpc_get_type(event)
+        if type == XPC_TYPE_ERROR {
+            queue.async { [weak self] in
+                self?.connection = nil
+            }
+            logger.info("notification client connection invalidated; will reopen on next notify")
+        }
+    }
+}


### PR DESCRIPTION
…led forward)

Closes demo beat #6: a denied AUTH_EXEC pops a Santa-shaped NSAlert on the user's desktop with the operator's custom_msg and an optional "More info" link.

Wire shape
- New XPC channel: extension → host app via Mach service `FDG8Q7N4CC.com.fleetdm.edr.notifications`. Message type `application_control.block_notification`; payload is a JSON-encoded BlockNotificationPayload (Codable on both sides, mirrored in extension/edr/extension/BlockNotification.swift and extension/edr/edr/BlockNotification.swift). Code-signing peer requirement matches the agent ↔ extension channel: any binary signed by team FDG8Q7N4CC.

Extension side
- NotificationClient.swift: lazy outbound XPC connection with the standard team-id peer-requirement gate. Serial queue keeps the ordering predictable; xpc_connection_send_message is fire-and-forget so a missing host app never stalls the AUTH_EXEC handler. Reconnects on the next notify when the cached connection invalidates.
- ESFSubscriber.swift: after the existing DENY response + audit event emission, fire `NotificationClient.shared.notify(payload)`. Runs after the kernel is already unblocked so the alert is post-hoc UX, not authorization.

Host-app side
- NotificationListener.swift: XPC listener mirroring the extension's XPCServer shape (same listener + per-peer event handler + peer-validation pattern). Decodes Codable payload and forwards to a BlockAlertPresenter.
- BlockAlert.swift: BlockAlertPresenterAppKit renders one NSAlert per accepted notification. Serial DispatchQueue + main-thread hop so two back-to-back denials don't stack overlapping modals; (rule_id, binary_path) tuples seen within a 30s dedup window are suppressed so a misbehaving caller can't paper the screen. "Dismiss" closes the modal; "More info" only renders when custom_url is set + scheme is http/https, and opens it via NSWorkspace.shared.open.
- main.swift: new `notify` mode that boots NSApplication with accessory activation policy (no Dock icon), starts the listener, and runs the AppKit run loop. Distinct from the other CLI modes' dispatchMain() because NSAlert needs the AppKit run loop's event dispatch.
- Info.plist: MachServices declaration so launchd registers the service name when the host app is run via the new LaunchAgent.

Deployment
- com.fleetdm.edr.notify.plist: per-user LaunchAgent that runs the host app in `notify` mode. KeepAlive=false + on-demand Mach-service binding so a crashed presenter doesn't crashloop on the user's desktop; the next AUTH_EXEC denial spawns a fresh instance.

Demo dry-run path (per ai/policy/demo-plan.md beat #6): on the SIP-disabled VM, install the LaunchAgent OR start the surface manually with `sudo /Applications/Fleet\ EDR.app/Contents/MacOS/edr notify` in a Terminal session. The next blocked exec pops the modal.

Out of scope (Phase B): hardening the modal into a true authorization dialog, custom-styled NSWindow, per-policy mute, notification-center integration.