### PR TITLE
app-control: per-row rule actions in UI — enable/disable, edit, delet…

### DIFF
--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -475,6 +475,86 @@ export async function createAppControlRule(
   return res.json() as Promise<ApplicationControlRule>;
 }
 
+// UpdateAppControlRuleRequest is the JSON body the PATCH endpoint accepts. Mirrors updateRuleRequest in
+// server/rules/internal/operator/appcontrol_handler.go. Every mutable field is optional so a body that flips only `enabled`
+// still validates; `reason` is required for the audit trail. Phase B's Detect-mode change will layer an `enforcement` field
+// on top of this shape.
+export interface UpdateAppControlRuleRequest {
+  enabled?: boolean;
+  severity?: string;
+  custom_msg?: string;
+  custom_url?: string;
+  comment?: string;
+  expires_at?: string;
+  reason: string;
+}
+
+// DeleteAppControlRuleRequest carries the audit reason for DELETE /rules/{id}.
+export interface DeleteAppControlRuleRequest {
+  reason: string;
+}
+
+// patchAppControlEndpoint is the shared body of updateAppControlRule + deleteAppControlRule. The two endpoints have the same
+// auth + reauth + typed-error handling as createAppControlRule; centralising here keeps the three calls in lockstep.
+async function patchAppControlEndpoint<T>(
+  method: "PATCH" | "DELETE",
+  path: string,
+  body: unknown,
+  parseResponse: (res: Response) => Promise<T>,
+): Promise<T> {
+  assertSafeAPIPath(path);
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  attachCsrfHeader(headers, method);
+  const target = new URL(API_BASE + path, globalThis.location.origin);
+  const res = await fetch(target, {
+    method,
+    credentials: "include",
+    headers,
+    body: JSON.stringify(body),
+  });
+  if (res.status === HTTP_STATUS_UNAUTHORIZED) {
+    clearCsrfToken();
+    throw new Unauthorized401Error();
+  }
+  if (res.status === HTTP_STATUS_FORBIDDEN) {
+    const reauth = await readReauthChallenge(res);
+    if (reauth) throw new ReauthRequiredError(reauth);
+  }
+  if (!res.ok) {
+    const errBody = (await res.clone().json().catch((): null => null)) as AppControlErrorBody | null;
+    if (errBody?.error) {
+      throw new AppControlApiError(errBody.error, errBody.message ?? errBody.error, res.status);
+    }
+    throw new Error(`API error: ${String(res.status)} ${res.statusText}`);
+  }
+  return parseResponse(res);
+}
+
+export async function updateAppControlRule(
+  ruleID: number,
+  req: UpdateAppControlRuleRequest,
+): Promise<ApplicationControlRule> {
+  return patchAppControlEndpoint(
+    "PATCH",
+    `/v1/app-control/rules/${String(ruleID)}`,
+    req,
+    (res) => res.json() as Promise<ApplicationControlRule>,
+  );
+}
+
+export async function deleteAppControlRule(
+  ruleID: number,
+  req: DeleteAppControlRuleRequest,
+): Promise<void> {
+  await patchAppControlEndpoint(
+    "DELETE",
+    `/v1/app-control/rules/${String(ruleID)}`,
+    req,
+    // DELETE returns 204 No Content; resolve to undefined without parsing.
+    () => Promise.resolve(undefined),
+  );
+}
+
 export async function createCommand(hostId: string, commandType: string, payload: Record<string, unknown>): Promise<{ id: number }> {
   return fetchJSON<{ id: number }>("/commands", {
     method: "POST",

--- a/ui/src/components/ApplicationControl/AddRuleModal.tsx
+++ b/ui/src/components/ApplicationControl/AddRuleModal.tsx
@@ -1,14 +1,13 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import {
   createAppControlRule,
-  AppControlApiError,
-  ReauthRequiredError,
   type CreateAppControlRuleRequest,
 } from "../../api";
 import { useReauthRetry } from "../../hooks/useReauthRetry";
 import { ReauthModal } from "../ReauthModal";
-import { Button } from "../ui/Button";
 import { Input, Select } from "../ui/Input";
+import { AppControlDialogShell } from "./AppControlDialogShell";
+import { applyAppControlSubmitError } from "./dialogErrors";
 import "./ApplicationControl.scss";
 
 // AddRuleModalProps is the parent contract. open drives showModal() /
@@ -120,7 +119,6 @@ const errorMessageByCode = new Map<string, string>([
 ]);
 
 export function AddRuleModal({ open, policyID, onClose, onCreated }: AddRuleModalProps) {
-  const dialogRef = useRef<HTMLDialogElement>(null);
   const [ruleType, setRuleType] = useState("BINARY");
   const [identifier, setIdentifier] = useState("");
   const [severity, setSeverity] = useState("medium");
@@ -130,9 +128,7 @@ export function AddRuleModal({ open, policyID, onClose, onCreated }: AddRuleModa
   const [busy, setBusy] = useState(false);
   const [formError, setFormError] = useState<string | null>(null);
 
-  // Reset the form whenever the dialog opens. Otherwise a Cancel +
-  // re-open would surface the previous attempt's values, which is
-  // confusing for the demo recording (and for real operators).
+  // Reset the form whenever the dialog opens. Otherwise a Cancel + re-open would surface the previous attempt's values.
   useEffect(() => {
     if (!open) return;
     // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional reset tied to the open prop transition
@@ -145,35 +141,6 @@ export function AddRuleModal({ open, policyID, onClose, onCreated }: AddRuleModa
     setBusy(false);
     setFormError(null);
   }, [open]);
-
-  // Open / close the native <dialog>. showModal() is what gives us
-  // backdrop, focus trap, and Escape-to-cancel for free; the
-  // declarative `open` attribute would render non-modal.
-  useEffect(() => {
-    const dlg = dialogRef.current;
-    if (!dlg) return;
-    if (open && !dlg.open) {
-      dlg.showModal();
-    } else if (!open && dlg.open) {
-      dlg.close();
-    }
-  }, [open]);
-
-  // Escape and backdrop click both route through onClose so the
-  // parent's open-state is the single source of truth.
-  const handleCancel = useCallback((e: React.SyntheticEvent<HTMLDialogElement>) => {
-    e.preventDefault();
-    onClose();
-  }, [onClose]);
-  useEffect(() => {
-    const dlg = dialogRef.current;
-    if (!dlg) return undefined;
-    const onBackdrop = (e: MouseEvent) => {
-      if (e.target === dlg) onClose();
-    };
-    dlg.addEventListener("click", onBackdrop);
-    return () => { dlg.removeEventListener("click", onBackdrop); };
-  }, [onClose]);
 
   const submitCreate = useCallback(
     (req: CreateAppControlRuleRequest) => createAppControlRule(policyID, req),
@@ -191,12 +158,8 @@ export function AddRuleModal({ open, policyID, onClose, onCreated }: AddRuleModa
       setFormError(validation);
       return;
     }
-    // The host-app modal only renders "More info" for http/https
-    // URLs (BlockAlert.swift rejects other schemes so a hostile
-    // rule author can't trigger arbitrary URL handlers from a
-    // single click). Enforce the same posture client-side so the
-    // operator sees the rejection at the form instead of saving
-    // a rule whose link will never appear in the modal.
+    // The host-app modal only renders "More info" for http/https URLs (BlockAlert.swift rejects other schemes so a hostile rule
+    // author can't trigger arbitrary URL handlers from a single click). Enforce the same posture client-side.
     const trimmedURL = customURL.trim();
     if (trimmedURL.length > 0) {
       try {
@@ -224,18 +187,8 @@ export function AddRuleModal({ open, policyID, onClose, onCreated }: AddRuleModa
       await callCreate(req);
       onCreated();
     } catch (err) {
-      if (err instanceof ReauthRequiredError) {
-        // useReauthRetry's modal is mounted at the bottom of this
-        // component; the user finishes the reauth and the original
-        // call retries on its own. No UI work to do here.
+      if (applyAppControlSubmitError(err, setFormError, errorMessageByCode, "Failed to create rule.")) {
         return;
-      }
-      if (err instanceof AppControlApiError) {
-        setFormError(errorMessageByCode.get(err.code) ?? err.message);
-      } else if (err instanceof Error) {
-        setFormError(err.message);
-      } else {
-        setFormError("Failed to create rule.");
       }
     } finally {
       setBusy(false);
@@ -243,122 +196,93 @@ export function AddRuleModal({ open, policyID, onClose, onCreated }: AddRuleModa
   }
 
   return (
-    <>
-      <dialog
-        ref={dialogRef}
-        className="app-control-dialog"
-        aria-labelledby={DIALOG_TITLE_ID}
-        onCancel={handleCancel}
+    <AppControlDialogShell
+      open={open}
+      onClose={onClose}
+      titleId={DIALOG_TITLE_ID}
+      title="Add rule"
+      subtitle="Block an executable on every assigned host. The rule fans out to enrolled agents on save."
+      formError={formError}
+      busy={busy}
+      submitDisabled={submitDisabled}
+      submitLabel="Save rule"
+      onSubmit={(e) => { void handleSubmit(e); }}
+      reauthModal={<ReauthModal {...reauthModal} />}
+    >
+      <Select
+        id="rule-type"
+        label="Type"
+        inline={false}
+        value={ruleType}
+        onChange={(e) => { setRuleType(e.target.value); }}
+        disabled={busy}
       >
-        <div className="app-control-dialog__header">
-          <h2 id={DIALOG_TITLE_ID} className="app-control-dialog__title">Add rule</h2>
-          <p className="app-control-dialog__subtitle">
-            Block an executable on every assigned host. The rule fans
-            out to enrolled agents on save.
-          </p>
-        </div>
-
-        {formError && (
-          <div className="app-control-dialog__error" role="alert">
-            {formError}
-          </div>
-        )}
-
-        <form
-          onSubmit={(e) => { void handleSubmit(e); }}
-          className="app-control-dialog__form"
-        >
-          <Select
-            id="rule-type"
-            label="Type"
-            inline={false}
-            value={ruleType}
-            onChange={(e) => { setRuleType(e.target.value); }}
-            disabled={busy}
+        {RULE_TYPES.map((t) => (
+          <option
+            key={t.value}
+            value={t.value}
+            disabled={!t.available}
           >
-            {RULE_TYPES.map((t) => (
-              <option
-                key={t.value}
-                value={t.value}
-                disabled={!t.available}
-              >
-                {t.label}{t.available ? "" : " (coming soon)"}
-              </option>
-            ))}
-          </Select>
+            {t.label}{t.available ? "" : " (coming soon)"}
+          </option>
+        ))}
+      </Select>
 
-          <Input
-            id="rule-identifier"
-            label="Identifier"
-            type="text"
-            autoComplete="off"
-            spellCheck={false}
-            placeholder={PLACEHOLDERS.get(ruleType) ?? ""}
-            value={identifier}
-            onChange={(e) => { setIdentifier(e.target.value); }}
-            disabled={busy}
-            autoFocus
-          />
+      <Input
+        id="rule-identifier"
+        label="Identifier"
+        type="text"
+        autoComplete="off"
+        spellCheck={false}
+        placeholder={PLACEHOLDERS.get(ruleType) ?? ""}
+        value={identifier}
+        onChange={(e) => { setIdentifier(e.target.value); }}
+        disabled={busy}
+        autoFocus
+      />
 
-          <Select
-            id="rule-severity"
-            label="Severity"
-            inline={false}
-            value={severity}
-            onChange={(e) => { setSeverity(e.target.value); }}
-            disabled={busy}
-          >
-            {SEVERITIES.map((s) => (
-              <option key={s} value={s}>{s}</option>
-            ))}
-          </Select>
+      <Select
+        id="rule-severity"
+        label="Severity"
+        inline={false}
+        value={severity}
+        onChange={(e) => { setSeverity(e.target.value); }}
+        disabled={busy}
+      >
+        {SEVERITIES.map((s) => (
+          <option key={s} value={s}>{s}</option>
+        ))}
+      </Select>
 
-          <Input
-            id="rule-custom-msg"
-            label="Custom message (optional)"
-            type="text"
-            placeholder="Blocked by corporate policy"
-            value={customMsg}
-            onChange={(e) => { setCustomMsg(e.target.value); }}
-            disabled={busy}
-          />
+      <Input
+        id="rule-custom-msg"
+        label="Custom message (optional)"
+        type="text"
+        placeholder="Blocked by corporate policy"
+        value={customMsg}
+        onChange={(e) => { setCustomMsg(e.target.value); }}
+        disabled={busy}
+      />
 
-          <Input
-            id="rule-custom-url"
-            label="More info URL (optional, http/https only)"
-            type="url"
-            placeholder="https://help.example.com/blocked"
-            value={customURL}
-            onChange={(e) => { setCustomURL(e.target.value); }}
-            disabled={busy}
-          />
+      <Input
+        id="rule-custom-url"
+        label="More info URL (optional, http/https only)"
+        type="url"
+        placeholder="https://help.example.com/blocked"
+        value={customURL}
+        onChange={(e) => { setCustomURL(e.target.value); }}
+        disabled={busy}
+      />
 
-          <Input
-            id="rule-reason"
-            label="Reason (required for audit log)"
-            type="text"
-            placeholder="Why are you authoring this rule?"
-            value={reason}
-            onChange={(e) => { setReason(e.target.value); }}
-            disabled={busy}
-          />
-
-          <div className="app-control-dialog__actions">
-            <Button
-              type="button"
-              variant="text-link"
-              onClick={onClose}
-              disabled={busy}
-            >
-              Cancel
-            </Button>
-            <Button type="submit" disabled={submitDisabled} isLoading={busy}>
-              {busy ? "Saving…" : "Save rule"}
-            </Button>
-          </div>
-        </form>
-      </dialog>
-      <ReauthModal {...reauthModal} />
-    </>
+      <Input
+        id="rule-reason"
+        label="Reason (required for audit log)"
+        type="text"
+        placeholder="Why are you authoring this rule?"
+        value={reason}
+        onChange={(e) => { setReason(e.target.value); }}
+        disabled={busy}
+      />
+    </AppControlDialogShell>
   );
 }

--- a/ui/src/components/ApplicationControl/AppControlDialogShell.tsx
+++ b/ui/src/components/ApplicationControl/AppControlDialogShell.tsx
@@ -1,0 +1,97 @@
+import type { ReactNode, SyntheticEvent } from "react";
+import { Button, type ButtonVariant } from "../ui/Button";
+import { useAppControlDialog } from "./useAppControlDialog";
+import "./ApplicationControl.scss";
+
+interface AppControlDialogShellProps {
+  // open mirrors the parent's open prop. The shell uses the shared useAppControlDialog hook to wire showModal/close + cancel +
+  // backdrop click handling.
+  readonly open: boolean;
+  readonly onClose: () => void;
+  // titleId + title + subtitle render the dialog header.
+  readonly titleId: string;
+  readonly title: string;
+  readonly subtitle?: ReactNode;
+  // formError + isBusy + submitDisabled control the action buttons row + the inline error display.
+  readonly formError: string | null;
+  readonly busy: boolean;
+  readonly submitDisabled: boolean;
+  readonly submitLabel: string;
+  readonly submitBusyLabel?: string;
+  readonly submitVariant?: ButtonVariant;
+  readonly onSubmit: (e: SyntheticEvent) => void;
+  // children renders the per-form inputs between the error box and the action buttons.
+  readonly children: ReactNode;
+  // reauthModal lets the caller mount useReauthRetry's modal as a sibling without leaking the dialog scaffolding above.
+  readonly reauthModal?: ReactNode;
+}
+
+// AppControlDialogShell wraps the duplicated dialog scaffolding (header + error box + form + action buttons + reauth modal) the
+// three app-control modals share. Per-modal form fields live in `children`. Sonar flagged the scaffold duplication on PR #189 as
+// 17.3% new_duplicated_lines_density (threshold 3%); collapsing here cuts the per-modal LOC by ~25 lines and brings the density
+// under the threshold while preserving the modal-specific copy + form fields in the caller.
+export function AppControlDialogShell({
+  open,
+  onClose,
+  titleId,
+  title,
+  subtitle,
+  formError,
+  busy,
+  submitDisabled,
+  submitLabel,
+  submitBusyLabel,
+  submitVariant,
+  onSubmit,
+  children,
+  reauthModal,
+}: AppControlDialogShellProps) {
+  const { dialogRef, handleCancel } = useAppControlDialog(open, onClose);
+  return (
+    <>
+      <dialog
+        ref={dialogRef}
+        className="app-control-dialog"
+        aria-labelledby={titleId}
+        onCancel={handleCancel}
+      >
+        <div className="app-control-dialog__header">
+          <h2 id={titleId} className="app-control-dialog__title">{title}</h2>
+          {subtitle !== undefined && (
+            <p className="app-control-dialog__subtitle">{subtitle}</p>
+          )}
+        </div>
+
+        {formError && (
+          <div className="app-control-dialog__error" role="alert">
+            {formError}
+          </div>
+        )}
+
+        <form onSubmit={onSubmit} className="app-control-dialog__form">
+          {children}
+
+          <div className="app-control-dialog__actions">
+            <Button
+              type="button"
+              variant="text-link"
+              onClick={onClose}
+              disabled={busy}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              variant={submitVariant}
+              disabled={submitDisabled}
+              isLoading={busy}
+            >
+              {busy ? (submitBusyLabel ?? "Saving…") : submitLabel}
+            </Button>
+          </div>
+        </form>
+      </dialog>
+      {reauthModal}
+    </>
+  );
+}

--- a/ui/src/components/ApplicationControl/ConfirmActionModal.test.tsx
+++ b/ui/src/components/ApplicationControl/ConfirmActionModal.test.tsx
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { ConfirmActionModal } from "./ConfirmActionModal";
+import { AppControlApiError } from "../../api";
+
+beforeEach(() => {
+  HTMLDialogElement.prototype.showModal = function showModal() {
+    this.open = true;
+  };
+  HTMLDialogElement.prototype.close = function close() {
+    this.open = false;
+  };
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("ConfirmActionModal", () => {
+  it("disables the submit button until a reason is typed", () => {
+    render(
+      <ConfirmActionModal
+        open
+        title="Delete rule"
+        description="will be removed"
+        confirmLabel="Delete rule"
+        confirmVariant="alert"
+        onClose={() => undefined}
+        onConfirm={vi.fn()}
+      />,
+    );
+    const confirm = screen.getByRole("button", { name: /delete rule/i });
+    expect(confirm).toBeDisabled();
+    fireEvent.change(screen.getByLabelText(/reason \(required/i), { target: { value: "good reason" } });
+    expect(confirm).not.toBeDisabled();
+  });
+
+  it("calls onConfirm with the trimmed reason on submit", async () => {
+    const onConfirm = vi.fn().mockResolvedValue(undefined);
+    render(
+      <ConfirmActionModal
+        open
+        title="Disable rule"
+        description="will be paused"
+        confirmLabel="Disable rule"
+        onClose={() => undefined}
+        onConfirm={onConfirm}
+      />,
+    );
+    fireEvent.change(screen.getByLabelText(/reason \(required/i), {
+      target: { value: "  trim me   " },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /disable rule/i }));
+    await waitFor(() => {
+      expect(onConfirm).toHaveBeenCalledWith("trim me");
+    });
+  });
+
+  it("maps a typed AppControlApiError onto the inline alert via dialogErrors", async () => {
+    const onConfirm = vi.fn().mockRejectedValue(
+      new AppControlApiError("application_control.policy_immutable", "cannot delete Default", 409),
+    );
+    render(
+      <ConfirmActionModal
+        open
+        title="Delete rule"
+        description="will be removed"
+        confirmLabel="Delete rule"
+        confirmVariant="alert"
+        onClose={() => undefined}
+        onConfirm={onConfirm}
+      />,
+    );
+    fireEvent.change(screen.getByLabelText(/reason \(required/i), { target: { value: "try delete" } });
+    fireEvent.click(screen.getByRole("button", { name: /delete rule/i }));
+    await waitFor(() => {
+      expect(screen.getByRole("alert").textContent).toMatch(/default policy cannot be deleted/i);
+    });
+  });
+
+  it("clicking Cancel routes through onClose", () => {
+    const onClose = vi.fn();
+    render(
+      <ConfirmActionModal
+        open
+        title="Enable rule"
+        description="will resume"
+        confirmLabel="Enable rule"
+        onClose={onClose}
+        onConfirm={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/ui/src/components/ApplicationControl/ConfirmActionModal.tsx
+++ b/ui/src/components/ApplicationControl/ConfirmActionModal.tsx
@@ -1,9 +1,9 @@
-import { useCallback, useEffect, useRef, useState } from "react";
-import { AppControlApiError, ReauthRequiredError } from "../../api";
+import { useEffect, useState } from "react";
 import { useReauthRetry } from "../../hooks/useReauthRetry";
 import { ReauthModal } from "../ReauthModal";
-import { Button } from "../ui/Button";
 import { Input } from "../ui/Input";
+import { AppControlDialogShell } from "./AppControlDialogShell";
+import { applyAppControlSubmitError } from "./dialogErrors";
 import "./ApplicationControl.scss";
 
 // ConfirmActionModal asks the operator to type a reason before a destructive or visible action goes through. Used by the
@@ -48,12 +48,12 @@ export function ConfirmActionModal({
   onClose,
   onConfirm,
 }: ConfirmActionModalProps) {
-  const dialogRef = useRef<HTMLDialogElement>(null);
   const [reason, setReason] = useState("");
   const [busy, setBusy] = useState(false);
   const [formError, setFormError] = useState<string | null>(null);
 
-  // Reset on every open so the previous attempt's reason doesn't leak across actions.
+  // Reset on every open so the previous attempt's reason doesn't leak across actions. The parent also re-mounts this component
+  // via a key on each new pending action (PolicyDetail.tsx) so this effect's reset is a defense-in-depth path.
   useEffect(() => {
     if (!open) return;
     // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional reset tied to the open prop transition
@@ -62,36 +62,7 @@ export function ConfirmActionModal({
     setFormError(null);
   }, [open]);
 
-  useEffect(() => {
-    const dlg = dialogRef.current;
-    if (!dlg) return;
-    if (open && !dlg.open) {
-      dlg.showModal();
-    } else if (!open && dlg.open) {
-      dlg.close();
-    }
-  }, [open]);
-
-  const handleCancel = useCallback((e: React.SyntheticEvent<HTMLDialogElement>) => {
-    e.preventDefault();
-    onClose();
-  }, [onClose]);
-
-  useEffect(() => {
-    const dlg = dialogRef.current;
-    if (!dlg) return undefined;
-    const onBackdrop = (e: MouseEvent) => {
-      if (e.target === dlg) onClose();
-    };
-    dlg.addEventListener("click", onBackdrop);
-    return () => { dlg.removeEventListener("click", onBackdrop); };
-  }, [onClose]);
-
-  const wrappedConfirm = useCallback(
-    (trimmedReason: string) => onConfirm(trimmedReason),
-    [onConfirm],
-  );
-  const { call: callConfirm, modal: reauthModal } = useReauthRetry(wrappedConfirm);
+  const { call: callConfirm, modal: reauthModal } = useReauthRetry(onConfirm);
 
   const trimmedReason = reason.trim();
   const submitDisabled = busy || trimmedReason.length === 0;
@@ -106,17 +77,8 @@ export function ConfirmActionModal({
       // Caller is responsible for closing the modal in response to onConfirm resolving;
       // staying open here lets a multi-step parent flow render an in-place success state if it wants.
     } catch (err) {
-      if (err instanceof ReauthRequiredError) {
-        // useReauthRetry's modal is mounted at the bottom of this component; the user finishes the reauth and the original call
-        // retries on its own. No UI work to do here.
-        return;
-      }
-      if (err instanceof AppControlApiError) {
-        setFormError(errorMessageByCode.get(err.code) ?? err.message);
-      } else if (err instanceof Error) {
-        setFormError(err.message);
-      } else {
-        setFormError("Action failed.");
+      if (applyAppControlSubmitError(err, setFormError, errorMessageByCode, "Action failed.")) {
+        return; // ReauthRequiredError — useReauthRetry's modal handles the rest.
       }
     } finally {
       setBusy(false);
@@ -124,60 +86,30 @@ export function ConfirmActionModal({
   }
 
   return (
-    <>
-      <dialog
-        ref={dialogRef}
-        className="app-control-dialog"
-        aria-labelledby={DIALOG_TITLE_ID}
-        onCancel={handleCancel}
-      >
-        <div className="app-control-dialog__header">
-          <h2 id={DIALOG_TITLE_ID} className="app-control-dialog__title">{title}</h2>
-          <p className="app-control-dialog__subtitle">{description}</p>
-        </div>
-
-        {formError && (
-          <div className="app-control-dialog__error" role="alert">
-            {formError}
-          </div>
-        )}
-
-        <form
-          onSubmit={(e) => { void handleSubmit(e); }}
-          className="app-control-dialog__form"
-        >
-          <Input
-            id="confirm-action-reason"
-            label="Reason (required for audit log)"
-            type="text"
-            placeholder={reasonPlaceholder ?? "Why are you making this change?"}
-            value={reason}
-            onChange={(e) => { setReason(e.target.value); }}
-            disabled={busy}
-            autoFocus
-          />
-
-          <div className="app-control-dialog__actions">
-            <Button
-              type="button"
-              variant="text-link"
-              onClick={onClose}
-              disabled={busy}
-            >
-              Cancel
-            </Button>
-            <Button
-              type="submit"
-              variant={confirmVariant}
-              disabled={submitDisabled}
-              isLoading={busy}
-            >
-              {busy ? "Saving…" : confirmLabel}
-            </Button>
-          </div>
-        </form>
-      </dialog>
-      <ReauthModal {...reauthModal} />
-    </>
+    <AppControlDialogShell
+      open={open}
+      onClose={onClose}
+      titleId={DIALOG_TITLE_ID}
+      title={title}
+      subtitle={description}
+      formError={formError}
+      busy={busy}
+      submitDisabled={submitDisabled}
+      submitLabel={confirmLabel}
+      submitVariant={confirmVariant}
+      onSubmit={(e) => { void handleSubmit(e); }}
+      reauthModal={<ReauthModal {...reauthModal} />}
+    >
+      <Input
+        id="confirm-action-reason"
+        label="Reason (required for audit log)"
+        type="text"
+        placeholder={reasonPlaceholder ?? "Why are you making this change?"}
+        value={reason}
+        onChange={(e) => { setReason(e.target.value); }}
+        disabled={busy}
+        autoFocus
+      />
+    </AppControlDialogShell>
   );
 }

--- a/ui/src/components/ApplicationControl/ConfirmActionModal.tsx
+++ b/ui/src/components/ApplicationControl/ConfirmActionModal.tsx
@@ -1,0 +1,183 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { AppControlApiError, ReauthRequiredError } from "../../api";
+import { useReauthRetry } from "../../hooks/useReauthRetry";
+import { ReauthModal } from "../ReauthModal";
+import { Button } from "../ui/Button";
+import { Input } from "../ui/Input";
+import "./ApplicationControl.scss";
+
+// ConfirmActionModal asks the operator to type a reason before a destructive or visible action goes through. Used by the
+// disable/enable toggle + delete button on the rules table — both endpoints require a reason on the wire for the audit row, so a
+// confirmation dialog is the right UX rather than a one-click action. The shared shape keeps the dialog vocabulary uniform
+// across actions; per-action labels + button copy are passed in.
+interface ConfirmActionModalProps {
+  readonly open: boolean;
+  readonly title: string;
+  readonly description: React.ReactNode;
+  readonly confirmLabel: string;
+  // confirmVariant controls the Save button's color — `alert` for delete (red), `primary` for non-destructive confirmations.
+  readonly confirmVariant?: "primary" | "alert";
+  readonly reasonPlaceholder?: string;
+  readonly onClose: () => void;
+  // onConfirm receives the trimmed reason and returns a promise; the modal stays open until the promise resolves so the operator
+  // sees the "Saving…" state. Errors thrown from onConfirm surface inline as form errors (typed AppControlApiError codes are
+  // mapped to human messages via errorMessageByCode); ReauthRequiredError is intercepted by useReauthRetry.
+  readonly onConfirm: (reason: string) => Promise<void>;
+}
+
+const DIALOG_TITLE_ID = "confirm-action-modal-title";
+
+// errorMessageByCode mirrors the AddRuleModal pattern: known typed error codes map to a UI-readable message; anything else falls
+// through to the server's free-form `message` (already operator-readable).
+const errorMessageByCode = new Map<string, string>([
+  ["application_control.rule_not_found", "The rule was deleted before the change could be saved."],
+  ["application_control.policy_not_found", "The policy was deleted before the change could be saved."],
+  ["application_control.policy_immutable", "The seed Default policy cannot be deleted."],
+  ["application_control.invalid_rule", "The change didn't pass server-side validation."],
+  ["application_control.invalid_policy", "The change didn't pass server-side validation."],
+  ["application_control.invalid_json", "The request body was not valid JSON."],
+]);
+
+export function ConfirmActionModal({
+  open,
+  title,
+  description,
+  confirmLabel,
+  confirmVariant = "primary",
+  reasonPlaceholder,
+  onClose,
+  onConfirm,
+}: ConfirmActionModalProps) {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const [reason, setReason] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+
+  // Reset on every open so the previous attempt's reason doesn't leak across actions.
+  useEffect(() => {
+    if (!open) return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional reset tied to the open prop transition
+    setReason("");
+    setBusy(false);
+    setFormError(null);
+  }, [open]);
+
+  useEffect(() => {
+    const dlg = dialogRef.current;
+    if (!dlg) return;
+    if (open && !dlg.open) {
+      dlg.showModal();
+    } else if (!open && dlg.open) {
+      dlg.close();
+    }
+  }, [open]);
+
+  const handleCancel = useCallback((e: React.SyntheticEvent<HTMLDialogElement>) => {
+    e.preventDefault();
+    onClose();
+  }, [onClose]);
+
+  useEffect(() => {
+    const dlg = dialogRef.current;
+    if (!dlg) return undefined;
+    const onBackdrop = (e: MouseEvent) => {
+      if (e.target === dlg) onClose();
+    };
+    dlg.addEventListener("click", onBackdrop);
+    return () => { dlg.removeEventListener("click", onBackdrop); };
+  }, [onClose]);
+
+  const wrappedConfirm = useCallback(
+    (trimmedReason: string) => onConfirm(trimmedReason),
+    [onConfirm],
+  );
+  const { call: callConfirm, modal: reauthModal } = useReauthRetry(wrappedConfirm);
+
+  const trimmedReason = reason.trim();
+  const submitDisabled = busy || trimmedReason.length === 0;
+
+  async function handleSubmit(e: React.SyntheticEvent) {
+    e.preventDefault();
+    if (submitDisabled) return;
+    setFormError(null);
+    setBusy(true);
+    try {
+      await callConfirm(trimmedReason);
+      // Caller is responsible for closing the modal in response to onConfirm resolving;
+      // staying open here lets a multi-step parent flow render an in-place success state if it wants.
+    } catch (err) {
+      if (err instanceof ReauthRequiredError) {
+        // useReauthRetry's modal is mounted at the bottom of this component; the user finishes the reauth and the original call
+        // retries on its own. No UI work to do here.
+        return;
+      }
+      if (err instanceof AppControlApiError) {
+        setFormError(errorMessageByCode.get(err.code) ?? err.message);
+      } else if (err instanceof Error) {
+        setFormError(err.message);
+      } else {
+        setFormError("Action failed.");
+      }
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <>
+      <dialog
+        ref={dialogRef}
+        className="app-control-dialog"
+        aria-labelledby={DIALOG_TITLE_ID}
+        onCancel={handleCancel}
+      >
+        <div className="app-control-dialog__header">
+          <h2 id={DIALOG_TITLE_ID} className="app-control-dialog__title">{title}</h2>
+          <p className="app-control-dialog__subtitle">{description}</p>
+        </div>
+
+        {formError && (
+          <div className="app-control-dialog__error" role="alert">
+            {formError}
+          </div>
+        )}
+
+        <form
+          onSubmit={(e) => { void handleSubmit(e); }}
+          className="app-control-dialog__form"
+        >
+          <Input
+            id="confirm-action-reason"
+            label="Reason (required for audit log)"
+            type="text"
+            placeholder={reasonPlaceholder ?? "Why are you making this change?"}
+            value={reason}
+            onChange={(e) => { setReason(e.target.value); }}
+            disabled={busy}
+            autoFocus
+          />
+
+          <div className="app-control-dialog__actions">
+            <Button
+              type="button"
+              variant="text-link"
+              onClick={onClose}
+              disabled={busy}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              variant={confirmVariant}
+              disabled={submitDisabled}
+              isLoading={busy}
+            >
+              {busy ? "Saving…" : confirmLabel}
+            </Button>
+          </div>
+        </form>
+      </dialog>
+      <ReauthModal {...reauthModal} />
+    </>
+  );
+}

--- a/ui/src/components/ApplicationControl/EditRuleModal.test.tsx
+++ b/ui/src/components/ApplicationControl/EditRuleModal.test.tsx
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { EditRuleModal } from "./EditRuleModal";
+import * as api from "../../api";
+import type { ApplicationControlRule } from "../../types";
+
+const makeRule = (over: Partial<ApplicationControlRule> = {}): ApplicationControlRule => ({
+  id: 1,
+  policy_id: 1,
+  rule_type: "BINARY",
+  identifier: "a".repeat(64),
+  action: "BLOCK",
+  enforcement: "PROTECT",
+  enabled: true,
+  severity: "medium",
+  source: "admin",
+  custom_msg: "",
+  custom_url: "",
+  comment: "",
+  created_at: "2026-05-14T00:00:00Z",
+  updated_at: "2026-05-14T00:00:00Z",
+  created_by: "user:1",
+  ...over,
+});
+
+beforeEach(() => {
+  HTMLDialogElement.prototype.showModal = function showModal() {
+    this.open = true;
+  };
+  HTMLDialogElement.prototype.close = function close() {
+    this.open = false;
+  };
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("EditRuleModal", () => {
+  it("disables Save until a field actually changes AND a reason is typed", () => {
+    render(
+      <EditRuleModal open rule={makeRule()} onClose={() => undefined} onSaved={() => undefined} />,
+    );
+    const save = screen.getByRole("button", { name: /save changes/i });
+    // Initial state: no diff, no reason → disabled.
+    expect(save).toBeDisabled();
+
+    // Reason alone, no field change → still disabled.
+    fireEvent.change(screen.getByLabelText(/reason \(required/i), {
+      target: { value: "reason but no field change" },
+    });
+    expect(save).toBeDisabled();
+
+    // Now flip severity → enables.
+    fireEvent.change(screen.getByLabelText(/^severity$/i), { target: { value: "critical" } });
+    expect(save).not.toBeDisabled();
+  });
+
+  it("rejects a non-http(s) More info URL client-side", async () => {
+    const updateSpy = vi.spyOn(api, "updateAppControlRule").mockResolvedValue(makeRule());
+    render(
+      <EditRuleModal open rule={makeRule()} onClose={() => undefined} onSaved={() => undefined} />,
+    );
+    fireEvent.change(screen.getByLabelText(/more info url/i), {
+      target: { value: "javascript:alert(1)" },
+    });
+    fireEvent.change(screen.getByLabelText(/reason \(required/i), {
+      target: { value: "trying bad URL" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /save changes/i }));
+    await waitFor(() => {
+      expect(screen.getByRole("alert").textContent).toMatch(/http or https/i);
+    });
+    expect(updateSpy).not.toHaveBeenCalled();
+  });
+
+  // NOTE: the catch-block branch of EditRuleModal's URL guard (new URL throws on malformed input) is not directly reachable
+  // through fireEvent because <input type="url"> performs HTML5 form validation BEFORE submit fires; the browser intercepts a
+  // truly malformed value with its native tooltip and never invokes handleSubmit. The branch is defense-in-depth for any
+  // future caller that bypasses the input element entirely. The protocol-check branch is covered by the test above.
+
+  it("surfaces a typed AppControlApiError as an inline form error", async () => {
+    vi.spyOn(api, "updateAppControlRule").mockRejectedValue(
+      new api.AppControlApiError("application_control.rule_not_found", "rule not found", 404),
+    );
+    render(
+      <EditRuleModal open rule={makeRule()} onClose={() => undefined} onSaved={() => undefined} />,
+    );
+    fireEvent.change(screen.getByLabelText(/^severity$/i), { target: { value: "critical" } });
+    fireEvent.change(screen.getByLabelText(/reason \(required/i), { target: { value: "x" } });
+    fireEvent.click(screen.getByRole("button", { name: /save changes/i }));
+    await waitFor(() => {
+      // EditRuleModal's errorMessageByCode maps rule_not_found to a UI-friendly message.
+      expect(screen.getByRole("alert").textContent).toMatch(/rule was deleted/i);
+    });
+  });
+
+  it("calls onSaved on the happy path and submits only the changed fields + reason", async () => {
+    const updateSpy = vi.spyOn(api, "updateAppControlRule").mockResolvedValue(
+      makeRule({ severity: "critical" }),
+    );
+    const onSaved = vi.fn();
+    render(
+      <EditRuleModal open rule={makeRule()} onClose={() => undefined} onSaved={onSaved} />,
+    );
+    fireEvent.change(screen.getByLabelText(/^severity$/i), { target: { value: "critical" } });
+    fireEvent.change(screen.getByLabelText(/reason \(required/i), { target: { value: "promote" } });
+    fireEvent.click(screen.getByRole("button", { name: /save changes/i }));
+    await waitFor(() => {
+      expect(onSaved).toHaveBeenCalled();
+    });
+    expect(updateSpy.mock.calls[0]).toEqual([1, { severity: "critical", reason: "promote" }]);
+  });
+
+  it("renders harmlessly with rule=null and short-circuits submit", async () => {
+    const updateSpy = vi.spyOn(api, "updateAppControlRule");
+    render(
+      <EditRuleModal open rule={null} onClose={() => undefined} onSaved={() => undefined} />,
+    );
+    // Reason input is reachable (the dialog is open); the rule=null parameter is a defensive prop signaling the parent has
+    // no row to edit. Typing a reason + clicking save must NOT issue an API call because handleSubmit's `if (!rule) return`
+    // short-circuit fires. Without this guard, a stale modal instance could PATCH against a deleted rule.
+    fireEvent.change(screen.getByLabelText(/reason \(required/i), { target: { value: "x" } });
+    fireEvent.click(screen.getByRole("button", { name: /save changes/i }));
+    await waitFor(() => {
+      expect(updateSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/ui/src/components/ApplicationControl/EditRuleModal.tsx
+++ b/ui/src/components/ApplicationControl/EditRuleModal.tsx
@@ -1,0 +1,260 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  updateAppControlRule,
+  AppControlApiError,
+  ReauthRequiredError,
+  type UpdateAppControlRuleRequest,
+} from "../../api";
+import { useReauthRetry } from "../../hooks/useReauthRetry";
+import { ReauthModal } from "../ReauthModal";
+import type { ApplicationControlRule } from "../../types";
+import { Button } from "../ui/Button";
+import { Input, Select } from "../ui/Input";
+import "./ApplicationControl.scss";
+
+interface EditRuleModalProps {
+  readonly open: boolean;
+  // rule is the row being edited. The modal pre-fills its inputs from this on open; the parent passes the current row so the
+  // operator doesn't see stale data after a sibling action refreshed the list.
+  readonly rule: ApplicationControlRule | null;
+  readonly onClose: () => void;
+  readonly onSaved: () => void;
+}
+
+const DIALOG_TITLE_ID = "edit-rule-modal-title";
+const SEVERITIES = ["low", "medium", "high", "critical"];
+
+// errorMessageByCode mirrors AddRuleModal: known typed error codes map to UI-readable messages; anything else falls through to
+// the server's free-form `message` which the handler already writes as operator-readable.
+const errorMessageByCode = new Map<string, string>([
+  ["application_control.rule_not_found", "The rule was deleted before the change could be saved."],
+  ["application_control.invalid_rule", "The change didn't pass server-side validation."],
+  ["application_control.invalid_json", "The request body was not valid JSON."],
+]);
+
+export function EditRuleModal({ open, rule, onClose, onSaved }: EditRuleModalProps) {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  // initialState mirrors the rule's mutable fields at the moment the modal opened. The submit handler diffs current state
+  // against this baseline so the PATCH body only carries fields that actually changed — that keeps the audit log honest
+  // (a 1-field-changed PATCH audits as a 1-field change, not a 5-field rewrite).
+  const initialState = useMemo(() => ({
+    severity: rule?.severity ?? "medium",
+    customMsg: rule?.custom_msg ?? "",
+    customURL: rule?.custom_url ?? "",
+    comment: rule?.comment ?? "",
+  }), [rule]);
+
+  const [severity, setSeverity] = useState(initialState.severity);
+  const [customMsg, setCustomMsg] = useState(initialState.customMsg);
+  const [customURL, setCustomURL] = useState(initialState.customURL);
+  const [comment, setComment] = useState(initialState.comment);
+  const [reason, setReason] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+
+  // Reset on every open so a Cancel + re-open doesn't surface the previous attempt's edits.
+  useEffect(() => {
+    if (!open) return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional reset tied to the open prop transition
+    setSeverity(initialState.severity);
+    setCustomMsg(initialState.customMsg);
+    setCustomURL(initialState.customURL);
+    setComment(initialState.comment);
+    setReason("");
+    setBusy(false);
+    setFormError(null);
+  }, [open, initialState]);
+
+  useEffect(() => {
+    const dlg = dialogRef.current;
+    if (!dlg) return;
+    if (open && !dlg.open) {
+      dlg.showModal();
+    } else if (!open && dlg.open) {
+      dlg.close();
+    }
+  }, [open]);
+
+  const handleCancel = useCallback((e: React.SyntheticEvent<HTMLDialogElement>) => {
+    e.preventDefault();
+    onClose();
+  }, [onClose]);
+
+  useEffect(() => {
+    const dlg = dialogRef.current;
+    if (!dlg) return undefined;
+    const onBackdrop = (e: MouseEvent) => {
+      if (e.target === dlg) onClose();
+    };
+    dlg.addEventListener("click", onBackdrop);
+    return () => { dlg.removeEventListener("click", onBackdrop); };
+  }, [onClose]);
+
+  const submitUpdate = useCallback(
+    (ruleID: number, req: UpdateAppControlRuleRequest) => updateAppControlRule(ruleID, req),
+    [],
+  );
+  const { call: callUpdate, modal: reauthModal } = useReauthRetry(submitUpdate);
+
+  // diff captures only the fields the operator actually changed. Sending the unchanged baseline would still bump the policy
+  // version on the server (because UpdateRule treats any field as a mutation), inflating the audit row + the snapshot fan-out
+  // for no observable change. Comparing against initialState keeps the wire body honest.
+  const diff = useMemo<Partial<UpdateAppControlRuleRequest>>(() => {
+    const d: Partial<UpdateAppControlRuleRequest> = {};
+    if (severity !== initialState.severity) d.severity = severity;
+    if (customMsg.trim() !== initialState.customMsg) d.custom_msg = customMsg.trim();
+    if (customURL.trim() !== initialState.customURL) d.custom_url = customURL.trim();
+    if (comment.trim() !== initialState.comment) d.comment = comment.trim();
+    return d;
+  }, [severity, customMsg, customURL, comment, initialState]);
+
+  const hasChanges = Object.keys(diff).length > 0;
+  // Submit is disabled when busy, when no reason has been typed yet, or when nothing actually changed. The rule-null case is
+  // handled by the early return below — when the parent hasn't given us a rule the modal also wouldn't be `open`, so this
+  // path is defensive rather than load-bearing.
+  const submitDisabled = busy || reason.trim().length === 0 || !hasChanges;
+
+  async function handleSubmit(e: React.SyntheticEvent) {
+    e.preventDefault();
+    if (!rule) return; // narrows rule to non-null for the rule.id access below.
+    if (submitDisabled) return;
+    // Mirror AddRuleModal's URL guard so an http/https check fires client-side; BlockAlert.swift rejects other schemes
+    // server-side but a round-trip is wasteful.
+    if (customURL.trim().length > 0) {
+      try {
+        const parsed = new URL(customURL.trim());
+        if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+          setFormError("More info URL must use http or https.");
+          return;
+        }
+      } catch {
+        setFormError("More info URL is not a valid URL.");
+        return;
+      }
+    }
+    setFormError(null);
+    setBusy(true);
+    try {
+      await callUpdate(rule.id, { ...diff, reason: reason.trim() });
+      onSaved();
+    } catch (err) {
+      if (err instanceof ReauthRequiredError) {
+        // useReauthRetry's modal is mounted at the bottom; the user finishes the reauth and the original call retries.
+        return;
+      }
+      if (err instanceof AppControlApiError) {
+        setFormError(errorMessageByCode.get(err.code) ?? err.message);
+      } else if (err instanceof Error) {
+        setFormError(err.message);
+      } else {
+        setFormError("Failed to update rule.");
+      }
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <>
+      <dialog
+        ref={dialogRef}
+        className="app-control-dialog"
+        aria-labelledby={DIALOG_TITLE_ID}
+        onCancel={handleCancel}
+      >
+        <div className="app-control-dialog__header">
+          <h2 id={DIALOG_TITLE_ID} className="app-control-dialog__title">Edit rule</h2>
+          <p className="app-control-dialog__subtitle">
+            Severity + custom message + URL + comment are editable. Rule type and identifier are fixed
+            once the rule is created.
+          </p>
+        </div>
+
+        {formError && (
+          <div className="app-control-dialog__error" role="alert">
+            {formError}
+          </div>
+        )}
+
+        <form
+          onSubmit={(e) => { void handleSubmit(e); }}
+          className="app-control-dialog__form"
+        >
+          {rule && (
+            <p className="app-control-dialog__readonly">
+              <strong>{rule.rule_type}</strong> · <code>{rule.identifier}</code>
+            </p>
+          )}
+
+          <Select
+            id="edit-rule-severity"
+            label="Severity"
+            inline={false}
+            value={severity}
+            onChange={(e) => { setSeverity(e.target.value); }}
+            disabled={busy}
+          >
+            {SEVERITIES.map((s) => (
+              <option key={s} value={s}>{s}</option>
+            ))}
+          </Select>
+
+          <Input
+            id="edit-rule-custom-msg"
+            label="Custom message"
+            type="text"
+            placeholder="Blocked by corporate policy"
+            value={customMsg}
+            onChange={(e) => { setCustomMsg(e.target.value); }}
+            disabled={busy}
+          />
+
+          <Input
+            id="edit-rule-custom-url"
+            label="More info URL (http/https only)"
+            type="url"
+            placeholder="https://help.example.com/blocked"
+            value={customURL}
+            onChange={(e) => { setCustomURL(e.target.value); }}
+            disabled={busy}
+          />
+
+          <Input
+            id="edit-rule-comment"
+            label="Comment (internal)"
+            type="text"
+            placeholder="Optional note for other admins"
+            value={comment}
+            onChange={(e) => { setComment(e.target.value); }}
+            disabled={busy}
+          />
+
+          <Input
+            id="edit-rule-reason"
+            label="Reason (required for audit log)"
+            type="text"
+            placeholder="Why are you editing this rule?"
+            value={reason}
+            onChange={(e) => { setReason(e.target.value); }}
+            disabled={busy}
+          />
+
+          <div className="app-control-dialog__actions">
+            <Button
+              type="button"
+              variant="text-link"
+              onClick={onClose}
+              disabled={busy}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={submitDisabled} isLoading={busy}>
+              {busy ? "Saving…" : "Save changes"}
+            </Button>
+          </div>
+        </form>
+      </dialog>
+      <ReauthModal {...reauthModal} />
+    </>
+  );
+}

--- a/ui/src/components/ApplicationControl/EditRuleModal.tsx
+++ b/ui/src/components/ApplicationControl/EditRuleModal.tsx
@@ -1,15 +1,14 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   updateAppControlRule,
-  AppControlApiError,
-  ReauthRequiredError,
   type UpdateAppControlRuleRequest,
 } from "../../api";
 import { useReauthRetry } from "../../hooks/useReauthRetry";
 import { ReauthModal } from "../ReauthModal";
 import type { ApplicationControlRule } from "../../types";
-import { Button } from "../ui/Button";
 import { Input, Select } from "../ui/Input";
+import { AppControlDialogShell } from "./AppControlDialogShell";
+import { applyAppControlSubmitError } from "./dialogErrors";
 import "./ApplicationControl.scss";
 
 interface EditRuleModalProps {
@@ -33,7 +32,6 @@ const errorMessageByCode = new Map<string, string>([
 ]);
 
 export function EditRuleModal({ open, rule, onClose, onSaved }: EditRuleModalProps) {
-  const dialogRef = useRef<HTMLDialogElement>(null);
   // initialState mirrors the rule's mutable fields at the moment the modal opened. The submit handler diffs current state
   // against this baseline so the PATCH body only carries fields that actually changed — that keeps the audit log honest
   // (a 1-field-changed PATCH audits as a 1-field change, not a 5-field rewrite).
@@ -52,7 +50,8 @@ export function EditRuleModal({ open, rule, onClose, onSaved }: EditRuleModalPro
   const [busy, setBusy] = useState(false);
   const [formError, setFormError] = useState<string | null>(null);
 
-  // Reset on every open so a Cancel + re-open doesn't surface the previous attempt's edits.
+  // Reset on every open so a Cancel + re-open doesn't surface the previous attempt's edits. The parent also keys this component
+  // on the target rule id (PolicyDetail.tsx) so this effect's reset is a defense-in-depth path.
   useEffect(() => {
     if (!open) return;
     // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional reset tied to the open prop transition
@@ -65,36 +64,9 @@ export function EditRuleModal({ open, rule, onClose, onSaved }: EditRuleModalPro
     setFormError(null);
   }, [open, initialState]);
 
-  useEffect(() => {
-    const dlg = dialogRef.current;
-    if (!dlg) return;
-    if (open && !dlg.open) {
-      dlg.showModal();
-    } else if (!open && dlg.open) {
-      dlg.close();
-    }
-  }, [open]);
-
-  const handleCancel = useCallback((e: React.SyntheticEvent<HTMLDialogElement>) => {
-    e.preventDefault();
-    onClose();
-  }, [onClose]);
-
-  useEffect(() => {
-    const dlg = dialogRef.current;
-    if (!dlg) return undefined;
-    const onBackdrop = (e: MouseEvent) => {
-      if (e.target === dlg) onClose();
-    };
-    dlg.addEventListener("click", onBackdrop);
-    return () => { dlg.removeEventListener("click", onBackdrop); };
-  }, [onClose]);
-
-  const submitUpdate = useCallback(
+  const { call: callUpdate, modal: reauthModal } = useReauthRetry(
     (ruleID: number, req: UpdateAppControlRuleRequest) => updateAppControlRule(ruleID, req),
-    [],
   );
-  const { call: callUpdate, modal: reauthModal } = useReauthRetry(submitUpdate);
 
   // diff captures only the fields the operator actually changed. Sending the unchanged baseline would still bump the policy
   // version on the server (because UpdateRule treats any field as a mutation), inflating the audit row + the snapshot fan-out
@@ -109,14 +81,11 @@ export function EditRuleModal({ open, rule, onClose, onSaved }: EditRuleModalPro
   }, [severity, customMsg, customURL, comment, initialState]);
 
   const hasChanges = Object.keys(diff).length > 0;
-  // Submit is disabled when busy, when no reason has been typed yet, or when nothing actually changed. The rule-null case is
-  // handled by the early return below — when the parent hasn't given us a rule the modal also wouldn't be `open`, so this
-  // path is defensive rather than load-bearing.
   const submitDisabled = busy || reason.trim().length === 0 || !hasChanges;
 
   async function handleSubmit(e: React.SyntheticEvent) {
     e.preventDefault();
-    if (!rule) return; // narrows rule to non-null for the rule.id access below.
+    if (!rule) return;
     if (submitDisabled) return;
     // Mirror AddRuleModal's URL guard so an http/https check fires client-side; BlockAlert.swift rejects other schemes
     // server-side but a round-trip is wasteful.
@@ -138,16 +107,8 @@ export function EditRuleModal({ open, rule, onClose, onSaved }: EditRuleModalPro
       await callUpdate(rule.id, { ...diff, reason: reason.trim() });
       onSaved();
     } catch (err) {
-      if (err instanceof ReauthRequiredError) {
-        // useReauthRetry's modal is mounted at the bottom; the user finishes the reauth and the original call retries.
+      if (applyAppControlSubmitError(err, setFormError, errorMessageByCode, "Failed to update rule.")) {
         return;
-      }
-      if (err instanceof AppControlApiError) {
-        setFormError(errorMessageByCode.get(err.code) ?? err.message);
-      } else if (err instanceof Error) {
-        setFormError(err.message);
-      } else {
-        setFormError("Failed to update rule.");
       }
     } finally {
       setBusy(false);
@@ -155,106 +116,78 @@ export function EditRuleModal({ open, rule, onClose, onSaved }: EditRuleModalPro
   }
 
   return (
-    <>
-      <dialog
-        ref={dialogRef}
-        className="app-control-dialog"
-        aria-labelledby={DIALOG_TITLE_ID}
-        onCancel={handleCancel}
+    <AppControlDialogShell
+      open={open}
+      onClose={onClose}
+      titleId={DIALOG_TITLE_ID}
+      title="Edit rule"
+      subtitle="Severity + custom message + URL + comment are editable. Rule type and identifier are fixed once the rule is created."
+      formError={formError}
+      busy={busy}
+      submitDisabled={submitDisabled}
+      submitLabel="Save changes"
+      onSubmit={(e) => { void handleSubmit(e); }}
+      reauthModal={<ReauthModal {...reauthModal} />}
+    >
+      {rule && (
+        <p className="app-control-dialog__readonly">
+          <strong>{rule.rule_type}</strong> · <code>{rule.identifier}</code>
+        </p>
+      )}
+
+      <Select
+        id="edit-rule-severity"
+        label="Severity"
+        inline={false}
+        value={severity}
+        onChange={(e) => { setSeverity(e.target.value); }}
+        disabled={busy}
+        autoFocus
       >
-        <div className="app-control-dialog__header">
-          <h2 id={DIALOG_TITLE_ID} className="app-control-dialog__title">Edit rule</h2>
-          <p className="app-control-dialog__subtitle">
-            Severity + custom message + URL + comment are editable. Rule type and identifier are fixed
-            once the rule is created.
-          </p>
-        </div>
+        {SEVERITIES.map((s) => (
+          <option key={s} value={s}>{s}</option>
+        ))}
+      </Select>
 
-        {formError && (
-          <div className="app-control-dialog__error" role="alert">
-            {formError}
-          </div>
-        )}
+      <Input
+        id="edit-rule-custom-msg"
+        label="Custom message"
+        type="text"
+        placeholder="Blocked by corporate policy"
+        value={customMsg}
+        onChange={(e) => { setCustomMsg(e.target.value); }}
+        disabled={busy}
+      />
 
-        <form
-          onSubmit={(e) => { void handleSubmit(e); }}
-          className="app-control-dialog__form"
-        >
-          {rule && (
-            <p className="app-control-dialog__readonly">
-              <strong>{rule.rule_type}</strong> · <code>{rule.identifier}</code>
-            </p>
-          )}
+      <Input
+        id="edit-rule-custom-url"
+        label="More info URL (http/https only)"
+        type="url"
+        placeholder="https://help.example.com/blocked"
+        value={customURL}
+        onChange={(e) => { setCustomURL(e.target.value); }}
+        disabled={busy}
+      />
 
-          <Select
-            id="edit-rule-severity"
-            label="Severity"
-            inline={false}
-            value={severity}
-            onChange={(e) => { setSeverity(e.target.value); }}
-            disabled={busy}
-          >
-            {SEVERITIES.map((s) => (
-              <option key={s} value={s}>{s}</option>
-            ))}
-          </Select>
+      <Input
+        id="edit-rule-comment"
+        label="Comment (internal)"
+        type="text"
+        placeholder="Optional note for other admins"
+        value={comment}
+        onChange={(e) => { setComment(e.target.value); }}
+        disabled={busy}
+      />
 
-          <Input
-            id="edit-rule-custom-msg"
-            label="Custom message"
-            type="text"
-            placeholder="Blocked by corporate policy"
-            value={customMsg}
-            onChange={(e) => { setCustomMsg(e.target.value); }}
-            disabled={busy}
-          />
-
-          <Input
-            id="edit-rule-custom-url"
-            label="More info URL (http/https only)"
-            type="url"
-            placeholder="https://help.example.com/blocked"
-            value={customURL}
-            onChange={(e) => { setCustomURL(e.target.value); }}
-            disabled={busy}
-          />
-
-          <Input
-            id="edit-rule-comment"
-            label="Comment (internal)"
-            type="text"
-            placeholder="Optional note for other admins"
-            value={comment}
-            onChange={(e) => { setComment(e.target.value); }}
-            disabled={busy}
-          />
-
-          <Input
-            id="edit-rule-reason"
-            label="Reason (required for audit log)"
-            type="text"
-            placeholder="Why are you editing this rule?"
-            value={reason}
-            onChange={(e) => { setReason(e.target.value); }}
-            disabled={busy}
-          />
-
-          <div className="app-control-dialog__actions">
-            <Button
-              type="button"
-              variant="text-link"
-              onClick={onClose}
-              disabled={busy}
-            >
-              Cancel
-            </Button>
-            <Button type="submit" disabled={submitDisabled} isLoading={busy}>
-              {busy ? "Saving…" : "Save changes"}
-            </Button>
-          </div>
-        </form>
-      </dialog>
-      <ReauthModal {...reauthModal} />
-    </>
+      <Input
+        id="edit-rule-reason"
+        label="Reason (required for audit log)"
+        type="text"
+        placeholder="Why are you editing this rule?"
+        value={reason}
+        onChange={(e) => { setReason(e.target.value); }}
+        disabled={busy}
+      />
+    </AppControlDialogShell>
   );
 }

--- a/ui/src/components/ApplicationControl/PolicyDetail.test.tsx
+++ b/ui/src/components/ApplicationControl/PolicyDetail.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent, within } from "@testing-library/react";
 import { MemoryRouter, Routes, Route } from "react-router-dom";
 import { PolicyDetail } from "./PolicyDetail";
 import * as api from "../../api";
@@ -79,9 +79,116 @@ describe("PolicyDetail", () => {
     // Identifier is truncated to 16 chars + ellipsis in the table.
     expect(screen.getByText("aaaaaaaaaaaaaaaa…")).toBeInTheDocument();
     expect(screen.getByText(/blocked by corp policy/i)).toBeInTheDocument();
-    // Per-row Edit/Disable/Delete render disabled with the coming-soon tooltip.
+    // Per-row Edit/Disable/Delete are wired and enabled (Phase A close-out PR-1d): each opens a modal that prompts for an audit
+    // reason before firing the PATCH / DELETE endpoint.
     const edit = screen.getByRole("button", { name: "Edit" });
-    expect(edit).toBeDisabled();
+    expect(edit).not.toBeDisabled();
+    expect(screen.getByRole("button", { name: "Disable" })).not.toBeDisabled();
+    expect(screen.getByRole("button", { name: "Delete" })).not.toBeDisabled();
+  });
+
+  // PolicyDetail mounts three modals at once (Add, Edit, Confirm) — each is a <dialog> that renders its inner DOM even when
+  // closed in JSDOM. RTL queries against `screen` find labels in all three; scope to the modal addressed by its accessible
+  // name to disambiguate.
+  function openModal(name: RegExp): HTMLElement {
+    return screen.getByRole("dialog", { name });
+  }
+
+  it("opens the disable-confirm modal, fires PATCH with reason + enabled=false, refreshes the policy", async () => {
+    const getSpy = vi.spyOn(api, "getAppControlPolicy");
+    getSpy.mockResolvedValueOnce(makePolicy({ rules: [makeRule()] }));
+    const updateSpy = vi.spyOn(api, "updateAppControlRule").mockResolvedValue(
+      makeRule({ enabled: false }),
+    );
+    // Refresh fetches the policy a second time; return the disabled-rule shape so the table reflects the new state.
+    getSpy.mockResolvedValueOnce(makePolicy({ rules: [makeRule({ enabled: false })], version: 6 }));
+
+    renderPolicyDetailAt("/app-control/policies/7");
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Disable" })).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Disable" }));
+
+    // Confirm modal is now open; scope all the queries to that dialog so RTL doesn't pick up the Add/Edit modals' inputs.
+    const dialog = await waitFor(() => openModal(/disable rule/i));
+    const reasonInput = within(dialog).getByLabelText(/reason \(required for audit log\)/i);
+    fireEvent.change(reasonInput, { target: { value: "Pause for triage" } });
+    fireEvent.click(within(dialog).getByRole("button", { name: /disable rule/i }));
+
+    await waitFor(() => {
+      expect(updateSpy).toHaveBeenCalledTimes(1);
+    });
+    expect(updateSpy.mock.calls[0]).toEqual([
+      1,
+      { enabled: false, reason: "Pause for triage" },
+    ]);
+    // Page refetched after success; the second mocked policy load fires.
+    await waitFor(() => {
+      expect(getSpy).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it("opens the delete-confirm modal, fires DELETE with reason, refreshes the policy", async () => {
+    const getSpy = vi.spyOn(api, "getAppControlPolicy");
+    getSpy.mockResolvedValueOnce(makePolicy({ rules: [makeRule()] }));
+    const deleteSpy = vi.spyOn(api, "deleteAppControlRule").mockResolvedValue();
+    getSpy.mockResolvedValueOnce(makePolicy({ rules: [] }));
+
+    renderPolicyDetailAt("/app-control/policies/7");
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Delete" })).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+
+    const dialog = await waitFor(() => openModal(/delete rule/i));
+    const reasonInput = within(dialog).getByLabelText(/reason \(required for audit log\)/i);
+    fireEvent.change(reasonInput, { target: { value: "Misfire on legit binary" } });
+    fireEvent.click(within(dialog).getByRole("button", { name: /delete rule/i }));
+
+    await waitFor(() => {
+      expect(deleteSpy).toHaveBeenCalledTimes(1);
+    });
+    expect(deleteSpy.mock.calls[0]).toEqual([
+      1,
+      { reason: "Misfire on legit binary" },
+    ]);
+    await waitFor(() => {
+      expect(getSpy).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it("opens the edit modal, sends only changed fields + reason on save", async () => {
+    const getSpy = vi.spyOn(api, "getAppControlPolicy");
+    getSpy.mockResolvedValueOnce(makePolicy({ rules: [makeRule()] }));
+    const updateSpy = vi.spyOn(api, "updateAppControlRule").mockResolvedValue(
+      makeRule({ severity: "critical" }),
+    );
+    getSpy.mockResolvedValueOnce(makePolicy({ rules: [makeRule({ severity: "critical" })], version: 6 }));
+
+    renderPolicyDetailAt("/app-control/policies/7");
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Edit" })).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+
+    const dialog = await waitFor(() => openModal(/edit rule/i));
+    // Severity dropdown reflects the current value; change it.
+    const severitySelect = within(dialog).getByLabelText(/^severity$/i);
+    fireEvent.change(severitySelect, { target: { value: "critical" } });
+    // Reason is required.
+    const reasonInput = within(dialog).getByLabelText(/reason \(required for audit log\)/i);
+    fireEvent.change(reasonInput, { target: { value: "Promote based on intel signal" } });
+    fireEvent.click(within(dialog).getByRole("button", { name: /save changes/i }));
+
+    await waitFor(() => {
+      expect(updateSpy).toHaveBeenCalledTimes(1);
+    });
+    // PATCH body carries only the changed field (severity) + reason; custom_msg / custom_url / comment did not change so
+    // they MUST NOT appear on the wire (the audit log would otherwise show a multi-field edit for a single-field intent).
+    expect(updateSpy.mock.calls[0]).toEqual([
+      1,
+      { severity: "critical", reason: "Promote based on intel signal" },
+    ]);
   });
 
   it("renders an empty-state CTA when the policy has zero rules", async () => {

--- a/ui/src/components/ApplicationControl/PolicyDetail.test.tsx
+++ b/ui/src/components/ApplicationControl/PolicyDetail.test.tsx
@@ -87,11 +87,17 @@ describe("PolicyDetail", () => {
     expect(screen.getByRole("button", { name: "Delete" })).not.toBeDisabled();
   });
 
-  // PolicyDetail mounts three modals at once (Add, Edit, Confirm) — each is a <dialog> that renders its inner DOM even when
-  // closed in JSDOM. RTL queries against `screen` find labels in all three; scope to the modal addressed by its accessible
-  // name to disambiguate.
+  // PolicyDetail mounts the modals as siblings. Each modal renders a <dialog> that, even when closed in JSDOM, keeps its
+  // children in the DOM — so RTL queries against `screen` match labels in closed dialogs too. Scope to the dialog addressed by
+  // its accessible name AND require its `open` attribute to be set so a test that fires the action but doesn't actually open
+  // the dialog (e.g. a regression in the wiring) fails loudly instead of false-passing on the closed dialog. Addresses the
+  // Copilot finding on PR #189.
   function openModal(name: RegExp): HTMLElement {
-    return screen.getByRole("dialog", { name });
+    const dialog = screen.getByRole("dialog", { name });
+    if (!(dialog as HTMLDialogElement).open) {
+      throw new Error(`expected dialog matching ${String(name)} to be open, but its .open attribute is false`);
+    }
+    return dialog;
   }
 
   it("opens the disable-confirm modal, fires PATCH with reason + enabled=false, refreshes the policy", async () => {

--- a/ui/src/components/ApplicationControl/PolicyDetail.tsx
+++ b/ui/src/components/ApplicationControl/PolicyDetail.tsx
@@ -15,12 +15,16 @@ import { EditRuleModal } from "./EditRuleModal";
 import { ConfirmActionModal } from "./ConfirmActionModal";
 import "./ApplicationControl.scss";
 
-// pendingConfirm captures which per-row action the operator clicked + the row it targets, so the shared ConfirmActionModal can
-// render the right copy and dispatch the right API call when the operator submits a reason. The kind discriminator drives both
-// the modal labels AND the onConfirm side-effect.
-type PendingConfirm =
-  | { kind: "delete"; rule: ApplicationControlRule }
-  | { kind: "toggle"; rule: ApplicationControlRule };
+// ActiveModal is the union that captures which per-row modal is currently open. Encoding mutual exclusion in the type closes
+// the Copilot finding on PR #189 — the previous shape kept two independent `useState` slots and relied on call-site discipline
+// to avoid opening two modals at once. Now `add`, `edit`, `confirm-delete`, and `confirm-toggle` are exclusive by construction
+// and a future helper that forgets to clear the previous state is a type error rather than a UX bug.
+type ActiveModal =
+  | { kind: "none" }
+  | { kind: "add" }
+  | { kind: "edit"; rule: ApplicationControlRule }
+  | { kind: "confirm-delete"; rule: ApplicationControlRule }
+  | { kind: "confirm-toggle"; rule: ApplicationControlRule };
 
 const SEVERITY_VARIANTS: Record<string, BadgeVariant> = {
   critical: "critical",
@@ -54,11 +58,10 @@ export function PolicyDetail() {
   const [policy, setPolicy] = useState<ApplicationControlPolicy | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [addOpen, setAddOpen] = useState(false);
-  // editingRule + pendingConfirm own the per-row modal state. Only one of the two is ever populated at a time; the modals close
-  // when their target is set to null. Defined here so the rules table inside RulesTable can fire the open callbacks via props.
-  const [editingRule, setEditingRule] = useState<ApplicationControlRule | null>(null);
-  const [pendingConfirm, setPendingConfirm] = useState<PendingConfirm | null>(null);
+  // activeModal is the union of every possible per-row modal state. Mutually exclusive by construction; opening a new modal
+  // implicitly closes whichever was previously active because there's exactly one state slot.
+  const [activeModal, setActiveModal] = useState<ActiveModal>({ kind: "none" });
+  const closeModal = useCallback(() => { setActiveModal({ kind: "none" }); }, []);
 
   // refreshKey bumps to force a re-fetch (e.g. after Save in the
   // modal). useEffect below owns the actual fetch lifecycle so the
@@ -123,7 +126,7 @@ export function PolicyDetail() {
   const actions = (
     <Button
       variant="primary"
-      onClick={() => { setAddOpen(true); }}
+      onClick={() => { setActiveModal({ kind: "add" }); }}
       disabled={!policy}
     >
       Add rule
@@ -131,6 +134,15 @@ export function PolicyDetail() {
   );
 
   const rules = policy?.rules ?? [];
+
+  // confirmRule extracts the rule from a confirm-* modal kind so the JSX below stays terse; returns null for non-confirm
+  // modals (the ConfirmActionModal won't render its content in that case).
+  const confirmKind = activeModal.kind === "confirm-delete" || activeModal.kind === "confirm-toggle"
+    ? activeModal.kind
+    : null;
+  const confirmRule = activeModal.kind === "confirm-delete" || activeModal.kind === "confirm-toggle"
+    ? activeModal.rule
+    : null;
 
   return (
     <>
@@ -150,52 +162,59 @@ export function PolicyDetail() {
           ) : (
             <RulesTable
               rules={rules}
-              onEdit={(rule) => { setEditingRule(rule); }}
-              onToggle={(rule) => { setPendingConfirm({ kind: "toggle", rule }); }}
-              onDelete={(rule) => { setPendingConfirm({ kind: "delete", rule }); }}
+              onEdit={(rule) => { setActiveModal({ kind: "edit", rule }); }}
+              onToggle={(rule) => { setActiveModal({ kind: "confirm-toggle", rule }); }}
+              onDelete={(rule) => { setActiveModal({ kind: "confirm-delete", rule }); }}
             />
           )}
         </>
       )}
       {policy && (
         <AddRuleModal
-          open={addOpen}
+          open={activeModal.kind === "add"}
           policyID={policy.id}
-          onClose={() => { setAddOpen(false); }}
+          onClose={closeModal}
           onCreated={() => {
-            setAddOpen(false);
+            closeModal();
             refresh();
           }}
         />
       )}
+      {/*
+        key={editKey}: forces React to remount EditRuleModal when the target rule changes (Gemini finding on PR #189).
+        Without it, the autoFocus on the severity Select would only fire on the very first open of this component instance.
+        Keyed by rule id so re-opening on the same row replays initialState; switching rows replays with the new row.
+      */}
       <EditRuleModal
-        open={editingRule !== null}
-        rule={editingRule}
-        onClose={() => { setEditingRule(null); }}
+        key={activeModal.kind === "edit" ? `edit-${String(activeModal.rule.id)}` : "edit-closed"}
+        open={activeModal.kind === "edit"}
+        rule={activeModal.kind === "edit" ? activeModal.rule : null}
+        onClose={closeModal}
         onSaved={() => {
-          setEditingRule(null);
+          closeModal();
           refresh();
         }}
       />
       <ConfirmActionModal
-        open={pendingConfirm !== null}
-        title={confirmTitleFor(pendingConfirm)}
-        description={confirmDescriptionFor(pendingConfirm)}
-        confirmLabel={confirmLabelFor(pendingConfirm)}
-        confirmVariant={pendingConfirm?.kind === "delete" ? "alert" : "primary"}
-        reasonPlaceholder={confirmReasonPlaceholderFor(pendingConfirm)}
-        onClose={() => { setPendingConfirm(null); }}
+        key={confirmRule ? `confirm-${String(confirmKind)}-${String(confirmRule.id)}` : "confirm-closed"}
+        open={confirmRule !== null}
+        title={confirmTitleFor(activeModal)}
+        description={confirmDescriptionFor(activeModal)}
+        confirmLabel={confirmLabelFor(activeModal)}
+        confirmVariant={activeModal.kind === "confirm-delete" ? "alert" : "primary"}
+        reasonPlaceholder={confirmReasonPlaceholderFor(activeModal)}
+        onClose={closeModal}
         onConfirm={async (reason) => {
-          if (!pendingConfirm) return;
-          if (pendingConfirm.kind === "delete") {
-            await deleteAppControlRule(pendingConfirm.rule.id, { reason });
-          } else {
-            await updateAppControlRule(pendingConfirm.rule.id, {
-              enabled: !pendingConfirm.rule.enabled,
+          if (!confirmRule) return;
+          if (activeModal.kind === "confirm-delete") {
+            await deleteAppControlRule(confirmRule.id, { reason });
+          } else if (activeModal.kind === "confirm-toggle") {
+            await updateAppControlRule(confirmRule.id, {
+              enabled: !confirmRule.enabled,
               reason,
             });
           }
-          setPendingConfirm(null);
+          closeModal();
           refresh();
         }}
       />
@@ -205,16 +224,16 @@ export function PolicyDetail() {
 
 // confirmTitleFor + the three sibling helpers shape the per-action copy passed into the shared ConfirmActionModal. Keeping the
 // switch outside the component body so the modal can stay generic and the per-action vocabulary lives next to the dispatch.
-function confirmTitleFor(pending: PendingConfirm | null): string {
-  if (!pending) return "";
-  if (pending.kind === "delete") return "Delete rule";
-  return pending.rule.enabled ? "Disable rule" : "Enable rule";
+function confirmTitleFor(active: ActiveModal): string {
+  if (active.kind === "confirm-delete") return "Delete rule";
+  if (active.kind === "confirm-toggle") return active.rule.enabled ? "Disable rule" : "Enable rule";
+  return "";
 }
 
-function confirmDescriptionFor(pending: PendingConfirm | null): React.ReactNode {
-  if (!pending) return "";
-  const ident = pending.rule.identifier;
-  if (pending.kind === "delete") {
+function confirmDescriptionFor(active: ActiveModal): React.ReactNode {
+  if (active.kind !== "confirm-delete" && active.kind !== "confirm-toggle") return "";
+  const ident = active.rule.identifier;
+  if (active.kind === "confirm-delete") {
     return (
       <>
         The rule for <code>{ident}</code> will be removed and the policy version
@@ -222,7 +241,7 @@ function confirmDescriptionFor(pending: PendingConfirm | null): React.ReactNode 
       </>
     );
   }
-  if (pending.rule.enabled) {
+  if (active.rule.enabled) {
     return (
       <>
         Disabling pauses enforcement for <code>{ident}</code>. The rule stays
@@ -239,18 +258,20 @@ function confirmDescriptionFor(pending: PendingConfirm | null): React.ReactNode 
   );
 }
 
-function confirmLabelFor(pending: PendingConfirm | null): string {
-  if (!pending) return "Confirm";
-  if (pending.kind === "delete") return "Delete rule";
-  return pending.rule.enabled ? "Disable rule" : "Enable rule";
+function confirmLabelFor(active: ActiveModal): string {
+  if (active.kind === "confirm-delete") return "Delete rule";
+  if (active.kind === "confirm-toggle") return active.rule.enabled ? "Disable rule" : "Enable rule";
+  return "Confirm";
 }
 
-function confirmReasonPlaceholderFor(pending: PendingConfirm | null): string {
-  if (!pending) return "";
-  if (pending.kind === "delete") return "Why are you deleting this rule?";
-  return pending.rule.enabled
-    ? "Why are you disabling this rule?"
-    : "Why are you re-enabling this rule?";
+function confirmReasonPlaceholderFor(active: ActiveModal): string {
+  if (active.kind === "confirm-delete") return "Why are you deleting this rule?";
+  if (active.kind === "confirm-toggle") {
+    return active.rule.enabled
+      ? "Why are you disabling this rule?"
+      : "Why are you re-enabling this rule?";
+  }
+  return "";
 }
 
 interface RulesTableProps {

--- a/ui/src/components/ApplicationControl/PolicyDetail.tsx
+++ b/ui/src/components/ApplicationControl/PolicyDetail.tsx
@@ -1,13 +1,26 @@
 import { useCallback, useEffect, useState } from "react";
 import { Link, useParams } from "react-router-dom";
-import { getAppControlPolicy } from "../../api";
+import {
+  getAppControlPolicy,
+  deleteAppControlRule,
+  updateAppControlRule,
+} from "../../api";
 import type { ApplicationControlPolicy, ApplicationControlRule } from "../../types";
 import { PageHeader } from "../ui/PageHeader";
 import { Table, EmptyState } from "../ui/Table";
 import { Button } from "../ui/Button";
 import { Badge, type BadgeVariant } from "../ui/Badge";
 import { AddRuleModal } from "./AddRuleModal";
+import { EditRuleModal } from "./EditRuleModal";
+import { ConfirmActionModal } from "./ConfirmActionModal";
 import "./ApplicationControl.scss";
+
+// pendingConfirm captures which per-row action the operator clicked + the row it targets, so the shared ConfirmActionModal can
+// render the right copy and dispatch the right API call when the operator submits a reason. The kind discriminator drives both
+// the modal labels AND the onConfirm side-effect.
+type PendingConfirm =
+  | { kind: "delete"; rule: ApplicationControlRule }
+  | { kind: "toggle"; rule: ApplicationControlRule };
 
 const SEVERITY_VARIANTS: Record<string, BadgeVariant> = {
   critical: "critical",
@@ -42,6 +55,10 @@ export function PolicyDetail() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [addOpen, setAddOpen] = useState(false);
+  // editingRule + pendingConfirm own the per-row modal state. Only one of the two is ever populated at a time; the modals close
+  // when their target is set to null. Defined here so the rules table inside RulesTable can fire the open callbacks via props.
+  const [editingRule, setEditingRule] = useState<ApplicationControlRule | null>(null);
+  const [pendingConfirm, setPendingConfirm] = useState<PendingConfirm | null>(null);
 
   // refreshKey bumps to force a re-fetch (e.g. after Save in the
   // modal). useEffect below owns the actual fetch lifecycle so the
@@ -131,7 +148,12 @@ export function PolicyDetail() {
               author the first one.
             </EmptyState>
           ) : (
-            <RulesTable rules={rules} />
+            <RulesTable
+              rules={rules}
+              onEdit={(rule) => { setEditingRule(rule); }}
+              onToggle={(rule) => { setPendingConfirm({ kind: "toggle", rule }); }}
+              onDelete={(rule) => { setPendingConfirm({ kind: "delete", rule }); }}
+            />
           )}
         </>
       )}
@@ -146,15 +168,99 @@ export function PolicyDetail() {
           }}
         />
       )}
+      <EditRuleModal
+        open={editingRule !== null}
+        rule={editingRule}
+        onClose={() => { setEditingRule(null); }}
+        onSaved={() => {
+          setEditingRule(null);
+          refresh();
+        }}
+      />
+      <ConfirmActionModal
+        open={pendingConfirm !== null}
+        title={confirmTitleFor(pendingConfirm)}
+        description={confirmDescriptionFor(pendingConfirm)}
+        confirmLabel={confirmLabelFor(pendingConfirm)}
+        confirmVariant={pendingConfirm?.kind === "delete" ? "alert" : "primary"}
+        reasonPlaceholder={confirmReasonPlaceholderFor(pendingConfirm)}
+        onClose={() => { setPendingConfirm(null); }}
+        onConfirm={async (reason) => {
+          if (!pendingConfirm) return;
+          if (pendingConfirm.kind === "delete") {
+            await deleteAppControlRule(pendingConfirm.rule.id, { reason });
+          } else {
+            await updateAppControlRule(pendingConfirm.rule.id, {
+              enabled: !pendingConfirm.rule.enabled,
+              reason,
+            });
+          }
+          setPendingConfirm(null);
+          refresh();
+        }}
+      />
     </>
   );
 }
 
-interface RulesTableProps {
-  readonly rules: ApplicationControlRule[];
+// confirmTitleFor + the three sibling helpers shape the per-action copy passed into the shared ConfirmActionModal. Keeping the
+// switch outside the component body so the modal can stay generic and the per-action vocabulary lives next to the dispatch.
+function confirmTitleFor(pending: PendingConfirm | null): string {
+  if (!pending) return "";
+  if (pending.kind === "delete") return "Delete rule";
+  return pending.rule.enabled ? "Disable rule" : "Enable rule";
 }
 
-function RulesTable({ rules }: RulesTableProps) {
+function confirmDescriptionFor(pending: PendingConfirm | null): React.ReactNode {
+  if (!pending) return "";
+  const ident = pending.rule.identifier;
+  if (pending.kind === "delete") {
+    return (
+      <>
+        The rule for <code>{ident}</code> will be removed and the policy version
+        will bump so every agent drops it on the next snapshot.
+      </>
+    );
+  }
+  if (pending.rule.enabled) {
+    return (
+      <>
+        Disabling pauses enforcement for <code>{ident}</code>. The rule stays
+        on the policy and the agents drop it on the next snapshot until you
+        re-enable.
+      </>
+    );
+  }
+  return (
+    <>
+      Re-enabling resumes enforcement for <code>{ident}</code>. The agents
+      pick it up on the next snapshot.
+    </>
+  );
+}
+
+function confirmLabelFor(pending: PendingConfirm | null): string {
+  if (!pending) return "Confirm";
+  if (pending.kind === "delete") return "Delete rule";
+  return pending.rule.enabled ? "Disable rule" : "Enable rule";
+}
+
+function confirmReasonPlaceholderFor(pending: PendingConfirm | null): string {
+  if (!pending) return "";
+  if (pending.kind === "delete") return "Why are you deleting this rule?";
+  return pending.rule.enabled
+    ? "Why are you disabling this rule?"
+    : "Why are you re-enabling this rule?";
+}
+
+interface RulesTableProps {
+  readonly rules: ApplicationControlRule[];
+  readonly onEdit: (rule: ApplicationControlRule) => void;
+  readonly onToggle: (rule: ApplicationControlRule) => void;
+  readonly onDelete: (rule: ApplicationControlRule) => void;
+}
+
+function RulesTable({ rules, onEdit, onToggle, onDelete }: RulesTableProps) {
   return (
     <Table>
       <thead>
@@ -184,30 +290,27 @@ function RulesTable({ rules }: RulesTableProps) {
             <td>{rule.custom_msg ?? <span className="app-control__muted">—</span>}</td>
             <td>{new Date(rule.updated_at).toLocaleString()}</td>
             <td className="app-control__row-actions">
-              {/* Edit / Disable / Delete are scaffolding only in
-                  the demo cut. The disabled state + tooltip make
-                  the roadmap visible without faking behaviour. */}
+              {/* Edit / Disable / Delete each open a modal that prompts for an audit reason before firing the PATCH / DELETE
+                  endpoint server-side. The handlers live on PolicyDetail so refresh-on-success is wired in one place. */}
               <Button
                 variant="text-link"
                 size="small"
-                disabled
-                title="Editing rules is coming in the next release"
+                onClick={() => { onEdit(rule); }}
               >
                 Edit
               </Button>
               <Button
                 variant="text-link"
                 size="small"
-                disabled
-                title={rule.enabled ? "Disabling rules is coming in the next release" : "Enabling rules is coming in the next release"}
+                onClick={() => { onToggle(rule); }}
+                title={rule.enabled ? "Pause enforcement for this rule" : "Resume enforcement for this rule"}
               >
                 {rule.enabled ? "Disable" : "Enable"}
               </Button>
               <Button
                 variant="text-link"
                 size="small"
-                disabled
-                title="Deleting rules is coming in the next release"
+                onClick={() => { onDelete(rule); }}
               >
                 Delete
               </Button>

--- a/ui/src/components/ApplicationControl/api.test.ts
+++ b/ui/src/components/ApplicationControl/api.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import {
   createAppControlRule,
+  deleteAppControlRule,
   listAppControlPolicies,
   getAppControlPolicy,
+  updateAppControlRule,
   AppControlApiError,
   Unauthorized401Error,
   setCsrfToken,
@@ -117,5 +119,85 @@ describe("createAppControlRule", () => {
         reason: "demo",
       }),
     ).rejects.toThrow(/API error/);
+  });
+});
+
+// updateAppControlRule + deleteAppControlRule share patchAppControlEndpoint, so the test pairs cover the auth + typed-error
+// machinery with two different verbs (PATCH happy + DELETE happy + one typed 4xx per verb + one 401 per verb).
+
+describe("updateAppControlRule", () => {
+  it("returns the updated rule body on the happy path", async () => {
+    setCsrfToken("FAKE_CSRF_TOKEN");
+    const fakeRule = { id: 7, enabled: false, severity: "high" };
+    const fetchMock = mockFetch(fakeRule, 200);
+    const got = await updateAppControlRule(7, { enabled: false, reason: "test" });
+    expect(got).toEqual(fakeRule);
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [, init] = fetchMock.mock.calls[0] as [URL, RequestInit];
+    expect(init.method).toBe("PATCH");
+  });
+
+  it("surfaces a typed AppControlApiError for application_control.rule_not_found 404", async () => {
+    setCsrfToken("FAKE_CSRF_TOKEN");
+    mockFetch({ error: "application_control.rule_not_found", message: "rule not found" }, 404);
+    try {
+      await updateAppControlRule(99, { enabled: true, reason: "x" });
+      throw new Error("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(AppControlApiError);
+      if (err instanceof AppControlApiError) {
+        expect(err.code).toBe("application_control.rule_not_found");
+        expect(err.status).toBe(404);
+      }
+    }
+  });
+
+  it("throws Unauthorized401Error on a 401", async () => {
+    setCsrfToken("FAKE_CSRF_TOKEN");
+    mockFetch({}, 401);
+    await expect(
+      updateAppControlRule(1, { enabled: false, reason: "x" }),
+    ).rejects.toBeInstanceOf(Unauthorized401Error);
+  });
+
+  it("falls through to plain API error when the 4xx body lacks the typed envelope", async () => {
+    setCsrfToken("FAKE_CSRF_TOKEN");
+    mockFetch({ something: "else" }, 400);
+    await expect(
+      updateAppControlRule(1, { reason: "x" }),
+    ).rejects.toThrow(/API error/);
+  });
+});
+
+describe("deleteAppControlRule", () => {
+  it("resolves on 204 No Content with no body", async () => {
+    setCsrfToken("FAKE_CSRF_TOKEN");
+    const fetchMock = mockFetch(undefined, 204);
+    await deleteAppControlRule(7, { reason: "test" });
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [, init] = fetchMock.mock.calls[0] as [URL, RequestInit];
+    expect(init.method).toBe("DELETE");
+  });
+
+  it("surfaces a typed AppControlApiError when the rule is gone", async () => {
+    setCsrfToken("FAKE_CSRF_TOKEN");
+    mockFetch({ error: "application_control.rule_not_found", message: "rule not found" }, 404);
+    try {
+      await deleteAppControlRule(99, { reason: "x" });
+      throw new Error("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(AppControlApiError);
+      if (err instanceof AppControlApiError) {
+        expect(err.code).toBe("application_control.rule_not_found");
+      }
+    }
+  });
+
+  it("throws Unauthorized401Error on a 401", async () => {
+    setCsrfToken("FAKE_CSRF_TOKEN");
+    mockFetch({}, 401);
+    await expect(
+      deleteAppControlRule(1, { reason: "x" }),
+    ).rejects.toBeInstanceOf(Unauthorized401Error);
   });
 });

--- a/ui/src/components/ApplicationControl/dialogErrors.test.ts
+++ b/ui/src/components/ApplicationControl/dialogErrors.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi } from "vitest";
+import { applyAppControlSubmitError } from "./dialogErrors";
+import { AppControlApiError, ReauthRequiredError } from "../../api";
+
+const KNOWN_CODES = new Map<string, string>([
+  ["application_control.rule_not_found", "Rule gone."],
+  ["application_control.policy_immutable", "Default policy is immutable."],
+]);
+
+describe("applyAppControlSubmitError", () => {
+  it("returns true for ReauthRequiredError and does NOT set a form error", () => {
+    const setFormError = vi.fn<(msg: string) => void>();
+    const result = applyAppControlSubmitError(
+      new ReauthRequiredError({ authMethod: "local_password", reauthURL: "/login" }),
+      setFormError,
+      KNOWN_CODES,
+      "fallback",
+    );
+    expect(result).toBe(true);
+    expect(setFormError).not.toHaveBeenCalled();
+  });
+
+  it("maps a known AppControlApiError code to the human-readable message", () => {
+    const setFormError = vi.fn<(msg: string) => void>();
+    const result = applyAppControlSubmitError(
+      new AppControlApiError("application_control.rule_not_found", "rule not found", 404),
+      setFormError,
+      KNOWN_CODES,
+      "fallback",
+    );
+    expect(result).toBe(false);
+    expect(setFormError).toHaveBeenCalledWith("Rule gone.");
+  });
+
+  it("falls back to the server message when the AppControlApiError code is unknown", () => {
+    const setFormError = vi.fn<(msg: string) => void>();
+    const result = applyAppControlSubmitError(
+      new AppControlApiError("application_control.future_code", "the wire said this", 400),
+      setFormError,
+      KNOWN_CODES,
+      "fallback",
+    );
+    expect(result).toBe(false);
+    expect(setFormError).toHaveBeenCalledWith("the wire said this");
+  });
+
+  it("uses the Error.message for plain Error instances", () => {
+    const setFormError = vi.fn<(msg: string) => void>();
+    const result = applyAppControlSubmitError(
+      new Error("network blew up"),
+      setFormError,
+      KNOWN_CODES,
+      "fallback",
+    );
+    expect(result).toBe(false);
+    expect(setFormError).toHaveBeenCalledWith("network blew up");
+  });
+
+  it("uses the fallback for unknown thrown values", () => {
+    const setFormError = vi.fn<(msg: string) => void>();
+    const result = applyAppControlSubmitError(
+      { weird: "object" },
+      setFormError,
+      KNOWN_CODES,
+      "operation failed",
+    );
+    expect(result).toBe(false);
+    expect(setFormError).toHaveBeenCalledWith("operation failed");
+  });
+});

--- a/ui/src/components/ApplicationControl/dialogErrors.ts
+++ b/ui/src/components/ApplicationControl/dialogErrors.ts
@@ -1,0 +1,30 @@
+import { AppControlApiError, ReauthRequiredError } from "../../api";
+
+// applyAppControlSubmitError centralises the error-mapping each app-control modal repeats inside its submit-try-catch.
+// Sonar flagged the duplicated catch blocks across AddRuleModal / EditRuleModal / ConfirmActionModal as a
+// new_duplicated_lines_density violation on PR #189; collapsing the mapping here keeps the per-modal handler one line.
+//
+// Returns true when the error was a ReauthRequiredError — the caller MUST return early in that case because useReauthRetry's
+// modal is mounted as a sibling and will re-run the original call after the reauth completes. Returns false for every other
+// error (which has been mapped onto setFormError) so the caller can fall through to its `finally { setBusy(false) }`.
+export function applyAppControlSubmitError(
+  err: unknown,
+  setFormError: (msg: string) => void,
+  codeMap: ReadonlyMap<string, string>,
+  fallback: string,
+): boolean {
+  if (err instanceof ReauthRequiredError) {
+    // useReauthRetry's modal mounts as a sibling; the user finishes the reauth and the original call retries on its own.
+    return true;
+  }
+  if (err instanceof AppControlApiError) {
+    setFormError(codeMap.get(err.code) ?? err.message);
+    return false;
+  }
+  if (err instanceof Error) {
+    setFormError(err.message);
+    return false;
+  }
+  setFormError(fallback);
+  return false;
+}

--- a/ui/src/components/ApplicationControl/useAppControlDialog.ts
+++ b/ui/src/components/ApplicationControl/useAppControlDialog.ts
@@ -1,0 +1,47 @@
+import { useCallback, useEffect, useRef } from "react";
+
+// useAppControlDialog encapsulates the open/close + backdrop + escape-to-cancel wiring every app-control modal repeats. Sonar flagged
+// the duplicated useEffect blocks across AddRuleModal / EditRuleModal / ConfirmActionModal as a new_duplicated_lines_density
+// violation on PR #189; collapsing the scaffolding here brings every modal under one helper.
+//
+// Returns {dialogRef, handleCancel}. The caller passes dialogRef into <dialog ref={dialogRef}> and handleCancel into <dialog
+// onCancel>. The hook owns the showModal()/close() lifecycle keyed on `open` AND the backdrop-click handler that routes through
+// onClose so the parent's open state stays the single source of truth.
+//
+// Test note: in JSDOM, HTMLDialogElement.prototype.showModal / .close need polyfills (the existing AddRuleModal.test.tsx +
+// PolicyDetail.test.tsx setup blocks already supply them via prototype assignment).
+export function useAppControlDialog(open: boolean, onClose: () => void) {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+
+  // Open / close the native <dialog>. showModal() is what gives us backdrop + focus trap + Escape-to-cancel for free; the
+  // declarative `open` attribute would render non-modal.
+  useEffect(() => {
+    const dlg = dialogRef.current;
+    if (!dlg) return;
+    if (open && !dlg.open) {
+      dlg.showModal();
+    } else if (!open && dlg.open) {
+      dlg.close();
+    }
+  }, [open]);
+
+  // Escape (via dialog's onCancel event) routes through this so the parent's open-state stays authoritative.
+  const handleCancel = useCallback((e: React.SyntheticEvent<HTMLDialogElement>) => {
+    e.preventDefault();
+    onClose();
+  }, [onClose]);
+
+  // Backdrop click: native <dialog> does not fire close on backdrop click; we synthesize it by detecting clicks whose target IS
+  // the dialog element itself (content clicks have a child target).
+  useEffect(() => {
+    const dlg = dialogRef.current;
+    if (!dlg) return undefined;
+    const onBackdrop = (e: MouseEvent) => {
+      if (e.target === dlg) onClose();
+    };
+    dlg.addEventListener("click", onBackdrop);
+    return () => { dlg.removeEventListener("click", onBackdrop); };
+  }, [onClose]);
+
+  return { dialogRef, handleCancel };
+}


### PR DESCRIPTION
…e (#68 / 11.4.10)

Stacks on PR #188 (REST mutation surface). The previous Edit / Disable / Delete buttons on the rules table rendered disabled with "coming soon" tooltips; this commit wires them through to the PATCH / DELETE endpoints shipped in PR #188 and closes openspec section 11.4.10.

UI:
- New ConfirmActionModal (ui/src/components/ApplicationControl/ConfirmActionModal.tsx): shared confirmation dialog for the disable/enable toggle and the delete button. Prompts for a reason (required for the audit row) before firing the API call; the parent supplies the title / description / button label / variant per action. Maps the typed AppControlApiError codes (rule_not_found / policy_immutable / etc.) onto operator-readable copy via the same errorMessageByCode pattern AddRuleModal uses.
- New EditRuleModal (EditRuleModal.tsx): full edit form for the mutable fields (severity, custom_msg, custom_url, comment). Pre-populates from the row being edited and diffs current state against initialState so the PATCH body only carries the fields the operator actually changed — keeps the audit log honest. Reuses AddRuleModal's URL guard so the http/https check fires client-side. The rule_type + identifier display read-only at the top of the form since they're immutable post-create.
- PolicyDetail.tsx: replaces the three disabled buttons with onClick handlers. Each opens the right modal; refresh-on-success is wired in one place. confirmTitleFor / confirmDescriptionFor / confirmLabelFor / confirmReasonPlaceholderFor helpers keep the per-action vocabulary next to the dispatch instead of inside the shared modal.

API client (ui/src/api.ts):
- New updateAppControlRule + deleteAppControlRule functions, sharing a patchAppControlEndpoint helper that centralises the auth + reauth + typed-error handling (parallel to createAppControlRule). New UpdateAppControlRuleRequest + DeleteAppControlRuleRequest types match the server wire shapes.

Tests:
- PolicyDetail.test.tsx: 3 new tests covering disable / delete / edit flows. Each scopes RTL queries to the open dialog via within(getByRole("dialog", {name})) since PolicyDetail mounts three modals at once (Add + Edit + Confirm) and JSDOM doesn't hide closed-dialog children from RTL by default.
- The edit test pins the diff-only-changed-fields semantic: changing only severity sends {severity, reason} not {severity, custom_msg, custom_url, comment, reason}. Without this the audit log would show a multi-field rewrite for a single-field intent.
- Updated the existing "renders the policy header" test to assert the three buttons are no longer disabled.

Verification: npx tsc --noEmit clean; npx eslint src/ clean; vitest 45/45 (7 in PolicyDetail.test); production bundle builds.

Manual QA via Chrome MCP against dev:server lands in the next commit on this branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Edit application control rules, including severity, custom messages, and reference URLs
  * Delete application control rules
  * Toggle enable/disable status for application control rules
  * Added confirmation dialogs requiring audit reasons for all rule modifications
  * Enhanced error handling and reauthentication support for rule operations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/getvictor/fleet-edr/pull/189?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->