### PR TITLE
app-control: per-policy assignment_count + overlap fan-out dedup test…

### DIFF
--- a/server/detection/internal/tests/integration_test.go
+++ b/server/detection/internal/tests/integration_test.go
@@ -708,10 +708,18 @@ func TestGraph_ExecPayloadCDHashRoundTrips(t *testing.T) {
 			Payload: json.RawMessage(`{"pid":1002,"ppid":1,"path":"/usr/bin/legacy","args":["legacy"],"sha256":"cafef00d"}`)},
 	})
 
+	// Wait until BOTH rows have landed before asserting either one's shape. The processor is async and the two exec events
+	// are not guaranteed to materialise in the order they were posted; without this combined wait, a CI run that races the
+	// 1001 Eventually-pass against the 1002 row commit would return nil for nonHR even though both are inflight (issue
+	// caught in the PR #197 CI run where 1001 landed first and 1002 was still queued when the test asserted).
 	require.Eventually(t, func() bool {
-		p, err := d.Service().GetProcessDetail(ctx, "h-cdh", 1001, now+1)
-		return err == nil && p != nil && p.Process.CDHash != nil && *p.Process.CDHash == cdhash
-	}, 5*time.Second, 50*time.Millisecond, "HR exec must persist cdhash on the processes row")
+		hr, err := d.Service().GetProcessDetail(ctx, "h-cdh", 1001, now+1)
+		if err != nil || hr == nil || hr.Process.CDHash == nil || *hr.Process.CDHash != cdhash {
+			return false
+		}
+		nonHR, err := d.Service().GetProcessDetail(ctx, "h-cdh", 1002, now+2)
+		return err == nil && nonHR != nil
+	}, 5*time.Second, 50*time.Millisecond, "both HR + non-HR exec rows must materialise before the shape assertions")
 
 	hr, err := d.Service().GetProcessDetail(ctx, "h-cdh", 1001, now+1)
 	require.NoError(t, err)

