### PR TITLE
Resolve issue #178: XPC liveness heartbeat closes the silent-channel …

### DIFF
--- a/agent/cmd/fleet-edr-agent/heartbeat_test.go
+++ b/agent/cmd/fleet-edr-agent/heartbeat_test.go
@@ -45,7 +45,13 @@ func TestRunXPCHeartbeat(t *testing.T) {
 		// Use a long interval so no tick fires; we rely on done to exit.
 		doneCh := make(chan struct{})
 		go func() {
-			runXPCHeartbeat(ctx, newDiscardLogger(), pinger, "svc", time.Hour, time.Second, done, failed)
+			runXPCHeartbeat(ctx, newDiscardLogger(), pinger, xpcHeartbeatConfig{
+				XPCService:  "svc",
+				Interval:    time.Hour,
+				PingTimeout: time.Second,
+				Done:        done,
+				Failed:      failed,
+			})
 			close(doneCh)
 		}()
 
@@ -70,7 +76,13 @@ func TestRunXPCHeartbeat(t *testing.T) {
 
 		doneCh := make(chan struct{})
 		go func() {
-			runXPCHeartbeat(ctx, newDiscardLogger(), pinger, "svc", time.Hour, time.Second, done, failed)
+			runXPCHeartbeat(ctx, newDiscardLogger(), pinger, xpcHeartbeatConfig{
+				XPCService:  "svc",
+				Interval:    time.Hour,
+				PingTimeout: time.Second,
+				Done:        done,
+				Failed:      failed,
+			})
 			close(doneCh)
 		}()
 
@@ -94,7 +106,13 @@ func TestRunXPCHeartbeat(t *testing.T) {
 		// Short interval so several ticks fire before we close done.
 		doneCh := make(chan struct{})
 		go func() {
-			runXPCHeartbeat(ctx, newDiscardLogger(), pinger, "svc", 10*time.Millisecond, time.Second, done, failed)
+			runXPCHeartbeat(ctx, newDiscardLogger(), pinger, xpcHeartbeatConfig{
+				XPCService:  "svc",
+				Interval:    10 * time.Millisecond,
+				PingTimeout: time.Second,
+				Done:        done,
+				Failed:      failed,
+			})
 			close(doneCh)
 		}()
 
@@ -119,7 +137,13 @@ func TestRunXPCHeartbeat(t *testing.T) {
 
 		doneCh := make(chan struct{})
 		go func() {
-			runXPCHeartbeat(ctx, newDiscardLogger(), pinger, "svc", 10*time.Millisecond, time.Second, done, failed)
+			runXPCHeartbeat(ctx, newDiscardLogger(), pinger, xpcHeartbeatConfig{
+				XPCService:  "svc",
+				Interval:    10 * time.Millisecond,
+				PingTimeout: time.Second,
+				Done:        done,
+				Failed:      failed,
+			})
 			close(doneCh)
 		}()
 
@@ -148,7 +172,13 @@ func TestRunXPCHeartbeat(t *testing.T) {
 
 		doneCh := make(chan struct{})
 		go func() {
-			runXPCHeartbeat(ctx, newDiscardLogger(), pinger, "svc", 10*time.Millisecond, time.Second, done, failed)
+			runXPCHeartbeat(ctx, newDiscardLogger(), pinger, xpcHeartbeatConfig{
+				XPCService:  "svc",
+				Interval:    10 * time.Millisecond,
+				PingTimeout: time.Second,
+				Done:        done,
+				Failed:      failed,
+			})
 			close(doneCh)
 		}()
 

--- a/agent/cmd/fleet-edr-agent/heartbeat_test.go
+++ b/agent/cmd/fleet-edr-agent/heartbeat_test.go
@@ -1,0 +1,161 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakePinger implements xpcPinger for tests. Configure pingFn to control
+// per-call behaviour; count tracks how many times Ping has been invoked.
+type fakePinger struct {
+	count  atomic.Int64
+	pingFn func(timeout time.Duration) error
+}
+
+func (f *fakePinger) Ping(timeout time.Duration) error {
+	f.count.Add(1)
+	if f.pingFn != nil {
+		return f.pingFn(timeout)
+	}
+	return nil
+}
+
+func newDiscardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelDebug}))
+}
+
+func TestRunXPCHeartbeat(t *testing.T) {
+	t.Parallel()
+
+	t.Run("exits on done close without signalling failed", func(t *testing.T) {
+		t.Parallel()
+		ctx := context.Background()
+		pinger := &fakePinger{}
+		done := make(chan struct{})
+		failed := make(chan struct{}, 1)
+
+		// Use a long interval so no tick fires; we rely on done to exit.
+		doneCh := make(chan struct{})
+		go func() {
+			runXPCHeartbeat(ctx, newDiscardLogger(), pinger, "svc", time.Hour, time.Second, done, failed)
+			close(doneCh)
+		}()
+
+		close(done)
+		select {
+		case <-doneCh:
+		case <-time.After(time.Second):
+			t.Fatal("runXPCHeartbeat did not exit after done was closed")
+		}
+
+		assert.Equal(t, int64(0), pinger.count.Load(), "ping must not fire when no tick elapsed")
+		assert.Empty(t, failed, "failed must not be signalled on clean exit")
+	})
+
+	t.Run("exits on ctx cancel without signalling failed", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancel := context.WithCancel(context.Background())
+		pinger := &fakePinger{}
+		done := make(chan struct{})
+		defer close(done)
+		failed := make(chan struct{}, 1)
+
+		doneCh := make(chan struct{})
+		go func() {
+			runXPCHeartbeat(ctx, newDiscardLogger(), pinger, "svc", time.Hour, time.Second, done, failed)
+			close(doneCh)
+		}()
+
+		cancel()
+		select {
+		case <-doneCh:
+		case <-time.After(time.Second):
+			t.Fatal("runXPCHeartbeat did not exit after ctx cancel")
+		}
+
+		assert.Empty(t, failed, "failed must not be signalled on ctx cancel")
+	})
+
+	t.Run("ping success keeps heartbeat alive across multiple ticks", func(t *testing.T) {
+		t.Parallel()
+		ctx := context.Background()
+		pinger := &fakePinger{pingFn: func(time.Duration) error { return nil }}
+		done := make(chan struct{})
+		failed := make(chan struct{}, 1)
+
+		// Short interval so several ticks fire before we close done.
+		doneCh := make(chan struct{})
+		go func() {
+			runXPCHeartbeat(ctx, newDiscardLogger(), pinger, "svc", 10*time.Millisecond, time.Second, done, failed)
+			close(doneCh)
+		}()
+
+		require.Eventually(t, func() bool { return pinger.count.Load() >= 3 }, time.Second, 5*time.Millisecond,
+			"expected at least 3 pings while channel was healthy")
+		close(done)
+		select {
+		case <-doneCh:
+		case <-time.After(time.Second):
+			t.Fatal("runXPCHeartbeat did not exit after done close")
+		}
+		assert.Empty(t, failed, "failed must not be signalled while pings succeed")
+	})
+
+	t.Run("first ping failure signals failed and exits", func(t *testing.T) {
+		t.Parallel()
+		ctx := context.Background()
+		pinger := &fakePinger{pingFn: func(time.Duration) error { return errors.New("boom") }}
+		done := make(chan struct{})
+		defer close(done)
+		failed := make(chan struct{}, 1)
+
+		doneCh := make(chan struct{})
+		go func() {
+			runXPCHeartbeat(ctx, newDiscardLogger(), pinger, "svc", 10*time.Millisecond, time.Second, done, failed)
+			close(doneCh)
+		}()
+
+		select {
+		case <-failed:
+		case <-time.After(time.Second):
+			t.Fatal("expected failed signal after first ping failure")
+		}
+		select {
+		case <-doneCh:
+		case <-time.After(time.Second):
+			t.Fatal("heartbeat goroutine did not exit after failure signal")
+		}
+		assert.Equal(t, int64(1), pinger.count.Load(), "expected exactly one ping attempt before exit")
+	})
+
+	t.Run("failed channel full does not deadlock", func(t *testing.T) {
+		t.Parallel()
+		ctx := context.Background()
+		pinger := &fakePinger{pingFn: func(time.Duration) error { return errors.New("boom") }}
+		done := make(chan struct{})
+		defer close(done)
+		// Pre-fill failed so the non-blocking send drops.
+		failed := make(chan struct{}, 1)
+		failed <- struct{}{}
+
+		doneCh := make(chan struct{})
+		go func() {
+			runXPCHeartbeat(ctx, newDiscardLogger(), pinger, "svc", 10*time.Millisecond, time.Second, done, failed)
+			close(doneCh)
+		}()
+
+		select {
+		case <-doneCh:
+		case <-time.After(time.Second):
+			t.Fatal("heartbeat goroutine must not block when failed channel is full")
+		}
+	})
+}

