### PR TITLE
app-control: filterable rules table on PolicyDetail (#68 / 8.3 / 8.7)

### DIFF
--- a/ui/src/components/ApplicationControl/ApplicationControl.scss
+++ b/ui/src/components/ApplicationControl/ApplicationControl.scss
@@ -35,6 +35,55 @@
   font-size: $xx-small;
 }
 
+// Rules-table filter bar. Flex row that wraps on narrow viewports so the four controls don't squeeze the search input. The
+// summary line ("Showing N of M rules · Clear filters") only renders when filterIsActive, so it lays out as a separate flex
+// child that drops to its own line when the controls take the full width.
+.app-control__filter-bar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: $pad-small;
+  margin-bottom: $pad-medium;
+}
+
+.app-control__filter-search {
+  flex: 1 1 240px;
+  min-width: 200px;
+  padding: $pad-xsmall $pad-small;
+  border: 1px solid $ui-fleet-black-25;
+  border-radius: 4px;
+  font-size: $xx-small;
+}
+
+.app-control__filter-select {
+  padding: $pad-xsmall $pad-small;
+  border: 1px solid $ui-fleet-black-25;
+  border-radius: 4px;
+  font-size: $xx-small;
+  background: white;
+}
+
+.app-control__filter-summary {
+  flex-basis: 100%;
+  color: $ui-fleet-black-50;
+  font-size: $xx-small;
+}
+
+// Inline-link-shaped button for the "Clear filters" action inside the summary + the empty-state copy. Matches the visual
+// language of the existing link-button class on the policy-detail back-to-policies link without coupling to its CSS.
+.app-control__link-button {
+  background: transparent;
+  border: none;
+  color: $core-vibrant-blue;
+  cursor: pointer;
+  font: inherit;
+  padding: 0;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
 .app-control__row-actions {
   display: flex;
   gap: $pad-xsmall;

--- a/ui/src/components/ApplicationControl/PolicyDetail.test.tsx
+++ b/ui/src/components/ApplicationControl/PolicyDetail.test.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, waitFor, fireEvent, within } from "@testing-library/react";
 import { MemoryRouter, Routes, Route } from "react-router-dom";
@@ -360,5 +361,40 @@ describe("PolicyDetail", () => {
       target: { value: "aaaa" },
     });
     expect(screen.getByText(/showing 1 of 4 rules/i)).toBeInTheDocument();
+  });
+
+  it("resets the filter when the operator navigates to a different policy", async () => {
+    // PolicyDetail reuses the same component instance across :id changes via React Router. Without the policyID-keyed
+    // reset effect, the previous policy's filter would persist (Copilot finding on PR #193). Render under a parent that
+    // can swap the :id at runtime and assert the filter clears when policyID changes.
+    const getSpy = vi.spyOn(api, "getAppControlPolicy");
+    getSpy.mockImplementation((id: number) => {
+      if (id === 7) return Promise.resolve(makePolicy({ id: 7, rules: makeFilterFixture() }));
+      return Promise.resolve(makePolicy({ id: 8, name: "Other", rules: [makeRule({ id: 99, rule_type: "BINARY", identifier: "z".repeat(64) })] }));
+    });
+
+    function Parent() {
+      const [path, setPath] = React.useState("/app-control/policies/7");
+      return (
+        <MemoryRouter initialEntries={[path]} key={path}>
+          <button type="button" onClick={() => { setPath("/app-control/policies/8"); }}>switch</button>
+          <Routes>
+            <Route path="/app-control/policies/:id" element={<PolicyDetail />} />
+          </Routes>
+        </MemoryRouter>
+      );
+    }
+    render(<Parent />);
+    await waitFor(() => expect(screen.getByRole("table")).toBeInTheDocument());
+    // Activate the filter on policy 7.
+    fireEvent.change(screen.getByLabelText(/search rules by identifier or comment/i), { target: { value: "platform" } });
+    expect(screen.getByText(/showing 1 of 4 rules/i)).toBeInTheDocument();
+    // Switch to policy 8.
+    fireEvent.click(screen.getByRole("button", { name: /switch/i }));
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Other" })).toBeInTheDocument());
+    // Filter is back to defaults: no summary line; search input is empty.
+    expect(screen.queryByText(/showing \d+ of \d+ rules/i)).toBeNull();
+    const searchInput = screen.getByLabelText(/search rules by identifier or comment/i);
+    expect(searchInput).toHaveProperty("value", "");
   });
 });

--- a/ui/src/components/ApplicationControl/PolicyDetail.test.tsx
+++ b/ui/src/components/ApplicationControl/PolicyDetail.test.tsx
@@ -223,4 +223,142 @@ describe("PolicyDetail", () => {
       expect(screen.getByText(/error: nope/i)).toBeInTheDocument();
     });
   });
