### PR TITLE
arch-drift: scrub stale doc + arch-go refs to non-existent rules.api …

### DIFF
--- a/arch-go.yml
+++ b/arch-go.yml
@@ -37,7 +37,6 @@ dependenciesRules:
         - "**.attrkeys"
         - "**.httpserver"
         - "**.identity.api"  # identity.api.AuditRecorder for enrollment.revoke audit
-        - "**.rules.api"   # rules.api.PolicyService satisfies endpoint's PolicyProvider
         - "**.testdb"
 
   # rules context internals. Cross-context test allowance is

--- a/docs/maintenance/log.md
+++ b/docs/maintenance/log.md
@@ -18,4 +18,5 @@ or change the cadence - running tasks with no record is the same as not running 
 
 2026-05-03  doc-accuracy-sweep  partial  scope: root-level READMEs + `docs/*.md` (subdirs deferred to next rotation)
 2026-05-12  best-practices-refresh  done  1 demotion (ATT&CK mapping → [~] pending v19 re-validation), 1 path fix (observability), 4 new unchecked items, 1 ADR-gap issue filed
+2026-05-19  architecture-drift  done  boundary heat map clean (every cross-context import lands on `<other>/api` + sanctioned testkit/testdb test-only paths). Cleared one drift cluster in this PR: stale `PolicyService` / `ActiveCommandPayload` / `ActiveHostsLister` doc references in `rules/api`, `rules/bootstrap`, `detection/bootstrap` and a dead `**.rules.api` allowance for `endpoint.internal` in arch-go.yml (endpoint does not import rules.api; the cited type was never landed). No god-structs, no test-fixture drift, no cross-context FKs, no migration-ordering issues. ADR-0004 still describes intent. arch-go green.
 

--- a/server/detection/bootstrap/doc.go
+++ b/server/detection/bootstrap/doc.go
@@ -11,7 +11,6 @@
 //   - LoadActive(rulesapi.RuleProvider) to register the active rule
 //     set with the engine after rulesCtx exists.
 //
-// ActiveHostsLister and CommandInserter are unrelated to detection;
 // detection's only outbound closure is UserExists, which cmd/main
 // supplies from identity.api.Service.UserExists. UserExists is the
 // cross-context guard that replaces a FK from alerts.updated_by to

--- a/server/rules/api/doc.go
+++ b/server/rules/api/doc.go
@@ -1,14 +1,13 @@
 // Package api is the public surface of the rules bounded context.
 //
-// rules owns the server-driven blocklist policy (policies table) and the
-// detection rule catalog (eight Go-coded matchers + ATT&CK metadata +
-// per-rule documentation). Cross-context callers consume rules through
-// three interfaces:
+// rules owns the detection rule catalog (Go-coded matchers + ATT&CK metadata
+// + per-rule documentation) and the application-control policy/rule store.
+// Cross-context callers consume rules through three interfaces:
 //
-//   - PolicyService: GET/UPDATE the active blocklist policy (operator) +
-//     ActiveCommandPayload pre-marshaled for agent fan-out (endpoint).
 //   - Lister: enumerate rule metadata for /api/rules and /api/attack-coverage.
 //   - RuleProvider: load executable rules into the detection engine.
+//   - ApplicationControlStore: read/write app-control policies, rules, host
+//     groups, and assignments (consumed by rules' own REST handler and tests).
 //
 // Per ADR-0004, rules/api re-exports detection/api types
 // (Event/Process/TimeRange/GraphReader/Finding/NullRawJSON) as type

--- a/server/rules/api/doc.go
+++ b/server/rules/api/doc.go
@@ -2,12 +2,17 @@
 //
 // rules owns the detection rule catalog (Go-coded matchers + ATT&CK metadata
 // + per-rule documentation) and the application-control policy/rule store.
-// Cross-context callers consume rules through three interfaces:
+//
+// Two interfaces are designed for consumption by other bounded contexts:
 //
 //   - Lister: enumerate rule metadata for /api/rules and /api/attack-coverage.
 //   - RuleProvider: load executable rules into the detection engine.
-//   - ApplicationControlStore: read/write app-control policies, rules, host
-//     groups, and assignments (consumed by rules' own REST handler and tests).
+//
+// ApplicationControlStore is also exposed here, but solely so the rules-context
+// REST handler and tests can depend on the contract instead of importing the
+// internal package (ADR-0004's bounded-context import rule). No other context
+// consumes it today; it lives in api/ for ADR-conformance, not cross-context
+// use.
 //
 // Per ADR-0004, rules/api re-exports detection/api types
 // (Event/Process/TimeRange/GraphReader/Finding/NullRawJSON) as type

--- a/server/rules/bootstrap/doc.go
+++ b/server/rules/bootstrap/doc.go
@@ -1,13 +1,13 @@
 // Package bootstrap wires the rules bounded context. cmd/* binaries call
 // rulesbootstrap.New(deps) once at startup, then ApplySchema, then
 // RegisterAuthedRoutes. The returned *Rules handle exposes three
-// accessor methods -- PolicyService(), ContentService(), and
-// Catalog() -- that return api.PolicyService, api.RuleProvider, and
-// api.Lister respectively. The accessor names stay descriptive
-// (caller-facing) while the interface names follow Effective Go's
-// "method-name + er" convention internally.
+// accessor methods -- ContentService(), Catalog(), and
+// ApplicationControlStore() -- that return api.RuleProvider, api.Lister,
+// and api.ApplicationControlStore respectively. The accessor names stay
+// descriptive (caller-facing) while the interface names follow Effective
+// Go's "method-name + er" convention internally.
 //
-// ActiveHostsLister and CommandInserter are closure types so cmd/main
-// can supply late-bound implementations without rules taking a hard
-// dependency on endpoint or response.
+// HostLister and CommandInserter are closure types Deps takes so cmd/main
+// can supply late-bound implementations of the app-control fan-out without
+// rules taking a hard dependency on detection or response.
 package bootstrap


### PR DESCRIPTION
…types

Architecture-drift audit (docs/maintenance/tasks/architecture-drift.md) caught one drift cluster:

- rules/api/doc.go listed PolicyService + ActiveCommandPayload as part of the public surface. Neither exists; the live interfaces are Lister, RuleProvider, and ApplicationControlStore.
- rules/bootstrap/doc.go listed PolicyService() as one of three accessor methods and ActiveHostsLister as a closure type. The accessors are ContentService(), Catalog(), ApplicationControlStore(); the closure is HostLister (with CommandInserter).
- detection/bootstrap/doc.go disclaimed irrelevance to ActiveHostsLister, a symbol that never existed.
- arch-go.yml granted endpoint.internal permission to import rules.api with the rationale "rules.api.PolicyService satisfies endpoint's PolicyProvider". endpoint does not import rules.api; the cited type was never landed. Removing the dead allowance.

Heat map otherwise clean; no god-structs, no test-fixture drift, no cross-context FKs, no migration-ordering issues. ADR-0004 still describes intent. arch-go (./test/arch) stays green with the allow-list trim.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal architecture documentation to reflect current service interfaces and responsibilities.

* **Chores**
  * Updated dependency configuration rules for architectural constraints.
  * Added maintenance audit completion log entry.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/getvictor/fleet-edr/pull/198?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->