### PR TITLE
M4: L3 headless-agent + server integration test

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,3 +1,7 @@
 BasedOnStyle: LLVM
 IndentWidth: 4
 ColumnLimit: 120
+# Treat Go build-constraint comments (`//go:build ...`) as pragmas so clang-format leaves them alone. Without this, clang-format flags
+# the missing space after `//` as a style violation, but Go's toolchain requires the exact `//go:build` syntax with no space (per
+# Go's build-constraint spec); the two style rules are non-negotiable, so we exempt the directive. See agent/receiver/bridge.c.
+CommentPragmas: '^go:build'

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -231,6 +231,23 @@ tasks:
     cmds:
       - task: test:go:server:integration
 
+  test:integration:agent-server:
+    desc: |
+      Run just the UAT plan L3 (M4) agent-server integration test:
+      test/integration/agentserver/. This is the headless agent + real server
+      + 5-scenario starter-corpus pipeline check. Sets CGO_ENABLED=0 so the
+      test runs on darwin dev machines too (the test code imports the headless
+      package which is tagged `//go:build !darwin || !cgo`).
+
+      Requires a real MySQL via $EDR_TEST_DSN. CI does not call this directly;
+      the same tests are picked up automatically by test:go:server:integration
+      under the recursive ./test/integration/... glob on the ubuntu runner.
+    env:
+      EDR_TEST_DSN: '{{.EDR_TEST_DSN | default "root@tcp(127.0.0.1:3317)/edr_test?parseTime=true"}}'
+      CGO_ENABLED: 0
+    cmds:
+      - go test -count=1 -timeout=5m -tags=integration ./test/integration/agentserver/...
+
   test:go:server:coverage:
     desc: |
       Server + shared coverage flavor of test:go:server. Emits coverage-server.out

--- a/agent/cmd/fleet-edr-agent-headless/headless/control.go
+++ b/agent/cmd/fleet-edr-agent-headless/headless/control.go
@@ -1,6 +1,6 @@
 //go:build !darwin || !cgo
 
