### PR TITLE
app-control: Phase A close-out — host_groups + 3 rule types + cdhash …

### DIFF
--- a/extension/edr/extension/ESFSubscriber.swift
+++ b/extension/edr/extension/ESFSubscriber.swift
@@ -4,13 +4,25 @@ import os.log
 
 private let logger = Logger(subsystem: "com.fleetdm.edr.securityextension", category: "ESFSubscriber")
 
-/// Our Apple Developer Team ID. Any binary signed with this team_id is
-/// allowed through AUTH_EXEC regardless of rule match — the failsafe that
-/// prevents a misconfigured rule from blocking the agent, extension, or
-/// host app itself. Hardcoded for the application-control demo cut; Phase B
-/// of the broader change replaces this with a server-pushed failsafe list
-/// so operators can extend it without an agent re-release.
+/// Our Apple Developer Team ID. The self-allow failsafe (AUTH_EXEC) requires both
+/// this team_id AND a fleetSelfAllowSigningIDs membership; matching team_id alone
+/// would exempt every binary signed by Fleet (including any legacy or unrelated
+/// utility sharing the cert). Phase B replaces this with a server-pushed failsafe
+/// list so operators can extend it without an agent re-release.
 private let extensionTeamID = "FDG8Q7N4CC"
+
+/// fleetSelfAllowSigningIDs is the exhaustive set of Fleet EDR bundle identifiers the
+/// AUTH_EXEC failsafe exempts from app-control enforcement: the agent daemon, the two
+/// system extensions, and the host app. A binary whose signing_id is NOT on this list
+/// is subject to the precedence walker even if signed by extensionTeamID. Hardcoded
+/// for the Phase A close-out; Phase B server-pushes the same list so operators can
+/// extend it for in-house tooling without an agent re-release.
+private let fleetSelfAllowSigningIDs: Set<String> = [
+    "com.fleetdm.edr.agent",
+    "com.fleetdm.edr.securityextension",
+    "com.fleetdm.edr.networkextension",
+    "com.fleetdm.edr"
+]
 
 /// ESFSubscriber manages the Endpoint Security client and subscribes to
 /// process lifecycle events (exec, fork, exit, open).
