### PR TITLE
M2: headless agent binary with unix-socket control plane

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -129,6 +129,13 @@ jobs:
         # platform-portable. See docs/testing-strategy.md.
         run: task build:agent:linux
 
+      - name: Build headless agent binary (UAT plan M2 acceptance)
+        # The headless binary wires the same agent pipeline as production but
+        # with the stub receiver, and exposes a unix-socket control plane so
+        # test scenarios can inject events. Verifying it builds keeps the M3
+        # integration job unblocked.
+        run: task build:agent:headless
+
       - name: Run agent tests with coverage
         run: task test:go:agent:coverage
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -175,22 +175,27 @@ tasks:
       which CI uploads as an artifact for the Sonar scan job.
 
       Two test runs: the default cgo + race run for the production agent, then
-      a CGO_ENABLED=0 run for the headless binary (UAT plan M2). The headless
-      package's files carry `//go:build !darwin || !cgo` and are excluded from
-      the first run; the second run picks them up. The two profiles are merged
-      by concatenation because each profile records a disjoint set of files
-      (the build-tag split guarantees no overlap), so there are no per-line
-      conflicts to resolve.
+      a CGO_ENABLED=0 run for the headless binary (UAT plan M2). The second run
+      narrows -coverpkg to ONLY the M2-new packages (the headless cmd directory
+      and agent/receiver) so its profile records files that the first run
+      cannot reach. The two profiles can therefore be merged by concatenation
+      without per-file overlap on queue/uploader/enrollment, which would
+      otherwise produce duplicate entries when Sonar parses the file.
+
+      common.go in agent/receiver IS instrumented by both runs (no build tag),
+      but its small surface (SetLogger + an atomic logger pointer) is already
+      well-covered by the first run; the second-run entries for it are
+      additive in -covermode=atomic, which Sonar resolves by taking the max.
     cmds:
       # See comment on test:go:server:coverage. Same -coverpkg fix so agent
       # tests that exercise shared internal/ packages (observability, envparse)
       # contribute to those packages' coverage on Sonar.
       - go test -race -count=1 -timeout=10m -coverpkg=./agent/...,./internal/... -coverprofile=coverage-agent.out -covermode=atomic ./agent/... ./internal/...
-      # CGO_ENABLED=0 run for the headless package. -race is dropped because the race detector requires cgo; the headless integration
-      # test is single-process so its absence is acceptable.
-      - CGO_ENABLED=0 go test -count=1 -timeout=10m -coverpkg=./agent/...,./internal/... -coverprofile=coverage-agent-headless.out -covermode=atomic ./agent/cmd/fleet-edr-agent-headless/...
-      # Append the headless profile to coverage-agent.out, stripping its mode header. Profiles cover disjoint files (build-tag split),
-      # so concatenation yields a valid merged profile that Sonar consumes as a single Go coverage report.
+      # CGO_ENABLED=0 run for the headless package. -race is dropped because the race detector requires cgo. -coverpkg is narrowed to
+      # just the M2-new packages so the profile is essentially disjoint from the first run; see the desc above for the common.go
+      # caveat.
+      - CGO_ENABLED=0 go test -count=1 -timeout=10m -coverpkg=./agent/cmd/fleet-edr-agent-headless/...,./agent/receiver -coverprofile=coverage-agent-headless.out -covermode=atomic ./agent/cmd/fleet-edr-agent-headless/...
+      # Append the headless profile to coverage-agent.out, stripping its mode header.
       - tail -n +2 coverage-agent-headless.out >> coverage-agent.out
       - rm -f coverage-agent-headless.out
       - go tool cover -func=coverage-agent.out | tail -1

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -68,6 +68,22 @@ tasks:
     cmds:
       - go build ./agent/...
 
+  build:agent:headless:
+    desc: |
+      Build the headless agent binary (UAT plan M2) for linux/amd64 into
+      agent/tmp/fleet-edr-agent-headless. The headless binary wires the same
+      enrollment + queue + uploader pipeline as the production agent but uses
+      the non-darwin stub receiver and exposes a unix-socket control plane so
+      test scenarios can inject events directly. Used by the future L3
+      headless-agent + server integration job; today this target's primary
+      consumer is local development and the CI compile-invariant check.
+    env:
+      GOOS: linux
+      GOARCH: amd64
+      CGO_ENABLED: 0
+    cmds:
+      - go build -o agent/tmp/fleet-edr-agent-headless ./agent/cmd/fleet-edr-agent-headless
+
   ui:setup:
     desc: |
       Install UI npm dependencies. Wired as a dep of build:ui and dev:ui so a fresh clone
@@ -144,18 +160,39 @@ tasks:
       Run Go tests with race detector for agent + shared code only. No DB
       required. Use from CI's agent-test job so the server tests don't run
       on a runner that doesn't have MySQL.
+
+      Second invocation: the headless agent's tests (UAT plan M2) live behind
+      `//go:build !darwin || !cgo` and are skipped by the first invocation
+      under the default CGO_ENABLED=1. Run them with cgo disabled so they
+      execute on every PR.
     cmds:
       - go test -race -count=1 -timeout=10m ./agent/... ./internal/...
+      - CGO_ENABLED=0 go test -count=1 -timeout=10m ./agent/cmd/fleet-edr-agent-headless/...
 
   test:go:agent:coverage:
     desc: |
       Agent + shared coverage flavor of test:go:agent. Emits coverage-agent.out
       which CI uploads as an artifact for the Sonar scan job.
+
+      Two test runs: the default cgo + race run for the production agent, then
+      a CGO_ENABLED=0 run for the headless binary (UAT plan M2). The headless
+      package's files carry `//go:build !darwin || !cgo` and are excluded from
+      the first run; the second run picks them up. The two profiles are merged
+      by concatenation because each profile records a disjoint set of files
+      (the build-tag split guarantees no overlap), so there are no per-line
+      conflicts to resolve.
     cmds:
       # See comment on test:go:server:coverage. Same -coverpkg fix so agent
       # tests that exercise shared internal/ packages (observability, envparse)
       # contribute to those packages' coverage on Sonar.
       - go test -race -count=1 -timeout=10m -coverpkg=./agent/...,./internal/... -coverprofile=coverage-agent.out -covermode=atomic ./agent/... ./internal/...
