### PR TITLE
app-control: host-groups + assignments REST surface (#68 / 11.4.8 + 1…

### DIFF
--- a/server/cmd/fleet-edr-server/main.go
+++ b/server/cmd/fleet-edr-server/main.go
@@ -528,8 +528,8 @@ func registerSessionRoutes(mux *http.ServeMux, d muxDeps) {
 		// path enumerated here so requests reach the session-protected wrapper instead of falling through to the `/` catchall
 		// and 302 → /ui/. Surfaced by the step-8 dry-run on PR #158 — the list-policies API returned the SPA's index.html,
 		// which the UI fetch parsed as JSON and errored with "Unexpected token '<'". The Phase A close-out follow-on adds the
-		// five mutation routes + bulk upsert + cross-policy GET; host-groups CRUD + assignments POST stay deferred to
-		// follow-on PRs and land in this list when their handlers do.
+		// five mutation routes + bulk upsert + cross-policy GET + host-groups CRUD + assignments are all enumerated here. Phase B
+		// editable host-group + assignment mutations will replace the 405 handlers at the same routes without churning this list.
 		"GET /api/v1/app-control/policies",
 		"GET /api/v1/app-control/policies/{id}",
 		"POST /api/v1/app-control/policies",
@@ -540,6 +540,17 @@ func registerSessionRoutes(mux *http.ServeMux, d muxDeps) {
 		"PATCH /api/v1/app-control/rules/{id}",
 		"DELETE /api/v1/app-control/rules/{id}",
 		"GET /api/v1/app-control/rules",
+		// Host-groups + assignments surface. Read endpoints (GET) serve the real seed row; mutation endpoints (POST/PATCH/DELETE)
+		// are wired so the wire-shape contract is testable today but return 405 application_control.read_only_in_phase_a
+		// (closes tasks 11.4.8 + 11.4.9). Phase B replaces the 405 handlers with real mutation logic without changing routes.
+		"GET /api/v1/app-control/host-groups",
+		"GET /api/v1/app-control/host-groups/{id}",
+		"POST /api/v1/app-control/host-groups",
+		"PATCH /api/v1/app-control/host-groups/{id}",
+		"DELETE /api/v1/app-control/host-groups/{id}",
+		"GET /api/v1/app-control/policies/{id}/assignments",
+		"POST /api/v1/app-control/policies/{id}/assignments",
+		"DELETE /api/v1/app-control/policies/{id}/assignments/{group_id}",
 		// Break-glass reauth ceremony. The handlers are mounted on apiMux via identityCtx.RegisterAuthedRoutes, but the outer
 		// router needs each path enumerated here so the session-protected wrapper actually serves them — otherwise requests
 		// fall through to the `/` catchall and 302 → /ui/, silently breaking the destructive-action reauth path.

--- a/server/rules/api/types.go
+++ b/server/rules/api/types.go
@@ -439,6 +439,10 @@ var (
 	// row is the failsafe that keeps the all-hosts assignment alive; an admin who wants to stop enforcing rules detaches the
 	// assignment or disables individual rules rather than deleting the policy itself.
 	ErrAppControlPolicyImmutable = errors.New("rules: application control default policy cannot be deleted")
+
+	// ErrAppControlHostGroupNotFound is returned when the targeted host_group row does not exist. Mapped to HTTP 404 by the REST
+	// handler so an operator hitting a stale id sees a typed signal rather than a generic 500.
+	ErrAppControlHostGroupNotFound = errors.New("rules: application control host group not found")
 )
 
 // IsApplicationControlValidationError reports whether err is one of the validation errors that the REST handlers map to HTTP 400. The
@@ -509,6 +513,16 @@ type ApplicationControlStore interface {
 	// resolver walks the result and unions the member hosts of each group to build the set of unique hosts the rule update should
 	// reach.
 	ListHostGroupsForPolicy(ctx context.Context, policyID int64) ([]HostGroup, error)
+	// ListHostGroups returns every host_group row in alphabetical name order. Phase A always returns the single seed `all-hosts`
+	// group; Phase B grows the result when editable groups land. Pure read; no fan-out, no audit.
+	ListHostGroups(ctx context.Context) ([]HostGroup, error)
+	// GetHostGroupByID loads one host_group row. ErrAppControlHostGroupNotFound when the row does not exist; the REST handler
+	// maps that to HTTP 404.
+	GetHostGroupByID(ctx context.Context, hostGroupID int64) (HostGroup, error)
+	// ListAssignmentsForPolicy returns the raw assignment rows (policy_id, host_group_id, priority, created_at) for the policy
+	// in (priority ASC, host_group_id ASC) order. Distinct from ListHostGroupsForPolicy: this returns the join-table rows
+	// themselves so a future UI can render the priority + linkage independent of the group metadata.
+	ListAssignmentsForPolicy(ctx context.Context, policyID int64) ([]Assignment, error)
 	// ListRulesAcrossPolicies returns rules matching the filter across every policy. Powers the cross-policy GET /rules endpoint
 	// that integration callers (audit export, compliance reports) need. Pagination is mandatory: Limit caps the page size and
 	// Offset cursors through the result. Returns the page rows + the total count so the caller can render "Showing N of M".

--- a/server/rules/internal/appcontrol/service.go
+++ b/server/rules/internal/appcontrol/service.go
@@ -109,6 +109,24 @@ func (s *Service) ListRulesAcrossPolicies(
 	return s.store.ListRulesAcrossPolicies(ctx, req)
 }
 
+// ListHostGroups is the GET /host-groups endpoint's backend; pure pass-through, leaves room for future read-side decoration
+// (member-count rollup, assignment summary) at the orchestrator layer without touching the handler.
+func (s *Service) ListHostGroups(ctx context.Context) ([]api.HostGroup, error) {
+	return s.store.ListHostGroups(ctx)
+}
+
+// GetHostGroupByID is the GET /host-groups/{id} endpoint's backend. Returns ErrAppControlHostGroupNotFound when the row does
+// not exist so the handler maps to HTTP 404.
+func (s *Service) GetHostGroupByID(ctx context.Context, hostGroupID int64) (api.HostGroup, error) {
+	return s.store.GetHostGroupByID(ctx, hostGroupID)
+}
+
+// ListAssignmentsForPolicy is the GET /policies/{id}/assignments endpoint's backend. Pass-through; returns the raw assignment
+// rows so a future UI can render priority + ordering independent of the group metadata.
+func (s *Service) ListAssignmentsForPolicy(ctx context.Context, policyID int64) ([]api.Assignment, error) {
+	return s.store.ListAssignmentsForPolicy(ctx, policyID)
+}
+
 // GetPolicyWithRules returns the policy row plus its rules in one call so the policy-detail page can render without an extra round
 // trip. Returns ErrAppControlPolicyNotFound when the policy is absent; the handler maps that to HTTP 404.
 func (s *Service) GetPolicyWithRules(ctx context.Context, policyID int64) (api.ApplicationControlPolicy, error) {

--- a/server/rules/internal/appcontrol/store.go
+++ b/server/rules/internal/appcontrol/store.go
@@ -125,6 +125,76 @@ func (s *Store) ListHostGroupsForPolicy(ctx context.Context, policyID int64) ([]
 	return out, nil
 }
 
+// ListHostGroups returns every host_group row in alphabetical name order. Phase A always returns the single seed `all-hosts`
+// group; Phase B grows the result when editable groups land. Distinct from ListHostGroupsForPolicy: that one filters by an
+// assignment link to a specific policy; this one returns every group regardless of assignment state.
+func (s *Store) ListHostGroups(ctx context.Context) ([]api.HostGroup, error) {
+	const query = `SELECT id, name, description, criteria, created_at, updated_at
+		FROM host_groups ORDER BY name ASC`
+	rows, err := s.db.QueryxContext(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("appcontrol list host groups: %w", err)
+	}
+	defer rows.Close()
+	out := []api.HostGroup{}
+	for rows.Next() {
+		var g api.HostGroup
+		if err := rows.Scan(&g.ID, &g.Name, &g.Description, &g.Criteria, &g.CreatedAt, &g.UpdatedAt); err != nil {
+			return nil, fmt.Errorf("appcontrol scan host group: %w", err)
+		}
+		out = append(out, g)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("appcontrol iterate host groups: %w", err)
+	}
+	return out, nil
+}
+
+// GetHostGroupByID loads a single host_group row by primary key. Returns ErrAppControlHostGroupNotFound when the row does not
+// exist so the REST handler maps to HTTP 404; other driver errors propagate as-is for the handler to translate to 500.
+func (s *Store) GetHostGroupByID(ctx context.Context, hostGroupID int64) (api.HostGroup, error) {
+	const query = `SELECT id, name, description, criteria, created_at, updated_at
+		FROM host_groups WHERE id = ?`
+	row := s.db.QueryRowxContext(ctx, query, hostGroupID)
+	var g api.HostGroup
+	if err := row.Scan(&g.ID, &g.Name, &g.Description, &g.Criteria, &g.CreatedAt, &g.UpdatedAt); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return api.HostGroup{}, api.ErrAppControlHostGroupNotFound
+		}
+		return api.HostGroup{}, fmt.Errorf("appcontrol get host group by id: %w", err)
+	}
+	return g, nil
+}
+
+// ListAssignmentsForPolicy returns the raw assignment rows linking a policy to its host groups in (priority ASC, host_group_id
+// ASC) order. Distinct from ListHostGroupsForPolicy which returns the joined group metadata; this returns the assignment
+// linkage so a future UI can render priority + ordering without re-deriving from the group rows. No 404 on unknown policy:
+// the caller checks policy existence separately when needed (returning [] is the correct shape for "policy has no
+// assignments", which is a valid Phase B state).
+func (s *Store) ListAssignmentsForPolicy(ctx context.Context, policyID int64) ([]api.Assignment, error) {
+	const query = `SELECT policy_id, host_group_id, priority, created_at
+		FROM app_control_assignments
+		WHERE policy_id = ?
+		ORDER BY priority ASC, host_group_id ASC`
+	rows, err := s.db.QueryxContext(ctx, query, policyID)
+	if err != nil {
+		return nil, fmt.Errorf("appcontrol list assignments: %w", err)
+	}
+	defer rows.Close()
+	out := []api.Assignment{}
+	for rows.Next() {
+		var a api.Assignment
+		if err := rows.Scan(&a.PolicyID, &a.HostGroupID, &a.Priority, &a.CreatedAt); err != nil {
+			return nil, fmt.Errorf("appcontrol scan assignment: %w", err)
+		}
+		out = append(out, a)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("appcontrol iterate assignments: %w", err)
+	}
+	return out, nil
+}
+
 // GetPolicyByName loads the policy row by name. Rules are NOT populated; callers that need rules call ListRulesByPolicy explicitly.
 // A future GetPolicyWithRules helper can join the two queries when an endpoint shows up that needs both in one round trip; today's
 // REST surface fetches them separately.

--- a/server/rules/internal/appcontrol/store.go
+++ b/server/rules/internal/appcontrol/store.go
@@ -252,6 +252,40 @@ func (s *Store) ListPolicies(ctx context.Context) ([]api.ApplicationControlPolic
 	return out, nil
 }
 
+// buildListRulesAcrossPoliciesWhere assembles the parameterised WHERE clause + args slice from the set filter dimensions on
+// req. Each dimension appends its placeholder + arg in lockstep so the SQL stays parameterised end-to-end (no string
+// concatenation of operator input). Empty filter returns "1=1" + empty args so the caller can splice unconditionally.
+// Extracted from ListRulesAcrossPolicies to keep that method under Sonar's S3776 cognitive-complexity threshold.
+func buildListRulesAcrossPoliciesWhere(req api.ListRulesAcrossPoliciesRequest) (string, []any) {
+	clauses := []string{"1=1"}
+	args := []any{}
+	if req.PolicyID != nil {
+		clauses = append(clauses, "policy_id = ?")
+		args = append(args, *req.PolicyID)
+	}
+	if req.RuleType != "" {
+		clauses = append(clauses, "rule_type = ?")
+		args = append(args, req.RuleType)
+	}
+	if req.Enabled != nil {
+		clauses = append(clauses, "enabled = ?")
+		enabledArg := 0
+		if *req.Enabled {
+			enabledArg = 1
+		}
+		args = append(args, enabledArg)
+	}
+	if req.Severity != "" {
+		clauses = append(clauses, "severity = ?")
+		args = append(args, req.Severity)
+	}
+	if req.Source != "" {
+		clauses = append(clauses, "source = ?")
+		args = append(args, req.Source)
+	}
+	return strings.Join(clauses, " AND "), args
+}
+
 // ListRulesAcrossPolicies returns rules matching the filter across every policy (or one, when req.PolicyID is set). Powers the
 // cross-policy GET /rules endpoint that integration callers + audit exports need. Two queries: one count, one page. The page
 // is ordered by (policy_id, rule_type, identifier, id) so pagination is deterministic across sibling rows with identical
@@ -268,35 +302,7 @@ func (s *Store) ListRulesAcrossPolicies(
 	}
 	offset := max(req.Offset, 0)
 
-	// Build the dynamic WHERE clause from the set dimensions. Each branch appends its placeholder + arg in lockstep so the
-	// SQL stays parameterised end-to-end (no string concatenation of operator input). Empty filter -> WHERE 1=1, full scan.
-	clauses := []string{"1=1"}
-	args := []any{}
-	if req.PolicyID != nil {
-		clauses = append(clauses, "policy_id = ?")
-		args = append(args, *req.PolicyID)
-	}
-	if req.RuleType != "" {
-		clauses = append(clauses, "rule_type = ?")
-		args = append(args, req.RuleType)
-	}
-	if req.Enabled != nil {
-		clauses = append(clauses, "enabled = ?")
-		if *req.Enabled {
-			args = append(args, 1)
-		} else {
-			args = append(args, 0)
-		}
-	}
-	if req.Severity != "" {
-		clauses = append(clauses, "severity = ?")
-		args = append(args, req.Severity)
-	}
-	if req.Source != "" {
-		clauses = append(clauses, "source = ?")
-		args = append(args, req.Source)
-	}
-	where := strings.Join(clauses, " AND ")
+	where, args := buildListRulesAcrossPoliciesWhere(req)
 
 	// Count first so the wire response can render "Showing N of M" without a second client-side round trip.
 	var total int

--- a/server/rules/internal/operator/appcontrol_handler.go
+++ b/server/rules/internal/operator/appcontrol_handler.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -693,63 +694,11 @@ func (h *AppControlHandler) handleListRulesAcrossPolicies(w http.ResponseWriter,
 		identityapi.Resource{Type: "application_control"}) {
 		return
 	}
-	q := r.URL.Query()
-	req := api.ListRulesAcrossPoliciesRequest{}
-	if raw := q.Get("policy_id"); raw != "" {
-		id, err := strconv.ParseInt(raw, 10, 64)
-		if err != nil || id <= 0 {
-			writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, errCodeInvalidQuery, "invalid policy_id query parameter")
-			return
-		}
-		req.PolicyID = &id
+	req, errMsg := parseListRulesAcrossPoliciesQuery(r.URL.Query())
+	if errMsg != "" {
+		writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, errCodeInvalidQuery, errMsg)
+		return
 	}
-	if raw := q.Get("rule_type"); raw != "" {
-		rt := api.RuleType(raw)
-		if !api.IsValidRuleType(rt) {
-			writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, errCodeInvalidQuery,
-				"invalid rule_type query parameter (one of: BINARY, CDHASH, SIGNINGID, CERTIFICATE, TEAMID, PATH)")
-			return
-		}
-		req.RuleType = rt
-	}
-	if raw := q.Get("enabled"); raw != "" {
-		b, err := strconv.ParseBool(raw)
-		if err != nil {
-			writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, errCodeInvalidQuery, "invalid enabled query parameter (use true/false)")
-			return
-		}
-		req.Enabled = &b
-	}
-	if raw := q.Get("severity"); raw != "" {
-		sev := api.Severity(raw)
-		if !api.IsValidSeverity(sev) {
-			writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, errCodeInvalidQuery,
-				"invalid severity query parameter (one of: low, medium, high, critical)")
-			return
-		}
-		req.Severity = sev
-	}
-	req.Source = q.Get("source")
-	if raw := q.Get("limit"); raw != "" {
-		n, err := strconv.Atoi(raw)
-		if err != nil || n < 1 || n > api.MaxListRulesAcrossPoliciesLimit {
-			writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, errCodeInvalidQuery,
-				"invalid limit query parameter (1.."+strconv.Itoa(api.MaxListRulesAcrossPoliciesLimit)+")")
-			return
-		}
-		req.Limit = n
-	} else {
-		req.Limit = api.DefaultListRulesAcrossPoliciesLimit
-	}
-	if raw := q.Get("offset"); raw != "" {
-		n, err := strconv.Atoi(raw)
-		if err != nil || n < 0 {
-			writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, errCodeInvalidQuery, "invalid offset query parameter (>= 0)")
-			return
-		}
-		req.Offset = n
-	}
-
 	result, err := h.svc.ListRulesAcrossPolicies(ctx, req)
 	if err != nil {
 		h.logger.ErrorContext(ctx, "appcontrol list rules across policies", "err", err)
@@ -762,6 +711,79 @@ func (h *AppControlHandler) handleListRulesAcrossPolicies(w http.ResponseWriter,
 		Limit:  req.Limit,
 		Offset: req.Offset,
 	})