+
+  // Filter tests. Per spec task 8.7 + the web-ui spec's filterable-rules-table requirement, these pin the four filter
+  // dimensions and the empty-state behavior when no rule matches.
+
+  const makeFilterFixture = (): ApplicationControlRule[] => [
+    makeRule({ id: 1, rule_type: "BINARY",    identifier: "aaaa1111".repeat(8), source: "admin",  enabled: true,  custom_msg: "blocked by IT" }),
+    makeRule({ id: 2, rule_type: "CDHASH",    identifier: "bbbb2222".repeat(5), source: "import", enabled: false, comment: "legacy paste", custom_msg: undefined }),
+    makeRule({ id: 3, rule_type: "TEAMID",    identifier: "ABCDE12345",         source: "admin",  enabled: true,  custom_msg: undefined }),
+    makeRule({ id: 4, rule_type: "SIGNINGID", identifier: "platform:com.apple.curl", source: "import", enabled: true, custom_msg: undefined }),
+  ];
+
+  function identifiersInTable(): string[] {
+    const table = screen.getByRole("table");
+    return within(table).getAllByRole("row").slice(1).map((row) => {
+      const cells = within(row).getAllByRole("cell");
+      // Identifier is the second column; its full value is on the title attribute (the cell text is truncated).
+      return cells[1].getAttribute("title") ?? "";
+    });
+  }
+
+  it("renders the filter bar with adaptive type + source dropdowns", async () => {
+    vi.spyOn(api, "getAppControlPolicy").mockResolvedValue(
+      makePolicy({ rules: makeFilterFixture() }),
+    );
+    renderPolicyDetailAt("/app-control/policies/7");
+    await waitFor(() => {
+      expect(screen.getByRole("search")).toBeInTheDocument();
+    });
+    const typeSelect = screen.getByLabelText(/filter by rule type/i);
+    const sourceSelect = screen.getByLabelText(/filter by source/i);
+    expect(Array.from((typeSelect as HTMLSelectElement).options).map((o) => o.value))
+      .toEqual(["", "BINARY", "CDHASH", "SIGNINGID", "TEAMID"]);
+    expect(Array.from((sourceSelect as HTMLSelectElement).options).map((o) => o.value))
+      .toEqual(["", "admin", "import"]);
+  });
+
+  it("filters by free-text search over identifier", async () => {
+    vi.spyOn(api, "getAppControlPolicy").mockResolvedValue(
+      makePolicy({ rules: makeFilterFixture() }),
+    );
+    renderPolicyDetailAt("/app-control/policies/7");
+    await waitFor(() => expect(screen.getByRole("table")).toBeInTheDocument());
+    fireEvent.change(screen.getByLabelText(/search rules by identifier or comment/i), {
+      target: { value: "platform" },
+    });
+    expect(identifiersInTable()).toEqual(["platform:com.apple.curl"]);
+    expect(screen.getByText(/showing 1 of 4 rules/i)).toBeInTheDocument();
+  });
+
+  it("filters by free-text search over comment", async () => {
+    vi.spyOn(api, "getAppControlPolicy").mockResolvedValue(
+      makePolicy({ rules: makeFilterFixture() }),
+    );
+    renderPolicyDetailAt("/app-control/policies/7");
+    await waitFor(() => expect(screen.getByRole("table")).toBeInTheDocument());
+    fireEvent.change(screen.getByLabelText(/search rules by identifier or comment/i), {
+      target: { value: "LEGACY" },
+    });
+    // CDHASH rule's comment is "legacy paste" — case-insensitive match should surface only it.
+    expect(identifiersInTable().map((id) => id.slice(0, 8))).toEqual(["bbbb2222"]);
+  });
+
+  it("filters by exact rule_type", async () => {
+    vi.spyOn(api, "getAppControlPolicy").mockResolvedValue(
+      makePolicy({ rules: makeFilterFixture() }),
+    );
+    renderPolicyDetailAt("/app-control/policies/7");
+    await waitFor(() => expect(screen.getByRole("table")).toBeInTheDocument());
+    fireEvent.change(screen.getByLabelText(/filter by rule type/i), { target: { value: "TEAMID" } });
+    expect(identifiersInTable()).toEqual(["ABCDE12345"]);
+  });
+
+  it("filters by enabled tri-state (Enabled then Disabled)", async () => {
+    vi.spyOn(api, "getAppControlPolicy").mockResolvedValue(
+      makePolicy({ rules: makeFilterFixture() }),
+    );
+    renderPolicyDetailAt("/app-control/policies/7");
+    await waitFor(() => expect(screen.getByRole("table")).toBeInTheDocument());
+    const statusSelect = screen.getByLabelText(/filter by status/i);
+    fireEvent.change(statusSelect, { target: { value: "enabled" } });
+    expect(identifiersInTable()).toHaveLength(3);
+    fireEvent.change(statusSelect, { target: { value: "disabled" } });
+    expect(identifiersInTable().map((id) => id.slice(0, 8))).toEqual(["bbbb2222"]);
+  });
+
+  it("filters by source", async () => {
+    vi.spyOn(api, "getAppControlPolicy").mockResolvedValue(
+      makePolicy({ rules: makeFilterFixture() }),
+    );
+    renderPolicyDetailAt("/app-control/policies/7");
+    await waitFor(() => expect(screen.getByRole("table")).toBeInTheDocument());
+    fireEvent.change(screen.getByLabelText(/filter by source/i), { target: { value: "import" } });
+    const ids = identifiersInTable();
+    expect(ids).toHaveLength(2);
+    expect(ids).toContain("platform:com.apple.curl");
+  });
+
+  it("intersects multiple filter dimensions (BINARY + enabled)", async () => {
+    vi.spyOn(api, "getAppControlPolicy").mockResolvedValue(
+      makePolicy({ rules: makeFilterFixture() }),
+    );
+    renderPolicyDetailAt("/app-control/policies/7");
+    await waitFor(() => expect(screen.getByRole("table")).toBeInTheDocument());
+    fireEvent.change(screen.getByLabelText(/filter by rule type/i), { target: { value: "BINARY" } });
+    fireEvent.change(screen.getByLabelText(/filter by status/i), { target: { value: "enabled" } });
+    expect(identifiersInTable()).toHaveLength(1);
+    expect(screen.getByText(/showing 1 of 4 rules/i)).toBeInTheDocument();
+  });
+
+  it("shows the no-match empty state when filters exclude every rule, with a working Clear link", async () => {
+    vi.spyOn(api, "getAppControlPolicy").mockResolvedValue(
+      makePolicy({ rules: makeFilterFixture() }),
+    );
+    renderPolicyDetailAt("/app-control/policies/7");
+    await waitFor(() => expect(screen.getByRole("table")).toBeInTheDocument());
+    fireEvent.change(screen.getByLabelText(/filter by rule type/i), { target: { value: "TEAMID" } });
+    fireEvent.change(screen.getByLabelText(/filter by source/i), { target: { value: "import" } });
+    expect(screen.queryByRole("table")).toBeNull();
+    expect(screen.getByText(/no rules match the current filter/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /clear filters/i }));
+    // After clear, every rule is visible again.
+    expect(identifiersInTable()).toHaveLength(4);
+  });
+
+  it("hides the filter summary when no filter is active and shows it when one is", async () => {
+    vi.spyOn(api, "getAppControlPolicy").mockResolvedValue(
+      makePolicy({ rules: makeFilterFixture() }),
+    );
+    renderPolicyDetailAt("/app-control/policies/7");
+    await waitFor(() => expect(screen.getByRole("table")).toBeInTheDocument());
+    // No filter applied -> no summary line.
+    expect(screen.queryByText(/showing \d+ of \d+ rules/i)).toBeNull();
+    // Type something into the search to activate the filter.
+    fireEvent.change(screen.getByLabelText(/search rules by identifier or comment/i), {
+      target: { value: "aaaa" },
+    });
+    expect(screen.getByText(/showing 1 of 4 rules/i)).toBeInTheDocument();
+  });
 });