@@ -108,29 +120,34 @@ final class ESFSubscriber: Sendable {
         let target = msg.event.exec.target.pointee
         let path = esTokenString(target.executable.pointee.path)
         let teamID = esTokenString(target.team_id)
+        let signingID = esTokenString(target.signing_id)
         let fileStat = target.executable.pointee.stat
 
-        if teamID == extensionTeamID {
+        // Self-allow failsafe: exempt the agent + extensions + host app from app-control enforcement so a misconfigured rule cannot
+        // brick the EDR itself. Match BOTH team_id and the exhaustive Fleet bundle-id set; team_id alone would exempt every binary
+        // ever signed by extensionTeamID, which is broader than intended.
+        if teamID == extensionTeamID, fleetSelfAllowSigningIDs.contains(signingID) {
             es_respond_auth_result(client, message, ES_AUTH_RESULT_ALLOW, false)
             return
         }
 
         let snapshot = ApplicationControlStore.shared.currentSnapshot()
         let tuple = buildAuthTuple(target: target, fileStat: fileStat, lazyFillPath: path)
-        if let match = walkPrecedence(tuple: tuple, snapshot: snapshot) {
-            if match.rule.action == ApplicationControlAction.block,
-               match.rule.enforcement == ApplicationControlEnforcement.protect {
-                let denyPath = path
-                let denyRuleType = match.rule.ruleType
-                let denyID = match.matchedIdentifier
-                logger.warning(
-                    "AUTH_EXEC DENIED path=\(denyPath, privacy: .public) type=\(denyRuleType, privacy: .public) id=\(denyID, privacy: .public)"
-                )
-                es_respond_auth_result(client, message, ES_AUTH_RESULT_DENY, false)
-                emitBlockEvent(target: target, rule: match.rule, matchedIdentifier: match.matchedIdentifier, snapshot: snapshot)
-                emitBlockNotification(target: target, rule: match.rule, matchedIdentifier: match.matchedIdentifier, snapshot: snapshot)
-                return
-            }
+        // Sonar S1066: optional binding + condition co-located in one if so the deny branch is one block. Keep `denyPath` redacted in
+        // the log (no `privacy: .public`) so PII embedded in exec paths — usernames, project tokens — doesn't leak to os.log readers;
+        // the full path still flows on the block event payload for the server-side alert.
+        if let match = walkPrecedence(tuple: tuple, snapshot: snapshot),
+           match.rule.action == ApplicationControlAction.block,
+           match.rule.enforcement == ApplicationControlEnforcement.protect {
+            let denyRuleType = match.rule.ruleType
+            let denyID = match.matchedIdentifier
+            logger.warning(
+                "AUTH_EXEC DENIED path=\(path) type=\(denyRuleType, privacy: .public) id=\(denyID, privacy: .public)"
+            )
+            es_respond_auth_result(client, message, ES_AUTH_RESULT_DENY, false)
+            emitBlockEvent(target: target, rule: match.rule, matchedIdentifier: match.matchedIdentifier, snapshot: snapshot)
+            emitBlockNotification(target: target, rule: match.rule, matchedIdentifier: match.matchedIdentifier, snapshot: snapshot)
+            return
         }
         es_respond_auth_result(client, message, ES_AUTH_RESULT_ALLOW, false)
     }

--- a/extension/edr/extension/ESFSubscriber.swift
+++ b/extension/edr/extension/ESFSubscriber.swift
@@ -120,7 +120,12 @@ final class ESFSubscriber: Sendable {
         if let match = walkPrecedence(tuple: tuple, snapshot: snapshot) {
             if match.rule.action == ApplicationControlAction.block,
                match.rule.enforcement == ApplicationControlEnforcement.protect {
-                logger.warning("AUTH_EXEC DENIED by application control: \(path, privacy: .public) rule_type=\(match.rule.ruleType, privacy: .public) identifier=\(match.matchedIdentifier, privacy: .public)")
+                let denyPath = path
+                let denyRuleType = match.rule.ruleType
+                let denyID = match.matchedIdentifier
+                logger.warning(
+                    "AUTH_EXEC DENIED path=\(denyPath, privacy: .public) type=\(denyRuleType, privacy: .public) id=\(denyID, privacy: .public)"
+                )
                 es_respond_auth_result(client, message, ES_AUTH_RESULT_DENY, false)
                 emitBlockEvent(target: target, rule: match.rule, matchedIdentifier: match.matchedIdentifier, snapshot: snapshot)
                 emitBlockNotification(target: target, rule: match.rule, matchedIdentifier: match.matchedIdentifier, snapshot: snapshot)
@@ -200,8 +205,10 @@ final class ESFSubscriber: Sendable {
     /// BINARY → SIGNINGID → TEAMID, returning on the first match. CERTIFICATE + PATH
     /// stay deferred and are not consulted here even though their snapshot maps are
     /// populated by ApplicationControlStore — Phase B activates them alongside the
-    /// leaf-cert cache and Launch Services edge cases.
-    func walkPrecedence(tuple: AuthTuple, snapshot: ApplicationControlSnapshot) -> PrecedenceMatch? {
+    /// leaf-cert cache and Launch Services edge cases. Private because it has no
+    /// caller outside handleAuthExec and a wider visibility would surface this
+    /// walker to anything that holds a snapshot reference.
+    private func walkPrecedence(tuple: AuthTuple, snapshot: ApplicationControlSnapshot) -> PrecedenceMatch? {
         if let cdhash = tuple.cdhash, let rule = snapshot.cdhashRules[cdhash] {
             return PrecedenceMatch(rule: rule, matchedIdentifier: cdhash)
         }
@@ -386,21 +393,43 @@ final class ESFSubscriber: Sendable {
     }
 }
 
-/// CS_RUNTIME is the codesigning_flags bit set when a binary runs under Apple's Hardened Runtime. Defined here (rather than imported
-/// from <kern/cs_blobs.h>) because the Swift bridging headers do not surface the constant directly; the literal value is stable per
-/// the public macOS code-signing documentation.
-private let CS_RUNTIME: UInt32 = 0x0001_0000
+/// csRuntimeFlag is the codesigning_flags bit set when a binary runs under Apple's Hardened Runtime. Defined here (rather than
+/// imported from <kern/cs_blobs.h>) because the Swift bridging headers do not surface the constant directly; the literal value
+/// is stable per the public macOS code-signing documentation. Lowercased to satisfy SwiftLint's identifier_name rule (CS_RUNTIME
+/// would be the literal C symbol but Swift conventions reject all-caps identifiers).
+private let csRuntimeFlag: UInt32 = 0x0001_0000
 
 /// isHardenedRuntime reports whether the codesigning_flags bitfield indicates Apple's Hardened Runtime. CDHASH rules only match
 /// hardened-runtime processes because CDHash on non-hardened processes is not a reliable integrity check (page mapping is lazy and
 /// not re-verified post-load). Mirrors Santa's behavior so a migrating Santa admin's mental model carries over.
 private func isHardenedRuntime(flags: UInt32) -> Bool {
-    return (flags & CS_RUNTIME) != 0
+    return (flags & csRuntimeFlag) != 0
 }
 
-/// cdhashHexString lowercases-hex the 20-byte CDHash array from es_process_t.cdhash into the 40-char string the server's validator
-/// + the snapshot's cdhashRules map index on. Returns nil when the cdhash is all zero (es_process_t conventions: unsigned binaries
-/// report a zeroed cdhash, which is not a real identity).
+/// hexCharsPerByte is the fixed expansion ratio of a byte to its 2-char lowercase hex representation. Extracted so the capacity
+/// reserve in cdhashHexString is self-documenting (SwiftLint's no_magic_numbers rule would otherwise flag the literal `2`).
+private let hexCharsPerByte = 2
+
+/// hexDigitsLowercase is the lookup table cdhashHexString walks instead of calling String(format:"%02x", b). The format-string path
+/// bridges to Foundation and parses the format spec on every call; this matters because the helper runs inside AUTH_EXEC's
+/// kernel-deadline window. The table is private so it doesn't pollute symbol search at the module level.
+private let hexDigitsLowercase: [Character] = [
+    "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "a", "b", "c", "d", "e", "f"
+]
+
+/// hexLowNibbleMask is the bitmask used to extract the low 4 bits of a byte when looking up its hex digit in the
+/// hexDigitsLowercase table. Named so the no_magic_numbers SwiftLint rule doesn't flag the literal 0x0f.
+private let hexLowNibbleMask: UInt8 = 0x0f
+
+// swiftlint:disable large_tuple
+//
+// cdhashHexString lowercases-hex the 20-byte CDHash array from es_process_t.cdhash into the 40-char string the server's validator
+// + the snapshot's cdhashRules map index on. Returns nil when the cdhash is all zero (es_process_t conventions: unsigned binaries
+// report a zeroed cdhash, which is not a real identity).
+//
+// The parameter is a 20-element tuple because the C surface (es_process_t.cdhash) is a fixed-size array that Swift imports as a
+// homogeneous tuple. The large_tuple lint is disabled around this declaration because the shape is dictated by the ESF SDK and
+// cannot be reshaped without breaking the C bridge.
 private func cdhashHexString(from cdhash: (UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
                                             UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8)) -> String? {
     var bytes = cdhash
@@ -411,10 +440,12 @@ private func cdhashHexString(from cdhash: (UInt8, UInt8, UInt8, UInt8, UInt8, UI
             return nil
         }
         var s = ""
-        s.reserveCapacity(raw.count * 2)
+        s.reserveCapacity(raw.count * hexCharsPerByte)
         for b in raw {
-            s.append(String(format: "%02x", b))
+            s.append(hexDigitsLowercase[Int(b >> 4)])
+            s.append(hexDigitsLowercase[Int(b & hexLowNibbleMask)])
         }
         return s
     }
 }
+// swiftlint:enable large_tuple

--- a/extension/edr/extension/ESFSubscriber.swift
+++ b/extension/edr/extension/ESFSubscriber.swift
@@ -51,12 +51,14 @@ final class ESFSubscriber: Sendable {
         }
 
         logger.info("Subscribed to \(events.count) event types (including AUTH_EXEC)")
-        // Application Control demo cut: AUTH_EXEC consults the
-        // ApplicationControlStore snapshot and denies BINARY-matched execs.
-        // Cache misses on the lazy file-hash cache return ALLOW silently;
-        // the cache fills off the callback so the next exec of the same
-        // binary catches. See FileHashCache + ApplicationControlStore.
-        logger.info("Application Control active: AUTH_EXEC consults BINARY rule snapshot")
+        // Application Control Phase A close-out: AUTH_EXEC consults the
+        // ApplicationControlStore snapshot and denies execs matching any of
+        // four rule types in fixed precedence: CDHASH → BINARY → SIGNINGID →
+        // TEAMID. CERTIFICATE + PATH stay deferred to Phase B (leaf-cert cache
+        // / Launch Services indirection). Cache misses on the lazy file-hash
+        // cache return ALLOW silently for the BINARY type; the cache fills
+        // off the callback so the next exec of the same binary catches.
+        logger.info("Application Control active: AUTH_EXEC walks CDHASH/BINARY/SIGNINGID/TEAMID rules")
     }
 
     func stop() {
@@ -85,72 +87,134 @@ final class ESFSubscriber: Sendable {
 
     /// AUTH_EXEC handler: application-control decision walk.
     ///
-    /// The demo cut enforces only the BINARY rule type. Walk:
-    ///   1. Failsafe — if the exec target's `team_id` is our own, ALLOW.
-    ///      Prevents a misconfigured rule from blocking the agent /
-    ///      extension / host app. The Phase B server-pushed failsafe list
-    ///      will widen this to include platform binaries (`launchd`,
-    ///      `systemextensionsd`, etc.) and additional admin-defined
-    ///      carve-outs.
-    ///   2. Lazy file SHA-256 cache lookup by `(dev, inode, mtime)`. Cache
-    ///      misses do NOT block the AUTH callback — the BINARY rule type
-    ///      silently misses for this exec, the cache fills off-thread,
-    ///      and the next exec of the same binary catches. This is the
-    ///      "first launch allowed, second launch blocked" behavior the
-    ///      demo plan documents and the recording exercises.
-    ///   3. Snapshot lookup — if the cached hash matches a BINARY rule
-    ///      with `action=BLOCK` and `enforcement=PROTECT`, DENY.
-    ///      Otherwise ALLOW.
+    /// Walks four rule types in fixed precedence: CDHASH → BINARY → SIGNINGID → TEAMID.
+    /// CERTIFICATE and PATH stay deferred to Phase B (leaf-cert cache / Launch Services
+    /// indirection). Returns on the first match. Decisions:
+    ///   - Failsafe — if the exec target's `team_id` is our own, ALLOW unconditionally.
+    ///     Prevents a misconfigured rule from blocking the agent / extension / host app.
+    ///     Phase B replaces this with a server-pushed failsafe list.
+    ///   - First matching rule with `action=BLOCK` and `enforcement=PROTECT` → DENY.
+    ///   - First matching rule with any other enforcement → ALLOW (DETECT semantics arrive
+    ///     in the follow-on add-application-control-detect-mode change).
+    ///   - No match → ALLOW.
     ///
-    /// The decision is reached inside the AUTH_EXEC deadline because every
-    /// step is a constant-time map lookup; signing-info fetch + file read
-    /// happen on the lazy-fill background path, never on the callback.
+    /// The walk is at most four constant-time map lookups. The file SHA-256 needed for the
+    /// BINARY map is fetched from the (inode, mtime) cache; a cold cache makes BINARY
+    /// silently miss for this exec (the cache fills off the callback so the next exec
+    /// catches). The leaf-cert SHA-256 needed for CERTIFICATE rules is NOT fetched here;
+    /// CERTIFICATE matching is gated to Phase B.
     private func handleAuthExec(_ message: UnsafePointer<es_message_t>) {
         let msg = message.pointee
         let target = msg.event.exec.target.pointee
-        // esTokenString uses the token's explicit length; es_string_token_t
-        // is NOT NUL-guaranteed and String(cString:) can overread.
         let path = esTokenString(target.executable.pointee.path)
         let teamID = esTokenString(target.team_id)
         let fileStat = target.executable.pointee.stat
 
-        // Failsafe carve-out.
         if teamID == extensionTeamID {
             es_respond_auth_result(client, message, ES_AUTH_RESULT_ALLOW, false)
             return
         }
 
         let snapshot = ApplicationControlStore.shared.currentSnapshot()
-        if let sha256 = FileHashCache.shared.lookup(stat: fileStat) {
-            if let rule = snapshot.binaryRules[sha256],
-               rule.action == ApplicationControlAction.block,
-               rule.enforcement == ApplicationControlEnforcement.protect {
-                logger.warning("AUTH_EXEC DENIED by application control: \(path, privacy: .public) sha256=\(sha256, privacy: .public)")
-                // Deny FIRST so the kernel is unblocked before any
-                // userspace work. The block-event serialize + upload
-                // happens off the AUTH callback's deadline.
+        let tuple = buildAuthTuple(target: target, fileStat: fileStat, lazyFillPath: path)
+        if let match = walkPrecedence(tuple: tuple, snapshot: snapshot) {
+            if match.rule.action == ApplicationControlAction.block,
+               match.rule.enforcement == ApplicationControlEnforcement.protect {
+                logger.warning("AUTH_EXEC DENIED by application control: \(path, privacy: .public) rule_type=\(match.rule.ruleType, privacy: .public) identifier=\(match.matchedIdentifier, privacy: .public)")
                 es_respond_auth_result(client, message, ES_AUTH_RESULT_DENY, false)
-                emitBlockEvent(
-                    target: target,
-                    rule: rule,
-                    matchedIdentifier: sha256,
-                    snapshot: snapshot
-                )
-                emitBlockNotification(
-                    target: target,
-                    rule: rule,
-                    matchedIdentifier: sha256,
-                    snapshot: snapshot
-                )
+                emitBlockEvent(target: target, rule: match.rule, matchedIdentifier: match.matchedIdentifier, snapshot: snapshot)
+                emitBlockNotification(target: target, rule: match.rule, matchedIdentifier: match.matchedIdentifier, snapshot: snapshot)
                 return
             }
-        } else {
-            // Cache miss: kick the async fill so the next exec of this
-            // binary hits the cache. Documented behavior — never block
-            // the AUTH callback on a file read.
-            FileHashCache.shared.startLazyFill(path: path, stat: fileStat)
         }
         es_respond_auth_result(client, message, ES_AUTH_RESULT_ALLOW, false)
+    }
+
+    /// AuthTuple captures the identifier values the decision walker compares against the
+    /// snapshot's per-type maps. Each field is optional: absent values mean "the target
+    /// has no value of this kind", and the precedence walker skips that map. Phase A
+    /// close-out wires CDHASH, BINARY, SIGNINGID, and TEAMID; CERTIFICATE + PATH stay
+    /// deferred and are absent here.
+    struct AuthTuple {
+        let cdhash: String?         // 40-char lowercase hex, only when target is hardened-runtime
+        let fileSHA256: String?     // 64-char lowercase hex, only when the FileHashCache is warm
+        let signingIDPrefixed: String? // "<TeamID>:<bundle.id>" or "platform:<bundle.id>"
+        let teamID: String?         // 10-char Apple Developer Team ID
+    }
+
+    /// PrecedenceMatch carries the rule that fired plus the actual identifier value from
+    /// the target that hit. The `matched_identifier` flows into the block event so the
+    /// alert pipeline can show "blocked by CDHASH rule matching <40 hex>" rather than just
+    /// the rule's own identifier (which is usually the same value but not always — a
+    /// TEAMID rule matches every binary signed by that team, so matched_identifier is the
+    /// rule's TeamID and the rule's own identifier are the same; for a CDHASH rule the two
+    /// are also the same; the distinction matters more for future PATH rules where the
+    /// rule's identifier is a glob and the matched value is the resolved path).
+    struct PrecedenceMatch {
+        let rule: ApplicationControlRule
+        let matchedIdentifier: String
+    }
+
+    /// buildAuthTuple reduces a Mach-O exec target to the four identifier values the
+    /// precedence walker reads. Side effect: when the file SHA-256 cache misses, kicks
+    /// the async lazy fill so the next exec of the same (inode, mtime) hits.
+    private func buildAuthTuple(target: es_process_t, fileStat: stat, lazyFillPath: String) -> AuthTuple {
+        let teamID = esTokenString(target.team_id)
+        let signingID = esTokenString(target.signing_id)
+
+        // CDHASH is a 20-byte raw array on es_process_t. Gate on Apple's Hardened Runtime
+        // (CS_RUNTIME = 0x00010000): per Santa's rationale, CDHash on non-hardened
+        // processes is not a reliable integrity check because pages are mapped lazily and
+        // the kernel does not re-verify post-load. CDHASH rules that nominally target a
+        // non-hardened binary silently no-op for this exec.
+        let cdhash: String? = isHardenedRuntime(flags: target.codesigning_flags) ? cdhashHexString(from: target.cdhash) : nil
+
+        // SIGNINGID is prefixed: "<TeamID>:<bundle.id>" for third-party signed binaries,
+        // "platform:<bundle.id>" for Apple platform binaries (those whose
+        // is_platform_binary flag is set). The server's validator accepts both shapes.
+        let signingIDPrefixed: String?
+        if signingID.isEmpty {
+            signingIDPrefixed = nil
+        } else if target.is_platform_binary {
+            signingIDPrefixed = "platform:\(signingID)"
+        } else if !teamID.isEmpty {
+            signingIDPrefixed = "\(teamID):\(signingID)"
+        } else {
+            signingIDPrefixed = nil
+        }
+
+        let fileSHA256 = FileHashCache.shared.lookup(stat: fileStat)
+        if fileSHA256 == nil {
+            FileHashCache.shared.startLazyFill(path: lazyFillPath, stat: fileStat)
+        }
+
+        return AuthTuple(
+            cdhash: cdhash,
+            fileSHA256: fileSHA256,
+            signingIDPrefixed: signingIDPrefixed,
+            teamID: teamID.isEmpty ? nil : teamID
+        )
+    }
+
+    /// walkPrecedence walks the snapshot's per-type maps in the fixed order CDHASH →
+    /// BINARY → SIGNINGID → TEAMID, returning on the first match. CERTIFICATE + PATH
+    /// stay deferred and are not consulted here even though their snapshot maps are
+    /// populated by ApplicationControlStore — Phase B activates them alongside the
+    /// leaf-cert cache and Launch Services edge cases.
+    func walkPrecedence(tuple: AuthTuple, snapshot: ApplicationControlSnapshot) -> PrecedenceMatch? {
+        if let cdhash = tuple.cdhash, let rule = snapshot.cdhashRules[cdhash] {
+            return PrecedenceMatch(rule: rule, matchedIdentifier: cdhash)
+        }
+        if let sha = tuple.fileSHA256, let rule = snapshot.binaryRules[sha] {
+            return PrecedenceMatch(rule: rule, matchedIdentifier: sha)
+        }
+        if let signingID = tuple.signingIDPrefixed, let rule = snapshot.signingIDRules[signingID] {
+            return PrecedenceMatch(rule: rule, matchedIdentifier: signingID)
+        }
+        if let teamID = tuple.teamID, let rule = snapshot.teamIDRules[teamID] {
+            return PrecedenceMatch(rule: rule, matchedIdentifier: teamID)
+        }
+        return nil
     }
 
     /// emitBlockEvent serializes an application_control_block event for the
@@ -235,6 +299,9 @@ final class ESFSubscriber: Sendable {
         // is gone or unreadable (deleted-between-AUTH-and-NOTIFY race);
         // the event still fires with the rest of the metadata.
         let sha256 = FileHashCache.shared.lookupOrCompute(path: path, stat: fileStat)
+        // CDHash is present only when the binary uses Hardened Runtime (per Phase A close-out spec). Server-side detection
+        // rules and the future leaf-cert correlator both consume this when available; absent for non-hardened binaries.
+        let cdhash: String? = isHardenedRuntime(flags: target.codesigning_flags) ? cdhashHexString(from: target.cdhash) : nil
 
         let payload = ExecPayload(
             pid: pid,
@@ -245,7 +312,8 @@ final class ESFSubscriber: Sendable {
             uid: uid,
             gid: gid,
             codeSigning: codeSigning,
-            sha256: sha256
+            sha256: sha256,
+            cdhash: cdhash
         )
 
         if let data = serializer.serialize(eventType: "exec", payload: payload) {
@@ -315,5 +383,38 @@ final class ESFSubscriber: Sendable {
             flags: process.codesigning_flags,
             isPlatformBinary: process.is_platform_binary
         )
+    }
+}
+
+/// CS_RUNTIME is the codesigning_flags bit set when a binary runs under Apple's Hardened Runtime. Defined here (rather than imported
+/// from <kern/cs_blobs.h>) because the Swift bridging headers do not surface the constant directly; the literal value is stable per
+/// the public macOS code-signing documentation.
+private let CS_RUNTIME: UInt32 = 0x0001_0000
+
+/// isHardenedRuntime reports whether the codesigning_flags bitfield indicates Apple's Hardened Runtime. CDHASH rules only match
+/// hardened-runtime processes because CDHash on non-hardened processes is not a reliable integrity check (page mapping is lazy and
+/// not re-verified post-load). Mirrors Santa's behavior so a migrating Santa admin's mental model carries over.
+private func isHardenedRuntime(flags: UInt32) -> Bool {
+    return (flags & CS_RUNTIME) != 0
+}
+
+/// cdhashHexString lowercases-hex the 20-byte CDHash array from es_process_t.cdhash into the 40-char string the server's validator
+/// + the snapshot's cdhashRules map index on. Returns nil when the cdhash is all zero (es_process_t conventions: unsigned binaries
+/// report a zeroed cdhash, which is not a real identity).
+private func cdhashHexString(from cdhash: (UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
+                                            UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8)) -> String? {
+    var bytes = cdhash
+    return withUnsafeBytes(of: &bytes) { raw -> String? in
+        // All-zero cdhash means "no real CDHash present" — unsigned or otherwise unverifiable. Return nil so the precedence walker
+        // skips the CDHASH map for this exec rather than matching a rule whose identifier is "00…00" by coincidence.
+        if raw.allSatisfy({ $0 == 0 }) {
+            return nil
+        }
+        var s = ""
+        s.reserveCapacity(raw.count * 2)
+        for b in raw {
+            s.append(String(format: "%02x", b))
+        }
+        return s
     }
 }

--- a/extension/edr/extension/EventSerializer.swift
+++ b/extension/edr/extension/EventSerializer.swift
@@ -30,6 +30,10 @@ struct ExecPayload: Codable, Sendable {
     let gid: gid_t
     let codeSigning: CodeSigning?
     let sha256: String?
+    /// 40-char lowercase hex of the binary's Code Directory hash. Populated only when the new process runs under Apple's
+    /// Hardened Runtime (per Phase A close-out spec). Absent for unsigned binaries and signed-but-not-hardened binaries; the
+    /// encoder below omits the key entirely in those cases so the wire shape stays compact and backwards-tolerant.
+    let cdhash: String?
     /// True only for synthetic exec events emitted by the ESF startup snapshot pass
     /// (issue #11). The custom encoder below OMITS the key entirely when false, so
     /// the wire shape for live execs stays byte-identical to the pre-#11 format.
@@ -42,12 +46,14 @@ struct ExecPayload: Codable, Sendable {
         case pid, ppid, path, args, cwd, uid, gid
         case codeSigning = "code_signing"
         case sha256
+        case cdhash
         case snapshot
     }
 
     init(
         pid: pid_t, ppid: pid_t, path: String, args: [String], cwd: String,
         uid: uid_t, gid: gid_t, codeSigning: CodeSigning?, sha256: String?,
+        cdhash: String? = nil,
         snapshot: Bool = false
     ) {
         self.pid = pid
@@ -59,6 +65,7 @@ struct ExecPayload: Codable, Sendable {
         self.gid = gid
         self.codeSigning = codeSigning
         self.sha256 = sha256
+        self.cdhash = cdhash
         self.snapshot = snapshot
     }
 
@@ -76,6 +83,7 @@ struct ExecPayload: Codable, Sendable {
         gid = try container.decode(gid_t.self, forKey: .gid)
         codeSigning = try container.decodeIfPresent(CodeSigning.self, forKey: .codeSigning)
         sha256 = try container.decodeIfPresent(String.self, forKey: .sha256)
+        cdhash = try container.decodeIfPresent(String.self, forKey: .cdhash)
         snapshot = try container.decodeIfPresent(Bool.self, forKey: .snapshot) ?? false
     }
 
@@ -90,6 +98,7 @@ struct ExecPayload: Codable, Sendable {
         try container.encode(gid, forKey: .gid)
         try container.encodeIfPresent(codeSigning, forKey: .codeSigning)
         try container.encodeIfPresent(sha256, forKey: .sha256)
+        try container.encodeIfPresent(cdhash, forKey: .cdhash)
         // Only emit snapshot when true — keeps the live-exec wire shape stable
         // and avoids tripping the server detection-engine bytes.Contains gate
         // on a `"snapshot":false` payload (false events would correctly be

--- a/server/rules/api/types.go
+++ b/server/rules/api/types.go
@@ -148,6 +148,16 @@ type RegistryOptions struct {
 // Multi-policy support is on the post-demo backlog; for the demo cut the deployment has exactly one policy with this name.
 const DefaultPolicyName = "Default"
 
+// DefaultHostGroupName is the name of the built-in "every enrolled host" host group seeded at bootstrap. The Default policy is
+// assigned to this group by default, which is what makes the fan-out reach every enrolled host in Phase A. Editable host groups
+// arrive in Phase B; Phase A only ever has this single row.
+const DefaultHostGroupName = "all-hosts"
+
+// HostGroupCriteriaTypeAll is the discriminator value the bootstrap writes into the built-in all-hosts group's `criteria` JSON
+// document. The resolver in the fan-out path expands `{"type":"all"}` into every enrolled host. Phase B extends the discriminator
+// with `"type":"tag"`, `"type":"hostname_pattern"`, etc., without a schema change because criteria is JSON.
+const HostGroupCriteriaTypeAll = "all"
+
 // RuleType is the wire-shape identifier of an application-control rule's matching dimension. The schema's `rule_type` ENUM mirrors
 // this set. In the demo cut only BINARY is enforced; the other five values exist on the type so the column accepts them when their
 // validators come online.
@@ -314,6 +324,27 @@ func IsApplicationControlValidationError(err error) bool {
 		errors.Is(err, ErrAppControlInvalidRequest)
 }
 
+// HostGroup mirrors a row in host_groups. Phase A has exactly one row (the built-in `all-hosts` group); editable groups arrive in
+// Phase B. Criteria is a JSON document the fan-out resolver interprets: `{"type":"all"}` matches every enrolled host today; Phase B
+// adds tag / hostname-pattern / OS predicates without a schema change.
+type HostGroup struct {
+	ID          int64           `json:"id"`
+	Name        string          `json:"name"`
+	Description string          `json:"description"`
+	Criteria    json.RawMessage `json:"criteria"`
+	CreatedAt   time.Time       `json:"created_at"`
+	UpdatedAt   time.Time       `json:"updated_at"`
+}
+
+// Assignment mirrors a row in app_control_assignments. Phase A has exactly one row (the seed `Default` → `all-hosts` link). Phase B
+// uses Priority for conflict resolution when overlapping groups are assigned to different policies; Phase A leaves it at 0.
+type Assignment struct {
+	PolicyID    int64     `json:"policy_id"`
+	HostGroupID int64     `json:"host_group_id"`
+	Priority    int       `json:"priority"`
+	CreatedAt   time.Time `json:"created_at"`
+}
+
 // ApplicationControlStore is the read+write surface the rules-context REST handler (and tests) consume. The concrete implementation
 // lives at server/rules/internal/appcontrol; this interface lets callers outside the rules tree depend on the contract without pulling
 // in the internal package (ADR-0004's bounded-context import rule).
@@ -322,6 +353,10 @@ type ApplicationControlStore interface {
 	ListPolicies(ctx context.Context) ([]ApplicationControlPolicy, error)
 	ListRulesByPolicy(ctx context.Context, policyID int64) ([]ApplicationControlRule, error)
 	CreateRule(ctx context.Context, req CreateRuleRequest) (ApplicationControlRule, error)
+	// ListHostGroupsForPolicy returns the host groups assigned to the policy, in priority order then by group name. The fan-out
+	// resolver walks the result and unions the member hosts of each group to build the set of unique hosts the rule update should
+	// reach.
+	ListHostGroupsForPolicy(ctx context.Context, policyID int64) ([]HostGroup, error)
 }
 
 // CommandTypeSetApplicationControl is the well-known command type the agent reads on every poll and routes to its application-control

--- a/server/rules/bootstrap/schema.go
+++ b/server/rules/bootstrap/schema.go
@@ -5,12 +5,12 @@ package bootstrap
 // No cross-context FKs.
 //
 // Phase 1 of the add-application-control change dropped the legacy
-// `policies` singleton table. The demo cut introduces the two
-// authoritative tables of the new subsystem — `app_control_policies`
-// and `app_control_rules` — plus the `Default` policy seed.
-// `host_groups` and `app_control_assignments` (the other two tables in
-// the full spec) are deferred to follow-on work; for the demo every
-// policy implicitly targets every host in the deployment.
+// `policies` singleton table. Phase A ships four tables:
+// `app_control_policies` and `app_control_rules` carry the authoritative
+// ruleset; `host_groups` and `app_control_assignments` carry the
+// policy-to-host scoping layer the spec mandates. Phase A seeds the
+// built-in `all-hosts` group and the single `Default` → `all-hosts`
+// assignment; editable groups + multi-policy assignment land in Phase B.
 var schemaStatements = []string{
 	// app_control_policies holds a named ruleset. The product is a single-instance deployment, so policies are unique by name across the
 	// deployment. `default_action` is constrained to `NONE` in this phase; the Lockdown change extends the enum to `('NONE','BLOCK')` so a
@@ -57,5 +57,33 @@ var schemaStatements = []string{
 		INDEX idx_app_control_rules_type_id (rule_type, identifier),
 		CONSTRAINT fk_app_control_rules_policy FOREIGN KEY (policy_id)
 			REFERENCES app_control_policies(id) ON DELETE CASCADE
+	)`,
+	// host_groups is the named, deployment-wide host-membership unit. `criteria` is a JSON document the bootstrap seeds with
+	// {"type":"all"} for the built-in `all-hosts` row, and that future Phase B work extends with tag/hostname/OS predicates without a
+	// schema migration. Phase A only ever creates the seed row; user-authored groups arrive in Phase B. Name is deployment-unique so the
+	// REST surface can address groups by name without exposing the integer id.
+	`CREATE TABLE IF NOT EXISTS host_groups (
+		id          BIGINT AUTO_INCREMENT PRIMARY KEY,
+		name        VARCHAR(64)  NOT NULL,
+		description VARCHAR(255) NOT NULL DEFAULT '',
+		criteria    JSON         NOT NULL,
+		created_at  TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+		updated_at  TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+		UNIQUE KEY uk_host_groups_name (name)
+	)`,
+	// app_control_assignments is the policy → host-group many-to-many. priority is reserved for Phase B conflict resolution when two
+	// policies are assigned to overlapping groups; Phase A only ever has one assignment row. CASCADE on both FK sides keeps an
+	// orphan-free state if either side is deleted; both FKs are intra-context so ADR-0004's no-cross-context-FK rule does not apply.
+	`CREATE TABLE IF NOT EXISTS app_control_assignments (
+		policy_id     BIGINT       NOT NULL,
+		host_group_id BIGINT       NOT NULL,
+		priority      INT          NOT NULL DEFAULT 0,
+		created_at    TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+		PRIMARY KEY (policy_id, host_group_id),
+		INDEX idx_app_control_assignments_group (host_group_id),
+		CONSTRAINT fk_app_control_assignments_policy FOREIGN KEY (policy_id)
+			REFERENCES app_control_policies(id) ON DELETE CASCADE,
+		CONSTRAINT fk_app_control_assignments_group FOREIGN KEY (host_group_id)
+			REFERENCES host_groups(id) ON DELETE CASCADE
 	)`,
 }

--- a/server/rules/internal/appcontrol/service.go
+++ b/server/rules/internal/appcontrol/service.go
@@ -217,6 +217,7 @@ const (
 	fanoutSkipReasonHostLister     = "host_lister_error"
 	fanoutSkipReasonAssignmentList = "assignment_list_error"
 	fanoutSkipReasonNoAssignments  = "no_assignments"
+	fanoutSkipReasonNoHosts        = "no_hosts_resolved"
 )
 
 // fanout enqueues exactly one set_application_control command per unique host the policy's assigned host groups cover. Phase A's
@@ -228,10 +229,12 @@ const (
 // idempotent).
 //
 // A non-empty skip_reason distinguishes failure modes that would all otherwise audit as fanout_hosts=0:
-//   - `host_lister_error`: the enrolled-host lookup itself failed.
+//   - `host_lister_error`: at least one assigned host group's resolver returned an error (e.g. the HostLister itself failed).
 //   - `assignment_list_error`: resolving the policy's assigned host groups failed.
 //   - `no_assignments`: the policy has no assigned host groups (a posture admins explicitly choose by detaching all groups; alarming
 //     if it happens to the seed Default policy, expected if it happens to a quiescent custom policy).
+//   - `no_hosts_resolved`: every assigned host group resolved successfully but to zero hosts (a fresh deployment before any enroll,
+//     or a custom group whose criteria currently match nothing — *not* an infra failure).
 func (s *Service) fanout(ctx context.Context, policyID int64, payload []byte) (attempted int, failed int, skipReason string) {
 	groups, err := s.store.ListHostGroupsForPolicy(ctx, policyID)
 	if err != nil {
@@ -245,11 +248,15 @@ func (s *Service) fanout(ctx context.Context, policyID int64, payload []byte) (a
 
 	// Resolve every group's membership to host IDs and union them. Phase A's only criteria is `{"type":"all"}` which delegates to
 	// the HostLister and returns every enrolled host. Unknown criteria types are logged and treated as empty so a malformed criteria
-	// document doesn't silently fan out to every host.
+	// document doesn't silently fan out to every host. We track whether ANY group's resolver errored so the zero-hosts skip reason
+	// can distinguish "infra broke" from "no hosts enrolled / no matches" — both shapes were previously audited as host_lister_error
+	// which mis-paged on a fresh deployment.
 	seen := make(map[string]struct{})
+	var anyResolveErr bool
 	for _, g := range groups {
 		members, mErr := s.resolveHostGroup(ctx, g)
 		if mErr != nil {
+			anyResolveErr = true
 			s.logger.WarnContext(ctx, "appcontrol: host group resolve failed", "err", mErr, "host_group", g.Name)
 			continue
 		}
@@ -258,9 +265,10 @@ func (s *Service) fanout(ctx context.Context, policyID int64, payload []byte) (a
 		}
 	}
 	if len(seen) == 0 {
-		// Every group resolved to empty membership. Phase A this can only happen if the HostLister failed under the all-hosts
-		// criteria; signal as host_lister_error so audit log surfaces the right cause.
-		return 0, 0, fanoutSkipReasonHostLister
+		if anyResolveErr {
+			return 0, 0, fanoutSkipReasonHostLister
+		}
+		return 0, 0, fanoutSkipReasonNoHosts
 	}
 	for h := range seen {
 		attempted++

--- a/server/rules/internal/appcontrol/service.go
+++ b/server/rules/internal/appcontrol/service.go
@@ -2,6 +2,7 @@ package appcontrol
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"strconv"
@@ -172,7 +173,7 @@ func (s *Service) CreateRule(
 		return api.ApplicationControlRule{}, fmt.Errorf("appcontrol snapshot compose: %w", err)
 	}
 
-	fanoutHosts, fanoutFailed, fanoutSkipReason := s.fanout(ctx, payload)
+	fanoutHosts, fanoutFailed, fanoutSkipReason := s.fanout(ctx, policy.ID, payload)
 	s.emitAudit(ctx, actor, req, rule, policy.Version, fanoutHosts, fanoutFailed, fanoutSkipReason)
 	return rule, nil
 }
@@ -213,32 +214,55 @@ func (s *Service) findPolicyByID(ctx context.Context, policyID int64) (api.Appli
 // fanoutSkipReason values land verbatim on the audit row when the fan-out couldn't run end-to-end. The empty string means "no skip;
 // the loop ran" and is the happy path.
 const (
-	fanoutSkipReasonHostLister = "host_lister_error"
+	fanoutSkipReasonHostLister     = "host_lister_error"
+	fanoutSkipReasonAssignmentList = "assignment_list_error"
+	fanoutSkipReasonNoAssignments  = "no_assignments"
 )
 
-// fanout enqueues exactly one set_application_control command per
-// enrolled host in the deployment. Returns (hosts_attempted,
-// hosts_failed, skip_reason). Per-host failures are logged but do NOT
-// abort the loop; the policy is already on disk and a missed host
-// will catch up on its next agent poll (the version-monotonic apply
-// in the extension is idempotent).
+// fanout enqueues exactly one set_application_control command per unique host the policy's assigned host groups cover. Phase A's
+// only host-group criteria is `{"type":"all"}` (the seed `all-hosts` group) which resolves to every enrolled host via the
+// HostLister; Phase B grows the resolver to honor tag / hostname / OS predicates without changing this loop's shape.
 //
-// A non-empty skip_reason distinguishes "host enumeration itself
-// failed" from "the deployment has zero enrolled hosts" - both would
-// otherwise audit as fanout_hosts=0 and an operator looking at the
-// dashboard could not tell them apart.
-func (s *Service) fanout(ctx context.Context, payload []byte) (attempted int, failed int, skipReason string) {
-	hosts, err := s.hosts(ctx)
+// Returns (hosts_attempted, hosts_failed, skip_reason). Per-host failures are logged but do NOT abort the loop; the policy is
+// already on disk and a missed host will catch up on its next agent poll (the version-monotonic apply in the extension is
+// idempotent).
+//
+// A non-empty skip_reason distinguishes failure modes that would all otherwise audit as fanout_hosts=0:
+//   - `host_lister_error`: the enrolled-host lookup itself failed.
+//   - `assignment_list_error`: resolving the policy's assigned host groups failed.
+//   - `no_assignments`: the policy has no assigned host groups (a posture admins explicitly choose by detaching all groups; alarming
+//     if it happens to the seed Default policy, expected if it happens to a quiescent custom policy).
+func (s *Service) fanout(ctx context.Context, policyID int64, payload []byte) (attempted int, failed int, skipReason string) {
+	groups, err := s.store.ListHostGroupsForPolicy(ctx, policyID)
 	if err != nil {
-		s.logger.WarnContext(ctx, "appcontrol: host list failed; fan-out skipped", "err", err)
-		return 0, 0, fanoutSkipReasonHostLister
+		s.logger.WarnContext(ctx, "appcontrol: assignment list failed; fan-out skipped", "err", err, "policy_id", policyID)
+		return 0, 0, fanoutSkipReasonAssignmentList
 	}
-	seen := make(map[string]struct{}, len(hosts))
-	for _, h := range hosts {
-		if _, dup := seen[h]; dup {
+	if len(groups) == 0 {
+		s.logger.WarnContext(ctx, "appcontrol: policy has no assigned host groups; fan-out skipped", "policy_id", policyID)
+		return 0, 0, fanoutSkipReasonNoAssignments
+	}
+
+	// Resolve every group's membership to host IDs and union them. Phase A's only criteria is `{"type":"all"}` which delegates to
+	// the HostLister and returns every enrolled host. Unknown criteria types are logged and treated as empty so a malformed criteria
+	// document doesn't silently fan out to every host.
+	seen := make(map[string]struct{})
+	for _, g := range groups {
+		members, mErr := s.resolveHostGroup(ctx, g)
+		if mErr != nil {
+			s.logger.WarnContext(ctx, "appcontrol: host group resolve failed", "err", mErr, "host_group", g.Name)
 			continue
 		}
-		seen[h] = struct{}{}
+		for _, h := range members {
+			seen[h] = struct{}{}
+		}
+	}
+	if len(seen) == 0 {
+		// Every group resolved to empty membership. Phase A this can only happen if the HostLister failed under the all-hosts
+		// criteria; signal as host_lister_error so audit log surfaces the right cause.
+		return 0, 0, fanoutSkipReasonHostLister
+	}
+	for h := range seen {
 		attempted++
 		if _, err := s.commands(ctx, h, api.CommandTypeSetApplicationControl, payload); err != nil {
 			failed++
@@ -246,6 +270,28 @@ func (s *Service) fanout(ctx context.Context, payload []byte) (attempted int, fa
 		}
 	}
 	return attempted, failed, ""
+}
+
+// hostGroupCriteria is the discriminator-only shape the fan-out uses to route to the right resolver. Phase B grows the type set with
+// criteria-specific predicate fields; we only need the type tag here.
+type hostGroupCriteria struct {
+	Type string `json:"type"`
+}
+
+// resolveHostGroup parses a host group's criteria JSON and returns the resolved host IDs. Phase A only honors `{"type":"all"}`,
+// which delegates to the HostLister. Phase B adds tag / hostname / OS predicates here without changing the fan-out loop above.
+func (s *Service) resolveHostGroup(ctx context.Context, g api.HostGroup) ([]string, error) {
+	var c hostGroupCriteria
+	if err := json.Unmarshal(g.Criteria, &c); err != nil {
+		return nil, fmt.Errorf("parse criteria for host_group=%q: %w", g.Name, err)
+	}
+	switch c.Type {
+	case api.HostGroupCriteriaTypeAll:
+		return s.hosts(ctx)
+	default:
+		s.logger.WarnContext(ctx, "appcontrol: unknown host group criteria type; resolving as empty", "criteria_type", c.Type, "host_group", g.Name)
+		return nil, nil
+	}
 }
 
 // emitAudit records the rule-create event with fanout counts on the

--- a/server/rules/internal/appcontrol/service.go
+++ b/server/rules/internal/appcontrol/service.go
@@ -247,14 +247,15 @@ func (s *Service) fanout(ctx context.Context, policyID int64, payload []byte) (a
 	}
 
 	// Resolve every group's membership to host IDs and union them. Phase A's only criteria is `{"type":"all"}` which delegates to
-	// the HostLister and returns every enrolled host. Unknown criteria types are logged and treated as empty so a malformed criteria
-	// document doesn't silently fan out to every host. We track whether ANY group's resolver errored so the zero-hosts skip reason
-	// can distinguish "infra broke" from "no hosts enrolled / no matches" — both shapes were previously audited as host_lister_error
-	// which mis-paged on a fresh deployment.
+	// the HostLister; the lookup is memoised per-fanout so a policy with N "all"-criteria groups only enumerates the host list once
+	// instead of N times (matters for Phase B custom groups that may also resolve to "all" at the leaf). We track whether ANY
+	// group's resolver errored so the audit row distinguishes infra failures from "no hosts enrolled" both when seen is empty AND
+	// when seen is partially populated (a partial-failure that drops some hosts would otherwise hide as a successful fan-out).
 	seen := make(map[string]struct{})
+	hostCache := &allHostsCache{loader: s.hosts}
 	var anyResolveErr bool
 	for _, g := range groups {
-		members, mErr := s.resolveHostGroup(ctx, g)
+		members, mErr := s.resolveHostGroup(ctx, g, hostCache)
 		if mErr != nil {
 			anyResolveErr = true
 			s.logger.WarnContext(ctx, "appcontrol: host group resolve failed", "err", mErr, "host_group", g.Name)
@@ -277,7 +278,32 @@ func (s *Service) fanout(ctx context.Context, policyID int64, payload []byte) (a
 			s.logger.WarnContext(ctx, "appcontrol: command insert failed", "host_id", h, "err", err)
 		}
 	}
+	// Partial-failure surfacing: even when some hosts were enqueued, signal host_lister_error if any group's resolver failed.
+	// Otherwise an operator scanning the audit log sees a "successful" fan-out while one of the policy's assigned groups
+	// silently dropped its host set.
+	if anyResolveErr {
+		return attempted, failed, fanoutSkipReasonHostLister
+	}
 	return attempted, failed, ""
+}
+
+// allHostsCache memoises the HostLister result inside a single fanout call. The loader is invoked at most once per fanout regardless
+// of how many host groups carry `{"type":"all"}`; subsequent calls return the cached slice (and any cached error). Zero value is a
+// valid cache.
+type allHostsCache struct {
+	loader func(context.Context) ([]string, error)
+	done   bool
+	hosts  []string
+	err    error
+}
+
+func (c *allHostsCache) get(ctx context.Context) ([]string, error) {
+	if c.done {
+		return c.hosts, c.err
+	}
+	c.hosts, c.err = c.loader(ctx)
+	c.done = true
+	return c.hosts, c.err
 }
 
 // hostGroupCriteria is the discriminator-only shape the fan-out uses to route to the right resolver. Phase B grows the type set with
@@ -287,18 +313,20 @@ type hostGroupCriteria struct {
 }
 
 // resolveHostGroup parses a host group's criteria JSON and returns the resolved host IDs. Phase A only honors `{"type":"all"}`,
-// which delegates to the HostLister. Phase B adds tag / hostname / OS predicates here without changing the fan-out loop above.
-func (s *Service) resolveHostGroup(ctx context.Context, g api.HostGroup) ([]string, error) {
+// which delegates to the memoised HostLister (one enumeration per fanout call, no matter how many groups carry the same criteria).
+// Phase B adds tag / hostname / OS predicates here without changing the fan-out loop. Unknown / malformed criteria are returned as
+// resolver errors so the fanout audit surfaces the misconfiguration as host_lister_error instead of silently dropping the group's
+// host set (which would mis-attribute as no_hosts_resolved).
+func (s *Service) resolveHostGroup(ctx context.Context, g api.HostGroup, cache *allHostsCache) ([]string, error) {
 	var c hostGroupCriteria
 	if err := json.Unmarshal(g.Criteria, &c); err != nil {
 		return nil, fmt.Errorf("parse criteria for host_group=%q: %w", g.Name, err)
 	}
 	switch c.Type {
 	case api.HostGroupCriteriaTypeAll:
-		return s.hosts(ctx)
+		return cache.get(ctx)
 	default:
-		s.logger.WarnContext(ctx, "appcontrol: unknown host group criteria type; resolving as empty", "criteria_type", c.Type, "host_group", g.Name)
-		return nil, nil
+		return nil, fmt.Errorf("unknown host group criteria type %q for host_group=%q", c.Type, g.Name)
 	}
 }
 

--- a/server/rules/internal/appcontrol/service_test.go
+++ b/server/rules/internal/appcontrol/service_test.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/jmoiron/sqlx"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -187,4 +188,190 @@ func TestService_NilAudit_RuleStillCreates(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotZero(t, rule.ID)
 	assert.Equal(t, 1, inserter.calls, "fan-out runs even without audit")
+}
+
+// fanoutAuditPayloadFor returns the most recent rule_create audit row's payload, or fails the test if none has been recorded. Used
+// by the fanout skip-reason tests below to pin the operator-visible diagnostic.
+func fanoutAuditPayloadFor(t *testing.T, audit *captureAudit) map[string]any {
+	t.Helper()
+	events := audit.snapshot()
+	require.NotEmpty(t, events, "expected at least one audit event")
+	return events[len(events)-1].Payload
+}
+
+// detachDefaultAssignment removes the Default-policy -> all-hosts assignment so the fanout audits as no_assignments rather than
+// fanning out to every enrolled host. Used by tests that pin the skip-reason for that specific posture.
+func detachDefaultAssignment(t *testing.T, db *sqlx.DB) {
+	t.Helper()
+	_, err := db.ExecContext(t.Context(), "DELETE FROM app_control_assignments WHERE policy_id = (SELECT id FROM app_control_policies WHERE name = ?)", api.DefaultPolicyName)
+	require.NoError(t, err)
+}
+
+// attachHostGroup creates a host group with the given criteria JSON and assigns it to the Default policy. Returns the new group's
+// id so the caller can re-detach it if needed. Inserts directly because the public Store has no Create/Assign API in Phase A.
+func attachHostGroup(t *testing.T, db *sqlx.DB, name string, criteria string) int64 {
+	t.Helper()
+	ctx := t.Context()
+	res, err := db.ExecContext(ctx, "INSERT INTO host_groups (name, description, criteria) VALUES (?, ?, ?)", name, "phase-a test", criteria)
+	require.NoError(t, err)
+	gID, err := res.LastInsertId()
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, "INSERT INTO app_control_assignments (policy_id, host_group_id, priority) SELECT id, ?, 0 FROM app_control_policies WHERE name = ?", gID, api.DefaultPolicyName)
+	require.NoError(t, err)
+	return gID
+}
+
+// newServiceWithHostsAndAudit is a small variation on newService that lets the caller plug in a custom HostLister + lets the caller
+// observe the audit recorder. Returned for the fanout skip-reason tests below.
+func newServiceWithHostsAndAudit(t *testing.T, hosts func(context.Context) ([]string, error)) (*appcontrol.Service, *appcontrol.Store, *sqlx.DB, *captureAudit) {
+	t.Helper()
+	db := testdb.Open(t)
+	require.NoError(t, rulestestkit.ApplySchema(t.Context(), db))
+	store := appcontrol.NewStore(db)
+	require.NoError(t, store.EnsureDefaultPolicy(t.Context()))
+	inserter := &captureInserter{}
+	audit := &captureAudit{}
+	svc := appcontrol.NewService(appcontrol.ServiceDeps{
+		Store:    store,
+		Commands: inserter.Insert,
+		Hosts:    hosts,
+		Audit:    audit,
+		Logger:   slog.Default(),
+	})
+	return svc, store, db, audit
+}
+
+// TestService_Fanout_NoAssignments pins the audit row when the policy has no assigned host groups: skip_reason is "no_assignments"
+// and the rule still persists (the rule body is on disk; only the fan-out is skipped).
+func TestService_Fanout_NoAssignments(t *testing.T) {
+	svc, store, db, audit := newServiceWithHostsAndAudit(t, func(context.Context) ([]string, error) {
+		t.Fatal("HostLister must not be called when there are no assignments")
+		return nil, nil
+	})
+	detachDefaultAssignment(t, db)
+	policy, err := store.GetPolicyByName(t.Context(), api.DefaultPolicyName)
+	require.NoError(t, err)
+
+	rule, err := svc.CreateRule(t.Context(), api.CreateRuleRequest{
+		PolicyID:   policy.ID,
+		RuleType:   api.RuleTypeBinary,
+		Identifier: strings.Repeat("a", 64),
+		Severity:   api.SeverityRuleMedium,
+		Actor:      "user:7",
+		Reason:     "fanout: no_assignments",
+	}, newAdmin())
+	require.NoError(t, err)
+	assert.NotZero(t, rule.ID)
+
+	payload := fanoutAuditPayloadFor(t, audit)
+	assert.Equal(t, "no_assignments", payload["fanout_skipped_reason"], "policy without assignments must audit as no_assignments")
+	assert.Equal(t, 0, payload["fanout_hosts"])
+}
+
+// TestService_Fanout_NoHostsResolved pins the audit row when every assigned group resolves successfully but to zero hosts. This is
+// the fresh-deployment posture: the HostLister has no errors, just no hosts enrolled yet. The previous demo cut mislabelled this as
+// host_lister_error which mis-paged operators on first deploy.
+func TestService_Fanout_NoHostsResolved(t *testing.T) {
+	svc, store, _, audit := newServiceWithHostsAndAudit(t, func(context.Context) ([]string, error) {
+		return []string{}, nil // empty, no error
+	})
+	policy, err := store.GetPolicyByName(t.Context(), api.DefaultPolicyName)
+	require.NoError(t, err)
+
+	_, err = svc.CreateRule(t.Context(), api.CreateRuleRequest{
+		PolicyID:   policy.ID,
+		RuleType:   api.RuleTypeBinary,
+		Identifier: strings.Repeat("b", 64),
+		Severity:   api.SeverityRuleMedium,
+		Actor:      "user:7",
+		Reason:     "fanout: no_hosts_resolved",
+	}, newAdmin())
+	require.NoError(t, err)
+
+	payload := fanoutAuditPayloadFor(t, audit)
+	assert.Equal(t, "no_hosts_resolved", payload["fanout_skipped_reason"], "empty HostLister result must audit as no_hosts_resolved, not host_lister_error")
+	assert.Equal(t, 0, payload["fanout_hosts"])
+}
+
+// TestService_Fanout_HostListerError covers the resolver-error path: a host group whose criteria type is unknown returns an error
+// from resolveHostGroup, which surfaces as host_lister_error in the audit row. This is also the only Phase A path that exercises
+// the "unknown criteria" error branch — Phase B's tag/hostname/OS resolvers don't exist yet.
+func TestService_Fanout_HostListerError(t *testing.T) {
+	svc, store, db, audit := newServiceWithHostsAndAudit(t, func(context.Context) ([]string, error) {
+		t.Fatal("HostLister must not be called when criteria is unknown")
+		return nil, nil
+	})
+	detachDefaultAssignment(t, db)
+	attachHostGroup(t, db, "phase-b-criteria", `{"type":"unknown"}`)
+	policy, err := store.GetPolicyByName(t.Context(), api.DefaultPolicyName)
+	require.NoError(t, err)
+
+	_, err = svc.CreateRule(t.Context(), api.CreateRuleRequest{
+		PolicyID:   policy.ID,
+		RuleType:   api.RuleTypeBinary,
+		Identifier: strings.Repeat("c", 64),
+		Severity:   api.SeverityRuleMedium,
+		Actor:      "user:7",
+		Reason:     "fanout: host_lister_error via unknown criteria",
+	}, newAdmin())
+	require.NoError(t, err)
+
+	payload := fanoutAuditPayloadFor(t, audit)
+	assert.Equal(t, "host_lister_error", payload["fanout_skipped_reason"], "unknown criteria must surface as host_lister_error")
+	assert.Equal(t, 0, payload["fanout_hosts"])
+}
+
+// TestService_Fanout_CachesHostLister pins the allHostsCache memoisation: when a policy has multiple assigned host groups all
+// resolving to {"type":"all"}, the HostLister is invoked exactly once per fanout call (not N times). Matters for Phase B policies
+// with overlapping groups that all leaf-resolve to "all".
+func TestService_Fanout_CachesHostLister(t *testing.T) {
+	var calls int
+	svc, store, db, audit := newServiceWithHostsAndAudit(t, func(context.Context) ([]string, error) {
+		calls++
+		return []string{"host-a", "host-b"}, nil
+	})
+	// Default policy already has the seeded all-hosts group; add a second all-hosts-2 group so the loop walks twice.
+	attachHostGroup(t, db, "all-hosts-2", `{"type":"all"}`)
+	policy, err := store.GetPolicyByName(t.Context(), api.DefaultPolicyName)
+	require.NoError(t, err)
+
+	_, err = svc.CreateRule(t.Context(), api.CreateRuleRequest{
+		PolicyID:   policy.ID,
+		RuleType:   api.RuleTypeBinary,
+		Identifier: strings.Repeat("e", 64),
+		Severity:   api.SeverityRuleMedium,
+		Actor:      "user:7",
+		Reason:     "fanout: hostLister cache",
+	}, newAdmin())
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, calls, "HostLister must be memoised across {\"type\":\"all\"} groups within a single fanout call")
+	payload := fanoutAuditPayloadFor(t, audit)
+	assert.EqualValues(t, 2, payload["fanout_hosts"], "union of host-a + host-b must dedupe across both all-criteria groups")
+}
+
+// TestService_Fanout_PartialFailureAuditsHostListerError covers the partial-failure semantic: one group resolves to a hosts list,
+// another's criteria errors. Even though some hosts were enqueued, the audit row carries host_lister_error so operators see the
+// partial coverage instead of a silent "successful" fanout.
+func TestService_Fanout_PartialFailureAuditsHostListerError(t *testing.T) {
+	svc, store, db, audit := newServiceWithHostsAndAudit(t, func(context.Context) ([]string, error) {
+		return []string{"host-a"}, nil
+	})
+	attachHostGroup(t, db, "phase-b-broken", `{"type":"unknown"}`)
+	policy, err := store.GetPolicyByName(t.Context(), api.DefaultPolicyName)
+	require.NoError(t, err)
+
+	_, err = svc.CreateRule(t.Context(), api.CreateRuleRequest{
+		PolicyID:   policy.ID,
+		RuleType:   api.RuleTypeBinary,
+		Identifier: strings.Repeat("f", 64),
+		Severity:   api.SeverityRuleMedium,
+		Actor:      "user:7",
+		Reason:     "fanout: partial failure surfaces host_lister_error",
+	}, newAdmin())
+	require.NoError(t, err)
+
+	payload := fanoutAuditPayloadFor(t, audit)
+	assert.Equal(t, "host_lister_error", payload["fanout_skipped_reason"], "any resolver error must surface even when some hosts succeed")
+	assert.EqualValues(t, 1, payload["fanout_hosts"], "successful group's hosts still get enqueued")
 }

--- a/server/rules/internal/appcontrol/store.go
+++ b/server/rules/internal/appcontrol/store.go
@@ -27,19 +27,88 @@ func NewStore(db *sqlx.DB) *Store {
 	return &Store{db: db}
 }
 
-// EnsureDefaultPolicy idempotently seeds the Default policy. Safe to call on every server boot (Bootstrap does so). Uses INSERT IGNORE
-// so a manual edit of the row's description or version is not clobbered on subsequent restarts.
+// EnsureDefaultPolicy idempotently seeds the Phase A built-ins: the `Default` policy, the `all-hosts` host group, and the single
+// assignment row connecting them. Safe to call on every server boot (Bootstrap does so). Uses INSERT IGNORE for all three so a manual
+// edit of any row's description or criteria is not clobbered on subsequent restarts. The three statements run in a transaction so a
+// partial bootstrap (policy without assignment) is impossible after the first successful boot.
 func (s *Store) EnsureDefaultPolicy(ctx context.Context) error {
-	const query = `INSERT IGNORE INTO app_control_policies
-		(name, description, version, default_action, created_by, updated_by)
-		VALUES (?, ?, 1, 'NONE', 'system', 'system')`
-	if _, err := s.db.ExecContext(ctx, query,
+	tx, err := s.db.BeginTxx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("appcontrol seed: begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.ExecContext(ctx,
+		`INSERT IGNORE INTO app_control_policies (name, description, version, default_action, created_by, updated_by)
+		 VALUES (?, ?, 1, 'NONE', 'system', 'system')`,
 		api.DefaultPolicyName,
-		"Default application control policy. Add rules to block executables by SHA-256 hash.",
+		"Default application control policy. Add rules to block executables by SHA-256 hash or signing identity.",
 	); err != nil {
 		return fmt.Errorf("appcontrol seed default policy: %w", err)
 	}
+
+	if _, err := tx.ExecContext(ctx,
+		`INSERT IGNORE INTO host_groups (name, description, criteria) VALUES (?, ?, ?)`,
+		api.DefaultHostGroupName,
+		"Built-in host group that matches every enrolled host. Phase A's only host group; editable groups arrive in Phase B.",
+		fmt.Sprintf(`{"type":"%s"}`, api.HostGroupCriteriaTypeAll),
+	); err != nil {
+		return fmt.Errorf("appcontrol seed all-hosts group: %w", err)
+	}
+
+	// Resolve the rows we just (idempotently) inserted so we can wire the assignment. SELECT BY NAME because LAST_INSERT_ID() returns
+	// 0 on the IGNORE-suppressed path; that's the second-boot case where the rows already exist.
+	var policyID, groupID int64
+	if err := tx.QueryRowxContext(ctx,
+		`SELECT id FROM app_control_policies WHERE name = ?`, api.DefaultPolicyName,
+	).Scan(&policyID); err != nil {
+		return fmt.Errorf("appcontrol seed: resolve default policy id: %w", err)
+	}
+	if err := tx.QueryRowxContext(ctx,
+		`SELECT id FROM host_groups WHERE name = ?`, api.DefaultHostGroupName,
+	).Scan(&groupID); err != nil {
+		return fmt.Errorf("appcontrol seed: resolve all-hosts group id: %w", err)
+	}
+
+	if _, err := tx.ExecContext(ctx,
+		`INSERT IGNORE INTO app_control_assignments (policy_id, host_group_id, priority) VALUES (?, ?, 0)`,
+		policyID, groupID,
+	); err != nil {
+		return fmt.Errorf("appcontrol seed default assignment: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("appcontrol seed: commit: %w", err)
+	}
 	return nil
+}
+
+// ListHostGroupsForPolicy returns the host groups assigned to a policy, ordered by priority (highest first) then by group name. The
+// fan-out path walks the result and unions the member hosts of each group to build the set of unique hosts a rule update should
+// reach. Phase A always returns the single built-in `all-hosts` group; Phase B grows the result when editable assignments land.
+func (s *Store) ListHostGroupsForPolicy(ctx context.Context, policyID int64) ([]api.HostGroup, error) {
+	const query = `SELECT g.id, g.name, g.description, g.criteria, g.created_at, g.updated_at
+		FROM host_groups g
+		INNER JOIN app_control_assignments a ON a.host_group_id = g.id
+		WHERE a.policy_id = ?
+		ORDER BY a.priority DESC, g.name ASC`
+	rows, err := s.db.QueryxContext(ctx, query, policyID)
+	if err != nil {
+		return nil, fmt.Errorf("appcontrol list host groups: %w", err)
+	}
+	defer rows.Close()
+	out := []api.HostGroup{}
+	for rows.Next() {
+		var g api.HostGroup
+		if err := rows.Scan(&g.ID, &g.Name, &g.Description, &g.Criteria, &g.CreatedAt, &g.UpdatedAt); err != nil {
+			return nil, fmt.Errorf("appcontrol scan host group: %w", err)
+		}
+		out = append(out, g)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("appcontrol iterate host groups: %w", err)
+	}
+	return out, nil
 }
 
 // GetPolicyByName loads the policy row by name. Rules are NOT populated; callers that need rules call ListRulesByPolicy explicitly.

--- a/server/rules/internal/appcontrol/validate.go
+++ b/server/rules/internal/appcontrol/validate.go
@@ -15,14 +15,15 @@ import (
 // future rename to a structured-error shape is a one-line change.
 const wrapFmt = "%w: %s"
 
-// ValidateRuleType reports whether rt is a recognized rule type. The demo cut enforces only BINARY; the other five types are
-// recognized (so REST callers see the precise "unsupported yet" error rather than a generic "unknown" error) but the validator path
-// below short-circuits with ErrAppControlUnsupportedRuleType for them.
+// ValidateRuleType reports whether rt is a recognized rule type. Phase A close-out accepts CDHASH, BINARY, SIGNINGID, and TEAMID.
+// CERTIFICATE and PATH stay gated (CERTIFICATE needs the leaf-cert cache plumbing Phase B brings; PATH needs Launch Services
+// indirection coverage Phase B brings); both return ErrAppControlUnsupportedRuleType so the operator audit log surfaces the
+// precise "not yet wired" cause rather than a generic invalid-type error.
 func ValidateRuleType(rt api.RuleType) error {
 	switch rt {
-	case api.RuleTypeBinary:
+	case api.RuleTypeBinary, api.RuleTypeCDHash, api.RuleTypeSigningID, api.RuleTypeTeamID:
 		return nil
-	case api.RuleTypeCDHash, api.RuleTypeSigningID, api.RuleTypeCertificate, api.RuleTypeTeamID, api.RuleTypePath:
+	case api.RuleTypeCertificate, api.RuleTypePath:
 		return fmt.Errorf(wrapFmt, api.ErrAppControlUnsupportedRuleType, rt)
 	default:
 		return fmt.Errorf(wrapFmt, api.ErrAppControlInvalidRuleType, rt)
@@ -60,7 +61,7 @@ func ValidateIdentifier(rt api.RuleType, identifier string) error {
 		if !hex40.MatchString(identifier) {
 			return fmt.Errorf(wrapFmt, api.ErrAppControlInvalidIdentifier, "CDHASH rule identifier must be 40 lowercase hex characters")
 		}
-		return fmt.Errorf(wrapFmt, api.ErrAppControlUnsupportedRuleType, rt)
+		return nil
 	case api.RuleTypeCertificate:
 		if !hex64.MatchString(identifier) {
 			return fmt.Errorf(wrapFmt, api.ErrAppControlInvalidIdentifier, "CERTIFICATE rule identifier must be 64 lowercase hex characters")
@@ -70,12 +71,12 @@ func ValidateIdentifier(rt api.RuleType, identifier string) error {
 		if !teamID.MatchString(identifier) {
 			return fmt.Errorf(wrapFmt, api.ErrAppControlInvalidIdentifier, "TEAMID rule identifier must be 10 uppercase alphanumeric characters")
 		}
-		return fmt.Errorf(wrapFmt, api.ErrAppControlUnsupportedRuleType, rt)
+		return nil
 	case api.RuleTypeSigningID:
 		if !signingID.MatchString(identifier) {
 			return fmt.Errorf(wrapFmt, api.ErrAppControlInvalidIdentifier, "SIGNINGID rule identifier must be <TeamID>:<bundle.id> or platform:<bundle.id>")
 		}
-		return fmt.Errorf(wrapFmt, api.ErrAppControlUnsupportedRuleType, rt)
+		return nil
 	case api.RuleTypePath:
 		if _, err := canonicalizePath(identifier); err != nil {
 			return fmt.Errorf(wrapFmt, api.ErrAppControlInvalidIdentifier, err.Error())

--- a/server/rules/internal/appcontrol/validate_test.go
+++ b/server/rules/internal/appcontrol/validate_test.go
@@ -11,9 +11,10 @@ import (
 	"github.com/fleetdm/edr/server/rules/internal/appcontrol"
 )
 
-// TestValidateRuleType_DemoCutAccepts covers the matrix of accepted / deferred / invalid rule_type values. The demo cut accepts BINARY
-// outright and reports the other five spec'd types as ErrAppControlUnsupportedRuleType so REST callers see a precise "not yet" instead
-// of a generic "unknown" error.
+// TestValidateRuleType_AcceptedAndDeferred covers the matrix of accepted / deferred / invalid rule_type values after the Phase A
+// close-out: BINARY, CDHASH, SIGNINGID, and TEAMID are accepted; CERTIFICATE and PATH remain gated as
+// ErrAppControlUnsupportedRuleType (Phase B unblocks them alongside the leaf-cert cache + Launch Services indirection); unknown /
+// empty values return ErrAppControlInvalidRuleType so REST callers can distinguish "not yet wired" from "not a real type".
 func TestValidateRuleType_AcceptedAndDeferred(t *testing.T) {
 	cases := []struct {
 		name    string

--- a/server/rules/internal/appcontrol/validate_test.go
+++ b/server/rules/internal/appcontrol/validate_test.go
@@ -14,17 +14,17 @@ import (
 // TestValidateRuleType_DemoCutAccepts covers the matrix of accepted / deferred / invalid rule_type values. The demo cut accepts BINARY
 // outright and reports the other five spec'd types as ErrAppControlUnsupportedRuleType so REST callers see a precise "not yet" instead
 // of a generic "unknown" error.
-func TestValidateRuleType_DemoCutAccepts(t *testing.T) {
+func TestValidateRuleType_AcceptedAndDeferred(t *testing.T) {
 	cases := []struct {
 		name    string
 		rt      api.RuleType
 		wantErr error
 	}{
 		{"binary accepted", api.RuleTypeBinary, nil},
-		{"cdhash deferred", api.RuleTypeCDHash, api.ErrAppControlUnsupportedRuleType},
-		{"signing id deferred", api.RuleTypeSigningID, api.ErrAppControlUnsupportedRuleType},
+		{"cdhash accepted", api.RuleTypeCDHash, nil},
+		{"signing id accepted", api.RuleTypeSigningID, nil},
+		{"team id accepted", api.RuleTypeTeamID, nil},
 		{"certificate deferred", api.RuleTypeCertificate, api.ErrAppControlUnsupportedRuleType},
-		{"team id deferred", api.RuleTypeTeamID, api.ErrAppControlUnsupportedRuleType},
 		{"path deferred", api.RuleTypePath, api.ErrAppControlUnsupportedRuleType},
 		{"unknown rejected", api.RuleType("BANANA"), api.ErrAppControlInvalidRuleType},
 		{"empty rejected", api.RuleType(""), api.ErrAppControlInvalidRuleType},
@@ -72,29 +72,54 @@ func TestValidateIdentifier_Binary(t *testing.T) {
 	}
 }
 
-// TestValidateIdentifier_DeferredTypes confirms the rest of the rule_type enum is wired through the validator. The format check for
-// the spec'd identifier fires first; on a well-formed value the validator still reports ErrAppControlUnsupportedRuleType so the REST
-// handler can return "not yet wired" rather than silently accepting the rule.
+// TestValidateIdentifier_AcceptedTypes pins the Phase A close-out additions: CDHASH, SIGNINGID, and TEAMID identifiers shaped
+// correctly return nil (the rule is created), and malformed identifiers return ErrAppControlInvalidIdentifier.
+func TestValidateIdentifier_AcceptedTypes(t *testing.T) {
+	cases := []struct {
+		name string
+		rt   api.RuleType
+		id   string
+		ok   bool
+	}{
+		{"cdhash 40 hex accepted", api.RuleTypeCDHash, strings.Repeat("a", 40), true},
+		{"cdhash 39 chars rejected", api.RuleTypeCDHash, strings.Repeat("a", 39), false},
+		{"cdhash uppercase rejected", api.RuleTypeCDHash, strings.Repeat("A", 40), false},
+		{"team id valid accepted", api.RuleTypeTeamID, "EQHXZ8M8AV", true},
+		{"team id lowercase rejected", api.RuleTypeTeamID, "eqhxz8m8av", false},
+		{"team id 9 chars rejected", api.RuleTypeTeamID, "EQHXZ8M8A", false},
+		{"signing id team:bundle accepted", api.RuleTypeSigningID, "EQHXZ8M8AV:com.google.Chrome", true},
+		{"signing id platform:bundle accepted", api.RuleTypeSigningID, "platform:com.apple.curl", true},
+		{"signing id missing colon rejected", api.RuleTypeSigningID, "EQHXZ8M8AVcom.google.Chrome", false},
+		{"signing id empty bundle rejected", api.RuleTypeSigningID, "EQHXZ8M8AV:", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := appcontrol.ValidateIdentifier(tc.rt, tc.id)
+			if tc.ok {
+				assert.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.ErrorIs(t, err, api.ErrAppControlInvalidIdentifier)
+		})
+	}
+}
+
+// TestValidateIdentifier_DeferredTypes pins the remaining types (CERTIFICATE, PATH) still gated as unsupported. The format check
+// fires first; on a well-formed value the validator still reports ErrAppControlUnsupportedRuleType so the REST handler returns
+// "not yet wired" rather than silently accepting the rule. Phase B unblocks these alongside the leaf-cert cache work.
 func TestValidateIdentifier_DeferredTypes(t *testing.T) {
 	cases := []struct {
 		name        string
 		rt          api.RuleType
 		id          string
-		shapeOK     bool
 		wantErrType error
 	}{
-		{"cdhash 40 hex - unsupported", api.RuleTypeCDHash, strings.Repeat("a", 40), true, api.ErrAppControlUnsupportedRuleType},
-		{"cdhash 39 chars - format rejected", api.RuleTypeCDHash, strings.Repeat("a", 39), false, api.ErrAppControlInvalidIdentifier},
-		{"team id valid - unsupported", api.RuleTypeTeamID, "EQHXZ8M8AV", true, api.ErrAppControlUnsupportedRuleType},
-		{"team id lowercase - format rejected", api.RuleTypeTeamID, "eqhxz8m8av", false, api.ErrAppControlInvalidIdentifier},
-		{"signing id valid - unsupported", api.RuleTypeSigningID, "EQHXZ8M8AV:com.google.Chrome", true, api.ErrAppControlUnsupportedRuleType},
-		{"signing id platform - unsupported", api.RuleTypeSigningID, "platform:com.apple.curl", true, api.ErrAppControlUnsupportedRuleType},
-		{"signing id missing colon - format rejected", api.RuleTypeSigningID, "EQHXZ8M8AVcom.google.Chrome", false, api.ErrAppControlInvalidIdentifier},
-		{"certificate 64 hex - unsupported", api.RuleTypeCertificate, strings.Repeat("c", 64), true, api.ErrAppControlUnsupportedRuleType},
-		{"certificate 63 chars - format rejected", api.RuleTypeCertificate, strings.Repeat("c", 63), false, api.ErrAppControlInvalidIdentifier},
-		{"path absolute - unsupported", api.RuleTypePath, "/usr/bin/ls", true, api.ErrAppControlUnsupportedRuleType},
-		{"path relative - format rejected", api.RuleTypePath, "usr/bin/ls", false, api.ErrAppControlInvalidIdentifier},
-		{"path empty - format rejected", api.RuleTypePath, "", false, api.ErrAppControlInvalidIdentifier},
+		{"certificate 64 hex unsupported", api.RuleTypeCertificate, strings.Repeat("c", 64), api.ErrAppControlUnsupportedRuleType},
+		{"certificate 63 chars format rejected", api.RuleTypeCertificate, strings.Repeat("c", 63), api.ErrAppControlInvalidIdentifier},
+		{"path absolute unsupported", api.RuleTypePath, "/usr/bin/ls", api.ErrAppControlUnsupportedRuleType},
+		{"path relative format rejected", api.RuleTypePath, "usr/bin/ls", api.ErrAppControlInvalidIdentifier},
+		{"path empty format rejected", api.RuleTypePath, "", api.ErrAppControlInvalidIdentifier},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/server/rules/internal/tests/app_control_test.go
+++ b/server/rules/internal/tests/app_control_test.go
@@ -1,7 +1,7 @@
 //go:build integration
 
-// Per-context integration tests for the Application Control subsystem
-// (rules-context demo cut). Skipped without EDR_TEST_DSN.
+// Per-context integration tests for the Application Control subsystem.
+// Skipped without EDR_TEST_DSN.
 
 package tests
 
@@ -151,27 +151,34 @@ func TestAppControl_CreateRule_DuplicateRejected(t *testing.T) {
 	assert.ErrorIs(t, err, api.ErrAppControlDuplicateRule)
 }
 
-// TestAppControl_CreateRule_RejectsUnsupportedTypes pins the demo cut's narrow validator: every non-BINARY type is rejected with the
-// "unsupported" sentinel. The schema accepts the values; the validator gates them so the REST surface is honest about what's wired
-// today.
+// TestAppControl_CreateRule_RejectsUnsupportedTypes pins the rule_type gate after the Phase A close-out: CDHASH / SIGNINGID / TEAMID
+// are accepted (they pass through the validator and the unsupported-sentinel does not fire), while CERTIFICATE + PATH remain
+// deferred and continue to surface ErrAppControlUnsupportedRuleType so the REST surface is honest about what's wired today.
+// The Identifier per type is shape-valid so the format check passes; the test isolates the rule_type gate from the identifier gate.
 func TestAppControl_CreateRule_RejectsUnsupportedTypes(t *testing.T) {
 	t.Parallel()
 	store, _ := newAppControlStore(t)
 	ctx := t.Context()
 	p, err := store.GetPolicyByName(ctx, api.DefaultPolicyName)
 	require.NoError(t, err)
-	for _, rt := range []api.RuleType{
-		api.RuleTypeCDHash, api.RuleTypeSigningID, api.RuleTypeCertificate, api.RuleTypeTeamID, api.RuleTypePath,
+	for _, tc := range []struct {
+		rt         api.RuleType
+		identifier string
+	}{
+		{api.RuleTypeCertificate, strings.Repeat("c", 64)},
+		{api.RuleTypePath, "/usr/bin/ls"},
 	} {
-		_, err := store.CreateRule(ctx, api.CreateRuleRequest{
-			PolicyID:   p.ID,
-			RuleType:   rt,
-			Identifier: "EQHXZ8M8AV", // shape-valid for TEAMID; unsupported sentinel still fires for all types
-			Actor:      "demo-admin",
-			Reason:     "should be rejected as unsupported",
+		t.Run(string(tc.rt), func(t *testing.T) {
+			_, err := store.CreateRule(ctx, api.CreateRuleRequest{
+				PolicyID:   p.ID,
+				RuleType:   tc.rt,
+				Identifier: tc.identifier,
+				Actor:      "demo-admin",
+				Reason:     "should be rejected as unsupported",
+			})
+			require.Error(t, err)
+			assert.ErrorIs(t, err, api.ErrAppControlUnsupportedRuleType)
 		})
-		require.Error(t, err)
-		assert.ErrorIs(t, err, api.ErrAppControlUnsupportedRuleType, "rule_type %s", rt)
 	}
 }
 

--- a/server/rules/internal/tests/app_control_test.go
+++ b/server/rules/internal/tests/app_control_test.go
@@ -182,6 +182,60 @@ func TestAppControl_CreateRule_RejectsUnsupportedTypes(t *testing.T) {
 	}
 }
 
+// TestAppControl_CreateRule_AcceptsCDHashSigningIDTeamID is the positive companion to the unsupported-types test. CDHASH /
+// SIGNINGID / TEAMID rules MUST round-trip the validator + store + schema after the Phase A close-out — a deferred enum value
+// in the schema or a regressed validator would otherwise silently break creating these rule types via the REST handler.
+func TestAppControl_CreateRule_AcceptsCDHashSigningIDTeamID(t *testing.T) {
+	t.Parallel()
+	store, _ := newAppControlStore(t)
+	ctx := t.Context()
+	p, err := store.GetPolicyByName(ctx, api.DefaultPolicyName)
+	require.NoError(t, err)
+	cases := []struct {
+		rt         api.RuleType
+		identifier string
+	}{
+		{api.RuleTypeCDHash, strings.Repeat("a", 40)},
+		{api.RuleTypeSigningID, "EQHXZ8M8AV:com.google.Chrome"},
+		{api.RuleTypeSigningID, "platform:com.apple.curl"},
+		{api.RuleTypeTeamID, "EQHXZ8M8AV"},
+	}
+	for _, tc := range cases {
+		t.Run(string(tc.rt)+"/"+tc.identifier, func(t *testing.T) {
+			rule, err := store.CreateRule(ctx, api.CreateRuleRequest{
+				PolicyID:   p.ID,
+				RuleType:   tc.rt,
+				Identifier: tc.identifier,
+				Actor:      "demo-admin",
+				Reason:     "phase A acceptance",
+			})
+			require.NoError(t, err)
+			assert.NotZero(t, rule.ID)
+			assert.Equal(t, tc.rt, rule.RuleType)
+			assert.Equal(t, tc.identifier, rule.Identifier)
+			assert.Equal(t, api.ActionBlock, rule.Action)
+			assert.True(t, rule.Enabled)
+		})
+	}
+}
+
+// TestAppControl_ListHostGroupsForPolicy_SeededDefault pins the Phase A bootstrap contract: EnsureDefaultPolicy must seed a Default
+// policy AND an all-hosts host group AND an assignment between them, and ListHostGroupsForPolicy must return that group. A regression
+// in any of those three rows would otherwise silently break the fan-out path (no assignment -> no_assignments skip).
+func TestAppControl_ListHostGroupsForPolicy_SeededDefault(t *testing.T) {
+	t.Parallel()
+	store, _ := newAppControlStore(t)
+	ctx := t.Context()
+	p, err := store.GetPolicyByName(ctx, api.DefaultPolicyName)
+	require.NoError(t, err)
+
+	groups, err := store.ListHostGroupsForPolicy(ctx, p.ID)
+	require.NoError(t, err)
+	require.Len(t, groups, 1, "Default policy must have exactly one seeded host-group assignment")
+	assert.Equal(t, api.DefaultHostGroupName, groups[0].Name)
+	assert.JSONEq(t, `{"type":"all"}`, string(groups[0].Criteria), "seed criteria must be the all-hosts shape")
+}
+
 // TestAppControl_CreateRule_RejectsBadBinaryIdentifier covers the negative half of the BINARY validator at the store level. The store
 // path is what the REST handler and any automation client both go through, so this is the gate that protects the database.
 func TestAppControl_CreateRule_RejectsBadBinaryIdentifier(t *testing.T) {

--- a/ui/src/components/ApplicationControl/AddRuleModal.test.tsx
+++ b/ui/src/components/ApplicationControl/AddRuleModal.test.tsx
@@ -268,4 +268,117 @@ describe("AddRuleModal", () => {
     fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
     expect(onClose).toHaveBeenCalledTimes(1);
   });
+
+  it("accepts a valid TEAMID identifier and submits with rule_type=TEAMID", async () => {
+    const createSpy = vi
+      .spyOn(api, "createAppControlRule")
+      .mockResolvedValue(makeRule({ rule_type: "TEAMID", identifier: "EQHXZ8M8AV" }));
+    render(
+      <AddRuleModal open policyID={1} onClose={() => undefined} onCreated={() => undefined} />,
+    );
+    fireEvent.change(screen.getByLabelText(/^type$/i), { target: { value: "TEAMID" } });
+    fireEvent.change(screen.getByLabelText(/identifier/i), { target: { value: "EQHXZ8M8AV" } });
+    fireEvent.change(screen.getByLabelText(/reason/i), { target: { value: "block this team" } });
+    fireEvent.click(screen.getByRole("button", { name: /save rule/i }));
+    await waitFor(() => {
+      expect(createSpy).toHaveBeenCalledWith(1, expect.objectContaining({
+        rule_type: "TEAMID",
+        identifier: "EQHXZ8M8AV",
+      }));
+    });
+  });
+
+  it("rejects a lowercase TEAMID identifier with a specific error", async () => {
+    const createSpy = vi.spyOn(api, "createAppControlRule");
+    render(
+      <AddRuleModal open policyID={1} onClose={() => undefined} onCreated={() => undefined} />,
+    );
+    fireEvent.change(screen.getByLabelText(/^type$/i), { target: { value: "TEAMID" } });
+    fireEvent.change(screen.getByLabelText(/identifier/i), { target: { value: "eqhxz8m8av" } });
+    fireEvent.change(screen.getByLabelText(/reason/i), { target: { value: "demo" } });
+    fireEvent.click(screen.getByRole("button", { name: /save rule/i }));
+    await waitFor(() => {
+      expect(screen.getByRole("alert").textContent).toMatch(/TEAMID must be 10 uppercase/i);
+    });
+    expect(createSpy).not.toHaveBeenCalled();
+  });
+
+  it("accepts a valid CDHASH identifier and submits with rule_type=CDHASH", async () => {
+    const createSpy = vi
+      .spyOn(api, "createAppControlRule")
+      .mockResolvedValue(makeRule({ rule_type: "CDHASH", identifier: "c".repeat(40) }));
+    render(
+      <AddRuleModal open policyID={1} onClose={() => undefined} onCreated={() => undefined} />,
+    );
+    fireEvent.change(screen.getByLabelText(/^type$/i), { target: { value: "CDHASH" } });
+    fireEvent.change(screen.getByLabelText(/identifier/i), { target: { value: "C".repeat(40) } });
+    fireEvent.change(screen.getByLabelText(/reason/i), { target: { value: "block this CDHash" } });
+    fireEvent.click(screen.getByRole("button", { name: /save rule/i }));
+    await waitFor(() => {
+      // CDHASH identifiers normalize to lowercase before submission.
+      expect(createSpy).toHaveBeenCalledWith(1, expect.objectContaining({
+        rule_type: "CDHASH",
+        identifier: "c".repeat(40),
+      }));
+    });
+  });
+
+  it("accepts a valid SIGNINGID identifier in TeamID:bundle.id form", async () => {
+    const createSpy = vi
+      .spyOn(api, "createAppControlRule")
+      .mockResolvedValue(makeRule({ rule_type: "SIGNINGID", identifier: "EQHXZ8M8AV:com.google.Chrome" }));
+    render(
+      <AddRuleModal open policyID={1} onClose={() => undefined} onCreated={() => undefined} />,
+    );
+    fireEvent.change(screen.getByLabelText(/^type$/i), { target: { value: "SIGNINGID" } });
+    fireEvent.change(screen.getByLabelText(/identifier/i), {
+      target: { value: "EQHXZ8M8AV:com.google.Chrome" },
+    });
+    fireEvent.change(screen.getByLabelText(/reason/i), { target: { value: "block chrome" } });
+    fireEvent.click(screen.getByRole("button", { name: /save rule/i }));
+    await waitFor(() => {
+      expect(createSpy).toHaveBeenCalledWith(1, expect.objectContaining({
+        rule_type: "SIGNINGID",
+        identifier: "EQHXZ8M8AV:com.google.Chrome",
+      }));
+    });
+  });
+
+  it("accepts a SIGNINGID identifier with the platform: prefix", async () => {
+    const createSpy = vi
+      .spyOn(api, "createAppControlRule")
+      .mockResolvedValue(makeRule({ rule_type: "SIGNINGID", identifier: "platform:com.apple.curl" }));
+    render(
+      <AddRuleModal open policyID={1} onClose={() => undefined} onCreated={() => undefined} />,
+    );
+    fireEvent.change(screen.getByLabelText(/^type$/i), { target: { value: "SIGNINGID" } });
+    fireEvent.change(screen.getByLabelText(/identifier/i), {
+      target: { value: "platform:com.apple.curl" },
+    });
+    fireEvent.change(screen.getByLabelText(/reason/i), { target: { value: "block platform curl" } });
+    fireEvent.click(screen.getByRole("button", { name: /save rule/i }));
+    await waitFor(() => {
+      expect(createSpy).toHaveBeenCalledWith(1, expect.objectContaining({
+        rule_type: "SIGNINGID",
+        identifier: "platform:com.apple.curl",
+      }));
+    });
+  });
+
+  it("rejects a malformed SIGNINGID missing the colon", async () => {
+    const createSpy = vi.spyOn(api, "createAppControlRule");
+    render(
+      <AddRuleModal open policyID={1} onClose={() => undefined} onCreated={() => undefined} />,
+    );
+    fireEvent.change(screen.getByLabelText(/^type$/i), { target: { value: "SIGNINGID" } });
+    fireEvent.change(screen.getByLabelText(/identifier/i), {
+      target: { value: "EQHXZ8M8AVcom.google.Chrome" },
+    });
+    fireEvent.change(screen.getByLabelText(/reason/i), { target: { value: "demo" } });
+    fireEvent.click(screen.getByRole("button", { name: /save rule/i }));
+    await waitFor(() => {
+      expect(screen.getByRole("alert").textContent).toMatch(/SIGNINGID must look like/i);
+    });
+    expect(createSpy).not.toHaveBeenCalled();
+  });
 });

--- a/ui/src/components/ApplicationControl/AddRuleModal.test.tsx
+++ b/ui/src/components/ApplicationControl/AddRuleModal.test.tsx
@@ -137,7 +137,7 @@ describe("AddRuleModal", () => {
     });
     fireEvent.click(screen.getByRole("button", { name: /save rule/i }));
     await waitFor(() => {
-      expect(screen.getByRole("alert").textContent).toMatch(/64 lowercase hex/i);
+      expect(screen.getByRole("alert").textContent).toMatch(/64 hex characters/i);
     });
     expect(createSpy).not.toHaveBeenCalled();
   });

--- a/ui/src/components/ApplicationControl/AddRuleModal.test.tsx
+++ b/ui/src/components/ApplicationControl/AddRuleModal.test.tsx
@@ -113,7 +113,7 @@ describe("AddRuleModal", () => {
     expect(createSpy).not.toHaveBeenCalled();
   });
 
-  it("rejects an upper-case hex identifier (BINARY requires lowercase)", async () => {
+  it("rejects a BINARY identifier with the wrong length", async () => {
     const createSpy = vi.spyOn(api, "createAppControlRule");
     render(
       <AddRuleModal
@@ -123,13 +123,12 @@ describe("AddRuleModal", () => {
         onCreated={() => undefined}
       />,
     );
+    // 40 hex chars is the CDHASH length, not the BINARY length (64). The validator
+    // should reject it on the length check, before the charset regex runs. We pick
+    // this shape because uppercase hex now intentionally passes (the validator
+    // lowercases via trim().toLowerCase() and the submit path normalises), so the
+    // distinct exercise is the length gate.
     fireEvent.change(screen.getByLabelText(/identifier/i), {
-      // Uppercase wouldn't even make it past the client validator
-      // (the server's BINARY rule is "64 lowercase hex"). The
-      // client normalises lowercase before POSTing, so an
-      // uppercase string passes the regex check after trim().toLowerCase().
-      // We instead test the truncated form to keep this distinct
-      // from the bad-charset case above.
       target: { value: "a".repeat(40) },
     });
     fireEvent.change(screen.getByLabelText(/reason/i), {
@@ -140,6 +139,44 @@ describe("AddRuleModal", () => {
       expect(screen.getByRole("alert").textContent).toMatch(/64 hex characters/i);
     });
     expect(createSpy).not.toHaveBeenCalled();
+  });
+
+  it("accepts BINARY hex with uppercase letters (lowercased before submit)", async () => {
+    const createSpy = vi.spyOn(api, "createAppControlRule").mockResolvedValue({
+      id: 99,
+      policy_id: 1,
+      rule_type: "BINARY",
+      identifier: "a".repeat(64),
+      action: "BLOCK",
+      enforcement: "PROTECT",
+      enabled: true,
+      severity: "medium",
+      source: "admin",
+      created_at: "2026-05-17T00:00:00Z",
+      updated_at: "2026-05-17T00:00:00Z",
+      created_by: "operator",
+    });
+    render(
+      <AddRuleModal
+        open
+        policyID={1}
+        onClose={() => undefined}
+        onCreated={() => undefined}
+      />,
+    );
+    fireEvent.change(screen.getByLabelText(/identifier/i), {
+      target: { value: "A".repeat(64) },
+    });
+    fireEvent.change(screen.getByLabelText(/reason/i), {
+      target: { value: "uppercase normalisation" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /save rule/i }));
+    await waitFor(() => {
+      expect(createSpy).toHaveBeenCalled();
+    });
+    // The submit body must carry the lowercased identifier even though the operator typed uppercase.
+    const submitted = createSpy.mock.calls[0][1] as { identifier: string };
+    expect(submitted.identifier).toBe("a".repeat(64));
   });
 
   it("rejects a non-http(s) More info URL", async () => {

--- a/ui/src/components/ApplicationControl/AddRuleModal.tsx
+++ b/ui/src/components/ApplicationControl/AddRuleModal.tsx
@@ -67,18 +67,18 @@ function validateIdentifier(ruleType: string, value: string): string | null {
   switch (ruleType) {
     case "BINARY":
       if (trimmed.length !== BINARY_HEX_LENGTH) {
-        return `BINARY identifier must be 64 lowercase hex characters (was ${String(trimmed.length)}).`;
+        return `BINARY identifier must be 64 hex characters (was ${String(trimmed.length)}).`;
       }
       if (!BINARY_HEX_REGEX.test(trimmed.toLowerCase())) {
-        return "BINARY identifier must contain only lowercase hex (0-9 a-f).";
+        return "BINARY identifier must contain only hex characters (0-9 a-f); will be normalized to lowercase before submit.";
       }
       return null;
     case "CDHASH":
       if (trimmed.length !== CDHASH_HEX_LENGTH) {
-        return `CDHASH identifier must be 40 lowercase hex characters (was ${String(trimmed.length)}).`;
+        return `CDHASH identifier must be 40 hex characters (was ${String(trimmed.length)}).`;
       }
       if (!CDHASH_HEX_REGEX.test(trimmed.toLowerCase())) {
-        return "CDHASH identifier must contain only lowercase hex (0-9 a-f).";
+        return "CDHASH identifier must contain only hex characters (0-9 a-f); will be normalized to lowercase before submit.";
       }
       return null;
     case "TEAMID":

--- a/ui/src/components/ApplicationControl/AddRuleModal.tsx
+++ b/ui/src/components/ApplicationControl/AddRuleModal.tsx
@@ -23,37 +23,88 @@ interface AddRuleModalProps {
 
 const DIALOG_TITLE_ID = "add-rule-modal-title";
 
-// RULE_TYPES enumerates the values the schema's rule_type ENUM
-// accepts. Only BINARY is enforced in the demo cut; the others
-// render in the type selector with the disabled flag set so the
-// camera-facing UI shows the post-demo roadmap without faking it.
+// RULE_TYPES enumerates the values the schema's rule_type ENUM accepts. Phase A close-out
+// enables CDHASH, BINARY, SIGNINGID, and TEAMID. CERTIFICATE + PATH stay deferred to
+// Phase B (CERTIFICATE needs the leaf-cert cache plumbing; PATH needs Launch Services
+// indirection coverage).
 const RULE_TYPES: { value: string; label: string; available: boolean }[] = [
   { value: "BINARY", label: "BINARY (file SHA-256)", available: true },
-  { value: "CDHASH", label: "CDHASH (code-directory hash)", available: false },
-  { value: "SIGNINGID", label: "SIGNINGID (Team:bundle.id)", available: false },
+  { value: "CDHASH", label: "CDHASH (code-directory hash)", available: true },
+  { value: "SIGNINGID", label: "SIGNINGID (Team:bundle.id)", available: true },
+  { value: "TEAMID", label: "TEAMID (Apple Developer team)", available: true },
   { value: "CERTIFICATE", label: "CERTIFICATE (leaf SHA-256)", available: false },
-  { value: "TEAMID", label: "TEAMID (Apple Developer team)", available: false },
   { value: "PATH", label: "PATH (canonical absolute)", available: false },
 ];
 
 const SEVERITIES = ["low", "medium", "high", "critical"];
-const BINARY_HEX_LENGTH = 64;
-const BINARY_HEX_REGEX = /^[a-f0-9]{64}$/;
 
-// validateBinaryIdentifier mirrors the server's BINARY validator
-// (server/rules/internal/appcontrol/validate.go). Catching the
-// format error client-side gives the operator immediate feedback
-// instead of a round trip + a typed 400.
-function validateBinaryIdentifier(value: string): string | null {
-  const trimmed = value.trim().toLowerCase();
+// Server-validator mirrors. Each regex matches the canonical shape per
+// server/rules/internal/appcontrol/validate.go. Catching format errors client-side gives
+// the operator immediate feedback instead of a round trip + typed 400.
+const BINARY_HEX_LENGTH = 64;
+const CDHASH_HEX_LENGTH = 40;
+const BINARY_HEX_REGEX = /^[a-f0-9]{64}$/;
+const CDHASH_HEX_REGEX = /^[a-f0-9]{40}$/;
+const TEAM_ID_REGEX = /^[A-Z0-9]{10}$/;
+const SIGNING_ID_REGEX = /^(?:[A-Z0-9]{10}|platform):[A-Za-z0-9._-]+$/;
+
+// PLACEHOLDERS gives each rule type a hint string the identifier field renders. Helps an
+// operator pasting a value see immediately whether they grabbed the right shape. Stored as
+// a Map so the type→string lookup never trips the object-injection lint.
+const PLACEHOLDERS = new Map<string, string>([
+  ["BINARY", "64 lowercase hex characters (sha256)"],
+  ["CDHASH", "40 lowercase hex characters"],
+  ["TEAMID", "10 uppercase alphanumeric (e.g. EQHXZ8M8AV)"],
+  ["SIGNINGID", "EQHXZ8M8AV:com.google.Chrome or platform:com.apple.curl"],
+]);
+
+// validateIdentifier dispatches to the per-type regex. Returns null on success or a
+// user-facing error string on failure. Identifiers are normalized (trimmed; BINARY/CDHASH
+// lowercased; TEAMID/SIGNINGID kept case-sensitive because the server is case-sensitive).
+function validateIdentifier(ruleType: string, value: string): string | null {
+  const trimmed = value.trim();
   if (trimmed.length === 0) return "Identifier is required.";
-  if (trimmed.length !== BINARY_HEX_LENGTH) {
-    return `BINARY identifier must be ${String(BINARY_HEX_LENGTH)} lowercase hex characters (was ${String(trimmed.length)}).`;
+  switch (ruleType) {
+    case "BINARY":
+      if (trimmed.length !== BINARY_HEX_LENGTH) {
+        return `BINARY identifier must be 64 lowercase hex characters (was ${String(trimmed.length)}).`;
+      }
+      if (!BINARY_HEX_REGEX.test(trimmed.toLowerCase())) {
+        return "BINARY identifier must contain only lowercase hex (0-9 a-f).";
+      }
+      return null;
+    case "CDHASH":
+      if (trimmed.length !== CDHASH_HEX_LENGTH) {
+        return `CDHASH identifier must be 40 lowercase hex characters (was ${String(trimmed.length)}).`;
+      }
+      if (!CDHASH_HEX_REGEX.test(trimmed.toLowerCase())) {
+        return "CDHASH identifier must contain only lowercase hex (0-9 a-f).";
+      }
+      return null;
+    case "TEAMID":
+      if (!TEAM_ID_REGEX.test(trimmed)) {
+        return "TEAMID must be 10 uppercase alphanumeric characters (e.g. EQHXZ8M8AV).";
+      }
+      return null;
+    case "SIGNINGID":
+      if (!SIGNING_ID_REGEX.test(trimmed)) {
+        return "SIGNINGID must look like <TeamID>:<bundle.id> or platform:<bundle.id>.";
+      }
+      return null;
+    default:
+      return `Rule type ${ruleType} is not accepted by this build.`;
   }
-  if (!BINARY_HEX_REGEX.test(trimmed)) {
-    return "BINARY identifier must contain only lowercase hex (0-9 a-f).";
+}
+
+// normalizeIdentifier prepares the value for submission to the server. BINARY and CDHASH
+// are lowercased (the server validator is strict on case); TEAMID and SIGNINGID stay
+// untouched because the format already constrains them.
+function normalizeIdentifier(ruleType: string, value: string): string {
+  const trimmed = value.trim();
+  if (ruleType === "BINARY" || ruleType === "CDHASH") {
+    return trimmed.toLowerCase();
   }
-  return null;
+  return trimmed;
 }
 
 // errorMessageForCode maps the server's typed application_control.*
@@ -135,12 +186,10 @@ export function AddRuleModal({ open, policyID, onClose, onCreated }: AddRuleModa
   async function handleSubmit(e: React.SyntheticEvent) {
     e.preventDefault();
     if (submitDisabled) return;
-    if (ruleType === "BINARY") {
-      const validation = validateBinaryIdentifier(identifier);
-      if (validation) {
-        setFormError(validation);
-        return;
-      }
+    const validation = validateIdentifier(ruleType, identifier);
+    if (validation) {
+      setFormError(validation);
+      return;
     }
     // The host-app modal only renders "More info" for http/https
     // URLs (BlockAlert.swift rejects other schemes so a hostile
@@ -166,7 +215,7 @@ export function AddRuleModal({ open, policyID, onClose, onCreated }: AddRuleModa
     try {
       const req: CreateAppControlRuleRequest = {
         rule_type: ruleType,
-        identifier: identifier.trim().toLowerCase(),
+        identifier: normalizeIdentifier(ruleType, identifier),
         severity,
         reason: reason.trim(),
       };
@@ -244,7 +293,7 @@ export function AddRuleModal({ open, policyID, onClose, onCreated }: AddRuleModa
             type="text"
             autoComplete="off"
             spellCheck={false}
-            placeholder={ruleType === "BINARY" ? "64 lowercase hex characters (sha256)" : ""}
+            placeholder={PLACEHOLDERS.get(ruleType) ?? ""}
             value={identifier}
             onChange={(e) => { setIdentifier(e.target.value); }}
             disabled={busy}

--- a/ui/src/components/ApplicationControl/AddRuleModal.tsx
+++ b/ui/src/components/ApplicationControl/AddRuleModal.tsx
@@ -67,7 +67,7 @@ function validateIdentifier(ruleType: string, value: string): string | null {
   switch (ruleType) {
     case "BINARY":
       if (trimmed.length !== BINARY_HEX_LENGTH) {
-        return `BINARY identifier must be 64 hex characters (was ${String(trimmed.length)}).`;
+        return `BINARY identifier must be ${String(BINARY_HEX_LENGTH)} hex characters (was ${String(trimmed.length)}).`;
       }
       if (!BINARY_HEX_REGEX.test(trimmed.toLowerCase())) {
         return "BINARY identifier must contain only hex characters (0-9 a-f); will be normalized to lowercase before submit.";
@@ -75,7 +75,7 @@ function validateIdentifier(ruleType: string, value: string): string | null {
       return null;
     case "CDHASH":
       if (trimmed.length !== CDHASH_HEX_LENGTH) {
-        return `CDHASH identifier must be 40 hex characters (was ${String(trimmed.length)}).`;
+        return `CDHASH identifier must be ${String(CDHASH_HEX_LENGTH)} hex characters (was ${String(trimmed.length)}).`;
       }
       if (!CDHASH_HEX_REGEX.test(trimmed.toLowerCase())) {
         return "CDHASH identifier must contain only hex characters (0-9 a-f); will be normalized to lowercase before submit.";


### PR DESCRIPTION
…(#68)

Closes Section 11 of openspec/changes/add-application-control/tasks.md items 11.1 (host_groups + assignments schema), 11.2 (CDHASH/SIGNINGID/ TEAMID rule types end-to-end), and 11.3 (cdhash on every exec event).

Server schema (server/rules/bootstrap/schema.go):
- Add host_groups (id, name UNIQUE, description, criteria JSON, timestamps).
- Add app_control_assignments (policy_id, host_group_id, priority, created_at) with PK (policy_id, host_group_id) and intra-context CASCADE FKs.

Seed (server/rules/internal/appcontrol/store.go):
- EnsureDefaultPolicy now runs the Default policy + the all-hosts host group + the Default->all-hosts assignment in a single transaction. INSERT IGNORE keeps each row idempotent; assignment lookup goes via SELECT BY NAME because LAST_INSERT_ID() is unreliable on suppressed inserts.
- ListHostGroupsForPolicy(policyID) inner-joins host_groups with app_control_assignments and returns rows ordered by (priority DESC, name ASC).

Public types (server/rules/api/types.go):
- DefaultHostGroupName='all-hosts', HostGroupCriteriaTypeAll='all'.
- HostGroup + Assignment struct types.
- ApplicationControlStore gains ListHostGroupsForPolicy.

Fan-out (server/rules/internal/appcontrol/service.go):
- fanout(ctx, policyID, payload) walks the assignment layer: resolves the policy's host groups, walks each group's criteria via resolveHostGroup, unions the host ids, dedups, and enqueues one command per unique host. Phase A's only criteria shape is {type:'all'} which delegates to the existing HostLister, so observable behavior matches the demo cut. Phase B grows the resolver with tag/hostname/OS predicates without touching this loop.
- New fanoutSkipReason values: assignment_list_error, no_assignments.

Validators (server/rules/internal/appcontrol/validate.go):
- ValidateRuleType accepts CDHASH, SIGNINGID, TEAMID alongside BINARY. CERTIFICATE + PATH stay gated until Phase B (leaf-cert cache + Launch Services indirection).
- ValidateIdentifier returns nil for well-formed CDHASH (40 hex), TEAMID (10 uppercase alnum), SIGNINGID (TeamID|platform:bundle.id) rather than the prior unsupported error.

Extension (extension/edr/extension/ESFSubscriber.swift):
- handleAuthExec is rewritten around the precedence walker. Extracts the AuthTuple (cdhash if hardened-runtime via CS_RUNTIME=0x10000 gate, file_sha256 from FileHashCache, prefixed signing_id, team_id) via the new buildAuthTuple helper; walkPrecedence walks CDHASH -> BINARY -> SIGNINGID -> TEAMID returning the first match.
- isHardenedRuntime(flags:) and cdhashHexString(from:) helpers. The hex encoder treats an all-zero cdhash as nil (unsigned binaries).

Extension exec event (extension/edr/extension/EventSerializer.swift):
- ExecPayload gains optional cdhash field. Encoder uses encodeIfPresent so the wire shape stays compact for non-hardened binaries; decoder uses decodeIfPresent for backwards-tolerance.

UI (ui/src/components/ApplicationControl/AddRuleModal.tsx):
- RULE_TYPES flips available:true for CDHASH, SIGNINGID, TEAMID.
- validateIdentifier(ruleType, value) dispatches to per-type regexes mirroring the server validator shapes. Length constants extracted so the no-magic-numbers lint stays clean.
- normalizeIdentifier lowercases BINARY/CDHASH only; TEAMID/SIGNINGID stay untouched. PLACEHOLDERS is a Map<string,string> so the lookup never trips the object-injection lint.

UI tests (AddRuleModal.test.tsx): 6 new cases covering CDHASH happy path + case normalization, TEAMID happy path + lowercase rejection, SIGNINGID TeamID:bundle.id form, SIGNINGID platform: prefix, and SIGNINGID missing-colon rejection. All 41 UI tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Application Control Phase A now accepts CDHash, SigningID, and TeamID rules and applies a multi-step precedence when evaluating execs; exec events include CDHash when applicable.
  * Add-rule UI accepts and normalizes multiple identifier types with updated validation.

* **Infrastructure**
  * Introduced host groups and policy-to-group assignments to target application control fan-out.

* **Tests**
  * Updated tests to reflect accepted/deferred rule types and identifier validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/getvictor/fleet-edr/pull/185?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->