-package main
+package headless
 
 import (
 	"context"

--- a/agent/cmd/fleet-edr-agent-headless/headless/headless.go
+++ b/agent/cmd/fleet-edr-agent-headless/headless/headless.go
@@ -1,10 +1,11 @@
 //go:build !darwin || !cgo
 
-// Package main is the headless agent: a development + test build of the agent's Go core that runs on linux (or on darwin with CGO
-// disabled) without the macOS XPC system extension. It wires the same enrollment + queue + uploader pipeline as the production agent,
-// substitutes the non-darwin stub receiver for the XPC bridge, and exposes a local unix-socket control plane so tests can inject
-// events directly into the receiver. Used by UAT plan layer L3 (headless agent + server integration). See docs/testing-strategy.md.
-package main
+// Package headless is the development + test build of the agent's Go core that runs on linux (or on darwin with CGO disabled) without
+// the macOS XPC system extension. It wires the same enrollment + queue + uploader pipeline as the production agent, substitutes the
+// non-darwin stub receiver for the XPC bridge, and exposes a local unix-socket control plane so tests can inject events directly into
+// the receiver. The fleet-edr-agent-headless binary (main.go alongside this package) is a thin entrypoint that calls Run; the L3
+// integration tests at test/integration/agentserver import Run directly. See docs/testing-strategy.md for the M2 + M4 design.
+package headless
 
 import (
 	"context"

--- a/agent/cmd/fleet-edr-agent-headless/headless/headless_test.go
+++ b/agent/cmd/fleet-edr-agent-headless/headless/headless_test.go
@@ -1,6 +1,6 @@
 //go:build !darwin || !cgo
 
-package main
+package headless
 
 import (
 	"bytes"

--- a/agent/cmd/fleet-edr-agent-headless/main.go
+++ b/agent/cmd/fleet-edr-agent-headless/main.go
@@ -4,9 +4,9 @@
 // the production agent, substitutes the non-darwin stub receiver for the XPC bridge, and exposes a unix-socket control plane so test
 // scenarios can inject events. See UAT plan layer L3 in docs/testing-strategy.md.
 //
-// This file is the entrypoint only; the actual wiring lives in headless.go (Run) and control.go (HTTP handlers) so the logic stays
-// covered by the integration test in headless_test.go. main.go is excluded from Sonar's new-code coverage gate via the
-// **/cmd/**/main.go rule in sonar-project.properties.
+// This file is the entrypoint only. All wiring lives in the headless sub-package so the L3 integration tests at
+// test/integration/agentserver can import the same Run / Options surface the binary calls. main.go is excluded from Sonar's new-code
+// coverage gate via the **/cmd/**/main.go rule in sonar-project.properties.
 package main
 
 import (
@@ -18,6 +18,7 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/fleetdm/edr/agent/cmd/fleet-edr-agent-headless/headless"
 	"github.com/fleetdm/edr/agent/config"
 	"github.com/fleetdm/edr/agent/enrollment"
 )
@@ -63,7 +64,7 @@ func mainErr() error {
 		return fmt.Errorf("enrollment: %w", err)
 	}
 
-	return Run(ctx, Options{
+	return headless.Run(ctx, headless.Options{
 		ServerURL:      cfg.ServerURL,
 		HostID:         tokenProvider.HostID(),
 		QueuePath:      cfg.QueueDBPath,

--- a/agent/receiver/bridge.c
+++ b/agent/receiver/bridge.c
@@ -1,3 +1,10 @@
+// Build constraint must match the sibling Go files (receiver.go, callbacks.go) so this C source is excluded under
+// linux + cgo=1 and darwin + cgo=0 alike. Without it, a `go build` under cgo finds bridge.c with no companion Go
+// file `import "C"`-ing on the matching platform and errors with "C source files not allowed when not using cgo
+// or SWIG". Plain `//go:build` directives are honoured by go/build for .c sources in cgo packages.
+//
+//go:build darwin && cgo
+
 #include "_cgo_export.h"
 #include "xpc_bridge.c"
 #include "xpc_bridge.h"

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -81,8 +81,14 @@ A run at any layer implies all lower layers have already passed; CI gates enforc
   production but with the stub receiver, and exposes a small local control plane on a unix socket:
   - `POST /event`: inject one JSON event into the stub receiver's events channel.
   - `GET /state`: return `{events_injected, inject_errors, last_inject_at_unix, queue_depth}`.
-  Built by `task build:agent:headless` (also gated in CI). UAT plan milestone **M2** delivered this binary; the L3
-  end-to-end CI job that drives it with a YAML scenario corpus lands in **M3** at `test/integration/agentserver/`.
+  Built by `task build:agent:headless` (also gated in CI). UAT plan milestone **M2** delivered this binary; **M3**
+  shipped the `test/fakeagent` library that loads YAML scenarios and feeds the control plane.
+- The L3 end-to-end test at `test/integration/agentserver/` is UAT plan milestone **M4**. It boots the real server
+  via `test/integration.Setup` (full Stack + real MySQL + processor goroutines), runs the M2 headless agent's
+  `Run` in-process, drives each scenario from the M3 fakeagent starter corpus via `FeedControlPlane`, and asserts
+  on the detection service's `ListHosts` event counts. Gated by the existing `server-test` CI job via the
+  recursive `./test/integration/...` glob; local devs run with `task test:integration:agent-server`. Scenarios
+  use canonical UUID host ids so they pass the enrollment endpoint's `hardware_uuid` regex.
 
 ### Browser E2E with the fake agent (L4)
 

--- a/test/fakeagent/feeder_test.go
+++ b/test/fakeagent/feeder_test.go
@@ -98,7 +98,7 @@ func TestFeedControlPlane_RoundTrip(t *testing.T) {
 	var first Envelope
 	require.NoError(t, json.Unmarshal(bodies[0], &first))
 	assert.Equal(t, "fork", first.EventType)
-	assert.Equal(t, "exec-fork-exit-host", first.HostID)
+	assert.Equal(t, "AAAA0002-0000-0000-0000-000000000002", first.HostID)
 	assert.Equal(t, "e-0", first.EventID)
 	assert.Equal(t, start.UnixNano(), first.TimestampNs)
 

--- a/test/fakeagent/scenarios/dns-and-network.yaml
+++ b/test/fakeagent/scenarios/dns-and-network.yaml
@@ -4,7 +4,7 @@
 name: "DNS then outbound TCP"
 mitre: T1071.004
 host:
-  id: dns-net-host
+  id: AAAA0003-0000-0000-0000-000000000003
   hostname: lab-mac.local
   os: macOS 14.4
 timeline:

--- a/test/fakeagent/scenarios/exec-fork-exit.yaml
+++ b/test/fakeagent/scenarios/exec-fork-exit.yaml
@@ -4,7 +4,7 @@
 # pipeline reorders by timestamp - and is covered by a dedicated future scenario, not by reordering this one.
 name: "Baseline process-graph: ls -la"
 host:
-  id: exec-fork-exit-host
+  id: AAAA0002-0000-0000-0000-000000000002
   hostname: lab-mac.local
   os: macOS 14.4
 timeline:

--- a/test/fakeagent/scenarios/mixed-events.yaml
+++ b/test/fakeagent/scenarios/mixed-events.yaml
@@ -1,0 +1,45 @@
+# Mixed-event scenario: a process forks, execs, opens a file, resolves a hostname, opens an outbound TCP connection, then exits.
+# Exercises five of the seven event types in a single timeline so the integration test covers every payload-shape branch in
+# fakeagent.buildPayload from one fixture. Remote IP is RFC 5737 TEST-NET-3 so the scenario reads as obviously synthetic.
+name: "Mixed events: one process touches the file, DNS, network paths"
+host:
+  id: AAAA0005-0000-0000-0000-000000000005
+  hostname: lab-mac.local
+  os: macOS 14.4
+timeline:
+  - at: 0ms
+    type: fork
+    child_pid: 7001
+    parent_pid: 1
+  - at: 2ms
+    type: exec
+    pid: 7001
+    ppid: 1
+    path: /usr/bin/curl
+    args: ["curl", "https://api.example.com/heartbeat"]
+    cwd: /tmp
+    uid: 501
+    gid: 20
+  - at: 5ms
+    type: open
+    pid: 7001
+    path: /etc/resolv.conf
+    flags: 0
+  - at: 8ms
+    type: dns_query
+    pid: 7001
+    query_name: api.example.com
+    query_type: A
+    response_addresses: ["203.0.113.99"]
+    protocol: udp
+  - at: 20ms
+    type: network_connect
+    pid: 7001
+    protocol: tcp
+    direction: outbound
+    remote_address: 203.0.113.99
+    remote_port: 443
+  - at: 150ms
+    type: exit
+    pid: 7001
+    exit_code: 0

--- a/test/fakeagent/scenarios/process-tree-deep.yaml
+++ b/test/fakeagent/scenarios/process-tree-deep.yaml
@@ -1,0 +1,61 @@
+# A 4-level-deep process tree: launchd -> shell -> python -> child -> grandchild. Exercises the agent's process-graph builder under
+# more than the trivial depth of exec-fork-exit.yaml, and gives the L3 + L4 tests a non-trivial tree shape to assert against. The
+# tree is fully built before any process exits so the graph at scenario end contains five live processes plus their fork+exec edges.
+name: "Deep process tree (4 levels)"
+host:
+  id: AAAA0004-0000-0000-0000-000000000004
+  hostname: lab-mac.local
+  os: macOS 14.4
+timeline:
+  - at: 0ms
+    type: fork
+    child_pid: 6001
+    parent_pid: 1
+  - at: 1ms
+    type: exec
+    pid: 6001
+    ppid: 1
+    path: /bin/zsh
+    args: ["zsh"]
+    cwd: /Users/victor
+    uid: 501
+    gid: 20
+  - at: 5ms
+    type: fork
+    child_pid: 6002
+    parent_pid: 6001
+  - at: 6ms
+    type: exec
+    pid: 6002
+    ppid: 6001
+    path: /usr/bin/python3
+    args: ["python3", "build.py"]
+    cwd: /Users/victor/project
+    uid: 501
+    gid: 20
+  - at: 10ms
+    type: fork
+    child_pid: 6003
+    parent_pid: 6002
+  - at: 11ms
+    type: exec
+    pid: 6003
+    ppid: 6002
+    path: /usr/bin/make
+    args: ["make", "test"]
+    cwd: /Users/victor/project
+    uid: 501
+    gid: 20
+  - at: 15ms
+    type: fork
+    child_pid: 6004
+    parent_pid: 6003
+  - at: 16ms
+    type: exec
+    pid: 6004
+    ppid: 6003
+    path: /usr/bin/go
+    args: ["go", "test", "./..."]
+    cwd: /Users/victor/project
+    uid: 501
+    gid: 20

--- a/test/fakeagent/scenarios/quiet-host.yaml
+++ b/test/fakeagent/scenarios/quiet-host.yaml
@@ -2,7 +2,7 @@
 # (M10): every rule that fires on a quiet host is by definition a false positive.
 name: "Quiet host"
 host:
-  id: quiet-host-1
+  id: AAAA0001-0000-0000-0000-000000000001
   hostname: quiet.lab.local
   os: macOS 14.4
 timeline:

--- a/test/integration/agentserver/agentserver_test.go
+++ b/test/integration/agentserver/agentserver_test.go
@@ -7,7 +7,8 @@
 // pumpEvents -> queue -> uploader -> /api/events -> detection processor -> events table -> ListHosts EventCount.
 //
 // One subtest per scenario in the starter corpus (M4 milestone: 5). Each subtest gets its own MySQL test database (testdb/full.Open
-// via integration.Setup) so it can run with t.Parallel without cross-test interference.
+// via integration.Setup) so per-subtest state is isolated. Subtests run serially rather than t.Parallel - see the runScenario
+// comment below for the connection-pressure rationale.
 //
 // Build tag pairing: `integration` matches the existing test/integration suite gate; `!darwin || !cgo` matches the headless package's
 // receiver-stub gate. CI's server-test job runs on ubuntu-latest where !darwin holds, so the suite picks these up automatically via

--- a/test/integration/agentserver/agentserver_test.go
+++ b/test/integration/agentserver/agentserver_test.go
@@ -1,0 +1,215 @@
+//go:build integration && (!darwin || !cgo)
+
+// Package agentserver is the UAT plan layer-3 (L3) integration test: a full real EDR server (via the M1-M3 production wiring composed
+// by test/integration.Setup), the real M2 headless agent (via the agent/cmd/fleet-edr-agent-headless/headless package, in-process so
+// the test doesn't pay subprocess startup), and the M3 fakeagent library driving each starter scenario through the agent's POST /event
+// control plane. The pipeline under test is: scenario YAML -> fakeagent envelopes -> headless control plane -> stub receiver ->
+// pumpEvents -> queue -> uploader -> /api/events -> detection processor -> events table -> ListHosts EventCount.
+//
+// One subtest per scenario in the starter corpus (M4 milestone: 5). Each subtest gets its own MySQL test database (testdb/full.Open
+// via integration.Setup) so it can run with t.Parallel without cross-test interference.
+//
+// Build tag pairing: `integration` matches the existing test/integration suite gate; `!darwin || !cgo` matches the headless package's
+// receiver-stub gate. CI's server-test job runs on ubuntu-latest where !darwin holds, so the suite picks these up automatically via
+// `task test:go:server:integration`'s `./test/integration/...` glob. Darwin devs run with `CGO_ENABLED=0 task test:integration:agent-server`.
+package agentserver
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/fleetdm/edr/agent/cmd/fleet-edr-agent-headless/headless"
+	"github.com/fleetdm/edr/test/fakeagent"
+	"github.com/fleetdm/edr/test/integration"
+)
+
+// scenarioCorpus is the M4 list. Paths are relative to this file so `go test` resolves them correctly under both `go test ./test/...`
+// and direct `go test ./test/integration/agentserver/...` invocations.
+var scenarioCorpus = []string{
+	"../../fakeagent/scenarios/quiet-host.yaml",
+	"../../fakeagent/scenarios/exec-fork-exit.yaml",
+	"../../fakeagent/scenarios/dns-and-network.yaml",
+	"../../fakeagent/scenarios/process-tree-deep.yaml",
+	"../../fakeagent/scenarios/mixed-events.yaml",
+}
+
+func TestL3_HeadlessAgentToServer(t *testing.T) {
+	// Subtests run SERIALLY rather than via t.Parallel. Each scenario stands up a fresh integration.Setup Stack which opens its own
+	// MySQL pool (~4 connections via testdb.Open); five parallel Stacks on top of the rest of the integration suite's parallel test
+	// load consistently push past MySQL's 500-connection ceiling (CI's bumped default) and cause Error 1040. Sequential keeps the
+	// agentserver package's peak connection count to ~4 and the full-suite wall time barely changes since each subtest is sub-second.
+	for _, path := range scenarioCorpus {
+		t.Run(filepath.Base(path), func(t *testing.T) {
+			runScenario(t, path)
+		})
+	}
+}
+
+// runScenario boots a fresh Stack, enrols a host using the scenario's host_id, spins headless.Run in a goroutine pointing at the
+// Stack, drives the scenario via fakeagent.FeedControlPlane, and waits for the detection service to report EventCount >= len(timeline)
+// for the host. The Eventually deadline is generous (10s) because the chain is queue.Open + uploader interval + server processor
+// interval; the actual end-to-end latency is sub-second in practice but a slow CI runner can extend it.
+func runScenario(t *testing.T, scenarioPath string) {
+	t.Helper()
+
+	scenario, err := fakeagent.LoadScenario(scenarioPath)
+	require.NoError(t, err)
+
+	stack := integration.Setup(t)
+	hostID := scenario.Host.ID
+	hostToken := enroll(t, stack, hostID)
+
+	socketPath := shortSocketPath(t)
+	opts := headless.Options{
+		ServerURL: stack.Server.URL,
+		HostID:    hostID,
+		QueuePath: filepath.Join(t.TempDir(), "queue.db"),
+		// UploadInterval is small so the uploader fires within the Eventually budget. BatchSize=100 fits any of the 5 scenarios in
+		// a single batch (largest is 9 events).
+		BatchSize:      100,
+		UploadInterval: 50 * time.Millisecond,
+		SocketPath:     socketPath,
+		TokenProvider:  &stubTokenProvider{token: hostToken, hostID: hostID},
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	runErrCh := make(chan error, 1)
+	go func() { runErrCh <- headless.Run(ctx, opts) }()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case err := <-runErrCh:
+			if err != nil && !isContextCanceled(err) {
+				t.Errorf("headless.Run returned non-cancel error: %v", err)
+			}
+		case <-time.After(10 * time.Second):
+			t.Errorf("headless.Run did not exit within 10s of ctx cancel")
+		}
+	})
+
+	waitForControlPlane(t, socketPath)
+	require.NoError(t, scenario.FeedControlPlane(ctx, socketPath))
+
+	expected := int64(len(scenario.Timeline))
+	require.Eventuallyf(t, func() bool {
+		hosts, err := stack.DetectionService().ListHosts(ctx)
+		if err != nil {
+			return false
+		}
+		for _, h := range hosts {
+			if h.HostID == hostID && h.EventCount >= expected {
+				return true
+			}
+		}
+		return false
+	}, 10*time.Second, 100*time.Millisecond,
+		"host %s never reached %d events through the agent pipeline", hostID, expected)
+}
+
+// enroll posts to /api/enroll with the integration test's pre-baked enroll secret and returns the issued host_token. The Setup helper
+// in test/integration wires integration.EnrollSecret into the endpoint context, so this mirrors the test/integration/full_path_test
+// pattern verbatim.
+func enroll(t *testing.T, stack *integration.Stack, hostID string) string {
+	t.Helper()
+	body, err := json.Marshal(map[string]string{
+		"enroll_secret": integration.EnrollSecret,
+		"hardware_uuid": hostID,
+		"hostname":      "l3-agentserver.local",
+		"agent_version": "l3-integration-test",
+		"os_version":    "macOS 26.0",
+	})
+	require.NoError(t, err)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost,
+		stack.Server.URL+"/api/enroll", bytes.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := stack.Server.Client().Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equalf(t, http.StatusOK, resp.StatusCode, "POST /api/enroll status for %s", hostID)
+
+	var er struct {
+		HostID    string `json:"host_id"`
+		HostToken string `json:"host_token"`
+	}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&er))
+	require.Equal(t, hostID, er.HostID)
+	require.NotEmpty(t, er.HostToken, "enroll response must carry host_token")
+	return er.HostToken
+}
+
+// waitForControlPlane polls the headless agent's GET /state until it returns 200 or the budget expires. Without this the test would
+// race FeedControlPlane against the listener bind.
+func waitForControlPlane(t *testing.T, socketPath string) {
+	t.Helper()
+	require.Eventuallyf(t, func() bool {
+		client := unixHTTPClient(socketPath)
+		resp, err := client.Get("http://unix/state")
+		if err != nil {
+			return false
+		}
+		_ = resp.Body.Close()
+		return resp.StatusCode == http.StatusOK
+	}, 5*time.Second, 50*time.Millisecond, "control plane at %s never came up", socketPath)
+}
+
+// stubTokenProvider implements enrollment.TokenProvider with fixed values so the integration test can skip the agent-side enrollment
+// network call. The host_token here is the real token the server minted via /api/enroll above; the uploader's Authorization header
+// gets it, the server's middleware accepts it, the event lands in the database.
+type stubTokenProvider struct {
+	token  string
+	hostID string
+}
+
+func (s *stubTokenProvider) Token() string                            { return s.token }
+func (s *stubTokenProvider) HostID() string                           { return s.hostID }
+func (s *stubTokenProvider) OnUnauthorized(_ context.Context)         {}
+func (s *stubTokenProvider) Rotate(_ context.Context, _ string) error { return nil }
+
+// shortSocketPath returns a unix-socket path short enough to fit AF_UNIX's 104-byte sun_path limit on macOS. t.TempDir embeds the
+// full test name which can easily exceed that limit; os.MkdirTemp with a short prefix keeps the path under the budget.
+//
+//nolint:usetesting // t.TempDir would emit paths longer than AF_UNIX's sun_path limit on macOS.
+func shortSocketPath(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "as")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return filepath.Join(dir, "c.sock")
+}
+
+// unixHTTPClient is a tiny http.Client that always dials the given unix socket. The "http://unix" URL host is a placeholder net/http
+// requires; the connection goes to socketPath. Matches the same shape fakeagent uses internally.
+func unixHTTPClient(socketPath string) *http.Client {
+	return &http.Client{
+		Timeout: 3 * time.Second,
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+				var d net.Dialer
+				return d.DialContext(ctx, "unix", socketPath)
+			},
+		},
+	}
+}
+
+// isContextCanceled tests for the typical shutdown-path error envelopes the headless pipeline produces. Plain context.Canceled doesn't
+// always cover wrapped variants from the uploader or the queue.
+func isContextCanceled(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := err.Error()
+	return s == context.Canceled.Error() ||
+		s == context.DeadlineExceeded.Error() ||
+		// Wrapped variants surface as "... : context canceled" from the uploader / queue.
+		bytes.Contains([]byte(s), []byte("context canceled"))
+}


