### PR TITLE
app-control: PATCH/DELETE/POST REST mutation surface (#68 / 11.4)

### DIFF
--- a/server/cmd/fleet-edr-server/main.go
+++ b/server/cmd/fleet-edr-server/main.go
@@ -524,13 +524,20 @@ func registerSessionRoutes(mux *http.ServeMux, d muxDeps) {
 		"GET /api/rules",
 		"GET /api/audit-events",
 		"GET /api/session",
-		// Application Control demo cut. rulesCtx.RegisterAuthedRoutes mounts these on apiMux; the outer router needs each
+		// Application Control admin surface. rulesCtx.RegisterAuthedRoutes mounts these on apiMux; the outer router needs each
 		// path enumerated here so requests reach the session-protected wrapper instead of falling through to the `/` catchall
 		// and 302 → /ui/. Surfaced by the step-8 dry-run on PR #158 — the list-policies API returned the SPA's index.html,
-		// which the UI fetch parsed as JSON and errored with "Unexpected token '<'".
+		// which the UI fetch parsed as JSON and errored with "Unexpected token '<'". The Phase A close-out follow-on adds the
+		// five mutation routes; bulk upsert + cross-policy GET + host-groups CRUD + assignments POST stay deferred to
+		// follow-on PRs and land in this list when their handlers do.
 		"GET /api/v1/app-control/policies",
 		"GET /api/v1/app-control/policies/{id}",
+		"POST /api/v1/app-control/policies",
+		"PATCH /api/v1/app-control/policies/{id}",
+		"DELETE /api/v1/app-control/policies/{id}",
 		"POST /api/v1/app-control/policies/{id}/rules",
+		"PATCH /api/v1/app-control/rules/{id}",
+		"DELETE /api/v1/app-control/rules/{id}",
 		// Break-glass reauth ceremony. The handlers are mounted on apiMux via identityCtx.RegisterAuthedRoutes, but the outer
 		// router needs each path enumerated here so the session-protected wrapper actually serves them — otherwise requests
 		// fall through to the `/` catchall and 302 → /ui/, silently breaking the destructive-action reauth path.

--- a/server/identity/api/audit.go
+++ b/server/identity/api/audit.go
@@ -47,9 +47,15 @@ const (
 	AuditAuthBreakglassFailure   AuditAction = "auth.breakglass.failure"
 
 	// Application Control mutations (rules context). The payload records actor reason, rule type / identifier, policy version post-bump,
-	// and fan-out counts (fanout_hosts / fanout_failed) so SIEM dashboards can trace which hosts received the rule. Stable wire string
-	// mirrored by AuthZ Action of the same name.
-	AuditAppControlRuleCreate AuditAction = "application_control.rule_create"
+	// and fan-out counts (fanout_hosts / fanout_failed) so SIEM dashboards can trace which hosts received the rule. Stable wire strings
+	// mirrored by AuthZ Actions of the same names. The five non-create actions are added by the Phase A close-out follow-on (PR-1b)
+	// that wires the full PATCH/DELETE/POST REST surface.
+	AuditAppControlRuleCreate   AuditAction = "application_control.rule_create"
+	AuditAppControlRuleUpdate   AuditAction = "application_control.rule_update"
+	AuditAppControlRuleDelete   AuditAction = "application_control.rule_delete"
+	AuditAppControlPolicyCreate AuditAction = "application_control.policy_create"
+	AuditAppControlPolicyUpdate AuditAction = "application_control.policy_update"
+	AuditAppControlPolicyDelete AuditAction = "application_control.policy_delete"
 )
 
 // AuditEvent is the value passed to AuditRecorder.Record. Caller

--- a/server/identity/api/authz.go
+++ b/server/identity/api/authz.go
@@ -63,10 +63,15 @@ const (
 	ActionAuditRead Action = "audit.read"
 
 	// Application Control. The admin surface manages the policies and rules that the extension consults on every AUTH_EXEC. Read covers
-	// the list + detail views; RuleCreate gates the POST that fans a `set_application_control` command out to every enrolled host.
-	// Other verbs (rule update / delete, bulk upsert) are post-demo; constants land as they ship.
-	ActionAppControlRead       Action = "application_control.read"
-	ActionAppControlRuleCreate Action = "application_control.rule_create"
+	// the list + detail views; the five mutation verbs each gate a corresponding POST/PATCH/DELETE handler that fans a fresh
+	// `set_application_control` command out to every enrolled host on the affected policy. Bulk upsert + host-groups CRUD stay deferred.
+	ActionAppControlRead         Action = "application_control.read"
+	ActionAppControlRuleCreate   Action = "application_control.rule_create"
+	ActionAppControlRuleUpdate   Action = "application_control.rule_update"
+	ActionAppControlRuleDelete   Action = "application_control.rule_delete"
+	ActionAppControlPolicyCreate Action = "application_control.policy_create"
+	ActionAppControlPolicyUpdate Action = "application_control.policy_update"
+	ActionAppControlPolicyDelete Action = "application_control.policy_delete"
 )
 
 // RegisteredActions returns the set of every Action constant declared
@@ -86,7 +91,9 @@ func RegisteredActions() []Action {
 		ActionEnrollmentRead, ActionEnrollmentRevoke, ActionEnrollmentRotateToken,
 		ActionUserRead, ActionUserInvite,
 		ActionAuditRead,
-		ActionAppControlRead, ActionAppControlRuleCreate,
+		ActionAppControlRead,
+		ActionAppControlRuleCreate, ActionAppControlRuleUpdate, ActionAppControlRuleDelete,
+		ActionAppControlPolicyCreate, ActionAppControlPolicyUpdate, ActionAppControlPolicyDelete,
 	}
 }
 

--- a/server/identity/internal/authz/policy/data/actions.json
+++ b/server/identity/internal/authz/policy/data/actions.json
@@ -17,6 +17,11 @@
     "user.invite",
     "audit.read",
     "application_control.read",
-    "application_control.rule_create"
+    "application_control.rule_create",
+    "application_control.rule_update",
+    "application_control.rule_delete",
+    "application_control.policy_create",
+    "application_control.policy_update",
+    "application_control.policy_delete"
   ]
 }

--- a/server/identity/internal/authz/policy/data/roles.json
+++ b/server/identity/internal/authz/policy/data/roles.json
@@ -21,7 +21,12 @@
         "enrollment.revoke",
         "enrollment.rotate_token",
         "application_control.read",