+}
+
+// parseListRulesAcrossPoliciesQuery parses the query string for GET /api/v1/app-control/rules into the typed request the
+// Store consumes. Returns (req, "") on success; (zero req, errMsg) on the first malformed value. Extracted from
+// handleListRulesAcrossPolicies to keep the handler under Sonar's S3776 cognitive-complexity threshold; the helper itself
+// further delegates filter + pagination parsing to two sub-helpers so each function stays under the threshold individually.
+func parseListRulesAcrossPoliciesQuery(q url.Values) (api.ListRulesAcrossPoliciesRequest, string) {
+	req := api.ListRulesAcrossPoliciesRequest{}
+	if msg := parseListRulesFilterParams(q, &req); msg != "" {
+		return api.ListRulesAcrossPoliciesRequest{}, msg
+	}
+	if msg := parseListRulesPaginationParams(q, &req); msg != "" {
+		return api.ListRulesAcrossPoliciesRequest{}, msg
+	}
+	return req, ""
+}
+
+// parseListRulesFilterParams handles the per-dimension filter parameters (policy_id, rule_type, enabled, severity, source).
+// Returns an error message string on the first invalid value; empty string on success. Mutates *req in place.
+func parseListRulesFilterParams(q url.Values, req *api.ListRulesAcrossPoliciesRequest) string {
+	if raw := q.Get("policy_id"); raw != "" {
+		id, err := strconv.ParseInt(raw, 10, 64)
+		if err != nil || id <= 0 {
+			return "invalid policy_id query parameter"
+		}
+		req.PolicyID = &id
+	}
+	if raw := q.Get("rule_type"); raw != "" {
+		rt := api.RuleType(raw)
+		if !api.IsValidRuleType(rt) {
+			return "invalid rule_type query parameter (one of: BINARY, CDHASH, SIGNINGID, CERTIFICATE, TEAMID, PATH)"
+		}
+		req.RuleType = rt
+	}
+	if raw := q.Get("enabled"); raw != "" {
+		b, err := strconv.ParseBool(raw)
+		if err != nil {
+			return "invalid enabled query parameter (use true/false)"
+		}
+		req.Enabled = &b
+	}
+	if raw := q.Get("severity"); raw != "" {
+		sev := api.Severity(raw)
+		if !api.IsValidSeverity(sev) {
+			return "invalid severity query parameter (one of: low, medium, high, critical)"
+		}
+		req.Severity = sev
+	}
+	req.Source = q.Get("source")
+	return ""
+}
+
+// parseListRulesPaginationParams handles the limit + offset query parameters. Limit defaults to DefaultListRulesAcrossPoliciesLimit
+// when absent and is clamped at [1, MaxListRulesAcrossPoliciesLimit]; offset defaults to 0 and rejects negatives. Returns an
+// error message on the first malformed value; empty string on success. Mutates *req in place.
+func parseListRulesPaginationParams(q url.Values, req *api.ListRulesAcrossPoliciesRequest) string {
+	if raw := q.Get("limit"); raw != "" {
+		n, err := strconv.Atoi(raw)
+		if err != nil || n < 1 || n > api.MaxListRulesAcrossPoliciesLimit {
+			return "invalid limit query parameter (1.." + strconv.Itoa(api.MaxListRulesAcrossPoliciesLimit) + ")"
+		}
+		req.Limit = n
+	} else {
+		req.Limit = api.DefaultListRulesAcrossPoliciesLimit
+	}
+	if raw := q.Get("offset"); raw != "" {
+		n, err := strconv.Atoi(raw)
+		if err != nil || n < 0 {
+			return "invalid offset query parameter (>= 0)"
+		}
+		req.Offset = n
+	}
+	return ""
 }
 
 // hostGroupResponse is the JSON wire shape the GET /host-groups list endpoint emits. Wraps the slice so future pagination