### PR DESCRIPTION
Fourth milestone of the UAT plan in docs/testing-strategy.md. With M1's build-tag split, M2's headless binary, and M3's fakeagent library all merged, M4 closes the L3 loop: a Go integration test that boots the real EDR server (via test/integration.Setup), runs the real headless agent in-process, drives the M3 starter scenario corpus through the agent's POST /event control plane, and asserts events landed in the server's detection service. End-to-end proof that scenario YAML -> fakeagent envelopes -> headless control plane -> stub receiver -> queue -> uploader -> /api/events -> processor -> events table works on every PR.

What this lands:

- agent/cmd/fleet-edr-agent-headless/headless/ is a new importable sub-package containing Run, Options, the receiver-pump goroutine, the control-plane HTTP handlers, and the M2 unit tests, all moved from the cmd directory's main package. main.go shrinks to a thin entrypoint that imports the new package. The split exists so the L3 integration test can call headless.Run in-process without building a subprocess. Production behaviour is byte-identical; the build tag (`//go:build !darwin || !cgo`) carries over.

- test/integration/agentserver/agentserver_test.go is the new L3 test. One subtest per scenario in the M3 corpus (5 total after this PR). Each subtest: enrolls a fresh host against the Setup Stack's /api/enroll, builds headless.Options pointing at the Stack URL with a stub TokenProvider carrying the minted token, spins headless.Run in a goroutine, waits for the control plane to bind, feeds the scenario via fakeagent.FeedControlPlane, then Eventually-polls detection.Service.ListHosts until EventCount matches len(timeline). Build tag: `integration && (!darwin || !cgo)` so CI ubuntu-latest picks it up automatically and darwin devs opt-in via CGO_ENABLED=0.

  Subtests run SERIALLY rather than t.Parallel because each Setup Stack opens its own MySQL pool; five concurrent Stacks on top of the rest of the integration suite's parallel load consistently push past MySQL's max_connections ceiling. Sequential keeps the package's peak connection count to ~4 and wall time stays under 3 seconds.

