### PR TITLE
app-control: PasteMany UI on the bulk-upsert endpoint (#68 / 8.5)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -458,11 +458,10 @@ jobs:
 
   codecov:
     name: Codecov upload
-    needs: [changes, agent-test, server-test, e2e-test]
-    # Codecov only consumes the agent + server flags (codecov.yml ignores
-    # ui/src/** globally — see comment further down), so this job is
-    # Go-relevant only: a UI-only PR skips it. Same `!cancelled()` +
-    # explicit failure check pattern as sonarcloud above.
+    needs: [changes, agent-test, server-test, ui-test, e2e-test]
+    # Codecov consumes the agent, server, AND ui flags. ui flag was previously E2E-only (E2E captures V8 coverage of the
+    # running React bundle) but now also receives the vitest LCOV from ui-test so unit-tested components count toward the
+    # ui patch/project gates. Same `!cancelled()` + explicit failure check pattern as sonarcloud above.
     #
     # Same Dependabot exclusion as sonarcloud: Dependabot PRs cannot read
     # repo secrets, so a CODECOV_TOKEN-gated upload would always fail.
@@ -473,6 +472,7 @@ jobs:
       && (needs.changes.result != 'success' || needs.changes.outputs.any == 'true')
       && needs.agent-test.result != 'failure'
       && needs.server-test.result != 'failure'
+      && needs.ui-test.result != 'failure'
       && needs.e2e-test.result != 'failure'
       && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
@@ -522,6 +522,17 @@ jobs:
           name: coverage-ui-e2e
           path: test/e2e/coverage
 
+      # The vitest LCOV from the `ui-test` job. SonarCloud was already reading this artifact (sonar.javascript.lcov.reportPaths
+      # picks it up), but codecov had no upload step for it — so PRs that only added vitest tests showed near-zero UI patch
+      # coverage to codecov even when Sonar saw the lines as covered. Uploading under the same `ui` flag the Playwright LCOV
+      # uses; codecov takes the union of LCOVs per flag so the two cover-paths (unit + E2E) merge cleanly.
+      - name: Download UI vitest coverage
+        if: needs.ui-test.result == 'success'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: coverage-ui
+          path: ui/coverage
+
       # disable_search: true -- codecov-action otherwise auto-searches
       # the workspace for *.out / lcov.info files in addition to the
       # explicit `files:` argument, so a stray coverage file landing in
@@ -570,6 +581,21 @@ jobs:
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           files: test/e2e/coverage/lcov-e2e.info
+          flags: ui
+          disable_search: true
+          fail_ci_if_error: false
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+      # Upload the vitest LCOV under the same `ui` flag. codecov takes the union with the Playwright-derived LCOV above so
+      # a line that's hit by either the unit suite or the E2E suite counts as covered. Closes the gap where vitest-only tests
+      # showed up as 0% UI coverage to codecov (issue surfaced on PR #192 where the entire new PasteManyModal showed 2.3%
+      # patch coverage despite the vitest tests exercising 91%+ of its statements).
+      - name: Upload UI vitest coverage
+        if: needs.ui-test.result == 'success'
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+        with:
+          files: ui/coverage/lcov.info
           flags: ui
           disable_search: true
           fail_ci_if_error: false

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -441,38 +441,12 @@ export async function createAppControlRule(
   policyID: number,
   req: CreateAppControlRuleRequest,
 ): Promise<ApplicationControlRule> {
-  // The handler writes typed error bodies on 4xx; intercept here so
-  // form components can switch on the code rather than parse a
-  // free-form message.
-  const path = `/v1/app-control/policies/${String(policyID)}/rules`;
-  assertSafeAPIPath(path);
-  const headers: Record<string, string> = {
-    "Content-Type": "application/json",
-  };
-  attachCsrfHeader(headers, "POST");
-  const target = new URL(API_BASE + path, globalThis.location.origin);
-  const res = await fetch(target, {
-    method: "POST",
-    credentials: "include",
-    headers,
-    body: JSON.stringify(req),
-  });
-  if (res.status === HTTP_STATUS_UNAUTHORIZED) {
-    clearCsrfToken();
-    throw new Unauthorized401Error();
-  }
-  if (res.status === HTTP_STATUS_FORBIDDEN) {
-    const reauth = await readReauthChallenge(res);
-    if (reauth) throw new ReauthRequiredError(reauth);
-  }
-  if (!res.ok) {
-    const body = (await res.clone().json().catch((): null => null)) as AppControlErrorBody | null;
-    if (body?.error) {
-      throw new AppControlApiError(body.error, body.message ?? body.error, res.status);
-    }
-    throw new Error(`API error: ${String(res.status)} ${res.statusText}`);
-  }
-  return res.json() as Promise<ApplicationControlRule>;
+  return appControlMutationEndpoint(
+    "POST",
+    `/v1/app-control/policies/${String(policyID)}/rules`,
+    req,
+    (res) => res.json() as Promise<ApplicationControlRule>,
+  );
 }
 
 // UpdateAppControlRuleRequest is the JSON body the PATCH endpoint accepts. Mirrors updateRuleRequest in
@@ -494,10 +468,12 @@ export interface DeleteAppControlRuleRequest {
   reason: string;
 }
 
-// patchAppControlEndpoint is the shared body of updateAppControlRule + deleteAppControlRule. The two endpoints have the same
-// auth + reauth + typed-error handling as createAppControlRule; centralising here keeps the three calls in lockstep.
-async function patchAppControlEndpoint<T>(
-  method: "PATCH" | "DELETE",
+// appControlMutationEndpoint is the shared body of every state-changing app-control endpoint (POST + PATCH + DELETE). All
+// four endpoints have the same auth + reauth + typed-error handling; centralising here keeps the per-verb wrappers thin and
+// avoids the duplicate-function-body trap Sonar's S4144 fires on parallel implementations. Method-widening from
+// "PATCH" | "DELETE" to include "POST" is the only change versus the prior signature.
+async function appControlMutationEndpoint<T>(
+  method: "POST" | "PATCH" | "DELETE",
   path: string,
   body: unknown,
   parseResponse: (res: Response) => Promise<T>,
@@ -534,7 +510,7 @@ export async function updateAppControlRule(
   ruleID: number,
   req: UpdateAppControlRuleRequest,
 ): Promise<ApplicationControlRule> {
-  return patchAppControlEndpoint(
+  return appControlMutationEndpoint(
     "PATCH",
     `/v1/app-control/rules/${String(ruleID)}`,
     req,
@@ -546,12 +522,55 @@ export async function deleteAppControlRule(
   ruleID: number,
   req: DeleteAppControlRuleRequest,
 ): Promise<void> {
-  await patchAppControlEndpoint(
+  await appControlMutationEndpoint(
     "DELETE",
     `/v1/app-control/rules/${String(ruleID)}`,
     req,
     // DELETE returns 204 No Content; resolve to undefined without parsing.
     () => Promise.resolve(undefined),
+  );
+}
+
+// BulkUpsertAppControlRuleItem is one row in the bulk-upsert request body. Mirrors bulkUpsertItem in
+// server/rules/internal/operator/appcontrol_handler.go. custom_msg + custom_url are optional pointer-shape fields server-side
+// so the empty-string vs. missing distinction round-trips; UI senders can always include them.
+export interface BulkUpsertAppControlRuleItem {
+  rule_type: string;
+  identifier: string;
+  severity?: string;
+  custom_msg?: string;
+  custom_url?: string;
+  comment?: string;
+}
+
+// BulkUpsertAppControlRulesRequest is the wire envelope. PolicyID rides in the URL path; the body carries the items + the
+// shared audit reason that lands on the single audit row regardless of how many items were in the batch.
+export interface BulkUpsertAppControlRulesRequest {
+  rules: BulkUpsertAppControlRuleItem[];
+  reason: string;
+}
+
+// BulkUpsertAppControlResult mirrors server/rules/api.BulkUpsertResult. inserted + updated are the per-row outcome counts,
+// rules is the post-upsert row set in request order so the UI can render the result without an extra round trip.
+export interface BulkUpsertAppControlResult {
+  inserted: number;
+  updated: number;
+  rules: ApplicationControlRule[];
+}
+
+// MAX_BULK_UPSERT_ITEMS mirrors server/rules/api.MaxBulkUpsertItems. The server returns a typed 400 above this; the modal
+// pre-validates so a 500-item paste fails locally before traversing the network round trip.
+export const MAX_BULK_UPSERT_ITEMS = 500;
+
+export async function bulkUpsertAppControlRules(
+  policyID: number,
+  req: BulkUpsertAppControlRulesRequest,
+): Promise<BulkUpsertAppControlResult> {
+  return appControlMutationEndpoint(
+    "POST",
+    `/v1/app-control/policies/${String(policyID)}/rules:bulkUpsert`,
+    req,
+    (res) => res.json() as Promise<BulkUpsertAppControlResult>,
   );
 }
 

--- a/ui/src/components/ApplicationControl/ApplicationControl.scss
+++ b/ui/src/components/ApplicationControl/ApplicationControl.scss
@@ -89,3 +89,101 @@
   gap: $pad-small;
   margin-top: $pad-medium;
 }
+
+// PasteManyModal phases. The paste textarea is wider than the other dialog inputs and the preview table needs its own
+// scroll container so a 500-row paste doesn't expand the dialog past the viewport.
+
+.app-control-dialog__field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.app-control-dialog__label {
+  font-size: $xx-small;
+  color: $core-vibrant-blue;
+}
+
+.app-control-dialog__textarea {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: $xx-small;
+  min-height: 220px;
+  padding: $pad-xsmall;
+  border: 1px solid $ui-fleet-black-25;
+  border-radius: 4px;
+  resize: vertical;
+}
+
+.app-control-dialog__paste-preview {
+  max-height: 320px;
+  overflow-y: auto;
+  border: 1px solid $ui-fleet-black-25;
+  border-radius: 4px;
+}
+
+.app-control-dialog__paste-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: $xx-small;
+
+  th,
+  td {
+    padding: $pad-xsmall;
+    text-align: left;
+    vertical-align: top;
+    border-bottom: 1px solid $ui-fleet-black-25;
+  }
+
+  th {
+    background: $ui-off-white;
+    position: sticky;
+    top: 0;
+  }
+}
+
+.app-control-dialog__paste-notes {
+  color: $core-vibrant-blue;
+  font-size: $xx-small;
+
+  span {
+    display: block;
+  }
+}
+
+.app-control-dialog__paste-remove {
+  background: transparent;
+  border: none;
+  color: $ui-fleet-black-50;
+  cursor: pointer;
+  font-size: $large;
+  line-height: 1;
+  padding: 0 $pad-xsmall;
+
+  &:hover {
+    color: $ui-error;
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+  }
+}
+
+.app-control-dialog__paste-back {
+  align-self: flex-start;
+  background: transparent;
+  border: none;
+  color: $core-vibrant-blue;
+  cursor: pointer;
+  font-size: $xx-small;
+  padding: 0;
+
+  &:hover {
+    text-decoration: underline;
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+  }
+}

--- a/ui/src/components/ApplicationControl/PasteManyModal.test.tsx
+++ b/ui/src/components/ApplicationControl/PasteManyModal.test.tsx
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { PasteManyModal } from "./PasteManyModal";
+import * as api from "../../api";
+import type { BulkUpsertAppControlResult } from "../../api";
+
+// PasteManyModal pins the two-phase paste flow: paste -> preview with per-row override -> bulk-upsert submit. Tests focus on
+// the behaviors that distinguish it from AddRuleModal: parse routing, per-row override, unresolved-type guard, and the typed
+// API error path.
+
+const fakeResult: BulkUpsertAppControlResult = { inserted: 2, updated: 0, rules: [] };
+
+beforeEach(() => {
+  HTMLDialogElement.prototype.showModal = function showModal() {
+    this.open = true;
+  };
+  HTMLDialogElement.prototype.close = function close() {
+    this.open = false;
+  };
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("PasteManyModal", () => {
+  it("does not surface the preview content until Parse runs", () => {
+    render(
+      <PasteManyModal open policyID={1} onClose={() => undefined} onUpserted={() => undefined} />,
+    );
+    expect(screen.queryByRole("table")).toBeNull();
+    expect(screen.getByRole("button", { name: /parse/i })).toBeDisabled();
+  });
+
+  it("parses the textarea into the preview table on Parse and infers types per the spec", () => {
+    render(
+      <PasteManyModal open policyID={1} onClose={() => undefined} onUpserted={() => undefined} />,
+    );
+    const textarea = screen.getByLabelText(/identifiers/i);
+    const input = [
+      "a".repeat(40),
+      "b".repeat(64),
+      "EQHXZ8M8AV",
+      "platform:com.apple.curl",
+    ].join("\n");
+    fireEvent.change(textarea, { target: { value: input } });
+    fireEvent.click(screen.getByRole("button", { name: /parse/i }));
+    expect(screen.getByRole("table")).toBeTruthy();
+    const selects = screen.getAllByRole("combobox", { name: /^type for row/i });
+    expect(selects).toHaveLength(4);
+    expect((selects[0] as HTMLSelectElement).value).toBe("CDHASH");
+    expect((selects[1] as HTMLSelectElement).value).toBe("BINARY");
+    expect((selects[2] as HTMLSelectElement).value).toBe("TEAMID");
+    expect((selects[3] as HTMLSelectElement).value).toBe("SIGNINGID");
+  });
+
+  it("disables Save when any row's type is unresolved (no shape matched)", () => {
+    render(
+      <PasteManyModal open policyID={1} onClose={() => undefined} onUpserted={() => undefined} />,
+    );
+    fireEvent.change(screen.getByLabelText(/identifiers/i), {
+      target: { value: "wat is this even\n" + "a".repeat(64) },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /parse/i }));
+    fireEvent.change(screen.getByLabelText(/reason/i), { target: { value: "import" } });
+    expect(screen.getByRole("button", { name: /save 2 rules/i })).toBeDisabled();
+  });
+
+  it("disables Save when an inferred type is unavailable (CERTIFICATE/PATH) until overridden", () => {
+    render(
+      <PasteManyModal open policyID={1} onClose={() => undefined} onUpserted={() => undefined} />,
+    );
+    // PATH is inferred but unavailable; the row's type must be switched to a supported type before Save unlocks.
+    fireEvent.change(screen.getByLabelText(/identifiers/i), {
+      target: { value: "/Applications/Mail.app/Contents/MacOS/Mail" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /parse/i }));
+    fireEvent.change(screen.getByLabelText(/reason/i), { target: { value: "import" } });
+    const save = screen.getByRole("button", { name: /save 1 rule/i });
+    expect(save).toBeDisabled();
+
+    // Override to BINARY (still wrong shape but the modal is advisory: server will reject; pre-submit gate is satisfied).
+    const select = screen.getByRole("combobox", { name: /^type for row 1/i });
+    fireEvent.change(select, { target: { value: "BINARY" } });
+    expect(save).not.toBeDisabled();
+  });
+
+  it("submits the bulk-upsert request and fires onUpserted on success", async () => {
+    const bulkSpy = vi.spyOn(api, "bulkUpsertAppControlRules").mockResolvedValue(fakeResult);
+    const onUpserted = vi.fn();
+    render(
+      <PasteManyModal open policyID={7} onClose={() => undefined} onUpserted={onUpserted} />,
+    );
+    fireEvent.change(screen.getByLabelText(/identifiers/i), {
+      target: { value: "a".repeat(64) + "\nb".repeat(0) + "\nEQHXZ8M8AV" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /parse/i }));
+    fireEvent.change(screen.getByLabelText(/reason/i), { target: { value: "import" } });
+    fireEvent.click(screen.getByRole("button", { name: /save 2 rules/i }));
+
+    await waitFor(() => {
+      expect(bulkSpy).toHaveBeenCalledTimes(1);
+      expect(onUpserted).toHaveBeenCalledWith(fakeResult);
+    });
+    expect(bulkSpy).toHaveBeenCalledWith(7, {
+      rules: [
+        { rule_type: "BINARY", identifier: "a".repeat(64), severity: "medium" },
+        { rule_type: "TEAMID", identifier: "EQHXZ8M8AV", severity: "medium" },
+      ],
+      reason: "import",
+    });
+  });
+
+  it("surfaces a typed AppControlApiError message inline without firing onUpserted", async () => {
+    vi.spyOn(api, "bulkUpsertAppControlRules").mockRejectedValue(
+      new api.AppControlApiError(
+        "application_control.invalid_rule",
+        "bulk item 1: identifier failed validation",
+        400,
+      ),
+    );
+    const onUpserted = vi.fn();
+    render(
+      <PasteManyModal open policyID={1} onClose={() => undefined} onUpserted={onUpserted} />,
+    );
+    fireEvent.change(screen.getByLabelText(/identifiers/i), { target: { value: "a".repeat(64) } });
+    fireEvent.click(screen.getByRole("button", { name: /parse/i }));
+    fireEvent.change(screen.getByLabelText(/reason/i), { target: { value: "import" } });
+    fireEvent.click(screen.getByRole("button", { name: /save 1 rule/i }));
+    await waitFor(() => {
+      expect(screen.getByRole("alert").textContent).toMatch(/server-side validation/i);
+    });
+    expect(onUpserted).not.toHaveBeenCalled();
+  });
+
+  it("Back button returns to the paste phase and clears rows", () => {
+    render(
+      <PasteManyModal open policyID={1} onClose={() => undefined} onUpserted={() => undefined} />,
+    );
+    fireEvent.change(screen.getByLabelText(/identifiers/i), {
+      target: { value: "EQHXZ8M8AV" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /parse/i }));
+    expect(screen.getByRole("table")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: /back to paste/i }));
+    expect(screen.queryByRole("table")).toBeNull();
+    expect(screen.getByLabelText(/identifiers/i)).toBeTruthy();
+  });
+
+  it("removes a single row via the per-row × button", () => {
+    render(
+      <PasteManyModal open policyID={1} onClose={() => undefined} onUpserted={() => undefined} />,
+    );
+    fireEvent.change(screen.getByLabelText(/identifiers/i), {
+      target: { value: ["a".repeat(64), "b".repeat(64)].join("\n") },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /parse/i }));
+    expect(screen.getAllByRole("combobox", { name: /^type for row/i })).toHaveLength(2);
+    fireEvent.click(screen.getByRole("button", { name: /remove row 1/i }));
+    expect(screen.getAllByRole("combobox", { name: /^type for row/i })).toHaveLength(1);
+  });
+});

--- a/ui/src/components/ApplicationControl/PasteManyModal.test.tsx
+++ b/ui/src/components/ApplicationControl/PasteManyModal.test.tsx
@@ -112,6 +112,8 @@ describe("PasteManyModal", () => {
   });
 
   it("surfaces a typed AppControlApiError message inline without firing onUpserted", async () => {
+    // For invalid_rule, the modal intentionally falls through to the server's per-item message (e.g. "bulk item 1: ...")
+    // rather than overriding with generic copy — the row index is strictly more useful to the operator than any UI string.
     vi.spyOn(api, "bulkUpsertAppControlRules").mockRejectedValue(
       new api.AppControlApiError(
         "application_control.invalid_rule",
@@ -128,7 +130,7 @@ describe("PasteManyModal", () => {
     fireEvent.change(screen.getByLabelText(/reason/i), { target: { value: "import" } });
     fireEvent.click(screen.getByRole("button", { name: /save 1 rule/i }));
     await waitFor(() => {
-      expect(screen.getByRole("alert").textContent).toMatch(/server-side validation/i);
+      expect(screen.getByRole("alert").textContent).toMatch(/bulk item 1: identifier failed validation/);
     });
     expect(onUpserted).not.toHaveBeenCalled();
   });

--- a/ui/src/components/ApplicationControl/PasteManyModal.tsx
+++ b/ui/src/components/ApplicationControl/PasteManyModal.tsx
@@ -1,0 +1,300 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  bulkUpsertAppControlRules,
+  MAX_BULK_UPSERT_ITEMS,
+  type BulkUpsertAppControlRuleItem,
+  type BulkUpsertAppControlRulesRequest,
+  type BulkUpsertAppControlResult,
+} from "../../api";
+import { useReauthRetry } from "../../hooks/useReauthRetry";
+import { ReauthModal } from "../ReauthModal";
+import { Input, Select } from "../ui/Input";
+import { AppControlDialogShell } from "./AppControlDialogShell";
+import { applyAppControlSubmitError } from "./dialogErrors";
+import {
+  PASTE_MANY_RULE_TYPES,
+  parsePasteInput,
+  type PasteInference,
+} from "./pasteInference";
+import "./ApplicationControl.scss";
+
+// PasteManyModalProps mirrors the AddRuleModal contract: open drives showModal()/close(); onClose fires on Cancel/Escape;
+// onUpserted fires after a successful bulk-upsert so the parent refreshes the policy.
+interface PasteManyModalProps {
+  readonly open: boolean;
+  readonly policyID: number;
+  readonly onClose: () => void;
+  readonly onUpserted: (result: BulkUpsertAppControlResult) => void;
+}
+
+const DIALOG_TITLE_ID = "paste-many-modal-title";
+const SEVERITIES = ["low", "medium", "high", "critical"];
+
+// PLACEHOLDER_BINARY_LENGTH is the placeholder SHA-256 length so the textarea hint matches the BINARY rule_type's hex width.
+const PLACEHOLDER_BINARY_LENGTH = 64;
+const PLACEHOLDER_TEXTAREA = "a".repeat(PLACEHOLDER_BINARY_LENGTH) + "\nEQHXZ8M8AV\nplatform:com.apple.curl";
+
+// AVAILABLE_RULE_TYPES are the same Phase A close-out values AddRuleModal accepts. CERTIFICATE + PATH are inferred from
+// shape but flagged as unavailable so the operator overrides them to BINARY (or removes the row) before submit. Keeping
+// the gate here in lockstep with AddRuleModal so both UI surfaces agree on what the server validators accept today.
+const AVAILABLE_RULE_TYPES = new Set(["BINARY", "CDHASH", "SIGNINGID", "TEAMID"]);
+
+const errorMessageByCode = new Map<string, string>([
+  ["application_control.invalid_rule", "One of the pasted rows didn't pass server-side validation."],
+  ["application_control.duplicate_rule", "Duplicate identifiers found in the batch."],
+  ["application_control.policy_not_found", "The policy was deleted before the batch could be saved."],
+  ["application_control.invalid_policy_id", "Invalid policy id."],
+  ["application_control.invalid_json", "The request body was not valid JSON."],
+]);
+
+// PasteRow is the modal's working copy of a parsed line: identifier + the inferrer's verdict + the operator's override
+// (initially equal to the inference). The unavailable flag short-circuits submit so we don't ship a CERTIFICATE/PATH
+// row the server will refuse anyway.
+interface PasteRow {
+  readonly identifier: string;
+  readonly raw: string;
+  readonly inferredType: string | null;
+  readonly hint?: string;
+  ruleType: string | null;
+}
+
+function rowsFromParse(parsed: PasteInference[]): PasteRow[] {
+  return parsed.map((p) => ({
+    identifier: p.identifier,
+    raw: p.raw,
+    inferredType: p.ruleType,
+    ruleType: p.ruleType,
+    ...(p.hint !== undefined ? { hint: p.hint } : {}),
+  }));
+}
+
+export function PasteManyModal({ open, policyID, onClose, onUpserted }: PasteManyModalProps) {
+  // Two phases: "paste" shows the textarea + Parse button; "preview" shows the per-row table + Save button. The phase
+  // transition is one-way: editing a row in preview happens in place. Cancel resets to paste on next open.
+  const [phase, setPhase] = useState<"paste" | "preview">("paste");
+  const [rawInput, setRawInput] = useState("");
+  const [rows, setRows] = useState<PasteRow[]>([]);
+  const [severity, setSeverity] = useState("medium");
+  const [reason, setReason] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+
+  // Reset the whole form whenever the dialog opens. Otherwise a Cancel + re-open would surface the prior paste's state.
+  useEffect(() => {
+    if (!open) return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional reset tied to the open prop transition
+    setPhase("paste");
+    setRawInput("");
+    setRows([]);
+    setSeverity("medium");
+    setReason("");
+    setBusy(false);
+    setFormError(null);
+  }, [open]);
+
+  const submitBulk = useCallback(
+    (req: BulkUpsertAppControlRulesRequest) => bulkUpsertAppControlRules(policyID, req),
+    [policyID],
+  );
+  const { call: callBulk, modal: reauthModal } = useReauthRetry(submitBulk);
+
+  // unresolvedCount captures rows the operator still needs to address: ruleType=null (no shape matched) or ruleType set to
+  // an unavailable type (CERTIFICATE / PATH). Submit is disabled until every row has a server-acceptable type.
+  const unresolvedCount = useMemo(
+    () => rows.filter((r) => r.ruleType === null || !AVAILABLE_RULE_TYPES.has(r.ruleType)).length,
+    [rows],
+  );
+
+  const submitDisabled =
+    busy || phase !== "preview" || rows.length === 0 || unresolvedCount > 0 || reason.trim().length === 0;
+
+  function handleParse(e: React.SyntheticEvent) {
+    e.preventDefault();
+    const parsed = parsePasteInput(rawInput);
+    if (parsed.length === 0) {
+      setFormError("Paste one identifier per line.");
+      return;
+    }
+    if (parsed.length > MAX_BULK_UPSERT_ITEMS) {
+      setFormError(`Too many identifiers in one batch (${String(parsed.length)} > ${String(MAX_BULK_UPSERT_ITEMS)}).`);
+      return;
+    }
+    setFormError(null);
+    setRows(rowsFromParse(parsed));
+    setPhase("preview");
+  }
+
+  function handleTypeChange(index: number, nextType: string) {
+    setRows((prev) => prev.map((row, i) => (i === index ? { ...row, ruleType: nextType } : row)));
+  }
+
+  function handleRemoveRow(index: number) {
+    setRows((prev) => prev.filter((_, i) => i !== index));
+  }
+
+  function handleBack() {
+    setPhase("paste");
+    setRows([]);
+    setFormError(null);
+  }
+
+  async function handleSubmit(e: React.SyntheticEvent) {
+    e.preventDefault();
+    if (phase === "paste") {
+      handleParse(e);
+      return;
+    }
+    if (submitDisabled) return;
+    setFormError(null);
+    setBusy(true);
+    try {
+      const items: BulkUpsertAppControlRuleItem[] = rows.map((r) => ({
+        rule_type: r.ruleType ?? "",
+        identifier: r.identifier,
+        severity,
+      }));
+      const result = await callBulk({ rules: items, reason: reason.trim() });
+      onUpserted(result);
+    } catch (err) {
+      if (applyAppControlSubmitError(err, setFormError, errorMessageByCode, "Failed to save bulk rules.")) {
+        return;
+      }
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const subtitle = phase === "paste"
+    ? "Paste one identifier per line. The next step infers the rule type per line and lets you override it before saving."
+    : `${String(rows.length)} row${rows.length === 1 ? "" : "s"} ready. Override any inferred type before saving.`;
+  const submitLabel = phase === "paste" ? "Parse" : `Save ${String(rows.length)} rule${rows.length === 1 ? "" : "s"}`;
+
+  return (
+    <AppControlDialogShell
+      open={open}
+      onClose={onClose}
+      titleId={DIALOG_TITLE_ID}
+      title="Paste many rules"
+      subtitle={subtitle}
+      formError={formError}
+      busy={busy}
+      submitDisabled={phase === "paste" ? rawInput.trim().length === 0 || busy : submitDisabled}
+      submitLabel={submitLabel}
+      submitBusyLabel="Saving…"
+      onSubmit={(e) => { void handleSubmit(e); }}
+      reauthModal={<ReauthModal {...reauthModal} />}
+    >
+      {phase === "paste" && (
+        <div className="app-control-dialog__field">
+          <label htmlFor="paste-many-input" className="app-control-dialog__label">
+            Identifiers (one per line)
+          </label>
+          <textarea
+            id="paste-many-input"
+            className="app-control-dialog__textarea"
+            rows={10}
+            spellCheck={false}
+            autoComplete="off"
+            placeholder={PLACEHOLDER_TEXTAREA}
+            value={rawInput}
+            onChange={(e) => { setRawInput(e.target.value); }}
+            disabled={busy}
+            autoFocus
+          />
+        </div>
+      )}
+
+      {phase === "preview" && (
+        <>
+          <div className="app-control-dialog__paste-preview">
+            <table className="app-control-dialog__paste-table">
+              <thead>
+                <tr>
+                  <th>Identifier</th>
+                  <th>Type</th>
+                  <th>Notes</th>
+                  <th />
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((row, index) => {
+                  const typeUnavailable = row.ruleType !== null && !AVAILABLE_RULE_TYPES.has(row.ruleType);
+                  return (
+                    <tr key={`${String(index)}-${row.identifier}`}>
+                      <td className="app-control__identifier" title={row.identifier}>
+                        {row.identifier}
+                      </td>
+                      <td>
+                        <select
+                          aria-label={`Type for row ${String(index + 1)}`}
+                          value={row.ruleType ?? ""}
+                          onChange={(e) => { handleTypeChange(index, e.target.value); }}
+                          disabled={busy}
+                        >
+                          <option value="">— pick a type —</option>
+                          {PASTE_MANY_RULE_TYPES.map((t) => (
+                            <option key={t} value={t} disabled={!AVAILABLE_RULE_TYPES.has(t)}>
+                              {t}{AVAILABLE_RULE_TYPES.has(t) ? "" : " (coming soon)"}
+                            </option>
+                          ))}
+                        </select>
+                      </td>
+                      <td className="app-control-dialog__paste-notes">
+                        {row.hint && <span>{row.hint}</span>}
+                        {row.ruleType === null && <span>No matching shape; pick a type.</span>}
+                        {typeUnavailable && <span>Type not enabled in this build.</span>}
+                      </td>
+                      <td>
+                        <button
+                          type="button"
+                          className="app-control-dialog__paste-remove"
+                          onClick={() => { handleRemoveRow(index); }}
+                          disabled={busy}
+                          aria-label={`Remove row ${String(index + 1)}`}
+                        >
+                          ×
+                        </button>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+
+          <Select
+            id="paste-many-severity"
+            label="Severity (applied to every row)"
+            inline={false}
+            value={severity}
+            onChange={(e) => { setSeverity(e.target.value); }}
+            disabled={busy}
+          >
+            {SEVERITIES.map((s) => (
+              <option key={s} value={s}>{s}</option>
+            ))}
+          </Select>
+
+          <Input
+            id="paste-many-reason"
+            label="Reason (required for audit log)"
+            type="text"
+            placeholder="Why are you importing these rules?"
+            value={reason}
+            onChange={(e) => { setReason(e.target.value); }}
+            disabled={busy}
+          />
+
+          <button
+            type="button"
+            className="app-control-dialog__paste-back"
+            onClick={handleBack}
+            disabled={busy}
+          >
+            ← Back to paste
+          </button>
+        </>
+      )}
+    </AppControlDialogShell>
+  );
+}

--- a/ui/src/components/ApplicationControl/PasteManyModal.tsx
+++ b/ui/src/components/ApplicationControl/PasteManyModal.tsx
@@ -39,18 +39,28 @@ const PLACEHOLDER_TEXTAREA = "a".repeat(PLACEHOLDER_BINARY_LENGTH) + "\nEQHXZ8M8
 // the gate here in lockstep with AddRuleModal so both UI surfaces agree on what the server validators accept today.
 const AVAILABLE_RULE_TYPES = new Set(["BINARY", "CDHASH", "SIGNINGID", "TEAMID"]);
 
+// errorMessageByCode maps server-typed application_control.* codes to operator-friendly copy. `invalid_rule` is intentionally
+// absent: the server's per-item message ("bulk item 1: identifier failed validation") names the offending row index, which is
+// strictly more useful than any generic UI copy could be, so applyAppControlSubmitError falls through to err.message verbatim
+// for that code.
 const errorMessageByCode = new Map<string, string>([
-  ["application_control.invalid_rule", "One of the pasted rows didn't pass server-side validation."],
   ["application_control.duplicate_rule", "Duplicate identifiers found in the batch."],
   ["application_control.policy_not_found", "The policy was deleted before the batch could be saved."],
   ["application_control.invalid_policy_id", "Invalid policy id."],
   ["application_control.invalid_json", "The request body was not valid JSON."],
 ]);
 
+// nextRowId is the module-level counter that mints a stable id per parsed row. React keys built from row index would shift
+// when a middle row is removed (Gemini finding on PR #192) and force every later row to unmount + remount, dropping any
+// in-flight select / focus state along the way. The counter survives across modal opens — collisions don't matter because
+// keys only need to be unique within a single React list reconciliation, not globally.
+let nextRowId = 0;
+
 // PasteRow is the modal's working copy of a parsed line: identifier + the inferrer's verdict + the operator's override
 // (initially equal to the inference). The unavailable flag short-circuits submit so we don't ship a CERTIFICATE/PATH
 // row the server will refuse anyway.
 interface PasteRow {
+  readonly id: number;
   readonly identifier: string;
   readonly raw: string;
   readonly inferredType: string | null;
@@ -59,13 +69,17 @@ interface PasteRow {
 }
 
 function rowsFromParse(parsed: PasteInference[]): PasteRow[] {
-  return parsed.map((p) => ({
-    identifier: p.identifier,
-    raw: p.raw,
-    inferredType: p.ruleType,
-    ruleType: p.ruleType,
-    ...(p.hint !== undefined ? { hint: p.hint } : {}),
-  }));
+  return parsed.map((p) => {
+    nextRowId += 1;
+    return {
+      id: nextRowId,
+      identifier: p.identifier,
+      raw: p.raw,
+      inferredType: p.ruleType,
+      ruleType: p.ruleType,
+      ...(p.hint ? { hint: p.hint } : {}),
+    };
+  });
 }
 
 export function PasteManyModal({ open, policyID, onClose, onUpserted }: PasteManyModalProps) {
@@ -164,10 +178,15 @@ export function PasteManyModal({ open, policyID, onClose, onUpserted }: PasteMan
     }
   }
 
+  // Pluralisation kept as a separate helper so the subtitle + submitLabel ternaries above don't nest one inside the other
+  // (Sonar S3358 — nested ternaries are unreadable). pluralSuffix returns "" or "s" only; the caller composes the noun.
+  const pluralSuffix = rows.length === 1 ? "" : "s";
+  const previewSubtitle = `${String(rows.length)} row${pluralSuffix} ready. Override any inferred type before saving.`;
+  const previewSubmitLabel = `Save ${String(rows.length)} rule${pluralSuffix}`;
   const subtitle = phase === "paste"
     ? "Paste one identifier per line. The next step infers the rule type per line and lets you override it before saving."
-    : `${String(rows.length)} row${rows.length === 1 ? "" : "s"} ready. Override any inferred type before saving.`;
-  const submitLabel = phase === "paste" ? "Parse" : `Save ${String(rows.length)} rule${rows.length === 1 ? "" : "s"}`;
+    : previewSubtitle;
+  const submitLabel = phase === "paste" ? "Parse" : previewSubmitLabel;
 
   return (
     <AppControlDialogShell
@@ -220,7 +239,7 @@ export function PasteManyModal({ open, policyID, onClose, onUpserted }: PasteMan
                 {rows.map((row, index) => {
                   const typeUnavailable = row.ruleType !== null && !AVAILABLE_RULE_TYPES.has(row.ruleType);
                   return (
-                    <tr key={`${String(index)}-${row.identifier}`}>
+                    <tr key={row.id}>
                       <td className="app-control__identifier" title={row.identifier}>
                         {row.identifier}
                       </td>

--- a/ui/src/components/ApplicationControl/PolicyDetail.tsx
+++ b/ui/src/components/ApplicationControl/PolicyDetail.tsx
@@ -13,6 +13,7 @@ import { Badge, type BadgeVariant } from "../ui/Badge";
 import { AddRuleModal } from "./AddRuleModal";
 import { EditRuleModal } from "./EditRuleModal";
 import { ConfirmActionModal } from "./ConfirmActionModal";
+import { PasteManyModal } from "./PasteManyModal";
 import "./ApplicationControl.scss";
 
 // ActiveModal is the union that captures which per-row modal is currently open. Encoding mutual exclusion in the type closes
@@ -22,6 +23,7 @@ import "./ApplicationControl.scss";
 type ActiveModal =
   | { kind: "none" }
   | { kind: "add" }
+  | { kind: "paste-many" }
   | { kind: "edit"; rule: ApplicationControlRule }
   | { kind: "confirm-delete"; rule: ApplicationControlRule }
   | { kind: "confirm-toggle"; rule: ApplicationControlRule };
@@ -124,13 +126,22 @@ export function PolicyDetail() {
   );
 
   const actions = (
-    <Button
-      variant="primary"
-      onClick={() => { setActiveModal({ kind: "add" }); }}
-      disabled={!policy}
-    >
-      Add rule
-    </Button>
+    <>
+      <Button
+        variant="inverse"
+        onClick={() => { setActiveModal({ kind: "paste-many" }); }}
+        disabled={!policy}
+      >
+        Paste many
+      </Button>
+      <Button
+        variant="primary"
+        onClick={() => { setActiveModal({ kind: "add" }); }}
+        disabled={!policy}
+      >
+        Add rule
+      </Button>
+    </>
   );
 
   const rules = policy?.rules ?? [];
@@ -175,6 +186,17 @@ export function PolicyDetail() {
           policyID={policy.id}
           onClose={closeModal}
           onCreated={() => {
+            closeModal();
+            refresh();
+          }}
+        />
+      )}
+      {policy && (
+        <PasteManyModal
+          open={activeModal.kind === "paste-many"}
+          policyID={policy.id}
+          onClose={closeModal}
+          onUpserted={() => {
             closeModal();
             refresh();
           }}

--- a/ui/src/components/ApplicationControl/api.test.ts
+++ b/ui/src/components/ApplicationControl/api.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import {
+  bulkUpsertAppControlRules,
   createAppControlRule,
   deleteAppControlRule,
   listAppControlPolicies,
@@ -198,6 +199,71 @@ describe("deleteAppControlRule", () => {
     mockFetch({}, 401);
     await expect(
       deleteAppControlRule(1, { reason: "x" }),
+    ).rejects.toBeInstanceOf(Unauthorized401Error);
+  });
+});
+
+describe("bulkUpsertAppControlRules", () => {
+  it("returns inserted/updated counts and rule rows on the happy path", async () => {
+    setCsrfToken("FAKE_CSRF_TOKEN");
+    const fakeResult = {
+      inserted: 2,
+      updated: 1,
+      rules: [
+        { id: 1, identifier: "a".repeat(64) },
+        { id: 2, identifier: "b".repeat(64) },
+        { id: 3, identifier: "EQHXZ8M8AV" },
+      ],
+    };
+    const fetchMock = mockFetch(fakeResult, 200);
+    const got = await bulkUpsertAppControlRules(7, {
+      rules: [
+        { rule_type: "BINARY", identifier: "a".repeat(64) },
+        { rule_type: "BINARY", identifier: "b".repeat(64) },
+        { rule_type: "TEAMID", identifier: "EQHXZ8M8AV" },
+      ],
+      reason: "import from spreadsheet",
+    });
+    expect(got.inserted).toBe(2);
+    expect(got.updated).toBe(1);
+    expect(got.rules).toHaveLength(3);
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [target, init] = fetchMock.mock.calls[0] as [URL, RequestInit];
+    expect(target.pathname).toMatch(/policies\/7\/rules:bulkUpsert$/);
+    expect(init.method).toBe("POST");
+  });
+
+  it("surfaces typed AppControlApiError when the server rejects an item", async () => {
+    setCsrfToken("FAKE_CSRF_TOKEN");
+    mockFetch(
+      {
+        error: "application_control.invalid_rule",
+        message: "bulk item 1: identifier failed validation",
+      },
+      400,
+    );
+    try {
+      await bulkUpsertAppControlRules(1, {
+        rules: [
+          { rule_type: "BINARY", identifier: "not-hex" },
+        ],
+        reason: "x",
+      });
+      throw new Error("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(AppControlApiError);
+      if (err instanceof AppControlApiError) {
+        expect(err.code).toBe("application_control.invalid_rule");
+        expect(err.message).toMatch(/bulk item 1/);
+      }
+    }
+  });
+
+  it("throws Unauthorized401Error on a 401", async () => {
+    setCsrfToken("FAKE_CSRF_TOKEN");
+    mockFetch({}, 401);
+    await expect(
+      bulkUpsertAppControlRules(1, { rules: [], reason: "x" }),
     ).rejects.toBeInstanceOf(Unauthorized401Error);
   });
 });

--- a/ui/src/components/ApplicationControl/pasteInference.test.ts
+++ b/ui/src/components/ApplicationControl/pasteInference.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "vitest";
+import {
+  HINT_BINARY_COULD_BE_CERTIFICATE,
+  inferRuleType,
+  parsePasteInput,
+} from "./pasteInference";
+
+// pasteInference is the per-line shape-detection the PasteManyModal renders. Tests pin the shape regexes the spec calls out
+// (web-ui spec.md, Requirement: Paste-many flow infers rule type by identifier shape) so a future regex tweak that drifts from
+// the server-side validators fails here rather than at first paste against a real server.
+
+describe("inferRuleType", () => {
+  it("infers CDHASH for 40 lowercase hex characters", () => {
+    expect(inferRuleType("a".repeat(40))).toEqual({ ruleType: "CDHASH" });
+  });
+
+  it("infers BINARY with a CERTIFICATE hint for 64 lowercase hex characters", () => {
+    expect(inferRuleType("0".repeat(64))).toEqual({
+      ruleType: "BINARY",
+      hint: HINT_BINARY_COULD_BE_CERTIFICATE,
+    });
+  });
+
+  it("infers TEAMID for exactly 10 uppercase alphanumeric characters", () => {
+    expect(inferRuleType("EQHXZ8M8AV")).toEqual({ ruleType: "TEAMID" });
+  });
+
+  it("infers SIGNINGID for <TeamID>:<bundle.id>", () => {
+    expect(inferRuleType("EQHXZ8M8AV:com.google.Chrome")).toEqual({ ruleType: "SIGNINGID" });
+  });
+
+  it("infers SIGNINGID for platform:<bundle.id>", () => {
+    expect(inferRuleType("platform:com.apple.curl")).toEqual({ ruleType: "SIGNINGID" });
+  });
+
+  it("infers PATH for absolute paths", () => {
+    expect(inferRuleType("/Applications/Mail.app/Contents/MacOS/Mail")).toEqual({ ruleType: "PATH" });
+  });
+
+  it("returns ruleType=null when no shape matches", () => {
+    expect(inferRuleType("not a shape")).toEqual({ ruleType: null });
+  });
+
+  it("rejects uppercase hex characters for BINARY (server validator is strict on case)", () => {
+    expect(inferRuleType("A".repeat(64))).toEqual({ ruleType: null });
+  });
+
+  it("rejects an 11-character TEAMID-shaped value", () => {
+    expect(inferRuleType("EQHXZ8M8AV1")).toEqual({ ruleType: null });
+  });
+
+  it("rejects lowercase TEAMID (server-side validator requires uppercase)", () => {
+    expect(inferRuleType("eqhxz8m8av")).toEqual({ ruleType: null });
+  });
+});
+
+describe("parsePasteInput", () => {
+  it("returns the spec's mixed-identifiers shape inferences in order", () => {
+    const input = [
+      "a".repeat(40),
+      "b".repeat(64),
+      "EQHXZ8M8AV",
+      "/Applications/Mail.app/Contents/MacOS/Mail",
+    ].join("\n");
+    const result = parsePasteInput(input);
+    expect(result.map((r) => r.ruleType)).toEqual(["CDHASH", "BINARY", "TEAMID", "PATH"]);
+    expect(result[1].hint).toBe(HINT_BINARY_COULD_BE_CERTIFICATE);
+  });
+
+  it("strips blank lines including trailing whitespace-only lines", () => {
+    const input = "\nEQHXZ8M8AV\n   \n\n";
+    expect(parsePasteInput(input).map((r) => r.identifier)).toEqual(["EQHXZ8M8AV"]);
+  });
+
+  it("trims each identifier so a trailing space doesn't fall through to ruleType=null", () => {
+    const input = "  EQHXZ8M8AV  \n";
+    const result = parsePasteInput(input);
+    expect(result).toHaveLength(1);
+    expect(result[0].identifier).toBe("EQHXZ8M8AV");
+    expect(result[0].ruleType).toBe("TEAMID");
+  });
+
+  it("handles CRLF line endings (Windows-pasted spreadsheets)", () => {
+    const input = "EQHXZ8M8AV\r\nplatform:com.apple.curl\r\n";
+    const result = parsePasteInput(input);
+    expect(result.map((r) => r.identifier)).toEqual([
+      "EQHXZ8M8AV",
+      "platform:com.apple.curl",
+    ]);
+  });
+
+  it("preserves the raw line so the modal can show the operator the original input", () => {
+    const result = parsePasteInput("  EQHXZ8M8AV  ");
+    expect(result[0].raw).toBe("  EQHXZ8M8AV  ");
+    expect(result[0].identifier).toBe("EQHXZ8M8AV");
+  });
+});

--- a/ui/src/components/ApplicationControl/pasteInference.ts
+++ b/ui/src/components/ApplicationControl/pasteInference.ts
@@ -73,7 +73,7 @@ export function parsePasteInput(input: string): PasteInference[] {
       raw,
       identifier,
       ruleType: inference.ruleType,
-      ...(inference.hint !== undefined ? { hint: inference.hint } : {}),
+      ...(inference.hint ? { hint: inference.hint } : {}),
     });
   }
   return out;

--- a/ui/src/components/ApplicationControl/pasteInference.ts
+++ b/ui/src/components/ApplicationControl/pasteInference.ts
@@ -1,0 +1,93 @@
+// Per-line rule_type inference for the paste-many flow. The shapes mirror server/rules/internal/appcontrol/validate.go so the
+// preview table renders the same rule_type the server would compute on submit. The operator can override the inferred type
+// per-line before submission (the spec scenario for mixed identifiers requires it), so this module is advisory: an inferred
+// type of null is "no shape matched" rather than an error.
+
+// Phase A close-out gates CERTIFICATE and PATH behind the same "coming soon" flag the AddRuleModal renders. inference still
+// returns those values when the shape matches so the operator sees that the row would map to a not-yet-supported type and can
+// switch to BINARY (for a 64-hex) or omit the row (for a PATH) — instead of the row being silently rejected by the server.
+const RULE_TYPE_CDHASH = "CDHASH";
+const RULE_TYPE_BINARY = "BINARY";
+const RULE_TYPE_TEAMID = "TEAMID";
+const RULE_TYPE_SIGNINGID = "SIGNINGID";
+const RULE_TYPE_CERTIFICATE = "CERTIFICATE";
+const RULE_TYPE_PATH = "PATH";
+
+const CDHASH_LENGTH = 40;
+const BINARY_LENGTH = 64;
+const TEAMID_LENGTH = 10;
+
+const CDHASH_REGEX = /^[a-f0-9]{40}$/;
+const BINARY_REGEX = /^[a-f0-9]{64}$/;
+const TEAMID_REGEX = /^[A-Z0-9]{10}$/;
+const SIGNINGID_REGEX = /^(?:[A-Z0-9]{10}|platform):[A-Za-z0-9._-]+$/;
+
+// HINT_BINARY_COULD_BE_CERTIFICATE is the visible hint the spec calls out: a 64-hex value is the SHA-256 of either a Mach-O
+// binary or a leaf certificate. The inferrer picks BINARY (the more common case in paste lists) and surfaces the alternate so
+// the operator can switch the row's type before submit. The hint is the string the modal renders next to the type select.
+export const HINT_BINARY_COULD_BE_CERTIFICATE = "Could also be CERTIFICATE";
+
+// PasteInference is what the modal renders per parsed line. ruleType is null when no shape matches; the modal renders a
+// "select a type" placeholder and disables submit until the operator picks one. hint is optional and surfaces only on
+// shapes where the inferrer needs to flag an ambiguity.
+export interface PasteInference {
+  readonly raw: string;
+  readonly identifier: string;
+  readonly ruleType: string | null;
+  readonly hint?: string;
+}
+
+// inferRuleType maps a single trimmed identifier to the rule_type the server's validators would accept. Order matters: the
+// 10-character TEAMID check has to come before SIGNINGID because both can start with the same prefix.
+export function inferRuleType(identifier: string): { ruleType: string | null; hint?: string } {
+  if (identifier.length === CDHASH_LENGTH && CDHASH_REGEX.test(identifier)) {
+    return { ruleType: RULE_TYPE_CDHASH };
+  }
+  if (identifier.length === BINARY_LENGTH && BINARY_REGEX.test(identifier)) {
+    return { ruleType: RULE_TYPE_BINARY, hint: HINT_BINARY_COULD_BE_CERTIFICATE };
+  }
+  if (identifier.length === TEAMID_LENGTH && TEAMID_REGEX.test(identifier)) {
+    return { ruleType: RULE_TYPE_TEAMID };
+  }
+  if (SIGNINGID_REGEX.test(identifier)) {
+    return { ruleType: RULE_TYPE_SIGNINGID };
+  }
+  if (identifier.startsWith("/")) {
+    return { ruleType: RULE_TYPE_PATH };
+  }
+  return { ruleType: null };
+}
+
+// parsePasteInput is the single entry the modal calls. Splits on newlines, strips blank lines (operators routinely paste from
+// spreadsheets that leave trailing newlines), and feeds each remaining line through inferRuleType. Duplicate identifiers are
+// NOT deduped here because the server's bulk-upsert validator rejects duplicate (rule_type, identifier) pairs inside one batch
+// with a typed error; the modal surfaces that error verbatim so the operator sees which line is the offender.
+export function parsePasteInput(input: string): PasteInference[] {
+  const lines = input.split(/\r?\n/);
+  const out: PasteInference[] = [];
+  for (const raw of lines) {
+    const identifier = raw.trim();
+    if (identifier.length === 0) continue;
+    const inference = inferRuleType(identifier);
+    out.push({
+      raw,
+      identifier,
+      ruleType: inference.ruleType,
+      ...(inference.hint !== undefined ? { hint: inference.hint } : {}),
+    });
+  }
+  return out;
+}
+
+// EXPORTED constants for the modal so the type-select uses the same vocabulary. Ordered the way AddRuleModal renders the
+// type select (BINARY first because demo cuts most often paste SHA-256s; CDHASH next; SIGNINGID + TEAMID after).
+export const PASTE_MANY_RULE_TYPES = [
+  RULE_TYPE_BINARY,
+  RULE_TYPE_CDHASH,
+  RULE_TYPE_SIGNINGID,
+  RULE_TYPE_TEAMID,
+  RULE_TYPE_CERTIFICATE,
+  RULE_TYPE_PATH,
+] as const;
+
+export type PasteManyRuleType = (typeof PASTE_MANY_RULE_TYPES)[number];


### PR DESCRIPTION
Closes openspec/changes/add-application-control task 8.5: the paste-many flow at ui/src/components/ApplicationControl/PasteManyModal.tsx with per-line type inference per the web-ui delta spec. Mounted as a second header action on PolicyDetail alongside Add rule.

UX:
- Phase 1 (paste): a single textarea, one identifier per line. Parse routes to phase 2.
- Phase 2 (preview): per-row table showing the inferred rule_type plus any disambiguating hint (the 64-hex shape carries "Could also be CERTIFICATE" because that ambiguity is the spec scenario). Operator overrides the inferred type per row via a select; per-row remove via the × button. Shared severity + audit-reason apply to every row in the batch.
- Submit: POST to /policies/{id}/rules:bulkUpsert (the endpoint shipped in PR #190). Modal closes + parent refreshes on 200; typed application_control.* 4xx codes map to inline error copy via the existing applyAppControlSubmitError helper.

Inference rules (server/rules/internal/appcontrol/validate.go shapes):
  40-hex lowercase  -> CDHASH
  64-hex lowercase  -> BINARY + "could also be CERTIFICATE" hint
  10 [A-Z0-9]       -> TEAMID
  <TID>:<bundle>    -> SIGNINGID
  platform:<bundle> -> SIGNINGID
  /absolute/path    -> PATH (gated behind "coming soon" since Phase A
                       does not enforce PATH yet)

API client: extends ui/src/api.ts with bulkUpsertAppControlRules + types
+ MAX_BULK_UPSERT_ITEMS const mirroring server/rules/api. To dodge the Sonar S4144 duplicate-function-body trap parallel implementations would hit, widened the existing patchAppControlEndpoint to accept POST too and renamed it to appControlMutationEndpoint; createAppControlRule now also routes through the shared helper (15 LOC delta vs. the prior copy).

Tests:
- pasteInference.test.ts (15 cases): every shape from the spec + the scenario's mixed list + CRLF + trimming + uppercase/lowercase guards.
- PasteManyModal.test.tsx (8 cases): parse routing, per-row type override, unresolved-type guard (no shape + unavailable type), submit payload shape, typed-error inline display, back-to-paste reset, and per-row remove.
- api.test.ts (+3 cases): bulk-upsert happy path + typed 4xx error + 401.

Manual QA on dev:server (real-tool, per CLAUDE.md): forged admin session via tmp/qa-paste-many-setup.sh; opened the modal in Chrome; pasted a 40-c CDHASH + 64-d BINARY + PASTEMNYAB TEAMID; verified the preview table inferred all three correctly; submitted with reason "paste-many QA via Chrome MCP"; observed the policy version bump from 13 to 14 and the three new rule rows appear in the table. The audit_events row landed with rules_inserted=3, rules_updated=0, policy_version=14, fanout_hosts=2, fanout_failed=0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bulk import capability for application control rules via paste workflow
  * Supports up to 500 rules per batch with automatic rule type inference
  * Provides a preview table to review and adjust inferred types before saving
  * Automatically detects rule types from identifier patterns (certificates, binaries, team IDs, signing IDs, paths)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/getvictor/fleet-edr/pull/192?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->