### PR TITLE
Update specs + ops doc + OpenAPI for snapshot heartbeat / pending-exi…

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -784,7 +784,7 @@ components:
         timestamp_ns: {type: integer, format: int64}
         event_type:
           type: string
-          enum: [exec, fork, exit, open, network_connect, dns_query]
+          enum: [exec, fork, exit, open, network_connect, dns_query, application_control_block, snapshot_heartbeat]
         payload:
           type: object
           description: Event-type-specific body; see schema/events.json in the repo

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -279,6 +279,19 @@ The two reconcilers are complementary: the agent closes rows within
 server's TTL is the safety net for hosts that go offline before they
 can reconcile themselves.
 
+**Long-lived processes captured at extension startup.** The extension
+enumerates the live process table when it starts so processes that
+pre-dated subscription (Safari, Slack, system daemons, login session
+processes) appear in the tree alongside organic fork/exec activity.
+These rows would otherwise be force-greyed by the 6h TTL because
+nothing further happens to them at the kernel level — they just keep
+running. To prevent that, the agent emits a periodic liveness
+heartbeat for each such process on the same `EDR_PROCESS_RECONCILE_INTERVAL`
+cadence as the kill-zero sweep; the server uses those heartbeats to
+extend the per-row freshness window. No additional configuration
+knob is exposed for the heartbeat; disabling
+`EDR_PROCESS_RECONCILE_INTERVAL` disables both behaviours together.
+
 ## Metrics and monitoring
 
 Server exports OpenTelemetry metrics via OTLP/gRPC to the endpoint in

--- a/openspec/specs/agent-event-queue/spec.md
+++ b/openspec/specs/agent-event-queue/spec.md
@@ -167,9 +167,10 @@ silently losing data.
 
 ### Requirement: Synthetic reconciliation events use the same queue
 
-The queue SHALL accept reconciliation events (synthetic exit events emitted by the agent and snapshot exec events
-emitted by the extension) on the same path as kernel-observed events, and MUST NOT distinguish them from organic events
-for the purposes of durability, ordering, or upload.
+The queue SHALL accept reconciliation events (synthetic exit events emitted by the agent, snapshot exec events emitted by
+the extension, and snapshot heartbeat events emitted by the agent for still-alive snapshot-originated processes) on the
+same path as kernel-observed events, and MUST NOT distinguish them from organic events for the purposes of durability,
+ordering, or upload.
 
 #### Scenario: Reconciliation exit event is queued and uploaded
 
@@ -178,3 +179,11 @@ for the purposes of durability, ordering, or upload.
 - **THEN** the queue persists it the same as any other event
 - **AND** the uploader returns it from a normal dequeue
 - **AND** the server receives the event with `exit_reason = host_reconciled` intact
+
+#### Scenario: Snapshot heartbeat event is queued and uploaded
+
+- **GIVEN** the agent has synthesized a `snapshot_heartbeat` event for a still-alive snapshot-originated process
+- **WHEN** the agent enqueues the synthetic event
+- **THEN** the queue persists it the same as any other event
+- **AND** the uploader returns it from a normal dequeue
+- **AND** the server receives the event with its `snapshot_heartbeat` event type intact

--- a/openspec/specs/agent-process-reconciliation/spec.md
+++ b/openspec/specs/agent-process-reconciliation/spec.md
@@ -13,6 +13,11 @@ stale rows as exited based on a long inactivity window, but that window is too c
 local sweep gives operators near-minute-granularity convergence on busy hosts while remaining explicit about provenance:
 synthetic exits carry a distinct reason code so the UI can tell them apart from observed exits.
 
+The pass also keeps long-lived processes that pre-dated agent startup visible. Such processes are introduced into the agent's
+tracking table by the extension's startup snapshot enumeration; they emit no further kernel events of their own, so without a
+positive liveness signal the server's TTL reconciler would eventually force-close them. Each pass emits a heartbeat event for
+every still-alive snapshot-originated process, telling the server to extend its freshness window for that row.
+
 ## Requirements
 
 ### Requirement: Periodic kill-zero sweep
@@ -40,6 +45,8 @@ and treat a "no such process" response as evidence the process has exited.
 - **WHEN** the reconciliation pass probes that identifier
 - **THEN** the entry is treated as alive and no synthetic exit is emitted
 - **AND** the entry remains in the table
+- **AND** if the entry is a snapshot-originated process, the pass emits a heartbeat event the same as for a fully signallable
+  live process, because permission denied is positive proof the process exists
 
 ### Requirement: Synthetic exits are distinguishable
 