-        "application_control.rule_create"
+        "application_control.rule_create",
+        "application_control.rule_update",
+        "application_control.rule_delete",
+        "application_control.policy_create",
+        "application_control.policy_update",
+        "application_control.policy_delete"
       ]
     },
     "senior_analyst": {

--- a/server/rules/api/types.go
+++ b/server/rules/api/types.go
@@ -280,6 +280,60 @@ type CreateRuleRequest struct {
 	Reason     string
 }
 
+// UpdateRuleRequest is the server-internal contract for PATCH /api/v1/app-control/rules/{id}. Every mutable field is a pointer so
+// "field absent" (nil) is distinguishable from "field set to zero value". Phase A allows mutating Enabled, Severity, CustomMsg,
+// CustomURL, Comment, and ExpiresAt. Phase B's Detect-mode change layers Enforcement on top; this struct does not carry it today.
+// PolicyID is set by the handler from the existing row (PATCH does not move a rule between policies), Actor and Reason are required
+// for every state-changing call so the audit row is honest.
+type UpdateRuleRequest struct {
+	RuleID    int64
+	Enabled   *bool
+	Severity  *Severity
+	CustomMsg *string
+	CustomURL *string
+	Comment   *string
+	ExpiresAt *time.Time
+	Actor     string
+	Reason    string
+}
+
+// DeleteRuleRequest is the server-internal contract for DELETE /api/v1/app-control/rules/{id}. Actor + Reason are required so the
+// audit row records who removed the rule and why; the store-layer guard fails closed if either is empty.
+type DeleteRuleRequest struct {
+	RuleID int64
+	Actor  string
+	Reason string
+}
+
+// CreatePolicyRequest is the server-internal contract for POST /api/v1/app-control/policies. Name is required and must be unique;
+// description is optional. Reason + Actor land on the audit row. The store hardcodes default_action='NONE' in Phase A (the column's
+// enum only carries that value; Lockdown extends it).
+type CreatePolicyRequest struct {
+	Name        string
+	Description string
+	Actor       string
+	Reason      string
+}
+
+// UpdatePolicyRequest is the server-internal contract for PATCH /api/v1/app-control/policies/{id}. Phase A only allows renaming and
+// editing the description. Pointer fields distinguish "absent" from "explicit zero" so a PATCH that wants to clear the description
+// (set it to "") sends `description: ""` rather than the field being omitted entirely.
+type UpdatePolicyRequest struct {
+	PolicyID    int64
+	Name        *string
+	Description *string
+	Actor       string
+	Reason      string
+}
+
+// DeletePolicyRequest is the server-internal contract for DELETE /api/v1/app-control/policies/{id}. The store-layer guard refuses
+// to delete the seed Default policy by name (ErrAppControlPolicyImmutable) so the failsafe assignment stays intact.
+type DeletePolicyRequest struct {
+	PolicyID int64
+	Actor    string
+	Reason   string
+}
+
 // Application Control validation errors. Mapped to HTTP 400 by the
 // REST handlers via IsApplicationControlValidationError.
 var (
@@ -312,6 +366,19 @@ var (
 	// ErrAppControlDuplicateRule is returned when a rule with the same (policy_id, rule_type, identifier) already exists. Mapped to HTTP
 	// 409 by the REST handlers so the client can dedup idempotent retries cleanly.
 	ErrAppControlDuplicateRule = errors.New("rules: application control rule already exists")
+
+	// ErrAppControlRuleNotFound is returned when the targeted rule row does not exist. Mapped to HTTP 404 by the REST handler so the
+	// REST client can distinguish "PATCH/DELETE on a stale id" from a server-side fault.
+	ErrAppControlRuleNotFound = errors.New("rules: application control rule not found")
+
+	// ErrAppControlDuplicatePolicy is returned when a policy with the same name already exists. Mapped to HTTP 409 by the POST policy
+	// handler so an operator typing a name collision sees a precise diagnostic rather than a generic 500.
+	ErrAppControlDuplicatePolicy = errors.New("rules: application control policy already exists")
+
+	// ErrAppControlPolicyImmutable is returned when a destructive mutation targets the seed Default policy (DELETE policy). The seed
+	// row is the failsafe that keeps the all-hosts assignment alive; an admin who wants to stop enforcing rules detaches the
+	// assignment or disables individual rules rather than deleting the policy itself.
+	ErrAppControlPolicyImmutable = errors.New("rules: application control default policy cannot be deleted")
 )
 
 // IsApplicationControlValidationError reports whether err is one of the validation errors that the REST handlers map to HTTP 400. The
@@ -353,6 +420,23 @@ type ApplicationControlStore interface {
 	ListPolicies(ctx context.Context) ([]ApplicationControlPolicy, error)
 	ListRulesByPolicy(ctx context.Context, policyID int64) ([]ApplicationControlRule, error)
 	CreateRule(ctx context.Context, req CreateRuleRequest) (ApplicationControlRule, error)
+	// GetRuleByID returns the rule row (or ErrAppControlRuleNotFound). The REST PATCH/DELETE paths use it to look up the policy_id
+	// the row belongs to before mutating, so the snapshot fan-out targets the right policy.
+	GetRuleByID(ctx context.Context, ruleID int64) (ApplicationControlRule, error)
+	// UpdateRule applies a partial update to an existing rule + bumps the parent policy's version. Returns the post-update row.
+	// ErrAppControlRuleNotFound when the rule does not exist; ErrAppControlInvalidRequest when actor/reason are empty.
+	UpdateRule(ctx context.Context, req UpdateRuleRequest) (ApplicationControlRule, error)
+	// DeleteRule removes the rule + bumps the parent policy's version. Returns the parent policy_id so the service can compose the
+	// post-delete snapshot the agents see. ErrAppControlRuleNotFound when the rule does not exist.
+	DeleteRule(ctx context.Context, req DeleteRuleRequest) (policyID int64, err error)
+	// CreatePolicy inserts a new policy row. ErrAppControlDuplicatePolicy when the name collides.
+	CreatePolicy(ctx context.Context, req CreatePolicyRequest) (ApplicationControlPolicy, error)
+	// UpdatePolicy applies a partial update (name / description) + bumps the policy version + sets updated_by. Returns the post-update
+	// row. ErrAppControlPolicyNotFound when the id does not exist; ErrAppControlDuplicatePolicy when the new name collides.
+	UpdatePolicy(ctx context.Context, req UpdatePolicyRequest) (ApplicationControlPolicy, error)
+	// DeletePolicy removes the policy row (CASCADEs rules + assignments). Refuses the seed Default policy via
+	// ErrAppControlPolicyImmutable. ErrAppControlPolicyNotFound when the id does not exist.
+	DeletePolicy(ctx context.Context, req DeletePolicyRequest) error
 	// ListHostGroupsForPolicy returns the host groups assigned to the policy, in priority order then by group name. The fan-out
 	// resolver walks the result and unions the member hosts of each group to build the set of unique hosts the rule update should
 	// reach.

--- a/server/rules/internal/appcontrol/service.go
+++ b/server/rules/internal/appcontrol/service.go
@@ -386,3 +386,184 @@ func (s *Service) emitAudit(
 		s.logger.WarnContext(ctx, "appcontrol: audit record failed", "err", err, "rule_id", rule.ID)
 	}
 }
+
+// recordAudit is the low-level audit emit the per-op helpers share. It centralises the nil-audit guard and the actor-id back-fill
+// so the per-op helpers focus on the payload shape rather than the boilerplate. Failed audit emission is logged but not returned;
+// audit is best-effort relative to the mutation that already committed (same posture as emitAudit's create-rule path).
+func (s *Service) recordAudit(ctx context.Context, actor *identityapi.Actor, evt identityapi.AuditEvent) {
+	if s.audit == nil {
+		return
+	}
+	if actor != nil {
+		userID := actor.UserID
+		evt.UserID = &userID
+	}
+	if err := s.audit.Record(ctx, evt); err != nil {
+		s.logger.WarnContext(ctx, "appcontrol: audit record failed", "err", err, "target_id", evt.TargetID, "action", string(evt.Action))
+	}
+}
+
+// UpdateRule wires PATCH /api/v1/app-control/rules/{id}: validates the actor + reason, applies the partial update through the
+// store, recomposes the post-update snapshot, fans it out, and emits the application_control.rule_update audit row. Validation
+// errors propagate untouched so the handler can errors.Is on the shared IsApplicationControlValidationError set.
+func (s *Service) UpdateRule(ctx context.Context, req api.UpdateRuleRequest, actor *identityapi.Actor) (api.ApplicationControlRule, error) {
+	if actor == nil {
+		return api.ApplicationControlRule{}, fmt.Errorf("%w: actor is required", api.ErrAppControlInvalidRequest)
+	}
+	rule, err := s.store.UpdateRule(ctx, req)
+	if err != nil {
+		return api.ApplicationControlRule{}, err
+	}
+	policy, payload, composeErr := s.buildSnapshotPayload(ctx, rule.PolicyID)
+	if composeErr != nil {
+		s.recordRuleMutationAudit(ctx, actor, identityapi.AuditAppControlRuleUpdate, rule, req.Reason, 0, 0, 0, "snapshot_compose_failed")
+		s.logger.ErrorContext(ctx, "appcontrol: snapshot compose after UpdateRule failed; rule mutation persisted but agents unaware until next mutation",
+			"err", composeErr, "policy_id", rule.PolicyID, "rule_id", rule.ID)
+		return api.ApplicationControlRule{}, fmt.Errorf("appcontrol snapshot compose: %w", composeErr)
+	}
+	fanoutHosts, fanoutFailed, fanoutSkipReason := s.fanout(ctx, policy.ID, payload)
+	s.recordRuleMutationAudit(ctx, actor, identityapi.AuditAppControlRuleUpdate, rule, req.Reason, policy.Version, fanoutHosts, fanoutFailed, fanoutSkipReason)
+	return rule, nil
+}
+
+// DeleteRule wires DELETE /api/v1/app-control/rules/{id}: looks up the rule (so the audit row records what was removed), deletes
+// it, fans out the post-delete snapshot, emits the rule_delete audit. The rule body is captured BEFORE the delete because the
+// audit payload references rule_type + identifier; reading after the DELETE would race with the cascade.
+func (s *Service) DeleteRule(ctx context.Context, req api.DeleteRuleRequest, actor *identityapi.Actor) error {
+	if actor == nil {
+		return fmt.Errorf("%w: actor is required", api.ErrAppControlInvalidRequest)
+	}
+	priorRule, err := s.store.GetRuleByID(ctx, req.RuleID)
+	if err != nil {
+		return err
+	}
+	if _, err := s.store.DeleteRule(ctx, req); err != nil {
+		return err
+	}
+	policy, payload, composeErr := s.buildSnapshotPayload(ctx, priorRule.PolicyID)
+	if composeErr != nil {
+		s.recordRuleMutationAudit(ctx, actor, identityapi.AuditAppControlRuleDelete, priorRule, req.Reason, 0, 0, 0, "snapshot_compose_failed")
+		s.logger.ErrorContext(ctx, "appcontrol: snapshot compose after DeleteRule failed; agents still see the deleted rule until next mutation",
+			"err", composeErr, "policy_id", priorRule.PolicyID, "rule_id", priorRule.ID)
+		return fmt.Errorf("appcontrol snapshot compose: %w", composeErr)
+	}
+	fanoutHosts, fanoutFailed, fanoutSkipReason := s.fanout(ctx, policy.ID, payload)
+	s.recordRuleMutationAudit(ctx, actor, identityapi.AuditAppControlRuleDelete, priorRule, req.Reason, policy.Version, fanoutHosts, fanoutFailed, fanoutSkipReason)
+	return nil
+}
+
+// recordRuleMutationAudit is the per-op audit emitter for rule mutations (update + delete). Payload shape matches the create
+// flow's so SIEM dashboards can filter on the same key set across all three actions.
+func (s *Service) recordRuleMutationAudit(
+	ctx context.Context,
+	actor *identityapi.Actor,
+	action identityapi.AuditAction,
+	rule api.ApplicationControlRule,
+	reason string,
+	policyVersion int64,
+	fanoutHosts int,
+	fanoutFailed int,
+	fanoutSkipReason string,
+) {
+	payload := map[string]any{
+		"policy_id":      rule.PolicyID,
+		"policy_version": policyVersion,
+		"rule_type":      string(rule.RuleType),
+		"identifier":     rule.Identifier,
+		"severity":       string(rule.Severity),
+		"reason":         reason,
+		"fanout_hosts":   fanoutHosts,
+		"fanout_failed":  fanoutFailed,
+	}
+	if fanoutSkipReason != "" {
+		payload["fanout_skipped_reason"] = fanoutSkipReason
+	}
+	actorIdentifier := ""
+	if actor != nil && actor.UserID > 0 {
+		actorIdentifier = "user:" + strconv.FormatInt(actor.UserID, 10)
+	}
+	s.recordAudit(ctx, actor, identityapi.AuditEvent{
+		Action:     action,
+		TargetType: "application_control_rule",
+		TargetID:   strconv.FormatInt(rule.ID, 10),
+		ActorEmail: actorIdentifier,
+		Payload:    payload,
+	})
+}
+
+// CreatePolicy wires POST /api/v1/app-control/policies. The new policy starts at version=1 with default_action='NONE' and zero
+// rules; no fan-out runs because no host group is assigned yet (Phase B exposes the assignments endpoint). The audit row records
+// the new policy id + name so an operator can trace the creation back to the request.
+func (s *Service) CreatePolicy(ctx context.Context, req api.CreatePolicyRequest, actor *identityapi.Actor) (api.ApplicationControlPolicy, error) {
+	if actor == nil {
+		return api.ApplicationControlPolicy{}, fmt.Errorf("%w: actor is required", api.ErrAppControlInvalidRequest)
+	}
+	policy, err := s.store.CreatePolicy(ctx, req)
+	if err != nil {
+		return api.ApplicationControlPolicy{}, err
+	}
+	s.recordPolicyMutationAudit(ctx, actor, identityapi.AuditAppControlPolicyCreate, policy, req.Reason)
+	return policy, nil
+}
+
+// UpdatePolicy wires PATCH /api/v1/app-control/policies/{id}. Renames + description edits do not change the rules snapshot the
+// agents receive, so this path does NOT fan out a new snapshot. The audit row records the post-update version + the actor-supplied
+// reason so a future "who renamed Default to corp-default" question has a single source of truth.
+func (s *Service) UpdatePolicy(ctx context.Context, req api.UpdatePolicyRequest, actor *identityapi.Actor) (api.ApplicationControlPolicy, error) {
+	if actor == nil {
+		return api.ApplicationControlPolicy{}, fmt.Errorf("%w: actor is required", api.ErrAppControlInvalidRequest)
+	}
+	policy, err := s.store.UpdatePolicy(ctx, req)
+	if err != nil {
+		return api.ApplicationControlPolicy{}, err
+	}
+	s.recordPolicyMutationAudit(ctx, actor, identityapi.AuditAppControlPolicyUpdate, policy, req.Reason)
+	return policy, nil
+}
+
+// DeletePolicy wires DELETE /api/v1/app-control/policies/{id}. Store refuses the seed Default policy (ErrAppControlPolicyImmutable);
+// non-Default policies have no assignments in Phase A so no fan-out runs (an admin who attached a custom group + rules in some
+// future code path would also need a follow-on snapshot push, but that path does not exist today). The audit captures the
+// deleted policy id + name so the deletion is reconstructable from the audit log alone.
+func (s *Service) DeletePolicy(ctx context.Context, req api.DeletePolicyRequest, actor *identityapi.Actor) error {
+	if actor == nil {
+		return fmt.Errorf("%w: actor is required", api.ErrAppControlInvalidRequest)
+	}
+	priorPolicy, err := s.findPolicyByID(ctx, req.PolicyID)
+	if err != nil {
+		return err
+	}
+	if err := s.store.DeletePolicy(ctx, req); err != nil {
+		return err
+	}
+	s.recordPolicyMutationAudit(ctx, actor, identityapi.AuditAppControlPolicyDelete, priorPolicy, req.Reason)
+	return nil
+}
+
+// recordPolicyMutationAudit is the per-op audit emitter for policy mutations (create + update + delete). Payload mirrors the
+// rule-mutation shape modulo fan-out fields (no fan-out on policy mutations in Phase A) so the dashboard query language stays
+// consistent across action types.
+func (s *Service) recordPolicyMutationAudit(
+	ctx context.Context,
+	actor *identityapi.Actor,
+	action identityapi.AuditAction,
+	policy api.ApplicationControlPolicy,
+	reason string,
+) {
+	actorIdentifier := ""
+	if actor != nil && actor.UserID > 0 {
+		actorIdentifier = "user:" + strconv.FormatInt(actor.UserID, 10)
+	}
+	s.recordAudit(ctx, actor, identityapi.AuditEvent{
+		Action:     action,
+		TargetType: "application_control_policy",
+		TargetID:   strconv.FormatInt(policy.ID, 10),
+		ActorEmail: actorIdentifier,
+		Payload: map[string]any{
+			"policy_id":      policy.ID,
+			"policy_name":    policy.Name,
+			"policy_version": policy.Version,
+			"reason":         reason,
+		},
+	})
+}

--- a/server/rules/internal/appcontrol/service.go
+++ b/server/rules/internal/appcontrol/service.go
@@ -12,6 +12,14 @@ import (
 	"github.com/fleetdm/edr/server/rules/api"
 )
 
+// Error-message format strings shared by the state-changing service methods. Extracted to constants so Sonar's duplicate-literal
+// rule (go:S1192) stays quiet AND wording changes propagate uniformly across CreateRule / UpdateRule / DeleteRule /
+// CreatePolicy / UpdatePolicy / DeletePolicy. Each is a fmt.Errorf format string wrapping a sentinel.
+const (
+	errSvcActorRequiredFmt   = "%w: actor is required"
+	errSvcSnapshotComposeFmt = "appcontrol snapshot compose: %w"
+)
+
 // CommandInserter is the closure cmd/main supplies so the application-control fan-out can enqueue `set_application_control` commands
 // per host. Method-value shape matches response.Service.Insert so cmd/main passes `responseCtx.Service().Insert` directly without an
 // adapter.
@@ -152,7 +160,7 @@ func (s *Service) CreateRule(
 	// closed at the service layer means a future caller that bypasses the handler (a CLI tool, a background job) can't silently produce an
 	// unattributed audit row.
 	if actor == nil {
-		return api.ApplicationControlRule{}, fmt.Errorf("%w: actor is required", api.ErrAppControlInvalidRequest)
+		return api.ApplicationControlRule{}, fmt.Errorf(errSvcActorRequiredFmt, api.ErrAppControlInvalidRequest)
 	}
 
 	rule, err := s.store.CreateRule(ctx, req)
@@ -170,7 +178,7 @@ func (s *Service) CreateRule(
 		s.emitAudit(ctx, actor, req, rule, 0, 0, 0, "snapshot_compose_failed")
 		s.logger.ErrorContext(ctx, "appcontrol: snapshot compose after CreateRule failed; rule is persisted but unenforced until next mutation",
 			"err", err, "policy_id", req.PolicyID, "rule_id", rule.ID)
-		return api.ApplicationControlRule{}, fmt.Errorf("appcontrol snapshot compose: %w", err)
+		return api.ApplicationControlRule{}, fmt.Errorf(errSvcSnapshotComposeFmt, err)
 	}
 
 	fanoutHosts, fanoutFailed, fanoutSkipReason := s.fanout(ctx, policy.ID, payload)
@@ -387,16 +395,31 @@ func (s *Service) emitAudit(
 	}
 }
 
-// recordAudit is the low-level audit emit the per-op helpers share. It centralises the nil-audit guard and the actor-id back-fill
-// so the per-op helpers focus on the payload shape rather than the boilerplate. Failed audit emission is logged but not returned;
-// audit is best-effort relative to the mutation that already committed (same posture as emitAudit's create-rule path).
+// recordAudit is the low-level audit emit the per-op helpers share. It centralises the nil-audit guard, the actor-id back-fill,
+// and the ActorEmail synthesis so per-op helpers focus on the payload shape rather than the boilerplate.
+//
+// Actor-id back-fill: when actor is non-nil with a positive UserID, the event's UserID pointer is set so the audit-recorder's
+// FK to users lands cleanly. The ActorEmail in the event is preferred when the caller supplied it (matching CreateRule's
+// req.Actor pass-through); otherwise a "user:<id>" identifier is synthesised so the event still attributes to a stable subject.
+//
+// Nil-audit visibility: when s.audit is nil the call drops the row but emits a WARN log per the NewService contract. Security
+// mutations otherwise lose their audit signal silently — the operator dashboard would show a normal mutation while the audit log
+// has nothing to correlate against, which is the failure mode CodeRabbit flagged on PR #188.
+//
+// Failed audit emission is logged but not returned; audit is best-effort relative to the mutation that already committed (same
+// posture as emitAudit's create-rule path).
 func (s *Service) recordAudit(ctx context.Context, actor *identityapi.Actor, evt identityapi.AuditEvent) {
-	if s.audit == nil {
-		return
-	}
-	if actor != nil {
+	if actor != nil && actor.UserID > 0 {
 		userID := actor.UserID
 		evt.UserID = &userID
+		if evt.ActorEmail == "" {
+			evt.ActorEmail = "user:" + strconv.FormatInt(actor.UserID, 10)
+		}
+	}
+	if s.audit == nil {
+		s.logger.WarnContext(ctx, "appcontrol: audit recorder is nil; dropping mutation audit row",
+			"action", string(evt.Action), "target_id", evt.TargetID)
+		return
 	}
 	if err := s.audit.Record(ctx, evt); err != nil {
 		s.logger.WarnContext(ctx, "appcontrol: audit record failed", "err", err, "target_id", evt.TargetID, "action", string(evt.Action))
@@ -408,7 +431,7 @@ func (s *Service) recordAudit(ctx context.Context, actor *identityapi.Actor, evt
 // errors propagate untouched so the handler can errors.Is on the shared IsApplicationControlValidationError set.
 func (s *Service) UpdateRule(ctx context.Context, req api.UpdateRuleRequest, actor *identityapi.Actor) (api.ApplicationControlRule, error) {
 	if actor == nil {
-		return api.ApplicationControlRule{}, fmt.Errorf("%w: actor is required", api.ErrAppControlInvalidRequest)
+		return api.ApplicationControlRule{}, fmt.Errorf(errSvcActorRequiredFmt, api.ErrAppControlInvalidRequest)
 	}
 	rule, err := s.store.UpdateRule(ctx, req)
 	if err != nil {
@@ -416,13 +439,20 @@ func (s *Service) UpdateRule(ctx context.Context, req api.UpdateRuleRequest, act
 	}
 	policy, payload, composeErr := s.buildSnapshotPayload(ctx, rule.PolicyID)
 	if composeErr != nil {
-		s.recordRuleMutationAudit(ctx, actor, identityapi.AuditAppControlRuleUpdate, rule, req.Reason, 0, 0, 0, "snapshot_compose_failed")
+		s.recordRuleMutationAudit(ctx, ruleMutationAuditArgs{
+			Action: identityapi.AuditAppControlRuleUpdate, Rule: rule, Actor: actor, ActorString: req.Actor,
+			Reason: req.Reason, FanoutSkipReason: "snapshot_compose_failed",
+		})
 		s.logger.ErrorContext(ctx, "appcontrol: snapshot compose after UpdateRule failed; rule mutation persisted but agents unaware until next mutation",
 			"err", composeErr, "policy_id", rule.PolicyID, "rule_id", rule.ID)
-		return api.ApplicationControlRule{}, fmt.Errorf("appcontrol snapshot compose: %w", composeErr)
+		return api.ApplicationControlRule{}, fmt.Errorf(errSvcSnapshotComposeFmt, composeErr)
 	}
 	fanoutHosts, fanoutFailed, fanoutSkipReason := s.fanout(ctx, policy.ID, payload)
-	s.recordRuleMutationAudit(ctx, actor, identityapi.AuditAppControlRuleUpdate, rule, req.Reason, policy.Version, fanoutHosts, fanoutFailed, fanoutSkipReason)
+	s.recordRuleMutationAudit(ctx, ruleMutationAuditArgs{
+		Action: identityapi.AuditAppControlRuleUpdate, Rule: rule, Actor: actor, ActorString: req.Actor,
+		Reason: req.Reason, PolicyVersion: policy.Version,
+		FanoutHosts: fanoutHosts, FanoutFailed: fanoutFailed, FanoutSkipReason: fanoutSkipReason,
+	})
 	return rule, nil
 }
 
@@ -431,7 +461,7 @@ func (s *Service) UpdateRule(ctx context.Context, req api.UpdateRuleRequest, act
 // audit payload references rule_type + identifier; reading after the DELETE would race with the cascade.
 func (s *Service) DeleteRule(ctx context.Context, req api.DeleteRuleRequest, actor *identityapi.Actor) error {
 	if actor == nil {
-		return fmt.Errorf("%w: actor is required", api.ErrAppControlInvalidRequest)
+		return fmt.Errorf(errSvcActorRequiredFmt, api.ErrAppControlInvalidRequest)
 	}
 	priorRule, err := s.store.GetRuleByID(ctx, req.RuleID)
 	if err != nil {
@@ -442,51 +472,60 @@ func (s *Service) DeleteRule(ctx context.Context, req api.DeleteRuleRequest, act
 	}
 	policy, payload, composeErr := s.buildSnapshotPayload(ctx, priorRule.PolicyID)
 	if composeErr != nil {
-		s.recordRuleMutationAudit(ctx, actor, identityapi.AuditAppControlRuleDelete, priorRule, req.Reason, 0, 0, 0, "snapshot_compose_failed")
+		s.recordRuleMutationAudit(ctx, ruleMutationAuditArgs{
+			Action: identityapi.AuditAppControlRuleDelete, Rule: priorRule, Actor: actor, ActorString: req.Actor,
+			Reason: req.Reason, FanoutSkipReason: "snapshot_compose_failed",
+		})
 		s.logger.ErrorContext(ctx, "appcontrol: snapshot compose after DeleteRule failed; agents still see the deleted rule until next mutation",
 			"err", composeErr, "policy_id", priorRule.PolicyID, "rule_id", priorRule.ID)
-		return fmt.Errorf("appcontrol snapshot compose: %w", composeErr)
+		return fmt.Errorf(errSvcSnapshotComposeFmt, composeErr)
 	}
 	fanoutHosts, fanoutFailed, fanoutSkipReason := s.fanout(ctx, policy.ID, payload)
-	s.recordRuleMutationAudit(ctx, actor, identityapi.AuditAppControlRuleDelete, priorRule, req.Reason, policy.Version, fanoutHosts, fanoutFailed, fanoutSkipReason)
+	s.recordRuleMutationAudit(ctx, ruleMutationAuditArgs{
+		Action: identityapi.AuditAppControlRuleDelete, Rule: priorRule, Actor: actor, ActorString: req.Actor,
+		Reason: req.Reason, PolicyVersion: policy.Version,
+		FanoutHosts: fanoutHosts, FanoutFailed: fanoutFailed, FanoutSkipReason: fanoutSkipReason,
+	})
 	return nil
 }
 
+// ruleMutationAuditArgs bundles the per-op inputs recordRuleMutationAudit needs. Struct shape rather than positional params so
+// Sonar's S107 (max 7 args) doesn't fire and the four caller sites stay readable. Each field is required; defaults are encoded
+// at the call site, not here.
+type ruleMutationAuditArgs struct {
+	Action           identityapi.AuditAction
+	Rule             api.ApplicationControlRule
+	Actor            *identityapi.Actor
+	ActorString      string // from req.Actor for consistency with CreateRule; recordAudit falls back to "user:<id>" if empty
+	Reason           string
+	PolicyVersion    int64
+	FanoutHosts      int
+	FanoutFailed     int
+	FanoutSkipReason string
+}
+
 // recordRuleMutationAudit is the per-op audit emitter for rule mutations (update + delete). Payload shape matches the create
-// flow's so SIEM dashboards can filter on the same key set across all three actions.
-func (s *Service) recordRuleMutationAudit(
-	ctx context.Context,
-	actor *identityapi.Actor,
-	action identityapi.AuditAction,
-	rule api.ApplicationControlRule,
-	reason string,
-	policyVersion int64,
-	fanoutHosts int,
-	fanoutFailed int,
-	fanoutSkipReason string,
-) {
+// flow's so SIEM dashboards can filter on the same key set across all three actions. Takes a struct (S107) so adding new fields
+// in Phase B's Detect-mode change (e.g. enforcement_before / enforcement_after) doesn't extend a positional argument list.
+func (s *Service) recordRuleMutationAudit(ctx context.Context, args ruleMutationAuditArgs) {
 	payload := map[string]any{
-		"policy_id":      rule.PolicyID,
-		"policy_version": policyVersion,
-		"rule_type":      string(rule.RuleType),
-		"identifier":     rule.Identifier,
-		"severity":       string(rule.Severity),
-		"reason":         reason,
-		"fanout_hosts":   fanoutHosts,
-		"fanout_failed":  fanoutFailed,
+		"policy_id":      args.Rule.PolicyID,
+		"policy_version": args.PolicyVersion,
+		"rule_type":      string(args.Rule.RuleType),
+		"identifier":     args.Rule.Identifier,
+		"severity":       string(args.Rule.Severity),
+		"reason":         args.Reason,
+		"fanout_hosts":   args.FanoutHosts,
+		"fanout_failed":  args.FanoutFailed,
 	}
-	if fanoutSkipReason != "" {
-		payload["fanout_skipped_reason"] = fanoutSkipReason
+	if args.FanoutSkipReason != "" {
+		payload["fanout_skipped_reason"] = args.FanoutSkipReason
 	}
-	actorIdentifier := ""
-	if actor != nil && actor.UserID > 0 {
-		actorIdentifier = "user:" + strconv.FormatInt(actor.UserID, 10)
-	}
-	s.recordAudit(ctx, actor, identityapi.AuditEvent{
-		Action:     action,
+	s.recordAudit(ctx, args.Actor, identityapi.AuditEvent{
+		Action:     args.Action,
 		TargetType: "application_control_rule",
-		TargetID:   strconv.FormatInt(rule.ID, 10),
-		ActorEmail: actorIdentifier,
+		TargetID:   strconv.FormatInt(args.Rule.ID, 10),
+		ActorEmail: args.ActorString,
 		Payload:    payload,
 	})
 }
@@ -496,13 +535,13 @@ func (s *Service) recordRuleMutationAudit(
 // the new policy id + name so an operator can trace the creation back to the request.
 func (s *Service) CreatePolicy(ctx context.Context, req api.CreatePolicyRequest, actor *identityapi.Actor) (api.ApplicationControlPolicy, error) {
 	if actor == nil {
-		return api.ApplicationControlPolicy{}, fmt.Errorf("%w: actor is required", api.ErrAppControlInvalidRequest)
+		return api.ApplicationControlPolicy{}, fmt.Errorf(errSvcActorRequiredFmt, api.ErrAppControlInvalidRequest)
 	}
 	policy, err := s.store.CreatePolicy(ctx, req)
 	if err != nil {
 		return api.ApplicationControlPolicy{}, err
 	}
-	s.recordPolicyMutationAudit(ctx, actor, identityapi.AuditAppControlPolicyCreate, policy, req.Reason)
+	s.recordPolicyMutationAudit(ctx, actor, req.Actor, identityapi.AuditAppControlPolicyCreate, policy, req.Reason)
 	return policy, nil
 }
 
@@ -511,13 +550,13 @@ func (s *Service) CreatePolicy(ctx context.Context, req api.CreatePolicyRequest,
 // reason so a future "who renamed Default to corp-default" question has a single source of truth.
 func (s *Service) UpdatePolicy(ctx context.Context, req api.UpdatePolicyRequest, actor *identityapi.Actor) (api.ApplicationControlPolicy, error) {
 	if actor == nil {
-		return api.ApplicationControlPolicy{}, fmt.Errorf("%w: actor is required", api.ErrAppControlInvalidRequest)
+		return api.ApplicationControlPolicy{}, fmt.Errorf(errSvcActorRequiredFmt, api.ErrAppControlInvalidRequest)
 	}
 	policy, err := s.store.UpdatePolicy(ctx, req)
 	if err != nil {
 		return api.ApplicationControlPolicy{}, err
 	}
-	s.recordPolicyMutationAudit(ctx, actor, identityapi.AuditAppControlPolicyUpdate, policy, req.Reason)
+	s.recordPolicyMutationAudit(ctx, actor, req.Actor, identityapi.AuditAppControlPolicyUpdate, policy, req.Reason)
 	return policy, nil
 }
 
@@ -527,7 +566,7 @@ func (s *Service) UpdatePolicy(ctx context.Context, req api.UpdatePolicyRequest,
 // deleted policy id + name so the deletion is reconstructable from the audit log alone.
 func (s *Service) DeletePolicy(ctx context.Context, req api.DeletePolicyRequest, actor *identityapi.Actor) error {
 	if actor == nil {
-		return fmt.Errorf("%w: actor is required", api.ErrAppControlInvalidRequest)
+		return fmt.Errorf(errSvcActorRequiredFmt, api.ErrAppControlInvalidRequest)
 	}
 	priorPolicy, err := s.findPolicyByID(ctx, req.PolicyID)
 	if err != nil {
@@ -536,29 +575,27 @@ func (s *Service) DeletePolicy(ctx context.Context, req api.DeletePolicyRequest,
 	if err := s.store.DeletePolicy(ctx, req); err != nil {
 		return err
 	}
-	s.recordPolicyMutationAudit(ctx, actor, identityapi.AuditAppControlPolicyDelete, priorPolicy, req.Reason)
+	s.recordPolicyMutationAudit(ctx, actor, req.Actor, identityapi.AuditAppControlPolicyDelete, priorPolicy, req.Reason)
 	return nil
 }
 
 // recordPolicyMutationAudit is the per-op audit emitter for policy mutations (create + update + delete). Payload mirrors the
 // rule-mutation shape modulo fan-out fields (no fan-out on policy mutations in Phase A) so the dashboard query language stays
-// consistent across action types.
+// consistent across action types. ActorString comes from req.Actor (matching CreateRule's pass-through); recordAudit falls back
+// to a synthesised "user:<id>" identifier when actorString is empty so the row still attributes to a stable subject.
 func (s *Service) recordPolicyMutationAudit(
 	ctx context.Context,
 	actor *identityapi.Actor,
+	actorString string,
 	action identityapi.AuditAction,
 	policy api.ApplicationControlPolicy,
 	reason string,
 ) {
-	actorIdentifier := ""
-	if actor != nil && actor.UserID > 0 {
-		actorIdentifier = "user:" + strconv.FormatInt(actor.UserID, 10)
-	}
 	s.recordAudit(ctx, actor, identityapi.AuditEvent{
 		Action:     action,
 		TargetType: "application_control_policy",
 		TargetID:   strconv.FormatInt(policy.ID, 10),
-		ActorEmail: actorIdentifier,
+		ActorEmail: actorString,
 		Payload: map[string]any{
 			"policy_id":      policy.ID,
 			"policy_name":    policy.Name,

--- a/server/rules/internal/appcontrol/service_test.go
+++ b/server/rules/internal/appcontrol/service_test.go
@@ -375,3 +375,92 @@ func TestService_Fanout_PartialFailureAuditsHostListerError(t *testing.T) {
 	assert.Equal(t, "host_lister_error", payload["fanout_skipped_reason"], "any resolver error must surface even when some hosts succeed")
 	assert.EqualValues(t, 1, payload["fanout_hosts"], "successful group's hosts still get enqueued")
 }
+
+// TestService_UpdateRule_FansOutAndAudits pins the PATCH path's contract: the post-update snapshot reaches every assigned host
+// (the seeded all-hosts group) and the audit row records rule_update with the post-bump policy version + fanout counts.
+func TestService_UpdateRule_FansOutAndAudits(t *testing.T) {
+	svc, store, _, audit := newServiceWithHostsAndAudit(t, func(context.Context) ([]string, error) {
+		return []string{"host-a", "host-b"}, nil
+	})
+	ctx := t.Context()
+	policy, err := store.GetPolicyByName(ctx, api.DefaultPolicyName)
+	require.NoError(t, err)
+	rule, err := svc.CreateRule(ctx, api.CreateRuleRequest{
+		PolicyID:   policy.ID,
+		RuleType:   api.RuleTypeBinary,
+		Identifier: strings.Repeat("1", 64),
+		Severity:   api.SeverityRuleMedium,
+		Actor:      "user:7",
+		Reason:     "fixture for update",
+	}, newAdmin())
+	require.NoError(t, err)
+	versionAfterCreate := policy.Version + 1 // CreateRule bumps once
+
+	enabled := false
+	updated, err := svc.UpdateRule(ctx, api.UpdateRuleRequest{
+		RuleID:  rule.ID,
+		Enabled: &enabled,
+		Actor:   "user:7",
+		Reason:  "disable rule",
+	}, newAdmin())
+	require.NoError(t, err)
+	assert.False(t, updated.Enabled)
+
+	payload := fanoutAuditPayloadFor(t, audit)
+	assert.EqualValues(t, versionAfterCreate+1, payload["policy_version"], "PATCH must bump version again")
+	assert.EqualValues(t, 2, payload["fanout_hosts"], "snapshot fans out to all hosts on update")
+}
+
+// TestService_DeleteRule_FansOutAndAudits pins the DELETE path: the rule is gone, the post-delete snapshot reaches every host so
+// agents drop the now-missing rule on their next apply, and the audit row captures the prior rule's type/identifier so the SIEM
+// query "what rule was deleted at <timestamp>" has a single source of truth.
+func TestService_DeleteRule_FansOutAndAudits(t *testing.T) {
+	svc, store, _, audit := newServiceWithHostsAndAudit(t, func(context.Context) ([]string, error) {
+		return []string{"host-a"}, nil
+	})
+	ctx := t.Context()
+	policy, err := store.GetPolicyByName(ctx, api.DefaultPolicyName)
+	require.NoError(t, err)
+	rule, err := svc.CreateRule(ctx, api.CreateRuleRequest{
+		PolicyID:   policy.ID,
+		RuleType:   api.RuleTypeBinary,
+		Identifier: strings.Repeat("2", 64),
+		Severity:   api.SeverityRuleMedium,
+		Actor:      "user:7",
+		Reason:     "fixture for delete",
+	}, newAdmin())
+	require.NoError(t, err)
+	versionAfterCreate := policy.Version + 1
+
+	require.NoError(t, svc.DeleteRule(ctx, api.DeleteRuleRequest{
+		RuleID: rule.ID, Actor: "user:7", Reason: "remove after triage",
+	}, newAdmin()))
+
+	payload := fanoutAuditPayloadFor(t, audit)
+	assert.EqualValues(t, versionAfterCreate+1, payload["policy_version"], "DELETE must bump version")
+	assert.Equal(t, "BINARY", payload["rule_type"], "audit captures the prior rule type")
+	assert.Equal(t, strings.Repeat("2", 64), payload["identifier"], "audit captures the prior rule identifier")
+	assert.EqualValues(t, 1, payload["fanout_hosts"], "post-delete snapshot fans out so agents drop the removed rule")
+}
+
+// TestService_CreatePolicy_AuditsAndDoesNotFanOut confirms POST /policies records the audit with policy_create action AND that
+// no fanout runs (no rules yet, no hosts to push to). Distinct from the rule paths so the SIEM dashboard can filter "policy
+// scoped audit" cleanly.
+func TestService_CreatePolicy_AuditsAndDoesNotFanOut(t *testing.T) {
+	hostListerCalls := 0
+	svc, _, _, audit := newServiceWithHostsAndAudit(t, func(context.Context) ([]string, error) {
+		hostListerCalls++
+		return []string{"host-a"}, nil
+	})
+	policy, err := svc.CreatePolicy(t.Context(), api.CreatePolicyRequest{
+		Name: "new-policy", Description: "test", Actor: "user:7", Reason: "create",
+	}, newAdmin())
+	require.NoError(t, err)
+	assert.NotZero(t, policy.ID)
+	assert.Equal(t, 0, hostListerCalls, "POST /policies must not fan out (no rules, no assignments)")
+
+	events := audit.snapshot()
+	require.Len(t, events, 1)
+	assert.Equal(t, identityapi.AuditAppControlPolicyCreate, events[0].Action)
+	assert.Equal(t, "application_control_policy", events[0].TargetType)
+}

--- a/server/rules/internal/appcontrol/store.go
+++ b/server/rules/internal/appcontrol/store.go
@@ -12,6 +12,16 @@ import (
 	"github.com/fleetdm/edr/server/rules/api"
 )
 
+// Error-message format strings shared by every state-changing store method. Extracted to constants so Sonar's duplicate-literal rule
+// (go:S1192) stays quiet AND so a wording change here propagates uniformly across CreateRule / UpdateRule / DeleteRule / CreatePolicy
+// / UpdatePolicy / DeletePolicy. Each is a fmt.Errorf format string for wrapping api.ErrAppControlInvalidRequest.
+const (
+	errActorRequiredFmt  = "%w: actor is required"
+	errReasonRequiredFmt = "%w: reason is required"
+	errBeginTxFmt        = "appcontrol begin tx: %w"
+	errCommitTxFmt       = "appcontrol commit tx: %w"
+)
+
 // Store wraps the *sqlx.DB handle for the app_control_policies + app_control_rules tables. Constructed once by the rules bootstrap and
 // shared across the REST handler, the fan-out path, and tests. Satisfies api.ApplicationControlStore.
 type Store struct {
@@ -207,10 +217,10 @@ func (s *Store) ListRulesByPolicy(ctx context.Context, policyID int64) ([]api.Ap
 // REST layer can map cleanly to HTTP 404 instead of 500).
 func (s *Store) CreateRule(ctx context.Context, req api.CreateRuleRequest) (api.ApplicationControlRule, error) {
 	if strings.TrimSpace(req.Actor) == "" {
-		return api.ApplicationControlRule{}, fmt.Errorf("%w: actor is required", api.ErrAppControlInvalidRequest)
+		return api.ApplicationControlRule{}, fmt.Errorf(errActorRequiredFmt, api.ErrAppControlInvalidRequest)
 	}
 	if strings.TrimSpace(req.Reason) == "" {
-		return api.ApplicationControlRule{}, fmt.Errorf("%w: reason is required", api.ErrAppControlInvalidRequest)
+		return api.ApplicationControlRule{}, fmt.Errorf(errReasonRequiredFmt, api.ErrAppControlInvalidRequest)
 	}
 	if err := ValidateRuleType(req.RuleType); err != nil {
 		return api.ApplicationControlRule{}, err
@@ -228,7 +238,7 @@ func (s *Store) CreateRule(ctx context.Context, req api.CreateRuleRequest) (api.
 
 	tx, err := s.db.BeginTxx(ctx, nil)
 	if err != nil {
-		return api.ApplicationControlRule{}, fmt.Errorf("appcontrol begin tx: %w", err)
+		return api.ApplicationControlRule{}, fmt.Errorf(errBeginTxFmt, err)
 	}
 	// Deferred rollback is a no-op once Commit has run; the early
 	// returns below leave the transaction to roll back here.
@@ -264,7 +274,7 @@ func (s *Store) CreateRule(ctx context.Context, req api.CreateRuleRequest) (api.
 		return api.ApplicationControlRule{}, fmt.Errorf("appcontrol bump policy version: %w", err)
 	}
 	if err := tx.Commit(); err != nil {
-		return api.ApplicationControlRule{}, fmt.Errorf("appcontrol commit tx: %w", err)
+		return api.ApplicationControlRule{}, fmt.Errorf(errCommitTxFmt, err)
 	}
 	return s.getRuleByID(ctx, ruleID)
 }
@@ -283,53 +293,20 @@ func (s *Store) GetRuleByID(ctx context.Context, id int64) (api.ApplicationContr
 	return rule, nil
 }
 
-// UpdateRule applies a partial update to one rule row and bumps the parent policy's version atomically. PolicyID is read from the
-// existing row rather than carried on the request so a PATCH cannot inadvertently move a rule between policies; the auth-gated
-// REST handler runs separately. ErrAppControlRuleNotFound when the row is missing, ErrAppControlInvalidRequest on empty
-// actor/reason, ErrAppControlInvalidSeverity when Severity is set to a bogus value.
-func (s *Store) UpdateRule(ctx context.Context, req api.UpdateRuleRequest) (api.ApplicationControlRule, error) {
-	if strings.TrimSpace(req.Actor) == "" {
-		return api.ApplicationControlRule{}, fmt.Errorf("%w: actor is required", api.ErrAppControlInvalidRequest)
-	}
-	if strings.TrimSpace(req.Reason) == "" {
-		return api.ApplicationControlRule{}, fmt.Errorf("%w: reason is required", api.ErrAppControlInvalidRequest)
-	}
-	if req.Severity != nil {
-		if err := ValidateSeverity(*req.Severity); err != nil {
-			return api.ApplicationControlRule{}, err
-		}
-		// ValidateSeverity accepts "" as "use default"; on UPDATE the operator must send a concrete value or omit the field.
-		if strings.TrimSpace(string(*req.Severity)) == "" {
-			return api.ApplicationControlRule{}, fmt.Errorf("%w: severity must be a non-empty enum value when present on a PATCH", api.ErrAppControlInvalidSeverity)
-		}
-	}
-
-	tx, err := s.db.BeginTxx(ctx, nil)
-	if err != nil {
-		return api.ApplicationControlRule{}, fmt.Errorf("appcontrol begin tx: %w", err)
-	}
-	defer func() { _ = tx.Rollback() }()
-
-	// Look up the existing row so we know which policy to bump and so we can return a 404 instead of silently updating zero rows.
-	var policyID int64
-	if err := tx.QueryRowxContext(ctx, `SELECT policy_id FROM app_control_rules WHERE id = ?`, req.RuleID).Scan(&policyID); err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return api.ApplicationControlRule{}, api.ErrAppControlRuleNotFound
-		}
-		return api.ApplicationControlRule{}, fmt.Errorf("appcontrol lookup rule for update: %w", err)
-	}
-
-	// Build the SET clause from the fields the caller actually sent. The pointer-or-nil shape of UpdateRuleRequest lets us tell
-	// "omitted" apart from "explicitly cleared" (e.g. clearing custom_msg by sending an explicit empty string).
+// buildRuleUpdateSetClause renders the SET-clause fragment + args slice for the partial-update fields the caller set in req.
+// Extracted from UpdateRule so the orchestrator's cognitive complexity stays under Sonar's 15-statement threshold (S3776).
+// Returns (clauseFragment, args, ok); ok is false when the caller sent zero mutable fields — the caller maps that to
+// ErrAppControlInvalidRequest at the top level.
+func buildRuleUpdateSetClause(req api.UpdateRuleRequest) (string, []any, bool) {
 	setClauses := make([]string, 0, 6)
 	args := make([]any, 0, 7)
 	if req.Enabled != nil {
 		setClauses = append(setClauses, "enabled = ?")
+		enabledInt := 0
 		if *req.Enabled {
-			args = append(args, 1)
-		} else {
-			args = append(args, 0)
+			enabledInt = 1
 		}
+		args = append(args, enabledInt)
 	}
 	if req.Severity != nil {
 		setClauses = append(setClauses, "severity = ?")
@@ -352,20 +329,85 @@ func (s *Store) UpdateRule(ctx context.Context, req api.UpdateRuleRequest) (api.
 		args = append(args, *req.ExpiresAt)
 	}
 	if len(setClauses) == 0 {
+		return "", nil, false
+	}
+	return strings.Join(setClauses, ", "), args, true
+}
+
+// validateUpdateRuleRequest covers the up-front guards: actor + reason required, severity (if present) must be a non-empty
+// enum value. Extracted so UpdateRule's body stays linear and Sonar's cognitive-complexity rule (S3776) does not fire.
+func validateUpdateRuleRequest(req api.UpdateRuleRequest) error {
+	if strings.TrimSpace(req.Actor) == "" {
+		return fmt.Errorf(errActorRequiredFmt, api.ErrAppControlInvalidRequest)
+	}
+	if strings.TrimSpace(req.Reason) == "" {
+		return fmt.Errorf(errReasonRequiredFmt, api.ErrAppControlInvalidRequest)
+	}
+	if req.Severity != nil {
+		if err := ValidateSeverity(*req.Severity); err != nil {
+			return err
+		}
+		// ValidateSeverity accepts "" as "use default"; on UPDATE the operator must send a concrete value or omit the field.
+		if strings.TrimSpace(string(*req.Severity)) == "" {
+			return fmt.Errorf("%w: severity must be a non-empty enum value when present on a PATCH", api.ErrAppControlInvalidSeverity)
+		}
+	}
+	return nil
+}
+
+// UpdateRule applies a partial update to one rule row and bumps the parent policy's version atomically. PolicyID is read from the
+// existing row rather than carried on the request so a PATCH cannot inadvertently move a rule between policies; the auth-gated
+// REST handler runs separately. ErrAppControlRuleNotFound when the row is missing, ErrAppControlInvalidRequest on empty
+// actor/reason or a body with no mutable field, ErrAppControlInvalidSeverity when Severity is set to a bogus value.
+//
+// Concurrency: the UPDATE result's RowsAffected is gated to 1 so a concurrent DELETE between the SELECT and the UPDATE returns
+// ErrAppControlRuleNotFound rather than silently bumping the policy version (which would trigger a spurious snapshot fan-out).
+func (s *Store) UpdateRule(ctx context.Context, req api.UpdateRuleRequest) (api.ApplicationControlRule, error) {
+	if err := validateUpdateRuleRequest(req); err != nil {
+		return api.ApplicationControlRule{}, err
+	}
+	setFragment, args, ok := buildRuleUpdateSetClause(req)
+	if !ok {
 		return api.ApplicationControlRule{}, fmt.Errorf("%w: at least one mutable field must be set on a PATCH", api.ErrAppControlInvalidRequest)
 	}
 
+	tx, err := s.db.BeginTxx(ctx, nil)
+	if err != nil {
+		return api.ApplicationControlRule{}, fmt.Errorf(errBeginTxFmt, err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	// Look up the existing row so we know which policy to bump and so we can return a 404 instead of silently updating zero rows.
+	var policyID int64
+	if err := tx.QueryRowxContext(ctx, `SELECT policy_id FROM app_control_rules WHERE id = ?`, req.RuleID).Scan(&policyID); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return api.ApplicationControlRule{}, api.ErrAppControlRuleNotFound
+		}
+		return api.ApplicationControlRule{}, fmt.Errorf("appcontrol lookup rule for update: %w", err)
+	}
+
 	args = append(args, req.RuleID)
-	updateSQL := "UPDATE app_control_rules SET " + strings.Join(setClauses, ", ") + " WHERE id = ?"
-	if _, err := tx.ExecContext(ctx, updateSQL, args...); err != nil {
+	updateSQL := "UPDATE app_control_rules SET " + setFragment + " WHERE id = ?"
+	res, err := tx.ExecContext(ctx, updateSQL, args...)
+	if err != nil {
 		return api.ApplicationControlRule{}, fmt.Errorf("appcontrol update rule: %w", err)
+	}
+	// Concurrent delete race: the SELECT above passed but the UPDATE hit zero rows because another transaction removed the row
+	// between the two statements. Fail with ErrAppControlRuleNotFound so the caller sees a stable 404 — without this, the policy
+	// version bump below would still fire, triggering a spurious snapshot push to every agent.
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return api.ApplicationControlRule{}, fmt.Errorf("appcontrol update rule rows affected: %w", err)
+	}
+	if affected == 0 {
+		return api.ApplicationControlRule{}, api.ErrAppControlRuleNotFound
 	}
 	if _, err := tx.ExecContext(ctx, `UPDATE app_control_policies SET version = version + 1, updated_by = ? WHERE id = ?`,
 		req.Actor, policyID); err != nil {
 		return api.ApplicationControlRule{}, fmt.Errorf("appcontrol bump policy version on update: %w", err)
 	}
 	if err := tx.Commit(); err != nil {
-		return api.ApplicationControlRule{}, fmt.Errorf("appcontrol commit tx: %w", err)
+		return api.ApplicationControlRule{}, fmt.Errorf(errCommitTxFmt, err)
 	}
 	return s.GetRuleByID(ctx, req.RuleID)
 }
@@ -374,15 +416,15 @@ func (s *Store) UpdateRule(ctx context.Context, req api.UpdateRuleRequest) (api.
 // downstream snapshot fan-out targets the right policy. ErrAppControlRuleNotFound when the row is missing.
 func (s *Store) DeleteRule(ctx context.Context, req api.DeleteRuleRequest) (int64, error) {
 	if strings.TrimSpace(req.Actor) == "" {
-		return 0, fmt.Errorf("%w: actor is required", api.ErrAppControlInvalidRequest)
+		return 0, fmt.Errorf(errActorRequiredFmt, api.ErrAppControlInvalidRequest)
 	}
 	if strings.TrimSpace(req.Reason) == "" {
-		return 0, fmt.Errorf("%w: reason is required", api.ErrAppControlInvalidRequest)
+		return 0, fmt.Errorf(errReasonRequiredFmt, api.ErrAppControlInvalidRequest)
 	}
 
 	tx, err := s.db.BeginTxx(ctx, nil)
 	if err != nil {
-		return 0, fmt.Errorf("appcontrol begin tx: %w", err)
+		return 0, fmt.Errorf(errBeginTxFmt, err)
 	}
 	defer func() { _ = tx.Rollback() }()
 
@@ -393,15 +435,26 @@ func (s *Store) DeleteRule(ctx context.Context, req api.DeleteRuleRequest) (int6
 		}
 		return 0, fmt.Errorf("appcontrol lookup rule for delete: %w", err)
 	}
-	if _, err := tx.ExecContext(ctx, `DELETE FROM app_control_rules WHERE id = ?`, req.RuleID); err != nil {
+	res, err := tx.ExecContext(ctx, `DELETE FROM app_control_rules WHERE id = ?`, req.RuleID)
+	if err != nil {
 		return 0, fmt.Errorf("appcontrol delete rule: %w", err)
+	}
+	// Concurrent delete race: same shape as UpdateRule. If another transaction removed the row between the SELECT and the DELETE,
+	// affected will be 0 — fail with ErrAppControlRuleNotFound so the policy version bump below does not fire and trigger a
+	// no-op snapshot push.
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("appcontrol delete rule rows affected: %w", err)
+	}
+	if affected == 0 {
+		return 0, api.ErrAppControlRuleNotFound
 	}
 	if _, err := tx.ExecContext(ctx, `UPDATE app_control_policies SET version = version + 1, updated_by = ? WHERE id = ?`,
 		req.Actor, policyID); err != nil {
 		return 0, fmt.Errorf("appcontrol bump policy version on delete: %w", err)
 	}
 	if err := tx.Commit(); err != nil {
-		return 0, fmt.Errorf("appcontrol commit tx: %w", err)
+		return 0, fmt.Errorf(errCommitTxFmt, err)
 	}
 	return policyID, nil
 }
@@ -410,10 +463,10 @@ func (s *Store) DeleteRule(ctx context.Context, req api.DeleteRuleRequest) (int6
 // Phase A has no assignments wired in to a fresh policy; the operator attaches host groups via the assignments endpoint (Phase B).
 func (s *Store) CreatePolicy(ctx context.Context, req api.CreatePolicyRequest) (api.ApplicationControlPolicy, error) {
 	if strings.TrimSpace(req.Actor) == "" {
-		return api.ApplicationControlPolicy{}, fmt.Errorf("%w: actor is required", api.ErrAppControlInvalidRequest)
+		return api.ApplicationControlPolicy{}, fmt.Errorf(errActorRequiredFmt, api.ErrAppControlInvalidRequest)
 	}
 	if strings.TrimSpace(req.Reason) == "" {
-		return api.ApplicationControlPolicy{}, fmt.Errorf("%w: reason is required", api.ErrAppControlInvalidRequest)
+		return api.ApplicationControlPolicy{}, fmt.Errorf(errReasonRequiredFmt, api.ErrAppControlInvalidRequest)
 	}
 	if strings.TrimSpace(req.Name) == "" {
 		return api.ApplicationControlPolicy{}, fmt.Errorf("%w: policy name is required", api.ErrAppControlInvalidRequest)
@@ -436,14 +489,38 @@ func (s *Store) CreatePolicy(ctx context.Context, req api.CreatePolicyRequest) (
 
 // UpdatePolicy applies a partial update (name and/or description) to a policy row, bumps version, and sets updated_by. Returns
 // ErrAppControlPolicyNotFound when the id is missing; ErrAppControlDuplicatePolicy if the new name collides with another row;
-// ErrAppControlInvalidRequest when no mutable field is provided.
+// ErrAppControlInvalidRequest when no mutable field is provided; ErrAppControlPolicyImmutable if the caller tries to rename the
+// seed Default policy (closing the Copilot-flagged bypass where a rename-then-delete would defeat the immutability guard).
 func (s *Store) UpdatePolicy(ctx context.Context, req api.UpdatePolicyRequest) (api.ApplicationControlPolicy, error) {
 	if strings.TrimSpace(req.Actor) == "" {
-		return api.ApplicationControlPolicy{}, fmt.Errorf("%w: actor is required", api.ErrAppControlInvalidRequest)
+		return api.ApplicationControlPolicy{}, fmt.Errorf(errActorRequiredFmt, api.ErrAppControlInvalidRequest)
 	}
 	if strings.TrimSpace(req.Reason) == "" {
-		return api.ApplicationControlPolicy{}, fmt.Errorf("%w: reason is required", api.ErrAppControlInvalidRequest)
+		return api.ApplicationControlPolicy{}, fmt.Errorf(errReasonRequiredFmt, api.ErrAppControlInvalidRequest)
 	}
+
+	tx, err := s.db.BeginTxx(ctx, nil)
+	if err != nil {
+		return api.ApplicationControlPolicy{}, fmt.Errorf(errBeginTxFmt, err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	// Look up the existing name inside the txn so the rename guard sees a consistent view: a concurrent rename cannot squeeze
+	// between the SELECT and the UPDATE because both run under the same transaction's repeatable-read snapshot.
+	var existingName string
+	if err := tx.QueryRowxContext(ctx, `SELECT name FROM app_control_policies WHERE id = ?`, req.PolicyID).Scan(&existingName); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return api.ApplicationControlPolicy{}, api.ErrAppControlPolicyNotFound
+		}
+		return api.ApplicationControlPolicy{}, fmt.Errorf("appcontrol lookup policy for update: %w", err)
+	}
+	// Failsafe: refuse to rename the seed Default policy. Without this, an admin could rename Default to "x" and then DELETE it,
+	// since DeletePolicy's immutability check fires on the current name. The seed policy's name is the stable anchor for the
+	// `all-hosts` assignment that every deployment inherits at boot.
+	if req.Name != nil && existingName == api.DefaultPolicyName && *req.Name != api.DefaultPolicyName {
+		return api.ApplicationControlPolicy{}, api.ErrAppControlPolicyImmutable
+	}
+
 	setClauses := make([]string, 0, 2)
 	args := make([]any, 0, 3)
 	if req.Name != nil {
@@ -463,7 +540,7 @@ func (s *Store) UpdatePolicy(ctx context.Context, req api.UpdatePolicyRequest) (
 	setClauses = append(setClauses, "version = version + 1", "updated_by = ?")
 	args = append(args, req.Actor, req.PolicyID)
 	updateSQL := "UPDATE app_control_policies SET " + strings.Join(setClauses, ", ") + " WHERE id = ?"
-	res, err := s.db.ExecContext(ctx, updateSQL, args...)
+	res, err := tx.ExecContext(ctx, updateSQL, args...)
 	if err != nil {
 		if isDuplicateKey(err) {
 			return api.ApplicationControlPolicy{}, api.ErrAppControlDuplicatePolicy
@@ -477,6 +554,9 @@ func (s *Store) UpdatePolicy(ctx context.Context, req api.UpdatePolicyRequest) (
 	if affected == 0 {
 		return api.ApplicationControlPolicy{}, api.ErrAppControlPolicyNotFound
 	}
+	if err := tx.Commit(); err != nil {
+		return api.ApplicationControlPolicy{}, fmt.Errorf(errCommitTxFmt, err)
+	}
 	return s.getPolicyByID(ctx, req.PolicyID)
 }
 
@@ -486,15 +566,15 @@ func (s *Store) UpdatePolicy(ctx context.Context, req api.UpdatePolicyRequest) (
 // only ever has the Default policy assigned to hosts so a non-Default delete affects zero hosts in practice.
 func (s *Store) DeletePolicy(ctx context.Context, req api.DeletePolicyRequest) error {
 	if strings.TrimSpace(req.Actor) == "" {
-		return fmt.Errorf("%w: actor is required", api.ErrAppControlInvalidRequest)
+		return fmt.Errorf(errActorRequiredFmt, api.ErrAppControlInvalidRequest)
 	}
 	if strings.TrimSpace(req.Reason) == "" {
-		return fmt.Errorf("%w: reason is required", api.ErrAppControlInvalidRequest)
+		return fmt.Errorf(errReasonRequiredFmt, api.ErrAppControlInvalidRequest)
 	}
 
 	tx, err := s.db.BeginTxx(ctx, nil)
 	if err != nil {
-		return fmt.Errorf("appcontrol begin tx: %w", err)
+		return fmt.Errorf(errBeginTxFmt, err)
 	}
 	defer func() { _ = tx.Rollback() }()
 
@@ -512,13 +592,14 @@ func (s *Store) DeletePolicy(ctx context.Context, req api.DeletePolicyRequest) e
 		return fmt.Errorf("appcontrol delete policy: %w", err)
 	}
 	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("appcontrol commit tx: %w", err)
+		return fmt.Errorf(errCommitTxFmt, err)
 	}
 	return nil
 }
 
-// getPolicyByID is the internal lookup the create/update paths use to return the post-mutation row. Returns sql.ErrNoRows wrapped
-// directly when the id is missing; callers translate to ErrAppControlPolicyNotFound where appropriate.
+// getPolicyByID is the internal lookup the create/update paths use to return the post-mutation row. The missing-row case is
+// translated to api.ErrAppControlPolicyNotFound inside this helper (mirroring GetRuleByID's contract); callers can errors.Is
+// directly without unwrapping a driver-level sql.ErrNoRows.
 func (s *Store) getPolicyByID(ctx context.Context, id int64) (api.ApplicationControlPolicy, error) {
 	const query = `SELECT id, name, description, version, default_action, created_at, updated_at, created_by, updated_by
 		FROM app_control_policies WHERE id = ?`

--- a/server/rules/internal/appcontrol/store.go
+++ b/server/rules/internal/appcontrol/store.go
@@ -269,6 +269,273 @@ func (s *Store) CreateRule(ctx context.Context, req api.CreateRuleRequest) (api.
 	return s.getRuleByID(ctx, ruleID)
 }
 
+// GetRuleByID returns one rule row keyed by id, mapping a missing row to ErrAppControlRuleNotFound so the REST PATCH / DELETE
+// handlers can respond 404 cleanly. Public wrapper around getRuleByID (which historically only the post-INSERT path called); the
+// underlying query is the same.
+func (s *Store) GetRuleByID(ctx context.Context, id int64) (api.ApplicationControlRule, error) {
+	rule, err := s.getRuleByID(ctx, id)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return api.ApplicationControlRule{}, api.ErrAppControlRuleNotFound
+		}
+		return api.ApplicationControlRule{}, err
+	}
+	return rule, nil
+}
+
+// UpdateRule applies a partial update to one rule row and bumps the parent policy's version atomically. PolicyID is read from the
+// existing row rather than carried on the request so a PATCH cannot inadvertently move a rule between policies; the auth-gated
+// REST handler runs separately. ErrAppControlRuleNotFound when the row is missing, ErrAppControlInvalidRequest on empty
+// actor/reason, ErrAppControlInvalidSeverity when Severity is set to a bogus value.
+func (s *Store) UpdateRule(ctx context.Context, req api.UpdateRuleRequest) (api.ApplicationControlRule, error) {
+	if strings.TrimSpace(req.Actor) == "" {
+		return api.ApplicationControlRule{}, fmt.Errorf("%w: actor is required", api.ErrAppControlInvalidRequest)
+	}
+	if strings.TrimSpace(req.Reason) == "" {
+		return api.ApplicationControlRule{}, fmt.Errorf("%w: reason is required", api.ErrAppControlInvalidRequest)
+	}
+	if req.Severity != nil {
+		if err := ValidateSeverity(*req.Severity); err != nil {
+			return api.ApplicationControlRule{}, err
+		}
+		// ValidateSeverity accepts "" as "use default"; on UPDATE the operator must send a concrete value or omit the field.
+		if strings.TrimSpace(string(*req.Severity)) == "" {
+			return api.ApplicationControlRule{}, fmt.Errorf("%w: severity must be a non-empty enum value when present on a PATCH", api.ErrAppControlInvalidSeverity)
+		}
+	}
+
+	tx, err := s.db.BeginTxx(ctx, nil)
+	if err != nil {
+		return api.ApplicationControlRule{}, fmt.Errorf("appcontrol begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	// Look up the existing row so we know which policy to bump and so we can return a 404 instead of silently updating zero rows.
+	var policyID int64
+	if err := tx.QueryRowxContext(ctx, `SELECT policy_id FROM app_control_rules WHERE id = ?`, req.RuleID).Scan(&policyID); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return api.ApplicationControlRule{}, api.ErrAppControlRuleNotFound
+		}
+		return api.ApplicationControlRule{}, fmt.Errorf("appcontrol lookup rule for update: %w", err)
+	}
+
+	// Build the SET clause from the fields the caller actually sent. The pointer-or-nil shape of UpdateRuleRequest lets us tell
+	// "omitted" apart from "explicitly cleared" (e.g. clearing custom_msg by sending an explicit empty string).
+	setClauses := make([]string, 0, 6)
+	args := make([]any, 0, 7)
+	if req.Enabled != nil {
+		setClauses = append(setClauses, "enabled = ?")
+		if *req.Enabled {
+			args = append(args, 1)
+		} else {
+			args = append(args, 0)
+		}
+	}
+	if req.Severity != nil {
+		setClauses = append(setClauses, "severity = ?")
+		args = append(args, *req.Severity)
+	}
+	if req.CustomMsg != nil {
+		setClauses = append(setClauses, "custom_msg = ?")
+		args = append(args, *req.CustomMsg)
+	}
+	if req.CustomURL != nil {
+		setClauses = append(setClauses, "custom_url = ?")
+		args = append(args, *req.CustomURL)
+	}
+	if req.Comment != nil {
+		setClauses = append(setClauses, "comment = ?")
+		args = append(args, *req.Comment)
+	}
+	if req.ExpiresAt != nil {
+		setClauses = append(setClauses, "expires_at = ?")
+		args = append(args, *req.ExpiresAt)
+	}
+	if len(setClauses) == 0 {
+		return api.ApplicationControlRule{}, fmt.Errorf("%w: at least one mutable field must be set on a PATCH", api.ErrAppControlInvalidRequest)
+	}
+
+	args = append(args, req.RuleID)
+	updateSQL := "UPDATE app_control_rules SET " + strings.Join(setClauses, ", ") + " WHERE id = ?"
+	if _, err := tx.ExecContext(ctx, updateSQL, args...); err != nil {
+		return api.ApplicationControlRule{}, fmt.Errorf("appcontrol update rule: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `UPDATE app_control_policies SET version = version + 1, updated_by = ? WHERE id = ?`,
+		req.Actor, policyID); err != nil {
+		return api.ApplicationControlRule{}, fmt.Errorf("appcontrol bump policy version on update: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return api.ApplicationControlRule{}, fmt.Errorf("appcontrol commit tx: %w", err)
+	}
+	return s.GetRuleByID(ctx, req.RuleID)
+}
+
+// DeleteRule removes a rule row + bumps the parent policy's version atomically. Returns the parent policy_id so the service's
+// downstream snapshot fan-out targets the right policy. ErrAppControlRuleNotFound when the row is missing.
+func (s *Store) DeleteRule(ctx context.Context, req api.DeleteRuleRequest) (int64, error) {
+	if strings.TrimSpace(req.Actor) == "" {
+		return 0, fmt.Errorf("%w: actor is required", api.ErrAppControlInvalidRequest)
+	}
+	if strings.TrimSpace(req.Reason) == "" {
+		return 0, fmt.Errorf("%w: reason is required", api.ErrAppControlInvalidRequest)
+	}
+
+	tx, err := s.db.BeginTxx(ctx, nil)
+	if err != nil {
+		return 0, fmt.Errorf("appcontrol begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	var policyID int64
+	if err := tx.QueryRowxContext(ctx, `SELECT policy_id FROM app_control_rules WHERE id = ?`, req.RuleID).Scan(&policyID); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return 0, api.ErrAppControlRuleNotFound
+		}
+		return 0, fmt.Errorf("appcontrol lookup rule for delete: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM app_control_rules WHERE id = ?`, req.RuleID); err != nil {
+		return 0, fmt.Errorf("appcontrol delete rule: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `UPDATE app_control_policies SET version = version + 1, updated_by = ? WHERE id = ?`,
+		req.Actor, policyID); err != nil {
+		return 0, fmt.Errorf("appcontrol bump policy version on delete: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, fmt.Errorf("appcontrol commit tx: %w", err)
+	}
+	return policyID, nil
+}
+
+// CreatePolicy inserts a new policy row with version=1, default_action='NONE', and the supplied actor on created_by + updated_by.
+// Phase A has no assignments wired in to a fresh policy; the operator attaches host groups via the assignments endpoint (Phase B).
+func (s *Store) CreatePolicy(ctx context.Context, req api.CreatePolicyRequest) (api.ApplicationControlPolicy, error) {
+	if strings.TrimSpace(req.Actor) == "" {
+		return api.ApplicationControlPolicy{}, fmt.Errorf("%w: actor is required", api.ErrAppControlInvalidRequest)
+	}
+	if strings.TrimSpace(req.Reason) == "" {
+		return api.ApplicationControlPolicy{}, fmt.Errorf("%w: reason is required", api.ErrAppControlInvalidRequest)
+	}
+	if strings.TrimSpace(req.Name) == "" {
+		return api.ApplicationControlPolicy{}, fmt.Errorf("%w: policy name is required", api.ErrAppControlInvalidRequest)
+	}
+
+	res, err := s.db.ExecContext(ctx, `INSERT INTO app_control_policies (name, description, version, default_action, created_by, updated_by) VALUES (?, ?, 1, 'NONE', ?, ?)`,
+		req.Name, req.Description, req.Actor, req.Actor)
+	if err != nil {
+		if isDuplicateKey(err) {
+			return api.ApplicationControlPolicy{}, api.ErrAppControlDuplicatePolicy
+		}
+		return api.ApplicationControlPolicy{}, fmt.Errorf("appcontrol create policy: %w", err)
+	}
+	policyID, err := res.LastInsertId()
+	if err != nil {
+		return api.ApplicationControlPolicy{}, fmt.Errorf("appcontrol create policy lastid: %w", err)
+	}
+	return s.getPolicyByID(ctx, policyID)
+}
+
+// UpdatePolicy applies a partial update (name and/or description) to a policy row, bumps version, and sets updated_by. Returns
+// ErrAppControlPolicyNotFound when the id is missing; ErrAppControlDuplicatePolicy if the new name collides with another row;
+// ErrAppControlInvalidRequest when no mutable field is provided.
+func (s *Store) UpdatePolicy(ctx context.Context, req api.UpdatePolicyRequest) (api.ApplicationControlPolicy, error) {
+	if strings.TrimSpace(req.Actor) == "" {
+		return api.ApplicationControlPolicy{}, fmt.Errorf("%w: actor is required", api.ErrAppControlInvalidRequest)
+	}
+	if strings.TrimSpace(req.Reason) == "" {
+		return api.ApplicationControlPolicy{}, fmt.Errorf("%w: reason is required", api.ErrAppControlInvalidRequest)
+	}
+	setClauses := make([]string, 0, 2)
+	args := make([]any, 0, 3)
+	if req.Name != nil {
+		if strings.TrimSpace(*req.Name) == "" {
+			return api.ApplicationControlPolicy{}, fmt.Errorf("%w: policy name cannot be empty when present", api.ErrAppControlInvalidRequest)
+		}
+		setClauses = append(setClauses, "name = ?")
+		args = append(args, *req.Name)
+	}
+	if req.Description != nil {
+		setClauses = append(setClauses, "description = ?")
+		args = append(args, *req.Description)
+	}
+	if len(setClauses) == 0 {
+		return api.ApplicationControlPolicy{}, fmt.Errorf("%w: at least one mutable field must be set on a PATCH", api.ErrAppControlInvalidRequest)
+	}
+	setClauses = append(setClauses, "version = version + 1", "updated_by = ?")
+	args = append(args, req.Actor, req.PolicyID)
+	updateSQL := "UPDATE app_control_policies SET " + strings.Join(setClauses, ", ") + " WHERE id = ?"
+	res, err := s.db.ExecContext(ctx, updateSQL, args...)
+	if err != nil {
+		if isDuplicateKey(err) {
+			return api.ApplicationControlPolicy{}, api.ErrAppControlDuplicatePolicy
+		}
+		return api.ApplicationControlPolicy{}, fmt.Errorf("appcontrol update policy: %w", err)
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return api.ApplicationControlPolicy{}, fmt.Errorf("appcontrol update policy rows affected: %w", err)
+	}
+	if affected == 0 {
+		return api.ApplicationControlPolicy{}, api.ErrAppControlPolicyNotFound
+	}
+	return s.getPolicyByID(ctx, req.PolicyID)
+}
+
+// DeletePolicy removes a policy row. Refuses the seed Default policy by name (ErrAppControlPolicyImmutable) so the failsafe
+// assignment that ships with every deployment stays intact. ON DELETE CASCADE on app_control_rules + app_control_assignments cleans
+// up child rows; agents that already cached this policy's rules will not see the deletion until the next snapshot push, but Phase A
+// only ever has the Default policy assigned to hosts so a non-Default delete affects zero hosts in practice.
+func (s *Store) DeletePolicy(ctx context.Context, req api.DeletePolicyRequest) error {
+	if strings.TrimSpace(req.Actor) == "" {
+		return fmt.Errorf("%w: actor is required", api.ErrAppControlInvalidRequest)
+	}
+	if strings.TrimSpace(req.Reason) == "" {
+		return fmt.Errorf("%w: reason is required", api.ErrAppControlInvalidRequest)
+	}
+
+	tx, err := s.db.BeginTxx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("appcontrol begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	var name string
+	if err := tx.QueryRowxContext(ctx, `SELECT name FROM app_control_policies WHERE id = ?`, req.PolicyID).Scan(&name); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return api.ErrAppControlPolicyNotFound
+		}
+		return fmt.Errorf("appcontrol lookup policy for delete: %w", err)
+	}
+	if name == api.DefaultPolicyName {
+		return api.ErrAppControlPolicyImmutable
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM app_control_policies WHERE id = ?`, req.PolicyID); err != nil {
+		return fmt.Errorf("appcontrol delete policy: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("appcontrol commit tx: %w", err)
+	}
+	return nil
+}
+
+// getPolicyByID is the internal lookup the create/update paths use to return the post-mutation row. Returns sql.ErrNoRows wrapped
+// directly when the id is missing; callers translate to ErrAppControlPolicyNotFound where appropriate.
+func (s *Store) getPolicyByID(ctx context.Context, id int64) (api.ApplicationControlPolicy, error) {
+	const query = `SELECT id, name, description, version, default_action, created_at, updated_at, created_by, updated_by
+		FROM app_control_policies WHERE id = ?`
+	row := s.db.QueryRowxContext(ctx, query, id)
+	var p api.ApplicationControlPolicy
+	if err := row.Scan(
+		&p.ID, &p.Name, &p.Description, &p.Version, &p.DefaultAction,
+		&p.CreatedAt, &p.UpdatedAt, &p.CreatedBy, &p.UpdatedBy,
+	); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return api.ApplicationControlPolicy{}, api.ErrAppControlPolicyNotFound
+		}
+		return api.ApplicationControlPolicy{}, fmt.Errorf("appcontrol get policy by id: %w", err)
+	}
+	return p, nil
+}
+
 func (s *Store) getRuleByID(ctx context.Context, id int64) (api.ApplicationControlRule, error) {
 	const query = `SELECT id, policy_id, rule_type, identifier, action, enforcement, enabled,
 		severity, source, source_ref, custom_msg, custom_url, comment, expires_at,

--- a/server/rules/internal/operator/appcontrol_handler.go
+++ b/server/rules/internal/operator/appcontrol_handler.go
@@ -1,6 +1,7 @@
 package operator
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -22,6 +23,33 @@ const applicationControlReadBodyLimit = 16 * 1024
 // internalErrorMessage is the human-readable body the handler writes on every 5xx response that isn't otherwise typed. Extracted to
 // one constant so the wire shape stays stable and Sonar's duplicate-literal rule (go:S1192) doesn't fire on the four call sites.
 const internalErrorMessage = "internal error"
+
+// Error-code + human-message constants shared by handler error-mapping paths. Each pair (code + msg) is duplicated 3-6x across the
+// 8 handler functions; collapsing here keeps the wire shape stable AND silences Sonar's duplicate-literal rule.
+const (
+	errCodeInvalidPolicyID = "application_control.invalid_policy_id"
+	errMsgInvalidPolicyID  = "invalid policy id"
+	errCodeInvalidRuleID   = "application_control.invalid_rule_id"
+	errMsgInvalidRuleID    = "invalid rule id"
+	errCodePolicyNotFound  = "application_control.policy_not_found"
+	errMsgPolicyNotFound   = "policy not found"
+	errCodeRuleNotFound    = "application_control.rule_not_found"
+	errMsgRuleNotFound     = "rule not found"
+	errCodeReadBody        = "application_control.read_body"
+	errMsgReadBody         = "could not read body"
+	errCodeInvalidJSON     = "application_control.invalid_json"
+	errMsgInvalidJSON      = "invalid json"
+	errCodeDuplicateRule   = "application_control.duplicate_rule"
+	errMsgDuplicateRule    = "rule already exists for this identifier"
+	errCodeInvalidRule     = "application_control.invalid_rule"
+	errCodeInvalidPolicy   = "application_control.invalid_policy"
+	errCodeDuplicatePolicy = "application_control.duplicate_policy"
+	errMsgDuplicatePolicy  = "a policy with that name already exists"
+	errCodePolicyImmutable = "application_control.policy_immutable"
+	errMsgPolicyImmutable  = "the seed Default policy cannot be deleted"
+	internalErrorCode      = "internal"
+	noActorOnContextLogMsg = "appcontrol handler: no actor on ctx despite session middleware"
+)
 
 // AppControlHandler serves the rules-context /api/v1/app-control/* admin routes. Separate from the catalog Handler because the
 // surface, the dependencies (audit + commands + hosts), and the auth gates don't overlap; folding both into one struct would force the
@@ -81,7 +109,7 @@ func (h *AppControlHandler) handleListPolicies(w http.ResponseWriter, r *http.Re
 	policies, err := h.svc.ListPolicies(ctx)
 	if err != nil {
 		h.logger.ErrorContext(ctx, "appcontrol list policies", "err", err)
-		writeAppControlErr(ctx, h.logger, w, http.StatusInternalServerError, "internal", internalErrorMessage)
+		writeAppControlErr(ctx, h.logger, w, http.StatusInternalServerError, internalErrorCode, internalErrorMessage)
 		return
 	}
 	writeJSON(ctx, h.logger, w, http.StatusOK, map[string]any{"policies": policies})
@@ -96,17 +124,17 @@ func (h *AppControlHandler) handleGetPolicy(w http.ResponseWriter, r *http.Reque
 	}
 	policyID, ok := parsePolicyID(r)
 	if !ok {
-		writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, "application_control.invalid_policy_id", "invalid policy id")
+		writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, errCodeInvalidPolicyID, errMsgInvalidPolicyID)
 		return
 	}
 	policy, err := h.svc.GetPolicyWithRules(ctx, policyID)
 	if err != nil {
 		if errors.Is(err, api.ErrAppControlPolicyNotFound) {
-			writeAppControlErr(ctx, h.logger, w, http.StatusNotFound, "application_control.policy_not_found", "policy not found")
+			writeAppControlErr(ctx, h.logger, w, http.StatusNotFound, errCodePolicyNotFound, errMsgPolicyNotFound)
 			return
 		}
 		h.logger.ErrorContext(ctx, "appcontrol get policy", "err", err, "policy_id", policyID)
-		writeAppControlErr(ctx, h.logger, w, http.StatusInternalServerError, "internal", internalErrorMessage)
+		writeAppControlErr(ctx, h.logger, w, http.StatusInternalServerError, internalErrorCode, internalErrorMessage)
 		return
 	}
 	writeJSON(ctx, h.logger, w, http.StatusOK, policy)
@@ -134,18 +162,18 @@ func (h *AppControlHandler) handleCreateRule(w http.ResponseWriter, r *http.Requ
 	}
 	policyID, ok := parsePolicyID(r)
 	if !ok {
-		writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, "application_control.invalid_policy_id", "invalid policy id")
+		writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, errCodeInvalidPolicyID, errMsgInvalidPolicyID)
 		return
 	}
 
 	body, err := io.ReadAll(io.LimitReader(r.Body, applicationControlReadBodyLimit))
 	if err != nil {
-		writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, "application_control.read_body", "could not read body")
+		writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, errCodeReadBody, errMsgReadBody)
 		return
 	}
 	var req createRuleRequest
 	if err := json.Unmarshal(body, &req); err != nil {
-		writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, "application_control.invalid_json", "invalid json")
+		writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, errCodeInvalidJSON, errMsgInvalidJSON)
 		return
 	}
 	actor, ok := identityapi.ActorFromContext(ctx)
@@ -153,8 +181,8 @@ func (h *AppControlHandler) handleCreateRule(w http.ResponseWriter, r *http.Requ
 		// Session middleware guarantees an actor on every request that reaches HTTPGate's allow path; an absent actor here
 		// is a wiring bug, not a user error. Surface a 500 so the regression is loud rather than silently let CreateRule fall
 		// through to a service-layer guard.
-		h.logger.ErrorContext(ctx, "appcontrol create rule: no actor on ctx despite session middleware")
-		writeAppControlErr(ctx, h.logger, w, http.StatusInternalServerError, "internal", internalErrorMessage)
+		h.logger.ErrorContext(ctx, noActorOnContextLogMsg)
+		writeAppControlErr(ctx, h.logger, w, http.StatusInternalServerError, internalErrorCode, internalErrorMessage)
 		return
 	}
 
@@ -181,14 +209,14 @@ func (h *AppControlHandler) handleCreateRule(w http.ResponseWriter, r *http.Requ
 func (h *AppControlHandler) writeCreateRuleError(ctx context.Context, w http.ResponseWriter, err error, policyID int64) {
 	switch {
 	case errors.Is(err, api.ErrAppControlPolicyNotFound):
-		writeAppControlErr(ctx, h.logger, w, http.StatusNotFound, "application_control.policy_not_found", "policy not found")
+		writeAppControlErr(ctx, h.logger, w, http.StatusNotFound, errCodePolicyNotFound, errMsgPolicyNotFound)
 	case errors.Is(err, api.ErrAppControlDuplicateRule):
-		writeAppControlErr(ctx, h.logger, w, http.StatusConflict, "application_control.duplicate_rule", "rule already exists for this identifier")
+		writeAppControlErr(ctx, h.logger, w, http.StatusConflict, errCodeDuplicateRule, errMsgDuplicateRule)
 	case api.IsApplicationControlValidationError(err):
-		writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, "application_control.invalid_rule", err.Error())
+		writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, errCodeInvalidRule, err.Error())
 	default:
 		h.logger.ErrorContext(ctx, "appcontrol create rule", "err", err, "policy_id", policyID)
-		writeAppControlErr(ctx, h.logger, w, http.StatusInternalServerError, "internal", internalErrorMessage)
+		writeAppControlErr(ctx, h.logger, w, http.StatusInternalServerError, internalErrorCode, internalErrorMessage)
 	}
 }
 
@@ -198,14 +226,14 @@ func (h *AppControlHandler) writeCreateRuleError(ctx context.Context, w http.Res
 func (h *AppControlHandler) writeRuleMutationError(ctx context.Context, w http.ResponseWriter, action string, err error, ruleID int64) {
 	switch {
 	case errors.Is(err, api.ErrAppControlRuleNotFound):
-		writeAppControlErr(ctx, h.logger, w, http.StatusNotFound, "application_control.rule_not_found", "rule not found")
+		writeAppControlErr(ctx, h.logger, w, http.StatusNotFound, errCodeRuleNotFound, errMsgRuleNotFound)
 	case errors.Is(err, api.ErrAppControlDuplicateRule):
-		writeAppControlErr(ctx, h.logger, w, http.StatusConflict, "application_control.duplicate_rule", "rule already exists for this identifier")
+		writeAppControlErr(ctx, h.logger, w, http.StatusConflict, errCodeDuplicateRule, errMsgDuplicateRule)
 	case api.IsApplicationControlValidationError(err):
-		writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, "application_control.invalid_rule", err.Error())
+		writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, errCodeInvalidRule, err.Error())
 	default:
 		h.logger.ErrorContext(ctx, "appcontrol "+action, "err", err, "rule_id", ruleID)
-		writeAppControlErr(ctx, h.logger, w, http.StatusInternalServerError, "internal", internalErrorMessage)
+		writeAppControlErr(ctx, h.logger, w, http.StatusInternalServerError, internalErrorCode, internalErrorMessage)
 	}
 }
 
@@ -214,16 +242,16 @@ func (h *AppControlHandler) writeRuleMutationError(ctx context.Context, w http.R
 func (h *AppControlHandler) writePolicyMutationError(ctx context.Context, w http.ResponseWriter, action string, err error, policyID int64) {
 	switch {
 	case errors.Is(err, api.ErrAppControlPolicyNotFound):
-		writeAppControlErr(ctx, h.logger, w, http.StatusNotFound, "application_control.policy_not_found", "policy not found")
+		writeAppControlErr(ctx, h.logger, w, http.StatusNotFound, errCodePolicyNotFound, errMsgPolicyNotFound)
 	case errors.Is(err, api.ErrAppControlDuplicatePolicy):
-		writeAppControlErr(ctx, h.logger, w, http.StatusConflict, "application_control.duplicate_policy", "a policy with that name already exists")
+		writeAppControlErr(ctx, h.logger, w, http.StatusConflict, errCodeDuplicatePolicy, errMsgDuplicatePolicy)
 	case errors.Is(err, api.ErrAppControlPolicyImmutable):
-		writeAppControlErr(ctx, h.logger, w, http.StatusConflict, "application_control.policy_immutable", "the seed Default policy cannot be deleted")
+		writeAppControlErr(ctx, h.logger, w, http.StatusConflict, errCodePolicyImmutable, errMsgPolicyImmutable)
 	case api.IsApplicationControlValidationError(err):
-		writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, "application_control.invalid_policy", err.Error())
+		writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, errCodeInvalidPolicy, err.Error())
 	default:
 		h.logger.ErrorContext(ctx, "appcontrol "+action, "err", err, "policy_id", policyID)
-		writeAppControlErr(ctx, h.logger, w, http.StatusInternalServerError, "internal", internalErrorMessage)
+		writeAppControlErr(ctx, h.logger, w, http.StatusInternalServerError, internalErrorCode, internalErrorMessage)
 	}
 }
 
@@ -249,23 +277,23 @@ func (h *AppControlHandler) handleUpdateRule(w http.ResponseWriter, r *http.Requ
 	}
 	ruleID, ok := parseRuleID(r)
 	if !ok {
-		writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, "application_control.invalid_rule_id", "invalid rule id")
+		writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, errCodeInvalidRuleID, errMsgInvalidRuleID)
 		return
 	}
 	body, err := io.ReadAll(io.LimitReader(r.Body, applicationControlReadBodyLimit))
 	if err != nil {
-		writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, "application_control.read_body", "could not read body")
+		writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, errCodeReadBody, errMsgReadBody)
 		return
 	}
 	var req updateRuleRequest
 	if err := json.Unmarshal(body, &req); err != nil {
-		writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, "application_control.invalid_json", "invalid json")
+		writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, errCodeInvalidJSON, errMsgInvalidJSON)
 		return
 	}
 	actor, ok := identityapi.ActorFromContext(ctx)
 	if !ok {
-		h.logger.ErrorContext(ctx, "appcontrol update rule: no actor on ctx despite session middleware")
-		writeAppControlErr(ctx, h.logger, w, http.StatusInternalServerError, "internal", internalErrorMessage)
+		h.logger.ErrorContext(ctx, noActorOnContextLogMsg)
+		writeAppControlErr(ctx, h.logger, w, http.StatusInternalServerError, internalErrorCode, internalErrorMessage)
 		return
 	}
 	rule, err := h.svc.UpdateRule(ctx, api.UpdateRuleRequest{
@@ -301,25 +329,27 @@ func (h *AppControlHandler) handleDeleteRule(w http.ResponseWriter, r *http.Requ
 	}
 	ruleID, ok := parseRuleID(r)
 	if !ok {
-		writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, "application_control.invalid_rule_id", "invalid rule id")
+		writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, errCodeInvalidRuleID, errMsgInvalidRuleID)
 		return
 	}
 	body, err := io.ReadAll(io.LimitReader(r.Body, applicationControlReadBodyLimit))
 	if err != nil {
-		writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, "application_control.read_body", "could not read body")
+		writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, errCodeReadBody, errMsgReadBody)
 		return
 	}
 	var req deleteRuleRequest
-	if len(body) > 0 {
+	// Whitespace-only bodies are normalised to empty so an operator sending a body of just spaces does not get a misleading
+	// invalid_json (the typed reason-required validation should fire instead). Copilot flagged this on PR #188.
+	if len(bytes.TrimSpace(body)) > 0 {
 		if err := json.Unmarshal(body, &req); err != nil {
-			writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, "application_control.invalid_json", "invalid json")
+			writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, errCodeInvalidJSON, errMsgInvalidJSON)
 			return
 		}
 	}
 	actor, ok := identityapi.ActorFromContext(ctx)
 	if !ok {
-		h.logger.ErrorContext(ctx, "appcontrol delete rule: no actor on ctx despite session middleware")
-		writeAppControlErr(ctx, h.logger, w, http.StatusInternalServerError, "internal", internalErrorMessage)
+		h.logger.ErrorContext(ctx, noActorOnContextLogMsg)
+		writeAppControlErr(ctx, h.logger, w, http.StatusInternalServerError, internalErrorCode, internalErrorMessage)
 		return
 	}
 	if err := h.svc.DeleteRule(ctx, api.DeleteRuleRequest{
@@ -349,18 +379,18 @@ func (h *AppControlHandler) handleCreatePolicy(w http.ResponseWriter, r *http.Re
 	}
 	body, err := io.ReadAll(io.LimitReader(r.Body, applicationControlReadBodyLimit))
 	if err != nil {
-		writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, "application_control.read_body", "could not read body")
+		writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, errCodeReadBody, errMsgReadBody)
 		return
 	}
 	var req createPolicyRequest
 	if err := json.Unmarshal(body, &req); err != nil {
-		writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, "application_control.invalid_json", "invalid json")
+		writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, errCodeInvalidJSON, errMsgInvalidJSON)
 		return
 	}
 	actor, ok := identityapi.ActorFromContext(ctx)
 	if !ok {
-		h.logger.ErrorContext(ctx, "appcontrol create policy: no actor on ctx despite session middleware")
-		writeAppControlErr(ctx, h.logger, w, http.StatusInternalServerError, "internal", internalErrorMessage)
+		h.logger.ErrorContext(ctx, noActorOnContextLogMsg)
+		writeAppControlErr(ctx, h.logger, w, http.StatusInternalServerError, internalErrorCode, internalErrorMessage)
 		return
 	}
 	policy, err := h.svc.CreatePolicy(ctx, api.CreatePolicyRequest{
@@ -392,23 +422,23 @@ func (h *AppControlHandler) handleUpdatePolicy(w http.ResponseWriter, r *http.Re
 	}
 	policyID, ok := parsePolicyID(r)
 	if !ok {
-		writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, "application_control.invalid_policy_id", "invalid policy id")
+		writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, errCodeInvalidPolicyID, errMsgInvalidPolicyID)
 		return
 	}
 	body, err := io.ReadAll(io.LimitReader(r.Body, applicationControlReadBodyLimit))
 	if err != nil {
-		writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, "application_control.read_body", "could not read body")
+		writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, errCodeReadBody, errMsgReadBody)
 		return
 	}
 	var req updatePolicyRequest
 	if err := json.Unmarshal(body, &req); err != nil {
-		writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, "application_control.invalid_json", "invalid json")
+		writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, errCodeInvalidJSON, errMsgInvalidJSON)
 		return
 	}
 	actor, ok := identityapi.ActorFromContext(ctx)
 	if !ok {
-		h.logger.ErrorContext(ctx, "appcontrol update policy: no actor on ctx despite session middleware")
-		writeAppControlErr(ctx, h.logger, w, http.StatusInternalServerError, "internal", internalErrorMessage)
+		h.logger.ErrorContext(ctx, noActorOnContextLogMsg)
+		writeAppControlErr(ctx, h.logger, w, http.StatusInternalServerError, internalErrorCode, internalErrorMessage)
 		return
 	}
 	policy, err := h.svc.UpdatePolicy(ctx, api.UpdatePolicyRequest{
@@ -439,25 +469,27 @@ func (h *AppControlHandler) handleDeletePolicy(w http.ResponseWriter, r *http.Re
 	}
 	policyID, ok := parsePolicyID(r)
 	if !ok {
-		writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, "application_control.invalid_policy_id", "invalid policy id")
+		writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, errCodeInvalidPolicyID, errMsgInvalidPolicyID)
 		return
 	}
 	body, err := io.ReadAll(io.LimitReader(r.Body, applicationControlReadBodyLimit))
 	if err != nil {
-		writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, "application_control.read_body", "could not read body")
+		writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, errCodeReadBody, errMsgReadBody)
 		return
 	}
 	var req deletePolicyRequest
-	if len(body) > 0 {
+	// Whitespace-only bodies are normalised to empty so an operator sending a body of just spaces does not get a misleading
+	// invalid_json (the typed reason-required validation should fire instead). Copilot flagged this on PR #188.
+	if len(bytes.TrimSpace(body)) > 0 {
 		if err := json.Unmarshal(body, &req); err != nil {
-			writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, "application_control.invalid_json", "invalid json")
+			writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, errCodeInvalidJSON, errMsgInvalidJSON)
 			return
 		}
 	}
 	actor, ok := identityapi.ActorFromContext(ctx)
 	if !ok {
-		h.logger.ErrorContext(ctx, "appcontrol delete policy: no actor on ctx despite session middleware")
-		writeAppControlErr(ctx, h.logger, w, http.StatusInternalServerError, "internal", internalErrorMessage)
+		h.logger.ErrorContext(ctx, noActorOnContextLogMsg)
+		writeAppControlErr(ctx, h.logger, w, http.StatusInternalServerError, internalErrorCode, internalErrorMessage)
 		return
 	}
 	if err := h.svc.DeletePolicy(ctx, api.DeletePolicyRequest{
@@ -471,9 +503,10 @@ func (h *AppControlHandler) handleDeletePolicy(w http.ResponseWriter, r *http.Re
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// parseRuleID extracts the {id} path value off /rules/{id} and parses it as int64. Symmetric to parsePolicyID; kept as a separate
-// helper so a future schema change that splits rule_id namespacing from policy_id has one place to update.
-func parseRuleID(r *http.Request) (int64, bool) {
+// parsePositiveInt64Path extracts the {id} path value and parses it as a positive int64. Used by parsePolicyID + parseRuleID — both
+// of which previously had identical implementations (Sonar S4144). The thin per-route wrappers keep call-site readability ("we're
+// pulling a policy id here") while collapsing the implementation to one source of truth.
+func parsePositiveInt64Path(r *http.Request) (int64, bool) {
 	raw := r.PathValue("id")
 	if raw == "" {
 		return 0, false
@@ -485,19 +518,13 @@ func parseRuleID(r *http.Request) (int64, bool) {
 	return id, true
 }
 
-// parsePolicyID extracts the {id} path value and parses it as int64. Reports false on missing or non-numeric values so callers respond
-// 400 with the typed error code rather than letting strconv error strings leak into the response.
-func parsePolicyID(r *http.Request) (int64, bool) {
-	raw := r.PathValue("id")
-	if raw == "" {
-		return 0, false
-	}
-	id, err := strconv.ParseInt(raw, 10, 64)
-	if err != nil || id <= 0 {
-		return 0, false
-	}
-	return id, true
-}
+// parseRuleID extracts the {id} path value off /rules/{id} as a positive int64. Wrapper around parsePositiveInt64Path so the call
+// site reads as "we're pulling a rule id here" and a future schema change that splits the namespace can land on one helper.
+func parseRuleID(r *http.Request) (int64, bool) { return parsePositiveInt64Path(r) }
+
+// parsePolicyID extracts the {id} path value off /policies/{id} as a positive int64. Wrapper around parsePositiveInt64Path; see
+// parseRuleID for the rationale.
+func parsePolicyID(r *http.Request) (int64, bool) { return parsePositiveInt64Path(r) }
 
 // actorIdentifierFromContext returns a stable string identifier the store + audit row use as the "who authored this" tag. The actor's
 // email isn't on identityapi.Actor today (Actor carries UserID + Roles but not email; the audit recorder fetches the email separately

--- a/server/rules/internal/operator/appcontrol_handler.go
+++ b/server/rules/internal/operator/appcontrol_handler.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net/http"
 	"strconv"
+	"time"
 
 	identityapi "github.com/fleetdm/edr/server/identity/api"
 	"github.com/fleetdm/edr/server/rules/api"
@@ -46,20 +47,28 @@ func NewAppControl(svc *appcontrol.Service, authz identityapi.AuthZ, logger *slo
 	return &AppControlHandler{svc: svc, authz: authz, logger: logger}
 }
 
-// RegisterRoutes wires the demo-cut application-control routes:
+// RegisterRoutes wires the application-control admin routes:
 //
-//	GET  /api/v1/app-control/policies
-//	GET  /api/v1/app-control/policies/{id}
-//	POST /api/v1/app-control/policies/{id}/rules
+//	GET    /api/v1/app-control/policies
+//	GET    /api/v1/app-control/policies/{id}
+//	POST   /api/v1/app-control/policies
+//	PATCH  /api/v1/app-control/policies/{id}
+//	DELETE /api/v1/app-control/policies/{id}
+//	POST   /api/v1/app-control/policies/{id}/rules
+//	PATCH  /api/v1/app-control/rules/{id}
+//	DELETE /api/v1/app-control/rules/{id}
 //
-// PATCH / DELETE / bulkUpsert / host-groups / assignments are
-// post-demo and not registered here. Caller wraps the mux in identity
-// Session + CSRF middleware before mounting (the existing operator
-// pattern in cmd/main).
+// Bulk-upsert / cross-policy rule list / host-groups CRUD / assignments POST stay deferred to follow-on PRs. Caller wraps the mux
+// in identity Session + CSRF middleware before mounting (the existing operator pattern in cmd/main).
 func (h *AppControlHandler) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/v1/app-control/policies", h.handleListPolicies)
 	mux.HandleFunc("GET /api/v1/app-control/policies/{id}", h.handleGetPolicy)
+	mux.HandleFunc("POST /api/v1/app-control/policies", h.handleCreatePolicy)
+	mux.HandleFunc("PATCH /api/v1/app-control/policies/{id}", h.handleUpdatePolicy)
+	mux.HandleFunc("DELETE /api/v1/app-control/policies/{id}", h.handleDeletePolicy)
 	mux.HandleFunc("POST /api/v1/app-control/policies/{id}/rules", h.handleCreateRule)
+	mux.HandleFunc("PATCH /api/v1/app-control/rules/{id}", h.handleUpdateRule)
+	mux.HandleFunc("DELETE /api/v1/app-control/rules/{id}", h.handleDeleteRule)
 }
 
 func (h *AppControlHandler) handleListPolicies(w http.ResponseWriter, r *http.Request) {
@@ -181,6 +190,299 @@ func (h *AppControlHandler) writeCreateRuleError(ctx context.Context, w http.Res
 		h.logger.ErrorContext(ctx, "appcontrol create rule", "err", err, "policy_id", policyID)
 		writeAppControlErr(ctx, h.logger, w, http.StatusInternalServerError, "internal", internalErrorMessage)
 	}
+}
+
+// writeRuleMutationError centralises the rule-update + rule-delete error mapping so the two handlers stay symmetric. RuleNotFound
+// → 404; the validator + invalid-request errors → 400; duplicate-rule cannot fire on update/delete today (we never re-write the
+// identifier) but the case is included so a Phase B refactor that changes that doesn't leak a 500.
+func (h *AppControlHandler) writeRuleMutationError(ctx context.Context, w http.ResponseWriter, action string, err error, ruleID int64) {
+	switch {
+	case errors.Is(err, api.ErrAppControlRuleNotFound):
+		writeAppControlErr(ctx, h.logger, w, http.StatusNotFound, "application_control.rule_not_found", "rule not found")
+	case errors.Is(err, api.ErrAppControlDuplicateRule):
+		writeAppControlErr(ctx, h.logger, w, http.StatusConflict, "application_control.duplicate_rule", "rule already exists for this identifier")
+	case api.IsApplicationControlValidationError(err):
+		writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, "application_control.invalid_rule", err.Error())
+	default:
+		h.logger.ErrorContext(ctx, "appcontrol "+action, "err", err, "rule_id", ruleID)
+		writeAppControlErr(ctx, h.logger, w, http.StatusInternalServerError, "internal", internalErrorMessage)
+	}
+}
+
+// writePolicyMutationError centralises the policy-create + policy-update + policy-delete error mapping so the three handlers stay
+// symmetric. PolicyNotFound → 404; DuplicatePolicy → 409; PolicyImmutable (DELETE on Default) → 409; validation → 400.
+func (h *AppControlHandler) writePolicyMutationError(ctx context.Context, w http.ResponseWriter, action string, err error, policyID int64) {
+	switch {
+	case errors.Is(err, api.ErrAppControlPolicyNotFound):
+		writeAppControlErr(ctx, h.logger, w, http.StatusNotFound, "application_control.policy_not_found", "policy not found")
+	case errors.Is(err, api.ErrAppControlDuplicatePolicy):
+		writeAppControlErr(ctx, h.logger, w, http.StatusConflict, "application_control.duplicate_policy", "a policy with that name already exists")
+	case errors.Is(err, api.ErrAppControlPolicyImmutable):
+		writeAppControlErr(ctx, h.logger, w, http.StatusConflict, "application_control.policy_immutable", "the seed Default policy cannot be deleted")
+	case api.IsApplicationControlValidationError(err):
+		writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, "application_control.invalid_policy", err.Error())
+	default:
+		h.logger.ErrorContext(ctx, "appcontrol "+action, "err", err, "policy_id", policyID)
+		writeAppControlErr(ctx, h.logger, w, http.StatusInternalServerError, "internal", internalErrorMessage)
+	}
+}
+
+// updateRuleRequest is the PATCH wire shape. Every mutable field is a pointer so a JSON omit / null is distinguishable from an
+// explicit zero (e.g. clearing custom_msg by sending ""). Phase B's Detect-mode change layers an Enforcement field on top of this
+// struct; for Phase A the field is unsupported (the schema column carries it, the handler doesn't accept it).
+type updateRuleRequest struct {
+	Enabled   *bool         `json:"enabled,omitempty"`
+	Severity  *api.Severity `json:"severity,omitempty"`
+	CustomMsg *string       `json:"custom_msg,omitempty"`
+	CustomURL *string       `json:"custom_url,omitempty"`
+	Comment   *string       `json:"comment,omitempty"`
+	ExpiresAt *time.Time    `json:"expires_at,omitempty"`
+	Reason    string        `json:"reason"`
+}
+
+func (h *AppControlHandler) handleUpdateRule(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	if !identityapi.HTTPGate(ctx, w, h.authz, h.logger,
+		identityapi.ActionAppControlRuleUpdate,
+		identityapi.Resource{Type: "application_control"}) {
+		return
+	}
+	ruleID, ok := parseRuleID(r)
+	if !ok {
+		writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, "application_control.invalid_rule_id", "invalid rule id")
+		return
+	}
+	body, err := io.ReadAll(io.LimitReader(r.Body, applicationControlReadBodyLimit))
+	if err != nil {
+		writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, "application_control.read_body", "could not read body")
+		return
+	}
+	var req updateRuleRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, "application_control.invalid_json", "invalid json")
+		return
+	}
+	actor, ok := identityapi.ActorFromContext(ctx)
+	if !ok {
+		h.logger.ErrorContext(ctx, "appcontrol update rule: no actor on ctx despite session middleware")
+		writeAppControlErr(ctx, h.logger, w, http.StatusInternalServerError, "internal", internalErrorMessage)
+		return
+	}
+	rule, err := h.svc.UpdateRule(ctx, api.UpdateRuleRequest{
+		RuleID:    ruleID,
+		Enabled:   req.Enabled,
+		Severity:  req.Severity,
+		CustomMsg: req.CustomMsg,
+		CustomURL: req.CustomURL,
+		Comment:   req.Comment,
+		ExpiresAt: req.ExpiresAt,
+		Actor:     actorIdentifierFromContext(ctx),
+		Reason:    req.Reason,
+	}, actor)
+	if err != nil {
+		h.writeRuleMutationError(ctx, w, "update rule", err, ruleID)
+		return
+	}
+	writeJSON(ctx, h.logger, w, http.StatusOK, rule)
+}
+
+// deleteRuleRequest carries the audit reason. DELETE bodies are unusual in HTTP norms but JSON-RPC-style admin APIs (which this
+// is) commonly send a body to satisfy audit-required-on-mutation policies; documented in the openspec REST surface.
+type deleteRuleRequest struct {
+	Reason string `json:"reason"`
+}
+
+func (h *AppControlHandler) handleDeleteRule(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	if !identityapi.HTTPGate(ctx, w, h.authz, h.logger,
+		identityapi.ActionAppControlRuleDelete,
+		identityapi.Resource{Type: "application_control"}) {
+		return
+	}
+	ruleID, ok := parseRuleID(r)
+	if !ok {
+		writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, "application_control.invalid_rule_id", "invalid rule id")
+		return
+	}
+	body, err := io.ReadAll(io.LimitReader(r.Body, applicationControlReadBodyLimit))
+	if err != nil {
+		writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, "application_control.read_body", "could not read body")
+		return
+	}
+	var req deleteRuleRequest
+	if len(body) > 0 {
+		if err := json.Unmarshal(body, &req); err != nil {
+			writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, "application_control.invalid_json", "invalid json")
+			return
+		}
+	}
+	actor, ok := identityapi.ActorFromContext(ctx)
+	if !ok {
+		h.logger.ErrorContext(ctx, "appcontrol delete rule: no actor on ctx despite session middleware")
+		writeAppControlErr(ctx, h.logger, w, http.StatusInternalServerError, "internal", internalErrorMessage)
+		return
+	}
+	if err := h.svc.DeleteRule(ctx, api.DeleteRuleRequest{
+		RuleID: ruleID,
+		Actor:  actorIdentifierFromContext(ctx),
+		Reason: req.Reason,
+	}, actor); err != nil {
+		h.writeRuleMutationError(ctx, w, "delete rule", err, ruleID)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// createPolicyRequest is the POST /policies wire shape. Description is optional; Reason is required for audit.
+type createPolicyRequest struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	Reason      string `json:"reason"`
+}
+
+func (h *AppControlHandler) handleCreatePolicy(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	if !identityapi.HTTPGate(ctx, w, h.authz, h.logger,
+		identityapi.ActionAppControlPolicyCreate,
+		identityapi.Resource{Type: "application_control"}) {
+		return
+	}
+	body, err := io.ReadAll(io.LimitReader(r.Body, applicationControlReadBodyLimit))
+	if err != nil {
+		writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, "application_control.read_body", "could not read body")
+		return
+	}
+	var req createPolicyRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, "application_control.invalid_json", "invalid json")
+		return
+	}
+	actor, ok := identityapi.ActorFromContext(ctx)
+	if !ok {
+		h.logger.ErrorContext(ctx, "appcontrol create policy: no actor on ctx despite session middleware")
+		writeAppControlErr(ctx, h.logger, w, http.StatusInternalServerError, "internal", internalErrorMessage)
+		return
+	}
+	policy, err := h.svc.CreatePolicy(ctx, api.CreatePolicyRequest{
+		Name:        req.Name,
+		Description: req.Description,
+		Actor:       actorIdentifierFromContext(ctx),
+		Reason:      req.Reason,
+	}, actor)
+	if err != nil {
+		h.writePolicyMutationError(ctx, w, "create policy", err, 0)
+		return
+	}
+	writeJSON(ctx, h.logger, w, http.StatusCreated, policy)
+}
+
+// updatePolicyRequest is the PATCH /policies/{id} wire shape. Both name and description are pointer-optional.
+type updatePolicyRequest struct {
+	Name        *string `json:"name,omitempty"`
+	Description *string `json:"description,omitempty"`
+	Reason      string  `json:"reason"`
+}
+
+func (h *AppControlHandler) handleUpdatePolicy(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	if !identityapi.HTTPGate(ctx, w, h.authz, h.logger,
+		identityapi.ActionAppControlPolicyUpdate,
+		identityapi.Resource{Type: "application_control"}) {
+		return
+	}
+	policyID, ok := parsePolicyID(r)
+	if !ok {
+		writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, "application_control.invalid_policy_id", "invalid policy id")
+		return
+	}
+	body, err := io.ReadAll(io.LimitReader(r.Body, applicationControlReadBodyLimit))
+	if err != nil {
+		writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, "application_control.read_body", "could not read body")
+		return
+	}
+	var req updatePolicyRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, "application_control.invalid_json", "invalid json")
+		return
+	}
+	actor, ok := identityapi.ActorFromContext(ctx)
+	if !ok {
+		h.logger.ErrorContext(ctx, "appcontrol update policy: no actor on ctx despite session middleware")
+		writeAppControlErr(ctx, h.logger, w, http.StatusInternalServerError, "internal", internalErrorMessage)
+		return
+	}
+	policy, err := h.svc.UpdatePolicy(ctx, api.UpdatePolicyRequest{
+		PolicyID:    policyID,
+		Name:        req.Name,
+		Description: req.Description,
+		Actor:       actorIdentifierFromContext(ctx),
+		Reason:      req.Reason,
+	}, actor)
+	if err != nil {
+		h.writePolicyMutationError(ctx, w, "update policy", err, policyID)
+		return
+	}
+	writeJSON(ctx, h.logger, w, http.StatusOK, policy)
+}
+
+// deletePolicyRequest carries the audit reason for DELETE /policies/{id}.
+type deletePolicyRequest struct {
+	Reason string `json:"reason"`
+}
+
+func (h *AppControlHandler) handleDeletePolicy(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	if !identityapi.HTTPGate(ctx, w, h.authz, h.logger,
+		identityapi.ActionAppControlPolicyDelete,
+		identityapi.Resource{Type: "application_control"}) {
+		return
+	}
+	policyID, ok := parsePolicyID(r)
+	if !ok {
+		writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, "application_control.invalid_policy_id", "invalid policy id")
+		return
+	}
+	body, err := io.ReadAll(io.LimitReader(r.Body, applicationControlReadBodyLimit))
+	if err != nil {
+		writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, "application_control.read_body", "could not read body")
+		return
+	}
+	var req deletePolicyRequest
+	if len(body) > 0 {
+		if err := json.Unmarshal(body, &req); err != nil {
+			writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, "application_control.invalid_json", "invalid json")
+			return
+		}
+	}
+	actor, ok := identityapi.ActorFromContext(ctx)
+	if !ok {
+		h.logger.ErrorContext(ctx, "appcontrol delete policy: no actor on ctx despite session middleware")
+		writeAppControlErr(ctx, h.logger, w, http.StatusInternalServerError, "internal", internalErrorMessage)
+		return
+	}
+	if err := h.svc.DeletePolicy(ctx, api.DeletePolicyRequest{
+		PolicyID: policyID,
+		Actor:    actorIdentifierFromContext(ctx),
+		Reason:   req.Reason,
+	}, actor); err != nil {
+		h.writePolicyMutationError(ctx, w, "delete policy", err, policyID)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// parseRuleID extracts the {id} path value off /rules/{id} and parses it as int64. Symmetric to parsePolicyID; kept as a separate
+// helper so a future schema change that splits rule_id namespacing from policy_id has one place to update.
+func parseRuleID(r *http.Request) (int64, bool) {
+	raw := r.PathValue("id")
+	if raw == "" {
+		return 0, false
+	}
+	id, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || id <= 0 {
+		return 0, false
+	}
+	return id, true
 }
 
 // parsePolicyID extracts the {id} path value and parses it as int64. Reports false on missing or non-numeric values so callers respond

--- a/server/rules/internal/tests/app_control_test.go
+++ b/server/rules/internal/tests/app_control_test.go
@@ -351,3 +351,263 @@ func TestAppControl_CreateRule_AtomicityOnVersionBumpFailure(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, rulesList, 1)
 }
