### PR TITLE
Streamline golangci-lint Taskfile logic: auto-build custom binary via…

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,11 +18,12 @@ Pinned in [`.tool-versions`](.tool-versions). Install [`mise`](https://mise.jdx.
 match local, CI, and AI-agent sandbox versions. Pre-commit hooks live in [`lefthook.yml`](lefthook.yml); install once with
 `lefthook install`.
 
-After cloning, run `task install` then `task lint:install`. The latter builds a custom golangci-lint binary at
-`tmp/golangci-lint-custom` with the repo's in-tree `commentwrap` plugin baked in (see
-[`tools/comment-wrap-check/lint/`](tools/comment-wrap-check/lint/) and [`.custom-gcl.yml`](.custom-gcl.yml)). `task lint:go`
-prefers that binary when present; running upstream `golangci-lint run` directly returns "unknown linter: commentwrap" because
-the plugin only exists in the custom build.
+After cloning, run `task install`. The first `task lint:go` auto-builds the custom golangci-lint binary at
+`tmp/golangci-lint-custom` (via the `lint:install` dep) with the repo's in-tree `commentwrap` plugin baked in (see
+[`tools/comment-wrap-check/lint/`](tools/comment-wrap-check/lint/) and [`.custom-gcl.yml`](.custom-gcl.yml)); subsequent runs
+short-circuit via Taskfile's sources/generates. Editor integrations or terminal invocations of upstream `golangci-lint run`
+return "unknown linter: commentwrap" because the plugin only exists in the custom build — point your editor at
+`tmp/golangci-lint-custom` (or run `task lint:install` once to materialize it).
 
 CI is the backstop, not the floor. If a check fails locally, fix it before pushing; do not push hoping CI will pass.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ After cloning, run `task install`. The first `task lint:go` auto-builds the cust
 `tmp/golangci-lint-custom` (via the `lint:install` dep) with the repo's in-tree `commentwrap` plugin baked in (see
 [`tools/comment-wrap-check/lint/`](tools/comment-wrap-check/lint/) and [`.custom-gcl.yml`](.custom-gcl.yml)); subsequent runs
 short-circuit via Taskfile's sources/generates. Editor integrations or terminal invocations of upstream `golangci-lint run`
-return "unknown linter: commentwrap" because the plugin only exists in the custom build — point your editor at
+return "unknown linter: commentwrap" because the plugin only exists in the custom build; point your editor at
 `tmp/golangci-lint-custom` (or run `task lint:install` once to materialize it).
 
 CI is the backstop, not the floor. If a check fails locally, fix it before pushing; do not push hoping CI will pass.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -285,30 +285,20 @@ tasks:
     desc: |
       golangci-lint across the whole Go module. Runs the CUSTOM golangci-lint binary
       at tmp/golangci-lint-custom which has the repo-local commentwrap plugin compiled
-      in (see .custom-gcl.yml). `task lint:install` builds it. The upstream binary
-      cannot load the plugin, so we refuse to fall back to it: `.golangci.yml` enables
-      `commentwrap` under `linters.enable` and the upstream binary aborts with
-      "unknown linter" before any real lint runs. Better to fail loud here with
-      actionable text than silently produce a non-equivalent lint result.
+      in (see .custom-gcl.yml). The lint:install dep auto-builds it on first run and
+      short-circuits on subsequent runs via sources/generates. The upstream binary
+      cannot load the plugin, so `.golangci.yml` enables `commentwrap` under
+      `linters.enable` and the upstream binary would abort with "unknown linter"
+      before any real lint runs.
+    deps: [lint:install]
     cmds:
-      - cmd: |
-          if [ ! -x tmp/golangci-lint-custom ]; then
-            echo "tmp/golangci-lint-custom missing." >&2
-            echo "Run 'task lint:install' first to build the custom binary that bakes in the commentwrap plugin." >&2
-            echo "(The upstream golangci-lint binary cannot load the plugin, so we deliberately do NOT fall back.)" >&2
-            exit 1
-          fi
-          tmp/golangci-lint-custom run ./server/... ./agent/... ./internal/... ./test/...
+      - tmp/golangci-lint-custom run ./server/... ./agent/... ./internal/... ./test/...
 
   lint:go:fix:
-    desc: golangci-lint with --fix for auto-fixable findings (uses the custom binary built by `task lint:install`)
+    desc: golangci-lint with --fix for auto-fixable findings (auto-builds the custom binary via lint:install)
+    deps: [lint:install]
     cmds:
-      - cmd: |
-          if [ ! -x tmp/golangci-lint-custom ]; then
-            echo "tmp/golangci-lint-custom missing. Run 'task lint:install' first." >&2
-            exit 1
-          fi
-          tmp/golangci-lint-custom run --fix ./server/... ./agent/... ./internal/... ./test/...
+      - tmp/golangci-lint-custom run --fix ./server/... ./agent/... ./internal/... ./test/...
 
   lint:install:
     desc: |

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -292,13 +292,13 @@ tasks:
       before any real lint runs.
     deps: [lint:install]
     cmds:
-      - tmp/golangci-lint-custom run ./server/... ./agent/... ./internal/... ./test/...
+      - tmp/golangci-lint-custom run ./...
 
   lint:go:fix:
     desc: golangci-lint with --fix for auto-fixable findings (auto-builds the custom binary via lint:install)
     deps: [lint:install]
     cmds:
-      - tmp/golangci-lint-custom run --fix ./server/... ./agent/... ./internal/... ./test/...
+      - tmp/golangci-lint-custom run --fix ./...
 
   lint:install:
     desc: |

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -124,11 +124,11 @@ pre-push:
       run: |
         mkdir -p server/ui/dist && touch server/ui/dist/.gitkeep
         if [ -x tmp/golangci-lint-custom ]; then
-          tmp/golangci-lint-custom run --fast-only ./server/... ./agent/... ./internal/... ./test/...
+          tmp/golangci-lint-custom run --fast-only ./...
         else
           echo "[lefthook] tmp/golangci-lint-custom missing; running upstream golangci-lint --no-config (no commentwrap)" >&2
           echo "[lefthook] Run 'task lint:install' once to enable the full linter set including commentwrap." >&2
-          golangci-lint run --no-config --fast-only ./server/... ./agent/... ./internal/... ./test/...
+          golangci-lint run --no-config --fast-only ./...
         fi
 
     arch-go:


### PR DESCRIPTION
… `lint:install` dependency, simplify commands, and update contributing instructions.