### PR TITLE
app-control: bulk-upsert rules endpoint (#68 / 11.4.6)

### DIFF
--- a/server/cmd/fleet-edr-server/main.go
+++ b/server/cmd/fleet-edr-server/main.go
@@ -536,6 +536,7 @@ func registerSessionRoutes(mux *http.ServeMux, d muxDeps) {
 		"PATCH /api/v1/app-control/policies/{id}",
 		"DELETE /api/v1/app-control/policies/{id}",
 		"POST /api/v1/app-control/policies/{id}/rules",
+		"POST /api/v1/app-control/policies/{id}/rules:bulkUpsert",
 		"PATCH /api/v1/app-control/rules/{id}",
 		"DELETE /api/v1/app-control/rules/{id}",
 		// Break-glass reauth ceremony. The handlers are mounted on apiMux via identityCtx.RegisterAuthedRoutes, but the outer

--- a/server/identity/api/audit.go
+++ b/server/identity/api/audit.go
@@ -50,12 +50,13 @@ const (
 	// and fan-out counts (fanout_hosts / fanout_failed) so SIEM dashboards can trace which hosts received the rule. Stable wire strings
 	// mirrored by AuthZ Actions of the same names. The five non-create actions are added by the Phase A close-out follow-on (PR-1b)
 	// that wires the full PATCH/DELETE/POST REST surface.
-	AuditAppControlRuleCreate   AuditAction = "application_control.rule_create"
-	AuditAppControlRuleUpdate   AuditAction = "application_control.rule_update"
-	AuditAppControlRuleDelete   AuditAction = "application_control.rule_delete"
-	AuditAppControlPolicyCreate AuditAction = "application_control.policy_create"
-	AuditAppControlPolicyUpdate AuditAction = "application_control.policy_update"
-	AuditAppControlPolicyDelete AuditAction = "application_control.policy_delete"
+	AuditAppControlRuleCreate     AuditAction = "application_control.rule_create"
+	AuditAppControlRuleUpdate     AuditAction = "application_control.rule_update"
+	AuditAppControlRuleDelete     AuditAction = "application_control.rule_delete"
+	AuditAppControlRuleBulkUpsert AuditAction = "application_control.rule_bulk_upsert"
+	AuditAppControlPolicyCreate   AuditAction = "application_control.policy_create"
+	AuditAppControlPolicyUpdate   AuditAction = "application_control.policy_update"
+	AuditAppControlPolicyDelete   AuditAction = "application_control.policy_delete"
 )
 
 // AuditEvent is the value passed to AuditRecorder.Record. Caller

--- a/server/identity/api/authz.go
+++ b/server/identity/api/authz.go
@@ -65,13 +65,14 @@ const (
 	// Application Control. The admin surface manages the policies and rules that the extension consults on every AUTH_EXEC. Read covers
 	// the list + detail views; the five mutation verbs each gate a corresponding POST/PATCH/DELETE handler that fans a fresh
 	// `set_application_control` command out to every enrolled host on the affected policy. Bulk upsert + host-groups CRUD stay deferred.
-	ActionAppControlRead         Action = "application_control.read"
-	ActionAppControlRuleCreate   Action = "application_control.rule_create"
-	ActionAppControlRuleUpdate   Action = "application_control.rule_update"
-	ActionAppControlRuleDelete   Action = "application_control.rule_delete"
-	ActionAppControlPolicyCreate Action = "application_control.policy_create"
-	ActionAppControlPolicyUpdate Action = "application_control.policy_update"
-	ActionAppControlPolicyDelete Action = "application_control.policy_delete"
+	ActionAppControlRead           Action = "application_control.read"
+	ActionAppControlRuleCreate     Action = "application_control.rule_create"
+	ActionAppControlRuleUpdate     Action = "application_control.rule_update"
+	ActionAppControlRuleDelete     Action = "application_control.rule_delete"
+	ActionAppControlRuleBulkUpsert Action = "application_control.rule_bulk_upsert"
+	ActionAppControlPolicyCreate   Action = "application_control.policy_create"
+	ActionAppControlPolicyUpdate   Action = "application_control.policy_update"
+	ActionAppControlPolicyDelete   Action = "application_control.policy_delete"
 )
 
 // RegisteredActions returns the set of every Action constant declared
@@ -92,7 +93,7 @@ func RegisteredActions() []Action {
 		ActionUserRead, ActionUserInvite,
 		ActionAuditRead,
 		ActionAppControlRead,
-		ActionAppControlRuleCreate, ActionAppControlRuleUpdate, ActionAppControlRuleDelete,
+		ActionAppControlRuleCreate, ActionAppControlRuleUpdate, ActionAppControlRuleDelete, ActionAppControlRuleBulkUpsert,
 		ActionAppControlPolicyCreate, ActionAppControlPolicyUpdate, ActionAppControlPolicyDelete,
 	}
 }

--- a/server/identity/internal/authz/policy/data/actions.json
+++ b/server/identity/internal/authz/policy/data/actions.json
@@ -20,6 +20,7 @@
     "application_control.rule_create",
     "application_control.rule_update",
     "application_control.rule_delete",
+    "application_control.rule_bulk_upsert",
     "application_control.policy_create",
     "application_control.policy_update",
     "application_control.policy_delete"

--- a/server/identity/internal/authz/policy/data/roles.json
+++ b/server/identity/internal/authz/policy/data/roles.json
@@ -24,6 +24,7 @@
         "application_control.rule_create",
         "application_control.rule_update",
         "application_control.rule_delete",
+        "application_control.rule_bulk_upsert",
         "application_control.policy_create",
         "application_control.policy_update",
         "application_control.policy_delete"

--- a/server/rules/api/types.go
+++ b/server/rules/api/types.go
@@ -334,6 +334,45 @@ type DeletePolicyRequest struct {
 	Reason   string
 }
 
+// BulkUpsertRuleItem is one row in a BulkUpsertRulesRequest. Mirrors the wire shape POST /policies/{id}/rules:bulkUpsert
+// consumes per element. Idempotency key is (policy_id, rule_type, identifier) per the openspec; severity / custom_msg /
+// custom_url / comment overwrite the existing row when the key collides. PolicyID is supplied by the request envelope, not by
+// each item, so the operator cannot accidentally mix policies inside one batch.
+type BulkUpsertRuleItem struct {
+	RuleType   RuleType
+	Identifier string
+	Severity   Severity
+	CustomMsg  *string
+	CustomURL  *string
+	Comment    string
+}
+
+// BulkUpsertRulesRequest is the server-internal contract for POST /policies/{id}/rules:bulkUpsert. All-or-nothing semantics:
+// any item that fails validation rejects the whole batch (the partial-commit alternative would leave the operator with a
+// half-imported state that's hard to reconcile). Actor + Reason land on the single audit row that fires for the logical
+// operation regardless of how many items the batch contained.
+type BulkUpsertRulesRequest struct {
+	PolicyID int64
+	Items    []BulkUpsertRuleItem
+	Actor    string
+	Reason   string
+}
+
+// BulkUpsertResult is the wire shape returned to a successful bulk-upsert. Inserted + Updated are the per-row outcome counts
+// (an item that matched the existing row exactly counts as Updated even if no field actually changed; MySQL's
+// ROW_COUNT() distinguishes "no row touched" from "matched and overwritten"). Rules is the full post-upsert row set in the
+// order the request supplied so a UI can render the final state without an extra round trip.
+type BulkUpsertResult struct {
+	Inserted int                      `json:"inserted"`
+	Updated  int                      `json:"updated"`
+	Rules    []ApplicationControlRule `json:"rules"`
+}
+
+// MaxBulkUpsertItems caps a single bulk-upsert batch. The handler's 16 KiB body limit imposes a practical ceiling but we also
+// gate on item count so a 1000-row paste that happens to fit under the byte cap doesn't tie up the txn for minutes. 500
+// matches the Phase A demo deployment's expected import size with headroom; Phase B can grow this when paste-many lands.
+const MaxBulkUpsertItems = 500
+
 // Application Control validation errors. Mapped to HTTP 400 by the
 // REST handlers via IsApplicationControlValidationError.
 var (
@@ -437,6 +476,11 @@ type ApplicationControlStore interface {
 	// DeletePolicy removes the policy row (CASCADEs rules + assignments). Refuses the seed Default policy via
 	// ErrAppControlPolicyImmutable. ErrAppControlPolicyNotFound when the id does not exist.
 	DeletePolicy(ctx context.Context, req DeletePolicyRequest) error
+	// BulkUpsertRules applies an idempotent upsert across the request's items, bumps the parent policy version once, and
+	// returns the post-upsert rows + insert/update counts. All-or-nothing: any item failing validation rejects the whole
+	// batch. ErrAppControlPolicyNotFound when policy_id is missing; the per-item validator errors propagate untouched so the
+	// REST handler can errors.Is on the shared IsApplicationControlValidationError set.
+	BulkUpsertRules(ctx context.Context, req BulkUpsertRulesRequest) (BulkUpsertResult, error)
 	// ListHostGroupsForPolicy returns the host groups assigned to the policy, in priority order then by group name. The fan-out
 	// resolver walks the result and unions the member hosts of each group to build the set of unique hosts the rule update should
 	// reach.

--- a/server/rules/api/types.go
+++ b/server/rules/api/types.go
@@ -359,17 +359,17 @@ type BulkUpsertRulesRequest struct {
 }
 
 // BulkUpsertResult is the wire shape returned to a successful bulk-upsert. Inserted + Updated are the per-row outcome counts
-// (an item that matched the existing row exactly counts as Updated even if no field actually changed; MySQL's
-// ROW_COUNT() distinguishes "no row touched" from "matched and overwritten"). Rules is the full post-upsert row set in the
-// order the request supplied so a UI can render the final state without an extra round trip.
+// classified by snapshotting the existing (policy_id, rule_type, identifier) keys inside the same SELECT ... FOR UPDATE that
+// serialises the batch — items whose key was already present count as Updated, the rest as Inserted. Rules is the full
+// post-upsert row set in the order the request supplied so a UI can render the final state without an extra round trip.
 type BulkUpsertResult struct {
 	Inserted int                      `json:"inserted"`
 	Updated  int                      `json:"updated"`
 	Rules    []ApplicationControlRule `json:"rules"`
 }
 
-// MaxBulkUpsertItems caps a single bulk-upsert batch. The handler's 16 KiB body limit imposes a practical ceiling but we also
-// gate on item count so a 1000-row paste that happens to fit under the byte cap doesn't tie up the txn for minutes. 500
+// MaxBulkUpsertItems caps a single bulk-upsert batch. The handler's 256 KiB body limit imposes a practical byte ceiling, but we
+// also gate on item count so a 1000-row paste that happens to fit under the byte cap doesn't tie up the txn for minutes. 500
 // matches the Phase A demo deployment's expected import size with headroom; Phase B can grow this when paste-many lands.
 const MaxBulkUpsertItems = 500
 

--- a/server/rules/internal/appcontrol/service.go
+++ b/server/rules/internal/appcontrol/service.go
@@ -624,13 +624,18 @@ func (s *Service) BulkUpsertRules(ctx context.Context, req api.BulkUpsertRulesRe
 	}
 	policy, payload, composeErr := s.buildSnapshotPayload(ctx, req.PolicyID)
 	if composeErr != nil {
-		s.recordBulkUpsertAudit(ctx, actor, req, result, 0, 0, 0, "snapshot_compose_failed")
+		s.recordBulkUpsertAudit(ctx, bulkUpsertAuditArgs{
+			Actor: actor, Req: req, Result: result, FanoutSkipReason: "snapshot_compose_failed",
+		})
 		s.logger.ErrorContext(ctx, "appcontrol: snapshot compose after BulkUpsertRules failed; rules persisted but agents unaware until next mutation",
 			"err", composeErr, "policy_id", req.PolicyID, "rules_total", len(result.Rules))
 		return api.BulkUpsertResult{}, fmt.Errorf(errSvcSnapshotComposeFmt, composeErr)
 	}
 	fanoutHosts, fanoutFailed, fanoutSkipReason := s.fanout(ctx, policy.ID, payload)
-	s.recordBulkUpsertAudit(ctx, actor, req, result, policy.Version, fanoutHosts, fanoutFailed, fanoutSkipReason)
+	s.recordBulkUpsertAudit(ctx, bulkUpsertAuditArgs{
+		Actor: actor, Req: req, Result: result, PolicyVersion: policy.Version,
+		FanoutHosts: fanoutHosts, FanoutFailed: fanoutFailed, FanoutSkipReason: fanoutSkipReason,
+	})
 	if fanoutSkipReason != "" {
 		s.logger.InfoContext(ctx, "appcontrol bulk upsert fan-out skipped",
 			"reason", fanoutSkipReason, "policy_id", req.PolicyID, "rules_total", len(result.Rules))
@@ -638,37 +643,41 @@ func (s *Service) BulkUpsertRules(ctx context.Context, req api.BulkUpsertRulesRe
 	return result, nil
 }
 
+// bulkUpsertAuditArgs bundles the per-call inputs recordBulkUpsertAudit needs. Struct shape rather than positional params so
+// Sonar's S107 (max 7 args) doesn't fire; the previous 8-param signature was flagged on PR #190. New fields (Phase B's
+// Detect-mode enforcement deltas, e.g.) extend the struct rather than the positional list.
+type bulkUpsertAuditArgs struct {
+	Actor            *identityapi.Actor
+	Req              api.BulkUpsertRulesRequest
+	Result           api.BulkUpsertResult
+	PolicyVersion    int64
+	FanoutHosts      int
+	FanoutFailed     int
+	FanoutSkipReason string
+}
+
 // recordBulkUpsertAudit emits the single audit row for one BulkUpsertRules call regardless of how many items the batch
 // contained. Payload shape adds rules_inserted + rules_updated + rules_total alongside the fan-out fields so the SIEM can
 // answer "how many rules did this import affect" without per-row joins.
-func (s *Service) recordBulkUpsertAudit(
-	ctx context.Context,
-	actor *identityapi.Actor,
-	req api.BulkUpsertRulesRequest,
-	result api.BulkUpsertResult,
-	policyVersion int64,
-	fanoutHosts int,
-	fanoutFailed int,
-	fanoutSkipReason string,
-) {
+func (s *Service) recordBulkUpsertAudit(ctx context.Context, args bulkUpsertAuditArgs) {
 	payload := map[string]any{
-		"policy_id":      req.PolicyID,
-		"policy_version": policyVersion,
-		"rules_inserted": result.Inserted,
-		"rules_updated":  result.Updated,
-		"rules_total":    len(result.Rules),
-		"reason":         req.Reason,
-		"fanout_hosts":   fanoutHosts,
-		"fanout_failed":  fanoutFailed,
+		"policy_id":      args.Req.PolicyID,
+		"policy_version": args.PolicyVersion,
+		"rules_inserted": args.Result.Inserted,
+		"rules_updated":  args.Result.Updated,
+		"rules_total":    len(args.Result.Rules),
+		"reason":         args.Req.Reason,
+		"fanout_hosts":   args.FanoutHosts,
+		"fanout_failed":  args.FanoutFailed,
 	}
-	if fanoutSkipReason != "" {
-		payload["fanout_skipped_reason"] = fanoutSkipReason
+	if args.FanoutSkipReason != "" {
+		payload["fanout_skipped_reason"] = args.FanoutSkipReason
 	}
-	s.recordAudit(ctx, actor, identityapi.AuditEvent{
+	s.recordAudit(ctx, args.Actor, identityapi.AuditEvent{
 		Action:     identityapi.AuditAppControlRuleBulkUpsert,
 		TargetType: "application_control_policy",
-		TargetID:   strconv.FormatInt(req.PolicyID, 10),
-		ActorEmail: req.Actor,
+		TargetID:   strconv.FormatInt(args.Req.PolicyID, 10),
+		ActorEmail: args.Req.Actor,
 		Payload:    payload,
 	})
 }

--- a/server/rules/internal/appcontrol/service.go
+++ b/server/rules/internal/appcontrol/service.go
@@ -604,3 +604,71 @@ func (s *Service) recordPolicyMutationAudit(
 		},
 	})
 }
+
+// BulkUpsertRules wires POST /api/v1/app-control/policies/{id}/rules:bulkUpsert. Sequence mirrors CreateRule's chokepoint
+// pattern modulo the per-item bulk shape: validate actor, hand the all-or-nothing upsert to the store (which validates each
+// item + runs the upserts in one txn + bumps the policy version once), compose the post-upsert snapshot, fan it out, emit a
+// single audit row for the logical operation.
+//
+// The audit payload differs from the per-rule mutation shape: rules_inserted + rules_updated + rules_total replace the
+// rule_type / identifier / severity fields so a SIEM query "show me bulk imports that touched more than 50 rules" works
+// without joining per-rule audit rows. Fan-out fields stay the same so the agent reach is queryable consistently across
+// every mutation type.
+func (s *Service) BulkUpsertRules(ctx context.Context, req api.BulkUpsertRulesRequest, actor *identityapi.Actor) (api.BulkUpsertResult, error) {
+	if actor == nil {
+		return api.BulkUpsertResult{}, fmt.Errorf(errSvcActorRequiredFmt, api.ErrAppControlInvalidRequest)
+	}
+	result, err := s.store.BulkUpsertRules(ctx, req)
+	if err != nil {
+		return api.BulkUpsertResult{}, err
+	}
+	policy, payload, composeErr := s.buildSnapshotPayload(ctx, req.PolicyID)
+	if composeErr != nil {
+		s.recordBulkUpsertAudit(ctx, actor, req, result, 0, 0, 0, "snapshot_compose_failed")
+		s.logger.ErrorContext(ctx, "appcontrol: snapshot compose after BulkUpsertRules failed; rules persisted but agents unaware until next mutation",
+			"err", composeErr, "policy_id", req.PolicyID, "rules_total", len(result.Rules))
+		return api.BulkUpsertResult{}, fmt.Errorf(errSvcSnapshotComposeFmt, composeErr)
+	}
+	fanoutHosts, fanoutFailed, fanoutSkipReason := s.fanout(ctx, policy.ID, payload)
+	s.recordBulkUpsertAudit(ctx, actor, req, result, policy.Version, fanoutHosts, fanoutFailed, fanoutSkipReason)
+	if fanoutSkipReason != "" {
+		s.logger.InfoContext(ctx, "appcontrol bulk upsert fan-out skipped",
+			"reason", fanoutSkipReason, "policy_id", req.PolicyID, "rules_total", len(result.Rules))
+	}
+	return result, nil
+}
+
+// recordBulkUpsertAudit emits the single audit row for one BulkUpsertRules call regardless of how many items the batch
+// contained. Payload shape adds rules_inserted + rules_updated + rules_total alongside the fan-out fields so the SIEM can
+// answer "how many rules did this import affect" without per-row joins.
+func (s *Service) recordBulkUpsertAudit(
+	ctx context.Context,
+	actor *identityapi.Actor,
+	req api.BulkUpsertRulesRequest,
+	result api.BulkUpsertResult,
+	policyVersion int64,
+	fanoutHosts int,
+	fanoutFailed int,
+	fanoutSkipReason string,
+) {
+	payload := map[string]any{
+		"policy_id":      req.PolicyID,
+		"policy_version": policyVersion,
+		"rules_inserted": result.Inserted,
+		"rules_updated":  result.Updated,
+		"rules_total":    len(result.Rules),
+		"reason":         req.Reason,
+		"fanout_hosts":   fanoutHosts,
+		"fanout_failed":  fanoutFailed,
+	}
+	if fanoutSkipReason != "" {
+		payload["fanout_skipped_reason"] = fanoutSkipReason
+	}
+	s.recordAudit(ctx, actor, identityapi.AuditEvent{
+		Action:     identityapi.AuditAppControlRuleBulkUpsert,
+		TargetType: "application_control_policy",
+		TargetID:   strconv.FormatInt(req.PolicyID, 10),
+		ActorEmail: req.Actor,
+		Payload:    payload,
+	})
+}

--- a/server/rules/internal/appcontrol/store.go
+++ b/server/rules/internal/appcontrol/store.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/jmoiron/sqlx"
@@ -20,6 +21,9 @@ const (
 	errReasonRequiredFmt = "%w: reason is required"
 	errBeginTxFmt        = "appcontrol begin tx: %w"
 	errCommitTxFmt       = "appcontrol commit tx: %w"
+	// errBulkItemFmt wraps a per-item validator error with the batch index. Sonar S1192 flagged this string as duplicated across
+	// three call sites in BulkUpsertRules' validation pass; extracting keeps the wire format stable.
+	errBulkItemFmt = "bulk item %d: %w"
 )
 
 // Store wraps the *sqlx.DB handle for the app_control_policies + app_control_rules tables. Constructed once by the rules bootstrap and
@@ -675,45 +679,185 @@ func errStringContains(err error, substr string) bool {
 	return strings.Contains(err.Error(), substr)
 }
 
+// bulkItemKey is the canonical (rule_type, identifier) key the bulk-upsert preflight + post-state maps index on. \x1f is the
+// ASCII unit-separator; using it as the join token avoids any collision with valid rule_type / identifier characters.
+func bulkItemKey(ruleType api.RuleType, identifier string) string {
+	return string(ruleType) + "\x1f" + identifier
+}
+
+// validateBulkUpsertRequest covers the envelope-level guards (actor, reason, item count). Extracted so BulkUpsertRules' body
+// stays under Sonar's cognitive-complexity threshold (S3776) AND so the duplicate-batch + per-item validators below stay
+// focused on item-shape concerns.
+func validateBulkUpsertRequest(req api.BulkUpsertRulesRequest) error {
+	if strings.TrimSpace(req.Actor) == "" {
+		return fmt.Errorf(errActorRequiredFmt, api.ErrAppControlInvalidRequest)
+	}
+	if strings.TrimSpace(req.Reason) == "" {
+		return fmt.Errorf(errReasonRequiredFmt, api.ErrAppControlInvalidRequest)
+	}
+	if len(req.Items) == 0 {
+		return fmt.Errorf("%w: bulk upsert requires at least one rule", api.ErrAppControlInvalidRequest)
+	}
+	if len(req.Items) > api.MaxBulkUpsertItems {
+		return fmt.Errorf("%w: batch size %d exceeds limit %d",
+			api.ErrAppControlInvalidRequest, len(req.Items), api.MaxBulkUpsertItems)
+	}
+	return nil
+}
+
+// validateBulkUpsertItems runs the per-item shape checks AND the in-batch duplicate-key guard. CodeRabbit on PR #190 flagged a
+// duplicate key in the same batch as a count-correctness bug: without this guard, the second occurrence of the same
+// (rule_type, identifier) tuple would be classified as Insert because the preflight only sees pre-batch state.
+func validateBulkUpsertItems(items []api.BulkUpsertRuleItem) error {
+	seen := make(map[string]int, len(items))
+	for i, item := range items {
+		if err := ValidateRuleType(item.RuleType); err != nil {
+			return fmt.Errorf(errBulkItemFmt, i, err)
+		}
+		if err := ValidateIdentifier(item.RuleType, item.Identifier); err != nil {
+			return fmt.Errorf(errBulkItemFmt, i, err)
+		}
+		if err := ValidateSeverity(item.Severity); err != nil {
+			return fmt.Errorf(errBulkItemFmt, i, err)
+		}
+		key := bulkItemKey(item.RuleType, item.Identifier)
+		if prev, dup := seen[key]; dup {
+			return fmt.Errorf("%w: bulk item %d duplicates the (rule_type, identifier) of item %d",
+				api.ErrAppControlInvalidRequest, i, prev)
+		}
+		seen[key] = i
+	}
+	return nil
+}
+
+// lockPolicyForBulkUpsert serialises concurrent bulk-upserts against the same policy by taking a row lock on the parent
+// app_control_policies row inside the txn. Two concurrent bulk-upserts on the same policy would otherwise have a TOCTOU race
+// between preflight (SELECT existing keys) and upsert (INSERT ... ON DUPLICATE KEY UPDATE) — both could classify the same key
+// as Insert and over-report inserted counts. Returns ErrAppControlPolicyNotFound when the policy doesn't exist (the row lock
+// surfaces missing rows as sql.ErrNoRows).
+func lockPolicyForBulkUpsert(ctx context.Context, tx *sqlx.Tx, policyID int64) error {
+	var id int64
+	err := tx.QueryRowxContext(ctx, `SELECT id FROM app_control_policies WHERE id = ? FOR UPDATE`, policyID).Scan(&id)
+	if errors.Is(err, sql.ErrNoRows) {
+		return api.ErrAppControlPolicyNotFound
+	}
+	if err != nil {
+		return fmt.Errorf("appcontrol bulk upsert: lock policy: %w", err)
+	}
+	return nil
+}
+
+// collectExistingBulkKeys returns the set of (rule_type, identifier) tuples that already exist for the policy among the items
+// in the batch. One SELECT replaces the previous N×SELECT preflight loop (Gemini HIGH on PR #190). Items are passed in so the
+// IN clause only spans the batch keys, not the whole policy's rules.
+func (s *Store) collectExistingBulkKeys(ctx context.Context, tx *sqlx.Tx, policyID int64, items []api.BulkUpsertRuleItem) (map[string]struct{}, error) {
+	if len(items) == 0 {
+		return map[string]struct{}{}, nil
+	}
+	// Compose `(?, ?), (?, ?), ...` placeholder list for the row-constructor IN clause.
+	placeholders := make([]string, len(items))
+	args := make([]any, 0, 1+2*len(items))
+	args = append(args, policyID)
+	for i, item := range items {
+		placeholders[i] = "(?, ?)"
+		args = append(args, item.RuleType, item.Identifier)
+	}
+	query := "SELECT rule_type, identifier FROM app_control_rules WHERE policy_id = ? AND (rule_type, identifier) IN (" +
+		strings.Join(placeholders, ", ") + ")"
+	rows, err := tx.QueryxContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("appcontrol bulk preflight: %w", err)
+	}
+	defer rows.Close()
+	out := make(map[string]struct{}, len(items))
+	for rows.Next() {
+		var rt api.RuleType
+		var ident string
+		if err := rows.Scan(&rt, &ident); err != nil {
+			return nil, fmt.Errorf("appcontrol bulk preflight scan: %w", err)
+		}
+		out[bulkItemKey(rt, ident)] = struct{}{}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("appcontrol bulk preflight rows: %w", err)
+	}
+	return out, nil
+}
+
+// fetchBulkUpsertRows is the single-SELECT post-state fetch that replaces the previous N×SELECT refetch loop (Gemini HIGH on
+// PR #190). Returns the rules indexed by (rule_type, identifier) key so the caller can re-order them to the request's order.
+func (s *Store) fetchBulkUpsertRows(ctx context.Context, policyID int64, items []api.BulkUpsertRuleItem) (map[string]api.ApplicationControlRule, error) {
+	if len(items) == 0 {
+		return map[string]api.ApplicationControlRule{}, nil
+	}
+	placeholders := make([]string, len(items))
+	args := make([]any, 0, 1+2*len(items))
+	args = append(args, policyID)
+	for i, item := range items {
+		placeholders[i] = "(?, ?)"
+		args = append(args, item.RuleType, item.Identifier)
+	}
+	query := `SELECT id, policy_id, rule_type, identifier, action, enforcement, enabled,
+		severity, source, source_ref, custom_msg, custom_url, comment, expires_at,
+		created_at, updated_at, created_by
+		FROM app_control_rules
+		WHERE policy_id = ? AND (rule_type, identifier) IN (` + strings.Join(placeholders, ", ") + ")"
+	rows, err := s.db.QueryxContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("appcontrol bulk upsert: refetch: %w", err)
+	}
+	defer rows.Close()
+	out := make(map[string]api.ApplicationControlRule, len(items))
+	for rows.Next() {
+		var rule api.ApplicationControlRule
+		var enabled int
+		if err := rows.Scan(
+			&rule.ID, &rule.PolicyID, &rule.RuleType, &rule.Identifier, &rule.Action, &rule.Enforcement, &enabled,
+			&rule.Severity, &rule.Source, &rule.SourceRef, &rule.CustomMsg, &rule.CustomURL, &rule.Comment, &rule.ExpiresAt,
+			&rule.CreatedAt, &rule.UpdatedAt, &rule.CreatedBy,
+		); err != nil {
+			return nil, fmt.Errorf("appcontrol bulk upsert refetch scan: %w", err)
+		}
+		rule.Enabled = enabled != 0
+		out[bulkItemKey(rule.RuleType, rule.Identifier)] = rule
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("appcontrol bulk upsert refetch rows: %w", err)
+	}
+	return out, nil
+}
+
 // BulkUpsertRules inserts or overwrites each row in req.Items inside one transaction, bumps the parent policy version once, and
 // returns the post-upsert rows + insert/update counts. Idempotency key is (policy_id, rule_type, identifier) per the openspec;
 // severity / custom_msg / custom_url / comment overwrite when the key collides. All-or-nothing: a per-item validator error
-// (rule_type, identifier shape, severity) rejects the whole batch before any UPDATE fires. Returns ErrAppControlPolicyNotFound
-// when the policy_id is missing (FK violation on the first INSERT surfaces it).
+// (rule_type, identifier shape, severity) OR an in-batch duplicate-key violation rejects the whole batch before any UPDATE
+// fires. Returns ErrAppControlPolicyNotFound when the policy_id is missing.
 //
-// Per-item counts use MySQL's "INSERT ... ON DUPLICATE KEY UPDATE" affected-row convention: 1 for a fresh insert, 2 for an
-// existing row that was overwritten. We translate by counting 1+2 totals and inferring insert vs update from a pre-query that
-// resolves existing ids; this is simpler than parsing the per-statement affected_rows.
+// Concurrency: the batch takes a row-level lock on the parent app_control_policies row (SELECT ... FOR UPDATE) so two
+// concurrent bulk-upserts on the same policy cannot interleave their preflight + write phases. Items are also sorted by
+// (rule_type, identifier) so lock acquisition order on the underlying rule rows is deterministic — defense-in-depth that
+// stays sound if Phase B relaxes the parent-policy row lock.
+//
+// Insert/update classification snapshots the existing (policy_id, rule_type, identifier) keys with one SELECT inside the
+// same txn (no N×SELECT preflight), then classifies each item by checking the snapshot. The post-state row set is fetched
+// with one SELECT after commit (no N×SELECT refetch); rows are returned in the original request order.
 func (s *Store) BulkUpsertRules(ctx context.Context, req api.BulkUpsertRulesRequest) (api.BulkUpsertResult, error) {
-	if strings.TrimSpace(req.Actor) == "" {
-		return api.BulkUpsertResult{}, fmt.Errorf(errActorRequiredFmt, api.ErrAppControlInvalidRequest)
+	if err := validateBulkUpsertRequest(req); err != nil {
+		return api.BulkUpsertResult{}, err
 	}
-	if strings.TrimSpace(req.Reason) == "" {
-		return api.BulkUpsertResult{}, fmt.Errorf(errReasonRequiredFmt, api.ErrAppControlInvalidRequest)
-	}
-	if len(req.Items) == 0 {
-		return api.BulkUpsertResult{}, fmt.Errorf("%w: bulk upsert requires at least one rule", api.ErrAppControlInvalidRequest)
-	}
-	if len(req.Items) > api.MaxBulkUpsertItems {
-		return api.BulkUpsertResult{}, fmt.Errorf("%w: batch size %d exceeds limit %d",
-			api.ErrAppControlInvalidRequest, len(req.Items), api.MaxBulkUpsertItems)
+	if err := validateBulkUpsertItems(req.Items); err != nil {
+		return api.BulkUpsertResult{}, err
 	}
 
-	// Validate every item up-front so the all-or-nothing contract holds. The error wrapping preserves the original sentinel
-	// (ErrAppControlInvalidRuleType / ErrAppControlInvalidIdentifier / ErrAppControlInvalidSeverity) so the handler's
-	// IsApplicationControlValidationError check still works; we add the batch index so an operator pasting 100 lines knows
-	// which row tripped the validator.
-	for i, item := range req.Items {
-		if err := ValidateRuleType(item.RuleType); err != nil {
-			return api.BulkUpsertResult{}, fmt.Errorf("bulk item %d: %w", i, err)
+	// Sort a copy so the caller's slice stays intact + lock ordering on rule rows is deterministic across concurrent batches.
+	sortedItems := make([]api.BulkUpsertRuleItem, len(req.Items))
+	copy(sortedItems, req.Items)
+	sort.Slice(sortedItems, func(i, j int) bool {
+		if sortedItems[i].RuleType != sortedItems[j].RuleType {
+			return sortedItems[i].RuleType < sortedItems[j].RuleType
 		}
-		if err := ValidateIdentifier(item.RuleType, item.Identifier); err != nil {
-			return api.BulkUpsertResult{}, fmt.Errorf("bulk item %d: %w", i, err)
-		}
-		if err := ValidateSeverity(item.Severity); err != nil {
-			return api.BulkUpsertResult{}, fmt.Errorf("bulk item %d: %w", i, err)
-		}
-	}
+		return sortedItems[i].Identifier < sortedItems[j].Identifier
+	})
 
 	tx, err := s.db.BeginTxx(ctx, nil)
 	if err != nil {
@@ -721,24 +865,12 @@ func (s *Store) BulkUpsertRules(ctx context.Context, req api.BulkUpsertRulesRequ
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	// Snapshot pre-upsert id set so we can count inserts vs updates after the upsert lands. Reading inside the txn keeps the
-	// count consistent with the rows written.
-	preIDs := map[string]struct{}{}
-	for _, item := range req.Items {
-		key := string(item.RuleType) + "\x1f" + item.Identifier
-		var existingID int64
-		err := tx.QueryRowxContext(ctx,
-			`SELECT id FROM app_control_rules WHERE policy_id = ? AND rule_type = ? AND identifier = ?`,
-			req.PolicyID, item.RuleType, item.Identifier,
-		).Scan(&existingID)
-		switch {
-		case errors.Is(err, sql.ErrNoRows):
-			// row absent; will be an insert
-		case err != nil:
-			return api.BulkUpsertResult{}, fmt.Errorf("appcontrol bulk preflight: %w", err)
-		default:
-			preIDs[key] = struct{}{}
-		}
+	if err := lockPolicyForBulkUpsert(ctx, tx, req.PolicyID); err != nil {
+		return api.BulkUpsertResult{}, err
+	}
+	existing, err := s.collectExistingBulkKeys(ctx, tx, req.PolicyID, sortedItems)
+	if err != nil {
+		return api.BulkUpsertResult{}, err
 	}
 
 	const upsert = `INSERT INTO app_control_rules
@@ -751,7 +883,7 @@ func (s *Store) BulkUpsertRules(ctx context.Context, req api.BulkUpsertRulesRequ
 			comment = VALUES(comment)`
 	inserted := 0
 	updated := 0
-	for _, item := range req.Items {
+	for _, item := range sortedItems {
 		severity := item.Severity
 		if severity == "" {
 			severity = api.SeverityRuleMedium
@@ -765,8 +897,7 @@ func (s *Store) BulkUpsertRules(ctx context.Context, req api.BulkUpsertRulesRequ
 			}
 			return api.BulkUpsertResult{}, fmt.Errorf("appcontrol bulk upsert item: %w", err)
 		}
-		key := string(item.RuleType) + "\x1f" + item.Identifier
-		if _, existed := preIDs[key]; existed {
+		if _, existedBefore := existing[bulkItemKey(item.RuleType, item.Identifier)]; existedBefore {
 			updated++
 		} else {
 			inserted++
@@ -781,24 +912,18 @@ func (s *Store) BulkUpsertRules(ctx context.Context, req api.BulkUpsertRulesRequ
 		return api.BulkUpsertResult{}, fmt.Errorf(errCommitTxFmt, err)
 	}
 
-	// Re-fetch the rows in request order so the caller sees the canonical post-upsert state. One round-trip per row keeps the
-	// query simple; the 500-item cap on the batch keeps the cost bounded.
+	// Post-upsert state: one SELECT replaces the N×SELECT refetch. Build the response in the original request order so
+	// indexable consumers (paste-many UI showing line-by-line) line up with the operator's input.
+	postMap, err := s.fetchBulkUpsertRows(ctx, req.PolicyID, req.Items)
+	if err != nil {
+		return api.BulkUpsertResult{}, err
+	}
 	rules := make([]api.ApplicationControlRule, 0, len(req.Items))
 	for _, item := range req.Items {
-		var rule api.ApplicationControlRule
-		var enabled int
-		const sel = `SELECT id, policy_id, rule_type, identifier, action, enforcement, enabled,
-			severity, source, source_ref, custom_msg, custom_url, comment, expires_at,
-			created_at, updated_at, created_by
-			FROM app_control_rules WHERE policy_id = ? AND rule_type = ? AND identifier = ?`
-		if err := s.db.QueryRowxContext(ctx, sel, req.PolicyID, item.RuleType, item.Identifier).Scan(
-			&rule.ID, &rule.PolicyID, &rule.RuleType, &rule.Identifier, &rule.Action, &rule.Enforcement, &enabled,
-			&rule.Severity, &rule.Source, &rule.SourceRef, &rule.CustomMsg, &rule.CustomURL, &rule.Comment, &rule.ExpiresAt,
-			&rule.CreatedAt, &rule.UpdatedAt, &rule.CreatedBy,
-		); err != nil {
-			return api.BulkUpsertResult{}, fmt.Errorf("appcontrol bulk upsert: refetch: %w", err)
+		rule, ok := postMap[bulkItemKey(item.RuleType, item.Identifier)]
+		if !ok {
+			return api.BulkUpsertResult{}, fmt.Errorf("appcontrol bulk upsert: refetch missed key %s/%s", item.RuleType, item.Identifier)
 		}
-		rule.Enabled = enabled != 0
 		rules = append(rules, rule)
 	}
 	return api.BulkUpsertResult{Inserted: inserted, Updated: updated, Rules: rules}, nil

--- a/server/rules/internal/appcontrol/store.go
+++ b/server/rules/internal/appcontrol/store.go
@@ -674,3 +674,132 @@ func errStringContains(err error, substr string) bool {
 	}
 	return strings.Contains(err.Error(), substr)
 }
+
+// BulkUpsertRules inserts or overwrites each row in req.Items inside one transaction, bumps the parent policy version once, and
+// returns the post-upsert rows + insert/update counts. Idempotency key is (policy_id, rule_type, identifier) per the openspec;
+// severity / custom_msg / custom_url / comment overwrite when the key collides. All-or-nothing: a per-item validator error
+// (rule_type, identifier shape, severity) rejects the whole batch before any UPDATE fires. Returns ErrAppControlPolicyNotFound
+// when the policy_id is missing (FK violation on the first INSERT surfaces it).
+//
+// Per-item counts use MySQL's "INSERT ... ON DUPLICATE KEY UPDATE" affected-row convention: 1 for a fresh insert, 2 for an
+// existing row that was overwritten. We translate by counting 1+2 totals and inferring insert vs update from a pre-query that
+// resolves existing ids; this is simpler than parsing the per-statement affected_rows.
+func (s *Store) BulkUpsertRules(ctx context.Context, req api.BulkUpsertRulesRequest) (api.BulkUpsertResult, error) {
+	if strings.TrimSpace(req.Actor) == "" {
+		return api.BulkUpsertResult{}, fmt.Errorf(errActorRequiredFmt, api.ErrAppControlInvalidRequest)
+	}
+	if strings.TrimSpace(req.Reason) == "" {
+		return api.BulkUpsertResult{}, fmt.Errorf(errReasonRequiredFmt, api.ErrAppControlInvalidRequest)
+	}
+	if len(req.Items) == 0 {
+		return api.BulkUpsertResult{}, fmt.Errorf("%w: bulk upsert requires at least one rule", api.ErrAppControlInvalidRequest)
+	}
+	if len(req.Items) > api.MaxBulkUpsertItems {
+		return api.BulkUpsertResult{}, fmt.Errorf("%w: batch size %d exceeds limit %d",
+			api.ErrAppControlInvalidRequest, len(req.Items), api.MaxBulkUpsertItems)
+	}
+
+	// Validate every item up-front so the all-or-nothing contract holds. The error wrapping preserves the original sentinel
+	// (ErrAppControlInvalidRuleType / ErrAppControlInvalidIdentifier / ErrAppControlInvalidSeverity) so the handler's
+	// IsApplicationControlValidationError check still works; we add the batch index so an operator pasting 100 lines knows
+	// which row tripped the validator.
+	for i, item := range req.Items {
+		if err := ValidateRuleType(item.RuleType); err != nil {
+			return api.BulkUpsertResult{}, fmt.Errorf("bulk item %d: %w", i, err)
+		}
+		if err := ValidateIdentifier(item.RuleType, item.Identifier); err != nil {
+			return api.BulkUpsertResult{}, fmt.Errorf("bulk item %d: %w", i, err)
+		}
+		if err := ValidateSeverity(item.Severity); err != nil {
+			return api.BulkUpsertResult{}, fmt.Errorf("bulk item %d: %w", i, err)
+		}
+	}
+
+	tx, err := s.db.BeginTxx(ctx, nil)
+	if err != nil {
+		return api.BulkUpsertResult{}, fmt.Errorf(errBeginTxFmt, err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	// Snapshot pre-upsert id set so we can count inserts vs updates after the upsert lands. Reading inside the txn keeps the
+	// count consistent with the rows written.
+	preIDs := map[string]struct{}{}
+	for _, item := range req.Items {
+		key := string(item.RuleType) + "\x1f" + item.Identifier
+		var existingID int64
+		err := tx.QueryRowxContext(ctx,
+			`SELECT id FROM app_control_rules WHERE policy_id = ? AND rule_type = ? AND identifier = ?`,
+			req.PolicyID, item.RuleType, item.Identifier,
+		).Scan(&existingID)
+		switch {
+		case errors.Is(err, sql.ErrNoRows):
+			// row absent; will be an insert
+		case err != nil:
+			return api.BulkUpsertResult{}, fmt.Errorf("appcontrol bulk preflight: %w", err)
+		default:
+			preIDs[key] = struct{}{}
+		}
+	}
+
+	const upsert = `INSERT INTO app_control_rules
+		(policy_id, rule_type, identifier, action, enforcement, enabled, severity, source, custom_msg, custom_url, comment, created_by)
+		VALUES (?, ?, ?, 'BLOCK', 'PROTECT', 1, ?, 'admin', ?, ?, ?, ?)
+		ON DUPLICATE KEY UPDATE
+			severity = VALUES(severity),
+			custom_msg = VALUES(custom_msg),
+			custom_url = VALUES(custom_url),
+			comment = VALUES(comment)`
+	inserted := 0
+	updated := 0
+	for _, item := range req.Items {
+		severity := item.Severity
+		if severity == "" {
+			severity = api.SeverityRuleMedium
+		}
+		if _, err := tx.ExecContext(ctx, upsert,
+			req.PolicyID, item.RuleType, item.Identifier, severity,
+			item.CustomMsg, item.CustomURL, item.Comment, req.Actor,
+		); err != nil {
+			if isForeignKeyViolation(err) {
+				return api.BulkUpsertResult{}, api.ErrAppControlPolicyNotFound
+			}
+			return api.BulkUpsertResult{}, fmt.Errorf("appcontrol bulk upsert item: %w", err)
+		}
+		key := string(item.RuleType) + "\x1f" + item.Identifier
+		if _, existed := preIDs[key]; existed {
+			updated++
+		} else {
+			inserted++
+		}
+	}
+
+	if _, err := tx.ExecContext(ctx, `UPDATE app_control_policies SET version = version + 1, updated_by = ? WHERE id = ?`,
+		req.Actor, req.PolicyID); err != nil {
+		return api.BulkUpsertResult{}, fmt.Errorf("appcontrol bulk upsert: bump policy version: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return api.BulkUpsertResult{}, fmt.Errorf(errCommitTxFmt, err)
+	}
+
+	// Re-fetch the rows in request order so the caller sees the canonical post-upsert state. One round-trip per row keeps the
+	// query simple; the 500-item cap on the batch keeps the cost bounded.
+	rules := make([]api.ApplicationControlRule, 0, len(req.Items))
+	for _, item := range req.Items {
+		var rule api.ApplicationControlRule
+		var enabled int
+		const sel = `SELECT id, policy_id, rule_type, identifier, action, enforcement, enabled,
+			severity, source, source_ref, custom_msg, custom_url, comment, expires_at,
+			created_at, updated_at, created_by
+			FROM app_control_rules WHERE policy_id = ? AND rule_type = ? AND identifier = ?`
+		if err := s.db.QueryRowxContext(ctx, sel, req.PolicyID, item.RuleType, item.Identifier).Scan(
+			&rule.ID, &rule.PolicyID, &rule.RuleType, &rule.Identifier, &rule.Action, &rule.Enforcement, &enabled,
+			&rule.Severity, &rule.Source, &rule.SourceRef, &rule.CustomMsg, &rule.CustomURL, &rule.Comment, &rule.ExpiresAt,
+			&rule.CreatedAt, &rule.UpdatedAt, &rule.CreatedBy,
+		); err != nil {
+			return api.BulkUpsertResult{}, fmt.Errorf("appcontrol bulk upsert: refetch: %w", err)
+		}
+		rule.Enabled = enabled != 0
+		rules = append(rules, rule)
+	}
+	return api.BulkUpsertResult{Inserted: inserted, Updated: updated, Rules: rules}, nil
+}

--- a/server/rules/internal/operator/appcontrol_handler.go
+++ b/server/rules/internal/operator/appcontrol_handler.go
@@ -83,11 +83,12 @@ func NewAppControl(svc *appcontrol.Service, authz identityapi.AuthZ, logger *slo
 //	PATCH  /api/v1/app-control/policies/{id}
 //	DELETE /api/v1/app-control/policies/{id}
 //	POST   /api/v1/app-control/policies/{id}/rules
+//	POST   /api/v1/app-control/policies/{id}/rules:bulkUpsert
 //	PATCH  /api/v1/app-control/rules/{id}
 //	DELETE /api/v1/app-control/rules/{id}
 //
-// Bulk-upsert / cross-policy rule list / host-groups CRUD / assignments POST stay deferred to follow-on PRs. Caller wraps the mux
-// in identity Session + CSRF middleware before mounting (the existing operator pattern in cmd/main).
+// Cross-policy rule list / host-groups CRUD / assignments POST stay deferred to follow-on PRs. Caller wraps the mux in identity
+// Session + CSRF middleware before mounting (the existing operator pattern in cmd/main).
 func (h *AppControlHandler) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/v1/app-control/policies", h.handleListPolicies)
 	mux.HandleFunc("GET /api/v1/app-control/policies/{id}", h.handleGetPolicy)
@@ -95,6 +96,7 @@ func (h *AppControlHandler) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("PATCH /api/v1/app-control/policies/{id}", h.handleUpdatePolicy)
 	mux.HandleFunc("DELETE /api/v1/app-control/policies/{id}", h.handleDeletePolicy)
 	mux.HandleFunc("POST /api/v1/app-control/policies/{id}/rules", h.handleCreateRule)
+	mux.HandleFunc("POST /api/v1/app-control/policies/{id}/rules:bulkUpsert", h.handleBulkUpsertRules)
 	mux.HandleFunc("PATCH /api/v1/app-control/rules/{id}", h.handleUpdateRule)
 	mux.HandleFunc("DELETE /api/v1/app-control/rules/{id}", h.handleDeleteRule)
 }
@@ -525,6 +527,96 @@ func parseRuleID(r *http.Request) (int64, bool) { return parsePositiveInt64Path(
 // parsePolicyID extracts the {id} path value off /policies/{id} as a positive int64. Wrapper around parsePositiveInt64Path; see
 // parseRuleID for the rationale.
 func parsePolicyID(r *http.Request) (int64, bool) { return parsePositiveInt64Path(r) }
+
+// bulkUpsertItem is one row in the POST /policies/{id}/rules:bulkUpsert wire shape. CustomMsg + CustomURL stay as pointer
+// fields so the operator can explicitly clear them by sending an empty string (the JSON shape that maps to *string is
+// distinguishable from "field omitted").
+type bulkUpsertItem struct {
+	RuleType   api.RuleType `json:"rule_type"`
+	Identifier string       `json:"identifier"`
+	Severity   api.Severity `json:"severity,omitempty"`
+	CustomMsg  *string      `json:"custom_msg,omitempty"`
+	CustomURL  *string      `json:"custom_url,omitempty"`
+	Comment    string       `json:"comment,omitempty"`
+}
+
+// bulkUpsertRulesRequest is the POST /rules:bulkUpsert envelope. Reason is required for the audit row that fires once
+// regardless of how many items the batch contained.
+type bulkUpsertRulesRequest struct {
+	Rules  []bulkUpsertItem `json:"rules"`
+	Reason string           `json:"reason"`
+}
+
+// handleBulkUpsertRules serves POST /api/v1/app-control/policies/{id}/rules:bulkUpsert. Body limit is bigger than the per-rule
+// endpoints because a paste-many of 500 items at ~150 bytes each lands around 80 KiB; we lift the cap for this route only.
+const bulkUpsertReadBodyLimit = 256 * 1024
+
+func (h *AppControlHandler) handleBulkUpsertRules(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	if !identityapi.HTTPGate(ctx, w, h.authz, h.logger,
+		identityapi.ActionAppControlRuleBulkUpsert,
+		identityapi.Resource{Type: "application_control"}) {
+		return
+	}
+	policyID, ok := parsePolicyID(r)
+	if !ok {
+		writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, errCodeInvalidPolicyID, errMsgInvalidPolicyID)
+		return
+	}
+	body, err := io.ReadAll(io.LimitReader(r.Body, bulkUpsertReadBodyLimit))
+	if err != nil {
+		writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, errCodeReadBody, errMsgReadBody)
+		return
+	}
+	var req bulkUpsertRulesRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, errCodeInvalidJSON, errMsgInvalidJSON)
+		return
+	}
+	actor, ok := identityapi.ActorFromContext(ctx)
+	if !ok {
+		h.logger.ErrorContext(ctx, noActorOnContextLogMsg)
+		writeAppControlErr(ctx, h.logger, w, http.StatusInternalServerError, internalErrorCode, internalErrorMessage)
+		return
+	}
+	items := make([]api.BulkUpsertRuleItem, 0, len(req.Rules))
+	for _, raw := range req.Rules {
+		items = append(items, api.BulkUpsertRuleItem{
+			RuleType:   raw.RuleType,
+			Identifier: raw.Identifier,
+			Severity:   raw.Severity,
+			CustomMsg:  raw.CustomMsg,
+			CustomURL:  raw.CustomURL,
+			Comment:    raw.Comment,
+		})
+	}
+	result, err := h.svc.BulkUpsertRules(ctx, api.BulkUpsertRulesRequest{
+		PolicyID: policyID,
+		Items:    items,
+		Actor:    actorIdentifierFromContext(ctx),
+		Reason:   req.Reason,
+	}, actor)
+	if err != nil {
+		h.writeBulkUpsertError(ctx, w, err, policyID)
+		return
+	}
+	writeJSON(ctx, h.logger, w, http.StatusOK, result)
+}
+
+// writeBulkUpsertError maps BulkUpsertRules errors onto the HTTP wire shape. Per-item validation errors come back wrapped with
+// a "bulk item N:" prefix from the store; IsApplicationControlValidationError still recognises the underlying sentinel via
+// errors.Is so the handler can return 400 with the full operator-facing message intact.
+func (h *AppControlHandler) writeBulkUpsertError(ctx context.Context, w http.ResponseWriter, err error, policyID int64) {
+	switch {
+	case errors.Is(err, api.ErrAppControlPolicyNotFound):
+		writeAppControlErr(ctx, h.logger, w, http.StatusNotFound, errCodePolicyNotFound, errMsgPolicyNotFound)
+	case api.IsApplicationControlValidationError(err):
+		writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, errCodeInvalidRule, err.Error())
+	default:
+		h.logger.ErrorContext(ctx, "appcontrol bulk upsert", "err", err, "policy_id", policyID)
+		writeAppControlErr(ctx, h.logger, w, http.StatusInternalServerError, internalErrorCode, internalErrorMessage)
+	}
+}
 
 // actorIdentifierFromContext returns a stable string identifier the store + audit row use as the "who authored this" tag. The actor's
 // email isn't on identityapi.Actor today (Actor carries UserID + Roles but not email; the audit recorder fetches the email separately

--- a/server/rules/internal/tests/app_control_test.go
+++ b/server/rules/internal/tests/app_control_test.go
@@ -723,16 +723,49 @@ func TestAppControl_BulkUpsertRules_BadItemRejectsBatch(t *testing.T) {
 
 // TestAppControl_BulkUpsertRules_EmptyBatchRejected covers the empty-input guard. An empty Items slice is operator confusion
 // (paste with no content); reject as ErrAppControlInvalidRequest so the REST handler returns 400 instead of silently no-op'ing.
+// Both shapes pinned: a nil slice AND an empty non-nil slice (CodeRabbit on PR #190 — Go treats them differently for some
+// reflection paths, so locking both keeps the contract honest).
 func TestAppControl_BulkUpsertRules_EmptyBatchRejected(t *testing.T) {
 	t.Parallel()
 	store, _ := newAppControlStore(t)
 	p, err := store.GetPolicyByName(t.Context(), api.DefaultPolicyName)
 	require.NoError(t, err)
+	for _, tc := range []struct {
+		name  string
+		items []api.BulkUpsertRuleItem
+	}{
+		{"nil slice", nil},
+		{"empty slice", []api.BulkUpsertRuleItem{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := store.BulkUpsertRules(t.Context(), api.BulkUpsertRulesRequest{
+				PolicyID: p.ID, Items: tc.items, Actor: "demo-admin", Reason: "empty",
+			})
+			require.Error(t, err)
+			assert.ErrorIs(t, err, api.ErrAppControlInvalidRequest)
+		})
+	}
+}
+
+// TestAppControl_BulkUpsertRules_DuplicateKeyInBatch rejects a batch with the same (rule_type, identifier) twice. Without this
+// guard, the second occurrence would be classified as Insert (it's not in the pre-batch state) which corrupts the audit row's
+// rules_inserted count. CodeRabbit on PR #190 surfaced this as a real correctness bug.
+func TestAppControl_BulkUpsertRules_DuplicateKeyInBatch(t *testing.T) {
+	t.Parallel()
+	store, _ := newAppControlStore(t)
+	p, err := store.GetPolicyByName(t.Context(), api.DefaultPolicyName)
+	require.NoError(t, err)
 	_, err = store.BulkUpsertRules(t.Context(), api.BulkUpsertRulesRequest{
-		PolicyID: p.ID, Items: nil, Actor: "demo-admin", Reason: "empty",
+		PolicyID: p.ID,
+		Items: []api.BulkUpsertRuleItem{
+			{RuleType: api.RuleTypeBinary, Identifier: strings.Repeat("7", 64), Severity: api.SeverityRuleMedium},
+			{RuleType: api.RuleTypeBinary, Identifier: strings.Repeat("7", 64), Severity: api.SeverityRuleHigh},
+		},
+		Actor: "demo-admin", Reason: "should reject the duplicate",
 	})
 	require.Error(t, err)
 	assert.ErrorIs(t, err, api.ErrAppControlInvalidRequest)
+	assert.Contains(t, err.Error(), "duplicates the (rule_type, identifier) of item 0")
 }
 
 // TestAppControl_BulkUpsertRules_BatchSizeCap confirms MaxBulkUpsertItems is enforced. 501 items must be rejected before any

--- a/server/rules/internal/tests/app_control_test.go
+++ b/server/rules/internal/tests/app_control_test.go
@@ -6,6 +6,7 @@
 package tests
 
 import (
+	"fmt"
 	"log/slog"
 	"strings"
 	"testing"
@@ -607,6 +608,166 @@ func TestAppControl_DeletePolicy_NotFound(t *testing.T) {
 	store, _ := newAppControlStore(t)
 	err := store.DeletePolicy(t.Context(), api.DeletePolicyRequest{
 		PolicyID: 9_999_999, Actor: "demo-admin", Reason: "stale id",
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, api.ErrAppControlPolicyNotFound)
+}
+
+// TestAppControl_BulkUpsertRules_HappyPath_MixedInsertAndUpdate covers the canonical batch flow: 2 brand-new rules + 1 row that
+// already exists on the policy + a different identifier shape per type. The result counts must reflect insert vs update
+// correctly; the post-upsert row set must reflect the overwritten severity on the pre-existing row.
+func TestAppControl_BulkUpsertRules_HappyPath_MixedInsertAndUpdate(t *testing.T) {
+	t.Parallel()
+	store, _ := newAppControlStore(t)
+	ctx := t.Context()
+	p, err := store.GetPolicyByName(ctx, api.DefaultPolicyName)
+	require.NoError(t, err)
+	// Seed one BINARY rule with severity=medium so we can verify the upsert overwrites to high in the batch below.
+	preSeed, err := store.CreateRule(ctx, api.CreateRuleRequest{
+		PolicyID: p.ID, RuleType: api.RuleTypeBinary,
+		Identifier: strings.Repeat("a", 64), Severity: api.SeverityRuleMedium,
+		Actor: "demo-admin", Reason: "pre-seed",
+	})
+	require.NoError(t, err)
+	preVersion, err := store.GetPolicyByName(ctx, api.DefaultPolicyName)
+	require.NoError(t, err)
+
+	result, err := store.BulkUpsertRules(ctx, api.BulkUpsertRulesRequest{
+		PolicyID: p.ID,
+		Items: []api.BulkUpsertRuleItem{
+			{RuleType: api.RuleTypeBinary, Identifier: strings.Repeat("a", 64), Severity: api.SeverityRuleHigh},
+			{RuleType: api.RuleTypeCDHash, Identifier: strings.Repeat("b", 40), Severity: api.SeverityRuleMedium},
+			{RuleType: api.RuleTypeTeamID, Identifier: "EQHXZ8M8AV", Severity: api.SeverityRuleMedium},
+		},
+		Actor:  "demo-admin",
+		Reason: "Q1 intel feed import",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 2, result.Inserted, "CDHASH + TEAMID are brand-new")
+	assert.Equal(t, 1, result.Updated, "BINARY row pre-existed; severity gets overwritten")
+	require.Len(t, result.Rules, 3, "result carries the post-upsert row for every requested item")
+
+	// The pre-existing BINARY row keeps its id but the severity is overwritten.
+	assert.Equal(t, preSeed.ID, result.Rules[0].ID)
+	assert.Equal(t, api.SeverityRuleHigh, result.Rules[0].Severity)
+
+	// Policy version bumps exactly once for the whole batch.
+	pAfter, err := store.GetPolicyByName(ctx, api.DefaultPolicyName)
+	require.NoError(t, err)
+	assert.Equal(t, preVersion.Version+1, pAfter.Version, "bulk upsert bumps policy version exactly once")
+}
+
+// TestAppControl_BulkUpsertRules_Idempotent confirms a re-run with the same payload produces 0 inserts + N updates and the
+// same final row set. The audit log would show two separate bulk_upsert rows but each with the same post-upsert state.
+func TestAppControl_BulkUpsertRules_Idempotent(t *testing.T) {
+	t.Parallel()
+	store, _ := newAppControlStore(t)
+	ctx := t.Context()
+	p, err := store.GetPolicyByName(ctx, api.DefaultPolicyName)
+	require.NoError(t, err)
+	batch := api.BulkUpsertRulesRequest{
+		PolicyID: p.ID,
+		Items: []api.BulkUpsertRuleItem{
+			{RuleType: api.RuleTypeBinary, Identifier: strings.Repeat("c", 64), Severity: api.SeverityRuleMedium},
+			{RuleType: api.RuleTypeCDHash, Identifier: strings.Repeat("d", 40), Severity: api.SeverityRuleMedium},
+		},
+		Actor: "demo-admin", Reason: "first import",
+	}
+
+	first, err := store.BulkUpsertRules(ctx, batch)
+	require.NoError(t, err)
+	assert.Equal(t, 2, first.Inserted)
+	assert.Equal(t, 0, first.Updated)
+
+	batch.Reason = "re-running, expect idempotent"
+	second, err := store.BulkUpsertRules(ctx, batch)
+	require.NoError(t, err)
+	assert.Equal(t, 0, second.Inserted)
+	assert.Equal(t, 2, second.Updated, "every key already existed; the upsert overwrites without changing fields")
+	// Row ids stay the same across the two upserts.
+	assert.Equal(t, first.Rules[0].ID, second.Rules[0].ID)
+	assert.Equal(t, first.Rules[1].ID, second.Rules[1].ID)
+}
+
+// TestAppControl_BulkUpsertRules_BadItemRejectsBatch confirms the all-or-nothing contract: one bad rule rejects the whole
+// batch and NO rows are persisted. Without this contract, a paste-many of 100 lines with one typo would leave the operator
+// with a half-imported state.
+func TestAppControl_BulkUpsertRules_BadItemRejectsBatch(t *testing.T) {
+	t.Parallel()
+	store, _ := newAppControlStore(t)
+	ctx := t.Context()
+	p, err := store.GetPolicyByName(ctx, api.DefaultPolicyName)
+	require.NoError(t, err)
+	preRules, err := store.ListRulesByPolicy(ctx, p.ID)
+	require.NoError(t, err)
+	preCount := len(preRules)
+
+	_, err = store.BulkUpsertRules(ctx, api.BulkUpsertRulesRequest{
+		PolicyID: p.ID,
+		Items: []api.BulkUpsertRuleItem{
+			{RuleType: api.RuleTypeBinary, Identifier: strings.Repeat("e", 64), Severity: api.SeverityRuleMedium},
+			{RuleType: api.RuleTypeBinary, Identifier: "TOO-SHORT", Severity: api.SeverityRuleMedium},
+			{RuleType: api.RuleTypeTeamID, Identifier: "EQHXZ8M8AV", Severity: api.SeverityRuleMedium},
+		},
+		Actor: "demo-admin", Reason: "should fail atomically",
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, api.ErrAppControlInvalidIdentifier)
+	assert.True(t, api.IsApplicationControlValidationError(err), "the wrapped error must still match the validation sentinel set")
+
+	// No rows from the batch landed.
+	postRules, err := store.ListRulesByPolicy(ctx, p.ID)
+	require.NoError(t, err)
+	assert.Equal(t, preCount, len(postRules), "all-or-nothing: the valid rules in the batch must NOT have persisted")
+}
+
+// TestAppControl_BulkUpsertRules_EmptyBatchRejected covers the empty-input guard. An empty Items slice is operator confusion
+// (paste with no content); reject as ErrAppControlInvalidRequest so the REST handler returns 400 instead of silently no-op'ing.
+func TestAppControl_BulkUpsertRules_EmptyBatchRejected(t *testing.T) {
+	t.Parallel()
+	store, _ := newAppControlStore(t)
+	p, err := store.GetPolicyByName(t.Context(), api.DefaultPolicyName)
+	require.NoError(t, err)
+	_, err = store.BulkUpsertRules(t.Context(), api.BulkUpsertRulesRequest{
+		PolicyID: p.ID, Items: nil, Actor: "demo-admin", Reason: "empty",
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, api.ErrAppControlInvalidRequest)
+}
+
+// TestAppControl_BulkUpsertRules_BatchSizeCap confirms MaxBulkUpsertItems is enforced. 501 items must be rejected before any
+// db round-trip so a hostile or buggy client can't tie up the txn for minutes.
+func TestAppControl_BulkUpsertRules_BatchSizeCap(t *testing.T) {
+	t.Parallel()
+	store, _ := newAppControlStore(t)
+	p, err := store.GetPolicyByName(t.Context(), api.DefaultPolicyName)
+	require.NoError(t, err)
+	items := make([]api.BulkUpsertRuleItem, api.MaxBulkUpsertItems+1)
+	for i := range items {
+		items[i] = api.BulkUpsertRuleItem{
+			RuleType:   api.RuleTypeBinary,
+			Identifier: strings.Repeat("0", 60) + fmt.Sprintf("%04d", i),
+			Severity:   api.SeverityRuleMedium,
+		}
+	}
+	_, err = store.BulkUpsertRules(t.Context(), api.BulkUpsertRulesRequest{
+		PolicyID: p.ID, Items: items, Actor: "demo-admin", Reason: "oversized",
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, api.ErrAppControlInvalidRequest)
+}
+
+// TestAppControl_BulkUpsertRules_UnknownPolicyMapsToNotFound exercises the FK violation path: a bulk-upsert against a stale
+// policy id must surface ErrAppControlPolicyNotFound so the REST handler maps to 404 instead of leaking a generic 500.
+func TestAppControl_BulkUpsertRules_UnknownPolicyMapsToNotFound(t *testing.T) {
+	t.Parallel()
+	store, _ := newAppControlStore(t)
+	_, err := store.BulkUpsertRules(t.Context(), api.BulkUpsertRulesRequest{
+		PolicyID: 9_999_999,
+		Items: []api.BulkUpsertRuleItem{
+			{RuleType: api.RuleTypeBinary, Identifier: strings.Repeat("f", 64), Severity: api.SeverityRuleMedium},
+		},
+		Actor: "demo-admin", Reason: "stale policy id",
 	})
 	require.Error(t, err)
 	assert.ErrorIs(t, err, api.ErrAppControlPolicyNotFound)

--- a/server/rules/internal/tests/appcontrol_rest_test.go
+++ b/server/rules/internal/tests/appcontrol_rest_test.go
@@ -971,7 +971,8 @@ func TestAppControlREST_BulkUpsertRules_HappyPath(t *testing.T) {
 
 	// Exactly one audit row regardless of batch size.
 	events := r.audit.snapshot()
-	last := events[len(events)-1]
+	require.Len(t, events, 1, "bulk upsert must emit exactly one audit event regardless of batch size")
+	last := events[0]
 	assert.Equal(t, identityapi.AuditAppControlRuleBulkUpsert, last.Action)
 	assert.Equal(t, "application_control_policy", last.TargetType)
 	assert.Equal(t, 3, last.Payload["rules_inserted"])
@@ -1004,6 +1005,11 @@ func TestAppControlREST_BulkUpsertRules_BadItem(t *testing.T) {
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
 	assert.Equal(t, "application_control.invalid_rule", body.Error)
 	assert.Contains(t, body.Message, "bulk item 1", "the operator-facing message names the offending row index")
+	// Side-effect assertions (CodeRabbit on PR #190): a failed batch must NOT enqueue any fan-out commands and must NOT emit
+	// an audit row. Without these the all-or-nothing contract could regress silently into a partial-success mode that the
+	// happy-path test wouldn't notice.
+	assert.Empty(t, r.inserter.snapshot(), "failed bulk upsert must not enqueue commands")
+	assert.Empty(t, r.audit.snapshot(), "failed bulk upsert must not emit an audit event")
 }
 
 // TestAppControlREST_BulkUpsertRules_UnknownPolicy maps the stale-policy FK violation to 404 policy_not_found.
@@ -1020,6 +1026,11 @@ func TestAppControlREST_BulkUpsertRules_UnknownPolicy(t *testing.T) {
 		})
 	defer resp.Body.Close()
 	require.Equal(t, http.StatusNotFound, resp.StatusCode)
+	var body struct {
+		Error string `json:"error"`
+	}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	assert.Equal(t, "application_control.policy_not_found", body.Error)
 }
 
 // TestAppControlREST_BulkUpsertRules_InvalidPolicyID covers the path-parse 400.
@@ -1036,10 +1047,17 @@ func TestAppControlREST_BulkUpsertRules_InvalidPolicyID(t *testing.T) {
 		})
 	defer resp.Body.Close()
 	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	var body struct {
+		Error string `json:"error"`
+	}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	assert.Equal(t, "application_control.invalid_policy_id", body.Error)
 }
 
 // TestAppControlREST_BulkUpsertRules_Idempotent confirms re-posting the same payload yields 0 inserted + N updated and the
-// audit log has TWO bulk_upsert rows. The policy version bumps twice (once per call) even though no field changed.
+// audit log has TWO bulk_upsert rows (one per call). The policy version bumps twice even though no field changed — bulk
+// upsert always treats the request as a fresh logical operation, which keeps the audit history honest about who re-imported
+// what at which time.
 func TestAppControlREST_BulkUpsertRules_Idempotent(t *testing.T) {
 	t.Parallel()
 	r := newAppControlRig(t, []string{"host-a"})
@@ -1064,4 +1082,15 @@ func TestAppControlREST_BulkUpsertRules_Idempotent(t *testing.T) {
 	require.NoError(t, json.NewDecoder(second.Body).Decode(&result))
 	assert.Equal(t, 0, result.Inserted)
 	assert.Equal(t, 1, result.Updated)
+
+	// Audit cardinality (CodeRabbit on PR #190): each bulk-upsert call emits exactly one row regardless of the in-batch
+	// count, so the comment's "TWO bulk_upsert rows after two re-posts" claim has to be backed by an assertion. The events
+	// snapshot here covers the whole rig's lifetime so both calls' rows show up.
+	events := r.audit.snapshot()
+	require.Len(t, events, 2, "two bulk-upsert calls must emit two audit rows")
+	assert.Equal(t, identityapi.AuditAppControlRuleBulkUpsert, events[0].Action)
+	assert.Equal(t, identityapi.AuditAppControlRuleBulkUpsert, events[1].Action)
+	assert.Equal(t, 1, events[0].Payload["rules_inserted"])
+	assert.Equal(t, 0, events[1].Payload["rules_inserted"])
+	assert.Equal(t, 1, events[1].Payload["rules_updated"])
 }

--- a/server/rules/internal/tests/appcontrol_rest_test.go
+++ b/server/rules/internal/tests/appcontrol_rest_test.go
@@ -937,3 +937,131 @@ func TestAppControlREST_Mutations_InvalidPolicyID(t *testing.T) {
 		})
 	}
 }
+
+// TestAppControlREST_BulkUpsertRules_HappyPath confirms POST /policies/{id}/rules:bulkUpsert lands a mixed insert+update batch,
+// returns the post-upsert row set + insert/update counts, bumps the policy version exactly once, fans out exactly once to every
+// host, and emits a single rule_bulk_upsert audit event.
+func TestAppControlREST_BulkUpsertRules_HappyPath(t *testing.T) {
+	t.Parallel()
+	r := newAppControlRig(t, []string{"host-a", "host-b"})
+	policyID := r.defaultPolicyID(t)
+	preCount := len(r.inserter.snapshot())
+
+	resp := r.do(t, http.MethodPost,
+		"/api/v1/app-control/policies/"+i64(policyID)+"/rules:bulkUpsert",
+		map[string]any{
+			"rules": []map[string]any{
+				{"rule_type": "BINARY", "identifier": strings.Repeat("1", 64), "severity": "medium"},
+				{"rule_type": "CDHASH", "identifier": strings.Repeat("2", 40), "severity": "medium"},
+				{"rule_type": "TEAMID", "identifier": "EQHXZ8M8AV", "severity": "high"},
+			},
+			"reason": "bulk REST test",
+		})
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	var result rulesapi.BulkUpsertResult
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&result))
+	assert.Equal(t, 3, result.Inserted)
+	assert.Equal(t, 0, result.Updated)
+	require.Len(t, result.Rules, 3)
+
+	// One fan-out cycle, two hosts → two enqueued commands beyond the seed baseline.
+	postCount := len(r.inserter.snapshot())
+	assert.Equal(t, 2, postCount-preCount, "bulk upsert fans out exactly one snapshot per host")
+
+	// Exactly one audit row regardless of batch size.
+	events := r.audit.snapshot()
+	last := events[len(events)-1]
+	assert.Equal(t, identityapi.AuditAppControlRuleBulkUpsert, last.Action)
+	assert.Equal(t, "application_control_policy", last.TargetType)
+	assert.Equal(t, 3, last.Payload["rules_inserted"])
+	assert.Equal(t, 0, last.Payload["rules_updated"])
+	assert.Equal(t, 3, last.Payload["rules_total"])
+	assert.Equal(t, 2, last.Payload["fanout_hosts"])
+}
+
+// TestAppControlREST_BulkUpsertRules_BadItem confirms a per-item validation failure rejects the whole batch with 400
+// invalid_rule and the operator-facing message identifies the offending row.
+func TestAppControlREST_BulkUpsertRules_BadItem(t *testing.T) {
+	t.Parallel()
+	r := newAppControlRig(t, []string{"host-a"})
+	policyID := r.defaultPolicyID(t)
+	resp := r.do(t, http.MethodPost,
+		"/api/v1/app-control/policies/"+i64(policyID)+"/rules:bulkUpsert",
+		map[string]any{
+			"rules": []map[string]any{
+				{"rule_type": "BINARY", "identifier": strings.Repeat("3", 64), "severity": "medium"},
+				{"rule_type": "BINARY", "identifier": "too-short", "severity": "medium"},
+			},
+			"reason": "should fail atomically",
+		})
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	var body struct {
+		Error   string `json:"error"`
+		Message string `json:"message"`
+	}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	assert.Equal(t, "application_control.invalid_rule", body.Error)
+	assert.Contains(t, body.Message, "bulk item 1", "the operator-facing message names the offending row index")
+}
+
+// TestAppControlREST_BulkUpsertRules_UnknownPolicy maps the stale-policy FK violation to 404 policy_not_found.
+func TestAppControlREST_BulkUpsertRules_UnknownPolicy(t *testing.T) {
+	t.Parallel()
+	r := newAppControlRig(t, []string{"host-a"})
+	resp := r.do(t, http.MethodPost,
+		"/api/v1/app-control/policies/9999999/rules:bulkUpsert",
+		map[string]any{
+			"rules": []map[string]any{
+				{"rule_type": "BINARY", "identifier": strings.Repeat("4", 64), "severity": "medium"},
+			},
+			"reason": "should be 404",
+		})
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusNotFound, resp.StatusCode)
+}
+
+// TestAppControlREST_BulkUpsertRules_InvalidPolicyID covers the path-parse 400.
+func TestAppControlREST_BulkUpsertRules_InvalidPolicyID(t *testing.T) {
+	t.Parallel()
+	r := newAppControlRig(t, []string{"host-a"})
+	resp := r.do(t, http.MethodPost,
+		"/api/v1/app-control/policies/not-a-number/rules:bulkUpsert",
+		map[string]any{
+			"rules": []map[string]any{
+				{"rule_type": "BINARY", "identifier": strings.Repeat("5", 64), "severity": "medium"},
+			},
+			"reason": "x",
+		})
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+// TestAppControlREST_BulkUpsertRules_Idempotent confirms re-posting the same payload yields 0 inserted + N updated and the
+// audit log has TWO bulk_upsert rows. The policy version bumps twice (once per call) even though no field changed.
+func TestAppControlREST_BulkUpsertRules_Idempotent(t *testing.T) {
+	t.Parallel()
+	r := newAppControlRig(t, []string{"host-a"})
+	policyID := r.defaultPolicyID(t)
+	batch := map[string]any{
+		"rules": []map[string]any{
+			{"rule_type": "BINARY", "identifier": strings.Repeat("6", 64), "severity": "medium"},
+		},
+		"reason": "first import",
+	}
+	first := r.do(t, http.MethodPost,
+		"/api/v1/app-control/policies/"+i64(policyID)+"/rules:bulkUpsert", batch)
+	first.Body.Close()
+	require.Equal(t, http.StatusOK, first.StatusCode)
+
+	batch["reason"] = "re-import"
+	second := r.do(t, http.MethodPost,
+		"/api/v1/app-control/policies/"+i64(policyID)+"/rules:bulkUpsert", batch)
+	defer second.Body.Close()
+	require.Equal(t, http.StatusOK, second.StatusCode)
+	var result rulesapi.BulkUpsertResult
+	require.NoError(t, json.NewDecoder(second.Body).Decode(&result))
+	assert.Equal(t, 0, result.Inserted)
+	assert.Equal(t, 1, result.Updated)
+}


### PR DESCRIPTION
Closes openspec section 11.4.6: POST /api/v1/app-control/policies/{id}/rules:bulkUpsert with idempotent (policy_id, rule_type, identifier) semantics and one audit event per logical operation regardless of batch size. Stacked on PR #189 (UI per-row actions); when both this and #189 land, paste-many UX (11.2.8) becomes a thin UI layer on top of this endpoint.

Wire surface:
- Request: { rules: [{rule_type, identifier, severity, custom_msg?, custom_url?, comment?}, ...], reason }
- Response: { inserted: int, updated: int, rules: [post-upsert row, ...] }
- Status: 200 OK on success; 400 on validation; 404 on unknown policy; 401/403 on auth.

Server (server/rules/internal/operator/appcontrol_handler.go):
- New route POST /api/v1/app-control/policies/{id}/rules:bulkUpsert + matching outer-mux allowlist entry in cmd/fleet-edr-server/main.go. Larger 256 KiB body cap (vs the 16 KiB per-rule cap) sized for a ~500-item paste at ~500 bytes/item.
- New writeBulkUpsertError helper maps the wrapped per-item validator errors back to 400 invalid_rule with the "bulk item N:" prefix intact so the operator sees which row tripped.

Service (server/rules/internal/appcontrol/service.go):
- BulkUpsertRules orchestrates the txn-bounded store call, snapshot recompose, fan-out, and audit row. One AuditAppControlRuleBulkUpsert event per call carries rules_inserted + rules_updated + rules_total + fan-out counts so a SIEM can query "imports that touched more than N rules" without joining per-rule audit rows.

Store (server/rules/internal/appcontrol/store.go):
- BulkUpsertRules validates every item up front so the all-or-nothing contract holds (no partial commits), then runs an INSERT ... ON DUPLICATE KEY UPDATE per item inside one transaction, bumps the policy version once, and re-fetches the post-upsert rows in request order. Insert vs update counts come from a pre-query that snapshots existing (policy_id, rule_type, identifier) keys — simpler + more reliable than parsing MySQL's affected_rows convention across multiple statements.
- Batch size capped at api.MaxBulkUpsertItems (500) so a buggy or hostile caller can't tie up the txn for minutes. Empty batches rejected as ErrAppControlInvalidRequest.

Types (server/rules/api/types.go):
- BulkUpsertRuleItem + BulkUpsertRulesRequest + BulkUpsertResult; MaxBulkUpsertItems const.
- ApplicationControlStore interface grows BulkUpsertRules so the rules-context REST handler depends on the contract not the internal package (ADR-0004 bounded-context rule).

Authz + audit (identity context):
- New ActionAppControlRuleBulkUpsert + AuditAppControlRuleBulkUpsert constants.
- policy/data/actions.json + roles.json admin grant updated. The Rego parity check + the "every registered action reaches a non-wildcard role" engine test both pass.

Tests (server/rules/internal/tests/):
- app_control_test.go: 7 new store-level integration tests covering happy path with mixed insert+update, idempotency (re-run yields 0 inserted + N updated with the same row ids), all-or-nothing on a bad item (no rows persist), empty batch rejected, batch size cap, and unknown-policy FK violation mapped to ErrAppControlPolicyNotFound.
- appcontrol_rest_test.go: 5 new REST-level tests covering the handler's happy path (response shape + fan-out + single audit row), bad-item batch rejection with the row index in the message, unknown-policy 404, invalid-policy-id 400, and the HTTP-level idempotency contract.

Verification: go build ./server/...; go test -tags=integration on the whole server/rules
+ server/identity authz trees passes; the Rego TestPolicy_ActionsParity check passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bulk upsert endpoint for application control policy rules, supporting up to 500 rules per request.
  * Implements atomic, all-or-nothing transaction processing with comprehensive audit logging.
  * Includes validation and error handling for malformed requests.
  * Restricted to admin users with appropriate permissions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/getvictor/fleet-edr/pull/190?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->