@@ -81,7 +88,8 @@ agent does not race against in-flight kernel-to-server propagation and falsely r
 ### Requirement: Per-pass cap on synthetic exits
 
 The system SHALL cap the number of synthetic exits emitted in a single reconciliation pass so a pathological gap of many
-thousands of missed exits cannot saturate the queue in one tick.
+thousands of missed exits cannot saturate the queue in one tick. The cap MUST apply only to synthetic exits; heartbeat
+emissions for live snapshot-originated processes MUST NOT be gated by the exit cap.
 
 #### Scenario: Many stale entries at once
 
@@ -89,6 +97,47 @@ thousands of missed exits cannot saturate the queue in one tick.
 - **WHEN** the pass runs
 - **THEN** the pass emits at most the configured number of synthetic exits
 - **AND** the remaining stale entries are reconciled by subsequent passes
+
+#### Scenario: Exit cap reached while live snapshot processes remain
+
+- **GIVEN** the table contains more dead snapshot-originated processes than the per-pass cap, plus other still-alive
+  snapshot-originated processes
+- **WHEN** the pass runs and the exit cap is reached partway through the table
+- **THEN** no further synthetic exits are emitted in this pass
+- **AND** heartbeat events continue to be emitted for the remaining live snapshot-originated processes in the same pass
+- **AND** the unreached dead entries are reconciled by subsequent passes
+
+### Requirement: Heartbeat emission for snapshot-originated processes
+
+The system SHALL emit a heartbeat event for every tracked process identifier that the kernel reports as live and that was
+introduced into the agent's tracking table by the extension's startup snapshot enumeration. The heartbeat MUST identify
+the process and MUST carry the host identifier so the server can attribute it correctly.
+
+#### Scenario: Live snapshot-originated process emits a heartbeat
+
+- **GIVEN** a process identifier in the tracking table that was first observed via the extension's startup snapshot, and the
+  kernel reports it as live
+- **WHEN** the reconciliation pass probes that identifier
+- **THEN** no synthetic exit is emitted for that identifier
+- **AND** the pass enqueues a heartbeat event for that identifier carrying the current host identifier
+- **AND** the entry remains in the tracking table
+
+#### Scenario: Live non-snapshot process does NOT emit a heartbeat
+
+- **GIVEN** a process identifier in the tracking table that was first observed via a kernel fork or exec event (not the
+  startup snapshot), and the kernel reports it as live
+- **WHEN** the reconciliation pass probes that identifier
+- **THEN** no event is emitted for that identifier
+- **AND** the entry remains in the tracking table
+
+#### Scenario: Dead snapshot-originated process emits a synthetic exit, not a heartbeat
+
+- **GIVEN** a process identifier in the tracking table that was first observed via the startup snapshot, and the kernel
+  reports it as gone
+- **WHEN** the reconciliation pass probes that identifier
+- **THEN** a synthetic exit event is enqueued for that identifier with the host-reconciled reason
+- **AND** no heartbeat event is enqueued for that identifier
+- **AND** the entry is removed from the tracking table
 
 ### Requirement: Skip when host identity is unknown
 

