### PR TITLE
Resolve issue #187: Fallback for redacted `team_id` and `is_platform_…

### DIFF
--- a/docs/lessons-and-gotchas.md
+++ b/docs/lessons-and-gotchas.md
@@ -154,7 +154,7 @@ Path strings and other dynamic values show as `<private>` in log output. Use
 
 ### Ad-hoc-signed host extension causes ESF to redact team_id + force is_platform_binary
 
-When the ESF host extension itself is not Developer-ID-signed + notarised, ESF
+When the ESF host extension itself is not Developer-ID-signed + notarized, ESF
 applies a per-client redaction: `target.team_id` returns `""` and
 `target.is_platform_binary` returns `true` for **every** exec the client sees,
 including unambiguously third-party Developer ID-signed binaries (issue #187
@@ -181,7 +181,7 @@ recover on edr-dev.
 
 Reproducer (after a fresh agent queue):
 
-```
+```bash
 curl -sL 'https://github.com/cli/cli/releases/download/v2.62.0/gh_2.62.0_macOS_arm64.zip' -o gh.zip
 unzip -q gh.zip && sudo install -m 0755 gh_2.62.0_macOS_arm64/bin/gh /usr/local/bin/gh
 # push a TEAMID rule for VEKTX9H2N7 from the server, then:
@@ -189,7 +189,7 @@ unzip -q gh.zip && sudo install -m 0755 gh_2.62.0_macOS_arm64/bin/gh /usr/local/
 # AUTH_EXEC DENIED in the extension log; application_control_block event on the wire.
 ```
 
-Long-term fix: notarise the extension on a release / QA channel; the fallback
+Long-term fix: notarize the extension on a release / QA channel; the fallback
 becomes a no-op once ESF stops redacting.
 
 ## Code signing and certificates

--- a/docs/lessons-and-gotchas.md
+++ b/docs/lessons-and-gotchas.md
@@ -152,6 +152,46 @@ disabled. Apply it via `codesign --entitlements`.
 Path strings and other dynamic values show as `<private>` in log output. Use
 `.public` privacy level in development, `.private(mask: .hash)` in production.
 
+### Ad-hoc-signed host extension causes ESF to redact team_id + force is_platform_binary
+
+When the ESF host extension itself is not Developer-ID-signed + notarised, ESF
+applies a per-client redaction: `target.team_id` returns `""` and
+`target.is_platform_binary` returns `true` for **every** exec the client sees,
+including unambiguously third-party Developer ID-signed binaries (issue #187
+quantified 393/393 exec events redacted on edr-dev). It is NOT a per-binary
+`CS_PLATFORM_BINARY` classification. The dev VM extension is ad-hoc-signed
+(`codesign -d` reports `adhoc, linker-signed`), which trips the redaction.
+
+Effect on app-control rules:
+
+- **TEAMID rules** cannot fire by `team_id` alone — the field is always empty.
+- **SIGNINGID rules** degrade from `<TeamID>:<bundle.id>` to
+  `platform:<bundle.id>` for every target, regardless of who actually signed
+  the binary.
+- **CDHASH** and **BINARY** rules are unaffected; the kernel still reports the
+  real `cdhash` and the binary's bytes are unchanged.
+
+Workaround (in tree):
+[`SigningInfoFallback`](../extension/edr/extension/SigningInfoFallback.swift)
+reads the binary's signing block via `SecCodeCopySigningInformation` — the
+same path `codesign -dvv` walks — and caches the result per (inode, mtime).
+`ESFSubscriber.buildAuthTuple` consults it whenever `target.team_id` is
+empty, so TEAMID matches and the SIGNINGID `<TeamID>:<bundle.id>` shape both
+recover on edr-dev.
+
+Reproducer (after a fresh agent queue):
+
+```
+curl -sL 'https://github.com/cli/cli/releases/download/v2.62.0/gh_2.62.0_macOS_arm64.zip' -o gh.zip
+unzip -q gh.zip && sudo install -m 0755 gh_2.62.0_macOS_arm64/bin/gh /usr/local/bin/gh
+# push a TEAMID rule for VEKTX9H2N7 from the server, then:
+/usr/local/bin/gh --version
+# AUTH_EXEC DENIED in the extension log; application_control_block event on the wire.
+```
+
+Long-term fix: notarise the extension on a release / QA channel; the fallback
+becomes a no-op once ESF stops redacting.
+
 ## Code signing and certificates
 
 ### Team ID is public, not a secret

--- a/extension/edr/extension/ESFSubscriber.swift
+++ b/extension/edr/extension/ESFSubscriber.swift
@@ -191,17 +191,19 @@ final class ESFSubscriber: Sendable {
         // non-hardened binary silently no-op for this exec.
         let cdhash: String? = isHardenedRuntime(flags: target.codesigning_flags) ? cdhashHexString(from: target.cdhash) : nil
 
-        // Resolve the canonical TeamID. On notarised release hosts target.team_id is the truth and the
-        // fallback is never consulted. On the edr-dev VM the extension itself is ad-hoc-signed
-        // (`codesign -d` reports `adhoc, linker-signed`); ESF responds by redacting target.team_id="" and
-        // forcing target.is_platform_binary=true for EVERY exec the client sees -- a per-client policy on
-        // ESF clients whose host extension is not Developer-ID-signed + notarised, not a per-binary
-        // CS_PLATFORM_BINARY classification. Quantified on a fresh queue: 393/393 exec events redacted (see
-        // issue #187). Without a fallback every TEAMID rule on edr-dev is effectively dead and every
-        // SIGNINGID rule degrades to the `platform:<bundle.id>` shape regardless of who actually signed the
-        // binary. SigningInfoFallback reads the binary via SecCodeCopySigningInformation -- the same path
-        // `codesign -dvv` walks -- and caches the result per (inode, mtime). The fix on a real release host
-        // is to notarise the extension; until then the fallback keeps edr-dev usable for end-to-end QA.
+        // Resolve the canonical TeamID. For Developer-ID-signed targets on notarized release hosts ESF
+        // reports the real team_id and the fallback branch is skipped; the fallback still fires for
+        // ad-hoc-signed or unsigned targets even there and correctly returns nil. On the edr-dev VM the
+        // extension itself is ad-hoc-signed (`codesign -d` reports `adhoc, linker-signed`); ESF responds
+        // by redacting target.team_id="" and forcing target.is_platform_binary=true for EVERY exec the
+        // client sees -- a per-client policy on ESF clients whose host extension is not Developer-ID-signed
+        // + notarized, not a per-binary CS_PLATFORM_BINARY classification. Quantified on a fresh queue:
+        // 393/393 exec events redacted (see issue #187). Without a fallback every TEAMID rule on edr-dev
+        // is effectively dead and every SIGNINGID rule degrades to the `platform:<bundle.id>` shape
+        // regardless of who actually signed the binary. SigningInfoFallback reads the binary via
+        // SecCodeCopySigningInformation -- the same path `codesign -dvv` walks -- and caches the result
+        // per (inode, mtime). The fix on a real release host is to notarize the extension; until then the
+        // fallback keeps edr-dev usable for end-to-end QA.
         let teamID: String
         if !esTeamID.isEmpty {
             teamID = esTeamID

--- a/extension/edr/extension/ESFSubscriber.swift
+++ b/extension/edr/extension/ESFSubscriber.swift
@@ -191,13 +191,17 @@ final class ESFSubscriber: Sendable {
         // non-hardened binary silently no-op for this exec.
         let cdhash: String? = isHardenedRuntime(flags: target.codesigning_flags) ? cdhashHexString(from: target.cdhash) : nil
 
-        // Resolve the canonical TeamID. On SIP-on production environments target.team_id is the truth and the
-        // fallback is never consulted. On SIP-off dev VMs the kernel can flag a developer-signed binary as
-        // CS_PLATFORM_BINARY (flags bit 0x04000000); ESF then reports is_platform_binary=true and team_id=""
-        // because platform binaries are Apple's by convention. Without a fallback, every TEAMID rule on a
-        // SIP-off VM is effectively dead even when the binary's signing block declares a TeamIdentifier.
-        // SigningInfoFallback reads the binary via SecCodeCopySigningInformation -- the same path
-        // `codesign -dvv` walks -- and caches the result per (inode, mtime).
+        // Resolve the canonical TeamID. On notarised release hosts target.team_id is the truth and the
+        // fallback is never consulted. On the edr-dev VM the extension itself is ad-hoc-signed
+        // (`codesign -d` reports `adhoc, linker-signed`); ESF responds by redacting target.team_id="" and
+        // forcing target.is_platform_binary=true for EVERY exec the client sees -- a per-client policy on
+        // ESF clients whose host extension is not Developer-ID-signed + notarised, not a per-binary
+        // CS_PLATFORM_BINARY classification. Quantified on a fresh queue: 393/393 exec events redacted (see
+        // issue #187). Without a fallback every TEAMID rule on edr-dev is effectively dead and every
+        // SIGNINGID rule degrades to the `platform:<bundle.id>` shape regardless of who actually signed the
+        // binary. SigningInfoFallback reads the binary via SecCodeCopySigningInformation -- the same path
+        // `codesign -dvv` walks -- and caches the result per (inode, mtime). The fix on a real release host
+        // is to notarise the extension; until then the fallback keeps edr-dev usable for end-to-end QA.
         let teamID: String
         if !esTeamID.isEmpty {
             teamID = esTeamID
@@ -206,12 +210,13 @@ final class ESFSubscriber: Sendable {
         }
 
         // SIGNINGID is prefixed: "<TeamID>:<bundle.id>" for third-party signed binaries,
-        // "platform:<bundle.id>" for Apple platform binaries (those whose
-        // is_platform_binary flag is set). The server's validator accepts both shapes. When the kernel
-        // mis-classifies a dev-signed binary as platform (SIP-off CS_PLATFORM_BINARY case above), the
-        // fallback team_id distinguishes a genuine Apple platform binary (real platform: prefix) from a
-        // dev-signed one that should carry the "<TeamID>:<bundle.id>" prefix -- otherwise the SIGNINGID
-        // walk on SIP-off VMs would also lose its discriminator alongside the TEAMID walk.
+        // "platform:<bundle.id>" for Apple platform binaries (those whose is_platform_binary flag is set).
+        // The server's validator accepts both shapes. Under the ad-hoc-extension redaction described above
+        // ESF reports is_platform_binary=true even for unambiguously third-party binaries (Developer ID
+        // signed `gh` was the issue #187 reproducer); the fallback team_id is what separates a genuine
+        // Apple platform binary (real `platform:` prefix) from a third-party one that should carry the
+        // "<TeamID>:<bundle.id>" prefix. Without that branch the SIGNINGID walk on edr-dev would lose its
+        // discriminator alongside TEAMID.
         let signingIDPrefixed: String?
         if signingID.isEmpty {
             signingIDPrefixed = nil

--- a/extension/edr/extension/SigningInfoFallback.swift
+++ b/extension/edr/extension/SigningInfoFallback.swift
@@ -7,14 +7,14 @@ private let logger = Logger(subsystem: "com.fleetdm.edr.securityextension", cate
 /// SigningInfoFallback fills in the canonical Team ID for a binary when ESF returns an empty `target.team_id`.
 ///
 /// Why this exists: ESF redacts `target.team_id=""` and forces `target.is_platform_binary=true` for every
-/// exec the client sees when the ESF host extension itself is not Developer-ID-signed + notarised. This is
+/// exec the client sees when the ESF host extension itself is not Developer-ID-signed + notarized. This is
 /// a documented per-client policy, not a per-binary CS_PLATFORM_BINARY classification: the redaction hits
 /// every exec, including unambiguously third-party Developer-ID-signed binaries (issue #187 quantified
 /// 393/393 exec events redacted on edr-dev). The edr-dev VM ships the extension ad-hoc-signed
 /// (`codesign -d` reports `adhoc, linker-signed`), which trips the redaction; AUTH_EXEC's TEAMID rule
 /// branch then has nothing to match against -- it cannot block a binary by `8VBZ3948LU` if ESF says
-/// team_id="". On notarised release hosts ESF reports the real team_id and this fallback is a no-op.
-/// The proper long-term fix is to notarise the extension (tracked separately); this fallback keeps the
+/// team_id="". On notarized release hosts ESF reports the real team_id and this fallback is a no-op.
+/// The proper long-term fix is to notarize the extension (tracked separately); this fallback keeps the
 /// dev VM usable for end-to-end QA of TEAMID + SIGNINGID rule flows in the meantime.
 ///
 /// The fallback reads the binary on disk via SecStaticCode + SecCodeCopySigningInformation and returns the

--- a/extension/edr/extension/SigningInfoFallback.swift
+++ b/extension/edr/extension/SigningInfoFallback.swift
@@ -6,12 +6,16 @@ private let logger = Logger(subsystem: "com.fleetdm.edr.securityextension", cate
 
 /// SigningInfoFallback fills in the canonical Team ID for a binary when ESF returns an empty `target.team_id`.
 ///
-/// Why this exists: on SIP-disabled environments, the kernel can flag developer-signed binaries as
-/// `CS_PLATFORM_BINARY` (codesigning_flags bit 0x04000000). ESF surfaces `is_platform_binary=true` for those
-/// processes and OMITS the team_id (platform binaries are Apple's; team_id is unset by convention).
-/// AUTH_EXEC's TEAMID rule branch then has nothing to match against -- it cannot block a binary by
-/// `8VBZ3948LU` if ESF says team_id="". On SIP-on production environments the kernel does not elevate
-/// dev-signed binaries this way and ESF reports the real team_id; this fallback is a no-op there.
+/// Why this exists: ESF redacts `target.team_id=""` and forces `target.is_platform_binary=true` for every
+/// exec the client sees when the ESF host extension itself is not Developer-ID-signed + notarised. This is
+/// a documented per-client policy, not a per-binary CS_PLATFORM_BINARY classification: the redaction hits
+/// every exec, including unambiguously third-party Developer-ID-signed binaries (issue #187 quantified
+/// 393/393 exec events redacted on edr-dev). The edr-dev VM ships the extension ad-hoc-signed
+/// (`codesign -d` reports `adhoc, linker-signed`), which trips the redaction; AUTH_EXEC's TEAMID rule
+/// branch then has nothing to match against -- it cannot block a binary by `8VBZ3948LU` if ESF says
+/// team_id="". On notarised release hosts ESF reports the real team_id and this fallback is a no-op.
+/// The proper long-term fix is to notarise the extension (tracked separately); this fallback keeps the
+/// dev VM usable for end-to-end QA of TEAMID + SIGNINGID rule flows in the meantime.
 ///
 /// The fallback reads the binary on disk via SecStaticCode + SecCodeCopySigningInformation and returns the
 /// `TeamIdentifier` value the codesign block declares. That is the same value `codesign -dvv` prints, and


### PR DESCRIPTION
…binary` on ad-hoc-signed dev VMs.

- Add `SigningInfoFallback` to recover signing metadata for binaries by reading the signing block when ESF redacts `team_id`.
- Update `ESFSubscriber` to utilize the fallback when `team_id` is empty.
- Document ESF's per-client redaction behavior and the impact on rule evaluation.
- Maintain QA usability on developer VMs until a long-term fix (notarization) is implemented.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation and code comments to clarify signing authentication behavior and provide development environment guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/getvictor/fleet-edr/pull/200?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->