@@ -822,7 +844,7 @@ type assignmentsResponse struct {
 }
 
 // handleListAssignments serves GET /api/v1/app-control/policies/{id}/assignments. Returns the raw assignment rows for the
-// policy in (priority, host_group_id) order. Returns [] for a policy with no assignments — does NOT 404 on unknown policy
+// policy in (priority, host_group_id) order. Returns [] for a policy with no assignments: does NOT 404 on unknown policy
 // id (returning an empty list is the correct shape for "policy exists but is unassigned", a valid Phase B state).
 func (h *AppControlHandler) handleListAssignments(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
@@ -850,12 +872,19 @@ func (h *AppControlHandler) handleListAssignments(w http.ResponseWriter, r *http
 // B's editable host-group + assignment mutations replace this with real handlers; until then any non-GET request returns
 // 405 with the typed application_control.read_only_in_phase_a code + an Allow header naming the read methods that DO work.
 //
-// Authz is intentionally NOT gated here: returning 405 to unauth callers is fine (no information leak — the route exists
-// independent of the caller's permissions, and the wire-shape test surface should be exercisable without a credential to
-// keep CI scaffolding lean).
+// Authz gates on ActionAppControlRead (CodeRabbit finding on PR #195): every route here is wired through the outer-mux
+// session-protected allowlist already, so callers ARE authenticated. Without the gate, an authenticated session lacking
+// app-control read permission would still receive the typed 405 + Allow header, leaking the API contract shape. Gating
+// on Read aligns with the GET endpoints on the same resource so the permission story is uniform across host-groups.
 func (h *AppControlHandler) handlePhaseAImmutable(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	if !identityapi.HTTPGate(ctx, w, h.authz, h.logger,
+		identityapi.ActionAppControlRead,
+		identityapi.Resource{Type: "application_control"}) {
+		return
+	}
 	w.Header().Set("Allow", phaseAImmutableAllowHeader(r.URL.Path))
-	writeAppControlErr(r.Context(), h.logger, w, http.StatusMethodNotAllowed, errCodeReadOnlyPhaseA, errMsgReadOnlyPhaseA)
+	writeAppControlErr(ctx, h.logger, w, http.StatusMethodNotAllowed, errCodeReadOnlyPhaseA, errMsgReadOnlyPhaseA)
 }
 
 // phaseAImmutableAllowHeader returns the Allow header value the 405 response carries. Per RFC 9110 §15.5.6 a 405 MUST include

--- a/server/rules/internal/operator/appcontrol_handler.go
+++ b/server/rules/internal/operator/appcontrol_handler.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	identityapi "github.com/fleetdm/edr/server/identity/api"
@@ -47,6 +48,14 @@ const (
 	errMsgDuplicatePolicy  = "a policy with that name already exists"
 	errCodePolicyImmutable = "application_control.policy_immutable"
 	errMsgPolicyImmutable  = "the seed Default policy cannot be deleted"
+	// errCodeHostGroupNotFound + errMsgHostGroupNotFound are surfaced by GET /host-groups/{id} on stale ids.
+	errCodeHostGroupNotFound = "application_control.host_group_not_found"
+	errMsgHostGroupNotFound  = "host group not found"
+	// errCodeReadOnlyPhaseA is the typed 405 code every host-group + assignment mutation returns until Phase B lands editable
+	// host-group + assignment mutations. The route exists so the wire-shape contract is testable today, but the surface is
+	// intentionally inert. The companion message names the action so a client can show a precise diagnostic.
+	errCodeReadOnlyPhaseA  = "application_control.read_only_in_phase_a"
+	errMsgReadOnlyPhaseA   = "host group and assignment mutations are deferred to Phase B; Phase A is read-only"
 	internalErrorCode      = "internal"
 	noActorOnContextLogMsg = "appcontrol handler: no actor on ctx despite session middleware"
 )
@@ -87,9 +96,16 @@ func NewAppControl(svc *appcontrol.Service, authz identityapi.AuthZ, logger *slo
 //	PATCH  /api/v1/app-control/rules/{id}
 //	DELETE /api/v1/app-control/rules/{id}
 //	GET    /api/v1/app-control/rules
+//	GET    /api/v1/app-control/host-groups
+//	GET    /api/v1/app-control/host-groups/{id}
+//	POST   /api/v1/app-control/host-groups               (Phase A: 405 read_only_in_phase_a)
+//	PATCH  /api/v1/app-control/host-groups/{id}          (Phase A: 405 read_only_in_phase_a)
+//	DELETE /api/v1/app-control/host-groups/{id}          (Phase A: 405 read_only_in_phase_a)
+//	GET    /api/v1/app-control/policies/{id}/assignments
+//	POST   /api/v1/app-control/policies/{id}/assignments              (Phase A: 405 read_only_in_phase_a)
+//	DELETE /api/v1/app-control/policies/{id}/assignments/{group_id}   (Phase A: 405 read_only_in_phase_a)
 //
-// host-groups CRUD / assignments POST stay deferred to follow-on PRs. Caller wraps the mux in identity Session + CSRF
-// middleware before mounting (the existing operator pattern in cmd/main).
+// Caller wraps the mux in identity Session + CSRF middleware before mounting (the existing operator pattern in cmd/main).
 func (h *AppControlHandler) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/v1/app-control/policies", h.handleListPolicies)
 	mux.HandleFunc("GET /api/v1/app-control/policies/{id}", h.handleGetPolicy)
@@ -101,6 +117,14 @@ func (h *AppControlHandler) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("PATCH /api/v1/app-control/rules/{id}", h.handleUpdateRule)
 	mux.HandleFunc("DELETE /api/v1/app-control/rules/{id}", h.handleDeleteRule)
 	mux.HandleFunc("GET /api/v1/app-control/rules", h.handleListRulesAcrossPolicies)
+	mux.HandleFunc("GET /api/v1/app-control/host-groups", h.handleListHostGroups)
+	mux.HandleFunc("GET /api/v1/app-control/host-groups/{id}", h.handleGetHostGroup)
+	mux.HandleFunc("POST /api/v1/app-control/host-groups", h.handlePhaseAImmutable)
+	mux.HandleFunc("PATCH /api/v1/app-control/host-groups/{id}", h.handlePhaseAImmutable)
+	mux.HandleFunc("DELETE /api/v1/app-control/host-groups/{id}", h.handlePhaseAImmutable)
+	mux.HandleFunc("GET /api/v1/app-control/policies/{id}/assignments", h.handleListAssignments)
+	mux.HandleFunc("POST /api/v1/app-control/policies/{id}/assignments", h.handlePhaseAImmutable)
+	mux.HandleFunc("DELETE /api/v1/app-control/policies/{id}/assignments/{group_id}", h.handlePhaseAImmutable)
 }
 
 func (h *AppControlHandler) handleListPolicies(w http.ResponseWriter, r *http.Request) {
@@ -738,6 +762,112 @@ func (h *AppControlHandler) handleListRulesAcrossPolicies(w http.ResponseWriter,
 		Limit:  req.Limit,
 		Offset: req.Offset,
 	})
+}
+
+// hostGroupResponse is the JSON wire shape the GET /host-groups list endpoint emits. Wraps the slice so future pagination
+// metadata can land alongside without a wire-shape break (same posture as the policies list).
+type hostGroupsResponse struct {
+	HostGroups []api.HostGroup `json:"host_groups"`
+}
+
+// handleListHostGroups serves GET /api/v1/app-control/host-groups. Returns every host_group row alphabetically by name.
+// Phase A always returns the single seed `all-hosts` group; Phase B grows the result when editable groups land.
+func (h *AppControlHandler) handleListHostGroups(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	if !identityapi.HTTPGate(ctx, w, h.authz, h.logger,
+		identityapi.ActionAppControlRead,
+		identityapi.Resource{Type: "application_control"}) {
+		return
+	}
+	groups, err := h.svc.ListHostGroups(ctx)
+	if err != nil {
+		h.logger.ErrorContext(ctx, "appcontrol list host groups", "err", err)
+		writeAppControlErr(ctx, h.logger, w, http.StatusInternalServerError, internalErrorCode, internalErrorMessage)
+		return
+	}
+	writeJSON(ctx, h.logger, w, http.StatusOK, hostGroupsResponse{HostGroups: groups})
+}
+
+// handleGetHostGroup serves GET /api/v1/app-control/host-groups/{id}. Returns 404 with the typed host_group_not_found code
+// on stale ids so the REST client can distinguish "the row was removed" from a generic 500.
+func (h *AppControlHandler) handleGetHostGroup(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	if !identityapi.HTTPGate(ctx, w, h.authz, h.logger,
+		identityapi.ActionAppControlRead,
+		identityapi.Resource{Type: "application_control"}) {
+		return
+	}
+	id, ok := parsePositiveInt64Path(r)
+	if !ok {
+		writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, errCodeInvalidQuery, "invalid host group id")
+		return
+	}
+	group, err := h.svc.GetHostGroupByID(ctx, id)
+	if err != nil {
+		if errors.Is(err, api.ErrAppControlHostGroupNotFound) {
+			writeAppControlErr(ctx, h.logger, w, http.StatusNotFound, errCodeHostGroupNotFound, errMsgHostGroupNotFound)
+			return
+		}
+		h.logger.ErrorContext(ctx, "appcontrol get host group", "err", err, "host_group_id", id)
+		writeAppControlErr(ctx, h.logger, w, http.StatusInternalServerError, internalErrorCode, internalErrorMessage)
+		return
+	}
+	writeJSON(ctx, h.logger, w, http.StatusOK, group)
+}
+
+// assignmentsResponse is the JSON wire shape the GET /policies/{id}/assignments endpoint emits. Wrapping the slice mirrors
+// the policies + host-groups list shape.
+type assignmentsResponse struct {
+	Assignments []api.Assignment `json:"assignments"`
+}
+
+// handleListAssignments serves GET /api/v1/app-control/policies/{id}/assignments. Returns the raw assignment rows for the
+// policy in (priority, host_group_id) order. Returns [] for a policy with no assignments — does NOT 404 on unknown policy
+// id (returning an empty list is the correct shape for "policy exists but is unassigned", a valid Phase B state).
+func (h *AppControlHandler) handleListAssignments(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	if !identityapi.HTTPGate(ctx, w, h.authz, h.logger,
+		identityapi.ActionAppControlRead,
+		identityapi.Resource{Type: "application_control"}) {
+		return
+	}
+	policyID, ok := parsePolicyID(r)
+	if !ok {
+		writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, errCodeInvalidPolicyID, errMsgInvalidPolicyID)
+		return
+	}
+	assignments, err := h.svc.ListAssignmentsForPolicy(ctx, policyID)
+	if err != nil {
+		h.logger.ErrorContext(ctx, "appcontrol list assignments", "err", err, "policy_id", policyID)
+		writeAppControlErr(ctx, h.logger, w, http.StatusInternalServerError, internalErrorCode, internalErrorMessage)
+		return
+	}
+	writeJSON(ctx, h.logger, w, http.StatusOK, assignmentsResponse{Assignments: assignments})
+}
+
+// handlePhaseAImmutable is the shared handler for every host-group + assignment mutation route in Phase A. The routes exist
+// so the wire-shape contract is testable today (closes tasks 11.4.8 + 11.4.9), but the surface is intentionally inert. Phase
+// B's editable host-group + assignment mutations replace this with real handlers; until then any non-GET request returns
+// 405 with the typed application_control.read_only_in_phase_a code + an Allow header naming the read methods that DO work.
+//
+// Authz is intentionally NOT gated here: returning 405 to unauth callers is fine (no information leak — the route exists
+// independent of the caller's permissions, and the wire-shape test surface should be exercisable without a credential to
+// keep CI scaffolding lean).
+func (h *AppControlHandler) handlePhaseAImmutable(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Allow", phaseAImmutableAllowHeader(r.URL.Path))
+	writeAppControlErr(r.Context(), h.logger, w, http.StatusMethodNotAllowed, errCodeReadOnlyPhaseA, errMsgReadOnlyPhaseA)
+}
+
+// phaseAImmutableAllowHeader returns the Allow header value the 405 response carries. Per RFC 9110 §15.5.6 a 405 MUST include
+// Allow with the methods the resource DOES accept. The two collection roots (/host-groups, /policies/{id}/assignments)
+// accept GET; the single-resource sub-paths (/host-groups/{id}) also accept GET. The /assignments/{group_id} sub-resource
+// has no GET today (the parent /assignments list covers it), so Allow is empty there.
+func phaseAImmutableAllowHeader(path string) string {
+	// Collection roots + single-resource sub-paths both accept GET; the /assignments/{group_id} leaf does not.
+	if strings.Contains(path, "/assignments/") {
+		return ""
+	}
+	return "GET"
 }
 
 // writeAppControlErr emits the typed ErrorResponse shape every other operator handler in the codebase uses. Code is the

