### PR TITLE
e2e: use top-level await in coverage-to-lcov.mjs

### DIFF
--- a/test/e2e/scripts/coverage-to-lcov.mjs
+++ b/test/e2e/scripts/coverage-to-lcov.mjs
@@ -120,7 +120,9 @@ async function main() {
   console.log(`wrote ${outPath} (${s.size} bytes)`);
 }
 
-main().catch((err) => {
+try {
+  await main();
+} catch (err) {
   console.error("coverage-to-lcov failed:", err);
   process.exit(1);
-});
+}


### PR DESCRIPTION
Resolves SonarCloud javascript:S7785 (key AZ5AvmOsnP6qpFu7uAYz): prefer top-level await over a trailing main().catch() chain. The script is ESM (.mjs) and runs under Node 22 in CI, so top-level await is supported. Behaviour is unchanged — the unhandled-rejection log + exit(1) still fire on every failure path inside main().