### PR TITLE
ci: lower codecov project target 80% to 75% (issue #124)

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -9,8 +9,11 @@ coverage:
   status:
     project:
       default:
-        # Matches sonar's overall project coverage on main; today ~80%.
-        target: 80%
+        # Tracks reality on main (today ~75.6% per codecov, ~75.2% per sonar). Sonar's per-PR
+        # new-code gate at 80% (configured in the SonarCloud UI) is the authoritative bar
+        # for what each change must meet; this project rollup just tracks the trend. Lowered
+        # from 80% to 75% per issue #124 after chronic non-PR-introduced project-gate failures.
+        target: 75%
         # Allow a 1% drift before failing the project status; smaller deltas are
         # noise from coverage tool reordering, not regressions.
         threshold: 1%


### PR DESCRIPTION
The codecov/project status check has been chronically failing on every PR because rolled-up coverage sits at ~75.6% (codecov) / ~75.2% (sonar), not 80%. That is independent of the per-PR patch coverage, which the same PRs hit at 100%. Sonar's per-PR "Coverage on New Code" gate at 80% (configured in the SonarCloud UI) is the authoritative gate; the codecov project rollup was duplicating Sonar's intent against a target that total coverage was never going to meet without a separate uplift sweep.

Lowering the project target to 75% (with the existing 1% drift threshold giving an effective 74% floor) lets the project status reflect reality while the per-PR new-code gate keeps trending coverage upward.

Author of the issue picked option (1) of three. The patch (per-PR new code) target stays at 80% so each individual change still has to clear the same bar Sonar enforces. Verified the yaml is accepted by the codecov.io/validate endpoint.