--- a/server/rules/internal/tests/app_control_test.go
+++ b/server/rules/internal/tests/app_control_test.go
@@ -984,3 +984,70 @@ func TestAppControl_BulkUpsertRules_UnknownPolicyMapsToNotFound(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorIs(t, err, api.ErrAppControlPolicyNotFound)
 }
+
+// TestAppControl_ListHostGroups_SurfacesSeedAllHosts: the bootstrap seeds the `all-hosts` group; the list method must return it.
+// Phase A always has exactly one row; this test pins that contract so a regression where the seed got skipped surfaces.
+func TestAppControl_ListHostGroups_SurfacesSeedAllHosts(t *testing.T) {
+	t.Parallel()
+	store, _ := newAppControlStore(t)
+
+	groups, err := store.ListHostGroups(t.Context())
+	require.NoError(t, err)
+	require.Len(t, groups, 1, "Phase A bootstrap seeds exactly one host group")
+	assert.Equal(t, api.DefaultHostGroupName, groups[0].Name)
+	assert.NotZero(t, groups[0].ID)
+}
+
+// TestAppControl_GetHostGroupByID_ReturnsSeedRow + NotFound: round-trip the lookup-by-id contract the REST handler depends on.
+func TestAppControl_GetHostGroupByID_ReturnsSeedRow(t *testing.T) {
+	t.Parallel()
+	store, _ := newAppControlStore(t)
+	groups, err := store.ListHostGroups(t.Context())
+	require.NoError(t, err)
+	require.NotEmpty(t, groups)
+
+	byID, err := store.GetHostGroupByID(t.Context(), groups[0].ID)
+	require.NoError(t, err)
+	assert.Equal(t, groups[0].ID, byID.ID)
+	assert.Equal(t, api.DefaultHostGroupName, byID.Name)
+}
+
+func TestAppControl_GetHostGroupByID_NotFound(t *testing.T) {
+	t.Parallel()
+	store, _ := newAppControlStore(t)
+	_, err := store.GetHostGroupByID(t.Context(), 99_999_999)
+	require.ErrorIs(t, err, api.ErrAppControlHostGroupNotFound)
+}
+
+// TestAppControl_ListAssignmentsForPolicy_SurfacesSeedAssignment: the bootstrap seeds the Default policy + the
+// Default → all-hosts assignment. ListAssignmentsForPolicy on the seed policy returns exactly one row pointing at the seed
+// host group with priority 0. Tests the raw-rows shape the REST handler emits (distinct from ListHostGroupsForPolicy which
+// returns the joined group metadata).
+func TestAppControl_ListAssignmentsForPolicy_SurfacesSeedAssignment(t *testing.T) {
+	t.Parallel()
+	store, _ := newAppControlStore(t)
+	defaultPolicy, err := store.GetPolicyByName(t.Context(), api.DefaultPolicyName)
+	require.NoError(t, err)
+	groups, err := store.ListHostGroups(t.Context())
+	require.NoError(t, err)
+	require.NotEmpty(t, groups)
+
+	assignments, err := store.ListAssignmentsForPolicy(t.Context(), defaultPolicy.ID)
+	require.NoError(t, err)
+	require.Len(t, assignments, 1, "seed bootstrap creates exactly one assignment row (Default → all-hosts)")
+	assert.Equal(t, defaultPolicy.ID, assignments[0].PolicyID)
+	assert.Equal(t, groups[0].ID, assignments[0].HostGroupID)
+	assert.Equal(t, 0, assignments[0].Priority)
+}
+
+// TestAppControl_ListAssignmentsForPolicy_UnknownPolicyReturnsEmpty: returning [] for a policy that does not exist is the
+// correct shape — the handler should not 404 on the assignments collection endpoint. Phase A's seed always has its
+// assignment so this dimension only surfaces for synthetic ids; pinning the contract makes Phase B's editable assignments
+// land without changing the response shape on an empty result.
+func TestAppControl_ListAssignmentsForPolicy_UnknownPolicyReturnsEmpty(t *testing.T) {
+	t.Parallel()
+	store, _ := newAppControlStore(t)
+	assignments, err := store.ListAssignmentsForPolicy(t.Context(), 99_999_999)
+	require.NoError(t, err)
+	assert.Empty(t, assignments)
+}

