### PR TITLE
M7: SwiftPM XCTest target for extension pure-logic classes

### DIFF
--- a/.github/workflows/swift-test.yml
+++ b/.github/workflows/swift-test.yml
@@ -1,0 +1,83 @@
+name: Swift tests
+
+# XCTest layer for the pure-logic Swift sources under extension/edr/ that have
+# no ESF / NetworkExtension framework dependency (DNSParser, EventSerializer
+# payload structs, BlockNotification, ApplicationControlStore, FileHashCache,
+# SigningInfoFallback). SwiftPM at extension/edr/Package.swift references these
+# files via explicit `sources:` paths so the package builds with `swift test`
+# while the Xcode project remains the production build path for the signed
+# system extension + network extension + host app bundles. See M7 in
+# docs/testing-strategy.md.
+#
+# The workflow follows the same path-filter shape as swift-lint.yml: only
+# extension/** and Taskfile / workflow changes trigger it, so doc-only PRs
+# don't pay for a macOS runner. Pushes to main and workflow_dispatch run
+# unconditionally.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "extension/**"
+      - "Taskfile.yml"
+      - ".github/workflows/swift-test.yml"
+  pull_request:
+    paths:
+      - "extension/**"
+      - "Taskfile.yml"
+      - ".github/workflows/swift-test.yml"
+  workflow_dispatch:
+
+# Top-level token has no permissions; each job grants the exact scopes it
+# needs (satisfies Scorecard Token-Permissions, Sonar githubactions:S8264,
+# zizmor excessive-permissions).
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  swift-test:
+    name: Swift unit tests
+    runs-on: macos-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Swift toolchain version
+        # Log the toolchain so a future Apple update that breaks the build
+        # surfaces a clean before/after rather than a cryptic compile error.
+        run: |
+          swift --version
+          xcrun --show-sdk-path
+
+      - name: Run swift test with coverage
+        # --enable-code-coverage produces an .profdata file under
+        # .build/<triple>/debug/codecov; we don't yet wire it into Sonar
+        # (Swift coverage on SonarCloud needs the `sonar.swift.coverage.reportPaths`
+        # property + an llvm-cov export pass), but the file is preserved
+        # below as a workflow artifact so the upload step is a one-line
+        # change when M8 turns Swift coverage on.
+        run: |
+          swift test --package-path extension/edr --enable-code-coverage
+
+      - name: Locate coverage data
+        # The path swift-test writes to depends on the host triple. Log it
+        # so the artifact-upload step's input path is auditable.
+        run: |
+          find extension/edr/.build -name '*.profdata' -type f -print || true
+          find extension/edr/.build -name 'EDRExtensionLogicPackageTests.xctest' -type d -print || true
+
+      - name: Upload coverage profdata
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: swift-coverage-profdata
+          # If the locator above found no file the upload step would fail;
+          # `if-no-files-found: warn` keeps the job green while still
+          # logging the absence so a regression is visible.
+          if-no-files-found: warn
+          path: extension/edr/.build/**/codecov/*.profdata

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,11 @@ xcuserdata/
 DerivedData/
 build/
 
+# SwiftPM (extension/edr/Package.swift, used for `swift test` on extension Swift sources)
+.build/
+.swiftpm/
+Package.resolved
+
 # IDEs
 .idea/
 

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -50,7 +50,16 @@ A run at any layer implies all lower layers have already passed; CI gates enforc
 
 - Per-package Go tests, co-located with the code.
 - Vitest + V8 coverage for `ui/`.
-- XCTest for Swift code in `extension/edr/` that does not require ESF or Network Extension framework objects.
+- XCTest for Swift code in `extension/edr/` that does not require ESF or Network Extension framework objects. Driven
+  by a SwiftPM package at `extension/edr/Package.swift` (sibling to `edr.xcodeproj`) that references the existing
+  Swift sources via explicit `sources:` paths, with tests under `extension/edr/Tests/EDRExtensionLogicTests/`. CI runs
+  `swift test --enable-code-coverage` on `macos-latest` via `.github/workflows/swift-test.yml`, gated by the same
+  `extension/**` path filter as `swift-lint.yml`. UAT plan milestone **M7** delivered the package + initial test
+  suites for `DNSParser`, `EventSerializer`'s payload + envelope structs, `BlockNotification`, `ApplicationControlStore`,
+  and `FileHashCache`; `SigningInfoFallback` is deferred until a reliably-signed test fixture binary is in tree
+  (it walks SecStaticCode against a real Mach-O on disk). The Xcode project remains the production build path for the
+  signed system extension, network extension, and host app bundles -- main.swift, XPCServer, ESFClient and friends
+  are deliberately NOT in the package's `sources:` list and only build inside their respective Xcode targets.
 - Style guide: see `## Testing` in `CLAUDE.md` and `docs/go-conventions.md`. Table-driven by default, property-based
   via `pgregory.net/rapid` for invariants, `go test -fuzz` for untrusted input parsers.
 
@@ -307,7 +316,7 @@ relevant inputs change.
 |---|---|---|
 | Unit (Go) | `go test -coverpkg=./server/...,./agent/...,./internal/...` | Sonar 80% on new code |
 | Unit (TS) | `vitest --coverage` (V8) | Sonar 80% on new code |
-| Unit (Swift) | `xcodebuild test -enableCodeCoverage YES` | Sonar 80% on new code (same unified gate as Go and TS) |
+| Unit (Swift) | `swift test --enable-code-coverage` via `extension/edr/Package.swift` | Sonar 80% on new code (same unified gate as Go and TS) |
 | Integration layers (per-context, cross-context, headless) | wide `-coverpkg`, merged via `go tool covdata textfmt` | feeds the same Sonar Go gate |
 | Browser E2E | monocart V8 coverage, merged into `lcov-e2e.info` | feeds the Sonar TS gate |
 | System / VM | per-scenario pass/fail; no line coverage | green/red checklist in the workflow run |

--- a/extension/edr/Package.swift
+++ b/extension/edr/Package.swift
@@ -1,0 +1,82 @@
+// swift-tools-version:5.9
+//
+// SwiftPM facade over the same Swift sources the Xcode `edr` project builds, so the pure-logic
+// classes can be exercised by XCTest without a full ESF/NetworkExtension host. `swift test` runs
+// in CI on every PR that touches extension/**.
+//
+// The Xcode project (edr.xcodeproj, sibling to this manifest) remains the production build path
+// for the signed system extension + network extension + host app bundles. This package only
+// references files that have no ESF / NetworkExtension framework dependencies; main.swift,
+// XPCServer, ESFClient and friends are deliberately NOT in the source list. Adding a file here
+// without considering its framework dependencies will trip the `swift build` invocation and
+// surface in CI as a red gate.
+//
+// Why not a test target inside edr.xcodeproj: the project deliberately has no shared framework
+// target (each binary slice carries its own entitlements), so adding an XCTest bundle would
+// require pbxproj surgery to wire test-host + framework search paths against the existing
+// targets. SwiftPM is the lighter touch: one Package.swift, one directory for tests, no manual
+// project-file edits.
+
+import PackageDescription
+
+let package = Package(
+    name: "EDRExtensionLogic",
+    platforms: [.macOS(.v13)],
+    products: [
+        .library(
+            name: "EDRExtensionLogic",
+            targets: ["EDRExtensionLogic"]
+        )
+    ],
+    targets: [
+        // Files explicitly listed via `sources:` so SwiftPM does NOT auto-walk extension/ or
+        // networkextension/ and pull in main.swift, XPCServer.swift, ESFClient.swift, etc. -- those
+        // import EndpointSecurity / NetworkExtension which only link inside their respective
+        // Xcode targets. Adding a new pure-logic file is a one-line edit here.
+        .target(
+            name: "EDRExtensionLogic",
+            // `exclude:` silences the SwiftPM "unhandled file" warning by telling the build
+            // graph that the Xcode project tree (host app, entitlements, Info.plist, build
+            // artifacts) is intentionally not part of this package. The explicit `sources:`
+            // list still defines what compiles -- exclude only suppresses scan noise.
+            path: ".",
+            exclude: [
+                "build",
+                "tmp",
+                "edr.xcodeproj",
+                "edr",
+                "Tests",
+                "extension/Info.plist",
+                "extension/extension.entitlements",
+                "extension/main.swift",
+                "extension/ESFStringToken.swift",
+                "extension/ESFSubscriber.swift",
+                "extension/NotificationClient.swift",
+                "extension/ProcessSnapshotEnumerator.swift",
+                "extension/XPCServer.swift",
+                "networkextension/Info.plist",
+                "networkextension/networkextension.entitlements",
+                "networkextension/main.swift",
+                "networkextension/DNSProxyProvider.swift",
+                "networkextension/NetworkEventSerializer.swift",
+                "networkextension/NetworkFilter.swift",
+                "networkextension/ProcessInfo.swift",
+                "networkextension/XPCServer.swift",
+                "com.fleetdm.edr.notify.plist",
+            ],
+            sources: [
+                "extension/ApplicationControlStore.swift",
+                "extension/BlockNotification.swift",
+                "extension/EventSerializer.swift",
+                "extension/FileHashCache.swift",
+                "extension/SigningInfoFallback.swift",
+                "networkextension/DNSParser.swift",
+            ]
+        ),
+        .testTarget(
+            name: "EDRExtensionLogicTests",
+            dependencies: ["EDRExtensionLogic"],
+            path: "Tests/EDRExtensionLogicTests"
+        ),
+    ]
+)

--- a/extension/edr/Package.swift
+++ b/extension/edr/Package.swift
@@ -62,7 +62,7 @@ let package = Package(
                 "networkextension/NetworkFilter.swift",
                 "networkextension/ProcessInfo.swift",
                 "networkextension/XPCServer.swift",
-                "com.fleetdm.edr.notify.plist",
+                "com.fleetdm.edr.notify.plist"
             ],
             sources: [
                 "extension/ApplicationControlStore.swift",
@@ -70,13 +70,13 @@ let package = Package(
                 "extension/EventSerializer.swift",
                 "extension/FileHashCache.swift",
                 "extension/SigningInfoFallback.swift",
-                "networkextension/DNSParser.swift",
+                "networkextension/DNSParser.swift"
             ]
         ),
         .testTarget(
             name: "EDRExtensionLogicTests",
             dependencies: ["EDRExtensionLogic"],
             path: "Tests/EDRExtensionLogicTests"
-        ),
+        )
     ]
 )

--- a/extension/edr/Tests/EDRExtensionLogicTests/ApplicationControlStoreTests.swift
+++ b/extension/edr/Tests/EDRExtensionLogicTests/ApplicationControlStoreTests.swift
@@ -1,0 +1,186 @@
+// ApplicationControlStore tests: exercise the snapshot-decode + per-rule-type
+// routing + monotonic-version gate that the AUTH_EXEC decision engine relies on.
+// ApplicationControlStore.shared is a singleton with a persistQueue.async that
+// writes to /var/db/com.fleetdm.edr/application-control.json -- the test user
+// has no write permission there, so the persist fails with a logged error and no
+// real-world side effect. Each test below uses a UNIQUE policy_id high enough to
+// not collide with anything any production / dev install would use, and an
+// always-increasing version, so test method ordering does not matter.
+
+import Foundation
+@testable import EDRExtensionLogic
+import XCTest
+
+final class ApplicationControlStoreTests: XCTestCase {
+    // MARK: - Helpers
+
+    /// document builds an ApplicationControlDocument as on-the-wire JSON bytes.
+    private func document(policyID: Int64, version: Int64, rules: [(type: String, identifier: String, ruleID: String)]) -> Data {
+        let ruleObjects = rules.map { rule in
+            """
+            {
+              "rule_id": "\(rule.ruleID)",
+              "rule_type": "\(rule.type)",
+              "identifier": "\(rule.identifier)",
+              "action": "BLOCK",
+              "enforcement": "PROTECT",
+              "severity": "high"
+            }
+            """
+        }
+        let joined = ruleObjects.joined(separator: ",")
+        let json = """
+        {
+          "policy_id": \(policyID),
+          "policy_version": \(version),
+          "rules": [\(joined)]
+        }
+        """
+        return Data(json.utf8)
+    }
+
+    // MARK: - ApplicationControlDocument decoder
+
+    func testDocumentDecodesValidJSON() throws {
+        let data = document(
+            policyID: 7, version: 12,
+            rules: [
+                (type: "BINARY", identifier: String(repeating: "a", count: 64), ruleID: "r1"),
+                (type: "TEAMID", identifier: "FDG8Q7N4CC", ruleID: "r2"),
+            ]
+        )
+        let decoded = try JSONDecoder().decode(ApplicationControlDocument.self, from: data)
+        XCTAssertEqual(decoded.policyID, 7)
+        XCTAssertEqual(decoded.policyVersion, 12)
+        XCTAssertEqual(decoded.rules.count, 2)
+        XCTAssertEqual(decoded.rules.first?.ruleID, "r1")
+        XCTAssertEqual(decoded.rules.first?.action, "BLOCK")
+    }
+
+    // MARK: - apply: per-rule-type routing
+
+    func testApplyRoutesEveryRuleTypeIntoItsOwnMap() {
+        // Send one rule per type and verify each lands in the matching map. Uses a
+        // policy_id (100001) far from any production value plus a high version so
+        // the monotonic gate accepts even if a previous test set the same id.
+        let payload = document(
+            policyID: 100001, version: 1000,
+            rules: [
+                (type: "BINARY", identifier: "binary-hex", ruleID: "r1"),
+                (type: "CDHASH", identifier: "cdhash-hex", ruleID: "r2"),
+                (type: "SIGNINGID", identifier: "FDG8Q7N4CC:com.fleetdm.edr", ruleID: "r3"),
+                (type: "CERTIFICATE", identifier: "cert-hex", ruleID: "r4"),
+                (type: "TEAMID", identifier: "FDG8Q7N4CC", ruleID: "r5"),
+                (type: "PATH", identifier: "/usr/local/bin/foo", ruleID: "r6"),
+            ]
+        )
+        ApplicationControlStore.shared.apply(rawJSON: payload)
+        let snapshot = ApplicationControlStore.shared.currentSnapshot()
+        XCTAssertGreaterThanOrEqual(snapshot.policyVersion, 1000)
+        XCTAssertEqual(snapshot.binaryRules["binary-hex"]?.ruleID, "r1")
+        XCTAssertEqual(snapshot.cdhashRules["cdhash-hex"]?.ruleID, "r2")
+        XCTAssertEqual(snapshot.signingIDRules["FDG8Q7N4CC:com.fleetdm.edr"]?.ruleID, "r3")
+        XCTAssertEqual(snapshot.certificateRules["cert-hex"]?.ruleID, "r4")
+        XCTAssertEqual(snapshot.teamIDRules["FDG8Q7N4CC"]?.ruleID, "r5")
+        XCTAssertEqual(snapshot.pathRules["/usr/local/bin/foo"]?.ruleID, "r6")
+    }
+
+    // MARK: - apply: monotonic-version gate
+
+    func testApplyHonorsMonotonicVersionGate() {
+        // Seed a baseline. Subsequent applies at policy_id 100002 with version <=
+        // baseline must NOT regress the snapshot.
+        let baseline = document(
+            policyID: 100002, version: 500,
+            rules: [(type: "BINARY", identifier: "baseline", ruleID: "baseline-rule")]
+        )
+        ApplicationControlStore.shared.apply(rawJSON: baseline)
+
+        // Same id, older version -> rejected; the snapshot must keep the baseline.
+        let older = document(
+            policyID: 100002, version: 100,
+            rules: [(type: "BINARY", identifier: "older", ruleID: "older-rule")]
+        )
+        ApplicationControlStore.shared.apply(rawJSON: older)
+
+        var snapshot = ApplicationControlStore.shared.currentSnapshot()
+        // The baseline rule survives; the older payload's rule did NOT land.
+        // We assert via the new identifier being absent rather than reading
+        // policyVersion -- a different test may have bumped the version with a
+        // different policy_id after this one ran.
+        XCTAssertNil(snapshot.binaryRules["older"], "stale apply must not introduce its rules")
+
+        // Same id, newer version -> accepted; the snapshot now reflects the new doc.
+        let newer = document(
+            policyID: 100002, version: 600,
+            rules: [(type: "BINARY", identifier: "newer", ruleID: "newer-rule")]
+        )
+        ApplicationControlStore.shared.apply(rawJSON: newer)
+        snapshot = ApplicationControlStore.shared.currentSnapshot()
+        if snapshot.policyID == 100002 {
+            XCTAssertEqual(snapshot.binaryRules["newer"]?.ruleID, "newer-rule")
+            // Wholesale replace: the baseline's rule is gone because the new doc's
+            // rule list does not include it. Pinning this prevents a future bug
+            // where apply() accidentally merges rather than replacing.
+            XCTAssertNil(snapshot.binaryRules["baseline"], "newer doc must replace, not merge")
+        }
+    }
+
+    // MARK: - apply: malformed input
+
+    func testApplyIgnoresMalformedJSON() {
+        // Snapshot the policyVersion before the bad apply so we can confirm it
+        // doesn't change. Using a sentinel policy_id keeps us insulated from other
+        // tests' state.
+        let beforeVersion = ApplicationControlStore.shared.currentSnapshot().policyVersion
+        ApplicationControlStore.shared.apply(rawJSON: Data("{not json}".utf8))
+        ApplicationControlStore.shared.apply(rawJSON: Data())
+        let afterVersion = ApplicationControlStore.shared.currentSnapshot().policyVersion
+        XCTAssertEqual(afterVersion, beforeVersion, "malformed JSON must not mutate snapshot state")
+    }
+
+    // MARK: - apply: unknown rule_type
+
+    func testApplySkipsUnknownRuleTypeButLandsKnownOnes() {
+        // FRUITCAKE is not a defined rule_type. The store logs a warning and skips
+        // that entry but accepts the rest of the document, so a server-side
+        // tagging mistake on a single rule does not break the entire snapshot.
+        let payload = document(
+            policyID: 100003, version: 1000,
+            rules: [
+                (type: "BINARY", identifier: "good-binary", ruleID: "good"),
+                (type: "FRUITCAKE", identifier: "weird", ruleID: "weird"),
+            ]
+        )
+        ApplicationControlStore.shared.apply(rawJSON: payload)
+        let snapshot = ApplicationControlStore.shared.currentSnapshot()
+        if snapshot.policyID == 100003 {
+            XCTAssertEqual(snapshot.binaryRules["good-binary"]?.ruleID, "good")
+            // No bucket exists for FRUITCAKE; the weird identifier must not have
+            // leaked into any of the six known maps.
+            XCTAssertNil(snapshot.binaryRules["weird"])
+            XCTAssertNil(snapshot.cdhashRules["weird"])
+            XCTAssertNil(snapshot.signingIDRules["weird"])
+            XCTAssertNil(snapshot.certificateRules["weird"])
+            XCTAssertNil(snapshot.teamIDRules["weird"])
+            XCTAssertNil(snapshot.pathRules["weird"])
+        }
+    }
+
+    // MARK: - empty snapshot constant
+
+    func testEmptySnapshotHasNoRulesAndZeroPolicy() {
+        // The static .empty is the cold-start state the store falls back to when
+        // there's no persisted file on disk. Pinning the shape here so a future
+        // tweak to the snapshot struct cannot quietly mint a non-empty default.
+        let empty = ApplicationControlSnapshot.empty
+        XCTAssertEqual(empty.policyID, 0)
+        XCTAssertEqual(empty.policyVersion, 0)
+        XCTAssertTrue(empty.binaryRules.isEmpty)
+        XCTAssertTrue(empty.cdhashRules.isEmpty)
+        XCTAssertTrue(empty.signingIDRules.isEmpty)
+        XCTAssertTrue(empty.certificateRules.isEmpty)
+        XCTAssertTrue(empty.teamIDRules.isEmpty)
+        XCTAssertTrue(empty.pathRules.isEmpty)
+    }
+}

--- a/extension/edr/Tests/EDRExtensionLogicTests/ApplicationControlStoreTests.swift
+++ b/extension/edr/Tests/EDRExtensionLogicTests/ApplicationControlStoreTests.swift
@@ -1,11 +1,21 @@
 // ApplicationControlStore tests: exercise the snapshot-decode + per-rule-type
-// routing + monotonic-version gate that the AUTH_EXEC decision engine relies on.
-// ApplicationControlStore.shared is a singleton with a persistQueue.async that
-// writes to /var/db/com.fleetdm.edr/application-control.json -- the test user
-// has no write permission there, so the persist fails with a logged error and no
-// real-world side effect. Each test below uses a UNIQUE policy_id high enough to
-// not collide with anything any production / dev install would use, and an
-// always-increasing version, so test method ordering does not matter.
+// routing + monotonic-version gate + persist/load round-trip the AUTH_EXEC
+// decision engine relies on.
+//
+// Each test builds its OWN ApplicationControlStore via makeStore() with a temp
+// storagePath under FileManager.default.temporaryDirectory. That gives every
+// test method:
+//
+//   1. A fresh ApplicationControlSnapshot.empty starting state -- no cross-test
+//      contamination via the process-global .shared singleton.
+//   2. An isolated on-disk policy file that addTeardownBlock removes when the
+//      test finishes, so the async persist no longer writes against (or fails
+//      against) /var/db/com.fleetdm.edr/application-control.json.
+//
+// The unique-policy-id-per-test gymnastics the previous revision needed are
+// gone. Policy IDs can be 1, 2, 3 -- whatever reads cleanly -- because each
+// store starts empty. ApplicationControlStore.shared is NOT touched by any of
+// these tests.
 
 import Foundation
 @testable import EDRExtensionLogic
@@ -21,6 +31,38 @@ final class ApplicationControlStoreTests: XCTestCase {
         let type: String
         let identifier: String
         let ruleID: String
+    }
+
+    /// makeStore returns a fresh ApplicationControlStore with a temp on-disk
+    /// policy path. The path is unique per call so concurrent / parallelized
+    /// test runs cannot stomp each other's persist files. The teardown block
+    /// removes the file (and any parent directory the persist code created).
+    private func makeStore() -> ApplicationControlStore {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("AppControlTests-\(UUID().uuidString)", isDirectory: true)
+            .appendingPathComponent("application-control.json")
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: url.deletingLastPathComponent())
+        }
+        return ApplicationControlStore(storagePath: url.path)
+    }
+
+    /// waitForFile polls for the file at `path` to exist within `deadline`. The
+    /// store's persistQueue is private, so we cannot synchronize on it directly;
+    /// the file-exists predicate is what the apply→persist→load round-trip test
+    /// needs to gate on before loading the snapshot back from disk. 2s is the
+    /// same budget testStartLazyFillPopulatesCacheEventually uses for the same
+    /// pattern.
+    @discardableResult
+    private func waitForFile(at path: String, deadline: TimeInterval = 2) -> Bool {
+        let stop = Date().addingTimeInterval(deadline)
+        while Date() < stop {
+            if FileManager.default.fileExists(atPath: path) {
+                return true
+            }
+            Thread.sleep(forTimeInterval: 0.01)
+        }
+        return FileManager.default.fileExists(atPath: path)
     }
 
     /// document builds an ApplicationControlDocument as on-the-wire JSON bytes.
@@ -69,11 +111,9 @@ final class ApplicationControlStoreTests: XCTestCase {
     // MARK: - apply: per-rule-type routing
 
     func testApplyRoutesEveryRuleTypeIntoItsOwnMap() {
-        // Send one rule per type and verify each lands in the matching map. Uses a
-        // policy_id (100001) far from any production value plus a high version so
-        // the monotonic gate accepts even if a previous test set the same id.
+        let store = makeStore()
         let payload = document(
-            policyID: 100001, version: 1000,
+            policyID: 1, version: 1,
             rules: [
                 RuleSpec(type: "BINARY", identifier: "binary-hex", ruleID: "r1"),
                 RuleSpec(type: "CDHASH", identifier: "cdhash-hex", ruleID: "r2"),
@@ -83,14 +123,10 @@ final class ApplicationControlStoreTests: XCTestCase {
                 RuleSpec(type: "PATH", identifier: "/usr/local/bin/foo", ruleID: "r6")
             ]
         )
-        ApplicationControlStore.shared.apply(rawJSON: payload)
-        let snapshot = ApplicationControlStore.shared.currentSnapshot()
-        // The store is a process-global singleton; assert policyID + policyVersion EXPLICITLY rather
-        // than letting a wrong-state read silently fall through to no-op assertions. If a later test
-        // ever leaves a higher version under this same policyID the monotonic gate would silently
-        // reject this apply -- this XCTAssertEqual surfaces that as a loud failure instead.
-        XCTAssertEqual(snapshot.policyID, 100001)
-        XCTAssertEqual(snapshot.policyVersion, 1000)
+        store.apply(rawJSON: payload)
+        let snapshot = store.currentSnapshot()
+        XCTAssertEqual(snapshot.policyID, 1)
+        XCTAssertEqual(snapshot.policyVersion, 1)
         XCTAssertEqual(snapshot.binaryRules["binary-hex"]?.ruleID, "r1")
         XCTAssertEqual(snapshot.cdhashRules["cdhash-hex"]?.ruleID, "r2")
         XCTAssertEqual(snapshot.signingIDRules["FDG8Q7N4CC:com.fleetdm.edr"]?.ruleID, "r3")
@@ -102,43 +138,41 @@ final class ApplicationControlStoreTests: XCTestCase {
     // MARK: - apply: monotonic-version gate
 
     func testApplyHonorsMonotonicVersionGate() {
-        // Seed a baseline. Subsequent applies at policy_id 100002 with version <=
-        // baseline must NOT regress the snapshot.
-        let baseline = document(
-            policyID: 100002, version: 500,
+        let store = makeStore()
+
+        // Baseline at version 500.
+        store.apply(rawJSON: document(
+            policyID: 1, version: 500,
             rules: [RuleSpec(type: "BINARY", identifier: "baseline", ruleID: "baseline-rule")]
-        )
-        ApplicationControlStore.shared.apply(rawJSON: baseline)
+        ))
 
-        // Same id, older version -> rejected; the snapshot must keep the baseline.
-        let older = document(
-            policyID: 100002, version: 100,
+        // Same id, older version -> rejected; the baseline must survive.
+        store.apply(rawJSON: document(
+            policyID: 1, version: 100,
             rules: [RuleSpec(type: "BINARY", identifier: "older", ruleID: "older-rule")]
-        )
-        ApplicationControlStore.shared.apply(rawJSON: older)
-
-        var snapshot = ApplicationControlStore.shared.currentSnapshot()
-        // After the rejected apply the baseline doc must still be the active snapshot. Pin
-        // both: the older rule did NOT land AND the baseline rule still survives, so a future
-        // bug where the older payload partially leaks (e.g. apply forgets to short-circuit
-        // before swapping) would fail loudly here.
-        XCTAssertEqual(snapshot.policyID, 100002)
-        XCTAssertEqual(snapshot.policyVersion, 500)
+        ))
+        var snapshot = store.currentSnapshot()
+        XCTAssertEqual(snapshot.policyID, 1)
+        XCTAssertEqual(snapshot.policyVersion, 500, "older-version apply must not advance policyVersion")
         XCTAssertNil(snapshot.binaryRules["older"], "stale apply must not introduce its rules")
         XCTAssertNotNil(snapshot.binaryRules["baseline"], "baseline rule must survive rejected apply")
 
+        // Same id, equal version -> rejected (gate is strictly greater).
+        store.apply(rawJSON: document(
+            policyID: 1, version: 500,
+            rules: [RuleSpec(type: "BINARY", identifier: "equal", ruleID: "equal-rule")]
+        ))
+        snapshot = store.currentSnapshot()
+        XCTAssertEqual(snapshot.policyVersion, 500, "equal-version apply must be a no-op")
+        XCTAssertNil(snapshot.binaryRules["equal"])
+        XCTAssertNotNil(snapshot.binaryRules["baseline"])
+
         // Same id, newer version -> accepted; the snapshot now reflects the new doc.
-        let newer = document(
-            policyID: 100002, version: 600,
+        store.apply(rawJSON: document(
+            policyID: 1, version: 600,
             rules: [RuleSpec(type: "BINARY", identifier: "newer", ruleID: "newer-rule")]
-        )
-        ApplicationControlStore.shared.apply(rawJSON: newer)
-        snapshot = ApplicationControlStore.shared.currentSnapshot()
-        // Assert the policyID explicitly rather than hiding the rest of the assertions behind an
-        // `if` guard -- a process-wide singleton means a different test's apply could land between
-        // this `apply` and `currentSnapshot()`, and an `if`-gated block would silently no-op
-        // through the failure. XCTAssertEqual surfaces it.
-        XCTAssertEqual(snapshot.policyID, 100002)
+        ))
+        snapshot = store.currentSnapshot()
         XCTAssertEqual(snapshot.policyVersion, 600)
         XCTAssertEqual(snapshot.binaryRules["newer"]?.ruleID, "newer-rule")
         // Wholesale replace: the baseline's rule is gone because the new doc's
@@ -147,17 +181,45 @@ final class ApplicationControlStoreTests: XCTestCase {
         XCTAssertNil(snapshot.binaryRules["baseline"], "newer doc must replace, not merge")
     }
 
+    // MARK: - apply: cross-policy regression accepted
+
+    func testApplyAcceptsDifferentPolicyEvenAtLowerVersion() {
+        // The monotonic gate is keyed on policyID -- a different policy can land at any version
+        // because it is, by construction, a fresh policy stream. Pin this so a future
+        // tightening of the gate (e.g. comparing version globally) doesn't accidentally start
+        // rejecting legitimate policy swaps.
+        let store = makeStore()
+        store.apply(rawJSON: document(
+            policyID: 1, version: 100,
+            rules: [RuleSpec(type: "BINARY", identifier: "old-policy-rule", ruleID: "old")]
+        ))
+        store.apply(rawJSON: document(
+            policyID: 2, version: 1,
+            rules: [RuleSpec(type: "BINARY", identifier: "new-policy-rule", ruleID: "new")]
+        ))
+        let snapshot = store.currentSnapshot()
+        XCTAssertEqual(snapshot.policyID, 2)
+        XCTAssertEqual(snapshot.policyVersion, 1)
+        XCTAssertEqual(snapshot.binaryRules["new-policy-rule"]?.ruleID, "new")
+        XCTAssertNil(snapshot.binaryRules["old-policy-rule"])
+    }
+
     // MARK: - apply: malformed input
 
     func testApplyIgnoresMalformedJSON() {
-        // Snapshot the policyVersion before the bad apply so we can confirm it
-        // doesn't change. Using a sentinel policy_id keeps us insulated from other
-        // tests' state.
-        let beforeVersion = ApplicationControlStore.shared.currentSnapshot().policyVersion
-        ApplicationControlStore.shared.apply(rawJSON: Data("{not json}".utf8))
-        ApplicationControlStore.shared.apply(rawJSON: Data())
-        let afterVersion = ApplicationControlStore.shared.currentSnapshot().policyVersion
-        XCTAssertEqual(afterVersion, beforeVersion, "malformed JSON must not mutate snapshot state")
+        let store = makeStore()
+        // Seed a real snapshot first; malformed input must NOT regress that state.
+        store.apply(rawJSON: document(
+            policyID: 1, version: 10,
+            rules: [RuleSpec(type: "BINARY", identifier: "good", ruleID: "good-rule")]
+        ))
+        store.apply(rawJSON: Data("{not json}".utf8))
+        store.apply(rawJSON: Data())
+        let snapshot = store.currentSnapshot()
+        XCTAssertEqual(snapshot.policyID, 1)
+        XCTAssertEqual(snapshot.policyVersion, 10)
+        XCTAssertEqual(snapshot.binaryRules["good"]?.ruleID, "good-rule",
+                       "malformed JSON must not regress previously-applied snapshot")
     }
 
     // MARK: - apply: unknown rule_type
@@ -166,19 +228,16 @@ final class ApplicationControlStoreTests: XCTestCase {
         // FRUITCAKE is not a defined rule_type. The store logs a warning and skips
         // that entry but accepts the rest of the document, so a server-side
         // tagging mistake on a single rule does not break the entire snapshot.
-        let payload = document(
-            policyID: 100003, version: 1000,
+        let store = makeStore()
+        store.apply(rawJSON: document(
+            policyID: 1, version: 1,
             rules: [
                 RuleSpec(type: "BINARY", identifier: "good-binary", ruleID: "good"),
                 RuleSpec(type: "FRUITCAKE", identifier: "weird", ruleID: "weird")
             ]
-        )
-        ApplicationControlStore.shared.apply(rawJSON: payload)
-        let snapshot = ApplicationControlStore.shared.currentSnapshot()
-        // Same explicit-policyID-assertion rationale as testApplyRoutesEveryRuleTypeIntoItsOwnMap:
-        // do not let a wrong-state singleton silently skip every check via an `if` guard.
-        XCTAssertEqual(snapshot.policyID, 100003)
-        XCTAssertEqual(snapshot.policyVersion, 1000)
+        ))
+        let snapshot = store.currentSnapshot()
+        XCTAssertEqual(snapshot.policyID, 1)
         XCTAssertEqual(snapshot.binaryRules["good-binary"]?.ruleID, "good")
         // No bucket exists for FRUITCAKE; the weird identifier must not have
         // leaked into any of the six known maps.
@@ -188,6 +247,77 @@ final class ApplicationControlStoreTests: XCTestCase {
         XCTAssertNil(snapshot.certificateRules["weird"])
         XCTAssertNil(snapshot.teamIDRules["weird"])
         XCTAssertNil(snapshot.pathRules["weird"])
+    }
+
+    // MARK: - persist + loadFromDisk round-trip
+
+    func testApplyPersistsToDiskAndFreshInstanceLoadsItBack() {
+        // The injectable storagePath unlocks a real end-to-end test: apply on one store writes
+        // the snapshot to disk; a fresh store with the same path can loadFromDisk and observe the
+        // identical snapshot. Previously this was untestable because the persist target was a
+        // production /var/db path no test could write to.
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("AppControlPersist-\(UUID().uuidString)", isDirectory: true)
+            .appendingPathComponent("application-control.json")
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: url.deletingLastPathComponent())
+        }
+
+        let writer = ApplicationControlStore(storagePath: url.path)
+        writer.apply(rawJSON: document(
+            policyID: 42, version: 7,
+            rules: [
+                RuleSpec(type: "BINARY", identifier: "hash-hex", ruleID: "r1"),
+                RuleSpec(type: "TEAMID", identifier: "FDG8Q7N4CC", ruleID: "r2")
+            ]
+        ))
+        XCTAssertTrue(waitForFile(at: url.path), "apply() must persist to disk within deadline")
+
+        // A fresh store reading the same path must see the same snapshot.
+        let reader = ApplicationControlStore(storagePath: url.path)
+        reader.loadFromDisk()
+        let snapshot = reader.currentSnapshot()
+        XCTAssertEqual(snapshot.policyID, 42)
+        XCTAssertEqual(snapshot.policyVersion, 7)
+        XCTAssertEqual(snapshot.binaryRules["hash-hex"]?.ruleID, "r1")
+        XCTAssertEqual(snapshot.teamIDRules["FDG8Q7N4CC"]?.ruleID, "r2")
+    }
+
+    // MARK: - loadFromDisk: cold start
+
+    func testLoadFromDiskWithMissingFileLeavesSnapshotEmpty() {
+        // Cold start path: no persisted file at the expected path. The store logs an info-level
+        // "no persisted snapshot at startup" and falls back to the empty snapshot rather than
+        // crashing. The agent will push the current snapshot on its next command poll.
+        let missing = FileManager.default.temporaryDirectory
+            .appendingPathComponent("does-not-exist-\(UUID().uuidString).json").path
+        let store = ApplicationControlStore(storagePath: missing)
+        store.loadFromDisk()
+        let snapshot = store.currentSnapshot()
+        XCTAssertEqual(snapshot.policyID, 0)
+        XCTAssertEqual(snapshot.policyVersion, 0)
+        XCTAssertTrue(snapshot.binaryRules.isEmpty)
+    }
+
+    // MARK: - loadFromDisk: corrupt file
+
+    func testLoadFromDiskWithMalformedFileLeavesSnapshotEmpty() {
+        // Corruption path: the persisted JSON is unparseable (truncated write, manual edit, etc).
+        // The store fails open with the empty snapshot rather than crashing or carrying stale
+        // bytes -- the agent will push a fresh snapshot on the next poll cycle.
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("AppControlCorrupt-\(UUID().uuidString)", isDirectory: true)
+            .appendingPathComponent("application-control.json")
+        try? FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try? Data("{not json}".utf8).write(to: url)
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: url.deletingLastPathComponent())
+        }
+        let store = ApplicationControlStore(storagePath: url.path)
+        store.loadFromDisk()
+        let snapshot = store.currentSnapshot()
+        XCTAssertEqual(snapshot.policyID, 0)
+        XCTAssertEqual(snapshot.policyVersion, 0)
     }
 
     // MARK: - empty snapshot constant

--- a/extension/edr/Tests/EDRExtensionLogicTests/ApplicationControlStoreTests.swift
+++ b/extension/edr/Tests/EDRExtensionLogicTests/ApplicationControlStoreTests.swift
@@ -14,8 +14,17 @@ import XCTest
 final class ApplicationControlStoreTests: XCTestCase {
     // MARK: - Helpers
 
+    /// RuleSpec is a named record for the document() helper's `rules` argument.
+    /// A 3-tuple would trip SwiftLint's large_tuple rule (max 2 members); a struct
+    /// also reads better at the call sites and lets us name the field at use.
+    private struct RuleSpec {
+        let type: String
+        let identifier: String
+        let ruleID: String
+    }
+
     /// document builds an ApplicationControlDocument as on-the-wire JSON bytes.
-    private func document(policyID: Int64, version: Int64, rules: [(type: String, identifier: String, ruleID: String)]) -> Data {
+    private func document(policyID: Int64, version: Int64, rules: [RuleSpec]) -> Data {
         let ruleObjects = rules.map { rule in
             """
             {
@@ -45,8 +54,8 @@ final class ApplicationControlStoreTests: XCTestCase {
         let data = document(
             policyID: 7, version: 12,
             rules: [
-                (type: "BINARY", identifier: String(repeating: "a", count: 64), ruleID: "r1"),
-                (type: "TEAMID", identifier: "FDG8Q7N4CC", ruleID: "r2"),
+                RuleSpec(type: "BINARY", identifier: String(repeating: "a", count: 64), ruleID: "r1"),
+                RuleSpec(type: "TEAMID", identifier: "FDG8Q7N4CC", ruleID: "r2")
             ]
         )
         let decoded = try JSONDecoder().decode(ApplicationControlDocument.self, from: data)
@@ -66,17 +75,22 @@ final class ApplicationControlStoreTests: XCTestCase {
         let payload = document(
             policyID: 100001, version: 1000,
             rules: [
-                (type: "BINARY", identifier: "binary-hex", ruleID: "r1"),
-                (type: "CDHASH", identifier: "cdhash-hex", ruleID: "r2"),
-                (type: "SIGNINGID", identifier: "FDG8Q7N4CC:com.fleetdm.edr", ruleID: "r3"),
-                (type: "CERTIFICATE", identifier: "cert-hex", ruleID: "r4"),
-                (type: "TEAMID", identifier: "FDG8Q7N4CC", ruleID: "r5"),
-                (type: "PATH", identifier: "/usr/local/bin/foo", ruleID: "r6"),
+                RuleSpec(type: "BINARY", identifier: "binary-hex", ruleID: "r1"),
+                RuleSpec(type: "CDHASH", identifier: "cdhash-hex", ruleID: "r2"),
+                RuleSpec(type: "SIGNINGID", identifier: "FDG8Q7N4CC:com.fleetdm.edr", ruleID: "r3"),
+                RuleSpec(type: "CERTIFICATE", identifier: "cert-hex", ruleID: "r4"),
+                RuleSpec(type: "TEAMID", identifier: "FDG8Q7N4CC", ruleID: "r5"),
+                RuleSpec(type: "PATH", identifier: "/usr/local/bin/foo", ruleID: "r6")
             ]
         )
         ApplicationControlStore.shared.apply(rawJSON: payload)
         let snapshot = ApplicationControlStore.shared.currentSnapshot()
-        XCTAssertGreaterThanOrEqual(snapshot.policyVersion, 1000)
+        // The store is a process-global singleton; assert policyID + policyVersion EXPLICITLY rather
+        // than letting a wrong-state read silently fall through to no-op assertions. If a later test
+        // ever leaves a higher version under this same policyID the monotonic gate would silently
+        // reject this apply -- this XCTAssertEqual surfaces that as a loud failure instead.
+        XCTAssertEqual(snapshot.policyID, 100001)
+        XCTAssertEqual(snapshot.policyVersion, 1000)
         XCTAssertEqual(snapshot.binaryRules["binary-hex"]?.ruleID, "r1")
         XCTAssertEqual(snapshot.cdhashRules["cdhash-hex"]?.ruleID, "r2")
         XCTAssertEqual(snapshot.signingIDRules["FDG8Q7N4CC:com.fleetdm.edr"]?.ruleID, "r3")
@@ -92,38 +106,45 @@ final class ApplicationControlStoreTests: XCTestCase {
         // baseline must NOT regress the snapshot.
         let baseline = document(
             policyID: 100002, version: 500,
-            rules: [(type: "BINARY", identifier: "baseline", ruleID: "baseline-rule")]
+            rules: [RuleSpec(type: "BINARY", identifier: "baseline", ruleID: "baseline-rule")]
         )
         ApplicationControlStore.shared.apply(rawJSON: baseline)
 
         // Same id, older version -> rejected; the snapshot must keep the baseline.
         let older = document(
             policyID: 100002, version: 100,
-            rules: [(type: "BINARY", identifier: "older", ruleID: "older-rule")]
+            rules: [RuleSpec(type: "BINARY", identifier: "older", ruleID: "older-rule")]
         )
         ApplicationControlStore.shared.apply(rawJSON: older)
 
         var snapshot = ApplicationControlStore.shared.currentSnapshot()
-        // The baseline rule survives; the older payload's rule did NOT land.
-        // We assert via the new identifier being absent rather than reading
-        // policyVersion -- a different test may have bumped the version with a
-        // different policy_id after this one ran.
+        // After the rejected apply the baseline doc must still be the active snapshot. Pin
+        // both: the older rule did NOT land AND the baseline rule still survives, so a future
+        // bug where the older payload partially leaks (e.g. apply forgets to short-circuit
+        // before swapping) would fail loudly here.
+        XCTAssertEqual(snapshot.policyID, 100002)
+        XCTAssertEqual(snapshot.policyVersion, 500)
         XCTAssertNil(snapshot.binaryRules["older"], "stale apply must not introduce its rules")
+        XCTAssertNotNil(snapshot.binaryRules["baseline"], "baseline rule must survive rejected apply")
 
         // Same id, newer version -> accepted; the snapshot now reflects the new doc.
         let newer = document(
             policyID: 100002, version: 600,
-            rules: [(type: "BINARY", identifier: "newer", ruleID: "newer-rule")]
+            rules: [RuleSpec(type: "BINARY", identifier: "newer", ruleID: "newer-rule")]
         )
         ApplicationControlStore.shared.apply(rawJSON: newer)
         snapshot = ApplicationControlStore.shared.currentSnapshot()
-        if snapshot.policyID == 100002 {
-            XCTAssertEqual(snapshot.binaryRules["newer"]?.ruleID, "newer-rule")
-            // Wholesale replace: the baseline's rule is gone because the new doc's
-            // rule list does not include it. Pinning this prevents a future bug
-            // where apply() accidentally merges rather than replacing.
-            XCTAssertNil(snapshot.binaryRules["baseline"], "newer doc must replace, not merge")
-        }
+        // Assert the policyID explicitly rather than hiding the rest of the assertions behind an
+        // `if` guard -- a process-wide singleton means a different test's apply could land between
+        // this `apply` and `currentSnapshot()`, and an `if`-gated block would silently no-op
+        // through the failure. XCTAssertEqual surfaces it.
+        XCTAssertEqual(snapshot.policyID, 100002)
+        XCTAssertEqual(snapshot.policyVersion, 600)
+        XCTAssertEqual(snapshot.binaryRules["newer"]?.ruleID, "newer-rule")
+        // Wholesale replace: the baseline's rule is gone because the new doc's
+        // rule list does not include it. Pinning this prevents a future bug
+        // where apply() accidentally merges rather than replacing.
+        XCTAssertNil(snapshot.binaryRules["baseline"], "newer doc must replace, not merge")
     }
 
     // MARK: - apply: malformed input
@@ -148,23 +169,25 @@ final class ApplicationControlStoreTests: XCTestCase {
         let payload = document(
             policyID: 100003, version: 1000,
             rules: [
-                (type: "BINARY", identifier: "good-binary", ruleID: "good"),
-                (type: "FRUITCAKE", identifier: "weird", ruleID: "weird"),
+                RuleSpec(type: "BINARY", identifier: "good-binary", ruleID: "good"),
+                RuleSpec(type: "FRUITCAKE", identifier: "weird", ruleID: "weird")
             ]
         )
         ApplicationControlStore.shared.apply(rawJSON: payload)
         let snapshot = ApplicationControlStore.shared.currentSnapshot()
-        if snapshot.policyID == 100003 {
-            XCTAssertEqual(snapshot.binaryRules["good-binary"]?.ruleID, "good")
-            // No bucket exists for FRUITCAKE; the weird identifier must not have
-            // leaked into any of the six known maps.
-            XCTAssertNil(snapshot.binaryRules["weird"])
-            XCTAssertNil(snapshot.cdhashRules["weird"])
-            XCTAssertNil(snapshot.signingIDRules["weird"])
-            XCTAssertNil(snapshot.certificateRules["weird"])
-            XCTAssertNil(snapshot.teamIDRules["weird"])
-            XCTAssertNil(snapshot.pathRules["weird"])
-        }
+        // Same explicit-policyID-assertion rationale as testApplyRoutesEveryRuleTypeIntoItsOwnMap:
+        // do not let a wrong-state singleton silently skip every check via an `if` guard.
+        XCTAssertEqual(snapshot.policyID, 100003)
+        XCTAssertEqual(snapshot.policyVersion, 1000)
+        XCTAssertEqual(snapshot.binaryRules["good-binary"]?.ruleID, "good")
+        // No bucket exists for FRUITCAKE; the weird identifier must not have
+        // leaked into any of the six known maps.
+        XCTAssertNil(snapshot.binaryRules["weird"])
+        XCTAssertNil(snapshot.cdhashRules["weird"])
+        XCTAssertNil(snapshot.signingIDRules["weird"])
+        XCTAssertNil(snapshot.certificateRules["weird"])
+        XCTAssertNil(snapshot.teamIDRules["weird"])
+        XCTAssertNil(snapshot.pathRules["weird"])
     }
 
     // MARK: - empty snapshot constant

--- a/extension/edr/Tests/EDRExtensionLogicTests/BlockNotificationTests.swift
+++ b/extension/edr/Tests/EDRExtensionLogicTests/BlockNotificationTests.swift
@@ -1,0 +1,108 @@
+// BlockNotification tests: the extension and host-app sides of the
+// application_control block-notification channel ship two copies of these constants
+// + the Codable payload struct (see the header comment in BlockNotification.swift
+// for why no shared framework target). These tests pin the canonical strings + the
+// wire shape of BlockNotificationPayload so a stray edit on the extension side
+// cannot silently drift away from the host-app side without a red gate. The host
+// app's matching tests live alongside its own BlockNotification.swift copy.
+
+import Foundation
+@testable import EDRExtensionLogic
+import XCTest
+
+final class BlockNotificationTests: XCTestCase {
+    // MARK: - Wire-shape constants
+
+    func testServiceNameIsCanonical() {
+        XCTAssertEqual(blockNotificationServiceName, "FDG8Q7N4CC.com.fleetdm.edr.notifications")
+    }
+
+    func testDropDirIsCanonical() {
+        XCTAssertEqual(blockNotificationDropDir, "/private/tmp/fleet-edr-notify-drop")
+    }
+
+    func testMessageTypeIsCanonical() {
+        XCTAssertEqual(blockNotificationMessageType, "application_control.block_notification")
+    }
+
+    func testPeerRequirementIsCanonical() {
+        // codesign(1) compiles this requirement string when both ends validate the
+        // peer. A typo here = a silent peer-mismatch failure at runtime.
+        XCTAssertEqual(
+            blockNotificationPeerRequirement,
+            "anchor apple generic and certificate leaf[subject.OU] = \"FDG8Q7N4CC\""
+        )
+    }
+
+    func testPurgeWindowIsFiveMinutes() {
+        XCTAssertEqual(blockNotificationPurgeWindow, 300)
+    }
+
+    // MARK: - BlockNotificationPayload Codable round-trip
+
+    func testPayloadRoundTrip() throws {
+        let original = BlockNotificationPayload(
+            ruleID: "app_control:42",
+            ruleType: "BINARY",
+            identifier: String(repeating: "f", count: 64),
+            customMsg: "Blocked by policy",
+            customURL: "https://example.test/info",
+            binaryPath: "/bin/blocked",
+            policyID: 7,
+            policyVersion: 12
+        )
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .sortedKeys
+        let encoded = try encoder.encode(original)
+        let decoded = try JSONDecoder().decode(BlockNotificationPayload.self, from: encoded)
+        XCTAssertEqual(decoded.ruleID, original.ruleID)
+        XCTAssertEqual(decoded.ruleType, original.ruleType)
+        XCTAssertEqual(decoded.identifier, original.identifier)
+        XCTAssertEqual(decoded.customMsg, original.customMsg)
+        XCTAssertEqual(decoded.customURL, original.customURL)
+        XCTAssertEqual(decoded.binaryPath, original.binaryPath)
+        XCTAssertEqual(decoded.policyID, original.policyID)
+        XCTAssertEqual(decoded.policyVersion, original.policyVersion)
+
+        // Pin the literal wire bytes so the host-app reader can decode this
+        // exact byte stream without surprise. Each entry below is a key the host-app
+        // BlockNotificationPayload's CodingKeys also names: rename either side and
+        // both these tests + the host-app copy must change.
+        let json = String(data: encoded, encoding: .utf8) ?? ""
+        XCTAssertTrue(json.contains("\"rule_id\":\"app_control:42\""))
+        XCTAssertTrue(json.contains("\"rule_type\":\"BINARY\""))
+        XCTAssertTrue(json.contains("\"custom_msg\":\"Blocked by policy\""))
+        XCTAssertTrue(json.contains("\"custom_url\":\"https:\\/\\/example.test\\/info\""))
+        XCTAssertTrue(json.contains("\"binary_path\":\"\\/bin\\/blocked\""))
+        XCTAssertTrue(json.contains("\"policy_id\":7"))
+        XCTAssertTrue(json.contains("\"policy_version\":12"))
+    }
+
+    func testPayloadOmitsNilOptionalsOnEncode() throws {
+        // customMsg + customURL are optional. The host app falls back to its default
+        // alert body when the field is ABSENT (issue #87 spec, not when explicitly
+        // null), so the wire must omit the keys entirely.
+        let payload = BlockNotificationPayload(
+            ruleID: "r", ruleType: "BINARY", identifier: "x",
+            customMsg: nil, customURL: nil,
+            binaryPath: "/x", policyID: 1, policyVersion: 1
+        )
+        let json = String(data: try JSONEncoder().encode(payload), encoding: .utf8) ?? ""
+        XCTAssertFalse(json.contains("custom_msg"))
+        XCTAssertFalse(json.contains("custom_url"))
+    }
+
+    func testPayloadDecodesMissingOptionalsAsNil() throws {
+        // Companion to the omit-on-encode test above: the host app emits payloads
+        // without optional fields, the extension's decoder accepts them as nil.
+        let wire = """
+        {"binary_path":"/x","identifier":"x","policy_id":1,"policy_version":1,"rule_id":"r","rule_type":"BINARY"}
+        """
+        let decoded = try JSONDecoder().decode(BlockNotificationPayload.self, from: Data(wire.utf8))
+        XCTAssertNil(decoded.customMsg)
+        XCTAssertNil(decoded.customURL)
+        XCTAssertEqual(decoded.ruleID, "r")
+        XCTAssertEqual(decoded.binaryPath, "/x")
+    }
+}

--- a/extension/edr/Tests/EDRExtensionLogicTests/DNSParserTests.swift
+++ b/extension/edr/Tests/EDRExtensionLogicTests/DNSParserTests.swift
@@ -120,7 +120,7 @@ final class DNSParserTests: XCTestCase {
             (16, "TXT"),
             (28, "AAAA"),
             (33, "SRV"),
-            (255, "ANY"),
+            (255, "ANY")
         ]
         for testCase in cases {
             var packet = header(id: 0x1234, qdcount: 1, ancount: 0)
@@ -170,7 +170,7 @@ final class DNSParserTests: XCTestCase {
         // 2001:db8::1 = 2001:0db8:0000:0000:0000:0000:0000:0001 = 16 bytes packed.
         let ipv6Bytes: [UInt8] = [
             0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00,
-            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01
         ]
         var packet = header(id: 0x1234, qdcount: 1, ancount: 1)
         packet.append(question(name: "example.com", qtype: 28))

--- a/extension/edr/Tests/EDRExtensionLogicTests/DNSParserTests.swift
+++ b/extension/edr/Tests/EDRExtensionLogicTests/DNSParserTests.swift
@@ -1,0 +1,223 @@
+// DNSParser tests: hand-rolled RFC 1035 packets exercise queryName, queryType, and
+// responseAddresses against the wire shapes the network extension actually emits via
+// NEDNSProxyProvider. The on-wire bytes are tiny and the parser is pure-Foundation, so
+// PBT isn't a fit -- example-based tests pin the exact bytes the production code must
+// accept, which is also what regressions look like in this layer.
+
+import Foundation
+@testable import EDRExtensionLogic
+import XCTest
+
+final class DNSParserTests: XCTestCase {
+    // MARK: - Packet builders (kept compact so the test bodies read as assertions on
+    // canonical byte sequences, not packet-construction boilerplate).
+
+    /// header builds the 12-byte fixed DNS header. id, qdcount, ancount tunables are
+    /// the only fields the parser actually consults.
+    private func header(id: UInt16, qdcount: UInt16, ancount: UInt16) -> Data {
+        var bytes = Data()
+        bytes.append(UInt8(id >> 8)); bytes.append(UInt8(id & 0xFF))
+        bytes.append(0x01); bytes.append(0x00) // flags: standard query, RD set
+        bytes.append(UInt8(qdcount >> 8)); bytes.append(UInt8(qdcount & 0xFF))
+        bytes.append(UInt8(ancount >> 8)); bytes.append(UInt8(ancount & 0xFF))
+        bytes.append(0x00); bytes.append(0x00) // NSCOUNT
+        bytes.append(0x00); bytes.append(0x00) // ARCOUNT
+        return bytes
+    }
+
+    /// encodeName encodes a DNS-format name (length-prefixed labels terminated by a
+    /// zero byte). E.g. "example.com" -> 0x07 e x a m p l e 0x03 c o m 0x00.
+    private func encodeName(_ name: String) -> Data {
+        var bytes = Data()
+        for label in name.split(separator: ".") {
+            let labelBytes = Array(label.utf8)
+            bytes.append(UInt8(labelBytes.count))
+            bytes.append(contentsOf: labelBytes)
+        }
+        bytes.append(0x00) // root terminator
+        return bytes
+    }
+
+    /// question section: NAME + QTYPE(2) + QCLASS(2). qtype is the wire code, e.g. 1
+    /// for A, 28 for AAAA.
+    private func question(name: String, qtype: UInt16) -> Data {
+        var bytes = encodeName(name)
+        bytes.append(UInt8(qtype >> 8)); bytes.append(UInt8(qtype & 0xFF))
+        bytes.append(0x00); bytes.append(0x01) // QCLASS = IN
+        return bytes
+    }
+
+    /// answerRecord encodes a single resource record. NAME is a 2-byte compression
+    /// pointer to offset 0x0C (the question section), matching what every real DNS
+    /// resolver emits -- this exercises the parser's skipName compression-pointer
+    /// branch end-to-end.
+    private func answerRecord(rrType: UInt16, rdata: Data) -> Data {
+        var bytes = Data()
+        bytes.append(0xC0); bytes.append(0x0C)                                   // NAME pointer to header end
+        bytes.append(UInt8(rrType >> 8)); bytes.append(UInt8(rrType & 0xFF))     // TYPE
+        bytes.append(0x00); bytes.append(0x01)                                   // CLASS = IN
+        bytes.append(0x00); bytes.append(0x00); bytes.append(0x00); bytes.append(0x3C) // TTL = 60
+        let rdlen = UInt16(rdata.count)
+        bytes.append(UInt8(rdlen >> 8)); bytes.append(UInt8(rdlen & 0xFF))       // RDLENGTH
+        bytes.append(rdata)
+        return bytes
+    }
+
+    // MARK: - queryName
+
+    func testQueryNameSimpleDotSeparated() {
+        var packet = header(id: 0x1234, qdcount: 1, ancount: 0)
+        packet.append(question(name: "example.com", qtype: 1))
+        XCTAssertEqual(DNSParser.queryName(from: packet), "example.com")
+    }
+
+    func testQueryNameMultiLabelSubdomain() {
+        var packet = header(id: 0x1234, qdcount: 1, ancount: 0)
+        packet.append(question(name: "api.fleetdm.com", qtype: 1))
+        XCTAssertEqual(DNSParser.queryName(from: packet), "api.fleetdm.com")
+    }
+
+    func testQueryNameReturnsNilForCompressionPointerInQname() {
+        // QNAME starts with a compression-pointer byte (0xC0). The parser refuses to
+        // resolve pointers in the query section -- they would not occur in real
+        // queries -- and returns nil rather than chasing the pointer.
+        var packet = header(id: 0x1234, qdcount: 1, ancount: 0)
+        packet.append(0xC0) // illegal first byte
+        packet.append(0x0C)
+        packet.append(0x00); packet.append(0x01) // QTYPE
+        packet.append(0x00); packet.append(0x01) // QCLASS
+        XCTAssertNil(DNSParser.queryName(from: packet))
+    }
+
+    func testQueryNameReturnsNilForEmptyPacket() {
+        XCTAssertNil(DNSParser.queryName(from: Data()))
+    }
+
+    func testQueryNameReturnsNilForHeaderOnlyPacket() {
+        // 12-byte header is the minimum possible packet but has no question section.
+        XCTAssertNil(DNSParser.queryName(from: header(id: 0, qdcount: 0, ancount: 0)))
+    }
+
+    func testQueryNameReturnsNilWhenLabelLengthOverflowsBuffer() {
+        // Claim a 100-byte label inside a buffer that has nowhere near 100 bytes
+        // left. The parser must not run past the end of the buffer.
+        var packet = header(id: 0x1234, qdcount: 1, ancount: 0)
+        packet.append(100)
+        packet.append(contentsOf: Array(repeating: 0x41, count: 5))
+        XCTAssertNil(DNSParser.queryName(from: packet))
+    }
+
+    // MARK: - queryType
+
+    func testQueryTypeRecognizesKnownTypes() {
+        let cases: [(qtype: UInt16, expected: String)] = [
+            (1, "A"),
+            (2, "NS"),
+            (5, "CNAME"),
+            (6, "SOA"),
+            (12, "PTR"),
+            (15, "MX"),
+            (16, "TXT"),
+            (28, "AAAA"),
+            (33, "SRV"),
+            (255, "ANY"),
+        ]
+        for testCase in cases {
+            var packet = header(id: 0x1234, qdcount: 1, ancount: 0)
+            packet.append(question(name: "example.com", qtype: testCase.qtype))
+            XCTAssertEqual(
+                DNSParser.queryType(from: packet),
+                testCase.expected,
+                "qtype=\(testCase.qtype) should map to \(testCase.expected)"
+            )
+        }
+    }
+
+    func testQueryTypeUnknownFallsBackToTypeCode() {
+        // 99 is not in the canonical map, so the parser falls back to TYPE99 rather
+        // than dropping the event entirely.
+        var packet = header(id: 0x1234, qdcount: 1, ancount: 0)
+        packet.append(question(name: "example.com", qtype: 99))
+        XCTAssertEqual(DNSParser.queryType(from: packet), "TYPE99")
+    }
+
+    func testQueryTypeReturnsUnknownForEmptyOrTruncatedPacket() {
+        XCTAssertEqual(DNSParser.queryType(from: Data()), "unknown")
+        // 12-byte header but no question section.
+        XCTAssertEqual(DNSParser.queryType(from: header(id: 0, qdcount: 0, ancount: 0)), "unknown")
+    }
+
+    // MARK: - responseAddresses
+
+    func testResponseAddressesSingleIPv4() {
+        var packet = header(id: 0x1234, qdcount: 1, ancount: 1)
+        packet.append(question(name: "example.com", qtype: 1))
+        packet.append(answerRecord(rrType: 1, rdata: Data([93, 184, 215, 14])))
+        XCTAssertEqual(DNSParser.responseAddresses(from: packet), ["93.184.215.14"])
+    }
+
+    func testResponseAddressesMultipleIPv4() {
+        // Two A records in the answer section. Order is preserved because the parser
+        // walks ancount records sequentially.
+        var packet = header(id: 0x1234, qdcount: 1, ancount: 2)
+        packet.append(question(name: "example.com", qtype: 1))
+        packet.append(answerRecord(rrType: 1, rdata: Data([10, 0, 0, 1])))
+        packet.append(answerRecord(rrType: 1, rdata: Data([10, 0, 0, 2])))
+        XCTAssertEqual(DNSParser.responseAddresses(from: packet), ["10.0.0.1", "10.0.0.2"])
+    }
+
+    func testResponseAddressesSingleIPv6() {
+        // 2001:db8::1 = 2001:0db8:0000:0000:0000:0000:0000:0001 = 16 bytes packed.
+        let ipv6Bytes: [UInt8] = [
+            0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
+        ]
+        var packet = header(id: 0x1234, qdcount: 1, ancount: 1)
+        packet.append(question(name: "example.com", qtype: 28))
+        packet.append(answerRecord(rrType: 28, rdata: Data(ipv6Bytes)))
+        // The parser emits the un-compressed colon-separated form: groups whose
+        // value is 0 stay as a literal "0", not the RFC 5952 "::" double-colon
+        // collapse. Pin this exact shape so detection-engine consumers downstream
+        // do not have to handle both forms.
+        XCTAssertEqual(DNSParser.responseAddresses(from: packet), ["2001:db8:0:0:0:0:0:1"])
+    }
+
+    func testResponseAddressesIgnoresUnknownRecordTypes() {
+        // TYPE16 (TXT) has no IP rdata, so the parser returns no addresses while
+        // still advancing past the record correctly. Adding a second known A record
+        // after a TXT proves the offset math is right.
+        var packet = header(id: 0x1234, qdcount: 1, ancount: 2)
+        packet.append(question(name: "example.com", qtype: 1))
+        packet.append(answerRecord(rrType: 16, rdata: Data("v=spf1".utf8)))
+        packet.append(answerRecord(rrType: 1, rdata: Data([8, 8, 8, 8])))
+        XCTAssertEqual(DNSParser.responseAddresses(from: packet), ["8.8.8.8"])
+    }
+
+    func testResponseAddressesEmptyForQueryOnlyPacket() {
+        // A query packet (ancount=0) yields no addresses but the parser must not crash
+        // when there is nothing past the question section.
+        var packet = header(id: 0x1234, qdcount: 1, ancount: 0)
+        packet.append(question(name: "example.com", qtype: 1))
+        XCTAssertEqual(DNSParser.responseAddresses(from: packet), [])
+    }
+
+    func testResponseAddressesEmptyForUndersizedPacket() {
+        // Packet shorter than the header is rejected outright.
+        XCTAssertEqual(DNSParser.responseAddresses(from: Data([0x00])), [])
+    }
+
+    func testResponseAddressesEmptyWhenRdlengthLies() {
+        // Header claims one answer, RR claims a 50-byte RDATA but the buffer ends.
+        // The parser must bail rather than reading past the end of the buffer.
+        var packet = header(id: 0x1234, qdcount: 1, ancount: 1)
+        packet.append(question(name: "example.com", qtype: 1))
+        // Hand-roll an RR with bogus RDLENGTH.
+        packet.append(0xC0); packet.append(0x0C) // NAME pointer
+        packet.append(0x00); packet.append(0x01) // TYPE=A
+        packet.append(0x00); packet.append(0x01) // CLASS=IN
+        packet.append(0x00); packet.append(0x00); packet.append(0x00); packet.append(0x3C) // TTL
+        packet.append(0x00); packet.append(0x32) // RDLENGTH=50 (lie)
+        packet.append(contentsOf: [1, 2, 3, 4])  // only 4 bytes of rdata actually here
+        XCTAssertEqual(DNSParser.responseAddresses(from: packet), [])
+    }
+}

--- a/extension/edr/Tests/EDRExtensionLogicTests/EventSerializerTests.swift
+++ b/extension/edr/Tests/EDRExtensionLogicTests/EventSerializerTests.swift
@@ -1,0 +1,212 @@
+// EventSerializer payload tests: pin the on-wire JSON shape of every payload type
+// the extension emits, because the server-side decoders in
+// `server/rules/internal/catalog/*` rely on these exact field names. A rename on
+// either side is a contract break, and these round-trip tests are the gate that
+// catches it before the wire shape ships.
+//
+// The serializer's runtime entry point (EventSerializer.serialize) is intentionally
+// NOT tested here: it pulls the hardware UUID via IOKit, which is environment-
+// coupled (test runners report different values, and the call has side effects).
+// What IS testable is the Codable shape of every payload + the EventEnvelope
+// generic, which is what the wire shape actually is.
+
+import Foundation
+@testable import EDRExtensionLogic
+import XCTest
+
+final class EventSerializerTests: XCTestCase {
+    // The serializer uses `.sortedKeys` formatting, so the wire bytes are stable
+    // across encodes. We mirror that here so the literal-string assertions below are
+    // not order-sensitive.
+    private let encoder: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .sortedKeys
+        return encoder
+    }()
+
+    private let decoder = JSONDecoder()
+
+    // MARK: - ExecPayload
+
+    func testExecPayloadRoundTripWithFullSigning() throws {
+        let signing = CodeSigning(teamID: "FDG8Q7N4CC", signingID: "com.apple.bash", flags: 0x2000, isPlatformBinary: true)
+        let payload = ExecPayload(
+            pid: 4242, ppid: 1, path: "/bin/bash", args: ["bash", "-c", "echo hi"],
+            cwd: "/Users/test", uid: 501, gid: 20,
+            codeSigning: signing,
+            sha256: String(repeating: "a", count: 64),
+            cdhash: String(repeating: "b", count: 40),
+            snapshot: false
+        )
+        let encoded = try encoder.encode(payload)
+        let decoded = try decoder.decode(ExecPayload.self, from: encoded)
+        XCTAssertEqual(decoded.pid, payload.pid)
+        XCTAssertEqual(decoded.ppid, payload.ppid)
+        XCTAssertEqual(decoded.path, payload.path)
+        XCTAssertEqual(decoded.args, payload.args)
+        XCTAssertEqual(decoded.cwd, payload.cwd)
+        XCTAssertEqual(decoded.uid, payload.uid)
+        XCTAssertEqual(decoded.gid, payload.gid)
+        XCTAssertEqual(decoded.codeSigning?.teamID, signing.teamID)
+        XCTAssertEqual(decoded.codeSigning?.signingID, signing.signingID)
+        XCTAssertEqual(decoded.codeSigning?.flags, signing.flags)
+        XCTAssertEqual(decoded.codeSigning?.isPlatformBinary, signing.isPlatformBinary)
+        XCTAssertEqual(decoded.sha256, payload.sha256)
+        XCTAssertEqual(decoded.cdhash, payload.cdhash)
+        XCTAssertEqual(decoded.snapshot, false)
+    }
+
+    func testExecPayloadOmitsSnapshotKeyWhenFalse() throws {
+        // The encoder DELIBERATELY drops `snapshot` when it is false so the wire
+        // bytes for live execs stay byte-identical to the pre-issue-#11 format and
+        // the server detection-engine bytes.Contains gate over `"snapshot":true`
+        // does not have to special-case `"snapshot":false`.
+        let payload = ExecPayload(
+            pid: 1, ppid: 0, path: "/bin/sh", args: ["sh"], cwd: "/", uid: 0, gid: 0,
+            codeSigning: nil, sha256: nil, cdhash: nil, snapshot: false
+        )
+        let encoded = try encoder.encode(payload)
+        let json = String(data: encoded, encoding: .utf8) ?? ""
+        XCTAssertFalse(json.contains("\"snapshot\""), "live-exec wire must not carry snapshot key, got: \(json)")
+        // Sanity-check the other always-emitted keys survive.
+        XCTAssertTrue(json.contains("\"pid\":1"))
+        XCTAssertTrue(json.contains("\"path\":\"\\/bin\\/sh\""))
+    }
+
+    func testExecPayloadEmitsSnapshotKeyWhenTrue() throws {
+        let payload = ExecPayload(
+            pid: 99, ppid: 1, path: "/bin/ls", args: ["ls"], cwd: "/", uid: 0, gid: 0,
+            codeSigning: nil, sha256: nil, cdhash: nil, snapshot: true
+        )
+        let encoded = try encoder.encode(payload)
+        let json = String(data: encoded, encoding: .utf8) ?? ""
+        XCTAssertTrue(json.contains("\"snapshot\":true"), "startup-snapshot exec must carry snapshot:true, got: \(json)")
+    }
+
+    func testExecPayloadOmitsOptionalSigningAndHashes() throws {
+        // Unsigned binaries lack code_signing / sha256 / cdhash. Verify the JSON
+        // omits the keys entirely rather than emitting nulls -- the server's
+        // decoders rely on absence, not null.
+        let payload = ExecPayload(
+            pid: 1, ppid: 0, path: "/tmp/unsigned", args: [], cwd: "/", uid: 0, gid: 0,
+            codeSigning: nil, sha256: nil, cdhash: nil, snapshot: false
+        )
+        let encoded = try encoder.encode(payload)
+        let json = String(data: encoded, encoding: .utf8) ?? ""
+        XCTAssertFalse(json.contains("code_signing"))
+        XCTAssertFalse(json.contains("sha256"))
+        XCTAssertFalse(json.contains("cdhash"))
+    }
+
+    func testExecPayloadDecodesLegacyWireWithoutSnapshotKey() throws {
+        // A pre-issue-#11 wire payload had no snapshot key. The custom decoder must
+        // accept that and default to false rather than rejecting the envelope.
+        let legacy = """
+        {"args":["sh"],"cwd":"/","gid":0,"path":"/bin/sh","pid":1,"ppid":0,"uid":0}
+        """
+        let decoded = try decoder.decode(ExecPayload.self, from: Data(legacy.utf8))
+        XCTAssertEqual(decoded.pid, 1)
+        XCTAssertEqual(decoded.snapshot, false)
+    }
+
+    // MARK: - ForkPayload, ExitPayload, OpenPayload
+
+    func testForkPayloadWireKeys() throws {
+        let payload = ForkPayload(childPid: 5, parentPid: 4)
+        let json = String(data: try encoder.encode(payload), encoding: .utf8) ?? ""
+        // Wire keys are snake_case, not Swift property names.
+        XCTAssertEqual(json, #"{"child_pid":5,"parent_pid":4}"#)
+        let decoded = try decoder.decode(ForkPayload.self, from: Data(json.utf8))
+        XCTAssertEqual(decoded.childPid, 5)
+        XCTAssertEqual(decoded.parentPid, 4)
+    }
+
+    func testExitPayloadWireKeys() throws {
+        let payload = ExitPayload(pid: 99, exitCode: 137)
+        let json = String(data: try encoder.encode(payload), encoding: .utf8) ?? ""
+        XCTAssertEqual(json, #"{"exit_code":137,"pid":99}"#)
+        let decoded = try decoder.decode(ExitPayload.self, from: Data(json.utf8))
+        XCTAssertEqual(decoded.pid, 99)
+        XCTAssertEqual(decoded.exitCode, 137)
+    }
+
+    func testOpenPayloadWireKeys() throws {
+        let payload = OpenPayload(pid: 12, path: "/etc/hosts", flags: 0)
+        let json = String(data: try encoder.encode(payload), encoding: .utf8) ?? ""
+        XCTAssertEqual(json, #"{"flags":0,"path":"\/etc\/hosts","pid":12}"#)
+        let decoded = try decoder.decode(OpenPayload.self, from: Data(json.utf8))
+        XCTAssertEqual(decoded.path, "/etc/hosts")
+    }
+
+    // MARK: - CodeSigning
+
+    func testCodeSigningWireKeys() throws {
+        let signing = CodeSigning(teamID: "FDG8Q7N4CC", signingID: "com.fleetdm.edr", flags: 0x600, isPlatformBinary: false)
+        let json = String(data: try encoder.encode(signing), encoding: .utf8) ?? ""
+        XCTAssertEqual(
+            json,
+            #"{"flags":1536,"is_platform_binary":false,"signing_id":"com.fleetdm.edr","team_id":"FDG8Q7N4CC"}"#
+        )
+    }
+
+    // MARK: - ApplicationControlBlockPayload
+
+    func testApplicationControlBlockPayloadRoundTrip() throws {
+        let payload = ApplicationControlBlockPayload(
+            pid: 1234, path: "/bin/sh",
+            ruleID: "app_control:42", ruleType: "BINARY", identifier: String(repeating: "f", count: 64),
+            severity: "high", customMsg: "Blocked by policy", customURL: "https://example.test/info",
+            policyID: 7, policyVersion: 12
+        )
+        let encoded = try encoder.encode(payload)
+        let json = String(data: encoded, encoding: .utf8) ?? ""
+        // Spot-check snake_case wire keys land in the JSON -- the Go decoder reads
+        // these literal names from server/rules/internal/catalog/application_control_block.go.
+        XCTAssertTrue(json.contains("\"rule_id\":\"app_control:42\""), "missing rule_id, got: \(json)")
+        XCTAssertTrue(json.contains("\"rule_type\":\"BINARY\""))
+        XCTAssertTrue(json.contains("\"custom_msg\":\"Blocked by policy\""))
+        XCTAssertTrue(json.contains("\"custom_url\":\"https:\\/\\/example.test\\/info\""))
+        XCTAssertTrue(json.contains("\"policy_id\":7"))
+        XCTAssertTrue(json.contains("\"policy_version\":12"))
+        let decoded = try decoder.decode(ApplicationControlBlockPayload.self, from: encoded)
+        XCTAssertEqual(decoded.ruleID, payload.ruleID)
+        XCTAssertEqual(decoded.policyVersion, payload.policyVersion)
+        XCTAssertEqual(decoded.customMsg, payload.customMsg)
+    }
+
+    func testApplicationControlBlockPayloadOmitsNilOptionals() throws {
+        let payload = ApplicationControlBlockPayload(
+            pid: 1, path: "/tmp/x", ruleID: "r", ruleType: "BINARY", identifier: "x",
+            severity: "low", customMsg: nil, customURL: nil, policyID: 1, policyVersion: 1
+        )
+        let json = String(data: try encoder.encode(payload), encoding: .utf8) ?? ""
+        XCTAssertFalse(json.contains("custom_msg"))
+        XCTAssertFalse(json.contains("custom_url"))
+    }
+
+    // MARK: - EventEnvelope
+
+    func testEventEnvelopeWireKeysAndNesting() throws {
+        let payload = ForkPayload(childPid: 11, parentPid: 10)
+        let envelope = EventEnvelope(
+            eventID: "11111111-1111-1111-1111-111111111111",
+            hostID: "AAAA0001-0000-0000-0000-000000000001",
+            timestampNs: 1_700_000_000_000_000_000,
+            eventType: "fork",
+            payload: payload
+        )
+        let encoded = try encoder.encode(envelope)
+        let json = String(data: encoded, encoding: .utf8) ?? ""
+        // event_id, host_id, timestamp_ns, event_type, payload must all be present
+        // with snake_case wire keys and the payload nested as-is.
+        XCTAssertTrue(json.contains("\"event_id\":\"11111111-1111-1111-1111-111111111111\""))
+        XCTAssertTrue(json.contains("\"host_id\":\"AAAA0001-0000-0000-0000-000000000001\""))
+        XCTAssertTrue(json.contains("\"event_type\":\"fork\""))
+        XCTAssertTrue(json.contains("\"timestamp_ns\":1700000000000000000"))
+        XCTAssertTrue(json.contains("\"payload\":{\"child_pid\":11,\"parent_pid\":10}"))
+        let decoded = try decoder.decode(EventEnvelope<ForkPayload>.self, from: encoded)
+        XCTAssertEqual(decoded.eventType, "fork")
+        XCTAssertEqual(decoded.payload.childPid, 11)
+        XCTAssertEqual(decoded.timestampNs, 1_700_000_000_000_000_000)
+    }
+}

--- a/extension/edr/Tests/EDRExtensionLogicTests/FileHashCacheTests.swift
+++ b/extension/edr/Tests/EDRExtensionLogicTests/FileHashCacheTests.swift
@@ -1,0 +1,150 @@
+// FileHashCache tests: write a real file under FileManager.default.temporaryDirectory,
+// stat it to obtain the live (dev, inode, mtime) tuple FileHashCache keys on, then
+// drive lookup / lookupOrCompute / startLazyFill. The cache is a singleton -- tests
+// use uniquely-generated file paths so cache entries from one test never collide
+// with another's. The shared cache still grows across tests; that's intentional --
+// it mirrors how the AUTH_EXEC handler hits the cache in production.
+
+import CryptoKit
+import Darwin
+import Foundation
+@testable import EDRExtensionLogic
+import XCTest
+
+final class FileHashCacheTests: XCTestCase {
+    /// makeTempFile writes `bytes` into a fresh path under the test temp dir and
+    /// returns the path plus the live stat used as the cache key. The caller is
+    /// responsible for cleanup at addTeardownBlock time.
+    private func makeTempFile(bytes: Data, file: StaticString = #filePath, line: UInt = #line) throws -> (path: String, stat: stat) {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent("EDRFileHashCacheTests", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let url = dir.appendingPathComponent("hash-\(UUID().uuidString).bin")
+        try bytes.write(to: url)
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: url)
+        }
+        var st = stat()
+        let rc = stat(url.path, &st)
+        XCTAssertEqual(rc, 0, "stat() must succeed on freshly-written temp file", file: file, line: line)
+        return (url.path, st)
+    }
+
+    /// expectedSHA256 returns the lowercase hex SHA-256 of `bytes`, mirroring the
+    /// production hash format (32-byte digest formatted as 64 lowercase hex chars).
+    private func expectedSHA256(of bytes: Data) -> String {
+        SHA256.hash(data: bytes).map { String(format: "%02x", $0) }.joined()
+    }
+
+    // MARK: - lookup
+
+    func testLookupReturnsNilForUncachedFile() throws {
+        let file = try makeTempFile(bytes: Data("lookup-cold".utf8))
+        // First-time lookup must be a cache miss: lookup() does NOT trigger a fill,
+        // it just reads the dictionary. The AUTH_EXEC fast path relies on this.
+        XCTAssertNil(FileHashCache.shared.lookup(stat: file.stat))
+    }
+
+    // MARK: - lookupOrCompute
+
+    func testLookupOrComputeReturnsExpectedHashAndCaches() throws {
+        let payload = Data("hello cache".utf8)
+        let file = try makeTempFile(bytes: payload)
+        let expected = expectedSHA256(of: payload)
+
+        let firstHash = FileHashCache.shared.lookupOrCompute(path: file.path, stat: file.stat)
+        XCTAssertEqual(firstHash, expected)
+
+        // After the synchronous compute, a plain lookup() with the same stat must
+        // hit the cache.
+        XCTAssertEqual(FileHashCache.shared.lookup(stat: file.stat), expected)
+
+        // Calling lookupOrCompute a second time returns the same value (cache hit
+        // path -- file is still on disk, but the implementation should not need
+        // to re-read it).
+        let secondHash = FileHashCache.shared.lookupOrCompute(path: file.path, stat: file.stat)
+        XCTAssertEqual(secondHash, expected)
+    }
+
+    func testLookupOrComputeReturnsNilForMissingFile() {
+        // No file at this path -- FileHandle(forReadingFrom:) throws, the function
+        // logs a warning and returns nil rather than crashing.
+        var fakeStat = stat()
+        fakeStat.st_dev = 1
+        fakeStat.st_ino = 999_999
+        fakeStat.st_mtimespec.tv_sec = 0
+        fakeStat.st_mtimespec.tv_nsec = 0
+        let path = "/tmp/edr-fileHashCacheTests-does-not-exist-\(UUID().uuidString)"
+        XCTAssertNil(FileHashCache.shared.lookupOrCompute(path: path, stat: fakeStat))
+    }
+
+    func testLookupOrComputeReturnsNilOnInodeMismatch() throws {
+        // TOCTOU guard: caller passes a stat whose (dev, inode, mtime) tuple does
+        // NOT match what fstat() reports for the opened FD. The function must
+        // refuse to hash and return nil so the cache stays empty rather than
+        // associating a wrong hash with the bogus key.
+        let file = try makeTempFile(bytes: Data("real-content".utf8))
+        var bogus = file.stat
+        // Forge a different inode value to simulate "file was replaced between
+        // AUTH and read." Real value is whatever fstat would return; we offset.
+        bogus.st_ino = file.stat.st_ino &+ 9999
+        XCTAssertNil(FileHashCache.shared.lookupOrCompute(path: file.path, stat: bogus))
+        // The honest stat still produces the hash.
+        let honest = FileHashCache.shared.lookupOrCompute(path: file.path, stat: file.stat)
+        XCTAssertEqual(honest, expectedSHA256(of: Data("real-content".utf8)))
+    }
+
+    func testLookupOrComputeHandlesEmptyFile() throws {
+        // SHA-256 of zero bytes is a well-known constant. Useful regression pin --
+        // catches "I forgot to call finalize when the read loop body never ran."
+        let file = try makeTempFile(bytes: Data())
+        let hash = FileHashCache.shared.lookupOrCompute(path: file.path, stat: file.stat)
+        XCTAssertEqual(hash, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
+    }
+
+    func testLookupOrComputeHandlesLargerThanChunkSize() throws {
+        // 200 KiB > 64 KiB streaming chunk. Exercises the multi-iteration read
+        // loop and confirms the streaming hash matches the one-shot reference.
+        let payload = Data(repeating: 0x7E, count: 200 * 1024)
+        let file = try makeTempFile(bytes: payload)
+        let hash = FileHashCache.shared.lookupOrCompute(path: file.path, stat: file.stat)
+        XCTAssertEqual(hash, expectedSHA256(of: payload))
+    }
+
+    // MARK: - startLazyFill
+
+    func testStartLazyFillPopulatesCacheEventually() throws {
+        // The lazy fill is async on a userInitiated concurrent queue. The test
+        // polls the cache for up to a few seconds before declaring a regression --
+        // this matches how the NOTIFY_EXEC path waits for the AUTH_EXEC-side
+        // fill to complete in production.
+        let payload = Data("lazy-fill-content".utf8)
+        let file = try makeTempFile(bytes: payload)
+        let expected = expectedSHA256(of: payload)
+
+        FileHashCache.shared.startLazyFill(path: file.path, stat: file.stat)
+
+        let deadline = Date().addingTimeInterval(2)
+        var got: String?
+        while Date() < deadline {
+            if let cached = FileHashCache.shared.lookup(stat: file.stat) {
+                got = cached
+                break
+            }
+            Thread.sleep(forTimeInterval: 0.01)
+        }
+        XCTAssertEqual(got, expected, "startLazyFill must populate the cache within the 2s deadline")
+    }
+
+    func testStartLazyFillIsNoOpWhenAlreadyCached() throws {
+        // After lookupOrCompute primes the cache, a follow-up startLazyFill must
+        // be a no-op -- the alreadyCached branch returns before dispatching. We
+        // can't directly observe the no-dispatch, but we can confirm the cached
+        // value is unchanged after the call.
+        let payload = Data("already-cached".utf8)
+        let file = try makeTempFile(bytes: payload)
+        let expected = expectedSHA256(of: payload)
+        XCTAssertEqual(FileHashCache.shared.lookupOrCompute(path: file.path, stat: file.stat), expected)
+        FileHashCache.shared.startLazyFill(path: file.path, stat: file.stat)
+        XCTAssertEqual(FileHashCache.shared.lookup(stat: file.stat), expected)
+    }
+}

--- a/extension/edr/Tests/EDRExtensionLogicTests/FileHashCacheTests.swift
+++ b/extension/edr/Tests/EDRExtensionLogicTests/FileHashCacheTests.swift
@@ -88,6 +88,11 @@ final class FileHashCacheTests: XCTestCase {
         // AUTH and read." Real value is whatever fstat would return; we offset.
         bogus.st_ino = file.stat.st_ino &+ 9999
         XCTAssertNil(FileHashCache.shared.lookupOrCompute(path: file.path, stat: bogus))
+        // A failed compute must NOT cache anything under the forged key -- if it did, the next
+        // AUTH_EXEC presenting that bogus (dev, ino, mtime) tuple would happily get served a wrong
+        // hash via a plain `lookup()`. Pin the negative so a future regression that quietly stores
+        // nil-or-stale-hash entries fails loudly.
+        XCTAssertNil(FileHashCache.shared.lookup(stat: bogus))
         // The honest stat still produces the hash.
         let honest = FileHashCache.shared.lookupOrCompute(path: file.path, stat: file.stat)
         XCTAssertEqual(honest, expectedSHA256(of: Data("real-content".utf8)))

--- a/extension/edr/extension/ApplicationControlStore.swift
+++ b/extension/edr/extension/ApplicationControlStore.swift
@@ -117,11 +117,26 @@ enum ApplicationControlEnforcement {
 ///  - The disk write uses Data.write(to:options:.atomic), which writes a
 ///    temporary file and renames it atomically.
 final class ApplicationControlStore {
+    /// Singleton entry point used by every production callsite. The AUTH_EXEC handler, the XPC
+    /// dispatcher and the extension's boot path all go through `.shared`. Tests should NOT use
+    /// `.shared` because it persists to `/var/db/com.fleetdm.edr/application-control.json`, which
+    /// is both global state and a real production file. Construct a per-test instance with
+    /// `ApplicationControlStore(storagePath: tempFile)` instead so each test gets an empty
+    /// snapshot AND the async persist lands in a temp directory the test cleans up.
     static let shared = ApplicationControlStore()
 
     private let lock = OSAllocatedUnfairLock(initialState: ApplicationControlSnapshot.empty)
     private let persistQueue = DispatchQueue(label: "com.fleetdm.edr.appcontrol.persist", qos: .utility)
-    private let storagePath = "/var/db/com.fleetdm.edr/application-control.json"
+    private let storagePath: String
+
+    /// The `storagePath` argument exists for XCTest isolation -- production code uses `.shared`
+    /// which initializes via the default value (the real on-disk policy file under /var/db).
+    /// The init is internal (not private) because @testable code in the SwiftPM Tests target
+    /// needs to call it; the doc comment on `.shared` discourages new production callers from
+    /// bypassing the singleton.
+    init(storagePath: String = "/var/db/com.fleetdm.edr/application-control.json") {
+        self.storagePath = storagePath
+    }
 
     /// currentSnapshot returns the active snapshot. The AUTH_EXEC handler
     /// calls this on every exec, so the critical section is constant time


### PR DESCRIPTION
Add extension/edr/Package.swift that references the existing Swift sources via explicit sources: paths, plus initial XCTest suites covering the five in-scope logic files: DNSParser, EventSerializer's payload + envelope structs, BlockNotification, ApplicationControlStore, FileHashCache. SigningInfoFallback is deferred until a reliably-signed fixture binary is in tree (it walks SecStaticCode on a real Mach-O).

50 tests, 0.18s wall clock. Run with swift test --package-path extension/edr.

The Xcode project remains the production build path for the signed system extension + network extension + host app bundles; main.swift, XPCServer, ESFClient and friends are NOT in the package's sources: list and only build inside their respective Xcode targets. exclude: pins the ignored files explicitly so SwiftPM doesn't emit "unhandled file" warnings against the Xcode project tree.

CI wired via .github/workflows/swift-test.yml on macos-latest, gated by the same extension/** path filter as swift-lint.yml. The job runs swift test --enable-code-coverage and uploads the resulting .profdata as a workflow artifact; the M8 work that wires Swift coverage into SonarCloud will reuse that artifact path.

docs/testing-strategy.md L0 section + the per-language coverage gates table updated to reflect the SwiftPM-vs-xcodebuild approach and to mark M7 as landed.

.gitignore now ignores SwiftPM's .build/, .swiftpm/, Package.resolved so the test artifacts don't show up under git status.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for validation of core logic components

* **Chores**
  * Established automated testing in the CI/CD pipeline
  * Updated project configuration

* **Documentation**
  * Enhanced testing strategy documentation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/getvictor/fleet-edr/pull/216?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->