--- a/ui/src/components/ApplicationControl/PolicyDetail.tsx
+++ b/ui/src/components/ApplicationControl/PolicyDetail.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { Link, useParams } from "react-router-dom";
 import {
   getAppControlPolicy,
@@ -14,6 +14,14 @@ import { AddRuleModal } from "./AddRuleModal";
 import { EditRuleModal } from "./EditRuleModal";
 import { ConfirmActionModal } from "./ConfirmActionModal";
 import { PasteManyModal } from "./PasteManyModal";
+import {
+  applyRulesFilter,
+  distinctRuleTypes,
+  distinctSources,
+  EMPTY_RULES_FILTER,
+  filterIsActive,
+  type RulesFilter,
+} from "./rulesFilter";
 import "./ApplicationControl.scss";
 
 // ActiveModal is the union that captures which per-row modal is currently open. Encoding mutual exclusion in the type closes
@@ -74,6 +82,12 @@ export function PolicyDetail() {
     setRefreshKey((k) => k + 1);
   }, []);
 
+  // Rules-table filter state. Stays component-local (no URL persistence in this PR) and intentionally survives a refresh
+  // bump so an operator who edited a rule mid-filter doesn't lose their place. Each dimension matches the web-ui spec's
+  // four filter axes: rule_type, enabled, source, free-text over identifier + comment.
+  const [filter, setFilter] = useState<RulesFilter>(EMPTY_RULES_FILTER);
+  const clearFilter = useCallback(() => { setFilter(EMPTY_RULES_FILTER); }, []);
+
   useEffect(() => {
     if (!Number.isFinite(policyID)) return;
     let cancelled = false;
@@ -91,6 +105,15 @@ export function PolicyDetail() {
       });
     return () => { cancelled = true; };
   }, [policyID, refreshKey]);