+
+// TestAppControl_UpdateRule_HappyPath confirms PATCH /rules/{id} applies the partial update and bumps the policy version. We
+// flip Enabled, change Severity, set CustomMsg + Comment, and assert the post-update row reflects every field.
+func TestAppControl_UpdateRule_HappyPath(t *testing.T) {
+	t.Parallel()
+	store, _ := newAppControlStore(t)
+	ctx := t.Context()
+	p, err := store.GetPolicyByName(ctx, api.DefaultPolicyName)
+	require.NoError(t, err)
+	rule, err := store.CreateRule(ctx, api.CreateRuleRequest{
+		PolicyID:   p.ID,
+		RuleType:   api.RuleTypeBinary,
+		Identifier: strings.Repeat("d", 64),
+		Severity:   api.SeverityRuleMedium,
+		Actor:      "demo-admin",
+		Reason:     "fixture for update",
+	})
+	require.NoError(t, err)
+	preVersion := p.Version + 1 // create bumped once
+
+	enabled := false
+	sev := api.SeverityRuleHigh
+	msg := "Blocked by policy v2"
+	comment := "raised severity after incident review"
+	updated, err := store.UpdateRule(ctx, api.UpdateRuleRequest{
+		RuleID:    rule.ID,
+		Enabled:   &enabled,
+		Severity:  &sev,
+		CustomMsg: &msg,
+		Comment:   &comment,
+		Actor:     "demo-admin",
+		Reason:    "PATCH coverage",
+	})
+	require.NoError(t, err)
+	assert.False(t, updated.Enabled, "enabled flips off")
+	assert.Equal(t, api.SeverityRuleHigh, updated.Severity)
+	if assert.NotNil(t, updated.CustomMsg) {
+		assert.Equal(t, msg, *updated.CustomMsg)
+	}
+	assert.Equal(t, comment, updated.Comment)
+
+	// Policy version bumped to (preVersion + 1).
+	pAfter, err := store.GetPolicyByName(ctx, api.DefaultPolicyName)
+	require.NoError(t, err)
+	assert.Equal(t, preVersion+1, pAfter.Version)
+}
+
+// TestAppControl_UpdateRule_NotFound pins the typed sentinel for a missing rule id; the REST handler maps it to 404.
+func TestAppControl_UpdateRule_NotFound(t *testing.T) {
+	t.Parallel()
+	store, _ := newAppControlStore(t)
+	enabled := false
+	_, err := store.UpdateRule(t.Context(), api.UpdateRuleRequest{
+		RuleID:  9_999_999,
+		Enabled: &enabled,
+		Actor:   "demo-admin",
+		Reason:  "should be 404",
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, api.ErrAppControlRuleNotFound)
+}
+
+// TestAppControl_UpdateRule_RequiresAtLeastOneField confirms a body with reason but no mutable field is rejected as
+// ErrAppControlInvalidRequest. Without this the handler would happily run an UPDATE that bumps version + updated_by with no
+// other side effect, which is a confusing no-op the audit log can't disambiguate.
+func TestAppControl_UpdateRule_RequiresAtLeastOneField(t *testing.T) {
+	t.Parallel()
+	store, _ := newAppControlStore(t)
+	ctx := t.Context()
+	p, err := store.GetPolicyByName(ctx, api.DefaultPolicyName)
+	require.NoError(t, err)
+	rule, err := store.CreateRule(ctx, api.CreateRuleRequest{
+		PolicyID: p.ID, RuleType: api.RuleTypeBinary,
+		Identifier: strings.Repeat("e", 64), Actor: "demo-admin", Reason: "fixture",
+	})
+	require.NoError(t, err)
+
+	_, err = store.UpdateRule(ctx, api.UpdateRuleRequest{
+		RuleID: rule.ID, Actor: "demo-admin", Reason: "no fields",
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, api.ErrAppControlInvalidRequest)
+}
+
+// TestAppControl_DeleteRule_HappyPath pins the delete + version-bump contract: the rule is gone from ListRulesByPolicy, and
+// the returned policy_id matches the rule's parent so the service-layer fan-out targets the right policy.
+func TestAppControl_DeleteRule_HappyPath(t *testing.T) {
+	t.Parallel()
+	store, _ := newAppControlStore(t)
+	ctx := t.Context()
+	p, err := store.GetPolicyByName(ctx, api.DefaultPolicyName)
+	require.NoError(t, err)
+	rule, err := store.CreateRule(ctx, api.CreateRuleRequest{
+		PolicyID: p.ID, RuleType: api.RuleTypeBinary,
+		Identifier: strings.Repeat("f", 64), Actor: "demo-admin", Reason: "fixture",
+	})
+	require.NoError(t, err)
+
+	policyID, err := store.DeleteRule(ctx, api.DeleteRuleRequest{
+		RuleID: rule.ID, Actor: "demo-admin", Reason: "remove after triage",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, p.ID, policyID)
+
+	rules, err := store.ListRulesByPolicy(ctx, p.ID)
+	require.NoError(t, err)
+	assert.Empty(t, rules, "rule list must be empty after delete")
+}
+
+// TestAppControl_DeleteRule_NotFound confirms the typed sentinel for a stale rule id.
+func TestAppControl_DeleteRule_NotFound(t *testing.T) {
+	t.Parallel()
+	store, _ := newAppControlStore(t)
+	_, err := store.DeleteRule(t.Context(), api.DeleteRuleRequest{
+		RuleID: 9_999_999, Actor: "demo-admin", Reason: "stale id",
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, api.ErrAppControlRuleNotFound)
+}
+
+// TestAppControl_CreatePolicy_HappyPath confirms POST /policies inserts a new row with version=1, default_action='NONE', and the
+// supplied name + description.
+func TestAppControl_CreatePolicy_HappyPath(t *testing.T) {
+	t.Parallel()
+	store, _ := newAppControlStore(t)
+	policy, err := store.CreatePolicy(t.Context(), api.CreatePolicyRequest{
+		Name:        "engineering-laptops",
+		Description: "Custom policy for the eng laptop fleet",
+		Actor:       "demo-admin",
+		Reason:      "second policy",
+	})
+	require.NoError(t, err)
+	assert.NotZero(t, policy.ID)
+	assert.Equal(t, "engineering-laptops", policy.Name)
+	assert.Equal(t, "Custom policy for the eng laptop fleet", policy.Description)
+	assert.Equal(t, int64(1), policy.Version)
+	assert.Equal(t, api.PolicyDefaultActionNone, policy.DefaultAction)
+	assert.Equal(t, "demo-admin", policy.CreatedBy)
+}
+
+// TestAppControl_CreatePolicy_DuplicateName confirms ErrAppControlDuplicatePolicy fires on a name collision. The seed Default
+// policy gives us a guaranteed collision target.
+func TestAppControl_CreatePolicy_DuplicateName(t *testing.T) {
+	t.Parallel()
+	store, _ := newAppControlStore(t)
+	_, err := store.CreatePolicy(t.Context(), api.CreatePolicyRequest{
+		Name: api.DefaultPolicyName, Actor: "demo-admin", Reason: "should collide",
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, api.ErrAppControlDuplicatePolicy)
+}
+
+// TestAppControl_UpdatePolicy_RenameAndBumpVersion confirms PATCH /policies/{id} renames the policy AND bumps the version. The
+// version bump matters because Phase B's UI will use it as a "dirty" indicator on the agents tab.
+func TestAppControl_UpdatePolicy_RenameAndBumpVersion(t *testing.T) {
+	t.Parallel()
+	store, _ := newAppControlStore(t)
+	ctx := t.Context()
+	policy, err := store.CreatePolicy(ctx, api.CreatePolicyRequest{
+		Name: "team-alpha", Actor: "demo-admin", Reason: "fixture",
+	})
+	require.NoError(t, err)
+
+	newName := "team-alpha-renamed"
+	newDescription := "team alpha rebrand"
+	updated, err := store.UpdatePolicy(ctx, api.UpdatePolicyRequest{
+		PolicyID:    policy.ID,
+		Name:        &newName,
+		Description: &newDescription,
+		Actor:       "demo-admin",
+		Reason:      "rename and edit description",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, newName, updated.Name)
+	assert.Equal(t, newDescription, updated.Description)
+	assert.Equal(t, policy.Version+1, updated.Version)
+	assert.Equal(t, "demo-admin", updated.UpdatedBy)
+}
+
+// TestAppControl_UpdatePolicy_NotFound + DuplicateName lock the two error sentinels the REST handler maps to 404 and 409.
+func TestAppControl_UpdatePolicy_NotFoundAndDuplicate(t *testing.T) {
+	t.Parallel()
+	store, _ := newAppControlStore(t)
+	ctx := t.Context()
+	defaultPolicy, err := store.GetPolicyByName(ctx, api.DefaultPolicyName)
+	require.NoError(t, err)
+
+	// Not found.
+	name := "doesnt-matter"
+	_, err = store.UpdatePolicy(ctx, api.UpdatePolicyRequest{
+		PolicyID: 9_999_999, Name: &name, Actor: "demo-admin", Reason: "404",
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, api.ErrAppControlPolicyNotFound)
+
+	// Duplicate name (rename a fresh policy to the Default policy's name).
+	other, err := store.CreatePolicy(ctx, api.CreatePolicyRequest{
+		Name: "fresh", Actor: "demo-admin", Reason: "fixture",
+	})
+	require.NoError(t, err)
+	collidingName := defaultPolicy.Name
+	_, err = store.UpdatePolicy(ctx, api.UpdatePolicyRequest{
+		PolicyID: other.ID, Name: &collidingName, Actor: "demo-admin", Reason: "should 409",
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, api.ErrAppControlDuplicatePolicy)
+}
+
+// TestAppControl_DeletePolicy_HappyPath + TestAppControl_DeletePolicy_RefusesDefault enforce the destructive-action contract: a
+// custom policy deletes cleanly and cascades its rules; the seed Default policy is rejected with ErrAppControlPolicyImmutable.
+func TestAppControl_DeletePolicy_HappyPath(t *testing.T) {
+	t.Parallel()
+	store, _ := newAppControlStore(t)
+	ctx := t.Context()
+	policy, err := store.CreatePolicy(ctx, api.CreatePolicyRequest{
+		Name: "to-be-deleted", Actor: "demo-admin", Reason: "fixture",
+	})
+	require.NoError(t, err)
+	// Add a rule so we can confirm the CASCADE.
+	_, err = store.CreateRule(ctx, api.CreateRuleRequest{
+		PolicyID: policy.ID, RuleType: api.RuleTypeBinary,
+		Identifier: strings.Repeat("9", 64), Actor: "demo-admin", Reason: "fixture",
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, store.DeletePolicy(ctx, api.DeletePolicyRequest{
+		PolicyID: policy.ID, Actor: "demo-admin", Reason: "cleanup",
+	}))
+
+	// Policy is gone.
+	_, err = store.GetPolicyByName(ctx, "to-be-deleted")
+	assert.ErrorIs(t, err, api.ErrAppControlPolicyNotFound)
+}
+
+// TestAppControl_DeletePolicy_RefusesDefault locks the failsafe guard: an admin cannot rip the seed policy out from under the
+// agents by accident. The handler maps the typed sentinel to HTTP 409.
+func TestAppControl_DeletePolicy_RefusesDefault(t *testing.T) {
+	t.Parallel()
+	store, _ := newAppControlStore(t)
+	ctx := t.Context()
+	policy, err := store.GetPolicyByName(ctx, api.DefaultPolicyName)
+	require.NoError(t, err)
+
+	err = store.DeletePolicy(ctx, api.DeletePolicyRequest{
+		PolicyID: policy.ID, Actor: "demo-admin", Reason: "should be blocked",
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, api.ErrAppControlPolicyImmutable)
+}
+
+// TestAppControl_DeletePolicy_NotFound confirms the typed sentinel for an unknown id.
+func TestAppControl_DeletePolicy_NotFound(t *testing.T) {
+	t.Parallel()
+	store, _ := newAppControlStore(t)
+	err := store.DeletePolicy(t.Context(), api.DeletePolicyRequest{
+		PolicyID: 9_999_999, Actor: "demo-admin", Reason: "stale id",
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, api.ErrAppControlPolicyNotFound)
+}

--- a/server/rules/internal/tests/appcontrol_rest_test.go
+++ b/server/rules/internal/tests/appcontrol_rest_test.go
@@ -537,3 +537,403 @@ func TestAppControlREST_CreateRule_HostListerFailureRecorded(t *testing.T) {
 func i64(v int64) string {
 	return strconv.FormatInt(v, 10)
 }
+
+// seedRule is a tiny helper that POSTs a BINARY rule and returns its id so the PATCH/DELETE tests have a fixture without
+// duplicating the create JSON 6 times. The identifier is per-test-unique so parallel runs don't collide on the (policy,
+// rule_type, identifier) unique key.
+func seedRule(t *testing.T, r *appControlRig, policyID int64, identifier string) int64 {
+	t.Helper()
+	resp := r.do(t, http.MethodPost,
+		"/api/v1/app-control/policies/"+i64(policyID)+"/rules",
+		map[string]any{
+			"rule_type":  rulesapi.RuleTypeBinary,
+			"identifier": identifier,
+			"severity":   rulesapi.SeverityRuleMedium,
+			"reason":     "seed for mutation test",
+		})
+	defer resp.Body.Close()
+	require.Equalf(t, http.StatusCreated, resp.StatusCode, "seed rule POST failed: status %d", resp.StatusCode)
+	var rule rulesapi.ApplicationControlRule
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&rule))
+	return rule.ID
+}
+
+// TestAppControlREST_UpdateRule_HappyPath_FansOutAndAudits hits PATCH /rules/{id}, asserts the response carries the updated
+// fields, that a fresh set_application_control command lands on every host, and that the rule_update audit row reflects the
+// post-bump policy_version and fanout counts.
+func TestAppControlREST_UpdateRule_HappyPath_FansOutAndAudits(t *testing.T) {
+	t.Parallel()
+	r := newAppControlRig(t, []string{"host-a", "host-b"})
+	policyID := r.defaultPolicyID(t)
+	ruleID := seedRule(t, r, policyID, strings.Repeat("1", 64))
+	// Capture inserter state after the seed-create so we assert on PATCH-only inserts.
+	preCount := len(r.inserter.snapshot())
+
+	resp := r.do(t, http.MethodPatch, "/api/v1/app-control/rules/"+i64(ruleID), map[string]any{
+		"enabled":  false,
+		"severity": "high",
+		"reason":   "PATCH coverage",
+	})
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	var updated rulesapi.ApplicationControlRule
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&updated))
+	assert.False(t, updated.Enabled)
+	assert.Equal(t, rulesapi.SeverityRuleHigh, updated.Severity)
+
+	postCount := len(r.inserter.snapshot())
+	assert.Equal(t, 2, postCount-preCount, "PATCH must fan out one snapshot per host")
+
+	events := r.audit.snapshot()
+	require.GreaterOrEqual(t, len(events), 2)
+	last := events[len(events)-1]
+	assert.Equal(t, identityapi.AuditAppControlRuleUpdate, last.Action)
+	assert.Equal(t, "application_control_rule", last.TargetType)
+	assert.Equal(t, i64(ruleID), last.TargetID)
+	assert.Equal(t, 2, last.Payload["fanout_hosts"])
+}
+
+// TestAppControlREST_UpdateRule_NotFound: a PATCH on a missing rule maps the typed sentinel to HTTP 404 with the rule_not_found
+// error code.
+func TestAppControlREST_UpdateRule_NotFound(t *testing.T) {
+	t.Parallel()
+	r := newAppControlRig(t, []string{"host-a"})
+	resp := r.do(t, http.MethodPatch, "/api/v1/app-control/rules/9999999", map[string]any{
+		"enabled": false, "reason": "404 path",
+	})
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusNotFound, resp.StatusCode)
+	var body struct {
+		Error string `json:"error"`
+	}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	assert.Equal(t, "application_control.rule_not_found", body.Error)
+}
+
+// TestAppControlREST_UpdateRule_NoMutableFieldIs400 confirms a body with only `reason` (no enabled/severity/etc.) is rejected
+// as 400 invalid_rule rather than silently bumping the policy version with a SET clause containing only `version`.
+func TestAppControlREST_UpdateRule_NoMutableFieldIs400(t *testing.T) {
+	t.Parallel()
+	r := newAppControlRig(t, []string{"host-a"})
+	policyID := r.defaultPolicyID(t)
+	ruleID := seedRule(t, r, policyID, strings.Repeat("2", 64))
+	resp := r.do(t, http.MethodPatch, "/api/v1/app-control/rules/"+i64(ruleID), map[string]any{
+		"reason": "no mutable field",
+	})
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+// TestAppControlREST_UpdateRule_InvalidRuleID covers the path-parse 400. Symmetric to InvalidPolicyID on the create-rule path.
+func TestAppControlREST_UpdateRule_InvalidRuleID(t *testing.T) {
+	t.Parallel()
+	r := newAppControlRig(t, []string{"host-a"})
+	resp := r.do(t, http.MethodPatch, "/api/v1/app-control/rules/not-an-int", map[string]any{
+		"enabled": true, "reason": "x",
+	})
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	var body struct {
+		Error string `json:"error"`
+	}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	assert.Equal(t, "application_control.invalid_rule_id", body.Error)
+}
+
+// TestAppControlREST_UpdateRule_InvalidJSON covers the malformed-body 400 path through the handler.
+func TestAppControlREST_UpdateRule_InvalidJSON(t *testing.T) {
+	t.Parallel()
+	r := newAppControlRig(t, []string{"host-a"})
+	policyID := r.defaultPolicyID(t)
+	ruleID := seedRule(t, r, policyID, strings.Repeat("3", 64))
+	// Build a raw HTTP request so we can send malformed JSON.
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPatch,
+		r.srv.URL+"/api/v1/app-control/rules/"+i64(ruleID), strings.NewReader("{not-json}"))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := r.srv.Client().Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+// TestAppControlREST_DeleteRule_HappyPath_FansOutAndAudits covers the DELETE path: rule is removed, a post-delete snapshot fans
+// out so agents drop the rule, and the audit row records the prior rule's type/identifier.
+func TestAppControlREST_DeleteRule_HappyPath_FansOutAndAudits(t *testing.T) {
+	t.Parallel()
+	r := newAppControlRig(t, []string{"host-a"})
+	policyID := r.defaultPolicyID(t)
+	ruleID := seedRule(t, r, policyID, strings.Repeat("4", 64))
+	preCount := len(r.inserter.snapshot())
+
+	resp := r.do(t, http.MethodDelete, "/api/v1/app-control/rules/"+i64(ruleID), map[string]any{
+		"reason": "DELETE coverage",
+	})
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+
+	postCount := len(r.inserter.snapshot())
+	assert.Equal(t, 1, postCount-preCount, "DELETE must fan out an empty-rules snapshot")
+
+	events := r.audit.snapshot()
+	last := events[len(events)-1]
+	assert.Equal(t, identityapi.AuditAppControlRuleDelete, last.Action)
+	assert.Equal(t, i64(ruleID), last.TargetID)
+	assert.Equal(t, "BINARY", last.Payload["rule_type"], "audit captures prior rule_type before delete")
+}
+
+// TestAppControlREST_DeleteRule_NotFound: missing rule id → 404 rule_not_found.
+func TestAppControlREST_DeleteRule_NotFound(t *testing.T) {
+	t.Parallel()
+	r := newAppControlRig(t, []string{"host-a"})
+	resp := r.do(t, http.MethodDelete, "/api/v1/app-control/rules/9999999", map[string]any{
+		"reason": "404 path",
+	})
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusNotFound, resp.StatusCode)
+}
+
+// TestAppControlREST_DeleteRule_EmptyAndWhitespaceBody both fall through to "reason is required" rather than invalid_json
+// (Copilot finding). Splitting into subtests so the bodies-of-various-shapes contract is one test with subtest attribution.
+func TestAppControlREST_DeleteRule_EmptyAndWhitespaceBody(t *testing.T) {
+	t.Parallel()
+	r := newAppControlRig(t, []string{"host-a"})
+	policyID := r.defaultPolicyID(t)
+	for _, tc := range []struct {
+		name    string
+		body    string
+		seedHex string // BINARY identifiers must be hex; one unique hex char per subtest avoids the unique-key collision.
+	}{
+		{"empty body", "", "e"},
+		{"whitespace body", "   \n\t  ", "f"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ruleID := seedRule(t, r, policyID, strings.Repeat(tc.seedHex, 64))
+			req, err := http.NewRequestWithContext(t.Context(), http.MethodDelete,
+				r.srv.URL+"/api/v1/app-control/rules/"+i64(ruleID), strings.NewReader(tc.body))
+			require.NoError(t, err)
+			req.Header.Set("Content-Type", "application/json")
+			resp, err := r.srv.Client().Do(req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+			// Whitespace + empty bodies parse as "no reason supplied" -> service-level validation 400 (not invalid_json).
+			require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+			var body struct {
+				Error string `json:"error"`
+			}
+			require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+			assert.NotEqual(t, "application_control.invalid_json", body.Error,
+				"whitespace-only body must NOT be misreported as invalid_json (Copilot finding on PR #188)")
+		})
+	}
+}
+
+// TestAppControlREST_CreatePolicy_HappyPath covers POST /policies: a new policy lands at version=1 with no rules and no fan-out
+// (no assignments yet). The audit row records policy_create + the new policy_id.
+func TestAppControlREST_CreatePolicy_HappyPath(t *testing.T) {
+	t.Parallel()
+	r := newAppControlRig(t, []string{"host-a"})
+	preInserts := len(r.inserter.snapshot())
+
+	resp := r.do(t, http.MethodPost, "/api/v1/app-control/policies", map[string]any{
+		"name":        "engineering-laptops",
+		"description": "Custom policy for the eng laptop fleet",
+		"reason":      "POST coverage",
+	})
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+	var policy rulesapi.ApplicationControlPolicy
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&policy))
+	assert.NotZero(t, policy.ID)
+	assert.Equal(t, "engineering-laptops", policy.Name)
+	assert.Equal(t, int64(1), policy.Version)
+
+	assert.Equal(t, preInserts, len(r.inserter.snapshot()), "POST /policies must not fan out (no assignments)")
+	events := r.audit.snapshot()
+	last := events[len(events)-1]
+	assert.Equal(t, identityapi.AuditAppControlPolicyCreate, last.Action)
+	assert.Equal(t, "application_control_policy", last.TargetType)
+}
+
+// TestAppControlREST_CreatePolicy_DuplicateName: posting a name that already exists returns 409 duplicate_policy.
+func TestAppControlREST_CreatePolicy_DuplicateName(t *testing.T) {
+	t.Parallel()
+	r := newAppControlRig(t, []string{"host-a"})
+	resp := r.do(t, http.MethodPost, "/api/v1/app-control/policies", map[string]any{
+		"name":   rulesapi.DefaultPolicyName, // collides with the seeded Default
+		"reason": "should collide",
+	})
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusConflict, resp.StatusCode)
+	var body struct {
+		Error string `json:"error"`
+	}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	assert.Equal(t, "application_control.duplicate_policy", body.Error)
+}
+
+// TestAppControlREST_CreatePolicy_InvalidJSON covers the 400 invalid_json path on POST /policies.
+func TestAppControlREST_CreatePolicy_InvalidJSON(t *testing.T) {
+	t.Parallel()
+	r := newAppControlRig(t, []string{"host-a"})
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost,
+		r.srv.URL+"/api/v1/app-control/policies", strings.NewReader("{not-json}"))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := r.srv.Client().Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+// TestAppControlREST_UpdatePolicy_HappyPath_RenamesAndBumps covers PATCH /policies/{id}.
+func TestAppControlREST_UpdatePolicy_HappyPath_RenamesAndBumps(t *testing.T) {
+	t.Parallel()
+	r := newAppControlRig(t, []string{"host-a"})
+	// Create a custom policy so we can rename it without tripping the Default-rename guard.
+	createResp := r.do(t, http.MethodPost, "/api/v1/app-control/policies", map[string]any{
+		"name": "alpha", "reason": "fixture",
+	})
+	defer createResp.Body.Close()
+	require.Equal(t, http.StatusCreated, createResp.StatusCode)
+	var p rulesapi.ApplicationControlPolicy
+	require.NoError(t, json.NewDecoder(createResp.Body).Decode(&p))
+
+	resp := r.do(t, http.MethodPatch, "/api/v1/app-control/policies/"+i64(p.ID), map[string]any{
+		"name":        "alpha-renamed",
+		"description": "after the rebrand",
+		"reason":      "PATCH coverage",
+	})
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	var updated rulesapi.ApplicationControlPolicy
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&updated))
+	assert.Equal(t, "alpha-renamed", updated.Name)
+	assert.Equal(t, "after the rebrand", updated.Description)
+	assert.Equal(t, p.Version+1, updated.Version)
+}
+
+// TestAppControlREST_UpdatePolicy_RefusesRenameOfDefault closes the Copilot-flagged bypass: renaming Default then deleting it
+// would defeat the immutability guard. The store layer now rejects the rename with PolicyImmutable; verify it surfaces here as
+// 409 with the typed error code.
+func TestAppControlREST_UpdatePolicy_RefusesRenameOfDefault(t *testing.T) {
+	t.Parallel()
+	r := newAppControlRig(t, []string{"host-a"})
+	policyID := r.defaultPolicyID(t)
+	resp := r.do(t, http.MethodPatch, "/api/v1/app-control/policies/"+i64(policyID), map[string]any{
+		"name":   "not-default",
+		"reason": "should be refused",
+	})
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusConflict, resp.StatusCode)
+	var body struct {
+		Error string `json:"error"`
+	}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	assert.Equal(t, "application_control.policy_immutable", body.Error,
+		"renaming the seed Default policy must be refused so the rename-then-delete bypass closes")
+}
+
+// TestAppControlREST_UpdatePolicy_DefaultDescriptionEditAllowed confirms the rename guard does NOT block a description-only
+// edit of the seed Default policy. Operators MUST still be able to amend the Default policy's metadata; only the rename is
+// gated.
+func TestAppControlREST_UpdatePolicy_DefaultDescriptionEditAllowed(t *testing.T) {
+	t.Parallel()
+	r := newAppControlRig(t, []string{"host-a"})
+	policyID := r.defaultPolicyID(t)
+	resp := r.do(t, http.MethodPatch, "/api/v1/app-control/policies/"+i64(policyID), map[string]any{
+		"description": "amended description for the seed policy",
+		"reason":      "description-only edit must pass",
+	})
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+// TestAppControlREST_UpdatePolicy_NotFound: PATCH on missing id → 404.
+func TestAppControlREST_UpdatePolicy_NotFound(t *testing.T) {
+	t.Parallel()
+	r := newAppControlRig(t, []string{"host-a"})
+	resp := r.do(t, http.MethodPatch, "/api/v1/app-control/policies/9999999", map[string]any{
+		"name": "x", "reason": "404 path",
+	})
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusNotFound, resp.StatusCode)
+}
+
+// TestAppControlREST_DeletePolicy_HappyPath covers the destructive path on a custom policy.
+func TestAppControlREST_DeletePolicy_HappyPath(t *testing.T) {
+	t.Parallel()
+	r := newAppControlRig(t, []string{"host-a"})
+	createResp := r.do(t, http.MethodPost, "/api/v1/app-control/policies", map[string]any{
+		"name": "to-be-deleted", "reason": "fixture",
+	})
+	defer createResp.Body.Close()
+	require.Equal(t, http.StatusCreated, createResp.StatusCode)
+	var p rulesapi.ApplicationControlPolicy
+	require.NoError(t, json.NewDecoder(createResp.Body).Decode(&p))
+
+	resp := r.do(t, http.MethodDelete, "/api/v1/app-control/policies/"+i64(p.ID), map[string]any{
+		"reason": "DELETE coverage",
+	})
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+
+	events := r.audit.snapshot()
+	last := events[len(events)-1]
+	assert.Equal(t, identityapi.AuditAppControlPolicyDelete, last.Action)
+	assert.Equal(t, i64(p.ID), last.TargetID)
+}
+
+// TestAppControlREST_DeletePolicy_RefusesDefault confirms the failsafe: deleting the seed Default policy returns 409 immutable.
+func TestAppControlREST_DeletePolicy_RefusesDefault(t *testing.T) {
+	t.Parallel()
+	r := newAppControlRig(t, []string{"host-a"})
+	policyID := r.defaultPolicyID(t)
+	resp := r.do(t, http.MethodDelete, "/api/v1/app-control/policies/"+i64(policyID), map[string]any{
+		"reason": "should be refused",
+	})
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusConflict, resp.StatusCode)
+	var body struct {
+		Error string `json:"error"`
+	}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	assert.Equal(t, "application_control.policy_immutable", body.Error)
+}
+
+// TestAppControlREST_DeletePolicy_NotFound: missing id → 404.
+func TestAppControlREST_DeletePolicy_NotFound(t *testing.T) {
+	t.Parallel()
+	r := newAppControlRig(t, []string{"host-a"})
+	resp := r.do(t, http.MethodDelete, "/api/v1/app-control/policies/9999999", map[string]any{
+		"reason": "404 path",
+	})
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusNotFound, resp.StatusCode)
+}
+
+// TestAppControlREST_Mutations_InvalidPolicyID covers the path-parse 400 branch on every policy-id-bearing endpoint. Each row
+// is a parameterised subtest so the four endpoints share a single setup.
+func TestAppControlREST_Mutations_InvalidPolicyID(t *testing.T) {
+	t.Parallel()
+	r := newAppControlRig(t, []string{"host-a"})
+	for _, tc := range []struct {
+		name   string
+		method string
+		body   map[string]any
+	}{
+		{"PATCH", http.MethodPatch, map[string]any{"name": "x", "reason": "x"}},
+		{"DELETE", http.MethodDelete, map[string]any{"reason": "x"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := r.do(t, tc.method, "/api/v1/app-control/policies/not-a-number", tc.body)
+			defer resp.Body.Close()
+			require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+			var body struct {
+				Error string `json:"error"`
+			}
+			require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+			assert.Equal(t, "application_control.invalid_policy_id", body.Error)
+		})
+	}
+}


