### PR TITLE
M5: Playwright agent fixture + L4 smoke spec

### DIFF
--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -89,7 +89,12 @@ A run at any layer implies all lower layers have already passed; CI gates enforc
 - Playwright tests live in `test/e2e/`. Real server + real MySQL + real UI; tests start the server via the
   `webServer` block in `playwright.config.ts`.
 - For tests that need realistic agent data (process trees, alerts, app-control flow, host list), the spec drives the
-  fake-agent control plane to inject a scenario, waits for the events to land, then drives the UI.
+  M5 fixture at `test/e2e/fixtures/agent.ts`: it reads the same YAML scenarios as the Go fakeagent library
+  (`test/fakeagent/scenarios/`), enrolls a per-test host via `/api/enroll`, generates wire envelopes matching
+  `schema/events.json`, then POSTs them to `/api/events` with the minted bearer token. The smoke spec at
+  `test/e2e/tests/qa/agent-events-flow.spec.ts` proves the wire end-to-end across the starter corpus. The fixture
+  bypasses the headless agent binary intentionally - the queue + uploader path is already L3-covered (M4); L4 is
+  about UI behavior under realistic data.
 - For pure auth/RBAC/session tests, direct SQL fixtures under `test/e2e/fixtures/db.ts` remain the right tool; they
   are faster and the data they seed is not exercised through the ingestion path.
 - CI runs Playwright in phases (`scripts/test-e2e-coverage.sh`) so env-isolation tests (rate limits, short session

--- a/test/e2e/fixtures/agent.ts
+++ b/test/e2e/fixtures/agent.ts
@@ -12,8 +12,13 @@
 //     isolated state.
 //
 // Why not port the Go fakeagent library to TypeScript? The YAML scenarios are the single source of truth shared between Go and TS;
-// the envelope-shaping logic is small and stable (six event types covered here, same as the Go side). Duplicating ~80 LOC of mapping
-// code is cheaper than maintaining a Go/Node FFI bridge.
+// the envelope-shaping logic is small and stable (seven event types: exec, fork, exit, open, network_connect, dns_query,
+// snapshot_heartbeat - same set as the Go side). Duplicating ~80 LOC of mapping is cheaper than a Go/Node FFI bridge.
+//
+// Wire-precision note: timestamp_ns is computed with BigInt so the value matches schema/events.json's integer type at full int64
+// precision, then emitted as an unquoted JSON number via a custom serialiser below. Plain `Number(epochMs) * 1e6` would silently
+// lose ~3 lower digits for current-epoch timestamps (epoch_ns ~1.8e18 > MAX_SAFE_INTEGER 9e15), drifting from the Go path's int64
+// arithmetic. event_id is `crypto.randomUUID()` to satisfy schema/events.json's `format: uuid` constraint.
 
 import { test as base, request as playwrightRequest, APIRequestContext } from "@playwright/test";
 import * as fs from "node:fs/promises";
@@ -49,6 +54,7 @@ export interface ScenarioEvent {
   args?: string[];
   cwd?: string;
   exit_code?: number;
+  exit_reason?: string; // schema/events.json exit_payload.exit_reason - matches the Go ScenarioEvent struct.
   flags?: number;
   protocol?: string;
   direction?: string;
@@ -73,7 +79,12 @@ export interface Scenario {
 export interface Envelope {
   event_id: string;
   host_id: string;
-  timestamp_ns: number;
+  /**
+   * Nanoseconds since Unix epoch. Stored as BigInt so values past JS's MAX_SAFE_INTEGER (9e15) - which every current-epoch
+   * nanosecond timestamp exceeds - retain int64 precision. Serialised to JSON as an unquoted number via the BigInt-aware
+   * stringify helper below.
+   */
+  timestamp_ns: bigint;
   event_type: string;
   payload: Record<string, unknown>;
 }
@@ -118,8 +129,10 @@ export const test = base.extend<AgentFixtures>({
           const hostId = opts?.hostIdOverride ?? scenario.host.id;
           const hostToken = await enrollHost(ctx, hostId, scenario.host.hostname ?? "playwright.lab.local");
           const envelopes = generateEnvelopes(scenario, hostId, opts?.startTime ?? new Date());
+          // stringifyEnvelopes serialises BigInt timestamp_ns as an unquoted JSON number. ctx.post's `data` field would JSON-encode
+          // via Object.prototype.toString on a BigInt, which throws; passing `body` skips that path.
           const resp = await ctx.post("/api/events", {
-            data: envelopes,
+            data: stringifyEnvelopes(envelopes),
             headers: { Authorization: `Bearer ${hostToken}`, "Content-Type": "application/json" },
           });
           if (!resp.ok()) {
@@ -176,16 +189,31 @@ async function enrollHost(ctx: APIRequestContext, hostId: string, hostname: stri
 }
 
 // generateEnvelopes materialises a scenario's timeline into wire envelopes. The shape matches schema/events.json and the Go
-// fakeagent.Envelopes function so the two paths can't drift. event_id is a 32-char hex random; timestamp_ns is startTime + at offset.
+// fakeagent.Envelopes function so the two paths can't drift. event_id is a canonical (lowercase, hyphenated) UUID per the schema's
+// `format: uuid` constraint. timestamp_ns is computed with BigInt because every current-epoch nanosecond timestamp exceeds JS's
+// Number.MAX_SAFE_INTEGER; storing as a plain Number would silently round and diverge from Go's int64.
 export function generateEnvelopes(scenario: Scenario, hostId: string, startTime: Date): Envelope[] {
-  const startNs = startTime.getTime() * 1_000_000;
+  const startNs = BigInt(startTime.getTime()) * 1_000_000n;
   return scenario.timeline.map((ev) => ({
-    event_id: randomHex32(),
+    event_id: crypto.randomUUID(),
     host_id: hostId,
     timestamp_ns: startNs + parseGoDuration(ev.at),
     event_type: ev.type,
     payload: buildPayload(ev),
   }));
+}
+
+// stringifyEnvelopes serialises a batch of envelopes to a JSON string with BigInt timestamp_ns emitted as an UNQUOTED JSON number,
+// matching the integer type schema/events.json declares. A sentinel + post-process regex is the only zero-dep path; the alternative
+// (JSON.stringify replacer returning a number) doesn't help because JS converts BigInt to Number at the toJSON boundary, losing the
+// precision we went to BigInt to preserve. The sentinel chars are chosen to be both regex-safe and JSON-impossible so the regex
+// can't accidentally match real payload content.
+export function stringifyEnvelopes(envelopes: Envelope[]): string {
+  const sentinel = "@@BIGINT@@";
+  const raw = JSON.stringify(envelopes, (_k, v) =>
+    typeof v === "bigint" ? `${sentinel}${v.toString()}${sentinel}` : v,
+  );
+  return raw.replace(/"@@BIGINT@@(\d+)@@BIGINT@@"/g, "$1");
 }
 
 // buildPayload picks the right field subset for each event_type and emits exactly the schema/events.json-required shape. Order +
@@ -206,6 +234,9 @@ function buildPayload(ev: ScenarioEvent): Record<string, unknown> {
       return { child_pid: ev.child_pid ?? 0, parent_pid: ev.parent_pid ?? 0 };
     case "exit": {
       const p: Record<string, unknown> = { pid: ev.pid ?? 0, exit_code: ev.exit_code ?? 0 };
+      // exit_reason is schema/events.json's optional discriminator between "event" (kernel-observed) and "host_reconciled" (synthetic).
+      // Only emit when the scenario set it so consumers see schema/events.json's "absent" semantics for default scenarios.
+      if (ev.exit_reason) p.exit_reason = ev.exit_reason;
       return p;
     }
     case "open":
@@ -219,7 +250,9 @@ function buildPayload(ev: ScenarioEvent): Record<string, unknown> {
         remote_port: ev.remote_port ?? 0,
       };
       if (ev.local_address) p.local_address = ev.local_address;
-      if (ev.local_port) p.local_port = ev.local_port;
+      // !== undefined so an explicitly-provided local_port: 0 isn't dropped by JS truthy semantics. Same shape for the address
+      // wouldn't matter (empty string is falsy + meaningless), so the local_address truthy check stays.
+      if (ev.local_port !== undefined) p.local_port = ev.local_port;
       return p;
     }
     case "dns_query": {
@@ -239,30 +272,32 @@ function buildPayload(ev: ScenarioEvent): Record<string, unknown> {
   }
 }
 
-// parseGoDuration accepts the Go time.Duration string form ("10ms", "5s", "1h", "100us"). Returns nanoseconds. Supports the unit
-// suffixes the M3 fakeagent + the rest of the EDR codebase actually use; rejects everything else with a clear error so a typo in a
-// scenario file surfaces immediately rather than silently producing 0.
-function parseGoDuration(input: string): number {
-  const match = /^(\d+(?:\.\d+)?)(ns|us|µs|ms|s|m|h)$/.exec(input);
+// parseGoDuration accepts the Go time.Duration string form ("10ms", "5s", "1h", "100us"). Returns nanoseconds as a BigInt so the
+// caller can add the value to a BigInt epoch without precision loss. Fractional input is rounded to the nearest nanosecond (via
+// integer-domain math, no float intermediates) so a value like "1.5s" yields exactly 1_500_000_000n.
+function parseGoDuration(input: string): bigint {
+  const match = /^(\d+)(?:\.(\d+))?(ns|us|µs|ms|s|m|h)$/.exec(input);
   if (!match) {
     throw new Error(`parseGoDuration: cannot parse ${JSON.stringify(input)}`);
   }
-  const value = parseFloat(match[1]);
-  const unitNs: Record<string, number> = {
-    ns: 1,
-    us: 1_000,
-    "µs": 1_000,
-    ms: 1_000_000,
-    s: 1_000_000_000,
-    m: 60 * 1_000_000_000,
-    h: 3600 * 1_000_000_000,
+  const unitNs: Record<string, bigint> = {
+    ns: 1n,
+    us: 1_000n,
+    "µs": 1_000n,
+    ms: 1_000_000n,
+    s: 1_000_000_000n,
+    m: 60n * 1_000_000_000n,
+    h: 3600n * 1_000_000_000n,
   };
-  return Math.round(value * unitNs[match[2]]);
-}
-
-// randomHex32 returns a 32-character lowercase hex string. Matches the Go fakeagent's default event_id generator.
-function randomHex32(): string {
-  return crypto.randomBytes(16).toString("hex");
+  const factor = unitNs[match[3]];
+  const wholeNs = BigInt(match[1]) * factor;
+  if (!match[2]) {
+    return wholeNs;
+  }
+  // Fractional part: "1.5s" -> wholeNs=1e9, fracDigits="5", scale 10^1=10. Add (5 * factor) / 10 in integer arithmetic.
+  const fracDigits = match[2];
+  const scale = 10n ** BigInt(fracDigits.length);
+  return wholeNs + (BigInt(fracDigits) * factor) / scale;
 }
 
 export { expect } from "@playwright/test";

--- a/test/e2e/fixtures/agent.ts
+++ b/test/e2e/fixtures/agent.ts
@@ -1,0 +1,268 @@
+// Playwright fixture for UAT plan layer L4 (M5): seed agent-shaped state via the same YAML scenarios the Go fakeagent library consumes
+// (test/fakeagent/scenarios/), rather than directly seeding the events table via SQL like fixtures/db.ts does. The fixture enrols a
+// fresh host via /api/enroll, materialises the scenario's timeline into wire envelopes that match schema/events.json byte-for-byte,
+// then POSTs them to /api/events with the minted bearer token. End-to-end this exercises the server's host-token middleware +
+// ingestion + processor, which gives UI tests realistic host / process / event data without the headless agent in the loop.
+//
+// Why not go through the M2 headless binary's POST /event control plane?
+//   - The agent's queue + uploader path is already covered end-to-end by M4 (test/integration/agentserver).
+//   - L4 is about UI-facing tests; the data shape is the contract that matters, not the queue mechanics.
+//   - Running the headless binary alongside Playwright would mean process orchestration in playwright.config.ts plus a single shared
+//     host_id across the suite (the binary enrols once at startup). Per-test enrollment is much cleaner for UI specs that want
+//     isolated state.
+//
+// Why not port the Go fakeagent library to TypeScript? The YAML scenarios are the single source of truth shared between Go and TS;
+// the envelope-shaping logic is small and stable (six event types covered here, same as the Go side). Duplicating ~80 LOC of mapping
+// code is cheaper than maintaining a Go/Node FFI bridge.
+
+import { test as base, request as playwrightRequest, APIRequestContext } from "@playwright/test";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import * as crypto from "node:crypto";
+import * as yaml from "js-yaml";
+
+const SCENARIOS_DIR = path.join(__dirname, "..", "..", "fakeagent", "scenarios");
+
+// EnrollSecret matches Taskfile.yml's `task dev:server*` env block (`EDR_ENROLL_SECRET: dev-enroll-secret`). Keep in sync if the dev
+// secret ever changes. Hardcoded because every test in this suite already targets the dev server explicitly.
+const ENROLL_SECRET = "dev-enroll-secret";
+
+// --- Scenario shape (mirrors test/fakeagent/fakeagent.go's Scenario struct) ---
+
+export interface ScenarioHost {
+  id: string;
+  hostname?: string;
+  os?: string;
+}
+
+export interface ScenarioEvent {
+  at: string; // "10ms", "5s", "1h" - parsed via parseGoDuration below.
+  type: string;
+  // Type-specific fields. Only those relevant to `type` are honoured.
+  pid?: number;
+  ppid?: number;
+  uid?: number;
+  gid?: number;
+  child_pid?: number;
+  parent_pid?: number;
+  path?: string;
+  args?: string[];
+  cwd?: string;
+  exit_code?: number;
+  flags?: number;
+  protocol?: string;
+  direction?: string;
+  local_address?: string;
+  local_port?: number;
+  remote_address?: string;
+  remote_port?: number;
+  query_name?: string;
+  query_type?: string;
+  response_addresses?: string[];
+}
+
+export interface Scenario {
+  name: string;
+  mitre?: string;
+  host: ScenarioHost;
+  timeline: ScenarioEvent[];
+}
+
+// --- Envelope shape (mirrors schema/events.json) ---
+
+export interface Envelope {
+  event_id: string;
+  host_id: string;
+  timestamp_ns: number;
+  event_type: string;
+  payload: Record<string, unknown>;
+}
+
+// --- Fixture API ---
+
+export interface AgentScenarioResult {
+  /** The host_id under which the scenario's events were posted. Use this in subsequent assertions. */
+  hostId: string;
+  /** Number of envelopes that landed at /api/events (HTTP 200). */
+  eventsPosted: number;
+  /** Bearer token the fixture used; available to the test if it needs to make follow-up host-scoped requests. */
+  hostToken: string;
+}
+
+export interface AgentScenarioOptions {
+  /** Override the scenario's host.id without editing the YAML. Useful when a single test wants N hosts from one scenario. */
+  hostIdOverride?: string;
+  /** Start time for the timeline. Defaults to `new Date()` at call time. Tests that need deterministic timestamps pass a fixed value. */
+  startTime?: Date;
+}
+
+export interface AgentFixtures {
+  agent: {
+    /** Load + post one scenario in one call. Returns once /api/events returns 200 for every envelope. */
+    runScenario(name: string, opts?: AgentScenarioOptions): Promise<AgentScenarioResult>;
+  };
+}
+
+// --- Implementation ---
+
+export const test = base.extend<AgentFixtures>({
+  agent: async ({ baseURL }, use) => {
+    if (!baseURL) {
+      throw new Error("agent fixture requires Playwright baseURL to be set in playwright.config.ts");
+    }
+    const ctx = await playwrightRequest.newContext({ baseURL, ignoreHTTPSErrors: true });
+    try {
+      await use({
+        async runScenario(name: string, opts?: AgentScenarioOptions): Promise<AgentScenarioResult> {
+          const scenario = await loadScenario(name);
+          const hostId = opts?.hostIdOverride ?? scenario.host.id;
+          const hostToken = await enrollHost(ctx, hostId, scenario.host.hostname ?? "playwright.lab.local");
+          const envelopes = generateEnvelopes(scenario, hostId, opts?.startTime ?? new Date());
+          const resp = await ctx.post("/api/events", {
+            data: envelopes,
+            headers: { Authorization: `Bearer ${hostToken}`, "Content-Type": "application/json" },
+          });
+          if (!resp.ok()) {
+            const body = await resp.text();
+            throw new Error(`POST /api/events for ${hostId}: HTTP ${resp.status()}: ${body}`);
+          }
+          return { hostId, eventsPosted: envelopes.length, hostToken };
+        },
+      });
+    } finally {
+      await ctx.dispose();
+    }
+  },
+});
+
+// loadScenario reads + parses a YAML file from the shared corpus. Returns the typed Scenario shape.
+export async function loadScenario(name: string): Promise<Scenario> {
+  const file = path.isAbsolute(name) ? name : path.join(SCENARIOS_DIR, name);
+  const raw = await fs.readFile(file, "utf-8");
+  const parsed = yaml.load(raw) as Scenario;
+  if (!parsed?.name) {
+    throw new Error(`scenario ${file}: missing 'name' field`);
+  }
+  if (!parsed.host?.id) {
+    throw new Error(`scenario ${file}: missing 'host.id' field`);
+  }
+  if (!Array.isArray(parsed.timeline) || parsed.timeline.length === 0) {
+    throw new Error(`scenario ${file}: 'timeline' must be a non-empty array`);
+  }
+  return parsed;
+}
+
+// enrollHost calls /api/enroll with the dev secret and returns the issued bearer token. hostId must be a canonical UUID; the server's
+// endpoint service rejects anything else.
+async function enrollHost(ctx: APIRequestContext, hostId: string, hostname: string): Promise<string> {
+  const resp = await ctx.post("/api/enroll", {
+    data: {
+      enroll_secret: ENROLL_SECRET,
+      hardware_uuid: hostId,
+      hostname,
+      agent_version: "playwright-l4-agent-fixture",
+      os_version: "macOS 26.0",
+    },
+  });
+  if (!resp.ok()) {
+    const body = await resp.text();
+    throw new Error(`/api/enroll for ${hostId}: HTTP ${resp.status()}: ${body}`);
+  }
+  const json = (await resp.json()) as { host_id?: string; host_token?: string };
+  if (!json.host_token) {
+    throw new Error(`/api/enroll for ${hostId}: response missing host_token: ${JSON.stringify(json)}`);
+  }
+  return json.host_token;
+}
+
+// generateEnvelopes materialises a scenario's timeline into wire envelopes. The shape matches schema/events.json and the Go
+// fakeagent.Envelopes function so the two paths can't drift. event_id is a 32-char hex random; timestamp_ns is startTime + at offset.
+export function generateEnvelopes(scenario: Scenario, hostId: string, startTime: Date): Envelope[] {
+  const startNs = startTime.getTime() * 1_000_000;
+  return scenario.timeline.map((ev) => ({
+    event_id: randomHex32(),
+    host_id: hostId,
+    timestamp_ns: startNs + parseGoDuration(ev.at),
+    event_type: ev.type,
+    payload: buildPayload(ev),
+  }));
+}
+
+// buildPayload picks the right field subset for each event_type and emits exactly the schema/events.json-required shape. Order +
+// shape mirrors test/fakeagent/feeder.go's buildPayload so the two implementations stay byte-identical for the same input.
+function buildPayload(ev: ScenarioEvent): Record<string, unknown> {
+  switch (ev.type) {
+    case "exec":
+      return {
+        pid: ev.pid ?? 0,
+        ppid: ev.ppid ?? 0,
+        path: ev.path ?? "",
+        args: ev.args ?? [],
+        cwd: ev.cwd ?? "",
+        uid: ev.uid ?? 0,
+        gid: ev.gid ?? 0,
+      };
+    case "fork":
+      return { child_pid: ev.child_pid ?? 0, parent_pid: ev.parent_pid ?? 0 };
+    case "exit": {
+      const p: Record<string, unknown> = { pid: ev.pid ?? 0, exit_code: ev.exit_code ?? 0 };
+      return p;
+    }
+    case "open":
+      return { pid: ev.pid ?? 0, path: ev.path ?? "", flags: ev.flags ?? 0 };
+    case "network_connect": {
+      const p: Record<string, unknown> = {
+        pid: ev.pid ?? 0,
+        protocol: ev.protocol ?? "tcp",
+        direction: ev.direction ?? "outbound",
+        remote_address: ev.remote_address ?? "",
+        remote_port: ev.remote_port ?? 0,
+      };
+      if (ev.local_address) p.local_address = ev.local_address;
+      if (ev.local_port) p.local_port = ev.local_port;
+      return p;
+    }
+    case "dns_query": {
+      const p: Record<string, unknown> = {
+        pid: ev.pid ?? 0,
+        query_name: ev.query_name ?? "",
+        query_type: ev.query_type ?? "A",
+      };
+      if (ev.response_addresses) p.response_addresses = ev.response_addresses;
+      if (ev.protocol) p.protocol = ev.protocol;
+      return p;
+    }
+    case "snapshot_heartbeat":
+      return { pid: ev.pid ?? 0 };
+    default:
+      throw new Error(`generateEnvelopes: unknown event_type ${JSON.stringify(ev.type)}`);
+  }
+}
+
+// parseGoDuration accepts the Go time.Duration string form ("10ms", "5s", "1h", "100us"). Returns nanoseconds. Supports the unit
+// suffixes the M3 fakeagent + the rest of the EDR codebase actually use; rejects everything else with a clear error so a typo in a
+// scenario file surfaces immediately rather than silently producing 0.
+function parseGoDuration(input: string): number {
+  const match = /^(\d+(?:\.\d+)?)(ns|us|µs|ms|s|m|h)$/.exec(input);
+  if (!match) {
+    throw new Error(`parseGoDuration: cannot parse ${JSON.stringify(input)}`);
+  }
+  const value = parseFloat(match[1]);
+  const unitNs: Record<string, number> = {
+    ns: 1,
+    us: 1_000,
+    "µs": 1_000,
+    ms: 1_000_000,
+    s: 1_000_000_000,
+    m: 60 * 1_000_000_000,
+    h: 3600 * 1_000_000_000,
+  };
+  return Math.round(value * unitNs[match[2]]);
+}
+
+// randomHex32 returns a 32-character lowercase hex string. Matches the Go fakeagent's default event_id generator.
+function randomHex32(): string {
+  return crypto.randomBytes(16).toString("hex");
+}
+
+export { expect } from "@playwright/test";

--- a/test/e2e/package-lock.json
+++ b/test/e2e/package-lock.json
@@ -9,7 +9,9 @@
       "version": "0.0.0",
       "devDependencies": {
         "@playwright/test": "1.50.1",
+        "@types/js-yaml": "^4.0.9",
         "@types/node": "22.10.5",
+        "js-yaml": "^4.1.1",
         "monocart-coverage-reports": "^2.12.6",
         "mysql2": "3.12.0",
         "typescript": "5.7.3"
@@ -30,6 +32,13 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "22.10.5",
@@ -79,6 +88,13 @@
       "engines": {
         "node": ">=0.4.0"
       }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
     },
     "node_modules/aws-ssl-profiles": {
       "version": "1.1.2",
@@ -262,6 +278,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/long": {

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -20,7 +20,9 @@
   "//": "Scripts split by required server env. `test` + `qa` run against the default `task dev:server:qa-oidc`. The env-specific ones (qa:allowlist needs EDR_BREAKGLASS_IP_ALLOWLIST, qa:jit-off needs EDR_OIDC_ALLOW_JIT_PROVISIONING=0, qa:lifecycle needs short EDR_SESSION_*_TIMEOUTs) MUST be invoked with the server restarted under that env, otherwise they will pass for the wrong reason or time out. The break-glass setup endpoint is globally rate-limited at 5/min — back-to-back full qa passes need a 90s pause between them; that's what test:all sleeps between the auth + qa runs.",
   "devDependencies": {
     "@playwright/test": "1.50.1",
+    "@types/js-yaml": "^4.0.9",
     "@types/node": "22.10.5",
+    "js-yaml": "^4.1.1",
     "monocart-coverage-reports": "^2.12.6",
     "mysql2": "3.12.0",
     "typescript": "5.7.3"

--- a/test/e2e/tests/qa/agent-events-flow.spec.ts
+++ b/test/e2e/tests/qa/agent-events-flow.spec.ts
@@ -1,0 +1,70 @@
+// L4 smoke test for the M5 Playwright agent fixture: drive each shared M3 scenario through fixtures/agent.ts and confirm the events
+// land in the server's `events` table with the right host_id and event_type. This is the wire test - no UI navigation - because the
+// fixture's primary contract is "scenario YAML -> /api/events" wire shape. UI specs that use the fixture (host list rendering,
+// process tree, alert detail) build on the wire contract proven here; if this spec is red, the UI specs would also be red but with
+// confusing DOM-level failures, so this one fails first.
+//
+// State management: each test mints a fresh UUID host_id via crypto.randomUUID() and passes it as hostIdOverride. This sidesteps
+// the global DB reset that fixtures/db.ts uses for the auth specs - the `events` table has FK relationships (alert_events references
+// it) that make a blanket DELETE awkward, and unique host_ids keep tests isolated from prior runs' rows just as effectively.
+// Cleanup is therefore none: rows accumulate, but only with test-tagged host_ids that no production code path produces.
+
+import * as crypto from "node:crypto";
+import { test, expect } from "../../fixtures/agent";
+import { openDB } from "../../fixtures/db";
+
+const scenarios = [
+  { file: "quiet-host.yaml", expectedEventTypes: ["snapshot_heartbeat"] },
+  { file: "exec-fork-exit.yaml", expectedEventTypes: ["fork", "exec", "exit"] },
+  { file: "dns-and-network.yaml", expectedEventTypes: ["dns_query", "network_connect"] },
+];
+
+test.describe("L4 agent fixture: scenarios land in events table", () => {
+  for (const sc of scenarios) {
+    test(`${sc.file}: events land at /api/events`, async ({ agent }) => {
+      const hostId = crypto.randomUUID().toUpperCase();
+      const result = await agent.runScenario(sc.file, { hostIdOverride: hostId });
+
+      expect(result.hostId).toBe(hostId);
+      expect(result.eventsPosted).toBeGreaterThan(0);
+      expect(result.hostToken).not.toBe("");
+
+      const db = await openDB();
+      try {
+        const [rows] = (await db.query(
+          `SELECT event_type, COUNT(*) AS n
+             FROM events
+            WHERE host_id = ?
+            GROUP BY event_type`,
+          [hostId],
+        )) as [Array<{ event_type: string; n: number | string }>, unknown];
+
+        const seen = new Set(rows.map((r) => r.event_type));
+        for (const want of sc.expectedEventTypes) {
+          expect(seen.has(want), `event_type ${want} present for ${sc.file}`).toBe(true);
+        }
+      } finally {
+        await db.end();
+      }
+    });
+  }
+
+  test("hostIdOverride wins over scenario host.id", async ({ agent }) => {
+    // The fixture promises a per-call host_id override so a single test can vary host_id without editing YAML. This case proves
+    // the override path actually changes which row the event lands under (vs. silently using the scenario's host.id).
+    const overrideId = crypto.randomUUID().toUpperCase();
+    const result = await agent.runScenario("quiet-host.yaml", { hostIdOverride: overrideId });
+    expect(result.hostId).toBe(overrideId);
+
+    const db = await openDB();
+    try {
+      const [rows] = (await db.query("SELECT host_id FROM events WHERE host_id = ?", [overrideId])) as [
+        Array<{ host_id: string }>,
+        unknown,
+      ];
+      expect(rows.length).toBeGreaterThan(0);
+    } finally {
+      await db.end();
+    }
+  });
+});

--- a/test/e2e/tests/qa/agent-events-flow.spec.ts
+++ b/test/e2e/tests/qa/agent-events-flow.spec.ts
@@ -1,32 +1,41 @@
 // L4 smoke test for the M5 Playwright agent fixture: drive each shared M3 scenario through fixtures/agent.ts and confirm the events
-// land in the server's `events` table with the right host_id and event_type. This is the wire test - no UI navigation - because the
-// fixture's primary contract is "scenario YAML -> /api/events" wire shape. UI specs that use the fixture (host list rendering,
-// process tree, alert detail) build on the wire contract proven here; if this spec is red, the UI specs would also be red but with
-// confusing DOM-level failures, so this one fails first.
+// land in the server's `events` table with the right host_id, event_type, AND event counts. This is the wire test - no UI navigation -
+// because the fixture's primary contract is "scenario YAML -> /api/events" wire shape. UI specs that use the fixture (host list
+// rendering, process tree, alert detail) build on the wire contract proven here; if this spec is red, the UI specs would also be red
+// but with confusing DOM-level failures, so this one fails first.
 //
-// State management: each test mints a fresh UUID host_id via crypto.randomUUID() and passes it as hostIdOverride. This sidesteps
-// the global DB reset that fixtures/db.ts uses for the auth specs - the `events` table has FK relationships (alert_events references
-// it) that make a blanket DELETE awkward, and unique host_ids keep tests isolated from prior runs' rows just as effectively.
-// Cleanup is therefore none: rows accumulate, but only with test-tagged host_ids that no production code path produces.
+// State management: each test mints a fresh canonical-lowercase UUID via crypto.randomUUID() and passes it as hostIdOverride.
+// This sidesteps the global DB reset that fixtures/db.ts uses for the auth specs - the events table has FK relationships
+// (alert_events references it) that make a blanket DELETE awkward, and unique host_ids keep tests isolated from prior runs' rows
+// just as effectively. Production agents also use canonical UUIDs (IOPlatformUUID), so what marks these rows as test-only is
+// the hostname (`playwright.lab.local`) + agent_version (`playwright-l4-agent-fixture`) set by the fixture during enrollment, not
+// the host_id format.
 
 import * as crypto from "node:crypto";
 import { test, expect } from "../../fixtures/agent";
 import { openDB } from "../../fixtures/db";
 
-const scenarios = [
-  { file: "quiet-host.yaml", expectedEventTypes: ["snapshot_heartbeat"] },
-  { file: "exec-fork-exit.yaml", expectedEventTypes: ["fork", "exec", "exit"] },
-  { file: "dns-and-network.yaml", expectedEventTypes: ["dns_query", "network_connect"] },
+interface ScenarioCase {
+  file: string;
+  /** Map of event_type -> expected exact count for that type. The sum is the expected total envelope count, asserted separately. */
+  expectedCounts: Record<string, number>;
+}
+
+const scenarios: ScenarioCase[] = [
+  { file: "quiet-host.yaml", expectedCounts: { snapshot_heartbeat: 1 } },
+  { file: "exec-fork-exit.yaml", expectedCounts: { fork: 1, exec: 1, exit: 1 } },
+  { file: "dns-and-network.yaml", expectedCounts: { dns_query: 1, network_connect: 1 } },
 ];
 
 test.describe("L4 agent fixture: scenarios land in events table", () => {
   for (const sc of scenarios) {
-    test(`${sc.file}: events land at /api/events`, async ({ agent }) => {
-      const hostId = crypto.randomUUID().toUpperCase();
+    test(`${sc.file}: events land at /api/events with exact counts`, async ({ agent }) => {
+      const hostId = crypto.randomUUID();
       const result = await agent.runScenario(sc.file, { hostIdOverride: hostId });
 
       expect(result.hostId).toBe(hostId);
-      expect(result.eventsPosted).toBeGreaterThan(0);
+      const expectedTotal = Object.values(sc.expectedCounts).reduce((a, b) => a + b, 0);
+      expect(result.eventsPosted).toBe(expectedTotal);
       expect(result.hostToken).not.toBe("");
 
       const db = await openDB();
@@ -39,9 +48,15 @@ test.describe("L4 agent fixture: scenarios land in events table", () => {
           [hostId],
         )) as [Array<{ event_type: string; n: number | string }>, unknown];
 
-        const seen = new Set(rows.map((r) => r.event_type));
-        for (const want of sc.expectedEventTypes) {
-          expect(seen.has(want), `event_type ${want} present for ${sc.file}`).toBe(true);
+        // Exact-set assertion: the event_types in the DB must equal exactly what the scenario declared - no missing types and no
+        // surprises (extra inserts would suggest the fixture leaked through to a wrong host, or the server's ingest accepted a
+        // mistyped event_type).
+        const dbTypes = rows.map((r) => r.event_type).sort();
+        expect(dbTypes).toEqual(Object.keys(sc.expectedCounts).sort());
+
+        // Exact-count per event_type: catches partial-ingest cases the presence-only check used to miss.
+        for (const row of rows) {
+          expect(Number(row.n), `count for ${row.event_type} in ${sc.file}`).toBe(sc.expectedCounts[row.event_type]);
         }
       } finally {
         await db.end();
@@ -51,18 +66,23 @@ test.describe("L4 agent fixture: scenarios land in events table", () => {
 
   test("hostIdOverride wins over scenario host.id", async ({ agent }) => {
     // The fixture promises a per-call host_id override so a single test can vary host_id without editing YAML. This case proves
-    // the override path actually changes which row the event lands under (vs. silently using the scenario's host.id).
-    const overrideId = crypto.randomUUID().toUpperCase();
+    // the override path actually changes which row the event lands under (vs. silently using the scenario's host.id). Asserts
+    // exact event count too: quiet-host.yaml has 1 snapshot_heartbeat, so any other count would mean either the override missed
+    // some envelopes (some went to the scenario's hard-coded host.id) or the assertion is reading the wrong host_id's rows.
+    const overrideId = crypto.randomUUID();
     const result = await agent.runScenario("quiet-host.yaml", { hostIdOverride: overrideId });
     expect(result.hostId).toBe(overrideId);
+    expect(result.eventsPosted).toBe(1);
 
     const db = await openDB();
     try {
-      const [rows] = (await db.query("SELECT host_id FROM events WHERE host_id = ?", [overrideId])) as [
-        Array<{ host_id: string }>,
-        unknown,
-      ];
-      expect(rows.length).toBeGreaterThan(0);
+      const [rows] = (await db.query(
+        "SELECT event_type, COUNT(*) AS n FROM events WHERE host_id = ? GROUP BY event_type",
+        [overrideId],
+      )) as [Array<{ event_type: string; n: number | string }>, unknown];
+      expect(rows).toHaveLength(1);
+      expect(rows[0].event_type).toBe("snapshot_heartbeat");
+      expect(Number(rows[0].n)).toBe(1);
     } finally {
       await db.end();
     }


### PR DESCRIPTION
Fifth milestone of the UAT plan in docs/testing-strategy.md. M1-M4 shipped the Go side of the agent + L3 integration test; M5 brings the same scenario corpus into the L4 browser-E2E layer so UI tests can seed realistic host / event / process state without direct-SQL hacks like fixtures/db.ts's seedCriticalAlert.

What this lands:

- test/e2e/fixtures/agent.ts is a new Playwright fixture. It reads the M3 YAML scenarios from test/fakeagent/scenarios/ (single source of truth shared with the Go library), enrols a fresh host via /api/enroll with the dev server's dev-enroll-secret, materialises the timeline into wire envelopes matching schema/events.json byte-for-byte, then POSTs them to /api/events with the minted bearer token. The Playwright `test` import is extended with an `agent.runScenario(name, opts?)` method that returns {hostId, eventsPosted, hostToken}.

  Why direct POST rather than going through the M2 headless binary's control plane: the queue + uploader path is already L3-covered by M4 (test/integration/agentserver). L4 cares about UI behavior under realistic data, not queue mechanics. Direct POST avoids process orchestration in playwright.config.ts and per-test host enrollment is much cleaner than the headless binary's single startup-time host_id.

  Why TypeScript rather than a Go/Node FFI bridge: the envelope shaping is small and stable (seven event types, ~80 LOC). The YAML scenarios are the contract; the mapping logic can sit in either language. Maintaining a shared mapping library is cheaper than maintaining the bridge.

- test/e2e/tests/qa/agent-events-flow.spec.ts is the L4 smoke spec. Four subtests: one per starter scenario (quiet-host / exec-fork-exit / dns-and-network) asserting the right event_types land in the events table for the per-test minted host_id, plus one that proves hostIdOverride wins over the scenario's host.id. Asserts via direct MySQL query (the same path fixtures/db.ts uses for the existing specs) rather than session-gated REST queries, to skip the operator-login ceremony.

  State isolation: each test mints a fresh UUID via crypto.randomUUID and passes it as hostIdOverride, so tests don't collide on host_id and the spec doesn't need a global DB wipe in beforeEach (the alert_events -> events FK constraint makes blanket DELETE awkward; unique host_ids keep the assertion accurate against accumulated rows from prior runs).

- test/e2e/package.json: adds js-yaml + @types/js-yaml (tiny, well-tested, what fixtures/agent.ts uses to parse the shared scenario corpus).

- docs/testing-strategy.md L4 section: now describes the fixture as it actually ships, including the rationale for not routing through the headless binary.

Verified locally: npx playwright test
tests/qa/agent-events-flow.spec.ts runs all 4 subtests against the existing dev server (started by Playwright's webServer block) in under 1 second. npx tsc --noEmit clean, task lint:md clean.

Existing specs (auth/break-glass, qa/reauth-modal-retry, etc.) are untouched - they still use fixtures/db.ts's direct-SQL helpers because seeding alert rows via /api/events requires rule-firing scenarios that don't exist in the corpus yet (M10 territory). The M5 fixture is for new specs and incremental migrations as rule- firing scenarios land.

Builds on M1 (#206), M2 (#211), M3 (#212), all merged. Independent of M4 (#213) which is still open. Refs UAT plan M5 milestone. M6 (UI specs expanded - host list pagination, process-tree fork bomb, alert detail per rule) is next.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated E2E testing strategy documentation with detailed guidance on agent fixture testing.

* **Tests**
  * Added agent event simulation fixture for E2E tests to seed event data from scenario files.
  * Added test scenarios validating agent event flow and persistence.
  * Added test dependencies for scenario file parsing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/getvictor/fleet-edr/pull/214?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->