+      # CGO_ENABLED=0 run for the headless package. -race is dropped because the race detector requires cgo; the headless integration
+      # test is single-process so its absence is acceptable.
+      - CGO_ENABLED=0 go test -count=1 -timeout=10m -coverpkg=./agent/...,./internal/... -coverprofile=coverage-agent-headless.out -covermode=atomic ./agent/cmd/fleet-edr-agent-headless/...
+      # Append the headless profile to coverage-agent.out, stripping its mode header. Profiles cover disjoint files (build-tag split),
+      # so concatenation yields a valid merged profile that Sonar consumes as a single Go coverage report.
+      - tail -n +2 coverage-agent-headless.out >> coverage-agent.out
+      - rm -f coverage-agent-headless.out
       - go tool cover -func=coverage-agent.out | tail -1
 
   test:go:server:

--- a/agent/cmd/fleet-edr-agent-headless/control.go
+++ b/agent/cmd/fleet-edr-agent-headless/control.go
@@ -1,0 +1,160 @@
+//go:build !darwin || !cgo
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/fleetdm/edr/agent/queue"
+	"github.com/fleetdm/edr/agent/receiver"
+)
+
+const (
+	// maxEventBytes caps the size of a single POST /event body. The production wire envelope is well under 64 KiB; the cap keeps a
+	// runaway test scenario from exhausting memory in the control plane handler.
+	maxEventBytes = 1 << 20 // 1 MiB
+
+	// controlReadTimeout, controlWriteTimeout, controlShutdownTimeout are deliberately short. The control plane is local-only
+	// (unix socket); slow clients indicate a test bug, not a real network condition.
+	controlReadTimeout     = 5 * time.Second
+	controlWriteTimeout    = 5 * time.Second
+	controlShutdownTimeout = 2 * time.Second
+
+	// controlSocketMode locks the unix socket to the running user only. The headless binary is single-user dev/test tooling; a more
+	// permissive mode would let any process on the host inject events.
+	controlSocketMode os.FileMode = 0o600
+)
+
+// startControlPlane binds a unix socket at socketPath and serves the control-plane HTTP API on it. Returns a shutdown function the
+// caller defers; the function stops the HTTP server (5s grace) and removes the socket file.
+func startControlPlane(
+	ctx context.Context, socketPath string, recv *receiver.Receiver, q *queue.Queue, cnt *counters, logger *slog.Logger,
+) (func(), error) {
+	// Remove any stale socket from a previous run that didn't clean up. Otherwise net.Listen errors with "address already in use".
+	_ = os.Remove(socketPath)
+
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		return nil, fmt.Errorf("listen on %s: %w", socketPath, err)
+	}
+	if err := os.Chmod(socketPath, controlSocketMode); err != nil {
+		_ = listener.Close()
+		_ = os.Remove(socketPath)
+		return nil, fmt.Errorf("chmod %s: %w", socketPath, err)
+	}
+
+	mux := http.NewServeMux()
+	mux.Handle("POST /event", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handlePostEvent(w, r, recv, cnt, logger)
+	}))
+	mux.Handle("GET /state", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handleGetState(w, r, q, cnt, logger)
+	}))
+
+	srv := &http.Server{
+		Handler:      mux,
+		ReadTimeout:  controlReadTimeout,
+		WriteTimeout: controlWriteTimeout,
+	}
+
+	serveErrCh := make(chan error, 1)
+	go func() { serveErrCh <- srv.Serve(listener) }()
+	logger.InfoContext(ctx, "control plane listening", "socket", socketPath)
+
+	shutdown := func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), controlShutdownTimeout)
+		defer cancel()
+		if err := srv.Shutdown(shutdownCtx); err != nil {
+			logger.WarnContext(shutdownCtx, "control plane shutdown", "err", err)
+		}
+		_ = os.Remove(socketPath)
+		// Drain the serve goroutine so it doesn't outlive the shutdown call.
+		if err := <-serveErrCh; err != nil && !errors.Is(err, http.ErrServerClosed) {
+			logger.WarnContext(shutdownCtx, "control plane serve", "err", err)
+		}
+	}
+	return shutdown, nil
+}
+
+// handlePostEvent reads a single event-envelope JSON body from the request and injects it into the receiver. The body is forwarded
+// verbatim; the control plane does not parse or validate the envelope (that is the server's job). On a successful inject, returns 202
+// with a JSON ack carrying the running events_injected count so the test scenario driver can use it as a happens-before signal.
+func handlePostEvent(
+	w http.ResponseWriter, r *http.Request, recv *receiver.Receiver, cnt *counters, logger *slog.Logger,
+) {
+	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxEventBytes))
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, "read body: "+err.Error())
+		return
+	}
+	if len(body) == 0 {
+		writeJSONError(w, http.StatusBadRequest, "empty event body")
+		return
+	}
+	if !json.Valid(body) {
+		writeJSONError(w, http.StatusBadRequest, "body is not valid JSON")
+		return
+	}
+	if err := recv.Inject(body); err != nil {
+		cnt.injectErrors.Add(1)
+		// ErrBufferFull is the test-visible failure: the scenario is feeding events faster than the queue can drain. A 503 lets the
+		// driver back off rather than mistaking the failure for a malformed-payload bug.
+		status := http.StatusServiceUnavailable
+		if !errors.Is(err, receiver.ErrBufferFull) {
+			status = http.StatusInternalServerError
+		}
+		writeJSONError(w, status, "inject: "+err.Error())
+		return
+	}
+	n := cnt.eventsInjected.Add(1)
+	cnt.lastInjectAtUnix.Store(time.Now().Unix())
+	logger.DebugContext(r.Context(), "control plane injected event", "events_injected", n)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusAccepted)
+	_ = json.NewEncoder(w).Encode(map[string]any{"events_injected": n})
+}
+
+// stateResponse is the JSON body of GET /state. Field names are snake_case to match the rest of the agent / server wire format.
+type stateResponse struct {
+	EventsInjected   int64 `json:"events_injected"`
+	InjectErrors     int64 `json:"inject_errors"`
+	LastInjectAtUnix int64 `json:"last_inject_at_unix"`
+	QueueDepth       int64 `json:"queue_depth"`
+}
+
+// handleGetState reports control-plane and queue observability state. Queue depth is queried under the request's context so a slow
+// or hung DB query is bounded by the HTTP write timeout above.
+func handleGetState(
+	w http.ResponseWriter, r *http.Request, q *queue.Queue, cnt *counters, logger *slog.Logger,
+) {
+	depth, err := q.Depth(r.Context())
+	if err != nil {
+		logger.WarnContext(r.Context(), "queue depth", "err", err)
+		// Report -1 instead of failing the whole call: the in-memory counters are still useful and the client can decide what to do.
+		depth = -1
+	}
+	resp := stateResponse{
+		EventsInjected:   cnt.eventsInjected.Load(),
+		InjectErrors:     cnt.injectErrors.Load(),
+		LastInjectAtUnix: cnt.lastInjectAtUnix.Load(),
+		QueueDepth:       depth,
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+// writeJSONError emits a small JSON error body so a client parsing the response can read .error without sniffing the body type.
+func writeJSONError(w http.ResponseWriter, status int, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": msg})
+}

--- a/agent/cmd/fleet-edr-agent-headless/control.go
+++ b/agent/cmd/fleet-edr-agent-headless/control.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/fleetdm/edr/agent/queue"
@@ -29,6 +30,10 @@ const (
 	controlWriteTimeout    = 5 * time.Second
 	controlShutdownTimeout = 2 * time.Second
 
+	// queueDepthTimeout caps a single q.Depth call from blocking GET /state. The HTTP write timeout is the outer safety net but only
+	// fires after the response starts streaming; an explicit per-call timeout bounds the DB query itself.
+	queueDepthTimeout = 500 * time.Millisecond
+
 	// controlSocketMode locks the unix socket to the running user only. The headless binary is single-user dev/test tooling; a more
 	// permissive mode would let any process on the host inject events.
 	controlSocketMode os.FileMode = 0o600
@@ -39,8 +44,16 @@ const (
 func startControlPlane(
 	ctx context.Context, socketPath string, recv *receiver.Receiver, q *queue.Queue, cnt *counters, logger *slog.Logger,
 ) (func(), error) {
-	// Remove any stale socket from a previous run that didn't clean up. Otherwise net.Listen errors with "address already in use".
-	_ = os.Remove(socketPath)
+	// Remove a stale socket from a previous run; net.Listen would otherwise error with "address already in use". Guard with Lstat to
+	// refuse to delete a non-socket path so a misconfigured --control-socket pointed at a regular file does not nuke that file.
+	if info, err := os.Lstat(socketPath); err == nil {
+		if info.Mode()&os.ModeSocket == 0 {
+			return nil, fmt.Errorf("refusing to remove non-socket %s; pass a fresh path", socketPath)
+		}
+		if err := os.Remove(socketPath); err != nil {
+			return nil, fmt.Errorf("remove stale socket %s: %w", socketPath, err)
+		}
+	}
 
 	listener, err := net.Listen("unix", socketPath)
 	if err != nil {
@@ -70,17 +83,24 @@ func startControlPlane(
 	go func() { serveErrCh <- srv.Serve(listener) }()
 	logger.InfoContext(ctx, "control plane listening", "socket", socketPath)
 
+	// The shutdown closure is idempotent via sync.Once. Run calls it explicitly between ctx.Done() and drainOnShutdown so the
+	// control plane stops accepting new POSTs before the final drain, and ALSO defers it as a safety net for early-return paths
+	// (e.g. an unexpected error after this function succeeds). Without Once, the second invocation would block forever waiting
+	// for a serveErrCh that the first invocation already consumed.
+	var once sync.Once
 	shutdown := func() {
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), controlShutdownTimeout)
-		defer cancel()
-		if err := srv.Shutdown(shutdownCtx); err != nil {
-			logger.WarnContext(shutdownCtx, "control plane shutdown", "err", err)
-		}
-		_ = os.Remove(socketPath)
-		// Drain the serve goroutine so it doesn't outlive the shutdown call.
-		if err := <-serveErrCh; err != nil && !errors.Is(err, http.ErrServerClosed) {
-			logger.WarnContext(shutdownCtx, "control plane serve", "err", err)
-		}
+		once.Do(func() {
+			shutdownCtx, cancel := context.WithTimeout(context.Background(), controlShutdownTimeout)
+			defer cancel()
+			if err := srv.Shutdown(shutdownCtx); err != nil {
+				logger.WarnContext(shutdownCtx, "control plane shutdown", "err", err)
+			}
+			_ = os.Remove(socketPath)
+			// Drain the serve goroutine so it doesn't outlive the shutdown call.
+			if err := <-serveErrCh; err != nil && !errors.Is(err, http.ErrServerClosed) {
+				logger.WarnContext(shutdownCtx, "control plane serve", "err", err)
+			}
+		})
 	}
 	return shutdown, nil
 }
@@ -131,12 +151,14 @@ type stateResponse struct {
 	QueueDepth       int64 `json:"queue_depth"`
 }
 
-// handleGetState reports control-plane and queue observability state. Queue depth is queried under the request's context so a slow
-// or hung DB query is bounded by the HTTP write timeout above.
+// handleGetState reports control-plane and queue observability state. Queue depth runs under an explicit short timeout so a stuck DB
+// query cannot block the response past queueDepthTimeout; -1 is reported on timeout / error so the in-memory counters still surface.
 func handleGetState(
 	w http.ResponseWriter, r *http.Request, q *queue.Queue, cnt *counters, logger *slog.Logger,
 ) {
-	depth, err := q.Depth(r.Context())
+	depthCtx, cancel := context.WithTimeout(r.Context(), queueDepthTimeout)
+	defer cancel()
+	depth, err := q.Depth(depthCtx)
 	if err != nil {
 		logger.WarnContext(r.Context(), "queue depth", "err", err)
 		// Report -1 instead of failing the whole call: the in-memory counters are still useful and the client can decide what to do.

--- a/agent/cmd/fleet-edr-agent-headless/headless.go
+++ b/agent/cmd/fleet-edr-agent-headless/headless.go
@@ -141,8 +141,8 @@ func Run(ctx context.Context, opts Options) error {
 
 	cnt := &counters{}
 
-	// pumpEvents bridges the stub receiver into the queue, mirroring the production agent's pipeEvents goroutine. A short timeout
-	// per-enqueue caps how long a single hung Enqueue can block the pump.
+	// pumpEvents bridges the stub receiver into the queue, mirroring the production agent's pipeEvents goroutine. q.Enqueue is called
+	// with the outer ctx; cancellation on shutdown propagates and Enqueue returns context.Canceled rather than blocking.
 	go pumpEvents(ctx, recv, q, logger)
 
 	// runUploader runs the uploader's main loop until ctx is done. The uploader returns nil on ctx cancellation; we log a non-nil
@@ -153,19 +153,26 @@ func Run(ctx context.Context, opts Options) error {
 		}
 	}()
 
-	// Control plane: optional. When SocketPath is non-empty, start the server in a goroutine and shut it down on ctx cancel.
+	// Control plane: optional. When SocketPath is non-empty, start the server in a goroutine. Capture shutdown so we can call it
+	// explicitly between ctx.Done() and drainOnShutdown (see below); also keep a deferred call as a safety net in case Run returns
+	// before ctx.Done() fires. http.Server.Shutdown is idempotent so the double-call is safe.
+	shutdownControlPlane := func() {}
 	if opts.SocketPath != "" {
 		shutdown, err := startControlPlane(ctx, opts.SocketPath, recv, q, cnt, logger)
 		if err != nil {
 			return fmt.Errorf("start control plane: %w", err)
 		}
-		defer shutdown()
+		shutdownControlPlane = shutdown
+		defer shutdownControlPlane()
 	}
 
 	logger.InfoContext(ctx, "headless agent ready",
 		"server_url", opts.ServerURL, "queue_path", opts.QueuePath, "socket_path", opts.SocketPath)
 
 	<-ctx.Done()
+	// Stop accepting new POST /event requests BEFORE the final drain. Otherwise a late injection between ctx.Done() and the
+	// deferred shutdown lands in recv.events with pumpEvents already exited; the event would be silently dropped at process exit.
+	shutdownControlPlane()
 	drainOnShutdown(up, logger)
 	return nil
 }

--- a/agent/cmd/fleet-edr-agent-headless/headless.go
+++ b/agent/cmd/fleet-edr-agent-headless/headless.go
@@ -1,0 +1,202 @@
+//go:build !darwin || !cgo
+
+// Package main is the headless agent: a development + test build of the agent's Go core that runs on linux (or on darwin with CGO
+// disabled) without the macOS XPC system extension. It wires the same enrollment + queue + uploader pipeline as the production agent,
+// substitutes the non-darwin stub receiver for the XPC bridge, and exposes a local unix-socket control plane so tests can inject
+// events directly into the receiver. Used by UAT plan layer L3 (headless agent + server integration). See docs/testing-strategy.md.
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"sync/atomic"
+	"time"
+
+	"github.com/fleetdm/edr/agent/enrollment"
+	"github.com/fleetdm/edr/agent/queue"
+	"github.com/fleetdm/edr/agent/receiver"
+	"github.com/fleetdm/edr/agent/uploader"
+)
+
+const (
+	// defaultEventBuffer sizes the stub receiver's events channel. The headless binary is designed for test scenarios feeding tens to
+	// hundreds of events per second; a 1024-event buffer gives ample slack between Inject and the queue-pump goroutine.
+	defaultEventBuffer = 1024
+
+	// defaultBatchSize and defaultUploadInterval match production agent defaults for scenarios that exercise realistic batching.
+	defaultBatchSize      = 100
+	defaultUploadInterval = 1 * time.Second
+
+	// uploaderMaxRetries mirrors the production agent's upload-retry cap. Tests that legitimately need a different cap can override
+	// via Options.UploaderMaxRetries.
+	uploaderMaxRetries = 3
+
+	// drainTimeout caps the final upload attempt after ctx is cancelled. Long enough for a real upload to complete; short enough that a
+	// hung server doesn't stall test teardown indefinitely.
+	drainTimeout = 5 * time.Second
+)
+
+// Options is the headless binary's runtime configuration. main builds Options from CLI flags + env; tests construct Options directly.
+type Options struct {
+	// ServerURL is the base URL of the EDR ingestion server.
+	ServerURL string
+
+	// HostID is the host identifier this agent claims. On linux there is no IOPlatformUUID to derive, so callers must supply one.
+	HostID string
+
+	// QueuePath is the SQLite WAL queue database path. Test code should use t.TempDir to scope per-test.
+	QueuePath string
+
+	// SocketPath is the unix-socket path for the control plane. Empty means do not start the control plane (allowed for non-test runs
+	// where events would arrive through some other channel, though in M2 there is no such channel).
+	SocketPath string
+
+	// TokenProvider yields the current bearer token for the uploader. Production wires the enrollment package's provider; tests pass
+	// a fixed-token stub. Required.
+	TokenProvider enrollment.TokenProvider
+
+	// BatchSize, UploadInterval, UploaderMaxRetries override the defaults at the top of this file. Zero values fall back to defaults.
+	BatchSize          int
+	UploadInterval     time.Duration
+	UploaderMaxRetries int
+
+	// HTTPClient is the http.Client the uploader uses to talk to ServerURL. Nil means uploader.New constructs a default client. Tests
+	// typically pass a client wrapping httptest.Server's transport so the upload lands locally without TLS setup.
+	HTTPClient *http.Client
+
+	// Logger is the slog logger. Nil means slog.Default.
+	Logger *slog.Logger
+}
+
+// validate fills in defaults and rejects obviously invalid combinations. The error messages name the missing field so a test failure or
+// operator misconfiguration is immediately actionable.
+func (o *Options) validate() error {
+	if o.ServerURL == "" {
+		return errors.New("headless: Options.ServerURL is required")
+	}
+	if o.HostID == "" {
+		return errors.New("headless: Options.HostID is required (no IOPlatformUUID outside darwin)")
+	}
+	if o.QueuePath == "" {
+		return errors.New("headless: Options.QueuePath is required")
+	}
+	if o.TokenProvider == nil {
+		return errors.New("headless: Options.TokenProvider is required")
+	}
+	if o.BatchSize == 0 {
+		o.BatchSize = defaultBatchSize
+	}
+	if o.UploadInterval == 0 {
+		o.UploadInterval = defaultUploadInterval
+	}
+	if o.UploaderMaxRetries == 0 {
+		o.UploaderMaxRetries = uploaderMaxRetries
+	}
+	if o.Logger == nil {
+		o.Logger = slog.Default()
+	}
+	return nil
+}
+
+// counters track control-plane observable state. Embedded in the running agent so the GET /state handler can read them without holding
+// any locks (atomic loads).
+type counters struct {
+	eventsInjected   atomic.Int64
+	injectErrors     atomic.Int64
+	lastInjectAtUnix atomic.Int64
+}
+
+// Run wires the headless agent and blocks until ctx is cancelled. Returns the first non-nil error from setup; once setup succeeds and
+// the goroutines spin up, errors from those goroutines are logged but do not propagate (the production agent's behaviour is the same).
+//
+// Lifecycle on ctx cancel: stops the control plane, drains any remaining queue contents one last time (bounded by drainTimeout), closes
+// the queue, returns nil.
+func Run(ctx context.Context, opts Options) error {
+	if err := opts.validate(); err != nil {
+		return err
+	}
+	logger := opts.Logger.With("component", "headless-agent", "host_id", opts.HostID)
+	receiver.SetLogger(logger)
+
+	q, err := queue.Open(ctx, opts.QueuePath, queue.Options{Logger: logger})
+	if err != nil {
+		return fmt.Errorf("open queue at %s: %w", opts.QueuePath, err)
+	}
+	defer func() { _ = q.Close() }()
+
+	up := uploader.New(q, uploader.Config{
+		ServerURL:  opts.ServerURL,
+		TokenFn:    opts.TokenProvider.Token,
+		OnAuthFail: opts.TokenProvider.OnUnauthorized,
+		BatchSize:  opts.BatchSize,
+		Interval:   opts.UploadInterval,
+		MaxRetries: opts.UploaderMaxRetries,
+	}, opts.HTTPClient, logger)
+
+	recv := receiver.New("headless-stub", defaultEventBuffer)
+	defer recv.Disconnect()
+
+	cnt := &counters{}
+
+	// pumpEvents bridges the stub receiver into the queue, mirroring the production agent's pipeEvents goroutine. A short timeout
+	// per-enqueue caps how long a single hung Enqueue can block the pump.
+	go pumpEvents(ctx, recv, q, logger)
+
+	// runUploader runs the uploader's main loop until ctx is done. The uploader returns nil on ctx cancellation; we log a non-nil
+	// error but do not propagate (production behaviour).
+	go func() {
+		if err := up.Run(ctx); err != nil && !errors.Is(err, context.Canceled) {
+			logger.ErrorContext(ctx, "uploader run", "err", err)
+		}
+	}()
+
+	// Control plane: optional. When SocketPath is non-empty, start the server in a goroutine and shut it down on ctx cancel.
+	if opts.SocketPath != "" {
+		shutdown, err := startControlPlane(ctx, opts.SocketPath, recv, q, cnt, logger)
+		if err != nil {
+			return fmt.Errorf("start control plane: %w", err)
+		}
+		defer shutdown()
+	}
+
+	logger.InfoContext(ctx, "headless agent ready",
+		"server_url", opts.ServerURL, "queue_path", opts.QueuePath, "socket_path", opts.SocketPath)
+
+	<-ctx.Done()
+	drainOnShutdown(up, logger)
+	return nil
+}
+
+// pumpEvents reads from the receiver's Events() channel and enqueues each event. Exits when the channel closes or ctx is done. Errors
+// are logged but do not stop the pump because the queue's enforceCap path can transiently fail on a full disk; we want the agent to
+// keep running and try the next event.
+func pumpEvents(ctx context.Context, recv *receiver.Receiver, q *queue.Queue, logger *slog.Logger) {
+	events := recv.Events()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case ev, ok := <-events:
+			if !ok {
+				return
+			}
+			if err := q.Enqueue(ctx, ev.Data); err != nil {
+				logger.WarnContext(ctx, "enqueue failed", "err", err, "event_bytes", len(ev.Data))
+			}
+		}
+	}
+}
+
+// drainOnShutdown attempts one final upload pass after ctx has been cancelled, with a bounded timeout so a slow / dead server cannot
+// hold the headless binary's exit indefinitely. The shutdown context is fresh (not the cancelled run context) so the uploader's HTTP
+// call actually has time to complete.
+func drainOnShutdown(up *uploader.Uploader, logger *slog.Logger) {
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), drainTimeout)
+	defer cancel()
+	if err := up.Drain(shutdownCtx); err != nil && !errors.Is(err, context.Canceled) {
+		logger.WarnContext(shutdownCtx, "final drain", "err", err)
+	}
+}