+
+  // Memoised filter result + adaptive dropdown option sets. Called BEFORE any early return so React hook order stays stable
+  // (react-hooks/rules-of-hooks). `rules` is wrapped in its own useMemo so the dependency arrays below don't see a fresh []
+  // literal every render when policy is null.
+  const rules = useMemo(() => policy?.rules ?? [], [policy]);
+  const visibleRules = useMemo(() => applyRulesFilter(rules, filter), [rules, filter]);
+  const availableTypes = useMemo(() => distinctRuleTypes(rules), [rules]);
+  const availableSources = useMemo(() => distinctSources(rules), [rules]);
+  const isFiltering = filterIsActive(filter);
 
   if (!Number.isFinite(policyID)) {
     return (
@@ -144,7 +167,6 @@ export function PolicyDetail() {
     </>
   );
 
-  const rules = policy?.rules ?? [];
 
   // confirmRule extracts the rule from a confirm-* modal kind so the JSX below stays terse; returns null for non-confirm
   // modals (the ConfirmActionModal won't render its content in that case).
@@ -171,12 +193,38 @@ export function PolicyDetail() {
               author the first one.
             </EmptyState>
           ) : (
-            <RulesTable
-              rules={rules}
-              onEdit={(rule) => { setActiveModal({ kind: "edit", rule }); }}
-              onToggle={(rule) => { setActiveModal({ kind: "confirm-toggle", rule }); }}
-              onDelete={(rule) => { setActiveModal({ kind: "confirm-delete", rule }); }}
-            />
+            <>
+              <RulesFilterBar
+                filter={filter}
+                onChange={setFilter}
+                availableTypes={availableTypes}
+                availableSources={availableSources}
+                visibleCount={visibleRules.length}
+                totalCount={rules.length}
+                onClear={clearFilter}
+                isFiltering={isFiltering}
+              />
+              {visibleRules.length === 0 ? (
+                <EmptyState>
+                  No rules match the current filter.{" "}
+                  <button
+                    type="button"
+                    className="app-control__link-button"
+                    onClick={clearFilter}
+                  >
+                    Clear filters
+                  </button>
+                  {" "}to see all {String(rules.length)} rule{rules.length === 1 ? "" : "s"}.
+                </EmptyState>
+              ) : (
+                <RulesTable
+                  rules={visibleRules}
+                  onEdit={(rule) => { setActiveModal({ kind: "edit", rule }); }}
+                  onToggle={(rule) => { setActiveModal({ kind: "confirm-toggle", rule }); }}
+                  onDelete={(rule) => { setActiveModal({ kind: "confirm-delete", rule }); }}
+                />
+              )}
+            </>
           )}
         </>
       )}
@@ -362,5 +410,90 @@ function RulesTable({ rules, onEdit, onToggle, onDelete }: RulesTableProps) {
         ))}
       </tbody>
     </Table>