--- a/server/rules/api/types.go
+++ b/server/rules/api/types.go
@@ -252,9 +252,11 @@ const (
 
 // ApplicationControlPolicy mirrors a row in app_control_policies. Used by the REST surface for list/get responses and by the fan-out
 // code when constructing the `set_application_control` agent command. Rules is populated by GetWithRules and the rule listing
-// endpoints; bare Get omits it. AssignmentCount is a derived field: ListPolicies and GetPolicyByID populate it via a LEFT JOIN
-// against the assignments aggregate so the UI's policies-list view can render "N host groups" without an N+1 round trip. Other
+// endpoints; bare Get omits it. AssignmentCount is a derived field every policy fetch path populates (GetPolicyByName,
+// GetPolicyByID, ListPolicies) so the UI's policies-list view can render "N host groups" without an N+1 round trip. Other
 // internal callers (create/update audit paths) get a populated count they may ignore; the field is always authoritative.
+// The seeded Default policy starts at 1 (its assignment to the seed all-hosts group); policies created via CreatePolicy start
+// at 0 and grow when Phase B opens up assignment editing.
 type ApplicationControlPolicy struct {
 	ID              int64                    `json:"id"`
 	Name            string                   `json:"name"`

--- a/server/rules/api/types.go
+++ b/server/rules/api/types.go
@@ -252,18 +252,21 @@ const (
 
 // ApplicationControlPolicy mirrors a row in app_control_policies. Used by the REST surface for list/get responses and by the fan-out
 // code when constructing the `set_application_control` agent command. Rules is populated by GetWithRules and the rule listing
-// endpoints; bare Get omits it.
+// endpoints; bare Get omits it. AssignmentCount is a derived field: ListPolicies and GetPolicyByID populate it via a LEFT JOIN
+// against the assignments aggregate so the UI's policies-list view can render "N host groups" without an N+1 round trip. Other
+// internal callers (create/update audit paths) get a populated count they may ignore; the field is always authoritative.
 type ApplicationControlPolicy struct {
-	ID            int64                    `json:"id"`
-	Name          string                   `json:"name"`
-	Description   string                   `json:"description"`
-	Version       int64                    `json:"version"`
-	DefaultAction PolicyDefaultAction      `json:"default_action"`
-	CreatedAt     time.Time                `json:"created_at"`
-	UpdatedAt     time.Time                `json:"updated_at"`
-	CreatedBy     string                   `json:"created_by"`
-	UpdatedBy     string                   `json:"updated_by"`
-	Rules         []ApplicationControlRule `json:"rules,omitempty"`
+	ID              int64                    `json:"id"`
+	Name            string                   `json:"name"`
+	Description     string                   `json:"description"`
+	Version         int64                    `json:"version"`
+	DefaultAction   PolicyDefaultAction      `json:"default_action"`
+	CreatedAt       time.Time                `json:"created_at"`
+	UpdatedAt       time.Time                `json:"updated_at"`
+	CreatedBy       string                   `json:"created_by"`
+	UpdatedBy       string                   `json:"updated_by"`
+	AssignmentCount int                      `json:"assignment_count"`
+	Rules           []ApplicationControlRule `json:"rules,omitempty"`
 }
 
 // ApplicationControlRule mirrors a row in app_control_rules.

--- a/server/rules/internal/appcontrol/store.go
+++ b/server/rules/internal/appcontrol/store.go
@@ -197,18 +197,17 @@ func (s *Store) ListAssignmentsForPolicy(ctx context.Context, policyID int64) ([
 	return out, nil
 }
 
-// policySelectWithAssignmentCount is the SELECT-list + FROM-clause every policy fetch uses. The LEFT JOIN against the
-// assignments aggregate populates the derived AssignmentCount field in a single round trip; COALESCE turns the LEFT-JOIN NULL
-// for policies with zero assignments into the integer zero scan target expects. The aggregate sub-query groups by policy_id so
-// each parent row joins to exactly one summary row regardless of how many host groups the policy has assigned. Centralised so
-// GetPolicyByName / getPolicyByID / ListPolicies stay structurally identical and the scan order they all share is one source
-// of truth.
+// policySelectWithAssignmentCount is the SELECT-list + FROM-clause every policy fetch uses. The correlated subquery in the
+// SELECT list computes the assignment count for each output row; MySQL's planner can use the (policy_id, host_group_id)
+// composite PK index on app_control_assignments to count without scanning the table. Cheaper than a LEFT JOIN against an
+// aggregate subquery for single-row PK lookups (GetPolicyByName, getPolicyByID) where that join would materialize counts for
+// every policy in the table; ListPolicies pays the per-row subquery cost N times but each one is the indexed COUNT(*) above.
+// Centralised so GetPolicyByName / getPolicyByID / ListPolicies stay structurally identical and the scan order they all share
+// is one source of truth.
 const policySelectWithAssignmentCount = `SELECT p.id, p.name, p.description, p.version, p.default_action,
-	p.created_at, p.updated_at, p.created_by, p.updated_by, COALESCE(a.cnt, 0) AS assignment_count
-	FROM app_control_policies p
-	LEFT JOIN (
-		SELECT policy_id, COUNT(*) AS cnt FROM app_control_assignments GROUP BY policy_id
-	) a ON a.policy_id = p.id`
+	p.created_at, p.updated_at, p.created_by, p.updated_by,
+	(SELECT COUNT(*) FROM app_control_assignments a WHERE a.policy_id = p.id) AS assignment_count
+	FROM app_control_policies p`
 
 // scanPolicyRow consumes one row from a query built atop policySelectWithAssignmentCount. The column order is fixed by the
 // SELECT list above and reused unchanged across GetPolicyByName / getPolicyByID / ListPolicies; a regression that reorders
@@ -247,10 +246,11 @@ func (s *Store) GetPolicyByID(ctx context.Context, policyID int64) (api.Applicat
 }
 
 // ListPolicies returns every policy in name order, each decorated with its assignment_count via the shared
-// policySelectWithAssignmentCount join. The policies-list UI renders the count in the assignments column so the spec's
-// "always 1 in Phase A" wiring is exercised end-to-end; Phase B's multi-group flows return non-1 values without a wire-shape
-// change. Rules are NOT populated; the list view shows the rule count only, which the REST handler computes via a separate
-// aggregate query when it needs it.
+// policySelectWithAssignmentCount subquery. The policies-list UI renders the count in the assignments column: the seeded
+// Default policy ships with count=1 (its assignment to the seed all-hosts group), policies created via CreatePolicy land at 0
+// until an assignment row is inserted, and Phase B multi-group editing grows the value without a wire-shape change. Rules
+// are NOT populated; the list view shows the rule count only, which the REST handler computes via a separate aggregate query
+// when it needs it.
 func (s *Store) ListPolicies(ctx context.Context) ([]api.ApplicationControlPolicy, error) {
 	rows, err := s.db.QueryxContext(ctx, policySelectWithAssignmentCount+` ORDER BY p.name ASC`)
 	if err != nil {

--- a/server/rules/internal/appcontrol/store.go
+++ b/server/rules/internal/appcontrol/store.go
@@ -197,19 +197,39 @@ func (s *Store) ListAssignmentsForPolicy(ctx context.Context, policyID int64) ([
 	return out, nil
 }
 
+// policySelectWithAssignmentCount is the SELECT-list + FROM-clause every policy fetch uses. The LEFT JOIN against the
+// assignments aggregate populates the derived AssignmentCount field in a single round trip; COALESCE turns the LEFT-JOIN NULL
+// for policies with zero assignments into the integer zero scan target expects. The aggregate sub-query groups by policy_id so
+// each parent row joins to exactly one summary row regardless of how many host groups the policy has assigned. Centralised so
+// GetPolicyByName / getPolicyByID / ListPolicies stay structurally identical and the scan order they all share is one source
+// of truth.
+const policySelectWithAssignmentCount = `SELECT p.id, p.name, p.description, p.version, p.default_action,
+	p.created_at, p.updated_at, p.created_by, p.updated_by, COALESCE(a.cnt, 0) AS assignment_count
+	FROM app_control_policies p
+	LEFT JOIN (
+		SELECT policy_id, COUNT(*) AS cnt FROM app_control_assignments GROUP BY policy_id
+	) a ON a.policy_id = p.id`
+
+// scanPolicyRow consumes one row from a query built atop policySelectWithAssignmentCount. The column order is fixed by the
+// SELECT list above and reused unchanged across GetPolicyByName / getPolicyByID / ListPolicies; a regression that reorders
+// either side surfaces as a typed scan error rather than a silent field swap. Returns the row's typed shape and the scan
+// error verbatim; callers translate sql.ErrNoRows themselves because the surrounding error wrapping varies per call site.
+func scanPolicyRow(scanner interface{ Scan(...any) error }) (api.ApplicationControlPolicy, error) {
+	var p api.ApplicationControlPolicy
+	err := scanner.Scan(
+		&p.ID, &p.Name, &p.Description, &p.Version, &p.DefaultAction,
+		&p.CreatedAt, &p.UpdatedAt, &p.CreatedBy, &p.UpdatedBy, &p.AssignmentCount,
+	)
+	return p, err
+}
+
 // GetPolicyByName loads the policy row by name. Rules are NOT populated; callers that need rules call ListRulesByPolicy explicitly.
 // A future GetPolicyWithRules helper can join the two queries when an endpoint shows up that needs both in one round trip; today's
-// REST surface fetches them separately.
+// REST surface fetches them separately. AssignmentCount IS populated via the shared policySelectWithAssignmentCount join.
 func (s *Store) GetPolicyByName(ctx context.Context, name string) (api.ApplicationControlPolicy, error) {
-	const query = `SELECT id, name, description, version, default_action,
-		created_at, updated_at, created_by, updated_by
-		FROM app_control_policies WHERE name = ?`
-	row := s.db.QueryRowxContext(ctx, query, name)
-	var p api.ApplicationControlPolicy
-	if err := row.Scan(
-		&p.ID, &p.Name, &p.Description, &p.Version, &p.DefaultAction,
-		&p.CreatedAt, &p.UpdatedAt, &p.CreatedBy, &p.UpdatedBy,
-	); err != nil {
+	row := s.db.QueryRowxContext(ctx, policySelectWithAssignmentCount+` WHERE p.name = ?`, name)
+	p, err := scanPolicyRow(row)
+	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return api.ApplicationControlPolicy{}, api.ErrAppControlPolicyNotFound
 		}
@@ -226,25 +246,22 @@ func (s *Store) GetPolicyByID(ctx context.Context, policyID int64) (api.Applicat
 	return s.getPolicyByID(ctx, policyID)
 }
 
-// ListPolicies returns every policy in name order. Rules are NOT populated; the list view shows the rule count only, which the REST
-// handler computes via a separate aggregate query when it needs it.
+// ListPolicies returns every policy in name order, each decorated with its assignment_count via the shared
+// policySelectWithAssignmentCount join. The policies-list UI renders the count in the assignments column so the spec's
+// "always 1 in Phase A" wiring is exercised end-to-end; Phase B's multi-group flows return non-1 values without a wire-shape
+// change. Rules are NOT populated; the list view shows the rule count only, which the REST handler computes via a separate
+// aggregate query when it needs it.
 func (s *Store) ListPolicies(ctx context.Context) ([]api.ApplicationControlPolicy, error) {
-	const query = `SELECT id, name, description, version, default_action,
-		created_at, updated_at, created_by, updated_by
-		FROM app_control_policies ORDER BY name ASC`
-	rows, err := s.db.QueryxContext(ctx, query)
+	rows, err := s.db.QueryxContext(ctx, policySelectWithAssignmentCount+` ORDER BY p.name ASC`)
 	if err != nil {
 		return nil, fmt.Errorf("appcontrol list policies: %w", err)
 	}
 	defer rows.Close()
 	out := []api.ApplicationControlPolicy{}
 	for rows.Next() {
-		var p api.ApplicationControlPolicy
-		if err := rows.Scan(
-			&p.ID, &p.Name, &p.Description, &p.Version, &p.DefaultAction,
-			&p.CreatedAt, &p.UpdatedAt, &p.CreatedBy, &p.UpdatedBy,
-		); err != nil {
-			return nil, fmt.Errorf("appcontrol list policies scan: %w", err)
+		p, scanErr := scanPolicyRow(rows)
+		if scanErr != nil {
+			return nil, fmt.Errorf("appcontrol list policies scan: %w", scanErr)
 		}
 		out = append(out, p)
 	}
@@ -772,16 +789,12 @@ func (s *Store) DeletePolicy(ctx context.Context, req api.DeletePolicyRequest) e
 
 // getPolicyByID is the internal lookup the create/update paths use to return the post-mutation row. The missing-row case is
 // translated to api.ErrAppControlPolicyNotFound inside this helper (mirroring GetRuleByID's contract); callers can errors.Is
-// directly without unwrapping a driver-level sql.ErrNoRows.
+// directly without unwrapping a driver-level sql.ErrNoRows. Uses the shared policySelectWithAssignmentCount join so
+// AssignmentCount is populated consistently with ListPolicies + GetPolicyByName.
 func (s *Store) getPolicyByID(ctx context.Context, id int64) (api.ApplicationControlPolicy, error) {
-	const query = `SELECT id, name, description, version, default_action, created_at, updated_at, created_by, updated_by
-		FROM app_control_policies WHERE id = ?`
-	row := s.db.QueryRowxContext(ctx, query, id)
-	var p api.ApplicationControlPolicy
-	if err := row.Scan(
-		&p.ID, &p.Name, &p.Description, &p.Version, &p.DefaultAction,
-		&p.CreatedAt, &p.UpdatedAt, &p.CreatedBy, &p.UpdatedBy,
-	); err != nil {
+	row := s.db.QueryRowxContext(ctx, policySelectWithAssignmentCount+` WHERE p.id = ?`, id)
+	p, err := scanPolicyRow(row)
+	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return api.ApplicationControlPolicy{}, api.ErrAppControlPolicyNotFound
 		}

--- a/server/rules/internal/tests/appcontrol_rest_test.go
+++ b/server/rules/internal/tests/appcontrol_rest_test.go
@@ -16,6 +16,7 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/jmoiron/sqlx"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -103,6 +104,7 @@ type appControlRig struct {
 	audit    *recordingAudit
 	hosts    []string
 	actor    *identityapi.Actor
+	db       *sqlx.DB
 }
 
 // newAppControlRig wires a rules bootstrap with the demo-cut REST surface live. Hosts are a fixed []string the recordingInserter
@@ -143,7 +145,7 @@ func newAppControlRig(t *testing.T, hosts []string) *appControlRig {
 	})
 	srv := httptest.NewServer(withActor)
 	t.Cleanup(srv.Close)
-	return &appControlRig{rules: rules, srv: srv, inserter: inserter, audit: audit, hosts: hostList, actor: actor}
+	return &appControlRig{rules: rules, srv: srv, inserter: inserter, audit: audit, hosts: hostList, actor: actor, db: db}
 }
 
 // defaultPolicyID returns the seeded Default policy's row id.
@@ -187,6 +189,10 @@ func TestAppControlREST_ListPolicies_ReturnsSeededDefault(t *testing.T) {
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
 	require.Len(t, body.Policies, 1)
 	assert.Equal(t, rulesapi.DefaultPolicyName, body.Policies[0].Name)
+	// AssignmentCount on the seed Default policy is 1 because EnsureDefaultPolicy creates the all-hosts group + the single
+	// assignment connecting Default to it. The field exists so the policies-list UI can render "N host groups" without an
+	// N+1 round trip; the value is always 1 in Phase A and grows as Phase B opens up multi-group assignment editing.
+	assert.Equal(t, 1, body.Policies[0].AssignmentCount, "seed Default policy is assigned to all-hosts (count=1)")
 }
 
 // TestAppControl_GetPolicy_IncludesRules: a freshly-seeded policy has zero rules; after a POST the GET path should include the new
@@ -202,6 +208,7 @@ func TestAppControlREST_GetPolicy_IncludesRules(t *testing.T) {
 	var policy rulesapi.ApplicationControlPolicy
 	require.NoError(t, json.NewDecoder(get.Body).Decode(&policy))
 	assert.Empty(t, policy.Rules)
+	assert.Equal(t, 1, policy.AssignmentCount, "single-policy GET decorates assignment_count consistently with the list view")
 
 	create := r.do(t, http.MethodPost,
 		"/api/v1/app-control/policies/"+i64(policyID)+"/rules",
@@ -271,6 +278,72 @@ func TestAppControlREST_CreateRule_FansOutToEveryHost(t *testing.T) {
 	assert.Equal(t, int64(42), *ev.UserID, "audit row carries the actor user_id")
 	assert.Equal(t, 3, ev.Payload["fanout_hosts"], "fanout_hosts must reflect unique host count")
 	assert.Equal(t, 0, ev.Payload["fanout_failed"], "no failures expected on the happy path")
+}
+
+// TestAppControlREST_CreateRule_FanOutDedupsAcrossOverlappingAssignments: closes openspec task 11.1.5. The Phase A walker
+// resolves hosts via the assignments -> host_groups walk in service.fanout; when a policy is assigned to two host groups
+// whose criteria resolve to overlapping host sets, each unique host must receive exactly ONE set_application_control
+// command. The pre-existing dedup test only exercises HostLister-side duplicates inside one group; this one wires a second
+// host_group with the same {"type":"all"} criteria and a second assignment row directly via SQL so the fan-out's
+// across-groups dedup invariant is exercised. Without this test, a regression that drops the seen-set or skips the
+// across-groups union would still pass the existing suite.
+func TestAppControlREST_CreateRule_FanOutDedupsAcrossOverlappingAssignments(t *testing.T) {
+	t.Parallel()
+	hosts := []string{"host-a", "host-b", "host-c"}
+	r := newAppControlRig(t, hosts)
+	policyID := r.defaultPolicyID(t)
+
+	// Insert a second "all"-criteria host group + a second assignment to the Default policy. Phase A's REST surface gates
+	// non-all-hosts host_group mutations behind 405 (the policy-spec keeps editable groups in Phase B), so we go through
+	// the raw DB. The fan-out walker reads both rows, resolves each to the same host set via allHostsCache, and unions the
+	// results into a single seen-map -- N hosts must enqueue N commands, not 2N.
+	res, err := r.db.ExecContext(t.Context(),
+		`INSERT INTO host_groups (name, description, criteria) VALUES (?, ?, ?)`,
+		"secondary-all-hosts", "test overlap with all-hosts", `{"type":"all"}`)
+	require.NoError(t, err)
+	secondaryGroupID, err := res.LastInsertId()
+	require.NoError(t, err)
+	_, err = r.db.ExecContext(t.Context(),
+		`INSERT INTO app_control_assignments (policy_id, host_group_id, priority) VALUES (?, ?, ?)`,
+		policyID, secondaryGroupID, 0)
+	require.NoError(t, err)
+
+	resp := r.do(t, http.MethodPost,
+		"/api/v1/app-control/policies/"+i64(policyID)+"/rules",
+		map[string]any{
+			"rule_type":  rulesapi.RuleTypeBinary,
+			"identifier": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+			"severity":   rulesapi.SeverityRuleHigh,
+			"reason":     "overlap fan-out coverage",
+		})
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	calls := r.inserter.snapshot()
+	require.Len(t, calls, len(hosts),
+		"two assignments to overlapping {\"type\":\"all\"} groups must dedup to one command per unique host")
+	seenHostIDs := map[string]int{}
+	for _, c := range calls {
+		seenHostIDs[c.HostID]++
+	}
+	for _, host := range hosts {
+		assert.Equal(t, 1, seenHostIDs[host],
+			"host %q must receive exactly one command even though it is reachable via two assignments", host)
+	}
+
+	events := r.audit.snapshot()
+	require.Len(t, events, 1)
+	assert.Equal(t, len(hosts), events[0].Payload["fanout_hosts"],
+		"fanout_hosts on the audit row reflects unique hosts, not assignment-fan crosses")
+	assert.Equal(t, 0, events[0].Payload["fanout_failed"])
+
+	// AssignmentCount on the post-mutation policy should reflect both assignments. Fetch via the public REST path the UI uses
+	// so the round-trip exercises the same JSON shape the policies-list view consumes.
+	get := r.do(t, http.MethodGet, "/api/v1/app-control/policies/"+i64(policyID), nil)
+	defer get.Body.Close()
+	var fetched rulesapi.ApplicationControlPolicy
+	require.NoError(t, json.NewDecoder(get.Body).Decode(&fetched))
+	assert.Equal(t, 2, fetched.AssignmentCount, "two assignment rows must show as count=2")
 }
 
 // TestAppControl_CreateRule_RecordsFanoutFailures: a per-host CommandInserter failure must not abort the loop AND must surface on the

--- a/server/rules/internal/tests/appcontrol_rest_test.go
+++ b/server/rules/internal/tests/appcontrol_rest_test.go
@@ -341,6 +341,7 @@ func TestAppControlREST_CreateRule_FanOutDedupsAcrossOverlappingAssignments(t *t
 	// so the round-trip exercises the same JSON shape the policies-list view consumes.
 	get := r.do(t, http.MethodGet, "/api/v1/app-control/policies/"+i64(policyID), nil)
 	defer get.Body.Close()
+	require.Equal(t, http.StatusOK, get.StatusCode, "GET must return 200 before we trust the decoded body")
 	var fetched rulesapi.ApplicationControlPolicy
 	require.NoError(t, json.NewDecoder(get.Body).Decode(&fetched))
 	assert.Equal(t, 2, fetched.AssignmentCount, "two assignment rows must show as count=2")

--- a/ui/src/components/ApplicationControl/PoliciesList.test.tsx
+++ b/ui/src/components/ApplicationControl/PoliciesList.test.tsx
@@ -15,6 +15,8 @@ const makePolicy = (over: Partial<ApplicationControlPolicy> = {}): ApplicationCo
   updated_at: "2026-05-14T00:00:00Z",
   created_by: "system",
   updated_by: "user:1",
+  // Default fixture mirrors the Phase A seed: Default policy assigned to all-hosts is exactly 1 assignment.
+  assignment_count: 1,
   ...over,
 });
 
@@ -88,5 +90,28 @@ describe("PoliciesList", () => {
     });
     // The "Rules" column should render the em dash placeholder.
     expect(screen.getByText("—")).toBeInTheDocument();
+  });
+
+  it("renders assignment_count with the appropriate singular / plural / zero label", async () => {
+    (api.listAppControlPolicies as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([
+      makePolicy({ id: 1, name: "SeedDefault", assignment_count: 1 }),
+      makePolicy({ id: 2, name: "MultiAssigned", assignment_count: 3 }),
+      makePolicy({ id: 3, name: "Unwired", assignment_count: 0 }),
+    ]);
+    render(
+      <MemoryRouter>
+        <PoliciesList />
+      </MemoryRouter>,
+    );
+    await waitFor(() => {
+      expect(screen.getByText("SeedDefault")).toBeInTheDocument();
+    });
+    // The Phase A "always 1" seed case renders as "1 host group". The plural form switches at 2+; the zero state renders
+    // "no host groups" (an admin posture, not a wire-shape error). The previous hardcoded "all hosts" placeholder must
+    // not appear anywhere -- if it does, the wiring regressed back to the demo-cut shape.
+    expect(screen.getByText("1 host group")).toBeInTheDocument();
+    expect(screen.getByText("3 host groups")).toBeInTheDocument();
+    expect(screen.getByText("no host groups")).toBeInTheDocument();
+    expect(screen.queryByText(/^all hosts$/)).not.toBeInTheDocument();
   });
 });

--- a/ui/src/components/ApplicationControl/PoliciesList.tsx
+++ b/ui/src/components/ApplicationControl/PoliciesList.tsx
@@ -43,9 +43,9 @@ export function PoliciesList() {
   const ruleCount = (p: ApplicationControlPolicy): string =>
     p.rules ? String(p.rules.length) : "—";
 
-  // assignmentLabel formats the assignment_count column. Phase A's seed always renders "1 host group" because the only
-  // assignment row is Default -> all-hosts; zero indicates an unwired policy (an admin posture, not a wire-shape error)
-  // and reads as "no host groups". Plural form switches at exactly count == 1.
+  // assignmentLabel formats the assignment_count column. The seed Default policy renders "1 host group" because its only
+  // assignment row connects it to all-hosts; policies created without assignments render "no host groups" (an admin posture,
+  // not a wire-shape error) and multi-group counts render with the plural form. Singular at exactly count == 1.
   const assignmentLabel = (count: number): string => {
     if (count === 0) return "no host groups";
     if (count === 1) return "1 host group";
@@ -104,10 +104,11 @@ export function PoliciesList() {
                 <td>{p.version}</td>
                 <td>{new Date(p.updated_at).toLocaleString()}</td>
                 <td>
-                  {/* assignment_count is server-decorated via a LEFT JOIN on app_control_assignments.
-                      Phase A always shows 1 (the seed Default -> all-hosts row); Phase B grows the
-                      count as editable groups land. Singular/plural handled inline so a zero state
-                      ("no host groups", which would indicate an unwired policy) reads sensibly too. */}
+                  {/* assignment_count is server-decorated via a correlated COUNT subquery on
+                      app_control_assignments. The seed Default policy ships with 1 (its assignment
+                      to all-hosts); policies created via the create endpoint land at 0 until an
+                      assignment is added, and Phase B's multi-group editing grows the value.
+                      Singular / plural / zero handled inline so an unwired policy reads sensibly. */}
                   <span className="app-control__assignment">{assignmentLabel(p.assignment_count)}</span>
                 </td>
               </tr>

--- a/ui/src/components/ApplicationControl/PoliciesList.tsx
+++ b/ui/src/components/ApplicationControl/PoliciesList.tsx
@@ -43,6 +43,15 @@ export function PoliciesList() {
   const ruleCount = (p: ApplicationControlPolicy): string =>
     p.rules ? String(p.rules.length) : "—";
 
+  // assignmentLabel formats the assignment_count column. Phase A's seed always renders "1 host group" because the only
+  // assignment row is Default -> all-hosts; zero indicates an unwired policy (an admin posture, not a wire-shape error)
+  // and reads as "no host groups". Plural form switches at exactly count == 1.
+  const assignmentLabel = (count: number): string => {
+    if (count === 0) return "no host groups";
+    if (count === 1) return "1 host group";
+    return `${String(count)} host groups`;
+  };
+
   const newPolicyAction = (
     <Button
       variant="primary"
@@ -95,11 +104,11 @@ export function PoliciesList() {
                 <td>{p.version}</td>
                 <td>{new Date(p.updated_at).toLocaleString()}</td>
                 <td>
-                  {/* Assignments are hardcoded "all-hosts" in the
-                      demo cut; host-group editing is post-demo so
-                      this column shows the literal value without an
-                      action link. */}
-                  <span className="app-control__assignment">all hosts</span>
+                  {/* assignment_count is server-decorated via a LEFT JOIN on app_control_assignments.
+                      Phase A always shows 1 (the seed Default -> all-hosts row); Phase B grows the
+                      count as editable groups land. Singular/plural handled inline so a zero state
+                      ("no host groups", which would indicate an unwired policy) reads sensibly too. */}
+                  <span className="app-control__assignment">{assignmentLabel(p.assignment_count)}</span>
                 </td>
               </tr>
             ))}

--- a/ui/src/components/ApplicationControl/PolicyDetail.test.tsx
+++ b/ui/src/components/ApplicationControl/PolicyDetail.test.tsx
@@ -32,6 +32,7 @@ const makePolicy = (over: Partial<ApplicationControlPolicy> = {}): ApplicationCo
   updated_at: "2026-05-14T00:00:00Z",
   created_by: "system",
   updated_by: "user:1",
+  assignment_count: 1,
   ...over,
 });
 

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -147,6 +147,10 @@ export interface ApplicationControlPolicy {
   updated_at: string;
   created_by: string;
   updated_by: string;
+  // assignment_count is the number of host_groups the policy is assigned to. Server-decorated via a LEFT JOIN on
+  // app_control_assignments so the PoliciesList view can render "N host groups" without an N+1 round trip. Always 1 in
+  // Phase A (the seed Default policy assigned to all-hosts); grows as Phase B opens up multi-group assignment editing.
+  assignment_count: number;
   rules?: ApplicationControlRule[];
 }
 

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -147,9 +147,10 @@ export interface ApplicationControlPolicy {
   updated_at: string;
   created_by: string;
   updated_by: string;
-  // assignment_count is the number of host_groups the policy is assigned to. Server-decorated via a LEFT JOIN on
-  // app_control_assignments so the PoliciesList view can render "N host groups" without an N+1 round trip. Always 1 in
-  // Phase A (the seed Default policy assigned to all-hosts); grows as Phase B opens up multi-group assignment editing.
+  // assignment_count is the number of host_groups the policy is assigned to. Server-decorated via a correlated COUNT
+  // subquery on app_control_assignments so the PoliciesList view can render "N host groups" without an N+1 round trip.
+  // The seeded Default policy starts at 1 (its assignment to all-hosts); policies created via the create endpoint start
+  // at 0 and grow as Phase B opens up multi-group assignment editing. The UI handles 0/1/N as singular/plural/zero labels.
   assignment_count: number;
   rules?: ApplicationControlRule[];
 }


### PR DESCRIPTION
… (#68 / 11.1.5 + 11.1.6)

Closes the last code-side items in the Phase A close-out (PR-1) for #68:

11.1.6 — PoliciesList real assignment count
  Add AssignmentCount (json:"assignment_count") to api.ApplicationControlPolicy.
  Server-decorate via a shared policySelectWithAssignmentCount LEFT JOIN against
  an app_control_assignments aggregate sub-query; COALESCE turns the LEFT-JOIN NULL
  for policies with zero assignments into the integer zero scan target expects.
  Three policy fetches share the JOIN: GetPolicyByName, getPolicyByID, ListPolicies.
  A shared scanPolicyRow helper pins the column order across all three so a future
  SELECT-list change surfaces as a typed scan error rather than a silent field swap.

  UI: PoliciesList renders the value via an assignmentLabel helper -- singular
  ("1 host group") at exactly count==1, plural at 2+, and an explicit "no host
  groups" at zero (an admin posture, not a wire-shape error). The hardcoded
  "all hosts" placeholder is gone; a regression that wires it back in is caught
  by the existing test asserting that text doesn't render.

11.1.5 — Overlap fan-out dedup test
  New TestAppControlREST_CreateRule_FanOutDedupsAcrossOverlappingAssignments inserts
  a second host_group with {"type":"all"} criteria + a second assignment row to the
  Default policy directly via SQL (Phase A's REST surface gates non-all-hosts group
  mutations behind 405). A single rule POST then exercises service.fanout's seen-set
  union: each of N hosts receives exactly ONE set_application_control command even
  though it is reachable via two assignments, and the audit row's fanout_hosts
  reflects unique hosts not assignment-fan crosses.

  Without this test, a regression that drops the seen-set or skips the across-groups
  union still passes the existing dedup test (which only exercises HostLister-side
  duplicates inside one group resolve, not the across-assignments union).

Local verification
  - task lint:go (custom golangci-lint with commentwrap): 0 issues across ./server/rules/... and ./test/integration.
  - go test ./server/rules/internal/appcontrol/... + the bootstrap + catalog
    + testdb suites: all pass.
  - go test -tags integration -count=1 ./server/rules/internal/tests/ and ./test/integration/: all pass against the local MySQL test instance, including the new overlap dedup case.
  - npm run build (ui): tsc + vite build clean.
  - npx vitest run on PoliciesList + PolicyDetail: 22/22 tests pass.

The remaining Phase A items are documentation-only (11.5.1: CLAUDE.md note, 11.5.2: developer-facing docs/ page). Those land as the final PR before the change can be archived.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ApplicationControl policies now display the number of host groups they are assigned to in the policies list.
  * Assignment counts include proper singular/plural formatting ("1 host group", "3 host groups", "no host groups").
  * Removed previous hardcoded "all hosts" placeholder text.

* **Tests**
  * Added integration test validating fan-out deduplication across overlapping policy assignments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/getvictor/fleet-edr/pull/197?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->