--- a/openspec/specs/endpoint-event-collection/spec.md
+++ b/openspec/specs/endpoint-event-collection/spec.md
@@ -123,8 +123,9 @@ since the Unix epoch, and `event_type` MUST be one of the documented values (`ex
 
 The system SHALL distinguish synthesized reconciliation events from kernel-observed events. Synthetic exit events
 emitted to close out processes whose kernel exit notification was missed SHALL carry `exit_reason = host_reconciled`,
-and synthetic exec events emitted at startup to materialize processes that already existed before subscription SHALL
-carry `snapshot = true`.
+synthetic exec events emitted at startup to materialize processes that already existed before subscription SHALL carry
+`snapshot = true`, and liveness pings for those snapshot-originated processes SHALL be emitted as a distinct event type
+`snapshot_heartbeat` carrying only the process identifier in its payload.
 
 #### Scenario: Agent fills a missing exit event
 
@@ -138,6 +139,13 @@ carry `snapshot = true`.
 - **WHEN** the system enumerates processes that already existed before subscription began
 - **THEN** the system emits one `exec` event per such process with `snapshot = true`
 - **AND** detection rules ignore those events because they describe historical state
+
+#### Scenario: Snapshot-originated process is still alive on a later pass
+
+- **GIVEN** a snapshot-originated process that the kernel still reports as live
+- **WHEN** the reconciliation pass probes the process
+- **THEN** the system emits a `snapshot_heartbeat` event whose payload identifies the process
+- **AND** detection rules ignore those events because they describe liveness rather than activity
 
 ### Requirement: Capture is non-fatal on individual event errors
 

--- a/openspec/specs/extension-xpc-server/spec.md
+++ b/openspec/specs/extension-xpc-server/spec.md
@@ -48,11 +48,21 @@ to the peer and before any inbound message from the peer is processed.
 - **AND** the rejected peer never receives any events
 - **AND** any inbound message from that peer is discarded
 
-#### Scenario: An ad-hoc-signed peer is rejected
+#### Scenario: An ad-hoc-signed peer is rejected in production builds
 
-- **GIVEN** an extension's XPC service is listening
+- **GIVEN** a release-configured extension's XPC service is listening
 - **WHEN** a process without a chain to the Apple anchor attempts to connect
 - **THEN** the extension cancels the connection
+
+#### Scenario: An ad-hoc-signed peer is accepted in debug builds when its code-directory hash matches the pinned value
+
+- **GIVEN** a debug-configured extension's XPC service is listening, built with a pinned ad-hoc peer code-directory hash for
+  local-iteration use on a SIP-disabled developer VM
+- **WHEN** a process signed ad-hoc with that exact code-directory hash attempts to connect
+- **THEN** the connection is accepted
+- **AND** the peer is added to the broadcast set
+- **AND** this code path is excluded from release builds, so a different ad-hoc-signed process cannot impersonate the agent
+  in production
 
 #### Scenario: A correctly-signed agent is accepted
 
@@ -77,8 +87,9 @@ dictionary message containing a `data` field whose value is the raw JSON event b
 
 - **GIVEN** the extension is running and no agents are connected
 - **WHEN** the extension emits an event
-- **THEN** the extension does not buffer the event for future peers
-- **AND** the event is silently discarded from the XPC channel
+- **THEN** the extension buffers the event for delivery to the next peer that completes the hello handshake
+- **AND** the buffer is bounded; once full, the oldest buffered events are dropped to make room for new ones so a permanently
+  absent agent cannot exhaust extension memory
 
 ### Requirement: Inbound policy update
 
@@ -100,17 +111,34 @@ with the policy described by `data` and MUST persist that policy so it survives 
 - **THEN** the extension does not change the active blocklist
 - **AND** the extension continues serving events to all peers
 
-### Requirement: Hello handshake support
+### Requirement: Hello handshake and reply
 
-The extensions SHALL accept an inbound XPC dictionary message with `type = hello` and treat it as a no-op. This allows
-clients to trigger the lazy Mach port bind without side effects.
+The extensions SHALL accept an inbound XPC dictionary message with `type = hello`. On receipt the extension MUST reply
+with an outbound XPC dictionary message with `type = hello-ack` on the same peer connection, so the client can confirm
+the channel is established in both directions. The exchange exists because the underlying Mach port lookup is one-way
+silent on failure: without a reply, a client cannot distinguish a real listener from a stale port binding.
+
+On receipt of `hello` the extension MUST also flush any events buffered while no peer was connected to the peer that
+sent the hello, and only to that peer. This binds the buffer to a client that has demonstrated a working bidirectional
+channel rather than to any peer that merely passed code-signing validation, which guards against transient phantom-peer
+connections that immediately fail.
 
 #### Scenario: The agent sends a hello after connecting
 
-- **GIVEN** a validated agent connection has just been established
+- **GIVEN** a validated agent connection has just been established and the buffer of events accumulated while no peer was
+  connected is non-empty
 - **WHEN** the agent sends a message with `type = hello`
-- **THEN** the extension processes the message without changing any state
-- **AND** the extension continues to broadcast events normally
+- **THEN** the extension sends back a `hello-ack` message on the same peer connection
+- **AND** the extension delivers every buffered event to the agent in the order it was emitted
+- **AND** the buffer is cleared
+
+#### Scenario: A peer connects and disconnects without ever sending hello
+
+- **GIVEN** a transient peer connection that completes code-signing validation but disconnects before sending any inbound
+  message
+- **WHEN** the connection terminates
+- **THEN** no buffered events are delivered to that peer
+- **AND** the buffer remains intact for the next peer that completes the hello exchange
 
 ### Requirement: Forward compatibility for unknown messages
 

--- a/openspec/specs/server-process-graph-builder/spec.md
+++ b/openspec/specs/server-process-graph-builder/spec.md
@@ -118,7 +118,9 @@ the event or with a future generation that had not yet forked.
 
 The system SHALL accept `exec` events flagged as snapshot (events synthesized by the agent at startup to materialize
 processes that existed before subscription) and use them to populate the process forest, while signaling to downstream
-consumers that they describe pre-existing state rather than new activity.
+consumers that they describe pre-existing state rather than new activity. The system MUST mark the resulting process
+records as snapshot-originated and seed a freshness timestamp on them so the freshness-TTL reconciler can distinguish
+them from organic rows.
 
 #### Scenario: Extension restarts and replays the live process set
 
@@ -126,6 +128,92 @@ consumers that they describe pre-existing state rather than new activity.
 - **WHEN** the builder applies the batch
 - **THEN** the corresponding process records are created or updated so the UI can render Safari, Slack, Finder, and other
   pre-existing processes
+- **AND** each created record carries a snapshot-originated marker
+- **AND** each created record carries a freshness timestamp equal to its fork time so it is not eligible for immediate TTL
+  reconciliation on the first pass after insert
 - **AND** the snapshot flag is preserved on the underlying events so detection rules can distinguish historical state from
   newly observed activity
+
+### Requirement: Snapshot heartbeat events extend the freshness window
+
+The system SHALL accept `snapshot_heartbeat` events and, for each, update the freshness timestamp on the matching
+snapshot-originated process record. The update MUST be scoped to records that are flagged snapshot-originated AND still
+live, so a stray heartbeat for a recycled PID cannot resurrect an exited row and cannot apply to a non-snapshot row.
+
+#### Scenario: Heartbeat for a live snapshot row bumps freshness
+
+- **GIVEN** a snapshot-originated process record that has not exited
+- **WHEN** a `snapshot_heartbeat` event for the same host and PID arrives
+- **THEN** the record's freshness timestamp is updated to the heartbeat's timestamp
+
+#### Scenario: Heartbeat for an exited row is a no-op
+
+- **GIVEN** a snapshot-originated process record that has an exit timestamp set
+- **WHEN** a `snapshot_heartbeat` event for the same host and PID arrives
+- **THEN** the record's freshness timestamp is NOT updated
+- **AND** no other field on the record changes
+
+#### Scenario: Heartbeat for a non-snapshot row is a no-op
+
+- **GIVEN** a process record that originated from kernel fork/exec events rather than the startup snapshot
+- **WHEN** a `snapshot_heartbeat` event for the same host and PID arrives
+- **THEN** no field on the record changes
+
+### Requirement: TTL reconciliation respects snapshot freshness
+
+The system SHALL periodically force-close process records whose freshness window has elapsed without observed activity,
+synthesizing an exit time and marking the row with a TTL-reconciliation reason code. The freshness window MUST use the
+record's freshness timestamp when set (which the snapshot path seeds and heartbeats update) and fall back to the fork
+timestamp otherwise, so heartbeated snapshot rows are exempt while ordinary rows whose exit events went missing remain
+subject to the existing freshness-TTL safety net.
+
+#### Scenario: Snapshot row with fresh heartbeats survives TTL
+
+- **GIVEN** a snapshot-originated process record whose freshness timestamp was updated within the TTL window
+- **WHEN** the TTL reconciliation pass runs
+- **THEN** the record is NOT closed
+- **AND** the record's exit fields remain unset
+
+#### Scenario: Snapshot row without recent heartbeats is closed
+
+- **GIVEN** a snapshot-originated process record whose freshness timestamp is older than the TTL window
+- **WHEN** the TTL reconciliation pass runs
+- **THEN** the record is force-closed with the TTL-reconciliation exit reason
+- **AND** the synthesized exit timestamp lands at the freshness timestamp plus the TTL window, so the UI can render the
+  reconciled exit at a meaningful moment rather than at the extension-startup snapshot moment
+
+#### Scenario: Non-snapshot row with missing exit is closed (issue #6 regression guard)
+
+- **GIVEN** a process record that originated from a fork event, whose fork timestamp is older than the TTL window, and
+  whose freshness timestamp is unset
+- **WHEN** the TTL reconciliation pass runs
+- **THEN** the record is force-closed with the TTL-reconciliation exit reason
+- **AND** the synthesized exit timestamp lands at the fork timestamp plus the TTL window
+
+### Requirement: Exit-before-snapshot-exec race buffer
+
+The system SHALL handle the race in which a kernel-observed `exit` event for a PID is processed BEFORE the snapshot
+`exec` event for the same PID is processed. Because the snapshot exec arrives last but describes an earlier moment, the
+exit's update would otherwise find no row and the later snapshot exec would synthesize a phantom alive row that survives
+until TTL. The builder MUST buffer such unmatched exits briefly and consume them when the companion snapshot exec
+arrives, producing a single record that is born already-exited.
+
+#### Scenario: Exit arrives before its companion snapshot exec
+
+- **GIVEN** an `exit` event for a host and PID with no existing record
+- **AND** within a short bounded window the matching snapshot `exec` event for the same host and PID arrives
+- **WHEN** the builder processes both
+- **THEN** the resulting process record exists, is marked snapshot-originated, and is born with the exit timestamp, exit
+  reason, and exit code from the buffered exit
+- **AND** no phantom alive row is produced for that PID
+
+#### Scenario: Exit arrives without a matching snapshot exec within the window
+
+- **GIVEN** an `exit` event for a host and PID with no existing record
+- **AND** no matching snapshot `exec` event arrives within the bounded buffer window
+- **WHEN** the buffer window elapses
+- **THEN** the buffered exit is discarded
+- **AND** no record is synthesized for that PID
+- **AND** a much-later snapshot exec for the same PID is treated as a fresh insert without inheriting the long-expired
+  exit, so a recycled PID cannot pick up a stale exit
 


### PR DESCRIPTION
…t / XPC

Specs that lagged the implementation in PR #180 (issues #173, #176, plus the XPC handshake fix from issue #178):

* openspec/specs/agent-process-reconciliation/spec.md - new requirement for emitting `snapshot_heartbeat` events for live snapshot-originated processes, plus three scenarios (live snapshot emits heartbeat, live non-snapshot doesn't, dead snapshot emits exit not heartbeat). EPERM scenario extended to call out heartbeat emission for snapshot PIDs (permission denied is positive proof the process exists). Per-pass cap requirement clarified: cap gates synthetic exits only, not heartbeats, and a new scenario locks that in.

* openspec/specs/server-process-graph-builder/spec.md - three new requirements: (1) snapshot exec inserts must mark the row as snapshot-originated and seed a freshness timestamp; (2) snapshot heartbeat events bump that timestamp on still-live snapshot rows (no-ops for exited / non-snapshot rows); (3) TTL reconciliation uses the freshness timestamp via COALESCE-style fallback so heartbeated snapshot rows survive while issue #6's existing missing-exit safety net for organic rows is preserved. Fourth new requirement covers the issue #176 exit-before-snapshot-exec race: unmatched exits buffer briefly, the companion snapshot exec consumes the buffer, and a stale buffer entry can't infect a recycled PID.

* openspec/specs/endpoint-event-collection/spec.md - "Reconciliation events are tagged" requirement extended with the `snapshot_heartbeat` event type and its payload (pid only), plus a scenario for the live-snapshot heartbeat shape.

* openspec/specs/agent-event-queue/spec.md - generalised "Synthetic reconciliation events use the same queue" requirement to include heartbeat events alongside synthetic exits and snapshot execs; new scenario for the heartbeat queue/upload path.

* openspec/specs/extension-xpc-server/spec.md - peer code-signing requirement scenario list now distinguishes release-build behaviour (team-ID-only) from debug-build behaviour (also accepts a pinned ad-hoc cdhash for local-iteration use on SIP-disabled dev VMs). Event broadcast requirement updated: events emitted while no peer is connected are buffered (bounded; oldest dropped on overflow) rather than silently discarded. Hello handshake requirement expanded into a hello/hello-ack handshake plus a buffer-flush contract scoped to peers that complete the inbound hello, with a scenario for transient phantom peers that never send hello.

* openspec validate --specs --strict -- 18/18 passed.

User-facing operations doc:

* docs/operations.md "Process-tree freshness (issue #6)" section gains a paragraph about long-lived processes captured by the startup snapshot. Operator-level only: explains the why (no kernel activity to keep them fresh) and the relevant knob (heartbeat shares the kill-zero sweep interval; disabling EDR_PROCESS_RECONCILE_INTERVAL turns both off together). No new configuration variable introduced.

Public API contract:

* docs/api/openapi.yaml EventEnvelope.event_type enum extended with `snapshot_heartbeat` (this PR) and `application_control_block` (omission inherited from prior PR; the schema/events.json source of truth has already had it for a while, but the human-readable OpenAPI surface was out of sync). Integrators reading the OpenAPI spec now see the complete event-type list.