### PR TITLE
M1: split receiver behind build tags so agent compiles on linux

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -122,6 +122,13 @@ jobs:
           version: 3.50.0
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Cross-build agent for linux (UAT plan M1 invariant)
+        # The agent's Go core must compile on linux so the headless integration
+        # job (UAT plan M3) and developer Linux machines can build it. The
+        # darwin-only XPC bridge is selected by build tags; everything else is
+        # platform-portable. See docs/testing-strategy.md.
+        run: task build:agent:linux
+
       - name: Run agent tests with coverage
         run: task test:go:agent:coverage
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -50,6 +50,20 @@ tasks:
     cmds:
       - go build -o {{.AGENT_BIN}} {{.AGENT_PKG}}
 
+  build:agent:linux:
+    desc: |
+      Cross-compile the agent for linux/amd64. Exercises the build-tag split in
+      agent/receiver (UAT plan M1): the darwin-only CGo XPC bridge is excluded
+      and the non-darwin stub is selected so the agent module compiles cleanly
+      on a non-macOS host. This is a compile-only check; the resulting binary
+      does not run usefully on linux. CI calls this from the agent-test job to
+      keep the platform-portability invariant green.
+    env:
+      GOOS: linux
+      GOARCH: amd64
+    cmds:
+      - go build ./agent/...
+
   ui:setup:
     desc: |
       Install UI npm dependencies. Wired as a dep of build:ui and dev:ui so a fresh clone

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -52,15 +52,19 @@ tasks:
 
   build:agent:linux:
     desc: |
-      Cross-compile the agent for linux/amd64. Exercises the build-tag split in
-      agent/receiver (UAT plan M1): the darwin-only CGo XPC bridge is excluded
-      and the non-darwin stub is selected so the agent module compiles cleanly
-      on a non-macOS host. This is a compile-only check; the resulting binary
-      does not run usefully on linux. CI calls this from the agent-test job to
-      keep the platform-portability invariant green.
+      Cross-compile the agent for linux/amd64 as a compile-only invariant check
+      (no binary is produced because the package pattern targets multiple
+      packages; `go build ./agent/...` reports compile errors but writes no
+      output). Exercises the build-tag split in agent/receiver (UAT plan M1):
+      the darwin-only CGo XPC bridge is excluded and the non-darwin stub is
+      selected so the agent module compiles cleanly on a non-macOS host.
+      CGO_ENABLED=0 keeps this check from accidentally depending on a local C
+      cross-toolchain when run on a native linux host. CI calls this from the
+      agent-test job to keep the platform-portability invariant green.
     env:
       GOOS: linux
       GOARCH: amd64
+      CGO_ENABLED: 0
     cmds:
       - go build ./agent/...
 

--- a/agent/receiver/callbacks.go
+++ b/agent/receiver/callbacks.go
@@ -1,3 +1,5 @@
+//go:build darwin
+
 package receiver
 
 // This file contains the //export functions that CGo exposes to C.

--- a/agent/receiver/callbacks.go
+++ b/agent/receiver/callbacks.go
@@ -1,4 +1,4 @@
-//go:build darwin
+//go:build darwin && cgo
 
 package receiver
 

--- a/agent/receiver/common.go
+++ b/agent/receiver/common.go
@@ -1,0 +1,44 @@
+// Package receiver delivers raw JSON event bytes from upstream sources (the
+// macOS ESF / Network Extension XPC peer on darwin, a no-op stub elsewhere)
+// to a Go channel that the agent's queue + uploader pipeline consumes.
+//
+// The darwin build is the production receiver and lives in receiver.go +
+// callbacks.go + bridge.c. The non-darwin build is the stub in
+// receiver_other.go: it satisfies the same public surface so the agent
+// module compiles on linux for the headless integration job (UAT plan M3),
+// but the stub Receiver's Connect, SendApplicationControl, and Ping all
+// return ErrUnsupported because there is no XPC service to talk to. A
+// future milestone (M2) replaces the stub with an inject-able variant
+// driven by the fake-agent control plane.
+package receiver
+
+import (
+	"log/slog"
+	"sync/atomic"
+)
+
+// Error codes matching xpc_bridge.h constants. The values are part of the agent's logging surface; main.go classifies which codes are
+// "expected" (transient reconnects) versus unexpected via these symbols, so they live in the shared file so the linux build sees them too.
+const (
+	ErrorConnectionInvalid     = 1
+	ErrorConnectionInterrupted = 2
+	ErrorTerminated            = 3
+)
+
+// Event is a raw JSON event received from an upstream source.
+type Event struct {
+	Data []byte
+}
+
+// logger is the package-level logger used from CGo callbacks where passing a per-request logger would be impractical. Callers can override
+// it via SetLogger; the default is slog.Default(). The darwin build's onEvent reads it via getLogger (in receiver.go); the non-darwin stub
+// never logs because it never produces events.
+var logger atomic.Pointer[slog.Logger]
+
+// SetLogger installs a logger for diagnostic output from the package's
+// callback paths. Safe to call concurrently.
+func SetLogger(l *slog.Logger) {
+	if l != nil {
+		logger.Store(l)
+	}
+}