+  );
+}
+
+interface RulesFilterBarProps {
+  readonly filter: RulesFilter;
+  readonly onChange: (next: RulesFilter) => void;
+  readonly availableTypes: readonly string[];
+  readonly availableSources: readonly string[];
+  readonly visibleCount: number;
+  readonly totalCount: number;
+  readonly onClear: () => void;
+  readonly isFiltering: boolean;
+}
+
+// RulesFilterBar renders the four filter dimensions the spec calls out (rule_type, enabled, source, free-text) above the
+// rules table. Pure presentational: state lives in PolicyDetail so a refresh after a mutation doesn't wipe the operator's
+// filter mid-edit. The "Showing X of Y" + "Clear filters" treatment only renders when at least one dimension is active so
+// the bar stays unobtrusive on policies with no filter applied.
+function RulesFilterBar({
+  filter,
+  onChange,
+  availableTypes,
+  availableSources,
+  visibleCount,
+  totalCount,
+  onClear,
+  isFiltering,
+}: RulesFilterBarProps) {
+  const ruleSuffix = totalCount === 1 ? "" : "s";
+  return (
+    <div className="app-control__filter-bar" role="search" aria-label="Filter rules">
+      <input
+        type="search"
+        className="app-control__filter-search"
+        placeholder="Search identifier or comment"
+        aria-label="Search rules by identifier or comment"
+        value={filter.search}
+        onChange={(e) => { onChange({ ...filter, search: e.target.value }); }}
+      />
+      <select
+        className="app-control__filter-select"
+        aria-label="Filter by rule type"
+        value={filter.ruleType}
+        onChange={(e) => { onChange({ ...filter, ruleType: e.target.value }); }}
+      >
+        <option value="">All types</option>
+        {availableTypes.map((t) => (
+          <option key={t} value={t}>{t}</option>
+        ))}
+      </select>
+      <select
+        className="app-control__filter-select"
+        aria-label="Filter by status"
+        value={filter.enabled}
+        onChange={(e) => { onChange({ ...filter, enabled: e.target.value as RulesFilter["enabled"] }); }}
+      >
+        <option value="all">All statuses</option>
+        <option value="enabled">Enabled</option>
+        <option value="disabled">Disabled</option>
+      </select>
+      <select
+        className="app-control__filter-select"
+        aria-label="Filter by source"
+        value={filter.source}
+        onChange={(e) => { onChange({ ...filter, source: e.target.value }); }}
+      >
+        <option value="">All sources</option>
+        {availableSources.map((s) => (
+          <option key={s} value={s}>{s}</option>
+        ))}
+      </select>
+      {isFiltering && visibleCount > 0 && (
+        <div className="app-control__filter-summary">
+          Showing {String(visibleCount)} of {String(totalCount)} rule{ruleSuffix}
+          {" "}<span className="app-control__divider">·</span>{" "}
+          <button
+            type="button"
+            className="app-control__link-button"
+            onClick={onClear}
+          >
+            Clear filters
+          </button>
+        </div>
+      )}
+    </div>
   );
 }