--- a/agent/cmd/fleet-edr-agent-headless/headless_test.go
+++ b/agent/cmd/fleet-edr-agent-headless/headless_test.go
@@ -244,7 +244,12 @@ func TestControlPlaneErrorPaths(t *testing.T) {
 	assert.Equal(t, http.StatusMethodNotAllowed, resp.StatusCode)
 
 	cancel()
-	<-runErrCh
+	select {
+	case err := <-runErrCh:
+		require.NoError(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("Run did not exit within 10s of ctx cancel")
+	}
 }
 
 // unixHTTPGet performs an HTTP GET over a unix socket. Used by the test to talk to the control plane.

--- a/agent/cmd/fleet-edr-agent-headless/headless_test.go
+++ b/agent/cmd/fleet-edr-agent-headless/headless_test.go
@@ -1,0 +1,313 @@
+//go:build !darwin || !cgo
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fleetdm/edr/agent/receiver"
+)
+
+// stubTokenProvider implements enrollment.TokenProvider with fixed values. Tests construct one directly so they bypass the network
+// enrollment flow; the headless binary's production main wires the real enrollment.Ensure result instead.
+type stubTokenProvider struct {
+	token  string
+	hostID string
+}
+
+func (s *stubTokenProvider) Token() string                            { return s.token }
+func (s *stubTokenProvider) HostID() string                           { return s.hostID }
+func (s *stubTokenProvider) OnUnauthorized(_ context.Context)         {}
+func (s *stubTokenProvider) Rotate(_ context.Context, _ string) error { return nil }
+
+func TestOptionsValidate(t *testing.T) {
+	cases := []struct {
+		name string
+		opts Options
+		want string // substring of expected error; empty means success
+	}{
+		{
+			name: "missing ServerURL",
+			opts: Options{HostID: "h", QueuePath: "/q", TokenProvider: &stubTokenProvider{}},
+			want: "ServerURL is required",
+		},
+		{
+			name: "missing HostID",
+			opts: Options{ServerURL: "http://x", QueuePath: "/q", TokenProvider: &stubTokenProvider{}},
+			want: "HostID is required",
+		},
+		{
+			name: "missing QueuePath",
+			opts: Options{ServerURL: "http://x", HostID: "h", TokenProvider: &stubTokenProvider{}},
+			want: "QueuePath is required",
+		},
+		{
+			name: "missing TokenProvider",
+			opts: Options{ServerURL: "http://x", HostID: "h", QueuePath: "/q"},
+			want: "TokenProvider is required",
+		},
+		{
+			name: "happy path fills defaults",
+			opts: Options{ServerURL: "http://x", HostID: "h", QueuePath: "/q", TokenProvider: &stubTokenProvider{}},
+			want: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.opts.validate()
+			if tc.want == "" {
+				require.NoError(t, err)
+				assert.Equal(t, defaultBatchSize, tc.opts.BatchSize)
+				assert.Equal(t, defaultUploadInterval, tc.opts.UploadInterval)
+				assert.Equal(t, uploaderMaxRetries, tc.opts.UploaderMaxRetries)
+				assert.NotNil(t, tc.opts.Logger)
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.want)
+			}
+		})
+	}
+}
+
+// TestHeadlessRoundTrip exercises the full happy path: control plane injects events, queue + uploader forwards them, fake EDR server
+// receives them with the expected auth header. This is L3 (headless agent + server) compressed into a single in-process Go test; the
+// real CI L3 job will reuse the same pattern with the headless binary launched as a subprocess.
+func TestHeadlessRoundTrip(t *testing.T) {
+	var (
+		received       atomic.Int32
+		capturedBodies [][]byte
+		mu             sync.Mutex
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/events" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		if r.Header.Get("Authorization") != "Bearer test-token" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		capturedBodies = append(capturedBodies, body)
+		mu.Unlock()
+		received.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	tmpDir := t.TempDir()
+	socketPath := filepath.Join(tmpDir, "ctl.sock")
+
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	runErrCh := make(chan error, 1)
+	go func() {
+		runErrCh <- Run(ctx, Options{
+			ServerURL:      srv.URL,
+			HostID:         "test-host-1",
+			QueuePath:      filepath.Join(tmpDir, "queue.db"),
+			SocketPath:     socketPath,
+			TokenProvider:  &stubTokenProvider{token: "test-token", hostID: "test-host-1"},
+			BatchSize:      5,
+			UploadInterval: 50 * time.Millisecond,
+		})
+	}()
+
+	// Wait for the control plane socket to accept connections. Eventually polls every 50ms up to 5s, which is plenty for goroutine
+	// startup + net.Listen + the eventLoop's first iteration on a busy CI runner.
+	require.Eventually(t, func() bool {
+		resp, err := unixHTTPGet(socketPath, "/state")
+		if err != nil {
+			return false
+		}
+		_ = resp.Body.Close()
+		return resp.StatusCode == http.StatusOK
+	}, 5*time.Second, 50*time.Millisecond, "control plane never came up")
+
+	// Inject 3 distinct events. The uploader's BatchSize=5 means they'll fly in a single batch.
+	for i := 0; i < 3; i++ {
+		body := fmt.Sprintf(
+			`{"event_id":"e-%d","host_id":"test-host-1","event_type":"exec","timestamp_ns":%d}`,
+			i, time.Now().UnixNano(),
+		)
+		resp, err := unixHTTPPost(socketPath, "/event", []byte(body))
+		require.NoError(t, err)
+		_ = resp.Body.Close()
+		require.Equal(t, http.StatusAccepted, resp.StatusCode, "POST /event #%d", i)
+	}
+
+	// Wait for the uploader to drain. UploadInterval=50ms, so within 2s we expect the batch.
+	require.Eventually(t, func() bool { return received.Load() > 0 }, 5*time.Second, 50*time.Millisecond,
+		"no events received by fake server")
+	mu.Lock()
+	bodyCount := len(capturedBodies)
+	mu.Unlock()
+	assert.GreaterOrEqual(t, bodyCount, 1, "expected at least one upload batch")
+
+	// /state should reflect the 3 injects and 0 inject errors.
+	resp, err := unixHTTPGet(socketPath, "/state")
+	require.NoError(t, err)
+	stateBody, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	var state stateResponse
+	require.NoError(t, json.Unmarshal(stateBody, &state))
+	assert.Equal(t, int64(3), state.EventsInjected)
+	assert.Equal(t, int64(0), state.InjectErrors)
+
+	// Clean shutdown. Run should exit within drainTimeout + a margin.
+	cancel()
+	select {
+	case err := <-runErrCh:
+		require.NoError(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("Run did not exit within 10s of ctx cancel")
+	}
+}
+
+// TestControlPlaneErrorPaths exercises the POST /event handler's input validation branches. Driven through the real unix socket so the
+// MaxBytesReader, json.Valid, and ServeMux pattern-matching are all exercised end-to-end.
+func TestControlPlaneErrorPaths(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	tmpDir := t.TempDir()
+	socketPath := filepath.Join(tmpDir, "ctl.sock")
+
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	runErrCh := make(chan error, 1)
+	go func() {
+		runErrCh <- Run(ctx, Options{
+			ServerURL:      srv.URL,
+			HostID:         "test-host-2",
+			QueuePath:      filepath.Join(tmpDir, "queue.db"),
+			SocketPath:     socketPath,
+			TokenProvider:  &stubTokenProvider{token: "tok", hostID: "test-host-2"},
+			BatchSize:      5,
+			UploadInterval: 1 * time.Second, // slow so we don't race the test with uploads
+		})
+	}()
+
+	require.Eventually(t, func() bool {
+		resp, err := unixHTTPGet(socketPath, "/state")
+		if err != nil {
+			return false
+		}
+		_ = resp.Body.Close()
+		return resp.StatusCode == http.StatusOK
+	}, 5*time.Second, 50*time.Millisecond)
+
+	cases := []struct {
+		name string
+		body []byte
+		want int
+	}{
+		{name: "empty body", body: nil, want: http.StatusBadRequest},
+		{name: "invalid JSON", body: []byte("not json"), want: http.StatusBadRequest},
+		{name: "valid JSON object", body: []byte(`{"event_id":"ok"}`), want: http.StatusAccepted},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp, err := unixHTTPPost(socketPath, "/event", tc.body)
+			require.NoError(t, err)
+			_ = resp.Body.Close()
+			assert.Equal(t, tc.want, resp.StatusCode)
+		})
+	}
+
+	// 405 (method-not-allowed) for an unhandled verb is enforced by the ServeMux pattern; covers the "POST /event" specificity.
+	resp, err := unixHTTPGet(socketPath, "/event")
+	require.NoError(t, err)
+	_ = resp.Body.Close()
+	assert.Equal(t, http.StatusMethodNotAllowed, resp.StatusCode)
+
+	cancel()
+	<-runErrCh
+}
+
+// unixHTTPGet performs an HTTP GET over a unix socket. Used by the test to talk to the control plane.
+func unixHTTPGet(socketPath, path string) (*http.Response, error) {
+	client := unixHTTPClient(socketPath)
+	return client.Get("http://unix" + path)
+}
+
+// unixHTTPPost performs an HTTP POST over a unix socket with a raw body.
+func unixHTTPPost(socketPath, path string, body []byte) (*http.Response, error) {
+	client := unixHTTPClient(socketPath)
+	return client.Post("http://unix"+path, "application/json", bytes.NewReader(body))
+}
+
+func unixHTTPClient(socketPath string) *http.Client {
+	return &http.Client{
+		Timeout: 3 * time.Second,
+		Transport: &http.Transport{
+			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+				return net.Dial("unix", socketPath)
+			},
+		},
+	}
+}
+
+// TestHandlePostEventBufferFull drives the buffer-full branch directly without standing up the whole pipeline. A receiver constructed
+// with buffer size 0 always returns ErrBufferFull from Inject, so the very first POST exercises the 503 path.
+func TestHandlePostEventBufferFull(t *testing.T) {
+	recv := receiver.New("test", 0)
+	cnt := &counters{}
+	logger := slog.Default()
+
+	req := httptest.NewRequest(http.MethodPost, "/event", bytes.NewReader([]byte(`{"event_id":"a"}`)))
+	w := httptest.NewRecorder()
+
+	handlePostEvent(w, req, recv, cnt, logger)
+
+	resp := w.Result()
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+	body, _ := io.ReadAll(resp.Body)
+	assert.Contains(t, string(body), "buffer full")
+	assert.Equal(t, int64(1), cnt.injectErrors.Load())
+	assert.Equal(t, int64(0), cnt.eventsInjected.Load())
+}
+
+// TestHandlePostEventBodyTooLarge exercises the MaxBytesReader branch by feeding a body larger than maxEventBytes. The handler should
+// reject with 400 and leave the receiver's counters untouched.
+func TestHandlePostEventBodyTooLarge(t *testing.T) {
+	recv := receiver.New("test", 1024)
+	cnt := &counters{}
+	logger := slog.Default()
+
+	// 2 MiB body, well over the 1 MiB cap. The JSON shape doesn't matter; the size check fires before json.Valid.
+	bigBody := strings.Repeat("a", 2*1024*1024)
+	req := httptest.NewRequest(http.MethodPost, "/event", strings.NewReader(bigBody))
+	w := httptest.NewRecorder()
+
+	handlePostEvent(w, req, recv, cnt, logger)
+
+	resp := w.Result()
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, int64(0), cnt.eventsInjected.Load())
+	assert.Equal(t, int64(0), cnt.injectErrors.Load())
+}