- test/fakeagent/scenarios/ gains 2 new YAML files so the M4 corpus = 5 total: process-tree-deep.yaml (4-level parent->child process chain, exercises depth) and mixed-events.yaml (fork+exec+ open+dns+network+exit covering 5 event types in a single timeline).

- The existing 3 scenarios got their host.id fields rewritten to canonical UUID form (AAAA000N-0000-0000-0000-00000000000N) so they pass the endpoint service's hardware_uuid regex; production agents use IOPlatformUUID which is always canonical-uuid-shaped, so this lines the scenarios up with reality.

- Taskfile.yml gets test:integration:agent-server for local-dev convenience (CGO_ENABLED=0, ./test/integration/agentserver/...). No new CI job: the existing server-test job's test:go:server:integration uses a recursive ./test/integration/... glob, and test/** is already in sonar.coverage.exclusions, so M4 ships without workflow surgery.

- docs/testing-strategy.md L3 section updated to describe M4 as it actually ships, including the canonical-UUID host_id convention.

Verified locally: task test:integration:agent-server passes all 5 subtests against a real MySQL test instance (~2s wall time). task lint:go (0 issues), task lint:md (0 errors), gofmt clean. The existing server-test integration suite's flakiness on my local MySQL setup ("Error 1040: Too many connections") reproduces on main without M4, so it's a pre-existing local-env issue with no relation to this PR; CI's clean container with max_connections=500 handles it.

Builds on M1 (#206), M2 (#211), M3 (#212), all merged to main. Refs UAT plan M4 milestone. M5 (Playwright fixture rewrite using the same fakeagent library) is next.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration test suite for agent-server interaction testing.
  * Added test scenarios for mixed events and deep process tree structures.
  * Standardized host identifiers across test fixtures.

* **Documentation**
  * Updated testing strategy documentation with detailed agent-server integration test walkthrough.

* **Chores**
  * Reorganized headless agent package structure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/getvictor/fleet-edr/pull/213?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->