--- a/ui/src/components/ApplicationControl/PolicyDetail.tsx
+++ b/ui/src/components/ApplicationControl/PolicyDetail.tsx
@@ -88,6 +88,13 @@ export function PolicyDetail() {
   const [filter, setFilter] = useState<RulesFilter>(EMPTY_RULES_FILTER);
   const clearFilter = useCallback(() => { setFilter(EMPTY_RULES_FILTER); }, []);
 
+  // Reset the filter whenever the operator navigates between policies. React Router reuses the same PolicyDetail instance
+  // when only the :id path param changes, so without this effect the previous policy's filter values (including type /
+  // source values that may not exist on the new policy) would carry over. Closes a Copilot finding on PR #193.
+  useEffect(() => {
+    setFilter(EMPTY_RULES_FILTER); // eslint-disable-line react-hooks/set-state-in-effect -- reset on prop change
+  }, [policyID]);
+
   useEffect(() => {
     if (!Number.isFinite(policyID)) return;
     let cancelled = false;

--- a/ui/src/components/ApplicationControl/rulesFilter.test.ts
+++ b/ui/src/components/ApplicationControl/rulesFilter.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from "vitest";
+import {
+  applyRulesFilter,
+  distinctRuleTypes,
+  distinctSources,
+  EMPTY_RULES_FILTER,
+  filterIsActive,
+  type RulesFilter,
+} from "./rulesFilter";
+import type { ApplicationControlRule } from "../../types";
+
+// Pin the filter contract the spec requires: the four dimensions (rule_type, enabled, source, free-text over identifier and
+// comment) act independently and intersect via logical AND. distinctRuleTypes orders by the canonical UI order; distinctSources
+// is alphabetical.
+
+const makeRule = (over: Partial<ApplicationControlRule>): ApplicationControlRule => ({
+  id: 1,
+  policy_id: 1,
+  rule_type: "BINARY",
+  identifier: "a".repeat(64),
+  action: "BLOCK",
+  enforcement: "PROTECT",
+  enabled: true,
+  severity: "medium",
+  source: "admin",
+  created_at: "2026-05-14T00:00:00Z",
+  updated_at: "2026-05-14T00:00:00Z",
+  created_by: "user:1",
+  ...over,
+});
+
+const rules: ApplicationControlRule[] = [
+  makeRule({ id: 1, rule_type: "BINARY",    identifier: "a".repeat(64), source: "admin",  enabled: true,  comment: "blocked by IT" }),
+  makeRule({ id: 2, rule_type: "CDHASH",    identifier: "b".repeat(40), source: "import", enabled: false, comment: "legacy entry" }),
+  makeRule({ id: 3, rule_type: "TEAMID",    identifier: "EQHXZ8M8AV",   source: "admin",  enabled: true,  comment: "" }),
+  makeRule({ id: 4, rule_type: "SIGNINGID", identifier: "platform:com.apple.curl", source: "import", enabled: true }),
+  makeRule({ id: 5, rule_type: "BINARY",    identifier: "c".repeat(64), source: "api",    enabled: false, comment: "rolled back" }),
+];
+
+describe("applyRulesFilter", () => {
+  it("returns every rule when the filter is empty (EMPTY_RULES_FILTER)", () => {
+    expect(applyRulesFilter(rules, EMPTY_RULES_FILTER)).toHaveLength(rules.length);
+  });
+
+  it("filters by exact rule_type", () => {
+    const filter: RulesFilter = { ...EMPTY_RULES_FILTER, ruleType: "BINARY" };
+    expect(applyRulesFilter(rules, filter).map((r) => r.id)).toEqual([1, 5]);
+  });
+
+  it("filters enabled-only and disabled-only via the tri-state", () => {
+    expect(applyRulesFilter(rules, { ...EMPTY_RULES_FILTER, enabled: "enabled" }).map((r) => r.id)).toEqual([1, 3, 4]);
+    expect(applyRulesFilter(rules, { ...EMPTY_RULES_FILTER, enabled: "disabled" }).map((r) => r.id)).toEqual([2, 5]);
+  });
+
+  it("filters by exact source", () => {
+    expect(applyRulesFilter(rules, { ...EMPTY_RULES_FILTER, source: "import" }).map((r) => r.id)).toEqual([2, 4]);
+  });
+
+  it("free-text search matches identifier substrings case-insensitively", () => {
+    expect(applyRulesFilter(rules, { ...EMPTY_RULES_FILTER, search: "PLATFORM" }).map((r) => r.id)).toEqual([4]);
+  });
+
+  it("free-text search also matches comment substrings", () => {
+    expect(applyRulesFilter(rules, { ...EMPTY_RULES_FILTER, search: "legacy" }).map((r) => r.id)).toEqual([2]);
+  });
+
+  it("free-text search treats whitespace-only as empty", () => {
+    expect(applyRulesFilter(rules, { ...EMPTY_RULES_FILTER, search: "   " })).toHaveLength(rules.length);
+  });
+
+  it("intersects dimensions: BINARY + enabled returns only rules satisfying both", () => {
+    const filter: RulesFilter = { ...EMPTY_RULES_FILTER, ruleType: "BINARY", enabled: "enabled" };
+    expect(applyRulesFilter(rules, filter).map((r) => r.id)).toEqual([1]);
+  });
+
+  it("returns empty array when no rule passes every dimension", () => {
+    const filter: RulesFilter = { ...EMPTY_RULES_FILTER, ruleType: "TEAMID", source: "api" };
+    expect(applyRulesFilter(rules, filter)).toEqual([]);
+  });
+
+  it("handles rules without a comment when free-text search is set (comment is optional)", () => {
+    // rule 3 has comment = "", rule 4 has no comment field at all. search "EQHX" matches identifier of rule 3 only.
+    expect(applyRulesFilter(rules, { ...EMPTY_RULES_FILTER, search: "EQHX" }).map((r) => r.id)).toEqual([3]);
+  });
+});
+
+describe("filterIsActive", () => {
+  it("returns false for EMPTY_RULES_FILTER", () => {
+    expect(filterIsActive(EMPTY_RULES_FILTER)).toBe(false);
+  });
+
+  it("returns true when ANY dimension is constraining", () => {
+    expect(filterIsActive({ ...EMPTY_RULES_FILTER, ruleType: "BINARY" })).toBe(true);
+    expect(filterIsActive({ ...EMPTY_RULES_FILTER, enabled: "disabled" })).toBe(true);
+    expect(filterIsActive({ ...EMPTY_RULES_FILTER, source: "admin" })).toBe(true);
+    expect(filterIsActive({ ...EMPTY_RULES_FILTER, search: "foo" })).toBe(true);
+  });
+
+  it("treats whitespace-only search as inactive (matches applyRulesFilter)", () => {
+    expect(filterIsActive({ ...EMPTY_RULES_FILTER, search: "   " })).toBe(false);
+  });
+});
+
+describe("distinctRuleTypes", () => {
+  it("returns unique types in canonical UI order (BINARY, CDHASH, SIGNINGID, TEAMID, ...)", () => {
+    expect(distinctRuleTypes(rules)).toEqual(["BINARY", "CDHASH", "SIGNINGID", "TEAMID"]);
+  });
+
+  it("returns an empty array for an empty rule list", () => {
+    expect(distinctRuleTypes([])).toEqual([]);
+  });
+});
+
+describe("distinctSources", () => {
+  it("returns unique sources alphabetically", () => {
+    expect(distinctSources(rules)).toEqual(["admin", "api", "import"]);
+  });
+
+  it("skips empty source values so they don't pollute the dropdown", () => {
+    const withEmpty = [...rules, makeRule({ id: 99, source: "" })];
+    expect(distinctSources(withEmpty)).toEqual(["admin", "api", "import"]);
+  });
+});

--- a/ui/src/components/ApplicationControl/rulesFilter.ts
+++ b/ui/src/components/ApplicationControl/rulesFilter.ts
@@ -1,0 +1,87 @@
+import type { ApplicationControlRule } from "../../types";
+
+// Filter dimensions for the policy-detail rules table. Mirrors the web-ui spec's "filtered by rule_type, enabled, source, and
+// free-text search over identifier and comment". Each dimension is independent: the empty / "all" value for a dimension means
+// it doesn't constrain. A rule passes the filter iff every dimension's predicate accepts it (logical AND across dimensions).
+export interface RulesFilter {
+  // search is matched as a case-insensitive substring against the identifier AND the comment. An empty string disables the
+  // search dimension entirely (every rule passes); a non-empty string passes a rule iff it appears in either field.
+  readonly search: string;
+  // ruleType matches the rule's rule_type EXACTLY. The empty string means "any type"; otherwise the rule must equal this
+  // value (BINARY / CDHASH / SIGNINGID / TEAMID / CERTIFICATE / PATH).
+  readonly ruleType: string;
+  // enabled is a tri-state: "all" disables the dimension; "enabled" / "disabled" require the corresponding boolean.
+  readonly enabled: "all" | "enabled" | "disabled";
+  // source matches the rule's source string EXACTLY (admin / import / api / system, etc). The set of available sources is
+  // derived from the policy's actual rules at render time so the dropdown adapts to whatever the deployment surfaces.
+  readonly source: string;
+}
+
+export const EMPTY_RULES_FILTER: RulesFilter = {
+  search: "",
+  ruleType: "",
+  enabled: "all",
+  source: "",
+};
+
+// filterIsActive returns true when at least one dimension is constraining the result set. The PolicyDetail page uses this to
+// decide whether to render the "Clear filters" link + the X-of-Y counter (both noisy when no filter is applied).
+export function filterIsActive(filter: RulesFilter): boolean {
+  return filter.search.trim() !== ""
+    || filter.ruleType !== ""
+    || filter.enabled !== "all"
+    || filter.source !== "";
+}
+
+// applyRulesFilter walks the rule list once and returns the subset that passes every dimension. Pure + memoizable: the
+// PolicyDetail caller wraps this in useMemo keyed on (rules, filter).
+export function applyRulesFilter(
+  rules: readonly ApplicationControlRule[],
+  filter: RulesFilter,
+): ApplicationControlRule[] {
+  const needle = filter.search.trim().toLowerCase();
+  return rules.filter((rule) => {
+    if (filter.ruleType !== "" && rule.rule_type !== filter.ruleType) return false;
+    if (filter.enabled === "enabled" && !rule.enabled) return false;
+    if (filter.enabled === "disabled" && rule.enabled) return false;
+    if (filter.source !== "" && rule.source !== filter.source) return false;
+    if (needle !== "") {
+      const identifier = rule.identifier.toLowerCase();
+      const comment = (rule.comment ?? "").toLowerCase();
+      if (!identifier.includes(needle) && !comment.includes(needle)) return false;
+    }
+    return true;
+  });
+}
+
+// distinctSources returns the unique source strings present in the policy's rules, sorted alphabetically. The Source select
+// in PolicyDetail builds its option list from this so the dropdown adapts to whatever values exist instead of hard-coding the
+// admin/import/api/system enumeration (which would drift if the server adds a value).
+export function distinctSources(rules: readonly ApplicationControlRule[]): string[] {
+  const set = new Set<string>();
+  for (const r of rules) {
+    if (r.source && r.source.length > 0) set.add(r.source);
+  }
+  return Array.from(set).sort((a, b) => a.localeCompare(b));
+}
+
+// RULE_TYPE_ORDER_KEYS is the canonical UI order the modals + dropdowns render rule types in (BINARY first since SHA-256
+// is the most-pasted shape). distinctRuleTypes' Map below derives its values from the array index so each ordinal is
+// self-documenting and the eslint no-magic-numbers rule doesn't trip on per-entry sort keys.
+const RULE_TYPE_ORDER_KEYS = ["BINARY", "CDHASH", "SIGNINGID", "TEAMID", "CERTIFICATE", "PATH"] as const;
+const RULE_TYPE_ORDER = new Map<string, number>(RULE_TYPE_ORDER_KEYS.map((k, i) => [k, i]));
+
+// RULE_TYPE_ORDER_TRAILING is the fallback sort key for any rule_type not enumerated above (defense-in-depth for a future
+// server addition the UI hasn't been taught yet). Sorts unknown values after every known type, then alphabetically.
+const RULE_TYPE_ORDER_TRAILING = Number.MAX_SAFE_INTEGER;
+
+export function distinctRuleTypes(rules: readonly ApplicationControlRule[]): string[] {
+  const set = new Set<string>();
+  for (const r of rules) set.add(r.rule_type);
+  return Array.from(set).sort((a, b) => {
+    const oa = RULE_TYPE_ORDER.get(a) ?? RULE_TYPE_ORDER_TRAILING;
+    const ob = RULE_TYPE_ORDER.get(b) ?? RULE_TYPE_ORDER_TRAILING;
+    if (oa !== ob) return oa - ob;
+    return a.localeCompare(b);
+  });
+}

--- a/ui/src/components/ApplicationControl/rulesFilter.ts
+++ b/ui/src/components/ApplicationControl/rulesFilter.ts
@@ -4,8 +4,9 @@ import type { ApplicationControlRule } from "../../types";
 // free-text search over identifier and comment". Each dimension is independent: the empty / "all" value for a dimension means
 // it doesn't constrain. A rule passes the filter iff every dimension's predicate accepts it (logical AND across dimensions).
 export interface RulesFilter {
-  // search is matched as a case-insensitive substring against the identifier AND the comment. An empty string disables the
-  // search dimension entirely (every rule passes); a non-empty string passes a rule iff it appears in either field.
+  // search is matched as a case-insensitive substring against the identifier OR the comment. An empty string disables the
+  // search dimension entirely (every rule passes); a non-empty string passes a rule iff it appears in EITHER field (not
+  // both).
   readonly search: string;
   // ruleType matches the rule's rule_type EXACTLY. The empty string means "any type"; otherwise the rule must equal this
   // value (BINARY / CDHASH / SIGNINGID / TEAMID / CERTIFICATE / PATH).


### PR DESCRIPTION
Closes the filter half of openspec task 8.3: a filterable rules table per the web-ui spec's four dimensions — rule_type, enabled, source, and free-text search over identifier and comment. Per-row actions + the assignment summary were already shipped (PR #189 and earlier). Also closes the rules-table-filter line of task 8.7 (RTL coverage).

UI:
- Filter bar above the rules table: a search input (matches identifier or comment substring, case-insensitive) plus three selects (Type / Status / Source). Type + Source options are derived from the policy's actual rules at render time so a policy with only BINARY rules doesn't surface every possible type. Status is a fixed tri-state (All / Enabled / Disabled).
- "Showing N of M rules · Clear filters" summary renders only when at least one dimension is constraining the result AND results are non-zero.
- When the filter excludes every rule, the table is replaced by an empty state ("No rules match the current filter. Clear filters to see all N rules.") whose Clear link resets the four dimensions in one click.
- The filter state survives a mutation-triggered refresh — an operator who edits a rule mid-filter doesn't lose their place. Each policy gets its own fresh filter state on navigation (no cross-policy carryover).

Module:
- New pure rulesFilter.ts with applyRulesFilter + filterIsActive + distinctRuleTypes + distinctSources. The filter is wrapped in useMemo keyed on (rules, filter) and the hook calls happen before any early return to satisfy react-hooks/rules-of-hooks.

Tests:
- rulesFilter.test.ts (17 cases): per-dimension predicates, intersection, whitespace-only search behavior, distinctRuleTypes canonical order, distinctSources alphabetical ordering, empty-rule edge cases.
- PolicyDetail.test.tsx (+8 cases): filter bar with adaptive type + source dropdowns; identifier search; comment search; rule_type filter; enabled tri-state; source filter; intersected filters; no-match empty state with working Clear; summary line visibility toggle.

Manual QA via Chrome MCP on dev:server: navigated to the Default policy with 8 rules, exercised the Type=BINARY filter (narrowed to 2 rows), the search "platform" filter (narrowed to 1 SIGNINGID row), the Type=TEAMID+Status=Disabled combination (no matches → empty state with Clear link), and the Clear link itself (restored all 8 rows). Captured rules-filter-qa.gif.

Also patched tmp/qa-paste-many-setup.sh to populate created_at + last_seen_at on the forged session row. Without them the session middleware's idle-timeout check fails immediately (now - last_seen_at > break-glass 15-min window) and every authenticated request 401s with invalid_session despite a valid row.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Rules table filtering with case-insensitive text search across rule identifiers and comments
  * Filter dropdown controls for rule type, enabled/disabled status, and source
  * Displays count of matching rules versus total rules when filters are active
  * "Clear filters" button to reset all filter selections and restore full rules list
  * Empty state message when no rules match active filters

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/getvictor/fleet-edr/pull/193?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->