### PR DESCRIPTION
Phase A close-out (PR #185) shipped POST /rules but left the rest of the mutation surface deferred. Detect-mode (separate change) needs PATCH /rules/{id} to flip per-rule enforcement, so the mutation endpoints land together as the natural next step. Stacked on top of issue-68-app-control-phase-a-closeout — open after #185 merges.

Routes added (server/rules/internal/operator/appcontrol_handler.go):
  POST   /api/v1/app-control/policies
  PATCH  /api/v1/app-control/policies/{id}
  DELETE /api/v1/app-control/policies/{id}
  PATCH  /api/v1/app-control/rules/{id}
  DELETE /api/v1/app-control/rules/{id}

Bulk upsert, cross-policy GET, /host-groups CRUD, and POST assignments stay deferred to follow-on PRs per the openspec.

Authz + audit (identity context):
- Five new Action constants (rule_update, rule_delete, policy_create, policy_update, policy_delete) added to api.RegisteredActions plus the policy/data/actions.json mirror. roles.json's admin role grants every new action; super_admin's wildcard already covers them. The Rego parity check + the "every registered action reaches a non-wildcard role" engine test both pass without further changes.
- Five matching AuditAction constants on identity/api/audit.go so the audit-recorder dispatch tables stay symmetric across all mutation surfaces; SIEM dashboards can filter by Action verbatim.

API types (server/rules/api/types.go):
- New error sentinels: ErrAppControlRuleNotFound (404 on PATCH/DELETE rule), ErrAppControlDuplicatePolicy (409 on POST/PATCH policy name collision), ErrAppControlPolicyImmutable (409 on DELETE of the seed Default policy).
- New request structs (UpdateRuleRequest, DeleteRuleRequest, CreatePolicyRequest, UpdatePolicyRequest, DeletePolicyRequest) with pointer-optional fields so PATCH bodies distinguish "absent" from "explicit zero" (e.g. clearing custom_msg by sending "").
- ApplicationControlStore interface grows GetRuleByID, UpdateRule, DeleteRule, CreatePolicy, UpdatePolicy, DeletePolicy methods so the rules-context REST handler depends on the contract without pulling in the internal package (ADR-0004's bounded-context rule).

Store (server/rules/internal/appcontrol/store.go):
- GetRuleByID is the public alias for the existing getRuleByID + maps sql.ErrNoRows to ErrAppControlRuleNotFound for the 404 path.
- UpdateRule applies a partial update + bumps the policy version in one transaction. PolicyID is read from the existing row inside the txn so a PATCH cannot inadvertently move a rule between policies.
- DeleteRule deletes + bumps version in one transaction, returns the parent policy_id so the service-layer fanout targets the right policy.
- CreatePolicy inserts a new row with version=1, default_action='NONE'. The seed Default's failsafe assignment is intentionally NOT replicated; the operator attaches groups via a Phase B endpoint.
- UpdatePolicy applies partial (name / description) + bumps version
  + sets updated_by. Duplicate-name collisions surface as ErrAppControlDuplicatePolicy.
- DeletePolicy refuses the seed Default policy by name (ErrAppControlPolicyImmutable); ON DELETE CASCADE on app_control_rules + app_control_assignments cleans child rows.

Service (server/rules/internal/appcontrol/service.go):
- UpdateRule + DeleteRule recompose the post-mutation snapshot and fan it out so agents drop / re-apply the affected rule on their next poll. The audit row records policy_id, post-bump policy_version, rule_type, identifier, severity, reason, fanout_hosts, fanout_failed, and (when set) fanout_skipped_reason — same shape as the create-rule audit so dashboards filter consistently.
- DeleteRule looks up the rule BEFORE deleting so the audit payload captures rule_type + identifier; reading after the cascade would race with the row removal.
- CreatePolicy + UpdatePolicy + DeletePolicy emit a smaller policy-scoped audit payload (no fanout fields, since policy rename / description does not touch the rules snapshot and a non-Default delete has no host assignments to push to in Phase A).
- recordAudit is a small low-level helper that centralises the nil-audit guard and the actor-id back-fill; the per-op recorders build their payload and pass a complete AuditEvent through.

Tests:
- server/rules/internal/tests/app_control_test.go: 11 new integration tests covering Update / Delete / Create / Update / Delete happy paths + 404 / 409 / immutable / no-fields sentinels.
- server/rules/internal/appcontrol/service_test.go: 3 service-layer tests covering UpdateRule fanout + audit, DeleteRule fanout + audit, CreatePolicy audits without fanning out.

Verification: go build ./server/...; go test -tags=integration on the whole server/rules + server/identity trees passes; the Rego TestPolicy_ActionsParity check passes (actions + grants both updated).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to update application control rules with customizable fields (enabled status, severity, messages, comments, expiration)
  * Added ability to delete application control rules
  * Added ability to create, update, and delete application control policies
  * Enabled comprehensive audit logging for all rule and policy lifecycle operations
  * Added role-based authorization controls for rule and policy management actions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/getvictor/fleet-edr/pull/188?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->