--- a/server/rules/internal/tests/app_control_test.go
+++ b/server/rules/internal/tests/app_control_test.go
@@ -1004,7 +1004,10 @@ func TestAppControl_GetHostGroupByID_ReturnsSeedRow(t *testing.T) {
 	store, _ := newAppControlStore(t)
 	groups, err := store.ListHostGroups(t.Context())
 	require.NoError(t, err)
-	require.NotEmpty(t, groups)
+	// Pin the Phase A cardinality contract: exactly one seeded host group (all-hosts). A future regression that ships
+	// additional seed groups would surface here, not via a brittle groups[0] dereference (CodeRabbit on PR #195).
+	require.Len(t, groups, 1)
+	assert.Equal(t, api.DefaultHostGroupName, groups[0].Name)
 
 	byID, err := store.GetHostGroupByID(t.Context(), groups[0].ID)
 	require.NoError(t, err)
@@ -1020,7 +1023,7 @@ func TestAppControl_GetHostGroupByID_NotFound(t *testing.T) {
 }
 
 // TestAppControl_ListAssignmentsForPolicy_SurfacesSeedAssignment: the bootstrap seeds the Default policy + the
-// Default → all-hosts assignment. ListAssignmentsForPolicy on the seed policy returns exactly one row pointing at the seed
+// Default -> all-hosts assignment. ListAssignmentsForPolicy on the seed policy returns exactly one row pointing at the seed
 // host group with priority 0. Tests the raw-rows shape the REST handler emits (distinct from ListHostGroupsForPolicy which
 // returns the joined group metadata).
 func TestAppControl_ListAssignmentsForPolicy_SurfacesSeedAssignment(t *testing.T) {
@@ -1030,18 +1033,19 @@ func TestAppControl_ListAssignmentsForPolicy_SurfacesSeedAssignment(t *testing.T
 	require.NoError(t, err)
 	groups, err := store.ListHostGroups(t.Context())
 	require.NoError(t, err)
-	require.NotEmpty(t, groups)
+	require.Len(t, groups, 1)
+	assert.Equal(t, api.DefaultHostGroupName, groups[0].Name)
 
 	assignments, err := store.ListAssignmentsForPolicy(t.Context(), defaultPolicy.ID)
 	require.NoError(t, err)
-	require.Len(t, assignments, 1, "seed bootstrap creates exactly one assignment row (Default → all-hosts)")
+	require.Len(t, assignments, 1, "seed bootstrap creates exactly one assignment row (Default -> all-hosts)")
 	assert.Equal(t, defaultPolicy.ID, assignments[0].PolicyID)
 	assert.Equal(t, groups[0].ID, assignments[0].HostGroupID)
 	assert.Equal(t, 0, assignments[0].Priority)
 }
 
 // TestAppControl_ListAssignmentsForPolicy_UnknownPolicyReturnsEmpty: returning [] for a policy that does not exist is the
-// correct shape — the handler should not 404 on the assignments collection endpoint. Phase A's seed always has its
+// correct shape - the handler should not 404 on the assignments collection endpoint. Phase A's seed always has its
 // assignment so this dimension only surfaces for synthetic ids; pinning the contract makes Phase B's editable assignments
 // land without changing the response shape on an empty result.
 func TestAppControl_ListAssignmentsForPolicy_UnknownPolicyReturnsEmpty(t *testing.T) {

--- a/server/rules/internal/tests/appcontrol_rest_test.go
+++ b/server/rules/internal/tests/appcontrol_rest_test.go
@@ -1311,6 +1311,34 @@ func TestAppControlREST_GetHostGroup_NotFound(t *testing.T) {
 	assert.Equal(t, "application_control.host_group_not_found", errBody.Error)
 }
 
+// TestAppControlREST_GetHostGroup_InvalidID pins the typed 400 contract for malformed path ids (non-numeric, zero, negative).
+// CodeRabbit on PR #195 noted the missing coverage: the handler parses {id} via parsePositiveInt64Path which short-circuits
+// these shapes to errCodeInvalidQuery, and the test surface should exercise that branch directly.
+func TestAppControlREST_GetHostGroup_InvalidID(t *testing.T) {
+	t.Parallel()
+	r := newAppControlRig(t, []string{"host-a"})
+	cases := []struct {
+		name string
+		path string
+	}{
+		{"non-numeric id", "/api/v1/app-control/host-groups/abc"},
+		{"zero id", "/api/v1/app-control/host-groups/0"},
+		{"negative id", "/api/v1/app-control/host-groups/-1"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := r.do(t, http.MethodGet, tc.path, nil)
+			defer resp.Body.Close()
+			require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+			var errBody struct {
+				Error string `json:"error"`
+			}
+			require.NoError(t, json.NewDecoder(resp.Body).Decode(&errBody))
+			assert.Equal(t, "application_control.invalid_query", errBody.Error)
+		})
+	}
+}
+
 // TestAppControlREST_ListAssignments_SurfacesSeedRow: the seed Default policy has exactly one assignment row pointing at
 // the all-hosts group. Pinning the wire shape so a Phase B regression that drops the assignment is caught.
 func TestAppControlREST_ListAssignments_SurfacesSeedRow(t *testing.T) {
@@ -1386,6 +1414,8 @@ func TestAppControlREST_HostGroupMutations_ReadOnlyInPhaseA(t *testing.T) {
 			assert.Equal(t, "application_control.read_only_in_phase_a", body.Error)
 			if tc.expectAllowGET {
 				assert.Equal(t, "GET", resp.Header.Get("Allow"))
+			} else {
+				assert.Empty(t, resp.Header.Get("Allow"), "leaf route with no GET surface must emit empty Allow")
 			}
 		})
 	}

--- a/server/rules/internal/tests/appcontrol_rest_test.go
+++ b/server/rules/internal/tests/appcontrol_rest_test.go
@@ -1260,3 +1260,133 @@ func TestAppControlREST_ListRulesAcrossPolicies_Pagination(t *testing.T) {
 		assert.False(t, seen[r.ID], "page 2 must not repeat any row from page 1")
 	}
 }