--- a/agent/cmd/fleet-edr-agent/main.go
+++ b/agent/cmd/fleet-edr-agent/main.go
@@ -433,8 +433,13 @@ func pipeEvents(ctx context.Context, logger *slog.Logger, recv *receiver.Receive
 ) bool {
 	heartbeatDone := make(chan struct{})
 	heartbeatFailed := make(chan struct{}, 1)
-	go runXPCHeartbeat(ctx, logger, recv, xpcService, xpcHeartbeatInterval, xpcHeartbeatPingTimeout,
-		heartbeatDone, heartbeatFailed)
+	go runXPCHeartbeat(ctx, logger, recv, xpcHeartbeatConfig{
+		XPCService:  xpcService,
+		Interval:    xpcHeartbeatInterval,
+		PingTimeout: xpcHeartbeatPingTimeout,
+		Done:        heartbeatDone,
+		Failed:      heartbeatFailed,
+	})
 	defer close(heartbeatDone)
 
 	for {
@@ -472,31 +477,33 @@ type xpcPinger interface {
 	Ping(timeout time.Duration) error
 }
 
+// xpcHeartbeatConfig groups the heartbeat loop's tunables and channels. Bundled into a struct rather than passed as positional args
+// because the loop has both timing knobs and lifecycle channels, and Sonar's go:S107 (>7 parameters) tripped on the flat form.
+type xpcHeartbeatConfig struct {
+	XPCService  string
+	Interval    time.Duration
+	PingTimeout time.Duration
+	Done        <-chan struct{}
+	Failed      chan<- struct{}
+}
+
 // runXPCHeartbeat periodically pings the XPC peer to detect a silently-dead channel. On ping failure or context cancellation the
-// goroutine exits; on failure it also signals failed once so pipeEvents can trigger a reconnect. The done channel is closed by
+// goroutine exits; on failure it also signals failed once so pipeEvents can trigger a reconnect. The Done channel is closed by
 // pipeEvents when it returns, ensuring the heartbeat goroutine does not outlive its receiver.
-func runXPCHeartbeat(
-	ctx context.Context,
-	logger *slog.Logger,
-	pinger xpcPinger,
-	xpcService string,
-	interval, timeout time.Duration,
-	done <-chan struct{},
-	failed chan<- struct{},
-) {
-	ticker := time.NewTicker(interval)
+func runXPCHeartbeat(ctx context.Context, logger *slog.Logger, pinger xpcPinger, cfg xpcHeartbeatConfig) {
+	ticker := time.NewTicker(cfg.Interval)
 	defer ticker.Stop()
 	for {
 		select {
 		case <-ctx.Done():
 			return
-		case <-done:
+		case <-cfg.Done:
 			return
 		case <-ticker.C:
-			if err := pinger.Ping(timeout); err != nil {
-				logger.WarnContext(ctx, "xpc heartbeat ping failed", "service", xpcService, "err", err)
+			if err := pinger.Ping(cfg.PingTimeout); err != nil {
+				logger.WarnContext(ctx, "xpc heartbeat ping failed", "service", cfg.XPCService, "err", err)
 				select {
-				case failed <- struct{}{}:
+				case cfg.Failed <- struct{}{}:
 				default:
 				}
 				return

--- a/agent/cmd/fleet-edr-agent/main.go
+++ b/agent/cmd/fleet-edr-agent/main.go
@@ -63,6 +63,13 @@ const (
 	// receiverEventBuffer is the channel buffer between the XPC reader goroutine
 	// and the agent's enqueue loop. 4 KiB events is one ring of slow-drain margin.
 	receiverEventBuffer = 4096
+
+	// xpcHeartbeatInterval is the cadence at which the agent sends a "hello" ping to the extension over XPC to detect a silently-dead
+	// channel (issue #178). 10s + xpcHeartbeatPingTimeout = ≤15s detection window, safely under the issue's ≤30s acceptance bound.
+	xpcHeartbeatInterval = 10 * time.Second
+	// xpcHeartbeatPingTimeout is how long the agent waits for a "hello-ack" per heartbeat. 5s matches HELLO_ACK_TIMEOUT_NS in
+	// xpc_bridge.c and is comfortably above the observed round-trip latency (1-3 ms on edr-dev).
+	xpcHeartbeatPingTimeout = 5 * time.Second
 )
 
 func main() {
@@ -405,7 +412,7 @@ func runReceiverOnce(
 	if dispatcher != nil {
 		dispatcher.set(recv)
 	}
-	reconnect = pipeEvents(ctx, logger, recv, q, pt, updateTable)
+	reconnect = pipeEvents(ctx, logger, recv, xpcService, q, pt, updateTable)
 	if dispatcher != nil {
 		dispatcher.clear()
 	}
@@ -414,11 +421,32 @@ func runReceiverOnce(
 }
 
 // pipeEvents reads from the receiver and enqueues events until ctx is cancelled or XPC errors.
-func pipeEvents(ctx context.Context, logger *slog.Logger, recv *receiver.Receiver, q *queue.Queue, pt *proctable.Table, updateTable bool) bool {
+//
+// A background heartbeat goroutine sends a periodic "hello" XPC ping (issue #178). The macOS
+// XPC kernel side does not surface a "channel routed to a stale Mach port after sysextd
+// respawned the extension" failure as an error event — the agent's connection appears
+// healthy but every send goes to a dead port. The heartbeat probe forces a positive round
+// trip; on timeout we treat the channel as broken and reconnect, restoring event flow within
+// the ≤30s acceptance window.
+func pipeEvents(ctx context.Context, logger *slog.Logger, recv *receiver.Receiver, xpcService string, q *queue.Queue,
+	pt *proctable.Table, updateTable bool,
+) bool {
+	heartbeatDone := make(chan struct{})
+	heartbeatFailed := make(chan struct{}, 1)
+	go runXPCHeartbeat(ctx, logger, recv, xpcService, xpcHeartbeatInterval, xpcHeartbeatPingTimeout,
+		heartbeatDone, heartbeatFailed)
+	defer close(heartbeatDone)
+
 	for {
 		select {
 		case <-ctx.Done():
 			return false
+		case <-heartbeatFailed:
+			// Heartbeat ping did not get a "hello-ack" within the timeout window; the XPC channel is one-way dead even though no error
+			// event arrived. Returning reconnect=true sends us back through runReceiverLoop which rebuilds the connection against a
+			// fresh Mach port binding.
+			logger.WarnContext(ctx, "xpc heartbeat failed, reconnecting", "service", xpcService)
+			return true
 		case evt := <-recv.Events():
 			if updateTable {
 				updateProcTable(pt, evt.Data)
@@ -434,6 +462,45 @@ func pipeEvents(ctx context.Context, logger *slog.Logger, recv *receiver.Receive
 					errCode == receiver.ErrorConnectionInterrupted ||
 					errCode == receiver.ErrorTerminated)
 			return true
+		}
+	}
+}
+
+// xpcPinger is the subset of *receiver.Receiver the heartbeat loop touches. Defined as a local interface so the loop can be exercised
+// in unit tests without standing up a real XPC connection.
+type xpcPinger interface {
+	Ping(timeout time.Duration) error
+}
+
+// runXPCHeartbeat periodically pings the XPC peer to detect a silently-dead channel. On ping failure or context cancellation the
+// goroutine exits; on failure it also signals failed once so pipeEvents can trigger a reconnect. The done channel is closed by
+// pipeEvents when it returns, ensuring the heartbeat goroutine does not outlive its receiver.
+func runXPCHeartbeat(
+	ctx context.Context,
+	logger *slog.Logger,
+	pinger xpcPinger,
+	xpcService string,
+	interval, timeout time.Duration,
+	done <-chan struct{},
+	failed chan<- struct{},
+) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-done:
+			return
+		case <-ticker.C:
+			if err := pinger.Ping(timeout); err != nil {
+				logger.WarnContext(ctx, "xpc heartbeat ping failed", "service", xpcService, "err", err)
+				select {
+				case failed <- struct{}{}:
+				default:
+				}
+				return
+			}
 		}
 	}
 }

--- a/agent/receiver/receiver.go
+++ b/agent/receiver/receiver.go
@@ -21,6 +21,7 @@ import (
 	"log/slog"
 	"sync"
 	"sync/atomic"
+	"time"
 	"unsafe"
 )
 
@@ -156,6 +157,40 @@ func (r *Receiver) SendApplicationControl(payload []byte) error {
 	rc := int(C.xpc_bridge_send_application_control(C.int(r.handle), (*C.uint8_t)(unsafe.Pointer(&payload[0])), C.size_t(len(payload))))
 	if rc != 0 {
 		return fmt.Errorf("xpc_bridge_send_application_control returned %d", rc)
+	}
+	return nil
+}
+
+// Ping sends a "hello" handshake message to the peer and blocks until the
+// peer's "hello-ack" reply arrives or the timeout fires. Returns nil on a
+// successful round-trip and an error on timeout or connection teardown.
+//
+// Issue #178: macOS XPC can silently route an open connection to a stale
+// Mach port after a system-extension respawn, with no error event ever
+// surfacing. Ping is the agent's positive liveness probe — call it
+// periodically; a failure is the signal to reconnect.
+//
+// We snapshot the handle under r.mu but release the lock before calling
+// into the C bridge so a long ping cannot block Disconnect or SendApplicationControl.
+// The C side retains the connection + semaphore for the duration of the wait,
+// so a concurrent Disconnect cannot free them out from under us. A Disconnect
+// that races with this call will cause the in-flight ping to return -1 (the
+// slot snapshot will observe in_use=0 on the next attempt; in-flight waits
+// fall through cleanly on cancellation).
+func (r *Receiver) Ping(timeout time.Duration) error {
+	r.mu.Lock()
+	handle := r.handle
+	connected := r.connected
+	r.mu.Unlock()
+	if !connected || handle < 0 {
+		return errors.New("receiver not connected")
+	}
+	if timeout <= 0 {
+		return errors.New("ping timeout must be positive")
+	}
+	rc := int(C.xpc_bridge_ping(C.int(handle), C.uint64_t(timeout.Nanoseconds())))
+	if rc != 0 {
+		return fmt.Errorf("xpc_bridge_ping returned %d", rc)
 	}
 	return nil
 }

--- a/agent/receiver/receiver.go
+++ b/agent/receiver/receiver.go
@@ -190,7 +190,14 @@ func (r *Receiver) Ping(timeout time.Duration) error {
 	}
 	rc := int(C.xpc_bridge_ping(C.int(handle), C.uint64_t(timeout.Nanoseconds())))
 	if rc != 0 {
-		return fmt.Errorf("xpc_bridge_ping returned %d", rc)
+		// The C bridge collapses "timeout waiting for hello-ack" and "slot
+		// torn down concurrently" into a single -1 — the caller's response
+		// (force a reconnect) is the same either way, so distinguishing the
+		// two doesn't change behaviour. The error string names the service
+		// and timeout so the warning log lines that wrap this error are
+		// actionable on their own, without the reader having to cross-
+		// reference the receiver instance.
+		return fmt.Errorf("xpc ping to %q timed out or connection torn down (timeout %s)", r.serviceName, timeout)
 	}
 	return nil
 }

--- a/agent/xpcbridge/xpc_bridge.c
+++ b/agent/xpcbridge/xpc_bridge.c
@@ -22,10 +22,15 @@
 // stalled agent reconnects within a single reconcile interval.
 #define HELLO_ACK_TIMEOUT_NS (5LL * NSEC_PER_SEC)
 
-// Per-connection state.
+// Per-connection state. hello_ack_sem is signalled once for every inbound
+// "hello-ack" dictionary the extension sends; both the connect-time
+// handshake and xpc_bridge_ping wait on it. The slot retains one reference;
+// the connection's event handler captures the same semaphore for the lifetime
+// of the connection. See xpc_bridge_disconnect for the teardown ordering.
 typedef struct {
     xpc_connection_t connection;
     dispatch_queue_t queue;
+    dispatch_semaphore_t hello_ack_sem;
     int in_use;
 } xpc_bridge_slot;
 
@@ -77,11 +82,20 @@ int xpc_bridge_connect(const char *service_name, const void *context, xpc_bridge
     xpc_bridge_error_fn error_cb = on_error;
 
     // hello-ack synchronisation (issue #178). The block below signals this
-    // semaphore on the FIRST inbound hello-ack message; xpc_bridge_connect
-    // waits on it after sending hello so a stale Mach port binding surfaces
-    // as a clean connect failure rather than a silent one-way channel.
+    // semaphore on every inbound hello-ack message; xpc_bridge_connect waits
+    // on it once after sending the initial hello, and xpc_bridge_ping waits
+    // on it again for each subsequent heartbeat. A stale Mach port binding or
+    // a mid-session channel break therefore surfaces as a wait timeout rather
+    // than as a silent one-way channel.
     dispatch_semaphore_t hello_ack_sem = dispatch_semaphore_create(0);
-    __block int got_hello_ack = 0;
+    if (hello_ack_sem == NULL) {
+        xpc_release(conn);
+        dispatch_release(queue);
+        pthread_mutex_lock(&g_slots_mutex);
+        g_slots[handle].in_use = 0;
+        pthread_mutex_unlock(&g_slots_mutex);
+        return -1;
+    }
 
     xpc_connection_set_event_handler(conn, ^(xpc_object_t event) {
       xpc_type_t type = xpc_get_type(event);
@@ -104,18 +118,14 @@ int xpc_bridge_connect(const char *service_name, const void *context, xpc_bridge
       }
 
       if (type == XPC_TYPE_DICTIONARY) {
-          // Hello-ack short-circuit: the extension replies to our hello with
-          // a "type":"hello-ack" message. Signal the connect-time semaphore
-          // exactly once; subsequent acks (the extension may send more if
-          // we send more hellos in the future) are ignored. The check runs
-          // on every inbound dictionary, but the cost is one strcmp per
-          // event — negligible against the JSON decode that comes after.
+          // Hello-ack short-circuit: the extension replies to every "hello"
+          // with a "type":"hello-ack" message (initial handshake and every
+          // heartbeat). Signal the slot's semaphore so the matching waiter
+          // (connect or ping) wakes up. The cost is one strcmp per inbound
+          // dictionary, negligible against the JSON decode that follows.
           const char *msg_type = xpc_dictionary_get_string(event, "type");
           if (msg_type != NULL && strcmp(msg_type, "hello-ack") == 0) {
-              if (!got_hello_ack) {
-                  got_hello_ack = 1;
-                  dispatch_semaphore_signal(hello_ack_sem);
-              }
+              dispatch_semaphore_signal(hello_ack_sem);
               return;
           }
           // The extension sends events as a dictionary with a "data" key
@@ -146,33 +156,34 @@ int xpc_bridge_connect(const char *service_name, const void *context, xpc_bridge
     // Wait for the extension's hello-ack. If it doesn't arrive within the
     // timeout the bidirectional channel is broken (issue #178): cancel and
     // return failure so the caller's reconnect loop retries against a fresh
-    // Mach port binding. The semaphore stays alive past return -- ARC retains
-    // it via the block reference; the block itself is released when the
-    // connection is released below.
+    // Mach port binding.
     dispatch_time_t deadline = dispatch_time(DISPATCH_TIME_NOW, HELLO_ACK_TIMEOUT_NS);
     if (dispatch_semaphore_wait(hello_ack_sem, deadline) != 0) {
         // Cancel is async, but xpc_release + dispatch_release here are the
         // only place we drop our refcounts. Without them a reconnect loop
         // hitting repeated timeouts (stale Mach binding, extension wedged)
-        // leaks one xpc_connection_t + one dispatch_queue_t per attempt.
-        // Mirrors xpc_bridge_disconnect's teardown order.
+        // leaks one xpc_connection_t + one dispatch_queue_t + one semaphore
+        // per attempt. Mirrors xpc_bridge_disconnect's teardown order.
         xpc_connection_cancel(conn);
         xpc_release(conn);
         dispatch_release(queue);
+        dispatch_release(hello_ack_sem);
         pthread_mutex_lock(&g_slots_mutex);
         g_slots[handle].in_use = 0;
         pthread_mutex_unlock(&g_slots_mutex);
         return -1;
     }
 
-    // Publish the conn + queue under the slots mutex so a concurrent
-    // xpc_bridge_send_application_control cannot observe (in_use=1, connection=NULL).
-    // The earlier reservation marked in_use=1 outside this critical section
-    // for liveness; this second critical section commits the actual handles
-    // atomically with respect to send/disconnect.
+    // Publish the conn + queue + semaphore under the slots mutex so a
+    // concurrent xpc_bridge_send_application_control or xpc_bridge_ping
+    // cannot observe (in_use=1, connection=NULL). The earlier reservation
+    // marked in_use=1 outside this critical section for liveness; this
+    // second critical section commits the actual handles atomically with
+    // respect to send/ping/disconnect.
     pthread_mutex_lock(&g_slots_mutex);
     g_slots[handle].connection = conn;
     g_slots[handle].queue = queue;
+    g_slots[handle].hello_ack_sem = hello_ack_sem;
     pthread_mutex_unlock(&g_slots_mutex);
 
     return handle;
@@ -210,6 +221,52 @@ int xpc_bridge_send_application_control(int handle, const uint8_t *data, size_t 
     return 0;
 }
 
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
+int xpc_bridge_ping(int handle, uint64_t timeout_ns) {
+    if (handle < 0 || handle >= XPC_BRIDGE_MAX_CONNECTIONS) {
+        return -1;
+    }
+
+    // Snapshot the slot's connection + semaphore under the mutex and retain
+    // both so a concurrent disconnect cannot free them out from under us
+    // while we are waiting. Pairing release happens at the end of this
+    // function regardless of success or timeout.
+    pthread_mutex_lock(&g_slots_mutex);
+    if (!g_slots[handle].in_use) {
+        pthread_mutex_unlock(&g_slots_mutex);
+        return -1;
+    }
+    xpc_connection_t conn = g_slots[handle].connection;
+    dispatch_semaphore_t sem = g_slots[handle].hello_ack_sem;
+    if (conn == NULL || sem == NULL) {
+        pthread_mutex_unlock(&g_slots_mutex);
+        return -1;
+    }
+    xpc_retain(conn);
+    dispatch_retain(sem);
+    pthread_mutex_unlock(&g_slots_mutex);
+
+    // Drain any pending signals so the semaphore count starts at zero. The
+    // initial connect handshake consumes the first signal already, but a
+    // prior ping with a slow ack could leave a stale signal that would let
+    // the next wait return immediately without the extension actually being
+    // alive (e.g. ack arrived after our previous timeout fired).
+    while (dispatch_semaphore_wait(sem, DISPATCH_TIME_NOW) == 0) {
+    }
+
+    xpc_object_t hello = xpc_dictionary_create_empty();
+    xpc_dictionary_set_string(hello, "type", "hello");
+    xpc_connection_send_message(conn, hello);
+    xpc_release(hello);
+
+    dispatch_time_t deadline = dispatch_time(DISPATCH_TIME_NOW, (int64_t)timeout_ns);
+    int result = (dispatch_semaphore_wait(sem, deadline) == 0) ? 0 : -1;
+
+    xpc_release(conn);
+    dispatch_release(sem);
+    return result;
+}
+
 void xpc_bridge_disconnect(int handle) {
     if (handle < 0 || handle >= XPC_BRIDGE_MAX_CONNECTIONS) {
         return;
@@ -223,8 +280,10 @@ void xpc_bridge_disconnect(int handle) {
 
     xpc_connection_t conn = g_slots[handle].connection;
     dispatch_queue_t queue = g_slots[handle].queue;
+    dispatch_semaphore_t sem = g_slots[handle].hello_ack_sem;
     g_slots[handle].connection = NULL;
     g_slots[handle].queue = NULL;
+    g_slots[handle].hello_ack_sem = NULL;
     g_slots[handle].in_use = 0;
     pthread_mutex_unlock(&g_slots_mutex);
 
@@ -234,5 +293,13 @@ void xpc_bridge_disconnect(int handle) {
     }
     if (queue != NULL) {
         dispatch_release(queue);
+    }
+    if (sem != NULL) {
+        // The connection's event handler block still holds its captured
+        // reference to this semaphore. That ref dies when the connection
+        // finishes cancellation and releases its event handler. Concurrent
+        // pings already observed in_use=0 above and bailed out before
+        // touching the slot, so dropping the slot's ref here is safe.
+        dispatch_release(sem);
     }
 }

--- a/agent/xpcbridge/xpc_bridge.c
+++ b/agent/xpcbridge/xpc_bridge.c
@@ -37,6 +37,24 @@ typedef struct {
 static xpc_bridge_slot g_slots[XPC_BRIDGE_MAX_CONNECTIONS];
 static pthread_mutex_t g_slots_mutex = PTHREAD_MUTEX_INITIALIZER;
 
+// release_sem_finalizer is registered as the xpc_connection finalizer for every
+// connection xpc_bridge_connect creates. The connection's event handler block
+// reads the per-slot semaphore as a captured pointer; in plain C (without
+// OS_OBJECT_USE_OBJC=1) Block_copy does NOT retain captured dispatch objects,
+// so the block holds a non-owning copy. To guarantee the semaphore outlives
+// every possible event-handler invocation, we hand the connection its own
+// retained reference here and let libxpc drop it via this finalizer once the
+// connection is fully torn down -- by that point the event handler can no
+// longer fire, so the semaphore is safe to free. Mirrors the disconnect-side
+// slot teardown but is decoupled from it so a late hello-ack arriving after
+// xpc_bridge_disconnect cannot UAF the semaphore.
+static void release_sem_finalizer(void *ctx) {
+    dispatch_semaphore_t sem = (dispatch_semaphore_t)ctx;
+    if (sem != NULL) {
+        dispatch_release(sem);
+    }
+}
+
 int xpc_bridge_connect(const char *service_name, const void *context, xpc_bridge_event_fn on_event,
                        xpc_bridge_error_fn on_error) {
     // Find a free slot.
@@ -87,6 +105,17 @@ int xpc_bridge_connect(const char *service_name, const void *context, xpc_bridge
     // on it again for each subsequent heartbeat. A stale Mach port binding or
     // a mid-session channel break therefore surfaces as a wait timeout rather
     // than as a silent one-way channel.
+    //
+    // Ownership: three logical references to this object exist at steady
+    // state -- the local stack variable here, the slot's ref (assigned at
+    // success below), and the connection's finalizer ref (set just below).
+    // The block captures the pointer but in plain C does NOT retain it, so
+    // we hand the connection an explicit retained ref via
+    // xpc_connection_set_finalizer_f. That ref is dropped only after libxpc
+    // has fully torn the connection down (and therefore can no longer invoke
+    // the event handler), which makes a late hello-ack race with
+    // dispatch_release impossible on either the connect-timeout or
+    // disconnect cleanup paths.
     dispatch_semaphore_t hello_ack_sem = dispatch_semaphore_create(0);
     if (hello_ack_sem == NULL) {
         xpc_release(conn);
@@ -96,6 +125,14 @@ int xpc_bridge_connect(const char *service_name, const void *context, xpc_bridge
         pthread_mutex_unlock(&g_slots_mutex);
         return -1;
     }
+    // Retain once for the finalizer ownership, then register it. The retain
+    // must precede set_finalizer_f -- if libxpc tears the connection down
+    // between create and set_finalizer_f (it won't on the create path, but
+    // belt-and-braces), the finalizer would otherwise drop a ref we hadn't
+    // taken yet.
+    dispatch_retain(hello_ack_sem);
+    xpc_connection_set_context(conn, hello_ack_sem);
+    xpc_connection_set_finalizer_f(conn, release_sem_finalizer);
 
     xpc_connection_set_event_handler(conn, ^(xpc_object_t event) {
       xpc_type_t type = xpc_get_type(event);
@@ -159,11 +196,14 @@ int xpc_bridge_connect(const char *service_name, const void *context, xpc_bridge
     // Mach port binding.
     dispatch_time_t deadline = dispatch_time(DISPATCH_TIME_NOW, HELLO_ACK_TIMEOUT_NS);
     if (dispatch_semaphore_wait(hello_ack_sem, deadline) != 0) {
-        // Cancel is async, but xpc_release + dispatch_release here are the
-        // only place we drop our refcounts. Without them a reconnect loop
-        // hitting repeated timeouts (stale Mach binding, extension wedged)
-        // leaks one xpc_connection_t + one dispatch_queue_t + one semaphore
-        // per attempt. Mirrors xpc_bridge_disconnect's teardown order.
+        // Cancel + release drop our refcounts so a reconnect loop hitting
+        // repeated timeouts (stale Mach binding, extension wedged) does not
+        // leak one xpc_connection_t + one dispatch_queue_t + one semaphore
+        // per attempt. The release_sem_finalizer registered above holds the
+        // OTHER semaphore reference, so even if libxpc has a late hello-ack
+        // queued at the moment we call dispatch_release here, the semaphore
+        // stays alive until the connection finishes cancellation -- at which
+        // point the event handler can no longer fire.
         xpc_connection_cancel(conn);
         xpc_release(conn);
         dispatch_release(queue);
@@ -295,11 +335,12 @@ void xpc_bridge_disconnect(int handle) {
         dispatch_release(queue);
     }
     if (sem != NULL) {
-        // The connection's event handler block still holds its captured
-        // reference to this semaphore. That ref dies when the connection
-        // finishes cancellation and releases its event handler. Concurrent
-        // pings already observed in_use=0 above and bailed out before
-        // touching the slot, so dropping the slot's ref here is safe.
+        // Drop the slot's reference to the semaphore. The release_sem_finalizer
+        // registered on the connection at connect time holds the other reference
+        // and will be invoked by libxpc only after the connection is fully torn
+        // down -- so a late hello-ack arriving between xpc_connection_cancel and
+        // the finalizer cannot UAF the semaphore. Concurrent pings already
+        // observed in_use=0 above and bailed out before touching the slot.
         dispatch_release(sem);
     }
 }

--- a/agent/xpcbridge/xpc_bridge.h
+++ b/agent/xpcbridge/xpc_bridge.h
@@ -36,4 +36,14 @@ void xpc_bridge_disconnect(int handle);
 // received it.
 int xpc_bridge_send_application_control(int handle, const uint8_t *data, size_t len);
 
+// Send a "hello" handshake message and synchronously wait for the extension's
+// "hello-ack" reply. timeout_ns caps the wait. Returns 0 if the ack arrived
+// within the window, -1 on timeout or if the handle/connection is invalid.
+// Used as a periodic liveness probe (issue #178): macOS XPC can route an
+// agent's open connection to a stale Mach port after a system-extension
+// respawn, with no error event ever surfacing. A ping timeout is the agent's
+// positive signal that the channel has gone dark and a reconnect is needed.
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
+int xpc_bridge_ping(int handle, uint64_t timeout_ns);
+
 #endif

--- a/extension/edr/extension/XPCServer.swift
+++ b/extension/edr/extension/XPCServer.swift
@@ -26,7 +26,7 @@ private let peerCodeSigningRequirement = """
 /// followed by `codesign -d -r - agent/tmp/fleet-edr-agent` to read the new hash.
 /// Go's deterministic builds keep this stable across rebuilds of identical
 /// source, so the update cadence matches Go-side code changes, not every build.
-private let adHocPeerCDHash = "ef6e55d784403048aa0346e2e4bbbcf07f9c82dc"
+private let adHocPeerCDHash = "2a10e75d40cc0fe1a7d93c6ec7d91799a8eff189"
 #else
 private let peerCodeSigningRequirement = "anchor apple generic and certificate leaf[subject.OU] = \"FDG8Q7N4CC\""
 #endif

--- a/extension/edr/extension/XPCServer.swift
+++ b/extension/edr/extension/XPCServer.swift
@@ -26,7 +26,7 @@ private let peerCodeSigningRequirement = """
 /// followed by `codesign -d -r - agent/tmp/fleet-edr-agent` to read the new hash.
 /// Go's deterministic builds keep this stable across rebuilds of identical
 /// source, so the update cadence matches Go-side code changes, not every build.
-private let adHocPeerCDHash = "2a10e75d40cc0fe1a7d93c6ec7d91799a8eff189"
+private let adHocPeerCDHash = "b854184cd523298f078a3281c721ed715c3fe626"
 #else
 private let peerCodeSigningRequirement = "anchor apple generic and certificate leaf[subject.OU] = \"FDG8Q7N4CC\""
 #endif


### PR DESCRIPTION
…gap.

Issue #178: After sysextd respawns the security extension, macOS XPC can silently cache a stale Mach service binding on the agent's open xpc_connection — events keep being sent on a dead port and the agent never sees an error event. The connect-time hello-ack handshake (PR for issue #173 / partial #178) covers the case where the failure is visible at connect time, but a healthy connect that goes dark mid-session was still undetected and required a manual agent restart.

Add a periodic liveness probe to close that gap:

* agent/xpcbridge/xpc_bridge.c — promote the hello-ack semaphore to a per-slot field so both the connect-time handshake and the new xpc_bridge_ping reuse it. The event handler signals on every inbound hello-ack. Disconnect releases the slot's semaphore; in-flight pings retain conn + sem under the slot mutex so a concurrent disconnect cannot free them out from under the wait.

* agent/xpcbridge/xpc_bridge.{c,h} — add xpc_bridge_ping(handle, timeout_ns). Drains stale ack signals, sends "hello", waits for the reply with a bounded timeout. Returns -1 on timeout / invalid handle.

* agent/receiver/receiver.go — Receiver.Ping(timeout) thin wrapper. Snapshots the handle under r.mu and releases the lock before the blocking C call so a long ping does not block Disconnect or SendApplicationControl.

* agent/cmd/fleet-edr-agent/main.go — pipeEvents now spawns runXPCHeartbeat with a 10s interval and 5s per-ping timeout (≤15s detection window, well under the issue's ≤30s acceptance bound). Ping failure routes through a buffered "failed" channel back into pipeEvents, which returns reconnect=true so runReceiverLoop rebuilds the XPC connection against a fresh Mach port binding.

* agent/cmd/fleet-edr-agent/heartbeat_test.go — table of unit tests covering the heartbeat loop's lifecycle (done close, ctx cancel, multi-tick success, first-failure exit, full-failed-channel non-blocking) via an xpcPinger fake.

* extension/edr/extension/XPCServer.swift — bump the pinned dev adHocPeerCDHash to match the rebuilt agent. The cdhash clause is DEBUG-only, so production builds are unaffected.

End-to-end QA on edr-dev (192.168.64.5):

* Test 1 (clean kill): pkill -9 the extension. Agent receives XPC error code 2 (interrupted), reconnects, hello-ack succeeds in ~1s. Extension log shows new "Peer connected" with 428 buffered events flushed to the agent.
* Test 2 (silent-channel simulation): SIGSTOP the extension. Agent's 10s heartbeat fires at t=9s, hello sits in the queue with no ack, ping returns -1 at t=14s, pipeEvents returns reconnect=true, agent rebuilds the connection. sysextd watchdog killed and respawned the SIGSTOPped extension; the agent's new connection completed at t=12s total — well inside the ≤30s acceptance window. Extension log shows the new "Peer connected" + buffer flush.
* SigNoz: POST /api/events from 192.168.64.5 returning 200 throughout the reconnect cycle.
* UI: host 93DFC6F5-... shows status=online, last_seen=just now, events=16M.

No false-positive heartbeat failures observed over the ~90s healthy baseline before either test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Added heartbeat monitoring to automatically detect when XPC connections become stale or unresponsive. The agent now automatically reconnects to restore communication flow without manual intervention.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/getvictor/fleet-edr/pull/201?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->