### PR TITLE
App Control demo cut step 7: UI for the Application Control admin sur…

### DIFF
--- a/server/cmd/fleet-edr-server/main.go
+++ b/server/cmd/fleet-edr-server/main.go
@@ -555,6 +555,16 @@ func registerSessionRoutes(mux *http.ServeMux, d muxDeps) {
 		"GET /api/rules",
 		"GET /api/audit-events",
 		"GET /api/session",
+		// Application Control demo cut. rulesCtx.RegisterAuthedRoutes
+		// mounts these on apiMux; the outer router needs each path
+		// enumerated here so requests reach the session-protected
+		// wrapper instead of falling through to the `/` catchall and
+		// 302 → /ui/. Surfaced by the step-8 dry-run on PR #158 — the
+		// list-policies API returned the SPA's index.html, which the
+		// UI fetch parsed as JSON and errored with "Unexpected token '<'".
+		"GET /api/v1/app-control/policies",
+		"GET /api/v1/app-control/policies/{id}",
+		"POST /api/v1/app-control/policies/{id}/rules",
 		// Break-glass reauth ceremony. The handlers are mounted on
 		// apiMux via identityCtx.RegisterAuthedRoutes, but the outer
 		// router needs each path enumerated here so the session-

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -4,6 +4,7 @@ import { HostList } from "./components/HostList";
 import { ProcessTreeView } from "./components/ProcessTree";
 import { AlertList } from "./components/AlertList";
 import { AttackCoverage } from "./components/AttackCoverage";
+import { ApplicationControlRoutes } from "./components/ApplicationControl/ApplicationControlRoutes";
 import { RuleDetail } from "./components/RuleDetail";
 import { Login } from "./components/Login";
 import { BreakGlassSetup } from "./components/BreakGlassSetup";
@@ -109,6 +110,7 @@ function AuthedApp() {
         <Routes>
           <Route path="/" element={<HostList />} />
           <Route path="/alerts" element={<AlertList />} />
+          <Route path="/app-control/*" element={<ApplicationControlRoutes />} />
           <Route path="/coverage" element={<AttackCoverage />} />
           <Route path="/rules/:ruleId" element={<RuleDetail />} />
           <Route path="/hosts/:hostId" element={<ProcessTreeView />} />

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -7,7 +7,16 @@
 // path was retired in Phase 5b. GET /api/session returns the cookie's
 // session JSON shape (including the CSRF token) and is the UI's
 // session-probe endpoint.
-import type { HostSummary, TreeResponse, ProcessDetail, Alert, AlertDetail, Command } from "./types";
+import type {
+  HostSummary,
+  TreeResponse,
+  ProcessDetail,
+  Alert,
+  AlertDetail,
+  Command,
+  ApplicationControlPolicy,
+  ApplicationControlRule,
+} from "./types";
 import {
   HTTP_STATUS_FORBIDDEN,
   HTTP_STATUS_NO_CONTENT,
@@ -351,6 +360,128 @@ export interface RuleDocEntry {
 export async function fetchRuleDocs(): Promise<RuleDocEntry[]> {
   const body = await fetchJSON<{ rules: RuleDocEntry[] }>("/rules");
   return body.rules;
+}
+
+// --- Application Control endpoints ---
+//
+// Mirrors the demo-cut REST surface mounted at /api/v1/app-control/* by
+// server/rules/internal/operator/appcontrol_handler.go. The server emits
+// typed error codes (application_control.invalid_rule, etc.); the UI
+// surfaces those via AppControlApiError so callers can switch on the
+// code rather than match a free-form message.
+
+// AppControlApiError carries the typed `error` code the handler writes
+// on its 4xx responses. Callers use `.code` to switch on the failure
+// (e.g. invalid_rule -> highlight the identifier field;
+// duplicate_rule -> show "this rule already exists" inline).
+export class AppControlApiError extends Error {
+  readonly code: string;
+  readonly status: number;
+  constructor(code: string, message: string, status: number) {
+    super(message);
+    this.name = "AppControlApiError";
+    this.code = code;
+    this.status = status;
+  }
+}
+
+// AppControlErrorBody is the wire shape every typed 4xx response from
+// the app-control handler carries. Narrow on purpose so unrelated 4xxs
+// (a stray HTML error page from a misconfigured proxy, e.g.) fall
+// through to the plain `API error` path.
+interface AppControlErrorBody {
+  error?: string;
+  message?: string;
+}
+
+// fetchAppControl wraps fetchJSON to surface typed AppControlApiError
+// on the documented 4xx shape from the handler. 5xx responses still
+// throw the plain `API error: ...` from fetchJSON so callers can tell
+// "the operator did something wrong" from "the server is broken."
+async function fetchAppControl<T>(path: string, init?: RequestInit): Promise<T> {
+  try {
+    return await fetchJSON<T>(path, init);
+  } catch (err) {
+    if (!(err instanceof Error)) throw err;
+    // fetchJSON throws `API error: <status> <statusText>` on non-OK
+    // responses. The error body has already been read+discarded
+    // there; re-fetch the same path with a HEAD-style preflight is
+    // wasteful, so we instead read once via a custom path here. To
+    // keep the change minimal, callers that want the typed code use
+    // this wrapper which expects the body shape directly.
+    throw err;
+  }
+}
+
+// AppControlListResponse is the GET /policies wire shape. The
+// underlying handler returns `{policies: [...]}` rather than a bare
+// array so future pagination + filter metadata can land alongside the
+// rows without a wire-shape break.
+interface AppControlListResponse {
+  policies: ApplicationControlPolicy[];
+}
+
+export async function listAppControlPolicies(): Promise<ApplicationControlPolicy[]> {
+  const body = await fetchAppControl<AppControlListResponse>("/v1/app-control/policies");
+  return body.policies;
+}
+
+export async function getAppControlPolicy(id: number): Promise<ApplicationControlPolicy> {
+  return fetchAppControl<ApplicationControlPolicy>(`/v1/app-control/policies/${String(id)}`);
+}
+
+// CreateAppControlRuleRequest is the JSON body the POST endpoint
+// accepts. Mirrors createRuleRequest in
+// server/rules/internal/operator/appcontrol_handler.go. The demo cut
+// only honours rule_type=BINARY; the form locks the type selector to
+// that value, but the type is on the wire so post-demo additions
+// don't break the contract.
+export interface CreateAppControlRuleRequest {
+  rule_type: string;
+  identifier: string;
+  custom_msg?: string;
+  custom_url?: string;
+  comment?: string;
+  severity?: string;
+  reason: string;
+}
+
+export async function createAppControlRule(
+  policyID: number,
+  req: CreateAppControlRuleRequest,
+): Promise<ApplicationControlRule> {
+  // The handler writes typed error bodies on 4xx; intercept here so
+  // form components can switch on the code rather than parse a
+  // free-form message.
+  const path = `/v1/app-control/policies/${String(policyID)}/rules`;
+  assertSafeAPIPath(path);
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  attachCsrfHeader(headers, "POST");
+  const target = new URL(API_BASE + path, globalThis.location.origin);
+  const res = await fetch(target, {
+    method: "POST",
+    credentials: "include",
+    headers,
+    body: JSON.stringify(req),
+  });
+  if (res.status === HTTP_STATUS_UNAUTHORIZED) {
+    clearCsrfToken();
+    throw new Unauthorized401Error();
+  }
+  if (res.status === HTTP_STATUS_FORBIDDEN) {
+    const reauth = await readReauthChallenge(res);
+    if (reauth) throw new ReauthRequiredError(reauth);
+  }
+  if (!res.ok) {
+    const body = (await res.clone().json().catch((): null => null)) as AppControlErrorBody | null;
+    if (body?.error) {
+      throw new AppControlApiError(body.error, body.message ?? body.error, res.status);
+    }
+    throw new Error(`API error: ${String(res.status)} ${res.statusText}`);
+  }
+  return res.json() as Promise<ApplicationControlRule>;
 }
 
 export async function createCommand(hostId: string, commandType: string, payload: Record<string, unknown>): Promise<{ id: number }> {

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -394,25 +394,6 @@ interface AppControlErrorBody {
   message?: string;
 }
 
-// fetchAppControl wraps fetchJSON to surface typed AppControlApiError
-// on the documented 4xx shape from the handler. 5xx responses still
-// throw the plain `API error: ...` from fetchJSON so callers can tell
-// "the operator did something wrong" from "the server is broken."
-async function fetchAppControl<T>(path: string, init?: RequestInit): Promise<T> {
-  try {
-    return await fetchJSON<T>(path, init);
-  } catch (err) {
-    if (!(err instanceof Error)) throw err;
-    // fetchJSON throws `API error: <status> <statusText>` on non-OK
-    // responses. The error body has already been read+discarded
-    // there; re-fetch the same path with a HEAD-style preflight is
-    // wasteful, so we instead read once via a custom path here. To
-    // keep the change minimal, callers that want the typed code use
-    // this wrapper which expects the body shape directly.
-    throw err;
-  }
-}
-
 // AppControlListResponse is the GET /policies wire shape. The
 // underlying handler returns `{policies: [...]}` rather than a bare
 // array so future pagination + filter metadata can land alongside the
@@ -421,13 +402,21 @@ interface AppControlListResponse {
   policies: ApplicationControlPolicy[];
 }
 
+// The read-side endpoints (list + get) route through fetchJSON because
+// they never produce typed application_control.* error codes on the
+// happy paths the UI exercises (4xx on read would be a 404 with the
+// typed code, which the call site already handles via the standard
+// "API error" path mapped to a user-visible error message). Only the
+// state-changing POST goes through the explicit AppControlApiError
+// path below; the typed-error surface only earns its complexity on
+// the write side.
 export async function listAppControlPolicies(): Promise<ApplicationControlPolicy[]> {
-  const body = await fetchAppControl<AppControlListResponse>("/v1/app-control/policies");
+  const body = await fetchJSON<AppControlListResponse>("/v1/app-control/policies");
   return body.policies;
 }
 
 export async function getAppControlPolicy(id: number): Promise<ApplicationControlPolicy> {
-  return fetchAppControl<ApplicationControlPolicy>(`/v1/app-control/policies/${String(id)}`);
+  return fetchJSON<ApplicationControlPolicy>(`/v1/app-control/policies/${String(id)}`);
 }
 
 // CreateAppControlRuleRequest is the JSON body the POST endpoint

--- a/ui/src/components/ApplicationControl/AddRuleModal.test.tsx
+++ b/ui/src/components/ApplicationControl/AddRuleModal.test.tsx
@@ -1,0 +1,271 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { AddRuleModal } from "./AddRuleModal";
+import * as api from "../../api";
+import type { ApplicationControlRule } from "../../types";
+
+// AddRuleModal is the demo cut's only complex form. The tests below
+// pin the validation contract the camera-facing flow depends on:
+//   - reason is required (gates Save)
+//   - BINARY identifier must be 64 lowercase hex chars
+//   - More info URL is rejected if it isn't http/https
+//   - typed AppControlApiError codes map to readable copy
+//   - happy path calls onCreated exactly once
+// Native <dialog>'s showModal() isn't implemented in jsdom; the tests
+// stub it minimally so the rest of the React tree renders.
+
+const makeRule = (over: Partial<ApplicationControlRule> = {}): ApplicationControlRule => ({
+  id: 1,
+  policy_id: 1,
+  rule_type: "BINARY",
+  identifier: "a".repeat(64),
+  action: "BLOCK",
+  enforcement: "PROTECT",
+  enabled: true,
+  severity: "medium",
+  source: "admin",
+  created_at: "2026-05-14T00:00:00Z",
+  updated_at: "2026-05-14T00:00:00Z",
+  created_by: "user:1",
+  ...over,
+});
+
+// jsdom doesn't implement HTMLDialogElement.showModal/close; patch
+// them as no-ops on the prototype so the modal renders without
+// throwing TypeError.
+beforeEach(() => {
+  // jsdom doesn't implement HTMLDialogElement.showModal/close.
+  // The TS prototype claims both exist, so the runtime existence
+  // check tripping no-unnecessary-condition is expected; assign
+  // unconditionally instead.
+  HTMLDialogElement.prototype.showModal = function showModal() {
+    this.open = true;
+  };
+  HTMLDialogElement.prototype.close = function close() {
+    this.open = false;
+  };
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("AddRuleModal", () => {
+  it("does not render content when closed", () => {
+    render(
+      <AddRuleModal
+        open={false}
+        policyID={1}
+        onClose={() => undefined}
+        onCreated={() => undefined}
+      />,
+    );
+    // Title only shows once the dialog is open; we can't assert
+    // it's gone (it's still in the DOM under jsdom's stubbed
+    // showModal) but the dialog element should not have its
+    // `open` attribute set.
+    const dialog = document.querySelector("dialog");
+    expect(dialog).not.toBeNull();
+    expect((dialog as HTMLDialogElement).open).toBe(false);
+  });
+
+  it("disables Save until both identifier and reason are populated", () => {
+    render(
+      <AddRuleModal
+        open
+        policyID={1}
+        onClose={() => undefined}
+        onCreated={() => undefined}
+      />,
+    );
+    const save = screen.getByRole("button", { name: /save rule/i });
+    expect(save).toBeDisabled();
+    fireEvent.change(screen.getByLabelText(/identifier/i), {
+      target: { value: "a".repeat(64) },
+    });
+    expect(save).toBeDisabled();
+    fireEvent.change(screen.getByLabelText(/reason/i), {
+      target: { value: "demo" },
+    });
+    expect(save).not.toBeDisabled();
+  });
+
+  it("rejects an identifier that is not 64 lowercase hex characters", async () => {
+    const createSpy = vi.spyOn(api, "createAppControlRule");
+    render(
+      <AddRuleModal
+        open
+        policyID={1}
+        onClose={() => undefined}
+        onCreated={() => undefined}
+      />,
+    );
+    fireEvent.change(screen.getByLabelText(/identifier/i), {
+      target: { value: "not-a-real-hash" },
+    });
+    fireEvent.change(screen.getByLabelText(/reason/i), {
+      target: { value: "demo" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /save rule/i }));
+    await waitFor(() => {
+      expect(screen.getByRole("alert").textContent).toMatch(/BINARY identifier/i);
+    });
+    expect(createSpy).not.toHaveBeenCalled();
+  });
+
+  it("rejects an upper-case hex identifier (BINARY requires lowercase)", async () => {
+    const createSpy = vi.spyOn(api, "createAppControlRule");
+    render(
+      <AddRuleModal
+        open
+        policyID={1}
+        onClose={() => undefined}
+        onCreated={() => undefined}
+      />,
+    );
+    fireEvent.change(screen.getByLabelText(/identifier/i), {
+      // Uppercase wouldn't even make it past the client validator
+      // (the server's BINARY rule is "64 lowercase hex"). The
+      // client normalises lowercase before POSTing, so an
+      // uppercase string passes the regex check after trim().toLowerCase().
+      // We instead test the truncated form to keep this distinct
+      // from the bad-charset case above.
+      target: { value: "a".repeat(40) },
+    });
+    fireEvent.change(screen.getByLabelText(/reason/i), {
+      target: { value: "demo" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /save rule/i }));
+    await waitFor(() => {
+      expect(screen.getByRole("alert").textContent).toMatch(/64 lowercase hex/i);
+    });
+    expect(createSpy).not.toHaveBeenCalled();
+  });
+
+  it("rejects a non-http(s) More info URL", async () => {
+    const createSpy = vi.spyOn(api, "createAppControlRule");
+    render(
+      <AddRuleModal
+        open
+        policyID={1}
+        onClose={() => undefined}
+        onCreated={() => undefined}
+      />,
+    );
+    fireEvent.change(screen.getByLabelText(/identifier/i), {
+      target: { value: "a".repeat(64) },
+    });
+    fireEvent.change(screen.getByLabelText(/reason/i), {
+      target: { value: "demo" },
+    });
+    fireEvent.change(screen.getByLabelText(/more info url/i), {
+      target: { value: "javascript:alert(1)" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /save rule/i }));
+    await waitFor(() => {
+      expect(screen.getByRole("alert").textContent).toMatch(/http or https/i);
+    });
+    expect(createSpy).not.toHaveBeenCalled();
+  });
+
+  it("submits and fires onCreated on the happy path", async () => {
+    const created = makeRule();
+    const createSpy = vi
+      .spyOn(api, "createAppControlRule")
+      .mockResolvedValue(created);
+    const onCreated = vi.fn();
+    render(
+      <AddRuleModal
+        open
+        policyID={42}
+        onClose={() => undefined}
+        onCreated={onCreated}
+      />,
+    );
+    fireEvent.change(screen.getByLabelText(/identifier/i), {
+      target: { value: "b".repeat(64) },
+    });
+    fireEvent.change(screen.getByLabelText(/reason/i), {
+      target: { value: "demo rehearsal" },
+    });
+    fireEvent.change(screen.getByLabelText(/custom message/i), {
+      target: { value: "Blocked by corp policy" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /save rule/i }));
+    await waitFor(() => {
+      expect(createSpy).toHaveBeenCalledTimes(1);
+    });
+    expect(createSpy).toHaveBeenCalledWith(42, expect.objectContaining({
+      rule_type: "BINARY",
+      identifier: "b".repeat(64),
+      reason: "demo rehearsal",
+      severity: "medium",
+      custom_msg: "Blocked by corp policy",
+    }));
+    await waitFor(() => {
+      expect(onCreated).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("maps a duplicate_rule AppControlApiError to a readable message", async () => {
+    vi.spyOn(api, "createAppControlRule").mockRejectedValue(
+      new api.AppControlApiError("application_control.duplicate_rule", "duplicate", 409),
+    );
+    render(
+      <AddRuleModal
+        open
+        policyID={1}
+        onClose={() => undefined}
+        onCreated={() => undefined}
+      />,
+    );
+    fireEvent.change(screen.getByLabelText(/identifier/i), {
+      target: { value: "c".repeat(64) },
+    });
+    fireEvent.change(screen.getByLabelText(/reason/i), {
+      target: { value: "demo" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /save rule/i }));
+    await waitFor(() => {
+      expect(screen.getByRole("alert").textContent).toMatch(/already exists/i);
+    });
+  });
+
+  it("falls back to the server's message for an unknown error code", async () => {
+    vi.spyOn(api, "createAppControlRule").mockRejectedValue(
+      new api.AppControlApiError("application_control.unmapped", "server message", 400),
+    );
+    render(
+      <AddRuleModal
+        open
+        policyID={1}
+        onClose={() => undefined}
+        onCreated={() => undefined}
+      />,
+    );
+    fireEvent.change(screen.getByLabelText(/identifier/i), {
+      target: { value: "d".repeat(64) },
+    });
+    fireEvent.change(screen.getByLabelText(/reason/i), {
+      target: { value: "demo" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /save rule/i }));
+    await waitFor(() => {
+      expect(screen.getByRole("alert").textContent).toMatch(/server message/i);
+    });
+  });
+
+  it("invokes onClose when the Cancel button is clicked", () => {
+    const onClose = vi.fn();
+    render(
+      <AddRuleModal
+        open
+        policyID={1}
+        onClose={onClose}
+        onCreated={() => undefined}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ui/src/components/ApplicationControl/AddRuleModal.tsx
+++ b/ui/src/components/ApplicationControl/AddRuleModal.tsx
@@ -6,6 +6,7 @@ import {
   type CreateAppControlRuleRequest,
 } from "../../api";
 import { useReauthRetry } from "../../hooks/useReauthRetry";
+import { ReauthModal } from "../ReauthModal";
 import { Button } from "../ui/Button";
 import { Input, Select } from "../ui/Input";
 import "./ApplicationControl.scss";
@@ -141,6 +142,25 @@ export function AddRuleModal({ open, policyID, onClose, onCreated }: AddRuleModa
         return;
       }
     }
+    // The host-app modal only renders "More info" for http/https
+    // URLs (BlockAlert.swift rejects other schemes so a hostile
+    // rule author can't trigger arbitrary URL handlers from a
+    // single click). Enforce the same posture client-side so the
+    // operator sees the rejection at the form instead of saving
+    // a rule whose link will never appear in the modal.
+    const trimmedURL = customURL.trim();
+    if (trimmedURL.length > 0) {
+      try {
+        const parsed = new URL(trimmedURL);
+        if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+          setFormError("More info URL must use http or https.");
+          return;
+        }
+      } catch {
+        setFormError("More info URL is not a valid URL.");
+        return;
+      }
+    }
     setFormError(null);
     setBusy(true);
     try {
@@ -254,7 +274,7 @@ export function AddRuleModal({ open, policyID, onClose, onCreated }: AddRuleModa
 
           <Input
             id="rule-custom-url"
-            label="More info URL (optional, https only)"
+            label="More info URL (optional, http/https only)"
             type="url"
             placeholder="https://help.example.com/blocked"
             value={customURL}
@@ -287,7 +307,7 @@ export function AddRuleModal({ open, policyID, onClose, onCreated }: AddRuleModa
           </div>
         </form>
       </dialog>
-      {reauthModal}
+      <ReauthModal {...reauthModal} />
     </>
   );
 }

--- a/ui/src/components/ApplicationControl/AddRuleModal.tsx
+++ b/ui/src/components/ApplicationControl/AddRuleModal.tsx
@@ -1,0 +1,293 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  createAppControlRule,
+  AppControlApiError,
+  ReauthRequiredError,
+  type CreateAppControlRuleRequest,
+} from "../../api";
+import { useReauthRetry } from "../../hooks/useReauthRetry";
+import { Button } from "../ui/Button";
+import { Input, Select } from "../ui/Input";
+import "./ApplicationControl.scss";
+
+// AddRuleModalProps is the parent contract. open drives showModal() /
+// close(); onClose fires on Cancel/Escape; onCreated fires after a
+// successful POST so the parent can re-fetch the policy.
+interface AddRuleModalProps {
+  readonly open: boolean;
+  readonly policyID: number;
+  readonly onClose: () => void;
+  readonly onCreated: () => void;
+}
+
+const DIALOG_TITLE_ID = "add-rule-modal-title";
+
+// RULE_TYPES enumerates the values the schema's rule_type ENUM
+// accepts. Only BINARY is enforced in the demo cut; the others
+// render in the type selector with the disabled flag set so the
+// camera-facing UI shows the post-demo roadmap without faking it.
+const RULE_TYPES: { value: string; label: string; available: boolean }[] = [
+  { value: "BINARY", label: "BINARY (file SHA-256)", available: true },
+  { value: "CDHASH", label: "CDHASH (code-directory hash)", available: false },
+  { value: "SIGNINGID", label: "SIGNINGID (Team:bundle.id)", available: false },
+  { value: "CERTIFICATE", label: "CERTIFICATE (leaf SHA-256)", available: false },
+  { value: "TEAMID", label: "TEAMID (Apple Developer team)", available: false },
+  { value: "PATH", label: "PATH (canonical absolute)", available: false },
+];
+
+const SEVERITIES = ["low", "medium", "high", "critical"];
+const BINARY_HEX_LENGTH = 64;
+const BINARY_HEX_REGEX = /^[a-f0-9]{64}$/;
+
+// validateBinaryIdentifier mirrors the server's BINARY validator
+// (server/rules/internal/appcontrol/validate.go). Catching the
+// format error client-side gives the operator immediate feedback
+// instead of a round trip + a typed 400.
+function validateBinaryIdentifier(value: string): string | null {
+  const trimmed = value.trim().toLowerCase();
+  if (trimmed.length === 0) return "Identifier is required.";
+  if (trimmed.length !== BINARY_HEX_LENGTH) {
+    return `BINARY identifier must be ${String(BINARY_HEX_LENGTH)} lowercase hex characters (was ${String(trimmed.length)}).`;
+  }
+  if (!BINARY_HEX_REGEX.test(trimmed)) {
+    return "BINARY identifier must contain only lowercase hex (0-9 a-f).";
+  }
+  return null;
+}
+
+// errorMessageForCode maps the server's typed application_control.*
+// error codes onto operator-readable copy. Anything unrecognised
+// falls back to the raw message the server returned (already
+// human-readable) so we don't black-hole unexpected failures.
+const errorMessageByCode = new Map<string, string>([
+  ["application_control.invalid_rule", "The rule didn't pass server-side validation."],
+  ["application_control.duplicate_rule", "A rule with this identifier already exists in this policy."],
+  ["application_control.policy_not_found", "The policy was deleted before the rule could be saved."],
+  ["application_control.invalid_policy_id", "Invalid policy id."],
+  ["application_control.invalid_json", "The request body was not valid JSON."],
+]);
+
+export function AddRuleModal({ open, policyID, onClose, onCreated }: AddRuleModalProps) {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const [ruleType, setRuleType] = useState("BINARY");
+  const [identifier, setIdentifier] = useState("");
+  const [severity, setSeverity] = useState("medium");
+  const [customMsg, setCustomMsg] = useState("");
+  const [customURL, setCustomURL] = useState("");
+  const [reason, setReason] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+
+  // Reset the form whenever the dialog opens. Otherwise a Cancel +
+  // re-open would surface the previous attempt's values, which is
+  // confusing for the demo recording (and for real operators).
+  useEffect(() => {
+    if (!open) return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional reset tied to the open prop transition
+    setRuleType("BINARY");
+    setIdentifier("");
+    setSeverity("medium");
+    setCustomMsg("");
+    setCustomURL("");
+    setReason("");
+    setBusy(false);
+    setFormError(null);
+  }, [open]);
+
+  // Open / close the native <dialog>. showModal() is what gives us
+  // backdrop, focus trap, and Escape-to-cancel for free; the
+  // declarative `open` attribute would render non-modal.
+  useEffect(() => {
+    const dlg = dialogRef.current;
+    if (!dlg) return;
+    if (open && !dlg.open) {
+      dlg.showModal();
+    } else if (!open && dlg.open) {
+      dlg.close();
+    }
+  }, [open]);
+
+  // Escape and backdrop click both route through onClose so the
+  // parent's open-state is the single source of truth.
+  const handleCancel = useCallback((e: React.SyntheticEvent<HTMLDialogElement>) => {
+    e.preventDefault();
+    onClose();
+  }, [onClose]);
+  useEffect(() => {
+    const dlg = dialogRef.current;
+    if (!dlg) return undefined;
+    const onBackdrop = (e: MouseEvent) => {
+      if (e.target === dlg) onClose();
+    };
+    dlg.addEventListener("click", onBackdrop);
+    return () => { dlg.removeEventListener("click", onBackdrop); };
+  }, [onClose]);
+
+  const submitCreate = useCallback(
+    (req: CreateAppControlRuleRequest) => createAppControlRule(policyID, req),
+    [policyID],
+  );
+  const { call: callCreate, modal: reauthModal } = useReauthRetry(submitCreate);
+
+  const submitDisabled = busy || reason.trim().length === 0 || identifier.trim().length === 0;
+
+  async function handleSubmit(e: React.SyntheticEvent) {
+    e.preventDefault();
+    if (submitDisabled) return;
+    if (ruleType === "BINARY") {
+      const validation = validateBinaryIdentifier(identifier);
+      if (validation) {
+        setFormError(validation);
+        return;
+      }
+    }
+    setFormError(null);
+    setBusy(true);
+    try {
+      const req: CreateAppControlRuleRequest = {
+        rule_type: ruleType,
+        identifier: identifier.trim().toLowerCase(),
+        severity,
+        reason: reason.trim(),
+      };
+      if (customMsg.trim().length > 0) req.custom_msg = customMsg.trim();
+      if (customURL.trim().length > 0) req.custom_url = customURL.trim();
+      await callCreate(req);
+      onCreated();
+    } catch (err) {
+      if (err instanceof ReauthRequiredError) {
+        // useReauthRetry's modal is mounted at the bottom of this
+        // component; the user finishes the reauth and the original
+        // call retries on its own. No UI work to do here.
+        return;
+      }
+      if (err instanceof AppControlApiError) {
+        setFormError(errorMessageByCode.get(err.code) ?? err.message);
+      } else if (err instanceof Error) {
+        setFormError(err.message);
+      } else {
+        setFormError("Failed to create rule.");
+      }
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <>
+      <dialog
+        ref={dialogRef}
+        className="app-control-dialog"
+        aria-labelledby={DIALOG_TITLE_ID}
+        onCancel={handleCancel}
+      >
+        <div className="app-control-dialog__header">
+          <h2 id={DIALOG_TITLE_ID} className="app-control-dialog__title">Add rule</h2>
+          <p className="app-control-dialog__subtitle">
+            Block an executable on every assigned host. The rule fans
+            out to enrolled agents on save.
+          </p>
+        </div>
+
+        {formError && (
+          <div className="app-control-dialog__error" role="alert">
+            {formError}
+          </div>
+        )}
+
+        <form
+          onSubmit={(e) => { void handleSubmit(e); }}
+          className="app-control-dialog__form"
+        >
+          <Select
+            id="rule-type"
+            label="Type"
+            value={ruleType}
+            onChange={(e) => { setRuleType(e.target.value); }}
+            disabled={busy}
+          >
+            {RULE_TYPES.map((t) => (
+              <option
+                key={t.value}
+                value={t.value}
+                disabled={!t.available}
+              >
+                {t.label}{t.available ? "" : " (coming soon)"}
+              </option>
+            ))}
+          </Select>
+
+          <Input
+            id="rule-identifier"
+            label="Identifier"
+            type="text"
+            autoComplete="off"
+            spellCheck={false}
+            placeholder={ruleType === "BINARY" ? "64 lowercase hex characters (sha256)" : ""}
+            value={identifier}
+            onChange={(e) => { setIdentifier(e.target.value); }}
+            disabled={busy}
+            autoFocus
+          />
+
+          <Select
+            id="rule-severity"
+            label="Severity"
+            value={severity}
+            onChange={(e) => { setSeverity(e.target.value); }}
+            disabled={busy}
+          >
+            {SEVERITIES.map((s) => (
+              <option key={s} value={s}>{s}</option>
+            ))}
+          </Select>
+
+          <Input
+            id="rule-custom-msg"
+            label="Custom message (optional)"
+            type="text"
+            placeholder="Blocked by corporate policy"
+            value={customMsg}
+            onChange={(e) => { setCustomMsg(e.target.value); }}
+            disabled={busy}
+          />
+
+          <Input
+            id="rule-custom-url"
+            label="More info URL (optional, https only)"
+            type="url"
+            placeholder="https://help.example.com/blocked"
+            value={customURL}
+            onChange={(e) => { setCustomURL(e.target.value); }}
+            disabled={busy}
+          />
+
+          <Input
+            id="rule-reason"
+            label="Reason (required for audit log)"
+            type="text"
+            placeholder="Why are you authoring this rule?"
+            value={reason}
+            onChange={(e) => { setReason(e.target.value); }}
+            disabled={busy}
+          />
+
+          <div className="app-control-dialog__actions">
+            <Button
+              type="button"
+              variant="text-link"
+              onClick={onClose}
+              disabled={busy}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={submitDisabled} isLoading={busy}>
+              {busy ? "Saving…" : "Save rule"}
+            </Button>
+          </div>
+        </form>
+      </dialog>
+      {reauthModal}
+    </>
+  );
+}

--- a/ui/src/components/ApplicationControl/ApplicationControl.scss
+++ b/ui/src/components/ApplicationControl/ApplicationControl.scss
@@ -1,0 +1,91 @@
+@use "../../styles/var/colors" as *;
+@use "../../styles/var/fonts" as *;
+@use "../../styles/var/padding" as *;
+
+.app-control__row-secondary {
+  font-size: $xx-small;
+  color: $ui-fleet-black-50;
+  margin-top: $pad-xsmall;
+}
+
+.app-control__description {
+  margin: 0 0 $pad-medium 0;
+  color: $ui-fleet-black-75;
+  max-width: 800px;
+}
+
+.app-control__assignment {
+  font-size: $xx-small;
+  text-transform: uppercase;
+  font-weight: $bold;
+  letter-spacing: 0.5px;
+  color: $ui-fleet-black-75;
+}
+
+.app-control__divider {
+  color: $ui-fleet-black-25;
+}
+
+.app-control__muted {
+  color: $ui-fleet-black-50;
+}
+
+.app-control__identifier {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: $xx-small;
+}
+
+.app-control__row-actions {
+  display: flex;
+  gap: $pad-xsmall;
+}
+
+.app-control-dialog {
+  border: none;
+  border-radius: 8px;
+  padding: $pad-large;
+  width: min(560px, 90vw);
+  background: $core-fleet-white;
+  color: $core-fleet-black;
+
+  &::backdrop {
+    background: rgba(0, 0, 0, 0.45);
+  }
+}
+
+.app-control-dialog__header {
+  margin-bottom: $pad-medium;
+}
+
+.app-control-dialog__title {
+  margin: 0 0 $pad-xsmall 0;
+  font-size: $large;
+}
+
+.app-control-dialog__subtitle {
+  margin: 0;
+  color: $ui-fleet-black-75;
+  font-size: $xx-small;
+}
+
+.app-control-dialog__error {
+  background: rgba($core-vibrant-red, 0.1);
+  color: $core-vibrant-red;
+  padding: $pad-small;
+  border-radius: 4px;
+  margin-bottom: $pad-medium;
+  font-size: $xx-small;
+}
+
+.app-control-dialog__form {
+  display: flex;
+  flex-direction: column;
+  gap: $pad-small;
+}
+
+.app-control-dialog__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: $pad-small;
+  margin-top: $pad-medium;
+}

--- a/ui/src/components/ApplicationControl/ApplicationControlRoutes.test.tsx
+++ b/ui/src/components/ApplicationControl/ApplicationControlRoutes.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+import { ApplicationControlRoutes } from "./ApplicationControlRoutes";
+import * as api from "../../api";
+
+// Shallow-render the feature router under several entry paths and
+// confirm the right page mounts. Mocks the api so the rendered
+// children stay deterministic; we're testing the route table here,
+// not the page contents.
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("ApplicationControlRoutes", () => {
+  it("renders PoliciesList at the index route", async () => {
+    vi.spyOn(api, "listAppControlPolicies").mockResolvedValue([]);
+    render(
+      <MemoryRouter initialEntries={["/app-control"]}>
+        <Routes>
+          <Route path="/app-control/*" element={<ApplicationControlRoutes />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      // PageHeader title "Application control" is unique to the
+      // PoliciesList page in this surface.
+      expect(screen.getByRole("heading", { name: /application control/i })).toBeInTheDocument();
+    });
+  });
+
+  it("falls back to the policies list on an unknown subpath", async () => {
+    vi.spyOn(api, "listAppControlPolicies").mockResolvedValue([]);
+    render(
+      <MemoryRouter initialEntries={["/app-control/garbage"]}>
+        <Routes>
+          <Route path="/app-control/*" element={<ApplicationControlRoutes />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      // After the Navigate fires, the index PoliciesList page mounts.
+      expect(screen.getByText(/no policies found/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/ui/src/components/ApplicationControl/ApplicationControlRoutes.tsx
+++ b/ui/src/components/ApplicationControl/ApplicationControlRoutes.tsx
@@ -14,9 +14,17 @@ import { PolicyDetail } from "./PolicyDetail";
 export function ApplicationControlRoutes() {
   return (
     <Routes>
-      <Route path="/" element={<PoliciesList />} />
-      <Route path="/policies/:id" element={<PolicyDetail />} />
-      <Route path="*" element={<Navigate to="." replace />} />
+      <Route index element={<PoliciesList />} />
+      <Route path="policies/:id" element={<PolicyDetail />} />
+      {/*
+          Catch-all falls back to the parent's index route (the
+          policies list). Using an explicit "/app-control" target so
+          a malformed link like /app-control/garbage lands on the
+          list page rather than the home page or the relative
+          fallback's risk of a redirect loop (Copilot flagged the
+          absolute-path-in-nested-Routes shape).
+      */}
+      <Route path="*" element={<Navigate to="/app-control" replace />} />
     </Routes>
   );
 }

--- a/ui/src/components/ApplicationControl/ApplicationControlRoutes.tsx
+++ b/ui/src/components/ApplicationControl/ApplicationControlRoutes.tsx
@@ -1,0 +1,22 @@
+import { Routes, Route, Navigate } from "react-router-dom";
+import { PoliciesList } from "./PoliciesList";
+import { PolicyDetail } from "./PolicyDetail";
+
+// ApplicationControlRoutes is the per-feature router under
+// /app-control. Two pages today:
+//   /app-control               → PoliciesList
+//   /app-control/policies/:id  → PolicyDetail (with the rules table)
+//
+// Splitting the router into a feature-local component keeps App.tsx's
+// outer Routes shallow and lets the Application Control surface grow
+// (paste-many, host-groups, audit history) without filling up the
+// top-level route table.
+export function ApplicationControlRoutes() {
+  return (
+    <Routes>
+      <Route path="/" element={<PoliciesList />} />
+      <Route path="/policies/:id" element={<PolicyDetail />} />
+      <Route path="*" element={<Navigate to="." replace />} />
+    </Routes>
+  );
+}

--- a/ui/src/components/ApplicationControl/PoliciesList.test.tsx
+++ b/ui/src/components/ApplicationControl/PoliciesList.test.tsx
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { PoliciesList } from "./PoliciesList";
+import * as api from "../../api";
+import type { ApplicationControlPolicy } from "../../types";
+
+const makePolicy = (over: Partial<ApplicationControlPolicy> = {}): ApplicationControlPolicy => ({
+  id: 1,
+  tenant_id: "default",
+  name: "Default",
+  description: "",
+  version: 3,
+  default_action: "NONE",
+  created_at: "2026-05-14T00:00:00Z",
+  updated_at: "2026-05-14T00:00:00Z",
+  created_by: "system",
+  updated_by: "user:1",
+  ...over,
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("PoliciesList", () => {
+  beforeEach(() => {
+    vi.spyOn(api, "listAppControlPolicies");
+  });
+
+  it("renders a loading state, then the seeded Default policy row", async () => {
+    (api.listAppControlPolicies as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([
+      makePolicy({ description: "Per-tenant default policy" }),
+    ]);
+    render(
+      <MemoryRouter>
+        <PoliciesList />
+      </MemoryRouter>,
+    );
+    expect(screen.getByText(/loading policies/i)).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText("Default")).toBeInTheDocument();
+    });
+    expect(screen.getByText(/per-tenant default policy/i)).toBeInTheDocument();
+    // The "New policy" button renders disabled with the coming-soon
+    // tooltip per the demo plan's section F.
+    const newPolicy = screen.getByRole("button", { name: /new policy/i });
+    expect(newPolicy).toBeDisabled();
+    expect(newPolicy).toHaveAttribute("title", expect.stringMatching(/coming/i));
+  });
+
+  it("renders an empty state when the tenant has no policies yet", async () => {
+    (api.listAppControlPolicies as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+    render(
+      <MemoryRouter>
+        <PoliciesList />
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      expect(screen.getByText(/no policies found/i)).toBeInTheDocument();
+    });
+  });
+
+  it("surfaces the error message when listAppControlPolicies rejects", async () => {
+    (api.listAppControlPolicies as unknown as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error("boom"),
+    );
+    render(
+      <MemoryRouter>
+        <PoliciesList />
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      expect(screen.getByText(/error: boom/i)).toBeInTheDocument();
+    });
+  });
+
+  it("shows a dash when the rule count isn't available (list endpoint omits it)", async () => {
+    (api.listAppControlPolicies as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([
+      makePolicy(),
+    ]);
+    render(
+      <MemoryRouter>
+        <PoliciesList />
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      expect(screen.getByText("Default")).toBeInTheDocument();
+    });
+    // The "Rules" column should render the em dash placeholder.
+    expect(screen.getByText("—")).toBeInTheDocument();
+  });
+});

--- a/ui/src/components/ApplicationControl/PoliciesList.tsx
+++ b/ui/src/components/ApplicationControl/PoliciesList.tsx
@@ -1,0 +1,111 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { listAppControlPolicies } from "../../api";
+import type { ApplicationControlPolicy } from "../../types";
+import { PageHeader } from "../ui/PageHeader";
+import { Table, EmptyState } from "../ui/Table";
+import { Button } from "../ui/Button";
+import "./ApplicationControl.scss";
+
+// PoliciesList renders the per-tenant Application Control policy
+// roster. In the demo cut the seeded `Default` policy is the only
+// row; multi-policy is post-demo, so the "New policy" button renders
+// disabled with a "coming soon" tooltip — honest scaffolding rather
+// than a 404. The list is the entry point for the camera-facing
+// admin surface (demo beat #1).
+export function PoliciesList() {
+  const [policies, setPolicies] = useState<ApplicationControlPolicy[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true); // eslint-disable-line react-hooks/set-state-in-effect -- data fetch pattern
+    setError(null);
+    listAppControlPolicies()
+      .then((result) => {
+        if (!cancelled) setPolicies(result);
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : "Unknown error");
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, []);
+
+  // ruleCount returns the number of rules attached to the policy. The
+  // list endpoint omits the rules array so the count is unknown until
+  // someone opens the detail page; show "—" rather than a fake 0 so
+  // the admin knows they have to click in. Post-demo work adds a
+  // rule_count aggregate to the list response.
+  const ruleCount = (p: ApplicationControlPolicy): string =>
+    p.rules ? String(p.rules.length) : "—";
+
+  const newPolicyAction = (
+    <Button
+      variant="primary"
+      disabled
+      title="Multi-policy support coming in the next release"
+    >
+      New policy
+    </Button>
+  );
+
+  return (
+    <>
+      <PageHeader
+        title="Application control"
+        subtitle="Per-tenant rules that the host extension consults on every exec"
+        actions={newPolicyAction}
+      />
+      {loading && <EmptyState>Loading policies...</EmptyState>}
+      {error && !loading && <EmptyState>Error: {error}</EmptyState>}
+      {!loading && !error && policies.length === 0 && (
+        <EmptyState>No policies found.</EmptyState>
+      )}
+      {!loading && !error && policies.length > 0 && (
+        <Table>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Rules</th>
+              <th>Version</th>
+              <th>Last modified</th>
+              <th>Assignments</th>
+            </tr>
+          </thead>
+          <tbody>
+            {policies.map((p) => (
+              <tr key={p.id}>
+                <td>
+                  <Link
+                    className="link-button"
+                    to={`/app-control/policies/${String(p.id)}`}
+                    title="Open this policy's rules table"
+                  >
+                    {p.name}
+                  </Link>
+                  {p.description && (
+                    <div className="app-control__row-secondary">{p.description}</div>
+                  )}
+                </td>
+                <td>{ruleCount(p)}</td>
+                <td>{p.version}</td>
+                <td>{new Date(p.updated_at).toLocaleString()}</td>
+                <td>
+                  {/* Assignments are hardcoded "all-hosts" in the
+                      demo cut; host-group editing is post-demo so
+                      this column shows the literal value without an
+                      action link. */}
+                  <span className="app-control__assignment">all hosts</span>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </Table>
+      )}
+    </>
+  );
+}

--- a/ui/src/components/ApplicationControl/PolicyDetail.test.tsx
+++ b/ui/src/components/ApplicationControl/PolicyDetail.test.tsx
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+import { PolicyDetail } from "./PolicyDetail";
+import * as api from "../../api";
+import type { ApplicationControlPolicy, ApplicationControlRule } from "../../types";
+
+const makeRule = (over: Partial<ApplicationControlRule> = {}): ApplicationControlRule => ({
+  id: 1,
+  policy_id: 1,
+  rule_type: "BINARY",
+  identifier: "a".repeat(64),
+  action: "BLOCK",
+  enforcement: "PROTECT",
+  enabled: true,
+  severity: "high",
+  source: "admin",
+  custom_msg: "Blocked by corp policy",
+  created_at: "2026-05-14T00:00:00Z",
+  updated_at: "2026-05-14T00:00:00Z",
+  created_by: "user:1",
+  ...over,
+});
+
+const makePolicy = (over: Partial<ApplicationControlPolicy> = {}): ApplicationControlPolicy => ({
+  id: 7,
+  tenant_id: "default",
+  name: "Default",
+  description: "Per-tenant default policy",
+  version: 5,
+  default_action: "NONE",
+  created_at: "2026-05-14T00:00:00Z",
+  updated_at: "2026-05-14T00:00:00Z",
+  created_by: "system",
+  updated_by: "user:1",
+  ...over,
+});
+
+// PolicyDetail uses useParams, so we route through MemoryRouter +
+// Routes so the :id parameter is bound. Wrapping the rendered
+// component this way keeps the test focused on the page output
+// rather than reproducing the App.tsx routing pyramid.
+function renderPolicyDetailAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/app-control/policies/:id" element={<PolicyDetail />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  // Same jsdom-stub posture as AddRuleModal.test.tsx; the runtime
+  // existence check trips no-unnecessary-condition because TS
+  // believes the prototype methods exist.
+  HTMLDialogElement.prototype.showModal = function showModal() {
+    this.open = true;
+  };
+  HTMLDialogElement.prototype.close = function close() {
+    this.open = false;
+  };
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("PolicyDetail", () => {
+  it("renders the policy header + a rules table including the truncated identifier", async () => {
+    vi.spyOn(api, "getAppControlPolicy").mockResolvedValue(
+      makePolicy({ rules: [makeRule()] }),
+    );
+    renderPolicyDetailAt("/app-control/policies/7");
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Default" })).toBeInTheDocument();
+    });
+    expect(screen.getByText(/version 5/i)).toBeInTheDocument();
+    expect(screen.getByText(/per-tenant default policy/i)).toBeInTheDocument();
+    // Identifier is truncated to 16 chars + ellipsis in the table.
+    expect(screen.getByText("aaaaaaaaaaaaaaaa…")).toBeInTheDocument();
+    expect(screen.getByText(/blocked by corp policy/i)).toBeInTheDocument();
+    // Per-row Edit/Disable/Delete render disabled with the coming-soon tooltip.
+    const edit = screen.getByRole("button", { name: "Edit" });
+    expect(edit).toBeDisabled();
+  });
+
+  it("renders an empty-state CTA when the policy has zero rules", async () => {
+    vi.spyOn(api, "getAppControlPolicy").mockResolvedValue(
+      makePolicy({ rules: [] }),
+    );
+    renderPolicyDetailAt("/app-control/policies/7");
+    await waitFor(() => {
+      expect(screen.getByText(/no rules yet/i)).toBeInTheDocument();
+    });
+    // Add rule button is the primary CTA; renders enabled once
+    // policy load completes.
+    const addRule = screen.getByRole("button", { name: /add rule/i });
+    expect(addRule).not.toBeDisabled();
+  });
+
+  it("shows the bad-id message when the URL parameter is not a number", () => {
+    renderPolicyDetailAt("/app-control/policies/not-a-number");
+    expect(screen.getByText(/invalid policy id/i)).toBeInTheDocument();
+  });
+
+  it("surfaces an error when getAppControlPolicy rejects", async () => {
+    vi.spyOn(api, "getAppControlPolicy").mockRejectedValue(new Error("nope"));
+    renderPolicyDetailAt("/app-control/policies/7");
+    await waitFor(() => {
+      expect(screen.getByText(/error: nope/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/ui/src/components/ApplicationControl/PolicyDetail.tsx
+++ b/ui/src/components/ApplicationControl/PolicyDetail.tsx
@@ -1,0 +1,220 @@
+import { useCallback, useEffect, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+import { getAppControlPolicy } from "../../api";
+import type { ApplicationControlPolicy, ApplicationControlRule } from "../../types";
+import { PageHeader } from "../ui/PageHeader";
+import { Table, EmptyState } from "../ui/Table";
+import { Button } from "../ui/Button";
+import { Badge, type BadgeVariant } from "../ui/Badge";
+import { AddRuleModal } from "./AddRuleModal";
+import "./ApplicationControl.scss";
+
+const SEVERITY_VARIANTS: Record<string, BadgeVariant> = {
+  critical: "critical",
+  high: "high",
+  medium: "medium",
+  low: "low",
+};
+
+// truncateIdentifier renders the leading 16 chars of a SHA-256
+// identifier so the rules table stays scannable without dropping the
+// disambiguating prefix. Full value is in the row's title attribute
+// for inspection. Identifiers shorter than the cap render verbatim
+// — TEAMID / SIGNINGID rules (post-demo) would otherwise come back
+// cropped.
+const IDENTIFIER_DISPLAY_CHARS = 16;
+function truncateIdentifier(value: string): string {
+  if (value.length <= IDENTIFIER_DISPLAY_CHARS) return value;
+  return value.slice(0, IDENTIFIER_DISPLAY_CHARS) + "…";
+}
+
+// PolicyDetail is the policy-rules surface the demo's Add Rule modal
+// hangs off. Demo beat #2 (admin pastes a SHA-256, hits Save, sees
+// the row appear) is its primary job; the per-row edit / disable /
+// delete buttons render disabled with the "coming soon" tooltip
+// pattern PoliciesList uses on its New Policy button. The Show
+// History toggle is the audit-history scaffolding for post-demo
+// work.
+export function PolicyDetail() {
+  const { id: idParam } = useParams<{ id: string }>();
+  const policyID = idParam ? Number.parseInt(idParam, 10) : Number.NaN;
+  const [policy, setPolicy] = useState<ApplicationControlPolicy | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [addOpen, setAddOpen] = useState(false);
+
+  // refreshKey bumps to force a re-fetch (e.g. after Save in the
+  // modal). useEffect below owns the actual fetch lifecycle so the
+  // setState calls happen in async callbacks rather than synchronously
+  // inside an effect body (react-hooks/set-state-in-effect).
+  const [refreshKey, setRefreshKey] = useState(0);
+  const refresh = useCallback(() => {
+    setRefreshKey((k) => k + 1);
+  }, []);
+
+  useEffect(() => {
+    if (!Number.isFinite(policyID)) return;
+    let cancelled = false;
+    setLoading(true); // eslint-disable-line react-hooks/set-state-in-effect -- data fetch pattern
+    setError(null);
+    getAppControlPolicy(policyID)
+      .then((result) => {
+        if (!cancelled) setPolicy(result);
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : "Unknown error");
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, [policyID, refreshKey]);
+
+  if (!Number.isFinite(policyID)) {
+    return (
+      <>
+        <PageHeader
+          title="Application control"
+          subtitle={
+            <Link className="link-button" to="/app-control">
+              ← Back to policies
+            </Link>
+          }
+        />
+        <EmptyState>Invalid policy id in URL.</EmptyState>
+      </>
+    );
+  }
+
+  const title = policy?.name ?? "Application control";
+  const subtitle = (
+    <>
+      <Link className="link-button" to="/app-control">
+        ← Back to policies
+      </Link>
+      {policy && (
+        <>
+          {" "}<span className="app-control__divider">·</span>{" "}
+          version {policy.version}
+          {" "}<span className="app-control__divider">·</span>{" "}
+          assignments: <span className="app-control__assignment">all hosts</span>
+        </>
+      )}
+    </>
+  );
+
+  const actions = (
+    <Button
+      variant="primary"
+      onClick={() => { setAddOpen(true); }}
+      disabled={!policy}
+    >
+      Add rule
+    </Button>
+  );
+
+  const rules = policy?.rules ?? [];
+
+  return (
+    <>
+      <PageHeader title={title} subtitle={subtitle} actions={actions} />
+      {loading && <EmptyState>Loading policy...</EmptyState>}
+      {error && !loading && <EmptyState>Error: {error}</EmptyState>}
+      {!loading && !error && policy && (
+        <>
+          {policy.description && (
+            <p className="app-control__description">{policy.description}</p>
+          )}
+          {rules.length === 0 ? (
+            <EmptyState>
+              This policy has no rules yet. Click <strong>Add rule</strong> to
+              author the first one.
+            </EmptyState>
+          ) : (
+            <RulesTable rules={rules} />
+          )}
+        </>
+      )}
+      {policy && (
+        <AddRuleModal
+          open={addOpen}
+          policyID={policy.id}
+          onClose={() => { setAddOpen(false); }}
+          onCreated={() => {
+            setAddOpen(false);
+            refresh();
+          }}
+        />
+      )}
+    </>
+  );
+}
+
+interface RulesTableProps {
+  readonly rules: ApplicationControlRule[];
+}
+
+function RulesTable({ rules }: RulesTableProps) {
+  return (
+    <Table>
+      <thead>
+        <tr>
+          <th>Type</th>
+          <th>Identifier</th>
+          <th>Severity</th>
+          <th>Custom message</th>
+          <th>Last modified</th>
+          <th>Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        {rules.map((rule) => (
+          <tr key={rule.id}>
+            <td>
+              <Badge variant="neutral">{rule.rule_type}</Badge>
+            </td>
+            <td title={rule.identifier} className="app-control__identifier">
+              {truncateIdentifier(rule.identifier)}
+            </td>
+            <td>
+              <Badge variant={SEVERITY_VARIANTS[rule.severity] ?? "neutral"}>
+                {rule.severity}
+              </Badge>
+            </td>
+            <td>{rule.custom_msg ?? <span className="app-control__muted">—</span>}</td>
+            <td>{new Date(rule.updated_at).toLocaleString()}</td>
+            <td className="app-control__row-actions">
+              {/* Edit / Disable / Delete are scaffolding only in
+                  the demo cut. The disabled state + tooltip make
+                  the roadmap visible without faking behaviour. */}
+              <Button
+                variant="text-link"
+                size="small"
+                disabled
+                title="Editing rules is coming in the next release"
+              >
+                Edit
+              </Button>
+              <Button
+                variant="text-link"
+                size="small"
+                disabled
+                title={rule.enabled ? "Disabling rules is coming in the next release" : "Enabling rules is coming in the next release"}
+              >
+                {rule.enabled ? "Disable" : "Enable"}
+              </Button>
+              <Button
+                variant="text-link"
+                size="small"
+                disabled
+                title="Deleting rules is coming in the next release"
+              >
+                Delete
+              </Button>
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </Table>
+  );
+}

--- a/ui/src/components/ApplicationControl/api.test.ts
+++ b/ui/src/components/ApplicationControl/api.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+  createAppControlRule,
+  listAppControlPolicies,
+  getAppControlPolicy,
+  AppControlApiError,
+  Unauthorized401Error,
+  setCsrfToken,
+} from "../../api";
+
+// fetchMock is the per-test wrapper for global.fetch. Vitest's
+// vi.spyOn(globalThis, "fetch") keeps the actual implementation
+// fenced off the tests so a leaked mock can't bleed into a sibling
+// suite.
+interface FakeResponse {
+  ok: boolean;
+  status: number;
+  statusText: string;
+  clone(): FakeResponse;
+  json(): Promise<unknown>;
+}
+
+function mockFetch(body: unknown, status = 200): ReturnType<typeof vi.fn> {
+  const fake: FakeResponse = {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: "",
+    clone(): FakeResponse {
+      return fake;
+    },
+    json(): Promise<unknown> {
+      return Promise.resolve(body);
+    },
+  };
+  const mock = vi.fn().mockResolvedValue(fake);
+  vi.stubGlobal("fetch", mock);
+  return mock;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("listAppControlPolicies", () => {
+  it("returns the policies array from the wrapped response shape", async () => {
+    const fakePolicies = [{ id: 1, name: "Default" }];
+    mockFetch({ policies: fakePolicies });
+    const got = await listAppControlPolicies();
+    expect(got).toEqual(fakePolicies);
+  });
+});
+
+describe("getAppControlPolicy", () => {
+  it("returns the policy body verbatim", async () => {
+    const policy = { id: 7, name: "Default", rules: [] };
+    mockFetch(policy);
+    const got = await getAppControlPolicy(7);
+    expect(got).toMatchObject({ id: 7 });
+  });
+});
+
+describe("createAppControlRule", () => {
+  it("returns the created rule on the happy path", async () => {
+    setCsrfToken("FAKE_CSRF_TOKEN");
+    const rule = { id: 99, rule_type: "BINARY" };
+    mockFetch(rule, 201);
+    const got = await createAppControlRule(1, {
+      rule_type: "BINARY",
+      identifier: "a".repeat(64),
+      reason: "demo",
+    });
+    expect(got).toMatchObject({ id: 99 });
+  });
+
+  it("throws Unauthorized401Error on a 401", async () => {
+    setCsrfToken("FAKE_CSRF_TOKEN");
+    mockFetch({}, 401);
+    await expect(
+      createAppControlRule(1, {
+        rule_type: "BINARY",
+        identifier: "a".repeat(64),
+        reason: "demo",
+      }),
+    ).rejects.toBeInstanceOf(Unauthorized401Error);
+  });
+
+  it("surfaces typed AppControlApiError for application_control.* 4xx codes", async () => {
+    setCsrfToken("FAKE_CSRF_TOKEN");
+    mockFetch(
+      { error: "application_control.duplicate_rule", message: "duplicate" },
+      409,
+    );
+    try {
+      await createAppControlRule(1, {
+        rule_type: "BINARY",
+        identifier: "a".repeat(64),
+        reason: "demo",
+      });
+      throw new Error("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(AppControlApiError);
+      if (err instanceof AppControlApiError) {
+        expect(err.code).toBe("application_control.duplicate_rule");
+        expect(err.status).toBe(409);
+      }
+    }
+  });
+
+  it("falls through to plain API error when the 4xx body lacks the typed envelope", async () => {
+    setCsrfToken("FAKE_CSRF_TOKEN");
+    mockFetch({ something: "else" }, 400);
+    await expect(
+      createAppControlRule(1, {
+        rule_type: "BINARY",
+        identifier: "a".repeat(64),
+        reason: "demo",
+      }),
+    ).rejects.toThrow(/API error/);
+  });
+});

--- a/ui/src/components/ui/TopNav.tsx
+++ b/ui/src/components/ui/TopNav.tsx
@@ -10,6 +10,7 @@ interface NavLink {
 const LINKS: NavLink[] = [
   { to: "/", label: "Hosts" },
   { to: "/alerts", label: "Alerts" },
+  { to: "/app-control", label: "Application control" },
   { to: "/coverage", label: "Coverage" },
 ];
 

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -132,3 +132,47 @@ export interface Command {
   completed_at?: string;
   result?: Record<string, unknown>;
 }
+
+// ApplicationControlPolicy mirrors server/rules/api.ApplicationControlPolicy.
+// The demo cut shows one per-tenant Default policy; multi-policy support is
+// post-demo. Rules is populated by the GET /policies/{id} endpoint and
+// omitted from the list response, so the field is optional.
+export interface ApplicationControlPolicy {
+  id: number;
+  tenant_id: string;
+  name: string;
+  description: string;
+  version: number;
+  default_action: string;
+  created_at: string;
+  updated_at: string;
+  created_by: string;
+  updated_by: string;
+  rules?: ApplicationControlRule[];
+}
+
+// ApplicationControlRule mirrors server/rules/api.ApplicationControlRule.
+// `rule_type` is BINARY in the demo cut; the other five values exist on the
+// schema's ENUM but the create handler rejects them until their validators
+// ship. custom_msg / custom_url are operator-authored optional strings; the
+// host-app modal renders custom_msg verbatim and "More info" links for
+// http/https custom_urls.
+export interface ApplicationControlRule {
+  id: number;
+  policy_id: number;
+  rule_type: string;
+  identifier: string;
+  action: string;
+  enforcement: string;
+  enabled: boolean;
+  severity: string;
+  source: string;
+  source_ref?: string;
+  custom_msg?: string | null;
+  custom_url?: string | null;
+  comment?: string;
+  expires_at?: string | null;
+  created_at: string;
+  updated_at: string;
+  created_by: string;
+}


### PR DESCRIPTION
…face

Unlocks demo beats #1, #2, and #3 — the camera-facing admin workflow (open Application Control, navigate to Default policy, paste a SHA-256, save).

Routes + nav
- New top-nav entry "Application control" between "Alerts" and "Coverage" (matches the demo plan's section F).
- New routes mounted via a feature-local ApplicationControlRoutes router so App.tsx stays shallow:
    /app-control                  → PoliciesList
    /app-control/policies/:id     → PolicyDetail

API clients
- types.ts: ApplicationControlPolicy + ApplicationControlRule interfaces mirror the server wire shape.
- api.ts: listAppControlPolicies, getAppControlPolicy, and createAppControlRule. Typed AppControlApiError surfaces the handler's `application_control.*` error codes so callers can switch on the code (e.g. duplicate_rule → inline "this identifier already exists" hint) rather than parse the message. POST routes through the existing CSRF / reauth challenge path for parity with the other state-changing endpoints.

Pages
- PoliciesList: renders the seed Default with rule count, version, last modified, and the hardcoded "all hosts" assignment. The "New policy" button renders disabled with the demo-cut "coming soon" tooltip (multi-policy is post-demo per plan section F).
- PolicyDetail: header + back link, rules table with the columns the demo plan calls for (type, identifier truncated to 16 hex chars with full value on hover, severity badge, custom message, last modified). Per-row Edit / Disable / Delete render disabled with the same coming-soon tooltip pattern. Refresh-on- save via a refreshKey counter so the new rule shows up without a manual reload.

Add Rule modal
- Native <dialog> opened via showModal() so the browser provides the backdrop, focus trap, and Escape-to-cancel — same pattern ReauthModal already uses.
- Type selector lists every rule_type value the schema's ENUM accepts, but only BINARY is selectable; the rest are rendered disabled with a "coming soon" suffix so the camera sees the roadmap without faking behaviour.
- Client-side validator mirrors the server's BINARY shape (64 lowercase hex chars) so the operator gets immediate feedback instead of a round-trip + a typed 400.
- Reason field is required (gates Save) so every authored rule has the audit-log row's `reason` populated.
- AppControlApiError → human-readable copy via an explicit Map; unrecognised codes fall back to the server's `message` field rather than disappearing.
- Reauth-gated via useReauthRetry so a critical-severity rule creation past the freshness window prompts the operator through the existing flow.

Out of scope for the demo cut (still in the OpenSpec backlog):
- Paste-many flow (8.5 in tasks.md)
- React Testing Library coverage (8.7) — the demo plan calls for visual polish iteration on the dry-run rather than upfront RTL tests; will land alongside the post-demo CRUD endpoints when the surfaces stabilise.