+
+// TestAppControlREST_ListHostGroups_HappyPath: GET /host-groups returns the seed `all-hosts` row in a {host_groups: [...]}
+// envelope. Phase A always has this single row.
+func TestAppControlREST_ListHostGroups_HappyPath(t *testing.T) {
+	t.Parallel()
+	r := newAppControlRig(t, []string{"host-a"})
+	resp := r.do(t, http.MethodGet, "/api/v1/app-control/host-groups", nil)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	var body struct {
+		HostGroups []rulesapi.HostGroup `json:"host_groups"`
+	}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	require.Len(t, body.HostGroups, 1)
+	assert.Equal(t, rulesapi.DefaultHostGroupName, body.HostGroups[0].Name)
+}
+
+// TestAppControlREST_GetHostGroup_HappyPath + NotFound + InvalidID round-trips the single-row read.
+func TestAppControlREST_GetHostGroup_HappyPath(t *testing.T) {
+	t.Parallel()
+	r := newAppControlRig(t, []string{"host-a"})
+	list := r.do(t, http.MethodGet, "/api/v1/app-control/host-groups", nil)
+	var body struct {
+		HostGroups []rulesapi.HostGroup `json:"host_groups"`
+	}
+	require.NoError(t, json.NewDecoder(list.Body).Decode(&body))
+	list.Body.Close()
+	require.NotEmpty(t, body.HostGroups)
+
+	resp := r.do(t, http.MethodGet, "/api/v1/app-control/host-groups/"+i64(body.HostGroups[0].ID), nil)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	var got rulesapi.HostGroup
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&got))
+	assert.Equal(t, body.HostGroups[0].ID, got.ID)
+	assert.Equal(t, rulesapi.DefaultHostGroupName, got.Name)
+}
+
+func TestAppControlREST_GetHostGroup_NotFound(t *testing.T) {
+	t.Parallel()
+	r := newAppControlRig(t, []string{"host-a"})
+	resp := r.do(t, http.MethodGet, "/api/v1/app-control/host-groups/99999999", nil)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusNotFound, resp.StatusCode)
+	var errBody struct {
+		Error string `json:"error"`
+	}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&errBody))
+	assert.Equal(t, "application_control.host_group_not_found", errBody.Error)
+}
+
+// TestAppControlREST_ListAssignments_SurfacesSeedRow: the seed Default policy has exactly one assignment row pointing at
+// the all-hosts group. Pinning the wire shape so a Phase B regression that drops the assignment is caught.
+func TestAppControlREST_ListAssignments_SurfacesSeedRow(t *testing.T) {
+	t.Parallel()
+	r := newAppControlRig(t, []string{"host-a"})
+	policyID := r.defaultPolicyID(t)
+	resp := r.do(t, http.MethodGet, "/api/v1/app-control/policies/"+i64(policyID)+"/assignments", nil)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	var body struct {
+		Assignments []rulesapi.Assignment `json:"assignments"`
+	}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	require.Len(t, body.Assignments, 1)
+	assert.Equal(t, policyID, body.Assignments[0].PolicyID)
+	assert.NotZero(t, body.Assignments[0].HostGroupID)
+	assert.Equal(t, 0, body.Assignments[0].Priority)
+}
+
+// TestAppControlREST_ListAssignments_UnknownPolicyReturnsEmpty: the assignments endpoint does NOT 404 on a stale policy id;
+// returning [] is the correct shape. Pinning that contract here so a Phase B regression that adds a 404 check is caught.
+func TestAppControlREST_ListAssignments_UnknownPolicyReturnsEmpty(t *testing.T) {
+	t.Parallel()
+	r := newAppControlRig(t, []string{"host-a"})
+	resp := r.do(t, http.MethodGet, "/api/v1/app-control/policies/99999999/assignments", nil)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	var body struct {
+		Assignments []rulesapi.Assignment `json:"assignments"`
+	}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	assert.Empty(t, body.Assignments)
+}
+
+// TestAppControlREST_HostGroupMutations_ReadOnlyInPhaseA pins the 405 + typed error contract for every host-group +
+// assignment mutation route. Each case asserts the status code, the typed application_control.read_only_in_phase_a code,
+// and (for non-leaf paths) the Allow: GET header per RFC 9110.
+func TestAppControlREST_HostGroupMutations_ReadOnlyInPhaseA(t *testing.T) {
+	t.Parallel()
+	r := newAppControlRig(t, []string{"host-a"})
+	policyID := r.defaultPolicyID(t)
+	list := r.do(t, http.MethodGet, "/api/v1/app-control/host-groups", nil)
+	var listBody struct {
+		HostGroups []rulesapi.HostGroup `json:"host_groups"`
+	}
+	require.NoError(t, json.NewDecoder(list.Body).Decode(&listBody))
+	list.Body.Close()
+	require.NotEmpty(t, listBody.HostGroups)
+	groupID := listBody.HostGroups[0].ID
+
+	cases := []struct {
+		name           string
+		method         string
+		path           string
+		expectAllowGET bool
+	}{
+		{"POST /host-groups", http.MethodPost, "/api/v1/app-control/host-groups", true},
+		{"PATCH /host-groups/{id}", http.MethodPatch, "/api/v1/app-control/host-groups/" + i64(groupID), true},
+		{"DELETE /host-groups/{id}", http.MethodDelete, "/api/v1/app-control/host-groups/" + i64(groupID), true},
+		{"POST /policies/{id}/assignments", http.MethodPost, "/api/v1/app-control/policies/" + i64(policyID) + "/assignments", true},
+		// The /assignments/{group_id} leaf has no GET surface today; Allow header is empty.
+		{"DELETE /assignments/{group_id}", http.MethodDelete, "/api/v1/app-control/policies/" + i64(policyID) + "/assignments/" + i64(groupID), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := r.do(t, tc.method, tc.path, map[string]any{"placeholder": "phase A test"})
+			defer resp.Body.Close()
+			require.Equal(t, http.StatusMethodNotAllowed, resp.StatusCode)
+			var body struct {
+				Error string `json:"error"`
+			}
+			require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+			assert.Equal(t, "application_control.read_only_in_phase_a", body.Error)
+			if tc.expectAllowGET {
+				assert.Equal(t, "GET", resp.Header.Get("Allow"))
+			}
+		})
+	}
+}


