### PR TITLE
openspec: annotate demo-cut + draft Detect-mode change (issue #68)

### DIFF
--- a/openspec/changes/add-application-control-detect-mode/design.md
+++ b/openspec/changes/add-application-control-detect-mode/design.md
@@ -141,21 +141,52 @@ Phase B work (allow-with-warn, silent-block) extends the same subtype dimension.
 produced the alert*, and both shapes are produced by application control. Subtype is the right
 axis.
 
-### Alert dedup still keys on `(source, host_id, rule_id, process_id)` — not `(source, subtype, ...)`
+### Alert dedup key is source-dependent: `(source, host_id, rule_id)` for application_control, `(source, host_id, rule_id, process_id)` for detection
 
-A would-block alert and a subsequent block alert for the same `(host, rule, process)` triple
-collapse into one row. The alert's subtype reflects the most recent decision; older subtypes are
-implicitly overwritten (or visible in audit history, depending on follow-on work).
+Phase A's dedup key was the triple `(host_id, rule_id, process_id)`, written before application
+control existed. That key is correct for `source='detection'` (catalog rules) where a long-lived
+process is re-evaluated across batches and we want one alert per matched process. It is wrong for
+`source='application_control'`: every AUTH_EXEC is a fresh `process_id`, so including it in the
+key means a Detect-mode rule and its later Protect-mode promotion produce two unrelated rows
+instead of the one lifecycle row the operator expects.
+
+The Detect-mode change splits the dedup key by source:
+
+- `source='detection'`: `(source, host_id, rule_id, process_id)`. Unchanged from Phase A; one alert
+  per (host, rule, matched process).
+- `source='application_control'`: `(source, host_id, rule_id)`. One alert per (host, rule). The
+  alert's `linked_process_id` reflects the most recent matching exec; subtype reflects the most
+  recent decision (`would_block` flips to `block` in place when the rule is promoted).
+
+The alert's subtype is NOT part of either key. A would-block alert and a subsequent block alert
+for the same `(host, rule)` on the application_control side collapse into one row whose subtype
+moves from `would_block` to `block` in place. Older subtypes are implicitly overwritten (or
+visible in audit history, depending on follow-on work).
 
 The reasoning: when an operator promotes a Detect rule to Protect, the next exec of the same
-binary on the same host should not produce a new alert row — it should update the existing one to
+binary on the same host should not produce a new alert row. It should update the existing one to
 `subtype='block'`. The alert's lifecycle (would_block → block) matches the operator's mental
-model. Separate rows per subtype would clutter the alert list with adjacent "would have blocked"
-and "blocked" entries for the same logical incident.
+model. Separate rows per subtype, or per process_id, would clutter the alert list with adjacent
+"would have blocked" and "blocked" entries for the same logical incident.
 
-*Alternatives considered:* include subtype in the dedup key. Rejected because of the post-promotion
-clutter; Phase B simulation will need its own alert lifecycle anyway (would-allow vs would-block
-in Lockdown), and we can revisit then.
+Implementation note: MySQL does not support partial unique indexes, so a single
+`UNIQUE (source, host_id, rule_id, process_id)` cannot enforce both semantics. The dedup is
+enforced at the application layer (UPSERT keyed on the source-appropriate tuple) and backed by two
+indexes that match the source-specific keys. The exact index shape (two unique indexes vs. a
+synthetic dedup_discriminator column) is an implementation choice in the schema PR; the spec only
+mandates the logical keys above.
+
+*Alternatives considered:*
+
+- *Keep `process_id` in the key for both sources.* Rejected — the original defect this section
+  fixes. The post-promotion clutter is the user-visible failure mode.
+- *Include subtype in the dedup key.* Rejected for the same reason: would split the
+  would_block → block lifecycle into two rows. Phase B simulation (would-allow vs would-block in
+  Lockdown) will need its own alert lifecycle anyway and can revisit then.
+- *Use a single key `(source, host_id, rule_id)` for both sources.* Rejected — would collapse
+  every match of one catalog rule on a host into one row even when the rule legitimately fires on
+  distinct processes (e.g. `suspicious_exec` catching three different malware instances on the
+  same host). The detection side needs the process dimension.
 
 ### PATCH `/api/v1/app-control/rules/{id}` enforcement-only body
 
@@ -171,9 +202,10 @@ generic rule PATCH already in scope.
 ## Risks / Trade-offs
 
 - **Detect-mode noise.** A broad Detect rule on a high-frequency exec target floods the alerts
-  view. Mitigation: same as Phase A blocks — alert dedup collapses repeats per
-  `(source, host_id, rule_id, process_id)`. Operators iterating on a Detect rule see one alert per
-  unique process triple, not one per exec.
+  view. Mitigation: alert dedup collapses repeats per `(source, host_id, rule_id)` on the
+  application_control side, so an operator iterating on a Detect rule sees one alert per (host,
+  rule) regardless of how many execs of the matching binary occur. The catalog side keeps the
+  Phase A `(host_id, rule_id, process_id)` key.
 - **Default-Detect regression risk.** A migrating Santa admin pastes their existing blocklist into
   the EDR expecting it to block on apply; instead it lands in Detect and silently logs. Mitigation
   is documentation + the explicit selector in the modal (the selector is non-defaultable, so the

--- a/openspec/changes/add-application-control-detect-mode/design.md
+++ b/openspec/changes/add-application-control-detect-mode/design.md
@@ -1,0 +1,233 @@
+# Application Control: Detect mode — design notes
+
+## Context
+
+The full Application Control plan lives at `ai/policy/plan.md` and the Phase A blueprint at
+`openspec/changes/add-application-control/`. This change opens the Phase B arc by activating one
+slice of it — per-rule Detect mode — and bundles two adjacent fixes that live on the same AUTH-path
+code (default-Detect on rule creation; the AUTH-deny telemetry gap).
+
+The remaining Phase B work — Lockdown (`default_action=BLOCK`), allowlist
+(`action=ALLOW`/`SILENT_BLOCK`), pre-deploy simulation, server-pushed failsafe carve-outs,
+CERTIFICATE/PATH rule types — lives in a separate change so this PR fits the v0.1.0 release window.
+
+**Current state (after the Phase A close-out PR):**
+
+- `app_control_rules.enforcement` is in the schema, default `'PROTECT'`, the column is propagated
+  through the wire payload, written to the extension's snapshot, but never consulted by the AUTH
+  decision engine.
+- `ESFSubscriber.handleAuthExec` denies on BINARY/CDHASH/SIGNINGID/TEAMID match with
+  `enforcement=PROTECT` (after the Phase A close-out's precedence-walker rewrite). The DETECT branch
+  is missing.
+- A denied AUTH_EXEC emits only `application_control_block`; no regular exec event is produced, so
+  the graph builder doesn't materialise the attempted-process row and catalog detection rules
+  (`suspicious_exec`, etc.) never observe the attempt.
+- Alerts table carries `source='application_control'` for blocks but has no subtype dimension, so
+  blocked and would-be-blocked rows can't be visually distinguished.
+
+**Constraints:**
+
+- ESF AUTH_EXEC deadline is a hard kernel-side limit. Adding the Detect branch adds zero map
+  lookups — same precedence walk; only the post-walk action changes. No latency budget impact.
+- Per ADR-0004, cross-context calls go through `api/` packages. The new event kind flows through
+  the existing event channel between `endpoint` and `rules`/`detection`. No new cross-context calls.
+- Per `CLAUDE.md` test-style matrix: PBT for the AUTH-path decision invariants; example-based for
+  the PATCH endpoint wire shape; integration tests for the closed-loop alert + promote flow.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Activate per-rule `enforcement=DETECT` end-to-end so an operator can author rules in log-only
+  mode, observe `application_control_would_block` alerts over time, and promote rules to PROTECT
+  when confident.
+- Make Detect the default for new rules so an operator who pastes a rule and forgets the toggle
+  doesn't brick production on first matching boot. The plan calls this out as the EDR-grade
+  rollout-safety norm.
+- Resolve the Phase A spec contradiction on AUTH-deny exec event emission by codifying that every
+  AUTH_EXEC decision emits a corresponding telemetry event so the regular detection pipeline
+  observes the attempt regardless of decision.
+- Surface the would-block subtype in the alerts UI so an operator iterating on a Detect-mode rule
+  sees the "would have blocked" alerts distinctly from real blocks.
+
+**Non-Goals:**
+
+- Lockdown (`default_action=BLOCK` on policies). Requires failsafe carve-outs + pre-deploy
+  simulation to ship safely. Phase B proper.
+- `ALLOW` / `SILENT_BLOCK` rule actions. Phase B proper.
+- Pre-deploy simulation (`POST /api/v1/app-control/policies/{id}/simulate`). Phase B proper.
+- Server-pushed failsafe carve-out list. Phase B proper.
+- Leaf-cert SHA-256 cache + CERTIFICATE rule type. Phase B proper.
+- PATH rule type acceptance + Launch Services indirection handling. Phase B proper.
+- "Rule from alert" workflow (operator clicks a button on a detection finding to auto-create an
+  app_control_rule). Worth its own change once the closed-loop telemetry surface stabilises here.
+
+## Decisions
+
+### Distinct event kind `application_control_would_block`, not a flag on `application_control_block`
+
+A new event kind keeps ingest, alert mapping, and visual distinction trivially separable. A flag
+would force every consumer (event router, alert mapper, alert detail UI) to branch on the field
+and risk silently treating one type as the other when the branch is forgotten. The wire-format
+cost is one new event_type string; the rule shape is otherwise identical to `application_control_block`.
+
+*Alternatives considered:* a discriminator field on `application_control_block`. Rejected — the
+flag's default value becomes the "old shape" assumption and consumers that don't yet branch on it
+silently misattribute. A new event kind makes the unknown-shape case loud.
+
+### Default `enforcement='DETECT'` for new rules
+
+The schema default flips. Existing rules retain whatever value they were created with. The UI's
+add-rule modal carries an explicit enforcement selector defaulting to DETECT; the operator can
+still pick PROTECT with one click. The PATCH endpoint accepts either value.
+
+The rationale is the EDR-grade rollout-safety norm CrowdStrike's IOC Management embodies: the
+*easy path* must be the *safe path*. An operator who pastes a rule and clicks Save lands in Detect
+mode, sees would-block alerts, decides whether to promote. An operator who consciously authors a
+PROTECT rule is making a deliberate choice. Inverting this — defaulting to PROTECT — means the
+first mistake is a brick, not an alert.
+
+*Alternatives considered:* keep the default at PROTECT and require operators to opt into Detect.
+Rejected — that's the Santa posture, where "Monitor mode" is a global setting and individual rule
+authoring assumes the operator knows what they're doing. The EDR-grade posture inverts the
+relationship.
+
+### Closed-loop telemetry: every AUTH_EXEC emits the regular exec event too
+
+The Phase A spec is inconsistent here. The MODIFIED `endpoint-event-collection` "Process exec
+authorization" requirement says `BLOCK`/`PROTECT` denies and "Otherwise the system MUST allow the
+exec and emit an `exec` event describing the new image" — implying the deny path skips the exec
+event. The ADDED scenario says "the canonical exec channel observes the denied attempt for normal
+telemetry purposes" — implying the opposite. The shipped code follows the MODIFIED requirement.
+
+The Detect-mode change reconciles by codifying that **every AUTH_EXEC decision emits a
+corresponding telemetry event**, with a `decision` field discriminating among `allowed`, `blocked`,
+and `would_block`. Reasoning:
+
+- Without the regular exec event on deny, the graph builder never materialises a process row for
+  the attempted-but-blocked exec. Catalog detection rules (which key on the process graph) don't
+  observe the attempt. An attacker probing with a blocked binary triggers only the deduped block
+  alert — the behavioral rules above don't fire on repetition because the events that would feed
+  them never reach the pipeline.
+- With the regular exec event on deny, repeated blocked attempts feed `suspicious_exec` and friends
+  exactly the way an allowed exec would. Two unrelated detection paths (rule-based blocking +
+  behavioral catalog rules) now compose instead of competing.
+- The Detect path needs the same telemetry: when an exec is allowed-but-flagged, the regular exec
+  event still fires (it's via NOTIFY_EXEC today). Adding `decision='would_block'` to the exec
+  event's optional payload lets the graph + catalog see the flag without breaking the existing
+  consumer shape.
+
+The `decision` field is **optional** on exec events. It is absent for ordinary allowed execs (the
+99.9% case) so the wire shape stays stable for every existing consumer. It is present only when
+the AUTH path made a non-trivial decision.
+
+*Alternatives considered:*
+
+- Emit a separate `auth_decision` event for every AUTH_EXEC. Rejected — doubles the AUTH-path
+  event volume and forces every catalog rule to join across two event kinds for what is logically
+  one process exec.
+- Keep AUTH-deny silent on the regular channel. Rejected — that's the status quo, and it's the bug
+  this change fixes.
+
+### Alert subtype, not a new source
+
+Adding `subtype` to the alerts table preserves the source enum as `('detection',
+'application_control')` and adds a free-form-but-disciplined string column for sub-classification.
+Phase A blocks become `subtype='block'`; would-blocks become `subtype='would_block'`. Future
+Phase B work (allow-with-warn, silent-block) extends the same subtype dimension.
+
+*Alternatives considered:* extend the `source` ENUM to `('detection', 'application_control_block',
+'application_control_would_block')`. Rejected — the source dimension communicates *which subsystem
+produced the alert*, and both shapes are produced by application control. Subtype is the right
+axis.
+
+### Alert dedup still keys on `(source, host_id, rule_id, process_id)` — not `(source, subtype, ...)`
+
+A would-block alert and a subsequent block alert for the same `(host, rule, process)` triple
+collapse into one row. The alert's subtype reflects the most recent decision; older subtypes are
+implicitly overwritten (or visible in audit history, depending on follow-on work).
+
+The reasoning: when an operator promotes a Detect rule to Protect, the next exec of the same
+binary on the same host should not produce a new alert row — it should update the existing one to
+`subtype='block'`. The alert's lifecycle (would_block → block) matches the operator's mental
+model. Separate rows per subtype would clutter the alert list with adjacent "would have blocked"
+and "blocked" entries for the same logical incident.
+
+*Alternatives considered:* include subtype in the dedup key. Rejected because of the post-promotion
+clutter; Phase B simulation will need its own alert lifecycle anyway (would-allow vs would-block
+in Lockdown), and we can revisit then.
+
+### PATCH `/api/v1/app-control/rules/{id}` enforcement-only body
+
+The Phase A close-out PR ships the full rule-mutation PATCH (every mutable field). This change
+specifies the *contract* for the partial-body shape that Detect mode uses: a body containing only
+`{enforcement, reason}` is valid; other fields default to "no change". Audit event is emitted with
+the diff.
+
+*Alternatives considered:* a dedicated `POST .../rules/{id}:promote` action endpoint. Rejected as
+unnecessary RPC-ification; PATCH with a partial body is the standard REST way and aligns with the
+generic rule PATCH already in scope.
+
+## Risks / Trade-offs
+
+- **Detect-mode noise.** A broad Detect rule on a high-frequency exec target floods the alerts
+  view. Mitigation: same as Phase A blocks — alert dedup collapses repeats per
+  `(source, host_id, rule_id, process_id)`. Operators iterating on a Detect rule see one alert per
+  unique process triple, not one per exec.
+- **Default-Detect regression risk.** A migrating Santa admin pastes their existing blocklist into
+  the EDR expecting it to block on apply; instead it lands in Detect and silently logs. Mitigation
+  is documentation + the explicit selector in the modal (the selector is non-defaultable, so the
+  operator can't miss the value). The migration path (`add-application-control-import-santa` in
+  Phase C) will set `enforcement=PROTECT` on imported rules to preserve the source-system
+  semantics.
+- **Telemetry-on-deny volume.** Adding the regular exec event to every blocked AUTH_EXEC roughly
+  doubles the event count on the deny path. For typical fleets this is negligible (blocks are
+  rare); for a misconfigured-broad-rule scenario the volume is bounded by the same alert dedup
+  that bounds the block-event volume — both share the upload batch.
+- **`decision` field absence semantics.** The field is absent for ordinary allowed execs and
+  present for AUTH-flagged execs. Consumers that switch on `decision` see `nil` for the 99.9% case
+  and one of `blocked`/`would_block` otherwise. This is the standard "optional field" Go/Swift
+  pattern; the schema declares the field optional and ingest is tolerant.
+- **Subtype value drift.** A new alert subtype landing in Phase B (e.g. `silent_block`,
+  `would_allow`) needs to be coordinated with the UI rendering layer. The string-not-enum choice
+  preserves forward-compat; the UI defaults to "Application Control" for unknown subtypes rather
+  than rendering blank.
+- **Rule promotion races.** A rule promoted from DETECT to PROTECT while an in-flight
+  `application_control_would_block` event is on the upload queue produces a `would_block` alert
+  *after* the rule already has `enforcement=PROTECT`. Operationally this is fine — the alert is
+  historically accurate (the AUTH decision at the time was Detect), and the next exec will block.
+  Worth documenting; not worth coordination.
+
+## Migration Plan
+
+No customer-facing migration. The product has not shipped its first release.
+
+**Deploy:**
+
+1. Apply the schema delta: add `alerts.subtype VARCHAR(32) NOT NULL DEFAULT 'block'`; flip
+   `app_control_rules.enforcement` default to `'DETECT'`. Existing rules retain their individual
+   enforcement values.
+2. Land the extension change, the new event kind, the alert mapper, the PATCH endpoint, the UI.
+3. Existing test databases re-bootstrap from the seed; the demo cut's existing fixtures keep their
+   `enforcement='PROTECT'` value where set explicitly.
+
+**Rollback** (pre-release):
+
+- Schema: drop `alerts.subtype`; reset enforcement default.
+- Events schema: server ingest tolerates unknown event types and unknown fields, so older agents
+  emitting old shapes against newer servers and vice versa both work for the in-flight transition.
+- Persisted host token: not touched.
+
+## Open Questions
+
+- **Alert subtype rendering.** The visual difference between "would have blocked" and "blocked" in
+  the alerts list — distinct chip color? distinct icon? text-only? Defer to the UI implementation;
+  the spec mandates that the two be visually distinguishable, not a specific palette.
+- **Promote-to-Protect confirmation.** Does promoting a rule require an explicit reason field, or
+  is the per-rule audit row sufficient? The spec mandates an audit event on enforcement change;
+  the modal-confirmation question is a UI policy call. The current draft requires a non-empty
+  reason. Worth reviewing once the alerts → promotion flow is on screen.
+- **Future "rule from alert" workflow.** When an operator sees a `suspicious_exec` detection
+  finding, should a button auto-create an `application_control_rule` with `enforcement=DETECT` from
+  the offending binary's SHA-256? Out of scope here; tracked as a follow-on change once Detect mode
+  is in operator hands.

--- a/openspec/changes/add-application-control-detect-mode/proposal.md
+++ b/openspec/changes/add-application-control-detect-mode/proposal.md
@@ -1,0 +1,158 @@
+# Application Control: per-rule Detect mode + closed-loop telemetry
+
+## Why
+
+Phase A of `add-application-control` shipped a Santa-shaped block engine sitting on EDR-shaped
+plumbing: named policies, per-rule lifecycle metadata, blocked-exec events flowing through the
+unified detection-rules pipeline. Phase A is operationally a blocklist — every rule, when matched,
+denies the exec and notifies. That is a faithful Santa port. It is not the EDR-grade differentiator
+the plan calls for in `ai/policy/plan.md:5-20`.
+
+The EDR-grade differentiator is **per-rule Detect mode**: an operator authors a rule, marks it
+Detect, watches the would-have-blocked alerts for a week, promotes the rule to Protect when
+confident. CrowdStrike and SentinelOne both have this as a first-class control. Santa has
+global-mode Monitor/Lockdown only. The `enforcement` column has been in the schema since the demo
+cut shipped; the decision engine has never consulted it (`ESFSubscriber.swift:127` only branches on
+`PROTECT`). This change activates `DETECT` semantics end-to-end.
+
+Two adjacent gaps are bundled into this change because they live on the same AUTH-path code that
+Detect mode touches, and shipping them separately would require touching the AUTH callback three
+times for changes that share a single design:
+
+1. **Default Detect on rule creation.** The current default is `enforcement=PROTECT`. Shipping
+   Detect as a feature but leaving the default at Protect means an operator who pastes a rule and
+   forgets to flip the toggle bricks production execs on first matching boot. CrowdStrike's IOC
+   Management defaults new IOCs to Detect for exactly this reason. The change makes Detect the new
+   default; Protect requires an explicit operator step.
+
+2. **Regular exec event emission on AUTH-deny.** The Phase A spec is self-contradictory on this
+   point (MODIFIED `endpoint-event-collection` "Process exec authorization" implies no exec event on
+   deny; ADDED scenario "the canonical exec channel observes the denied attempt for normal telemetry
+   purposes" implies the opposite). Shipped behavior: only `application_control_block` is emitted on
+   deny. The graph builder never materialises a process row; catalog rules
+   (`suspicious_exec`, `shell_from_office`, etc.) never observe the attempted exec. The Detect-mode
+   change fixes the spec contradiction by codifying that every AUTH_EXEC decision — allow, block, or
+   detect — emits a corresponding telemetry event so the regular detection pipeline observes the
+   attempt regardless of outcome.
+
+The result is a closed loop: an operator sees a `suspicious_exec` detection finding, clicks
+"Create block rule" on the binary's SHA-256, the rule lands in Detect mode by default, the operator
+watches `application_control_would_block` alerts accumulate over a week, promotes to Protect when
+confident. Santa cannot offer this loop because the rules are external; in an EDR the rules are an
+extension of the detection pipeline itself. That is the "best-class EDR, not just copying Santa"
+arc the plan opens with.
+
+This change is deliberately scoped to Detect mode only. Lockdown (`default_action=BLOCK`), allowlist
+(`action=ALLOW`/`SILENT_BLOCK`), pre-deploy simulation, the server-pushed failsafe list, and the
+CERTIFICATE/PATH rule types are tracked in a separate Phase B change so this PR fits the v0.1.0
+release window.
+
+## What Changes
+
+- **Activate `enforcement=DETECT` in the extension decision engine.** When the precedence walk
+  returns a `BLOCK` rule with `enforcement=DETECT`, the extension SHALL NOT deny the exec. It SHALL
+  emit a new event of kind `application_control_would_block` carrying the same fields as
+  `application_control_block` plus a discriminator, and SHALL allow the exec.
+- **Default new rules to `enforcement=DETECT`.** Server validation continues to accept both values;
+  the column default in `app_control_rules` flips from `'PROTECT'` to `'DETECT'`. Existing rules
+  retain whatever value they were created with.
+- **Closed-loop telemetry on every AUTH_EXEC.** When an AUTH_EXEC is denied because of a
+  `PROTECT`+`BLOCK` rule, the extension SHALL emit a regular exec event alongside the
+  `application_control_block` event so the graph builder and catalog detection rules observe the
+  attempt. The exec event carries the standard fields plus a new `decision='blocked'` or
+  `decision='would_block'` discriminator; absent for ordinary allowed execs to keep the wire shape
+  stable for existing consumers.
+- **Map `application_control_would_block` events to alerts** with `source='application_control'`
+  and a new `subtype='would_block'` (alerts for actual blocks carry `subtype='block'`). Subtype is a
+  string column on the alerts table; existing rows backfill to `'block'`. Alert dedup still keys on
+  `(source, host_id, rule_id, process_id)` — would-block and block alerts for the same
+  `(host, rule, process)` triple collapse, which is the behavior an operator wants while iterating
+  on a rule's Detect-to-Protect promotion.
+- **REST PATCH endpoint for rule enforcement.** `PATCH /api/v1/app-control/rules/{id}` accepts a
+  partial body `{enforcement: "PROTECT"|"DETECT", reason: "..."}`. (The broader rule-mutation PATCH
+  surface — every other mutable field — ships with the Phase A close-out PR.)
+- **UI: enforcement selector + Promote-to-Protect.** The add-rule modal carries an explicit
+  enforcement selector defaulting to `DETECT`. The policy-detail rules table shows the enforcement
+  value per row. A `Promote to Protect` action appears per row for `DETECT` rules; clicking it opens
+  a confirmation modal carrying a non-empty reason field and PATCHes the rule. The alerts table
+  surfaces the new subtype with a distinct chip ("Would have blocked" vs "Blocked").
+- **No new database tables.** The `enforcement` column already exists. The new `subtype` column on
+  the alerts table is the only schema change.
+- **No new agent command.** `set_application_control` snapshots already carry `enforcement` per
+  rule; the extension's `ApplicationControlStore` already populates the field. The change is
+  entirely in how the decision engine consumes it.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `server-application-control` — per-rule `enforcement=DETECT` becomes a first-class semantic; new
+  `application_control_would_block` event ingest; default value for new rules flips to `DETECT`;
+  PATCH endpoint for rule enforcement.
+- `extension-application-control` — AUTH_EXEC decision engine consults `enforcement` and branches:
+  `PROTECT` keeps today's deny+block-event behavior plus the new regular exec event; `DETECT`
+  allows the exec and emits `application_control_would_block` plus the regular exec event.
+- `endpoint-event-collection` — new event kind `application_control_would_block`; clarifies that
+  AUTH-denied execs also emit a regular exec event with `decision='blocked'`; resolves the Phase A
+  spec contradiction.
+- `server-detection-rules-engine` — `application_control_would_block` events map to alerts with
+  `source='application_control'` and `subtype='would_block'`; alerts table gains the subtype
+  column.
+- `web-ui` — add-rule modal carries an enforcement selector defaulting to DETECT; policy-detail
+  rules table renders enforcement and exposes the Promote-to-Protect action; alerts table
+  distinguishes block vs would_block subtypes.
+
+### Unchanged Capabilities
+
+- `agent-command-executor` — `set_application_control` snapshot already carries `enforcement` per
+  rule. No protocol change.
+- `server-rest-api` — the `/api/v1/app-control/rules/{id}` PATCH endpoint already exists in the
+  Phase A spec; this change specifies the partial-body shape for the enforcement field.
+
+## Impact
+
+**Code:**
+
+- `extension/edr/extension/ESFSubscriber.swift` — `handleAuthExec` branches on rule enforcement:
+  `PROTECT` keeps today's path; `DETECT` allows + emits the new event. Both paths also emit the
+  regular exec event so the graph builder and catalog rules observe the attempt.
+- `extension/edr/extension/EventSerializer.swift` — new `ApplicationControlWouldBlockPayload`
+  struct; `ExecPayload` gains an optional `decision` field.
+- `server/rules/bootstrap/schema.go` — `app_control_rules.enforcement` default flips from
+  `'PROTECT'` to `'DETECT'`. The `alerts` table gains a `subtype VARCHAR(32) NOT NULL DEFAULT 'block'`
+  column.
+- `server/rules/internal/catalog/application_control_would_block.go` — new catalog rule mirroring
+  `application_control_block.go` for the would-block event kind. Maps to an alert with subtype.
+- `server/rules/internal/appcontrol/handler.go` — PATCH handler for rule enforcement (partial
+  body).
+- `server/rules/api/types.go` — add the would-block payload type and the alert subtype constants.
+- `ui/src/components/ApplicationControl/AddRuleModal.tsx` — enforcement selector, default DETECT.
+- `ui/src/components/ApplicationControl/PolicyDetail.tsx` — enforcement column in the rules table
+  plus Promote-to-Protect action.
+- `ui/src/components/AlertList.tsx` — subtype-aware rendering ("Would have blocked" / "Blocked").
+- `ui/src/api.ts` — `patchAppControlRule({id, enforcement, reason})`.
+
+**Schema:**
+
+- One column added to `alerts` (`subtype`).
+- Default value flip on `app_control_rules.enforcement`.
+- No new tables.
+
+**Events schema:**
+
+- New event kind `application_control_would_block` (same shape as `application_control_block`).
+- Optional `decision` field on `exec` events (absent for ordinary allowed execs).
+
+**Cross-context:**
+
+- `rules` context owns the new event-type ingest mapping and the alert subtype.
+- `detection` context reads `decision` from exec payloads where present.
+- No new cross-context FKs.
+
+**Rollback:**
+
+- Schema: drop the `subtype` column and reset the enforcement default. Existing rules retain their
+  individual enforcement values.
+- Events schema: removing the `application_control_would_block` kind and the `decision` exec field
+  is a server-tolerant revert; older agents emit the old shape, newer servers accept it.
+- Persisted host token: untouched.

--- a/openspec/changes/add-application-control-detect-mode/specs/endpoint-event-collection/spec.md
+++ b/openspec/changes/add-application-control-detect-mode/specs/endpoint-event-collection/spec.md
@@ -1,0 +1,141 @@
+# Endpoint Event Collection Specification (delta)
+
+## ADDED Requirements
+
+### Requirement: Application control would-block event kind
+
+The system SHALL emit an event of kind `application_control_would_block` whenever the extension's
+application control decision engine returns a `BLOCK` decision for an AUTH_EXEC whose matched
+rule's `enforcement` is `DETECT`. The event SHALL carry, in addition to the canonical envelope
+fields, `policy_id`, `policy_version`, `rule_id`, `rule_type`, `rule_identifier`,
+`matched_identifier`, `severity`, `custom_msg` (nullable), `custom_url` (nullable), `process`, and
+`ancestry`. Field shapes match `application_control_block` exactly; the two kinds differ only in
+which path of the decision engine produced them and which alert subtype the detection-rules
+engine stamps on the resulting alert.
+
+#### Scenario: A DETECT match produces a would-block event
+
+- **GIVEN** a rule whose precedence walk matches a specific exec target with
+  `enforcement=DETECT`
+- **WHEN** the extension allows the AUTH_EXEC
+- **THEN** the extension emits an `application_control_would_block` event carrying the rule and
+  matched identifier
+- **AND** the canonical exec channel observes the allowed attempt for normal telemetry purposes
+
+### Requirement: Every AUTH_EXEC decision emits a corresponding exec event
+
+The system SHALL emit a regular `exec` event for every AUTH_EXEC the kernel raises, regardless of
+the decision the application control decision engine returned. The exec event's payload SHALL
+carry an optional `decision` field whose value is `'blocked'` for AUTH-denied execs (matched a
+PROTECT BLOCK rule), `'would_block'` for AUTH-allowed-but-flagged execs (matched a DETECT BLOCK
+rule), and absent for ordinary allowed execs (no rule match). Catalog detection rules and the
+graph builder consume the regular exec event for every shape; the optional `decision` field lets
+downstream views distinguish ordinary execs from AUTH-flagged execs without joining across event
+kinds.
+
+#### Scenario: A blocked AUTH_EXEC emits both the block event and a regular exec event
+
+- **GIVEN** a PROTECT BLOCK rule matches an exec
+- **WHEN** the extension denies the AUTH_EXEC
+- **THEN** an `application_control_block` event is emitted
+- **AND** a regular `exec` event is emitted with `decision='blocked'`
+
+#### Scenario: A would-blocked AUTH_EXEC emits both the would-block event and a regular exec event
+
+- **GIVEN** a DETECT BLOCK rule matches an exec
+- **WHEN** the extension allows the AUTH_EXEC
+- **THEN** an `application_control_would_block` event is emitted
+- **AND** a regular `exec` event is emitted with `decision='would_block'`
+
+#### Scenario: An ordinary allowed exec emits a regular exec event with no decision field
+
+- **GIVEN** no rule matches an exec
+- **WHEN** the extension allows the AUTH_EXEC
+- **THEN** a regular `exec` event is emitted
+- **AND** the event payload contains no `decision` field
+
+## MODIFIED Requirements
+
+### Requirement: Process exec authorization
+
+The system SHALL consult the application control decision engine on every AUTH_EXEC before allowing
+the new image to run. When the engine returns a rule whose `action=BLOCK` and
+`enforcement=PROTECT`, the system MUST deny the exec so the image never executes and SHALL emit an
+`application_control_block` event plus a regular `exec` event with `decision='blocked'`. When the
+engine returns a rule whose `action=BLOCK` and `enforcement=DETECT`, the system MUST allow the
+exec and SHALL emit an `application_control_would_block` event plus a regular `exec` event with
+`decision='would_block'`. When the engine returns no match, the system MUST allow the exec and
+SHALL emit a regular `exec` event with no `decision` field. Decisions MUST be reached within the
+AUTH_EXEC deadline; the system MUST NOT block the AUTH callback on signing-information fetches and
+MUST treat as-yet-uncached identifiers as silent misses for their rule types.
+
+The change from the prior requirement is the explicit `enforcement=DETECT` branch (which the Phase
+A spec contradicted itself on) and the explicit requirement that AUTH-denied execs ALSO emit a
+regular exec event so the graph builder and catalog rules observe the attempt. The Phase A spec's
+"Otherwise the system MUST allow the exec and emit an exec event" implication that the deny path
+skipped the exec event is reversed here.
+
+#### Scenario: A PROTECT block denies the exec and emits both events
+
+- **GIVEN** the decision engine returns a `BLOCK` / `PROTECT` rule for an exec target
+- **WHEN** the AUTH_EXEC callback runs
+- **THEN** the system denies the exec so the kernel returns the standard "operation not permitted"
+  error
+- **AND** the binary does not run
+- **AND** an `application_control_block` event is emitted
+- **AND** a regular `exec` event is emitted with `decision='blocked'`
+
+#### Scenario: A DETECT match allows the exec and emits both events
+
+- **GIVEN** the decision engine returns a `BLOCK` / `DETECT` rule for an exec target
+- **WHEN** the AUTH_EXEC callback runs
+- **THEN** the system allows the exec
+- **AND** the binary runs
+- **AND** an `application_control_would_block` event is emitted
+- **AND** a regular `exec` event is emitted with `decision='would_block'`
+
+#### Scenario: An allowed exec emits an exec event with no decision field
+
+- **GIVEN** the decision engine returns no match for an exec target
+- **WHEN** the AUTH_EXEC callback runs
+- **THEN** the system allows the exec
+- **AND** a regular `exec` event is emitted describing the new image
+- **AND** the event payload contains no `decision` field
+
+#### Scenario: A cold-cache exec on a CERTIFICATE-only target is allowed
+
+- **GIVEN** the snapshot contains only a `CERTIFICATE` rule for an exec target
+- **AND** the leaf certificate SHA-256 for that target is not yet cached
+- **WHEN** the AUTH_EXEC callback runs
+- **THEN** the `CERTIFICATE` rule silently misses for this exec
+- **AND** the system allows the exec
+- **AND** the cache is filled for subsequent execs
+- **AND** a regular `exec` event is emitted with no `decision` field
+
+### Requirement: Canonical event envelope
+
+Every event the system emits SHALL be serialized as a JSON envelope with the fields `event_id`,
+`host_id`, `timestamp_ns`, `event_type`, and `payload`. `event_id` MUST be a UUID unique to that
+event, `host_id` MUST identify the device that produced the event and MUST be stable across
+reboots of that device, `timestamp_ns` MUST be nanoseconds since the Unix epoch, and `event_type`
+MUST be one of the documented values (`exec`, `fork`, `exit`, `open`, `network_connect`,
+`dns_query`, `application_control_block`, `application_control_would_block`).
+
+The change from the prior requirement adds `application_control_would_block` to the documented
+`event_type` enum.
+
+#### Scenario: An event envelope is well-formed
+
+- **GIVEN** any captured event
+- **WHEN** the system serializes the event
+- **THEN** the resulting bytes parse as a JSON object containing `event_id`, `host_id`,
+  `timestamp_ns`, `event_type`, and `payload`
+- **AND** `event_type` matches one of the documented enum values
+- **AND** the payload conforms to the schema for that event type
+
+#### Scenario: Events from the same device share a host_id
+
+- **GIVEN** an enrolled device producing events
+- **WHEN** the device emits events from any source (process, network, DNS, application control)
+- **THEN** every emitted event carries the same `host_id` value
+- **AND** that value persists across reboots of the device

--- a/openspec/changes/add-application-control-detect-mode/specs/extension-application-control/spec.md
+++ b/openspec/changes/add-application-control-detect-mode/specs/extension-application-control/spec.md
@@ -1,0 +1,128 @@
+# Extension Application Control Specification (delta)
+
+## ADDED Requirements
+
+### Requirement: Detect-mode allows the exec and emits a would-block event
+
+When the precedence walk returns a rule whose `action=BLOCK` and `enforcement=DETECT`, the extension SHALL
+allow the AUTH_EXEC request to proceed and SHALL emit an event of kind `application_control_would_block`
+carrying the same payload fields as `application_control_block`. The extension SHALL NOT fire the host-app
+notification modal on the Detect path; the modal is reserved for actual blocks so the operator's desktop
+signal matches the operational reality.
+
+#### Scenario: A DETECT rule allows the exec and emits a would-block event
+
+- **GIVEN** the precedence walk for an exec returns a rule with `action=BLOCK`,
+  `enforcement=DETECT`
+- **WHEN** the extension responds to AUTH_EXEC
+- **THEN** the response is allow
+- **AND** an `application_control_would_block` event is emitted carrying the rule and matched
+  identifier
+- **AND** no host-app notification modal is presented
+
+#### Scenario: A DETECT rule's matched_identifier matches the rule type
+
+- **GIVEN** a `TEAMID` rule with `enforcement=DETECT` matches an exec by team id `EQHXZ8M8AV`
+- **WHEN** the extension emits the would-block event
+- **THEN** the event's `rule_type` is `TEAMID`
+- **AND** the event's `matched_identifier` is `EQHXZ8M8AV`
+
+### Requirement: Every AUTH_EXEC decision emits a regular exec event
+
+The extension SHALL emit a regular exec event for every AUTH_EXEC the kernel raises, regardless of
+the decision the precedence walker returns. The exec event SHALL carry the standard payload fields
+plus an optional `decision` field whose value is `'blocked'` when the AUTH path denied because of a
+PROTECT rule, `'would_block'` when the AUTH path allowed-but-flagged because of a DETECT rule, and
+absent in every other case. The regular exec event ensures the server-side graph builder
+materializes a process row for the attempted-but-blocked exec and that catalog detection rules
+observe the attempt the same way they observe ordinary execs.
+
+#### Scenario: A PROTECT block emits both the block event and the regular exec event
+
+- **GIVEN** a PROTECT rule matches an exec
+- **WHEN** the extension responds to AUTH_EXEC
+- **THEN** the response is deny
+- **AND** an `application_control_block` event is emitted
+- **AND** a regular `exec` event is emitted with `decision='blocked'`
+
+#### Scenario: A DETECT match emits both the would-block event and the regular exec event
+
+- **GIVEN** a DETECT rule matches an exec
+- **WHEN** the extension responds to AUTH_EXEC
+- **THEN** the response is allow
+- **AND** an `application_control_would_block` event is emitted
+- **AND** a regular `exec` event is emitted with `decision='would_block'`
+
+#### Scenario: An exec with no matching rule emits the regular exec event without the decision field
+
+- **GIVEN** the precedence walk for an exec returns no match
+- **WHEN** the extension responds to AUTH_EXEC
+- **THEN** the response is allow
+- **AND** a regular `exec` event is emitted with no `decision` field
+
+## MODIFIED Requirements
+
+### Requirement: AUTH_EXEC denial on BLOCK match
+
+When the precedence walk returns a rule whose `action=BLOCK` and `enforcement=PROTECT`, the extension SHALL
+deny the AUTH_EXEC request so the new image does not run and SHALL emit an `application_control_block` event
+plus a regular exec event with `decision='blocked'`. When the walk returns a rule whose `action=BLOCK` and
+`enforcement=DETECT`, the extension SHALL allow the AUTH_EXEC request to proceed and SHALL emit an
+`application_control_would_block` event plus a regular exec event with `decision='would_block'`. When the walk
+returns no match, the extension SHALL allow the AUTH_EXEC request to proceed and SHALL emit a regular exec
+event with no `decision` field. The decision SHALL be reached within the AUTH_EXEC deadline; the extension MUST
+NOT block on signing-info fetches to reach a decision.
+
+The change from the prior requirement is the explicit handling of the `enforcement=DETECT` branch
+(previously the requirement only covered `enforcement=PROTECT` and treated other values as
+unsupported) and the explicit requirement to emit the regular exec event on every decision.
+
+#### Scenario: A PROTECT rule denies the exec
+
+- **GIVEN** the precedence walk for an exec returns a `BLOCK` / `PROTECT` rule
+- **WHEN** the extension responds to AUTH_EXEC
+- **THEN** the response is a deny
+- **AND** the new image does not run
+- **AND** an `application_control_block` event and a regular exec event are emitted
+
+#### Scenario: A DETECT rule allows the exec
+
+- **GIVEN** the precedence walk for an exec returns a `BLOCK` / `DETECT` rule
+- **WHEN** the extension responds to AUTH_EXEC
+- **THEN** the response is allow
+- **AND** the new image runs
+- **AND** an `application_control_would_block` event and a regular exec event are emitted
+
+#### Scenario: No matching rule allows the exec
+
+- **GIVEN** the precedence walk for an exec returns no match
+- **WHEN** the extension responds to AUTH_EXEC
+- **THEN** the response is allow
+- **AND** a regular exec event is emitted with no `decision` field
+
+### Requirement: Block event emission
+
+Whenever the extension takes a non-trivial decision on an AUTH_EXEC because of a `BLOCK` rule, it SHALL emit
+one of two events. For `enforcement=PROTECT` matches the kind is `application_control_block` and the AUTH
+response is deny. For `enforcement=DETECT` matches the kind is `application_control_would_block` and the AUTH
+response is allow. Both events SHALL carry identical fields: `policy_id`, `policy_version`, `rule_id`,
+`rule_type`, `rule_identifier`, `matched_identifier`, `severity`, `custom_msg` (nullable), `custom_url`
+(nullable), `process`, and `ancestry`. The `matched_identifier` SHALL be the actual value from the target
+tuple that caused the match (for example, the CDHash that hit a `CDHASH` rule).
+
+The change from the prior requirement is the dual event kind (PROTECT → block, DETECT →
+would_block) with identical payload shape.
+
+#### Scenario: A block emits a block event whose matched_identifier matches the rule type
+
+- **GIVEN** a `TEAMID` rule with `enforcement=PROTECT` for `EQHXZ8M8AV` matches an exec
+- **WHEN** the extension denies and emits the block event
+- **THEN** the event's `rule_type` is `TEAMID`
+- **AND** the event's `matched_identifier` is `EQHXZ8M8AV`
+
+#### Scenario: A would-block emits a would-block event with the same shape
+
+- **GIVEN** a `TEAMID` rule with `enforcement=DETECT` for `EQHXZ8M8AV` matches an exec
+- **WHEN** the extension allows and emits the would-block event
+- **THEN** the event's `rule_type` is `TEAMID`
+- **AND** the event's `matched_identifier` is `EQHXZ8M8AV`

--- a/openspec/changes/add-application-control-detect-mode/specs/server-application-control/spec.md
+++ b/openspec/changes/add-application-control-detect-mode/specs/server-application-control/spec.md
@@ -1,0 +1,145 @@
+# Server Application Control Specification (delta)
+
+## ADDED Requirements
+
+### Requirement: Per-rule enforcement DETECT honors a log-only contract
+
+The system SHALL honor each rule's `enforcement` value when fanning out the rule to extensions and
+when persisting block-decision events back from those extensions. Rules with `enforcement='PROTECT'`
+SHALL produce `application_control_block` events on match and SHALL be authoritative blocks at the
+extension. Rules with `enforcement='DETECT'` SHALL produce `application_control_would_block` events
+on match and SHALL be allow-but-log at the extension. The server SHALL ingest both event kinds
+through the same `POST /api/events` channel that carries every other agent event, with the same
+host-token-authenticated authenticity binding.
+
+#### Scenario: A would-block event is accepted and authenticity-bound
+
+- **GIVEN** an authenticated agent posts an `application_control_would_block` event whose envelope
+  `host_id` matches the authenticated host
+- **WHEN** the server ingests the event
+- **THEN** the server responds with HTTP 200
+- **AND** the event is stamped with the authenticated `host_id`
+
+#### Scenario: A would-block event for a forged host_id is rejected
+
+- **GIVEN** an authenticated agent posts an `application_control_would_block` event whose envelope
+  `host_id` does not match the authenticated host
+- **WHEN** the server validates the request
+- **THEN** the server responds with HTTP 4xx
+- **AND** the event is not persisted
+
+### Requirement: Default Detect on rule creation
+
+The system SHALL default new `app_control_rules` to `enforcement='DETECT'` when the operator does
+not supply an explicit value. The PATCH endpoint SHALL accept either `PROTECT` or `DETECT` on
+update. The default is the schema-column default; existing rules retain their stored value across
+the deploy that activates this change.
+
+#### Scenario: Creating a rule without explicit enforcement lands in Detect
+
+- **GIVEN** an authenticated operator posts a rule create request with no `enforcement` field
+- **WHEN** the server validates and persists the rule
+- **THEN** the persisted rule has `enforcement='DETECT'`
+
+#### Scenario: An existing PROTECT rule is unaffected by the default flip
+
+- **GIVEN** a rule that was created before this change with `enforcement='PROTECT'`
+- **WHEN** the server boots with the new schema
+- **THEN** the rule retains `enforcement='PROTECT'`
+
+### Requirement: PATCH endpoint for rule enforcement change
+
+The system SHALL accept a partial-body `PATCH /api/v1/app-control/rules/{id}` request containing
+one or more of `enforcement`, `severity`, `custom_msg`, `custom_url`, `comment`, `enabled`, with a
+required non-empty `reason`. The system SHALL emit exactly one audit event per PATCH carrying the
+operator's identity, the supplied reason, the rule and policy identifiers, and a structured diff
+of the change. The system SHALL fan out the updated snapshot to every host the rule's policy is
+assigned to with the updated `enforcement` value.
+
+#### Scenario: Promoting a Detect rule to Protect
+
+- **GIVEN** an existing rule with `enforcement='DETECT'`
+- **WHEN** the operator PATCHes the rule with `{enforcement: "PROTECT", reason: "promote after
+  watching alerts for 7 days"}`
+- **THEN** the rule's persisted `enforcement` is `'PROTECT'`
+- **AND** an audit event records the operator, the reason, and a diff showing
+  `enforcement: DETECT → PROTECT`
+- **AND** a `set_application_control` fan-out command is enqueued for every host assigned to the
+  rule's policy
+
+#### Scenario: PATCH without a reason is rejected
+
+- **GIVEN** an existing rule
+- **WHEN** the operator PATCHes the rule with `{enforcement: "PROTECT"}` and no `reason` field
+- **THEN** the server responds with a typed error indicating the reason is required
+- **AND** the rule is not mutated
+- **AND** no audit event is emitted
+
+#### Scenario: PATCH with an invalid enforcement value is rejected
+
+- **GIVEN** an existing rule
+- **WHEN** the operator PATCHes the rule with `{enforcement: "MAYBE", reason: "experiment"}`
+- **THEN** the server responds with a typed error indicating the enforcement value is invalid
+- **AND** the rule is not mutated
+
+## MODIFIED Requirements
+
+### Requirement: Rule identifies one binary, signing identity, or path
+
+The system SHALL represent every rule as a row owned by exactly one policy and carrying: a
+`rule_type` from the set `{CDHASH, BINARY, SIGNINGID, CERTIFICATE, TEAMID, PATH}`; an `identifier`
+string whose format is determined by `rule_type`; an `action` constrained in this phase to `BLOCK`;
+an `enforcement` from `{PROTECT, DETECT}` defaulting to `DETECT`; an `enabled` flag; a `severity`
+from `{low, medium, high, critical}` defaulting to `medium`; a `source` from
+`{admin, imported, intel}` defaulting to `admin`; an optional `source_ref`; an optional
+`custom_msg`; an optional `custom_url`; an optional `comment`; an optional `expires_at`; and
+timestamps and actor identity. The triple `(policy_id, rule_type, identifier)` SHALL be unique.
+
+The change from the prior requirement is the `enforcement` default: it flips from `'PROTECT'` to
+`'DETECT'` so that new rules ship safely. Operators promote to Protect via PATCH once confident in
+the rule's behavior.
+
+#### Scenario: Two rules in the same policy can target the same identifier under different types
+
+- **GIVEN** a policy that already contains a `BINARY` rule for hash `H`
+- **WHEN** the operator adds a `PATH` rule for `/usr/local/bin/H`
+- **THEN** the system creates the new rule successfully because the unique key includes `rule_type`
+
+#### Scenario: Duplicating the same `(rule_type, identifier)` is rejected
+
+- **GIVEN** a policy that already contains a `TEAMID` rule for `EQHXZ8M8AV`
+- **WHEN** the operator attempts to create a second `TEAMID` rule with the same identifier in the
+  same policy
+- **THEN** the system rejects the request with a typed error indicating the rule already exists
+
+### Requirement: Application control block event contract
+
+The system SHALL accept ingest events of kind `application_control_block` and
+`application_control_would_block` from agents through the same host-token-authenticated
+`POST /api/events` channel that carries every other agent event. The system MUST bind every
+accepted event to the `host_id` resolved by the existing host-token middleware and MUST reject
+events whose envelope `host_id` does not match the authenticated host. Each event MUST carry
+`policy_id`, `policy_version`, `rule_id`, `rule_type`, `rule_identifier`, `matched_identifier`,
+`severity`, `process`, and `ancestry`. The event MAY carry optional `custom_msg` and `custom_url`.
+The system SHALL accept events whose `policy_id` or `rule_id` does not correspond to a known rule
+(so an in-flight decision is not lost when a rule is deleted after the AUTH path fired) and SHALL
+log a server-side warning for operator visibility on the unknown-rule path.
+
+The change from the prior requirement adds `application_control_would_block` to the set of
+recognised event kinds with identical handling. The two differ only in the alert subtype the
+detection-rules engine stamps on the resulting alert row.
+
+#### Scenario: A would-block event for an unknown rule is accepted but warned
+
+- **GIVEN** an agent posts an `application_control_would_block` event whose `rule_id` does not
+  exist
+- **WHEN** the server ingests the event
+- **THEN** the server responds with HTTP 200
+- **AND** the server emits a structured warning identifying the unknown rule id
+
+#### Scenario: A block event for a now-deleted rule is accepted
+
+- **GIVEN** a rule that existed when the agent denied the exec but was deleted before the event
+  reached the server
+- **WHEN** the agent posts the `application_control_block` event
+- **THEN** the server accepts and persists the event so the historical decision is not lost

--- a/openspec/changes/add-application-control-detect-mode/specs/server-detection-rules-engine/spec.md
+++ b/openspec/changes/add-application-control-detect-mode/specs/server-detection-rules-engine/spec.md
@@ -117,30 +117,51 @@ that catalog-rule alerts and application-control alerts populate it with the doc
 - **THEN** the resulting alert row carries the host id, rule id, severity,
   `source='application_control'`, `subtype='would_block'`, title, summary, and linked process id
 
-### Requirement: Alert dedup by (source, host, rule, process)
+### Requirement: Alert dedup key depends on source
 
-The system SHALL treat the tuple `(source, host_id, rule_id, process_id)` as the alert dedup key.
-`subtype` is NOT part of the dedup key. A would-block alert for `(host_a, rule_X, process_42)`
-followed by a block alert for the same triple SHALL update the existing row's `subtype` from
-`would_block` to `block` rather than create a new row. This reflects the operator's mental model:
-when a Detect rule is promoted to Protect and the same binary is exec'd again on the same host,
-the alert progresses through its lifecycle rather than producing two separate entries.
+The system SHALL dedup alerts using a source-specific key. `subtype` is NOT part of either key.
+The mapping is:
 
-Re-evaluating the same catalog rule against the same process on the same host in a later batch
-MUST NOT create a second alert row; the existing alert remains the single record for that
-finding. A subsequent `application_control_block` or `application_control_would_block` event for
-the same `(source, host, rule, process)` tuple MUST NOT create a second alert row either; the
-existing alert is updated in place.
+- `source='detection'`: dedup key `(source, host_id, rule_id, process_id)`. Re-evaluating the same
+  catalog rule against the same process on the same host in a later batch MUST NOT create a second
+  alert row; the existing alert remains the single record for that finding.
+- `source='application_control'`: dedup key `(source, host_id, rule_id)`. Each AUTH_EXEC produces a
+  fresh kernel `process_id`, so including it in the key would defeat the cross-execution
+  lifecycle. Subsequent `application_control_block` or `application_control_would_block` events
+  for the same `(source, host_id, rule_id)` tuple MUST NOT create a second alert row; the existing
+  alert is updated in place, the `linked_process_id` is replaced with the most recent matching
+  exec, and the `subtype` reflects the most recent decision.
 
-The change from the prior requirement clarifies the subtype update semantics on the would-block →
-block transition.
+The system SHALL enforce each key with an index that backs the in-application UPSERT used during
+event ingest. MySQL does not support partial unique indexes, so the implementation MAY use either
+two unique indexes (one per source) or a synthetic dedup_discriminator column that collapses to
+`process_id` for `detection` rows and to a fixed sentinel for `application_control` rows under a
+single unique index. The choice is an implementation detail; the spec mandates only that the
+logical keys above hold and that ingest writes them through an UPSERT path that cannot insert a
+duplicate.
+
+The change from the prior requirement is the split-by-source dedup semantics: Phase A's single
+`(host_id, rule_id, process_id)` key is preserved for `source='detection'`, and a new
+`(source, host_id, rule_id)` key is introduced for `source='application_control'` so the
+would_block → block lifecycle collapses into one row.
 
 #### Scenario: A would-block followed by a block updates the existing alert
 
 - **GIVEN** an existing alert with `source='application_control'`, `subtype='would_block'` for
-  `(host_a, rule_X, process_42)`
-- **WHEN** an `application_control_block` event arrives for the same tuple
-- **THEN** the existing alert row is updated with `subtype='block'`
+  `(host_a, rule_X)` whose `linked_process_id` is `process_42`
+- **WHEN** an `application_control_block` event arrives for `(host_a, rule_X)` with
+  `linked_process_id=process_99` after the rule is promoted from DETECT to PROTECT
+- **THEN** the existing alert row is updated with `subtype='block'` and
+  `linked_process_id=process_99`
+- **AND** no new alert row is inserted
+
+#### Scenario: Repeated would-block events on the same Detect rule collapse into one alert
+
+- **GIVEN** an `application_control_would_block` event has produced an alert for
+  `(host_a, rule_X)` with `linked_process_id=process_42`
+- **WHEN** a second `application_control_would_block` event for `(host_a, rule_X)` arrives with
+  `linked_process_id=process_43` (a separate exec of the same binary, fresh kernel PID)
+- **THEN** the existing alert row is reused with `linked_process_id` updated to `process_43`
 - **AND** no new alert row is inserted
 
 #### Scenario: A catalog rule re-fires on the same process in a later batch
@@ -148,6 +169,13 @@ block transition.
 - **GIVEN** an existing alert for a `(source='detection', host, rule, process)` tuple
 - **WHEN** a later batch causes the same rule to find the same process again
 - **THEN** the existing alert row is reused and no new alert row is inserted
+
+#### Scenario: A catalog rule fires on a different process on the same host
+
+- **GIVEN** an existing `source='detection'` alert for `(host_a, rule_X, process_42)`
+- **WHEN** the same rule fires against a different process on the same host, `process_99`
+- **THEN** a second alert row is inserted with `linked_process_id=process_99`
+- **AND** the original alert row for `process_42` is preserved
 
 #### Scenario: A catalog rule id and an app-control rule id collide on the same process
 

--- a/openspec/changes/add-application-control-detect-mode/specs/server-detection-rules-engine/spec.md
+++ b/openspec/changes/add-application-control-detect-mode/specs/server-detection-rules-engine/spec.md
@@ -1,0 +1,159 @@
+# Server Detection Rules Engine Specification (delta)
+
+## ADDED Requirements
+
+### Requirement: Would-block events map to alerts with subtype=would_block
+
+The system SHALL map every accepted `application_control_would_block` ingest event to an alert.
+The alert SHALL carry `source='application_control'`, `subtype='would_block'`, the matched rule's
+identifier as the alert's `rule_id`, the matched rule's severity as the alert's severity, the
+matched rule's `custom_msg` (or a sensible default that names the rule type and identifier) as the
+alert's summary, the `policy_id` and `policy_version` from the event as alert attributes, and the
+standard `host_id` and linked process identifier as on any other alert. The mapping SHALL be
+performed in-pipeline with `application_control_block` events so the alert read API returns both
+shapes through the same endpoints.
+
+#### Scenario: A would-block event produces a would-block alert
+
+- **GIVEN** an ingested `application_control_would_block` event carrying `rule_id=R1`,
+  `severity=high`, `custom_msg="Would have blocked: corporate policy"`, `policy_id=P1`,
+  `policy_version=7`
+- **WHEN** the engine processes the event
+- **THEN** an alert is persisted with `source='application_control'`, `subtype='would_block'`,
+  `rule_id=R1`, `severity=high`, `summary="Would have blocked: corporate policy"`, and attributes
+  including `policy_id=P1` and `policy_version=7`
+
+### Requirement: Alert subtype distinguishes block from would-block
+
+The system SHALL persist each application-control alert with a `subtype` column. Alerts produced
+from `application_control_block` events SHALL carry `subtype='block'`. Alerts produced from
+`application_control_would_block` events SHALL carry `subtype='would_block'`. Existing
+catalog-rule findings carry `subtype='detection'` so the column is non-NULL everywhere. Future
+Phase B subtypes (e.g. `silent_block`, `would_allow`) extend the same dimension without further
+schema migration.
+
+#### Scenario: A catalog rule's alert carries subtype=detection
+
+- **GIVEN** a catalog rule fires on an event batch
+- **WHEN** the engine persists the resulting alert
+- **THEN** the row carries `source='detection'` and `subtype='detection'`
+
+#### Scenario: A block alert carries subtype=block
+
+- **GIVEN** an ingested `application_control_block` event
+- **WHEN** the engine maps the event to an alert
+- **THEN** the row carries `source='application_control'` and `subtype='block'`
+
+#### Scenario: A would-block alert carries subtype=would_block
+
+- **GIVEN** an ingested `application_control_would_block` event
+- **WHEN** the engine maps the event to an alert
+- **THEN** the row carries `source='application_control'` and `subtype='would_block'`
+
+### Requirement: Alerts list filters by source and subtype
+
+The alerts read API SHALL accept `source` and `subtype` as filter parameters. Both filters are
+optional and combine with AND semantics. `subtype` accepts free-form string values so future Phase
+B subtypes work without API changes; unknown values return an empty result set rather than a 4xx.
+
+#### Scenario: Filter to would-block alerts only
+
+- **GIVEN** alerts of mixed source and subtype exist for a host
+- **WHEN** the operator queries
+  `GET /api/v1/alerts?source=application_control&subtype=would_block`
+- **THEN** the response contains only alerts with `source='application_control'` and
+  `subtype='would_block'`
+
+#### Scenario: Filter to a catalog source ignores subtype
+
+- **GIVEN** the operator queries `GET /api/v1/alerts?source=detection`
+- **WHEN** the server reads the alerts
+- **THEN** the response contains every catalog-rule alert for the operator's deployment
+
+#### Scenario: Filter on an unknown subtype returns empty
+
+- **GIVEN** the operator queries
+  `GET /api/v1/alerts?source=application_control&subtype=does_not_exist_yet`
+- **WHEN** the server reads the alerts
+- **THEN** the response is well-formed and contains zero alerts
+
+## MODIFIED Requirements
+
+### Requirement: Persisted alert schema
+
+The system SHALL persist each finding as an alert that carries a host identifier, a rule
+identifier, a severity (`low`, `medium`, `high`, or `critical`), a source (`detection` for
+catalog-rule findings or `application_control` for application-control events), a subtype string
+that further classifies the alert within its source (`detection` for catalog-rule findings,
+`block` for application-control block events, `would_block` for application-control would-block
+events, with the column reserved as a string for Phase B Sub-classes), a human-readable title, a
+human-readable summary or description, the linked process identifier, and, for catalog-rule alerts
+only, the list of MITRE ATT&CK technique identifiers that the firing rule maps to. Alerts with
+`source='application_control'` MAY have an empty technique list.
+
+The change from the prior requirement is the addition of the `subtype` column and the requirement
+that catalog-rule alerts and application-control alerts populate it with the documented values.
+
+#### Scenario: A catalog rule fires and creates an alert
+
+- **GIVEN** an event batch that satisfies one catalog rule's pattern against a known process
+- **WHEN** the engine evaluates the rule and persists the finding
+- **THEN** the resulting alert row carries the host id, rule id, severity,
+  `source='detection'`, `subtype='detection'`, title, description, linked process id, and
+  technique list of the firing rule
+
+#### Scenario: An application control block creates an alert with subtype=block
+
+- **GIVEN** an ingested `application_control_block` event for a known process on a known host
+- **WHEN** the engine maps the event to an alert
+- **THEN** the resulting alert row carries the host id, rule id, severity,
+  `source='application_control'`, `subtype='block'`, title, summary, and linked process id
+
+#### Scenario: An application control would-block creates an alert with subtype=would_block
+
+- **GIVEN** an ingested `application_control_would_block` event for a known process on a known
+  host
+- **WHEN** the engine maps the event to an alert
+- **THEN** the resulting alert row carries the host id, rule id, severity,
+  `source='application_control'`, `subtype='would_block'`, title, summary, and linked process id
+
+### Requirement: Alert dedup by (source, host, rule, process)
+
+The system SHALL treat the tuple `(source, host_id, rule_id, process_id)` as the alert dedup key.
+`subtype` is NOT part of the dedup key. A would-block alert for `(host_a, rule_X, process_42)`
+followed by a block alert for the same triple SHALL update the existing row's `subtype` from
+`would_block` to `block` rather than create a new row. This reflects the operator's mental model:
+when a Detect rule is promoted to Protect and the same binary is exec'd again on the same host,
+the alert progresses through its lifecycle rather than producing two separate entries.
+
+Re-evaluating the same catalog rule against the same process on the same host in a later batch
+MUST NOT create a second alert row; the existing alert remains the single record for that
+finding. A subsequent `application_control_block` or `application_control_would_block` event for
+the same `(source, host, rule, process)` tuple MUST NOT create a second alert row either; the
+existing alert is updated in place.
+
+The change from the prior requirement clarifies the subtype update semantics on the would-block →
+block transition.
+
+#### Scenario: A would-block followed by a block updates the existing alert
+
+- **GIVEN** an existing alert with `source='application_control'`, `subtype='would_block'` for
+  `(host_a, rule_X, process_42)`
+- **WHEN** an `application_control_block` event arrives for the same tuple
+- **THEN** the existing alert row is updated with `subtype='block'`
+- **AND** no new alert row is inserted
+
+#### Scenario: A catalog rule re-fires on the same process in a later batch
+
+- **GIVEN** an existing alert for a `(source='detection', host, rule, process)` tuple
+- **WHEN** a later batch causes the same rule to find the same process again
+- **THEN** the existing alert row is reused and no new alert row is inserted
+
+#### Scenario: A catalog rule id and an app-control rule id collide on the same process
+
+- **GIVEN** a catalog rule and an application-control rule that happen to share an identifier
+  value
+- **AND** both have already produced alerts for the same `(host, process)` pair
+- **WHEN** the alerts list is queried
+- **THEN** two distinct alert rows are returned, one with `source='detection'` and one with
+  `source='application_control'`

--- a/openspec/changes/add-application-control-detect-mode/specs/web-ui/spec.md
+++ b/openspec/changes/add-application-control-detect-mode/specs/web-ui/spec.md
@@ -1,0 +1,109 @@
+# Web UI Specification (delta)
+
+## ADDED Requirements
+
+### Requirement: Add-rule modal carries an enforcement selector
+
+The add-rule modal in the Application Control screen SHALL provide an enforcement selector with
+the options `PROTECT` and `DETECT`. The selector SHALL default to `DETECT` so a new rule lands
+in log-only mode unless the operator explicitly chooses to block. The selected value SHALL be
+passed to the create-rule API call as the rule's `enforcement` field. The modal SHALL render a
+short explanation next to the selector noting that DETECT rules log a would-block alert without
+preventing the exec, and that the operator can promote the rule to PROTECT after observing the
+alerts.
+
+#### Scenario: A new rule defaults to Detect
+
+- **GIVEN** an operator opens the add-rule modal
+- **WHEN** the modal renders
+- **THEN** the enforcement selector shows `DETECT` as the currently selected value
+
+#### Scenario: An operator can submit a PROTECT rule with one click
+
+- **GIVEN** an operator opens the add-rule modal and types a valid identifier and reason
+- **WHEN** the operator changes the enforcement selector to `PROTECT` and clicks Save
+- **THEN** the create-rule API call carries `enforcement='PROTECT'`
+
+### Requirement: Policy detail surfaces enforcement and offers Promote-to-Protect
+
+The policy detail view SHALL show the rule's `enforcement` value in the rules table. For rules
+with `enforcement='DETECT'` the view SHALL render a per-row `Promote to Protect` action. Clicking
+the action opens a confirmation modal that requires a non-empty `reason`. Submitting calls
+`PATCH /api/v1/app-control/rules/{id}` with `{enforcement: "PROTECT", reason}`. On success the
+row's enforcement value updates optimistically; on failure the modal surfaces the typed error.
+
+#### Scenario: Detect rule shows the Promote action
+
+- **GIVEN** a policy contains a rule with `enforcement='DETECT'`
+- **WHEN** the operator opens the policy detail view
+- **THEN** the rule's row shows a visible `Promote to Protect` action
+
+#### Scenario: Protect rule does not show the Promote action
+
+- **GIVEN** a policy contains a rule with `enforcement='PROTECT'`
+- **WHEN** the operator opens the policy detail view
+- **THEN** the rule's row does NOT show a `Promote to Protect` action
+
+#### Scenario: Promote-to-Protect requires a reason
+
+- **GIVEN** the Promote-to-Protect confirmation modal is open
+- **WHEN** the operator attempts to submit without entering a reason
+- **THEN** the modal refuses to submit and surfaces a visible error explaining the reason is
+  required
+
+#### Scenario: Promote-to-Protect updates the rule
+
+- **GIVEN** the Promote-to-Protect confirmation modal is open for a Detect rule
+- **WHEN** the operator enters a reason and submits
+- **THEN** the API call PATCHes the rule with `{enforcement: "PROTECT", reason: <text>}`
+- **AND** the rules table row optimistically renders the rule as PROTECT
+
+### Requirement: Alerts list distinguishes block vs would-block subtypes
+
+The alerts list SHALL render the `subtype` field of each alert as a distinct visual chip. Alerts
+with `subtype='block'` SHALL render with a chip labelled "Blocked" in a visually-stronger style
+than alerts with `subtype='would_block'`, which SHALL render with a chip labelled "Would have
+blocked". Alerts with `subtype='detection'` continue to render as today (no subtype chip, or a
+neutral chip; UI choice). Unknown subtype values SHALL render with a fallback chip labelled
+"Application Control" so future Phase B subtypes don't render blank.
+
+#### Scenario: Block alerts render with a Blocked chip
+
+- **GIVEN** an alert exists with `source='application_control'` and `subtype='block'`
+- **WHEN** the alerts list renders the alert
+- **THEN** the row shows a chip labelled "Blocked"
+
+#### Scenario: Would-block alerts render with a Would-have-blocked chip
+
+- **GIVEN** an alert exists with `source='application_control'` and `subtype='would_block'`
+- **WHEN** the alerts list renders the alert
+- **THEN** the row shows a chip labelled "Would have blocked"
+
+#### Scenario: Unknown subtype renders a fallback chip
+
+- **GIVEN** an alert exists with `source='application_control'` and an unrecognised subtype
+- **WHEN** the alerts list renders the alert
+- **THEN** the row shows a chip labelled "Application Control"
+- **AND** the row does not render blank or break the table layout
+
+### Requirement: Alerts list filters by subtype
+
+The alerts list SHALL accept a `subtype` filter alongside the existing `source` filter so an
+operator iterating on a Detect-mode rule can isolate the "would have blocked" alerts. The filter
+control SHALL be visible whenever `source='application_control'` is selected and SHALL offer
+"All", "Blocked", and "Would have blocked" as preset values. Unknown subtype values are not
+surfaced as preset options; future Phase B subtypes get UI presets when their respective changes
+land.
+
+#### Scenario: Filter to would-block only
+
+- **GIVEN** the alerts list is filtered to `source=application_control`
+- **WHEN** the operator selects "Would have blocked" in the subtype filter
+- **THEN** the list shows only alerts with `subtype='would_block'`
+- **AND** the URL query string carries `subtype=would_block`
+
+#### Scenario: Subtype filter hidden when source is not application_control
+
+- **GIVEN** the alerts list is filtered to `source=detection`
+- **WHEN** the operator looks for a subtype filter
+- **THEN** no subtype filter control is visible

--- a/openspec/changes/add-application-control-detect-mode/tasks.md
+++ b/openspec/changes/add-application-control-detect-mode/tasks.md
@@ -1,0 +1,132 @@
+# Application Control Detect mode rollout tasks
+
+This change layers per-rule Detect mode on the foundation shipped by `add-application-control`. It
+assumes the Phase A close-out PR has landed (precedence walker honors all wired rule types, the
+PATCH endpoint exists at least in skeleton, the `host_groups` + `app_control_assignments` tables
+are seeded, `cdhash` is on exec events). Each task below cites the matching spec requirement.
+
+## 1. Schema delta
+
+- [ ] 1.1 Flip the default value of `app_control_rules.enforcement` from `'PROTECT'` to `'DETECT'`
+  in `server/rules/bootstrap/schema.go`. Existing rows keep their stored value; only new rows
+  default. (spec: `server-application-control` "Default Detect on rule creation".)
+- [ ] 1.2 Add `subtype VARCHAR(32) NOT NULL DEFAULT 'block'` to the `alerts` table in the
+  detection-context bootstrap. Existing rows backfill to `'block'`. Add an index on
+  `(host_id, source, subtype)` so the alerts read API can filter without scanning. (spec:
+  `server-detection-rules-engine` "Alert subtype distinguishes block from would-block".)
+- [ ] 1.3 Per-context integration test in `server/rules/internal/tests/` for the default flip:
+  a new rule created without an explicit `enforcement` lands with `DETECT`.
+- [ ] 1.4 Per-context integration test in `server/detection/internal/tests/` for the subtype
+  backfill: a fresh schema bootstrap leaves `subtype='block'` on existing alert rows.
+
+## 2. Extension decision engine
+
+- [ ] 2.1 `extension/edr/extension/ESFSubscriber.swift:handleAuthExec`: branch on the matched
+  rule's `enforcement`. `PROTECT` keeps today's path (deny + block-event + notification).
+  `DETECT` calls `es_respond_auth_result(ALLOW)` and emits a new
+  `application_control_would_block` event. The host-app notification fires only on PROTECT.
+  (spec: `extension-application-control` "Detect mode allows the exec and emits a would-block
+  event".)
+- [ ] 2.2 In both `PROTECT` and `DETECT` branches, emit the regular exec event with a `decision`
+  field of `'blocked'` or `'would_block'` respectively. Allowed-execs (no rule match) continue to
+  emit the regular exec event with the `decision` field omitted. (spec: `endpoint-event-collection`
+  "Every AUTH_EXEC decision emits a corresponding telemetry event".)
+- [ ] 2.3 `extension/edr/extension/EventSerializer.swift`: add `ApplicationControlWouldBlockPayload`
+  with the same shape as `ApplicationControlBlockPayload`. Add an optional `decision` field on
+  `ExecPayload` (encoder omits it when nil; decoder accepts absence).
+- [ ] 2.4 Swift unit tests for the new branch: a snapshot containing one DETECT rule and one
+  PROTECT rule produces allow + would-block event for a DETECT match and deny + block event for
+  a PROTECT match. Confirms the host-app modal does NOT fire on the DETECT path.
+
+## 3. Agent + wire
+
+- [ ] 3.1 Verify (test only, no code change) that the existing `set_application_control` snapshot
+  format carries `enforcement` per rule and that the extension's `ApplicationControlStore`
+  populates the field on apply. Round-trip PBT in
+  `server/rules/internal/appcontrol/marshaltest.go` already covers this; add a fixture covering a
+  rule with `enforcement=DETECT` so the regression is pinned.
+
+## 4. Server domain and validation
+
+- [ ] 4.1 `server/rules/internal/appcontrol/validate.go`: confirm `ValidateEnforcement` accepts
+  both `PROTECT` and `DETECT`. Add scenario coverage for the empty-defaults-to-DETECT case.
+- [ ] 4.2 `server/rules/internal/appcontrol/store.go:CreateRule`: when the request body omits
+  `enforcement`, persist `'DETECT'`. (spec: `server-application-control` "Default Detect on rule
+  creation".)
+- [ ] 4.3 PATCH endpoint partial body: `PATCH /api/v1/app-control/rules/{id}` accepts a body
+  containing one or more of `{enforcement, severity, custom_msg, custom_url, comment, enabled,
+  reason}`. `reason` is required. Each mutation emits a single audit event with the diff. (spec:
+  `server-application-control` "PATCH endpoint for enforcement change".)
+- [ ] 4.4 Integration test: create a rule (lands in DETECT), PATCH it to PROTECT with a reason,
+  observe the audit row, observe the fan-out command with the updated `enforcement` field, observe
+  the next exec of the matching binary produces a `block` alert (not a `would_block`).
+- [ ] 4.5 Integration test: malformed PATCH body (`enforcement="MAYBE"`, missing `reason`) returns
+  a typed `application_control.invalid_request` error and does not mutate the rule.
+
+## 5. Detection-pipeline wiring
+
+- [ ] 5.1 New catalog rule `server/rules/internal/catalog/application_control_would_block.go`
+  mirroring `application_control_block.go`. Maps the new event kind to an alert with
+  `source='application_control'` and `subtype='would_block'`. Severity copied from the rule.
+- [ ] 5.2 Update the `application_control_block` catalog rule to stamp `subtype='block'` on the
+  alert it produces. (Today the column doesn't exist; this change adds the default and the explicit
+  stamp.) (spec: `server-detection-rules-engine` "Alert subtype distinguishes block from
+  would-block".)
+- [ ] 5.3 Update the alerts read API filter parameters: `subtype` is a valid filter alongside
+  `source`. (spec: `server-detection-rules-engine` "Alerts list filters by source and subtype".)
+- [ ] 5.4 Integration test for the dedup interaction: a would-block alert exists for
+  `(host_a, rule_X, process_42)`; a subsequent block event for the same tuple updates the existing
+  alert row to `subtype='block'` without creating a new row.
+- [ ] 5.5 Integration test for the alert subtype filter:
+  `GET /api/v1/alerts?source=application_control&subtype=would_block` returns only the would-block
+  alerts on the host.
+
+## 6. Web UI
+
+- [ ] 6.1 `ui/src/components/ApplicationControl/AddRuleModal.tsx`: add an enforcement selector
+  with PROTECT + DETECT options, defaulting to DETECT. Pass the value to the create-rule API call.
+  (spec: `web-ui` "Add-rule modal carries an enforcement selector".)
+- [ ] 6.2 `ui/src/components/ApplicationControl/PolicyDetail.tsx`: add an enforcement column to
+  the rules table. For DETECT rules, render a `Promote to Protect` action.
+- [ ] 6.3 Promote-to-Protect modal: confirmation modal carrying a non-empty reason field. Submit
+  calls `PATCH /api/v1/app-control/rules/{id}` with `{enforcement: "PROTECT", reason}`. On
+  success, optimistically updates the table row.
+- [ ] 6.4 `ui/src/components/AlertList.tsx`: render the new subtype as a distinct chip. Block:
+  red chip "Blocked". Would-block: yellow chip "Would have blocked". Unknown subtype falls back
+  to "Application Control" so future Phase B subtypes don't render blank. (spec: `web-ui`
+  "Alerts list distinguishes block vs would-block subtypes".)
+- [ ] 6.5 React Testing Library coverage:
+  - AddRuleModal renders with `enforcement=DETECT` selected by default; explicit PROTECT
+    selection persists into the submitted request body.
+  - PolicyDetail renders the enforcement column; the Promote-to-Protect button appears for DETECT
+    rules and is absent for PROTECT rules.
+  - Promote-to-Protect modal gates submission on a non-empty reason; happy path calls the PATCH
+    client.
+  - AlertList renders the correct chip for each subtype, including the unknown-subtype fallback.
+
+## 7. End-to-end verification on edr-dev VM
+
+- [ ] 7.1 Author a TEAMID rule for an arbitrary signed binary (e.g. Slack's team) with
+  `enforcement=DETECT` (the new default). Exec the binary, verify it is *allowed* and that an
+  `application_control_would_block` event lands in the events stream and an alert with
+  `subtype='would_block'` appears in the alerts view.
+- [ ] 7.2 Promote the rule to PROTECT via the UI. Exec the binary again; verify it is *denied*
+  and the existing alert row updates to `subtype='block'` (the dedup-by-triple invariant in
+  scenario 5.4). The host-app modal fires this time, not on the first exec.
+- [ ] 7.3 Author a Detect rule against the agent's own team_id. Exec the agent. Verify the
+  failsafe carve-out (currently hard-coded to `team_id == extensionTeamID`) overrides DETECT and
+  the agent runs without an alert. (Documents that the failsafe is enforcement-agnostic.)
+- [ ] 7.4 Confirm via SigNoz that the new event kind, the new alert subtype, and the
+  enforcement-change audit row all surface on the existing telemetry pipeline, and that the
+  `decision` field on exec events is queryable.
+
+## 8. Documentation
+
+- [ ] 8.1 Update `CLAUDE.md` to mention `enforcement=DETECT` as the v0.1.0 default and the
+  Detect-to-Protect promotion workflow.
+- [ ] 8.2 Update `docs/install-server.md` (or its app-control follow-on) with a "Rule rollout
+  posture" section: new rules ship Detect by default; operators promote to Protect after
+  observing would-block alerts. Add a screenshot of the alert chip pair.
+- [ ] 8.3 Add a developer-facing note under `docs/` clarifying the `decision` field's semantics on
+  exec events: absent for ordinary allowed execs, `'blocked'` for AUTH-denied execs, `'would_block'`
+  for DETECT-allowed-but-flagged execs.

--- a/openspec/changes/add-application-control-detect-mode/tasks.md
+++ b/openspec/changes/add-application-control-detect-mode/tasks.md
@@ -11,13 +11,28 @@ are seeded, `cdhash` is on exec events). Each task below cites the matching spec
   in `server/rules/bootstrap/schema.go`. Existing rows keep their stored value; only new rows
   default. (spec: `server-application-control` "Default Detect on rule creation".)
 - [ ] 1.2 Add `subtype VARCHAR(32) NOT NULL DEFAULT 'block'` to the `alerts` table in the
-  detection-context bootstrap. Existing rows backfill to `'block'`. Add an index on
+  detection-context bootstrap. Existing rows backfill to `'block'`. Add a non-unique index on
   `(host_id, source, subtype)` so the alerts read API can filter without scanning. (spec:
   `server-detection-rules-engine` "Alert subtype distinguishes block from would-block".)
-- [ ] 1.3 Per-context integration test in `server/rules/internal/tests/` for the default flip:
+- [ ] 1.3 Enforce the source-dependent dedup key with a unique index (or indexes) that backs the
+  ingest UPSERT. MySQL has no partial unique indexes, so pick one of:
+  - two unique indexes — `UNIQUE (source, host_id, rule_id, process_id)` enforced only on
+    `source='detection'` rows by writing a sentinel value (e.g. `''`) into `process_id` for
+    `source='application_control'` rows, plus the natural collision check on the sentinel; OR
+  - a synthetic `dedup_discriminator` column populated at write time as `process_id` for
+    `source='detection'` and a fixed sentinel for `source='application_control'`, covered by a
+    single `UNIQUE (source, host_id, rule_id, dedup_discriminator)`.
+  Whichever shape lands, the schema integration test in 1.4 MUST exercise both
+  insert-then-update-in-place and insert-twice-rejected paths for both sources. (spec:
+  `server-detection-rules-engine` "Alert dedup key depends on source".)
+- [ ] 1.4 Per-context integration test in `server/rules/internal/tests/` for the default flip:
   a new rule created without an explicit `enforcement` lands with `DETECT`.
-- [ ] 1.4 Per-context integration test in `server/detection/internal/tests/` for the subtype
+- [ ] 1.5 Per-context integration test in `server/detection/internal/tests/` for the subtype
   backfill: a fresh schema bootstrap leaves `subtype='block'` on existing alert rows.
+- [ ] 1.6 Per-context integration test in `server/detection/internal/tests/` for the dedup-index
+  invariants: two `application_control_would_block` events with distinct `process_id` on the same
+  `(host, rule)` produce one row; two `detection`-source findings on distinct `process_id` on the
+  same `(host, rule)` produce two rows.
 
 ## 2. Extension decision engine
 
@@ -74,9 +89,12 @@ are seeded, `cdhash` is on exec events). Each task below cites the matching spec
   would-block".)
 - [ ] 5.3 Update the alerts read API filter parameters: `subtype` is a valid filter alongside
   `source`. (spec: `server-detection-rules-engine` "Alerts list filters by source and subtype".)
-- [ ] 5.4 Integration test for the dedup interaction: a would-block alert exists for
-  `(host_a, rule_X, process_42)`; a subsequent block event for the same tuple updates the existing
-  alert row to `subtype='block'` without creating a new row.
+- [ ] 5.4 Integration test for the dedup interaction across a Detect-to-Protect promotion: a
+  `would_block` alert exists for `(host_a, rule_X)` with `linked_process_id=process_42`; the rule
+  is promoted to PROTECT; a subsequent `application_control_block` event for `(host_a, rule_X)`
+  with a different `linked_process_id=process_99` (a separate exec) updates the existing alert row
+  to `subtype='block'` and replaces `linked_process_id` with `process_99` without creating a new
+  row. (Verifies the source-specific dedup key from spec "Alert dedup key depends on source".)
 - [ ] 5.5 Integration test for the alert subtype filter:
   `GET /api/v1/alerts?source=application_control&subtype=would_block` returns only the would-block
   alerts on the host.

--- a/openspec/changes/add-application-control/tasks.md
+++ b/openspec/changes/add-application-control/tasks.md
@@ -1,22 +1,47 @@
 # Application Control rollout tasks
 
+## Status (2026-05-16)
+
+The demo cut shipped via PRs #151–#159 (`App control demo cut steps 1–9`). The slice that landed is a
+BINARY-only, single-policy, all-hosts foundation that closes most of Phase A's *shape* but explicitly
+punts three categories of work to a Phase A close-out PR before the change can be archived:
+
+1. **The other five rule identifier types** (CDHASH, SIGNINGID, CERTIFICATE, TEAMID, PATH) — schema
+   and snapshot maps exist for all six; the validator and the extension's precedence walk gate at
+   BINARY only (`server/rules/internal/appcontrol/validate.go:25-83`,
+   `extension/edr/extension/ESFSubscriber.swift:124-146`).
+2. **`host_groups` + `app_control_assignments` tables + the `all-hosts` seed** — explicitly deferred
+   with a comment in `server/rules/bootstrap/schema.go:11-13`. Fan-out (`appcontrol/service.go`)
+   currently targets every enrolled host directly, bypassing the assignment layer the spec mandates.
+3. **`cdhash` + `signing_id` + `team_id` + `leaf_cert_sha256` on every exec event** — `team_id` and
+   `signing_id` ship today nested under `code_signing` (`extension/edr/extension/EventSerializer.swift`);
+   `cdhash` and `leaf_cert_sha256` are not extracted from `es_process_t` at all.
+
+These three categories are the entire remaining Phase A surface relative to the spec. They are
+captured below as PR-1 close-out scope; the follow-on Phase B work (per-rule Detect mode, allowlist,
+Lockdown, simulation, failsafes) lives in a separate change (`add-application-control-detect-mode`).
+
 ## 1. Demolition (single PR, delete the legacy scaffolding)
 
-- [ ] 1.1 Delete `server/rules/internal/policy/` package, the `policies` table from
+- [x] 1.1 Delete `server/rules/internal/policy/` package, the `policies` table from
   `server/rules/bootstrap/schema.go`, the `BlocklistPolicy` types from `server/rules/api/types.go`,
-  and their tests.
-- [ ] 1.2 Delete the `GET /api/policy` and `PUT /api/policy` handlers and routes from
+  and their tests. *Shipped: PR #151.*
+- [x] 1.2 Delete the `GET /api/policy` and `PUT /api/policy` handlers and routes from
   `server/rules/internal/operator/handler.go` and the corresponding `server-rest-api` wiring.
-- [ ] 1.3 Delete the `set_blocklist` command type and the `setBlocklistPayload` codec from
+  *Shipped: PR #151.*
+- [x] 1.3 Delete the `set_blocklist` command type and the `setBlocklistPayload` codec from
   `agent/commander/commander.go`. Delete the `PolicySender` interface and any unit tests pinned to it.
-- [ ] 1.4 Delete `extension/edr/extension/PolicyStore.swift`, the `/var/db/com.fleetdm.edr/policy.json`
+  *Shipped: PR #151.*
+- [x] 1.4 Delete `extension/edr/extension/PolicyStore.swift`, the `/var/db/com.fleetdm.edr/policy.json`
   read path, and the `Set<String>` blocklist lookup site in `extension/edr/extension/ESFSubscriber.swift`.
   Leave AUTH_EXEC as an unconditional allow until task 4.5 lands the new decision engine call site.
-- [ ] 1.5 Delete `ui/src/components/PolicyEditor.tsx`, the `/policy` route, and the `fetchPolicy` /
-  `updatePolicy` clients from `ui/src/api.ts`. Remove the policy nav entry.
-- [ ] 1.6 Update `schema/events.json` to remove any references to the legacy blocklist payload (none
-  expected, but verify).
-- [ ] 1.7 Run the test suite; expect the pre-existing policy tests to vanish and nothing else to fail.
+  *Shipped: PR #151.*
+- [x] 1.5 Delete `ui/src/components/PolicyEditor.tsx`, the `/policy` route, and the `fetchPolicy` /
+  `updatePolicy` clients from `ui/src/api.ts`. Remove the policy nav entry. *Shipped: PR #151.*
+- [x] 1.6 Update `schema/events.json` to remove any references to the legacy blocklist payload (none
+  expected, but verify). *Shipped: PR #151.*
+- [x] 1.7 Run the test suite; expect the pre-existing policy tests to vanish and nothing else to fail.
+  *Shipped: PR #151.*
 
 ## 2. Schema and seed
 
@@ -24,146 +49,306 @@
   `app_control_rules`, `host_groups`, and `app_control_assignments` with the columns described in the
   `server-application-control` capability spec. Include the reserved columns (`default_action`,
   `enforcement`, `source`, `source_ref`, `severity`, `expires_at`) and the
-  `(policy_id, rule_type, identifier)` unique key.
+  `(policy_id, rule_type, identifier)` unique key. *Partial: `app_control_policies` + `app_control_rules`
+  shipped in PR #152. `host_groups` + `app_control_assignments` deferred (`schema.go:11-13`) — PR-1
+  close-out scope below.*
 - [ ] 2.2 Add idempotent bootstrap that seeds the built-in `all-hosts` host group, the `Default`
-  policy with zero rules and `default_action='NONE'`, and the assignment connecting them.
-- [ ] 2.3 Per-context integration tests at `server/rules/internal/tests/` covering the seed shape, the
-  unique-key dedup, the bootstrap idempotency, and the typed-enum constraints.
+  policy with zero rules and `default_action='NONE'`, and the assignment connecting them. *Partial:
+  `Default` policy seed shipped in PR #152 (`appcontrol/store.go:30:EnsureDefaultPolicy`); `all-hosts`
+  group + assignment row not yet seeded — PR-1 close-out scope below.*
+- [x] 2.3 Per-context integration tests at `server/rules/internal/tests/` covering the seed shape, the
+  unique-key dedup, the bootstrap idempotency, and the typed-enum constraints. *Shipped: PR #152
+  (`server/rules/internal/tests/app_control_test.go`).*
 
 ## 3. Server domain and validation
 
 - [ ] 3.1 New package `server/rules/internal/appcontrol/` with the policy, rule, host-group, and
-  assignment store types and their persistence methods.
+  assignment store types and their persistence methods. *Partial: policy + rule store shipped in
+  PR #155; host-group + assignment store deferred — PR-1 close-out scope below.*
 - [ ] 3.2 Public surface on `server/rules/api/`: `ApplicationControlPolicy`, `ApplicationControlRule`,
   `RuleType`, `Action`, `Enforcement`, `Severity`, `Source`, `HostGroup`, `Assignment`, error sentinels
-  for validation, and the `SetApplicationControlPayload` codec.
+  for validation, and the `SetApplicationControlPayload` codec. *Partial: policy/rule/codec types
+  shipped in PR #152; `HostGroup` + `Assignment` types deferred — PR-1 close-out scope below.*
 - [ ] 3.3 Per-type identifier validators in `server/rules/internal/appcontrol/validate.go` per the rules
   in the `server-application-control` capability spec (`CDHASH` 40 hex, `BINARY`/`CERTIFICATE` 64 hex,
   `TEAMID` 10 of `[A-Z0-9]`, `SIGNINGID` `<TeamID|platform>:bundle.id`, `PATH` canonical absolute).
-- [ ] 3.4 Path canonicalizer reused from the legacy module (the macOS `/tmp`, `/var`, `/etc` →
-  `/private/...` rewrite), promoted into `server/rules/internal/appcontrol/`.
-- [ ] 3.5 Fuzz test (`go test -fuzz`) per identifier validator.
-- [ ] 3.6 PBT (`pgregory.net/rapid`) for the `(Marshal, Unmarshal)` round-trip on
-  `SetApplicationControlPayload`.
+  *Partial: shape validators shipped for all six types in PR #152; BINARY accepts, the other five
+  return `ErrAppControlUnsupportedRuleType` (`validate.go:25-83`) — PR-1 close-out scope below.*
+- [x] 3.4 Path canonicalizer reused from the legacy module (the macOS `/tmp`, `/var`, `/etc` →
+  `/private/...` rewrite), promoted into `server/rules/internal/appcontrol/`. *Shipped: PR #152
+  (`appcontrol/validate.go:95-115:canonicalizePath`).*
+- [ ] 3.5 Fuzz test (`go test -fuzz`) per identifier validator. *Partial: BINARY validator fuzzed;
+  the other five wait on type acceptance — PR-1 close-out scope below.*
+- [x] 3.6 PBT (`pgregory.net/rapid`) for the `(Marshal, Unmarshal)` round-trip on
+  `SetApplicationControlPayload`. *Shipped: PR #152.*
 
 ## 4. Decision engine (extension)
 
-- [ ] 4.1 New `extension/edr/extension/ApplicationControl/` Swift sources for the typed snapshot, the
+- [x] 4.1 New `extension/edr/extension/ApplicationControl/` Swift sources for the typed snapshot, the
   per-`(inode, mtime)` caches for `file_sha256` and `leaf_cert_sha256`, and the precedence walker.
+  *Partial: `ApplicationControlStore.swift` + `FileHashCache.swift` shipped in PRs #153–#155. The
+  `leaf_cert_sha256` cache class is not yet created (deferred with the CERTIFICATE rule type to
+  Phase B).*
 - [ ] 4.2 Implement the target-tuple builder per the `extension-application-control` capability spec:
   read `cdhash`, `team_id`, `signing_id` from `es_process_t`; compute or lookup `file_sha256` lazily;
   compute or lookup `leaf_cert_sha256` via `SecCodeCopySigningInformation` off the AUTH path.
+  *Partial: `team_id` is read for the failsafe check and `file_sha256` is looked up for the BINARY
+  match in `ESFSubscriber.swift:114-124`. `cdhash`, `signing_id`-as-tuple-component, and `leaf_cert_sha256`
+  are not assembled into the target tuple — PR-1 close-out scope below (cdhash + signing_id), Phase B
+  for leaf_cert_sha256.*
 - [ ] 4.3 Implement the precedence walk in fixed order
   `CDHASH → BINARY → SIGNINGID → CERTIFICATE → TEAMID → PATH` returning on first match. Skip
-  unpopulated tuple components.
-- [ ] 4.4 Implement snapshot apply: validate `policy_version` is greater than the current value;
+  unpopulated tuple components. *Partial: walker only consults `binaryRules`
+  (`ESFSubscriber.swift:124-146`). The other five maps are populated by `ApplicationControlStore` but
+  never read — PR-1 close-out scope below.*
+- [x] 4.4 Implement snapshot apply: validate `policy_version` is greater than the current value;
   atomically swap the in-memory snapshot; atomically write the disk snapshot with
-  write-temp-then-rename to `/var/db/com.fleetdm.edr/application-control.json`.
+  write-temp-then-rename to `/var/db/com.fleetdm.edr/application-control.json`. *Shipped: PR #153
+  (`ApplicationControlStore.swift:apply`).*
 - [ ] 4.5 Wire the decision engine into `ESFSubscriber.handleAuthExec()`. On match return deny and emit
   the `application_control_block` event; on miss return allow and emit the regular `exec` event.
+  *Partial: deny + block-event emission shipped (PRs #153–#154); the "on miss return allow and emit
+  the regular `exec` event" half is met today via NOTIFY_EXEC; the spec's intent that a denied AUTH
+  also emit a denied-exec telemetry event is unmet — addressed in the
+  `add-application-control-detect-mode` change.*
 - [ ] 4.6 Extend the regular `exec` event payload to carry the optional `cdhash`, `signing_id`,
-  `team_id`, and `leaf_cert_sha256` fields when their cached values are available.
+  `team_id`, and `leaf_cert_sha256` fields when their cached values are available. *Partial: `team_id`
+  and `signing_id` ship today nested under `code_signing` (`EventSerializer.swift:CodeSigning`);
+  `cdhash` and `leaf_cert_sha256` are not on the payload — PR-1 close-out scope (cdhash), Phase B
+  (leaf_cert_sha256).*
 - [ ] 4.7 Unit tests for the precedence walker on a synthetic snapshot covering each rule type and the
   silent-miss-on-cold-cache path. Tag with `-tags=extensiontest` if needed by the existing Swift test
-  harness.
+  harness. *Partial: BINARY-only coverage shipped; the precedence walker tests come with PR-1
+  close-out.*
 - [ ] 4.8 PBT for the precedence walk invariant: for any random snapshot and random target tuple, the
   walker's decision equals the obvious linear scan in precedence order. Implemented as a Go-side test
   against a port of the walker logic, since the project does not run rapid in Swift; the port is
   exercised by a fixture comparison test that re-runs the same inputs through the Swift walker via the
-  extension test harness.
+  extension test harness. *Deferred: lands with the precedence walker in PR-1 close-out.*
 
 ## 5. Agent command executor
 
-- [ ] 5.1 Add the `set_application_control` command type to `agent/commander/commander.go` with the
+- [x] 5.1 Add the `set_application_control` command type to `agent/commander/commander.go` with the
   decode-and-forward-to-extension path. Reject malformed payloads, missing `policy_id`, non-positive
-  `policy_version`, and unknown `rule_type` values.
-- [ ] 5.2 Update the `Executor` interface and the agent-side wiring so the new command is recognized
+  `policy_version`, and unknown `rule_type` values. *Shipped: PR #153.*
+- [x] 5.2 Update the `Executor` interface and the agent-side wiring so the new command is recognized
   and the legacy `set_blocklist` is no longer accepted (the demolition step removed its codec; this
-  step removes the routing).
-- [ ] 5.3 Integration tests at `agent/internal/tests/` covering the happy path, missing extension
-  bridge, malformed payload, and unknown rule type.
+  step removes the routing). *Shipped: PRs #151 + #153.*
+- [x] 5.3 Integration tests at `agent/internal/tests/` covering the happy path, missing extension
+  bridge, malformed payload, and unknown rule type. *Shipped: PR #153.*
 
 ## 6. Server REST surface
 
 - [ ] 6.1 New REST handlers under `server/rules/internal/operator/appcontrol_handler.go` covering the
   endpoints listed in the `server-application-control` capability spec (`policies`, `rules`,
-  `host-groups`, `assignments`, `bulkUpsert`).
-- [ ] 6.2 Route registration under `/api/v1/app-control/` in `server/cmd/fleet-edr-server/main.go` (or
+  `host-groups`, `assignments`, `bulkUpsert`). *Partial: `GET /policies`, `GET /policies/{id}`,
+  `POST /policies/{id}/rules` shipped in PR #155. `PATCH /policies/{id}`, `DELETE /policies/{id}`,
+  `PATCH /rules/{id}`, `DELETE /rules/{id}`, `bulkUpsert`, `GET /rules`, `/host-groups/*`,
+  `/assignments` not yet — Phase A close-out follow-on below.*
+- [x] 6.2 Route registration under `/api/v1/app-control/` in `server/cmd/fleet-edr-server/main.go` (or
   the equivalent router-wiring file in the current layout). Reuse the existing session + CSRF
-  middleware.
-- [ ] 6.3 Error responses follow the existing `ErrorResponse` shape with typed codes prefixed by
-  `application_control.`.
-- [ ] 6.4 Audit-event emission per the `server-application-control` capability spec, including the
-  single-event-per-bulk-upsert rule.
+  middleware. *Shipped: PR #155.*
+- [x] 6.3 Error responses follow the existing `ErrorResponse` shape with typed codes prefixed by
+  `application_control.`. *Shipped: PR #155.*
+- [x] 6.4 Audit-event emission per the `server-application-control` capability spec, including the
+  single-event-per-bulk-upsert rule. *Shipped: PR #155 for the create path. Bulk-upsert audit lands
+  with the bulk endpoint.*
 - [ ] 6.5 Fan-out path: on mutation, gather hosts from every assigned host group, dedup by host id, and
   enqueue exactly one `set_application_control` command per unique host. Record `fanout_hosts` and
   `fanout_failed` as unique-host counts on the audit event. Use the existing command-enqueue path.
+  *Partial: per-host enqueue shipped in PR #155, but the assignment-layer resolution is short-circuited
+  to "every enrolled host" because `app_control_assignments` doesn't exist yet — PR-1 close-out scope
+  below.*
 - [ ] 6.6 Integration test for unique-host fan-out: a host that belongs to two assigned host groups
   receives exactly one command, and the audit event's `fanout_hosts` counts that host once. Failing this
   test guards against regression into the duplicate-enqueue shape that CodeRabbit flagged on the spec.
-- [ ] 6.7 Ingest handler for `application_control_block` events binds the event to the host_id resolved
+  *Deferred: lands with the assignment-layer in PR-1 close-out.*
+- [x] 6.7 Ingest handler for `application_control_block` events binds the event to the host_id resolved
   by the existing host-token middleware. The handler MUST reject (with 4xx) any event whose envelope
-  `host_id` does not match the authenticated host.
-- [ ] 6.8 Integration test for ingest authenticity binding: an authenticated agent posting an event
+  `host_id` does not match the authenticated host. *Shipped: PR #154.*
+- [x] 6.8 Integration test for ingest authenticity binding: an authenticated agent posting an event
   with a forged envelope `host_id` (someone else's host) is rejected; an event whose envelope omits
-  `host_id` is accepted and stamped with the authenticated host id.
-- [ ] 6.9 Cross-context integration test at `test/integration/app_control_test.go`: create a rule via
+  `host_id` is accepted and stamped with the authenticated host id. *Shipped: PR #154.*
+- [x] 6.9 Cross-context integration test at `test/integration/app_control_test.go`: create a rule via
   the REST API, observe the audit event, observe the enqueued command for the test host, observe the
   extension applies the snapshot and denies the matching exec, observe the resulting alert appears via
-  the alerts list endpoint with `source='application_control'`.
+  the alerts list endpoint with `source='application_control'`. *Shipped: PR #155
+  (`test/integration/app_control_block_test.go`, `app_control_rest_test.go`).*
 
 ## 7. Detection-pipeline wiring
 
-- [ ] 7.1 Update `server/detection/internal/rules/` to recognize the `application_control_block`
+- [x] 7.1 Update `server/detection/internal/rules/` to recognize the `application_control_block`
   ingest event and map it to an alert per the `server-detection-rules-engine` delta spec.
-- [ ] 7.2 Extend the persisted alert schema with a `source` column constrained to
+  *Shipped: PR #154 (`server/rules/internal/catalog/application_control_block.go`).*
+- [x] 7.2 Extend the persisted alert schema with a `source` column constrained to
   `('detection','application_control')`. Existing catalog-rule findings backfill to `'detection'`.
-- [ ] 7.3 Promote the alert dedup unique key from `(host_id, rule_id, process_id)` to
+  *Shipped: PR #154.*
+- [x] 7.3 Promote the alert dedup unique key from `(host_id, rule_id, process_id)` to
   `(source, host_id, rule_id, process_id)`. This is the schema half of the spec contract: a catalog rule
   and an application-control rule that happen to share an identifier never collapse into one row.
-- [ ] 7.4 Integration test for cross-source id collision: insert a `source='detection'` alert and a
+  *Shipped: PR #154.*
+- [x] 7.4 Integration test for cross-source id collision: insert a `source='detection'` alert and a
   `source='application_control'` alert that share `(host_id, rule_id, process_id)` and assert two rows
   persist. Then re-fire each source against the same triple and assert dedup-within-source holds.
-- [ ] 7.5 Update the alerts read API (`server-rest-api` `Filterable alerts list`) so the `source`
+  *Shipped: PR #154.*
+- [x] 7.5 Update the alerts read API (`server-rest-api` `Filterable alerts list`) so the `source`
   filter parameter accepts `application_control`. This is a no-op for the requirement text in the
   REST capability since the list is already filterable; verify the handler accepts the new value.
-- [ ] 7.6 Integration test: post an `application_control_block` event, observe the persisted alert,
+  *Shipped: PR #159 (alert-view source filter chip).*
+- [x] 7.6 Integration test: post an `application_control_block` event, observe the persisted alert,
   re-post the same event, observe dedup, fetch via `GET /api/v1/alerts?source=application_control`.
+  *Shipped: PR #154 + #159.*
 
 ## 8. Web UI
 
-- [ ] 8.1 Add the Application Control top-level nav entry and the `/app-control` route.
-- [ ] 8.2 Implement the policies list view at `ui/src/components/ApplicationControl/PoliciesList.tsx`
+- [x] 8.1 Add the Application Control top-level nav entry and the `/app-control` route.
+  *Shipped: PR #157.*
+- [x] 8.2 Implement the policies list view at `ui/src/components/ApplicationControl/PoliciesList.tsx`
   showing every policy with its rule count, assigned host-group count, and last modified time.
+  *Shipped: PR #157. Assigned host-group count column shows "all-hosts" placeholder until the
+  assignment layer lands.*
 - [ ] 8.3 Implement the policy detail view at
   `ui/src/components/ApplicationControl/PolicyDetail.tsx` with the filterable rules table, per-row
-  enable/disable/edit/delete actions, and the assignment summary.
+  enable/disable/edit/delete actions, and the assignment summary. *Partial: read-only table + add-rule
+  button shipped in PR #157. Per-row enable/disable/edit/delete buttons render but are non-functional —
+  Phase A close-out follow-on.*
 - [ ] 8.4 Implement the add-rule modal at
   `ui/src/components/ApplicationControl/AddRuleModal.tsx` with the type selector, type-aware
   identifier validation, optional fields (`custom_msg`, `custom_url`, `severity`, `comment`), and the
-  audit-reason gate.
+  audit-reason gate. *Partial: modal + BINARY validator + custom_msg/custom_url/severity/reason fields
+  shipped in PR #157. The other five rule types render with `available: false` and a "coming soon"
+  badge — PR-1 close-out scope below (CDHASH/SIGNINGID/TEAMID), Phase B (CERTIFICATE), follow-on (PATH).*
 - [ ] 8.5 Implement the paste-many flow at
   `ui/src/components/ApplicationControl/PasteManyModal.tsx` with the per-line type inference rules
-  from the web-ui delta spec.
-- [ ] 8.6 Typed API clients in `ui/src/api.ts` for the `/api/v1/app-control/*` endpoints.
-- [ ] 8.7 React Testing Library coverage for the rules-table filter, the add-rule validation, and the
-  paste-many inference logic.
+  from the web-ui delta spec. *Deferred: lands when at least two rule types accept submission —
+  PR-1 close-out scope below.*
+- [x] 8.6 Typed API clients in `ui/src/api.ts` for the `/api/v1/app-control/*` endpoints.
+  *Shipped: PR #157 for the demo subset; PATCH/DELETE/bulk clients land with the corresponding
+  REST surface.*
+- [x] 8.7 React Testing Library coverage for the rules-table filter, the add-rule validation, and the
+  paste-many inference logic. *Partial: AddRuleModal + PoliciesList + PolicyDetail covered in PR #157;
+  paste-many tests land with PR-1 close-out.*
 
 ## 9. End-to-end verification on edr-dev VM
 
-- [ ] 9.1 Build and install the agent, extension, and server changes onto the `edr-dev` VM following
+- [x] 9.1 Build and install the agent, extension, and server changes onto the `edr-dev` VM following
   the established workflow (signed extension via `codesign --force --sign - --entitlements ...`,
-  agent via `sudo ./agent`, server via `task dev:server`).
+  agent via `sudo ./agent`, server via `task dev:server`). *Shipped: demo dry-run per
+  `ai/policy/demo-plan.md`.*
 - [ ] 9.2 Author one rule of each `rule_type` against a real binary on the VM, exec the binary,
   verify the AUTH_EXEC denial, the structured `application_control_block` event, and the resulting
   alert in the alerts view. Capture screenshots / logs into `tmp/qa/app-control/` per the project's
-  real-tool QA convention.
-- [ ] 9.3 Confirm via SigNoz (using `mcp__signoz__*` tools) that the decision spans land under
-  `service.name="fleet"` and that the new event kind is queryable.
+  real-tool QA convention. *Partial: BINARY-only verified for the demo recording. The other five rule
+  types verify against this checklist as they come online — PR-1 close-out scope below for CDHASH /
+  SIGNINGID / TEAMID.*
+- [x] 9.3 Confirm via SigNoz (using `mcp__signoz__*` tools) that the decision spans land under
+  `service.name="fleet"` and that the new event kind is queryable. *Shipped: demo dry-run.*
 
 ## 10. Documentation
 
 - [ ] 10.1 Update `CLAUDE.md` to mention the new bounded subdomain (`server/rules/internal/appcontrol/`)
-  and the new event kind in the appropriate place.
+  and the new event kind in the appropriate place. *Deferred: ride with PR-1 close-out so the
+  Documentation section reflects the full Phase A surface, not the demo-cut subset.*
 - [ ] 10.2 Add a developer-facing note under `docs/` describing the rule precedence, the lazy
-  signing-info cache, and the deferred-failsafe caveat for Phase A.
+  signing-info cache, and the deferred-failsafe caveat for Phase A. *Deferred: ride with PR-1
+  close-out.*
+
+## 11. Phase A close-out scope (PR-1)
+
+A single PR closes out the remaining Phase A surface so this change can be archived. The bundling is
+deliberate — every item below either (a) was punted by the demo cut with a comment in the shipped
+code, or (b) is needed by the Phase B Detect-mode change (`add-application-control-detect-mode`).
+
+### 11.1 `host_groups` + `app_control_assignments` tables (closes tasks 2.1, 2.2, 3.1, 3.2, 6.5, 6.6, 8.2)
+
+- [ ] 11.1.1 Add `host_groups` and `app_control_assignments` to `schemaStatements` in
+  `server/rules/bootstrap/schema.go`. Drop the "deferred to follow-on work" comment.
+- [ ] 11.1.2 Extend `EnsureDefaultPolicy` in `server/rules/internal/appcontrol/store.go` to also
+  insert the built-in `all-hosts` host group and the single assignment row connecting `Default` to it.
+  Idempotent on repeated boot.
+- [ ] 11.1.3 Public types `HostGroup` + `Assignment` on `server/rules/api/`.
+- [ ] 11.1.4 Fan-out path: resolve hosts via the assignments → host-group → matching-host walk instead
+  of "every enrolled host". The `all-hosts` group's criteria matches every host, so observable
+  behavior is unchanged for the demo deployment; the code path is correct for future host-group work.
+- [ ] 11.1.5 Per-context integration test for the unique-host fan-out across two assignments
+  targeting overlapping groups (closes task 6.6).
+- [ ] 11.1.6 PoliciesList.tsx: replace the hard-coded "all-hosts" placeholder with the real assignment
+  count (still always 1 in Phase A; this is wiring, not visual change).
+
+### 11.2 Three new rule types end-to-end (closes tasks 3.3, 3.5, 4.2, 4.3, 4.7, 4.8, 8.4, 8.5, 9.2)
+
+CDHASH + SIGNINGID + TEAMID land together. CERTIFICATE + PATH stay deferred (CERTIFICATE needs the
+`SecCodeCopySigningInformation` cache plumbing the demo cut also deferred; PATH has known Launch
+Services indirection edge cases). Both stay in Phase B's scope.
+
+- [ ] 11.2.1 `server/rules/internal/appcontrol/validate.go`: drop the `ErrAppControlUnsupportedRuleType`
+  returns at lines 25-26 (for CDHASH/SIGNINGID/TEAMID only) and the matching returns at 59-78. Keep
+  the unsupported returns for CERTIFICATE (line 64) and PATH (line 79).
+- [ ] 11.2.2 Fuzz tests for the three new validators (closes task 3.5 for these three).
+- [ ] 11.2.3 Extension target-tuple extraction: read `cdhash` (20 bytes → 40 hex string, only when
+  `process.codesigning_flags & CS_HARD` indicates Hardened Runtime per the spec) and `signing_id` into
+  the AUTH-path tuple. `team_id` is already read for the failsafe.
+- [ ] 11.2.4 Replace the BINARY-only check in `ESFSubscriber.handleAuthExec` with the precedence walk:
+  `CDHASH → BINARY → SIGNINGID → TEAMID → PATH` (skip CERTIFICATE — its map stays unwalked until
+  Phase B lands the leaf-cert cache). PATH consulted as a no-op until the validator accepts it; the
+  map is empty.
+- [ ] 11.2.5 Swift unit tests for the precedence walker covering each of the four wired types and
+  the CDHASH hardened-runtime gate.
+- [ ] 11.2.6 Go-side PBT (`pgregory.net/rapid`) for the precedence-walk invariant (closes task 4.8).
+- [ ] 11.2.7 `AddRuleModal.tsx`: flip `available: true` for CDHASH/SIGNINGID/TEAMID. Add type-aware
+  client-side validators (40 hex / 10-char team / `(TeamID|platform):bundle.id` regex).
+- [ ] 11.2.8 `PasteManyModal.tsx`: paste-shape inference per the `web-ui` delta spec (closes task 8.5).
+  Inference: 10-char `[A-Z0-9]` → TEAMID; 40 hex → CDHASH; 64 hex → BINARY (with CERTIFICATE hint);
+  `<TeamID|platform>:bundle.id` → SIGNINGID; absolute path → PATH (disabled, "coming soon").
+- [ ] 11.2.9 Integration tests at `test/integration/app_control_block_test.go`: one fixture binary
+  per new rule type, assert AUTH_EXEC deny + block event + alert with correct `rule_type`.
+- [ ] 11.2.10 Real-tool QA on edr-dev for the three new types (closes task 9.2 for CDHASH/SIGNINGID/TEAMID).
+
+### 11.3 `cdhash` field on every exec event (closes task 4.6 for cdhash)
+
+- [ ] 11.3.1 Add `cdhash` (optional `String?`) to `EventSerializer.ExecPayload`. Populate from
+  `target.cdhash` when the process is Hardened-Runtime. Encode with `encodeIfPresent`.
+- [ ] 11.3.2 Add `cdhash` (`*string`) to `server/detection/internal/graph/builder.go:execPayload` and
+  the corresponding `api.Process` field if downstream consumers need it. Tolerant of absence.
+- [ ] 11.3.3 Update `schema/events.json` exec payload schema with optional `cdhash`.
+
+`leaf_cert_sha256` stays deferred until Phase B lands the lazy `SecCodeCopySigningInformation` cache
+(it ships paired with the CERTIFICATE rule type for the same reason — both need the same plumbing).
+
+### 11.4 Full REST CRUD (closes task 6.1)
+
+- [ ] 11.4.1 `PATCH /api/v1/app-control/policies/{id}` (rename, description, locked to
+  `default_action='NONE'` in Phase A).
+- [ ] 11.4.2 `DELETE /api/v1/app-control/policies/{id}` with rule cascade.
+- [ ] 11.4.3 `POST /api/v1/app-control/policies` (create new policy beyond the seeded Default).
+- [ ] 11.4.4 `PATCH /api/v1/app-control/rules/{id}` — every mutable field. Phase B Detect-mode change
+  layers on the `enforcement` toggle; this PR delivers the generic PATCH path.
+- [ ] 11.4.5 `DELETE /api/v1/app-control/rules/{id}`.
+- [ ] 11.4.6 `POST /api/v1/app-control/policies/{id}/rules:bulkUpsert` with idempotent
+  `(policy_id, rule_type, identifier)` semantics. One audit event for the logical operation.
+- [ ] 11.4.7 `GET /api/v1/app-control/rules` cross-policy list with filters.
+- [ ] 11.4.8 `/host-groups/*` CRUD endpoints. Phase A keeps these read-only-effective by gating
+  mutation behind a 405 (Method Not Allowed) for non-`all-hosts` operations; the table exists, the
+  full editing UX lands in Phase B.
+- [ ] 11.4.9 `POST /api/v1/app-control/policies/{id}/assignments` (Phase A only ever creates the seed
+  assignment; endpoint exists for completeness and the spec's API-first contract).
+- [ ] 11.4.10 UI: per-row enable/disable/edit/delete actions in PolicyDetail.tsx wired to the new
+  PATCH/DELETE endpoints (closes task 8.3).
+
+### 11.5 Documentation (closes tasks 10.1, 10.2)
+
+- [ ] 11.5.1 Add the new event kind, the new bounded subdomain, and the rule-precedence walk to
+  `CLAUDE.md` in the appropriate place.
+- [ ] 11.5.2 Developer-facing note under `docs/` covering rule precedence, the lazy file-hash cache,
+  the deferred-failsafe caveat, and the deferred CERTIFICATE/PATH/leaf-cert work that lives in
+  Phase B.
+
+### Not in Phase A close-out, intentionally
+
+- **Per-rule Detect mode semantics** — separate change
+  (`openspec/changes/add-application-control-detect-mode/`). Implemented after this close-out PR.
+- **Lockdown / allowlist / failsafe-list / pre-deploy simulation** — Phase B proper, separate
+  change.
+- **CERTIFICATE + PATH rule types** — Phase B (CERTIFICATE needs leaf-cert cache plumbing; PATH
+  needs Launch Services indirection coverage).
+- **Editable host groups + multi-policy assignments** — Phase B (UI work; schema is ready).


### PR DESCRIPTION
Two pieces of paperwork that unblock the next round of Application Control code. No code changes; pure openspec docs.

1) Updated openspec/changes/add-application-control/tasks.md

The demo cut shipped via PRs #151-159 but the openspec task list was still all-unchecked. Walked the audit done in this session against each task and:

  - Marked the items that genuinely shipped as [x], citing the demo-cut PR that delivered each one (e.g., 'Shipped: PR #157' for the UI nav + policies list).
  - Marked items that are partially done as [ ] with an annotated 'Partial: ...' caveat naming the file:line where the demo cut explicitly punted (e.g., schema.go:11-13 for the host_groups + app_control_assignments deferral; validate.go:25-83 for the ErrAppControlUnsupportedRuleType returns gating non-BINARY types).
  - Added a Status preamble naming the three categories of remaining Phase A work (rule types, host_groups + assignments tables, cdhash
    + leaf_cert on exec events).
  - Added section 11 'Phase A close-out scope (PR-1)' bundling the remaining work into a single coherent PR plan: host_groups tables (11.1), CDHASH/SIGNINGID/TEAMID end-to-end (11.2), cdhash on exec events (11.3), full REST CRUD (11.4), docs (11.5). CERTIFICATE + PATH stay deferred to the Phase B change.

2) New openspec/changes/add-application-control-detect-mode/

The EDR-grade differentiator from Santa: per-rule Detect mode (log the would-have-blocked decision, allow the exec). Phase A spec already reserved the enforcement column but the decision engine never consulted it. This change activates the DETECT semantics end-to-end, makes Detect the default for new rules (CrowdStrike- style rollout safety), and closes the AUTH-deny telemetry gap by codifying that every AUTH_EXEC decision emits a regular exec event so the graph builder + catalog rules observe the attempt.

The change ships:
  - proposal.md, design.md, tasks.md (8 task sections, 31 boxes).
  - 5 spec deltas: server-application-control, extension-application-control, endpoint-event-collection, server-detection-rules-engine, web-ui.
  - Decisions called out in design.md: distinct event_type (application_control_would_block) not a flag; default DETECT for new rules; closed-loop telemetry via the new optional 'decision' field on every AUTH-flagged exec event; alert subtype dimension (not source enum extension); dedup-by-triple updates subtype in place on Detect-to-Protect transition.

Scope explicitly excludes Lockdown, ALLOW/SILENT_BLOCK actions, pre-deploy simulation, server-pushed failsafe carve-outs, and the CERTIFICATE/PATH rule types — those land in a separate Phase B change.

Both changes validate clean (openspec validate <id> --strict).