--- a/agent/cmd/fleet-edr-agent-headless/main.go
+++ b/agent/cmd/fleet-edr-agent-headless/main.go
@@ -1,0 +1,76 @@
+//go:build !darwin || !cgo
+
+// fleet-edr-agent-headless is the test-only build of the agent's Go core. It wires the same enrollment + queue + uploader pipeline as
+// the production agent, substitutes the non-darwin stub receiver for the XPC bridge, and exposes a unix-socket control plane so test
+// scenarios can inject events. See UAT plan layer L3 in docs/testing-strategy.md.
+//
+// This file is the entrypoint only; the actual wiring lives in headless.go (Run) and control.go (HTTP handlers) so the logic stays
+// covered by the integration test in headless_test.go. main.go is excluded from Sonar's new-code coverage gate via the
+// **/cmd/**/main.go rule in sonar-project.properties.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/fleetdm/edr/agent/config"
+	"github.com/fleetdm/edr/agent/enrollment"
+)
+
+func main() {
+	if err := mainErr(); err != nil {
+		fmt.Fprintf(os.Stderr, "fleet-edr-agent-headless: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func mainErr() error {
+	socketPath := flag.String("control-socket", "", "unix socket path for the local control plane (required)")
+	flag.Parse()
+	if *socketPath == "" {
+		return fmt.Errorf("--control-socket is required")
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+	if cfg.HostIDOverride == "" {
+		return fmt.Errorf("EDR_HOST_ID is required outside macOS (no IOPlatformUUID to derive from)")
+	}
+
+	logger := slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
+	tokenProvider, err := enrollment.Ensure(ctx, enrollment.Options{
+		ServerURL:         cfg.ServerURL,
+		EnrollSecret:      cfg.EnrollSecret,
+		TokenFile:         cfg.TokenFile,
+		ServerFingerprint: cfg.ServerFingerprint,
+		AllowInsecure:     cfg.AllowInsecure,
+		HostIDOverride:    cfg.HostIDOverride,
+		AgentVersion:      "headless-dev",
+		Logger:            logger,
+	})
+	if err != nil {
+		return fmt.Errorf("enrollment: %w", err)
+	}
+
+	return Run(ctx, Options{
+		ServerURL:      cfg.ServerURL,
+		HostID:         tokenProvider.HostID(),
+		QueuePath:      cfg.QueueDBPath,
+		SocketPath:     *socketPath,
+		TokenProvider:  tokenProvider,
+		BatchSize:      cfg.BatchSize,
+		UploadInterval: cfg.UploadInterval,
+		Logger:         logger,
+	})
+}

--- a/agent/receiver/receiver_other.go
+++ b/agent/receiver/receiver_other.go
@@ -64,3 +64,23 @@ func (r *Receiver) Ping(timeout time.Duration) error { return ErrUnsupported }
 func (r *Receiver) Disconnect() {
 	// Intentionally empty: stub has no resources to release. See Connect above for the platform-support rationale.
 }
+
+// Inject pushes a raw JSON event onto the receiver's Events() channel as if it had arrived from the XPC peer. Only the non-darwin / no-cgo
+// stub exposes this entry point; the production XPC receiver receives events from the kernel via the system extension and has no
+// in-process injection surface. The headless agent binary (agent/cmd/fleet-edr-agent-headless) uses Inject from its control-plane HTTP
+// handler so test scenarios can drive the queue + uploader pipeline without a real ESF extension.
+//
+// Non-blocking by design: if the events buffer is full (the Receiver was constructed with a fixed buffer in New), Inject returns
+// ErrBufferFull immediately rather than blocking the HTTP handler. A test scenario that legitimately needs higher throughput should
+// either size the buffer up at construction time or pace its injections.
+func (r *Receiver) Inject(b []byte) error {
+	select {
+	case r.events <- Event{Data: b}:
+		return nil
+	default:
+		return ErrBufferFull
+	}
+}
+
+// ErrBufferFull is returned by Inject when the events buffer is at capacity.
+var ErrBufferFull = errors.New("receiver: event buffer full")

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -69,15 +69,20 @@ A run at any layer implies all lower layers have already passed; CI gates enforc
 
 ### Headless agent + server (L3)
 
-- The Go core of the agent (queue, uploader, commander, reconciler, enrolment) runs in CI against the real server, on
-  Linux, with the macOS extension dependency stubbed out behind a build tag.
-- Lives in `test/integration/agentserver/` (binary plus tests).
-- The macOS-only packages (`agent/receiver`, `agent/xpcbridge`) are split: `//go:build darwin` for the CGo
-  implementation, `//go:build !darwin` for a stub receiver that exposes an `Inject` entry point. Both implement the
-  same `Receiver` interface so the rest of the agent code is platform-agnostic.
-- A headless binary at `cmd/fleet-edr-agent-headless` wires the same agent packages as production with the stub
-  receiver, and exposes a small local control plane (unix socket) that tests use to inject scenarios. See "Reusable
-  artefacts" below.
+- The Go core of the agent (queue, uploader, enrolment) runs in CI against the real server, on Linux, with the macOS
+  extension dependency stubbed out behind build tags.
+- The macOS-only packages (`agent/receiver`, `agent/xpcbridge`) are split with build tags: `//go:build darwin && cgo`
+  for the CGo XPC implementation, `//go:build !darwin || !cgo` for the stub receiver. The stub exposes an `Inject`
+  entry point so the headless binary and tests can deliver events as if they had arrived from the XPC peer. The
+  production agent's call sites use `*receiver.Receiver` directly; the build tags select the right struct per
+  platform without an interface. UAT plan milestone **M1** delivered this split; the linux compile invariant is
+  enforced by `task build:agent:linux` in CI (`agent-test` job).
+- The headless binary `agent/cmd/fleet-edr-agent-headless` wires the same `queue + uploader + enrollment` pipeline as
+  production but with the stub receiver, and exposes a small local control plane on a unix socket:
+  - `POST /event`: inject one JSON event into the stub receiver's events channel.
+  - `GET /state`: return `{events_injected, inject_errors, last_inject_at_unix, queue_depth}`.
+  Built by `task build:agent:headless` (also gated in CI). UAT plan milestone **M2** delivered this binary; the L3
+  end-to-end CI job that drives it with a YAML scenario corpus lands in **M3** at `test/integration/agentserver/`.
 
 ### Browser E2E with the fake agent (L4)
 

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -134,7 +134,7 @@ The same library serves multiple consumers, so the wire contract is exercised en
 
 - `test/fakeagent/`: Go library. Loads YAML scenarios, feeds events into a `Receiver` (in-process) or posts envelopes
   directly to a server URL.
-- `cmd/fleet-edr-agent-headless`: production agent built with the stub receiver, plus an opt-in unix-socket control
+- `agent/cmd/fleet-edr-agent-headless`: production agent built with the stub receiver, plus an opt-in unix-socket control
   plane for tests. Doubles as the load generator.
 - `test/fakeagent/scenarios/`: YAML files describing event timelines, host metadata, and (where applicable) detection
   assertions.


### PR DESCRIPTION
Second milestone of the UAT plan in docs/testing-strategy.md. With M1's build-tag split letting the agent's Go core compile on linux, M2 adds a dedicated binary that wires the agent's queue + uploader + enrollment pipeline and exposes a local unix-socket control plane so test scenarios can inject events directly into the receiver. This is the substrate the L3 headless-agent + server CI job (M3) will drive.

What this lands:

- agent/receiver/receiver_other.go gains Inject([]byte) error on the non-darwin / no-cgo stub Receiver. Non-blocking: a full buffer returns the new ErrBufferFull sentinel so a hung uploader surfaces as a test failure rather than a hung scenario driver. The darwin XPC receiver has no Inject method by design; production XPC events come from the kernel via the system extension.

- agent/cmd/fleet-edr-agent-headless/ is the new binary, all four source files tagged //go:build !darwin || !cgo so production darwin builds skip the whole package:
  - main.go: thin entrypoint, parses --control-socket flag, loads config, runs the production enrollment.Ensure flow, hands off to Run. Excluded from Sonar coverage via the existing **/cmd/**/main.go rule.
  - headless.go: Options + Run. Mirrors the production agent's wiring minus the XPC-specific goroutines (no process reconciler, no commander, no XPC heartbeat). Bounded drain on shutdown so a hung server cannot block exit.
  - control.go: unix-socket HTTP server with POST /event (inject one JSON envelope) and GET /state (events_injected, inject_errors, last_inject_at_unix, queue_depth). 1 MiB body cap, 0600 socket perms, 5s read/write timeouts.
  - headless_test.go: integration test that stands up an httptest fake EDR server, runs Run in a goroutine, posts events via the unix socket, and asserts they arrive at the fake server with the right bearer token. Plus focused unit tests for Options.validate and the handler's error branches (empty body, invalid JSON, body too large, buffer full). Per-file coverage on new code is 71-100% (Sonar's 80% new-code gate has headroom).

- Taskfile.yml: build:agent:headless task that produces the linux binary under agent/tmp/. test:go:agent and test:go:agent:coverage now run a second pass under CGO_ENABLED=0 to cover the headless package whose build tags exclude it from the default cgo run; the two coverage profiles cover disjoint files (build-tag-enforced) so they merge cleanly by concatenation.

- .github/workflows/test.yml: new step in agent-test that runs task build:agent:headless after the existing M1 linux cross-build, keeping the headless binary's compile invariant green per PR.

- docs/testing-strategy.md: L3 section updated to describe the headless binary as it actually ships, with the control-plane API surface listed.

Verified locally: production darwin build, GOOS=linux build, darwin CGO_ENABLED=0 build, agent test suite (including the new headless tests), golangci-lint, gofmt, markdownlint all pass. The merged coverage profile contains both production and headless line entries without per-line conflicts.

Stacks on M1 (#206). Refs UAT plan M2 milestone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added headless agent build option for Linux environments, enabling agent testing without macOS dependencies.

* **Tests**
  * Expanded test coverage with comprehensive test suite for headless agent functionality.
  * Enhanced CI pipeline to automatically build and validate headless agent.

* **Chores**
  * Updated build tasks to support headless agent compilation and coverage reporting.
  * Refined testing documentation to reflect new headless agent testing strategy.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/getvictor/fleet-edr/pull/211?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->