### PR DESCRIPTION
…1.4.9)

Closes openspec tasks 11.4.8 + 11.4.9. The host_groups table + the seed `all-hosts` group + the seed Default → all-hosts assignment all already exist (PR #185); this PR exposes the read surface and wires the mutation routes as 405 stubs so the wire-shape contract is testable today and Phase B's editable mutations can land without route churn.

Read endpoints (GET, served from real seed data):
  GET /api/v1/app-control/host-groups
  GET /api/v1/app-control/host-groups/{id}
  GET /api/v1/app-control/policies/{id}/assignments

Phase A read-only stubs (POST/PATCH/DELETE -> 405 with typed code application_control.read_only_in_phase_a + Allow header per RFC 9110):
  POST   /api/v1/app-control/host-groups
  PATCH  /api/v1/app-control/host-groups/{id}
  DELETE /api/v1/app-control/host-groups/{id}
  POST   /api/v1/app-control/policies/{id}/assignments
  DELETE /api/v1/app-control/policies/{id}/assignments/{group_id}

Implementation:
- New api.ErrAppControlHostGroupNotFound sentinel + three Store methods (ListHostGroups, GetHostGroupByID, ListAssignmentsForPolicy) on the ApplicationControlStore interface, mirroring the existing GetPolicyByID / ListRulesByPolicy posture.
- Service pass-throughs leave the orchestrator layer in place for future read-side decoration (member-count rollup) without changing the handler contract.
- Single handlePhaseAImmutable handler shared by all five mutation routes; writes the Allow header from a path-shape switch (the /assignments/{group_id} leaf has no GET so its Allow is empty per RFC 9110 §15.5.6).
- Authz reuses ActionAppControlRead for the GET paths; handlePhaseAImmutable intentionally does NOT authz-gate so the wire-shape contract is exercisable without credentials.
- ListAssignmentsForPolicy returns [] for an unknown policy id rather than 404 — returning empty is the correct shape for a policy with no assignments (a valid Phase B state) and pins that contract upfront.

Outer-mux session-protected allowlist (cmd/fleet-edr-server/main.go) gains entries for all eight new routes.

Tests:
- Store-level: TestAppControl_ListHostGroups_SurfacesSeedAllHosts, GetHostGroupByID_ReturnsSeedRow + NotFound, ListAssignmentsForPolicy_SurfacesSeedAssignment + UnknownPolicyReturnsEmpty.
- REST-level: TestAppControlREST_ListHostGroups_HappyPath, GetHostGroup_HappyPath + NotFound, ListAssignments_SurfacesSeedRow
  + UnknownPolicyReturnsEmpty, plus a five-subtest HostGroupMutations_ReadOnlyInPhaseA pinning the 405 + typed-error
  + Allow header for every mutation route.

Manual QA on dev:server: drove all 10 endpoints via fetch from the authenticated SPA tab. Every read returned correctly-shaped JSON; every mutation returned 405 with application_control.read_only_in_phase_a and the documented Allow header.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added API endpoints for viewing host groups and policy assignments in Application Control
  * Implemented read-only mode for host group and assignment mutations with appropriate HTTP 405 responses

* **Improvements**
  * Enhanced error handling with specific error codes for missing host groups (HTTP 404)
  * Improved API response consistency for edge cases

* **Tests**
  * Added comprehensive integration test coverage for new host group and assignment endpoints

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/getvictor/fleet-edr/pull/195?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->