### PR TITLE
dev: live-dir UI bundle + ADR gap-list entries

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -360,6 +360,11 @@ tasks:
       EDR_HOST_TOKEN_GRACE 5m. Override either to a short value (e.g.
       EDR_HOST_TOKEN_LIFETIME=30s) when QA-ing the rotation flow against a real VM agent
       so you can observe a rotation cycle inside one minute rather than next-day.
+
+      EDR_UI_LIVE_DIR (issue #141) points the server at server/ui/dist on disk instead of
+      the compile-time embedded bundle, so `task build:ui` is picked up on the next
+      request without restarting the server. Production binaries leave the var unset and
+      serve the embedded copy.
     env:
       EDR_DSN: "root:@tcp(127.0.0.1:3316)/edr?parseTime=true"
       EDR_ENROLL_SECRET: dev-enroll-secret
@@ -368,6 +373,7 @@ tasks:
       EDR_LOG_FORMAT: text
       EDR_HOST_TOKEN_LIFETIME: 24h
       EDR_HOST_TOKEN_GRACE: 5m
+      EDR_UI_LIVE_DIR: server/ui/dist
       # Dev-only deterministic session HMAC key. Required when break-glass or OIDC is
       # configured (the server refuses to boot without it). Production deployments
       # MUST supply a real random secret via EDR_SESSION_SIGNING_KEY_FILE (Docker
@@ -402,12 +408,12 @@ tasks:
   dev:
     desc: |
       Run backend + UI dev servers in parallel for fast iteration. Backend lives at
-      http://127.0.0.1:8088 (Go server, serves the bundled `server/ui/dist/` -- so it
-      shows the LAST `task build:ui` output, not your live edits); UI HMR lives at
-      http://localhost:5173/ui/ (Vite dev server, proxies /api/* back to :8088). Edit
-      .tsx/.scss -> browser updates in <1s; edit .go -> Ctrl-C and re-run `task dev`
-      (Go has no built-in HMR). For QA against the embedded bundle (production shape),
-      use `task build:ui && task dev:server` instead.
+      http://127.0.0.1:8088 (Go server, serves `server/ui/dist/` via EDR_UI_LIVE_DIR --
+      a `task build:ui` in another terminal is picked up on the next request without
+      restarting the server, per issue #141); UI HMR lives at http://localhost:5173/ui/
+      (Vite dev server, proxies /api/* back to :8088). Edit .tsx/.scss -> Vite HMR
+      updates in <1s; edit .go -> Ctrl-C and re-run `task dev` (Go has no built-in HMR).
+      For QA against the embedded bundle (production shape), unset EDR_UI_LIVE_DIR.
     deps:
       - dev:server
       - dev:ui
@@ -541,6 +547,7 @@ tasks:
       EDR_LOG_FORMAT: text
       EDR_HOST_TOKEN_LIFETIME: 24h
       EDR_HOST_TOKEN_GRACE: 5m
+      EDR_UI_LIVE_DIR: server/ui/dist
       EDR_SESSION_SIGNING_KEY: dev-only-session-key-do-not-use-in-production-xyz
       EDR_BREAKGLASS_RP_ID: localhost
       EDR_BREAKGLASS_RP_ORIGINS: http://localhost:8088

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -230,6 +230,12 @@ Read endpoints for the UI:
 React 19 + TypeScript + Vite + D3.js. Embedded in the Go server binary via
 `//go:embed`. Served at `/ui/`.
 
+In dev, `task dev:server` sets `EDR_UI_LIVE_DIR=server/ui/dist` so the server
+reads the bundle from disk instead of the compile-time embedded copy. A
+`task build:ui` in another terminal is picked up on the next request without a
+server restart. Production builds leave `EDR_UI_LIVE_DIR` unset and serve the
+embedded bundle.
+
 Pages:
 - **Login** -- API key entry (stored in sessionStorage)
 - **Host list** -- table of enrolled hosts with event counts

--- a/docs/maintenance/tasks/adr-audit.md
+++ b/docs/maintenance/tasks/adr-audit.md
@@ -49,6 +49,8 @@ Go through these candidate decision domains and ask: is there an ADR for it? If 
 | `server/testdb/full.Open` as the integration-test seam | not yet | likely yes |
 | Co-Authored-By trailers policy | not yet | possibly (it's in MEMORY/CLAUDE.md only) |
 | AI-tooling-as-code (CLAUDE.md, skills, commands committed) | not yet | possibly |
+| MySQL-only data plane (no PostgreSQL) | not yet | yes (issue #145; best-practices.md §10) |
+| In-product auto-update: MDM-only by design | not yet | yes (issue #145; best-practices.md §11) |
 
 For each gap that's worth recording, file an issue tagged `adr` describing the decision, the constraints behind it, and the
 alternatives. Don't write the ADR during this audit unless it's trivial - it's a separate piece of writing that benefits from a

--- a/server/cmd/fleet-edr-server/main.go
+++ b/server/cmd/fleet-edr-server/main.go
@@ -582,7 +582,7 @@ func registerUIRoutes(
 	breakglassUIGate func(http.Handler) http.Handler,
 	logger *slog.Logger,
 ) {
-	uiDist, err := fs.Sub(ui.DistFS, "dist")
+	uiDist, err := ui.FS()
 	if err != nil {
 		logger.ErrorContext(context.Background(), "embed ui", "err", err)
 		mux.HandleFunc("/ui/", func(w http.ResponseWriter, _ *http.Request) {

--- a/server/ui/embed.go
+++ b/server/ui/embed.go
@@ -3,6 +3,7 @@ package ui
 
 import (
 	"embed"
+	"fmt"
 	"io/fs"
 	"os"
 )
@@ -22,10 +23,20 @@ const LiveDirEnv = "EDR_UI_LIVE_DIR"
 //     binary, identical for every request.
 //   - Dev: when EDR_UI_LIVE_DIR is set, reads from that directory on disk so
 //     `task build:ui` refreshes the bundle on the next request without a
-//     `task dev:server` restart. Vite writes new files atomically, so a request
-//     in flight when the rebuild lands sees a coherent old-or-new snapshot.
+//     `task dev:server` restart. Vite's `emptyOutDir: true` clears the dist
+//     directory before writing the new bundle, so a request that arrives mid-
+//     rebuild (sub-second window on this codebase) can see missing files; the
+//     SPA-fallback path in registerUIRoutes treats those as 404 and the next
+//     request after the rebuild settles serves the new bundle.
+//
+// Returns an error if EDR_UI_LIVE_DIR points at a non-existent or unreadable
+// path so a misconfigured dev server fails at boot with a clear message
+// instead of 500ing every request.
 func FS() (fs.FS, error) {
 	if dir := os.Getenv(LiveDirEnv); dir != "" {
+		if _, err := os.Stat(dir); err != nil { //nolint:gosec // dev-only env var, operator-supplied path is intentional
+			return nil, fmt.Errorf("%s=%q: %w", LiveDirEnv, dir, err)
+		}
 		return os.DirFS(dir), nil
 	}
 	return fs.Sub(embeddedDist, "dist")

--- a/server/ui/embed.go
+++ b/server/ui/embed.go
@@ -1,7 +1,32 @@
 // Package ui embeds the built React frontend assets for serving by the Go server.
 package ui
 
-import "embed"
+import (
+	"embed"
+	"io/fs"
+	"os"
+)
 
 //go:embed all:dist
-var DistFS embed.FS
+var embeddedDist embed.FS
+
+// LiveDirEnv is the env var that opts a process into reading the UI bundle from
+// disk instead of the compile-time embedded copy. Set by Taskfile's dev:server
+// task to server/ui/dist so `task build:ui` is picked up without restarting the
+// Go process. Production builds leave the var unset and serve the embedded copy.
+const LiveDirEnv = "EDR_UI_LIVE_DIR"
+
+// FS returns the filesystem the server should serve UI assets from.
+//
+//   - Production: the embedded bundle. Frozen at compile time, ships with the
+//     binary, identical for every request.
+//   - Dev: when EDR_UI_LIVE_DIR is set, reads from that directory on disk so
+//     `task build:ui` refreshes the bundle on the next request without a
+//     `task dev:server` restart. Vite writes new files atomically, so a request
+//     in flight when the rebuild lands sees a coherent old-or-new snapshot.
+func FS() (fs.FS, error) {
+	if dir := os.Getenv(LiveDirEnv); dir != "" {
+		return os.DirFS(dir), nil
+	}
+	return fs.Sub(embeddedDist, "dist")
+}

--- a/server/ui/embed_test.go
+++ b/server/ui/embed_test.go
@@ -5,73 +5,91 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
-func TestFS_DefaultsToEmbedded(t *testing.T) {
-	// An empty live-dir env must fall back to the compile-time embedded bundle.
-	t.Setenv(LiveDirEnv, "")
-	got, err := FS()
-	if err != nil {
-		t.Fatalf("FS() returned error: %v", err)
-	}
-	// The embedded bundle is built by `task build:ui` and always contains
-	// index.html at the root. If this fails, the dist/ tree is stale or empty.
-	if _, err := fs.Stat(got, "index.html"); err != nil {
-		t.Fatalf("expected embedded FS to contain index.html, got %v", err)
-	}
-}
+func TestFS(t *testing.T) {
+	cases := []struct {
+		name string
+		run  func(t *testing.T)
+	}{
+		{
+			name: "defaults to embedded when env unset",
+			run: func(t *testing.T) {
+				t.Helper()
+				t.Setenv(LiveDirEnv, "")
+				got, err := FS()
+				require.NoError(t, err)
+				// Assert the embedded subtree is readable, not the presence of any
+				// specific file: CI seeds server/ui/dist with .gitkeep only before
+				// running server tests, so checking for index.html would couple this
+				// unit test to a built UI bundle that doesn't exist in CI.
+				entries, err := fs.ReadDir(got, ".")
+				require.NoError(t, err)
+				require.NotEmpty(t, entries, "embedded FS should expose at least one entry")
+			},
+		},
+		{
+			name: "live dir override reads from disk",
+			run: func(t *testing.T) {
+				t.Helper()
+				dir := t.TempDir()
+				want := []byte("<!doctype html><html><body>live</body></html>")
+				require.NoError(t, os.WriteFile(filepath.Join(dir, "index.html"), want, 0o600))
 
-func TestFS_LiveDirOverrideReadsFromDisk(t *testing.T) {
-	dir := t.TempDir()
-	want := []byte("<!doctype html><html><body>live</body></html>")
-	if err := os.WriteFile(filepath.Join(dir, "index.html"), want, 0o600); err != nil {
-		t.Fatalf("seed live dir: %v", err)
+				t.Setenv(LiveDirEnv, dir)
+				got, err := FS()
+				require.NoError(t, err)
+				data, err := fs.ReadFile(got, "index.html")
+				require.NoError(t, err)
+				require.Equal(t, want, data)
+			},
+		},
+		{
+			name: "live dir reflects on-disk rewrites",
+			run: func(t *testing.T) {
+				t.Helper()
+				// Property the dev workflow depends on: an FS opened once must
+				// observe later writes to the underlying directory. Without this,
+				// a server boot that reads index.html once would never see
+				// `task build:ui` rebuilds.
+				dir := t.TempDir()
+				require.NoError(t, os.WriteFile(filepath.Join(dir, "index.html"), []byte("v1"), 0o600))
+				t.Setenv(LiveDirEnv, dir)
+
+				live, err := FS()
+				require.NoError(t, err)
+				first, err := fs.ReadFile(live, "index.html")
+				require.NoError(t, err)
+				require.Equal(t, []byte("v1"), first)
+
+				require.NoError(t, os.WriteFile(filepath.Join(dir, "index.html"), []byte("v2"), 0o600))
+				second, err := fs.ReadFile(live, "index.html")
+				require.NoError(t, err)
+				require.Equal(t, []byte("v2"), second, "FS must honour on-disk rewrites for `task build:ui` to take effect without restart")
+			},
+		},
+		{
+			name: "errors at boot when live dir does not exist",
+			run: func(t *testing.T) {
+				t.Helper()
+				// Bad EDR_UI_LIVE_DIR previously surfaced as generic per-request
+				// 500s. The os.Stat check in FS() means the dev server fails to
+				// boot with a clear message instead.
+				missing := filepath.Join(t.TempDir(), "does-not-exist")
+				t.Setenv(LiveDirEnv, missing)
+
+				_, err := FS()
+				require.Error(t, err)
+				require.ErrorIs(t, err, os.ErrNotExist)
+				require.Contains(t, err.Error(), LiveDirEnv)
+				require.Contains(t, err.Error(), missing)
+			},
+		},
 	}
 
-	t.Setenv(LiveDirEnv, dir)
-	got, err := FS()
-	if err != nil {
-		t.Fatalf("FS() returned error: %v", err)
-	}
-	data, err := fs.ReadFile(got, "index.html")
-	if err != nil {
-		t.Fatalf("read index.html from live FS: %v", err)
-	}
-	if string(data) != string(want) {
-		t.Fatalf("live FS served wrong bytes: got %q want %q", data, want)
-	}
-}
-
-func TestFS_LiveDirOverrideReflectsRewrites(t *testing.T) {
-	// Property the dev workflow depends on: an FS opened once must observe
-	// later writes to the underlying directory. Without this, a server boot
-	// that reads index.html once would never see `task build:ui` rebuilds.
-	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, "index.html"), []byte("v1"), 0o600); err != nil {
-		t.Fatalf("seed v1: %v", err)
-	}
-	t.Setenv(LiveDirEnv, dir)
-
-	live, err := FS()
-	if err != nil {
-		t.Fatalf("FS() returned error: %v", err)
-	}
-	first, err := fs.ReadFile(live, "index.html")
-	if err != nil {
-		t.Fatalf("read v1: %v", err)
-	}
-	if string(first) != "v1" {
-		t.Fatalf("first read got %q want v1", first)
-	}
-
-	if err := os.WriteFile(filepath.Join(dir, "index.html"), []byte("v2"), 0o600); err != nil {
-		t.Fatalf("seed v2: %v", err)
-	}
-	second, err := fs.ReadFile(live, "index.html")
-	if err != nil {
-		t.Fatalf("read v2: %v", err)
-	}
-	if string(second) != "v2" {
-		t.Fatalf("second read got %q want v2 (FS not honoring on-disk rewrites)", second)
+	for _, tc := range cases {
+		t.Run(tc.name, tc.run)
 	}
 }

--- a/server/ui/embed_test.go
+++ b/server/ui/embed_test.go
@@ -1,0 +1,77 @@
+package ui
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFS_DefaultsToEmbedded(t *testing.T) {
+	// An empty live-dir env must fall back to the compile-time embedded bundle.
+	t.Setenv(LiveDirEnv, "")
+	got, err := FS()
+	if err != nil {
+		t.Fatalf("FS() returned error: %v", err)
+	}
+	// The embedded bundle is built by `task build:ui` and always contains
+	// index.html at the root. If this fails, the dist/ tree is stale or empty.
+	if _, err := fs.Stat(got, "index.html"); err != nil {
+		t.Fatalf("expected embedded FS to contain index.html, got %v", err)
+	}
+}
+
+func TestFS_LiveDirOverrideReadsFromDisk(t *testing.T) {
+	dir := t.TempDir()
+	want := []byte("<!doctype html><html><body>live</body></html>")
+	if err := os.WriteFile(filepath.Join(dir, "index.html"), want, 0o600); err != nil {
+		t.Fatalf("seed live dir: %v", err)
+	}
+
+	t.Setenv(LiveDirEnv, dir)
+	got, err := FS()
+	if err != nil {
+		t.Fatalf("FS() returned error: %v", err)
+	}
+	data, err := fs.ReadFile(got, "index.html")
+	if err != nil {
+		t.Fatalf("read index.html from live FS: %v", err)
+	}
+	if string(data) != string(want) {
+		t.Fatalf("live FS served wrong bytes: got %q want %q", data, want)
+	}
+}
+
+func TestFS_LiveDirOverrideReflectsRewrites(t *testing.T) {
+	// Property the dev workflow depends on: an FS opened once must observe
+	// later writes to the underlying directory. Without this, a server boot
+	// that reads index.html once would never see `task build:ui` rebuilds.
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "index.html"), []byte("v1"), 0o600); err != nil {
+		t.Fatalf("seed v1: %v", err)
+	}
+	t.Setenv(LiveDirEnv, dir)
+
+	live, err := FS()
+	if err != nil {
+		t.Fatalf("FS() returned error: %v", err)
+	}
+	first, err := fs.ReadFile(live, "index.html")
+	if err != nil {
+		t.Fatalf("read v1: %v", err)
+	}
+	if string(first) != "v1" {
+		t.Fatalf("first read got %q want v1", first)
+	}
+
+	if err := os.WriteFile(filepath.Join(dir, "index.html"), []byte("v2"), 0o600); err != nil {
+		t.Fatalf("seed v2: %v", err)
+	}
+	second, err := fs.ReadFile(live, "index.html")
+	if err != nil {
+		t.Fatalf("read v2: %v", err)
+	}
+	if string(second) != "v2" {
+		t.Fatalf("second read got %q want v2 (FS not honoring on-disk rewrites)", second)
+	}
+}


### PR DESCRIPTION
Fixes #141: EDR_UI_LIVE_DIR opts the server into reading server/ui/dist from disk instead of the compile-time embedded copy, so a task build:ui in another terminal refreshes the bundle without restarting dev:server. Production binaries leave the env unset and serve the embedded path; the existing fs.Sub error branch in registerUIRoutes is preserved.

Fixes #145: adds MySQL-only data plane and MDM-only auto-update rows to the ADR audit gap-check table so the next audit pass picks them up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Development workflow improvement: UI changes are now automatically picked up on the next request without requiring a server restart.

* **Documentation**
  * Updated architecture documentation with development and production UI serving behavior.
  * Enhanced task audit documentation with additional decision domain coverage.

* **Tests**
  * Added test coverage for UI bundle loading in development and production modes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/getvictor/fleet-edr/pull/163)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->