--- a/agent/receiver/receiver.go
+++ b/agent/receiver/receiver.go
@@ -1,7 +1,9 @@
-//go:build darwin
+//go:build darwin && cgo
 
 // This file contains the production XPC-backed Receiver. Shared identifiers (Event, Error* constants, logger plumbing) live in common.go
-// so the non-darwin stub in receiver_other.go can reuse them without duplication.
+// so the non-darwin stub in receiver_other.go can reuse them without duplication. The `cgo` build constraint pairs with the stub's
+// `!darwin || !cgo` so a `GOOS=darwin CGO_ENABLED=0` build still resolves the Receiver type via the stub instead of failing with
+// missing symbols.
 package receiver
 
 /*

--- a/agent/receiver/receiver.go
+++ b/agent/receiver/receiver.go
@@ -1,5 +1,7 @@
-// Package receiver connects to XPC Mach services (ESF extension, network extension)
-// and delivers raw JSON event bytes to Go channels.
+//go:build darwin
+
+// This file contains the production XPC-backed Receiver. Shared identifiers (Event, Error* constants, logger plumbing) live in common.go
+// so the non-darwin stub in receiver_other.go can reuse them without duplication.
 package receiver
 
 /*
@@ -20,39 +22,15 @@ import (
 	"fmt"
 	"log/slog"
 	"sync"
-	"sync/atomic"
 	"time"
 	"unsafe"
 )
-
-// logger is the package-level logger used from CGo callbacks where passing a per-request logger
-// would be impractical. Callers can override it via SetLogger; the default is slog.Default().
-var logger atomic.Pointer[slog.Logger]
-
-// SetLogger installs a logger for diagnostic output from CGo callbacks. Safe to call concurrently.
-func SetLogger(l *slog.Logger) {
-	if l != nil {
-		logger.Store(l)
-	}
-}
 
 func getLogger() *slog.Logger {
 	if l := logger.Load(); l != nil {
 		return l
 	}
 	return slog.Default()
-}
-
-// Error codes matching xpc_bridge.h constants.
-const (
-	ErrorConnectionInvalid     = 1
-	ErrorConnectionInterrupted = 2
-	ErrorTerminated            = 3
-)
-
-// Event is a raw JSON event received from an XPC extension.
-type Event struct {
-	Data []byte
 }
 
 // Receiver manages a single XPC connection and delivers events.

--- a/agent/receiver/receiver_other.go
+++ b/agent/receiver/receiver_other.go
@@ -1,4 +1,4 @@
-//go:build !darwin
+//go:build !darwin || !cgo
 
 package receiver
 
@@ -59,5 +59,8 @@ func (r *Receiver) SendApplicationControl(payload []byte) error { return ErrUnsu
 // the heartbeat loop in main.go compile.
 func (r *Receiver) Ping(timeout time.Duration) error { return ErrUnsupported }
 
-// Disconnect is a no-op on non-darwin platforms.
-func (r *Receiver) Disconnect() {}
+// Disconnect is a no-op on non-darwin platforms. The stub never connects (Connect always returns ErrUnsupported) so there is no XPC
+// connection to tear down; Disconnect exists only to satisfy the darwin Receiver's public surface.
+func (r *Receiver) Disconnect() {
+	// Intentionally empty: stub has no resources to release. See Connect above for the platform-support rationale.
+}

--- a/agent/receiver/receiver_other.go
+++ b/agent/receiver/receiver_other.go
@@ -1,0 +1,63 @@
+//go:build !darwin
+
+package receiver
+
+import (
+	"errors"
+	"time"
+)
+
+// ErrUnsupported is returned by Connect, SendApplicationControl, and Ping
+// on every non-darwin platform. The agent's production receiver wraps a
+// macOS XPC Mach service; outside macOS there is no peer to talk to, so
+// the stub fails closed rather than appearing to succeed.
+//
+// The headless integration binary (UAT plan M2) replaces this stub with
+// an inject-able variant so cross-context tests can drive the agent on
+// linux. Until that lands, building on linux is for compile-only
+// verification, not for running the agent end to end.
+var ErrUnsupported = errors.New("receiver: XPC not available on this platform")
+
+// Receiver is the non-darwin stub. It exposes the same public surface as
+// the darwin Receiver in receiver.go so the agent's call sites
+// (cmd/fleet-edr-agent/main.go) compile without a per-platform import or
+// interface indirection.
+type Receiver struct {
+	serviceName string
+	events      chan Event
+	errors      chan int
+}
+
+// New constructs a stub receiver. The signature matches the darwin
+// constructor so callers do not branch on platform.
+func New(serviceName string, eventBuf int) *Receiver {
+	return &Receiver{
+		serviceName: serviceName,
+		events:      make(chan Event, eventBuf),
+		errors:      make(chan int, 8),
+	}
+}
+
+// Events returns the channel on which events would be delivered. The stub
+// never produces any, so any receive on this channel blocks forever.
+func (r *Receiver) Events() <-chan Event { return r.events }
+
+// Errors returns the channel on which connection errors would be
+// delivered. The stub never produces any.
+func (r *Receiver) Errors() <-chan int { return r.errors }
+
+// Connect always returns ErrUnsupported on non-darwin platforms.
+func (r *Receiver) Connect() error { return ErrUnsupported }
+
+// SendApplicationControl always returns ErrUnsupported on non-darwin
+// platforms. The signature mirrors the darwin method so commander code
+// compiles without a build tag.
+func (r *Receiver) SendApplicationControl(payload []byte) error { return ErrUnsupported }
+
+// Ping always returns ErrUnsupported on non-darwin platforms. The
+// timeout argument is accepted but unused; preserving the signature lets
+// the heartbeat loop in main.go compile.
+func (r *Receiver) Ping(timeout time.Duration) error { return ErrUnsupported }
+
+// Disconnect is a no-op on non-darwin platforms.
+func (r *Receiver) Disconnect() {}


### PR DESCRIPTION
First milestone of the UAT plan in docs/testing-strategy.md. The Go agent's core (queue, uploader, commander, reconciler, etc.) is already platform-portable; only agent/receiver pulls in macOS-only XPC via CGo (#cgo LDFLAGS: -framework Foundation, #include <xpc/xpc.h>). That single package was making `GOOS=linux go build ./agent/...` fail with "build constraints exclude all Go files in agent/receiver", which in turn blocks the headless-agent + server integration job (M3) and any future Linux-side developer ergonomics.

This change:

- Tags the existing CGo files //go:build darwin (receiver.go, callbacks.go) so they are explicit about their platform, not implicit via the cgo cross-compile default of CGO_ENABLED=0.
- Extracts platform-neutral identifiers (Event struct, Error* constants, SetLogger + logger atomic) into a new untagged common.go so the linux build sees them without duplicating definitions.
- Adds receiver_other.go (//go:build !darwin) with a stub Receiver that mirrors the darwin Receiver's public surface (New / Events / Errors / Connect / SendApplicationControl / Ping / Disconnect). Connect, SendApplicationControl, and Ping return a sentinel ErrUnsupported so the agent fails closed on linux today; the inject-able variant for tests is M2's scope.
- Adds task build:agent:linux as the named acceptance check and wires it into the agent-test CI job (runs on macos-latest via cross-compile) so the platform-portability invariant stays green going forward.

Verified locally: task build:agent (darwin), task build:agent:linux, task test:go:agent, task lint:go all pass. xpcbridge needs no changes because it has no .go files; only the darwin receiver references its C headers. hostid is already pure-Go and compiles on linux today.

No production darwin behaviour change. Refs UAT plan M1 milestone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored internal architecture to centralize shared logging definitions, event handling, and error codes across platform implementations. The codebase now provides native support for macOS with compatibility stubs for other platforms.

* **Chores**
  * Enhanced CI test workflow with a new cross-compilation validation step to ensure the agent builds correctly for Linux platforms, improving portability and compatibility checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/getvictor/fleet-edr/pull/206?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->