### PR TITLE
M12 scale-test harness: 100-agent fan-in driver + per-PR smoke

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -306,8 +306,10 @@ tasks:
       breached or any POST errors.
 
       Defaults: 100 hosts, 80/20 quiet/active mix, 5 minute lane against
-      https://localhost:8088 with insecure TLS (matches dev:server's mkcert
-      cert). The plan's 30 min baseline run is invoked via:
+      https://localhost:8088 with TLS verification enabled. Targeting
+      dev:server's mkcert cert requires either trusting the cert in the
+      system store (`task dev:certs`) or opt-in TLS skip via
+      `-- --insecure-tls=true`. The plan's 30 min baseline run is invoked via:
         task uat:scale -- --duration=30m --output=test/scale/baselines/baseline.json
 
       Required env:
@@ -340,7 +342,11 @@ tasks:
       # tests fully exercise them. Per the modular-monolith pattern,
       # cross-package exercise via the public api/ + bootstrap/ surface is
       # the intended coverage path; coverpkg makes Sonar see it.
-      - go test -race -count=1 -timeout=10m -tags=integration -coverpkg=./server/...,./internal/... -coverprofile=coverage-server.out -covermode=atomic ./server/... ./internal/... ./test/integration/...
+      #
+      # ./test/scale/... is included so M12's per-PR smoke (5 hosts x 5s
+      # against integration.Setup) runs on every push. Wall-clock cost is
+      # ~5s, dominated by the smoke's own load lane.
+      - go test -race -count=1 -timeout=10m -tags=integration -coverpkg=./server/...,./internal/... -coverprofile=coverage-server.out -covermode=atomic ./server/... ./internal/... ./test/integration/... ./test/scale/...
       - go tool cover -func=coverage-server.out | tail -1
 
   test:ui:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -297,6 +297,31 @@ tasks:
     cmds:
       - scripts/uat/system-test.sh {{.CLI_ARGS}}
 
+  uat:scale:
+    desc: |
+      Run the UAT plan M12 scale-test harness at test/scale/scaledriver against
+      an externally-running EDR server (e.g. `task dev:server`). Fans out N
+      simulated hosts via fakeagent's PostDirect, records client-observed
+      ingest p50/p95/p99 latency, fails if the p99 budget (default 250ms) is
+      breached or any POST errors.
+
+      Defaults: 100 hosts, 80/20 quiet/active mix, 5 minute lane against
+      https://localhost:8088 with insecure TLS (matches dev:server's mkcert
+      cert). The plan's 30 min baseline run is invoked via:
+        task uat:scale -- --duration=30m --output=test/scale/baselines/baseline.json
+
+      Required env:
+        EDR_ENROLL_SECRET  shared secret the server reads from the same name
+
+      CLI flags forwarded via the task's -- separator (see `go run
+      ./test/scale/scaledriver --help` for the full list). Common forms:
+        task uat:scale                                       # 100 hosts x 5min
+        task uat:scale -- --hosts=10 --duration=30s          # quick local check
+        task uat:scale -- --duration=30m \
+            --output=test/scale/baselines/baseline.json      # baseline capture
+    cmds:
+      - go run ./test/scale/scaledriver {{.CLI_ARGS}}
+
   test:go:server:coverage:
     desc: |
       Server + shared coverage flavor of test:go:server. Emits coverage-server.out

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -188,6 +188,14 @@ for 30 minutes, recorded baseline checked into the repo. Longer soak runs, 500-a
 chaos, and the operational tooling for all of them (`tools/chaosctl/`) are tracked separately. The fake-agent library
 and headless binary are the shared substrate.
 
+UAT plan milestone **M12** ships the first cut of the scale lane:
+`test/scale/` exposes a `scale.Run(ctx, Options)` runner plus a `scaledriver` binary invoked via `task uat:scale`.
+Each simulated host enrols via `/api/enroll`, then loops `fakeagent.PostDirect` against `/api/events` for the configured
+duration; the runner records client-observed p50/p95/p99 latency and asserts the documented gate
+(`p99 < 250ms`, zero errors). A per-PR smoke (5 hosts x 5s) at `test/scale/scale_test.go` proves the harness itself does
+not rot. The 30-minute baseline is captured manually and committed to `test/scale/baselines/baseline.json`. Queue-depth
+probes and SigNoz cross-checks (see the M12 row in `ai/uat/plan.md`) are explicitly deferred to a follow-up.
+
 ## Reusable artefacts
 
 ### Fake agent and headless agent binary

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -192,8 +192,9 @@ UAT plan milestone **M12** ships the first cut of the scale lane:
 `test/scale/` exposes a `scale.Run(ctx, Options)` runner plus a `scaledriver` binary invoked via `task uat:scale`.
 Each simulated host enrols via `/api/enroll`, then loops `fakeagent.PostDirect` against `/api/events` for the configured
 duration; the runner records client-observed p50/p95/p99 latency and asserts the documented gate
-(`p99 < 250ms`, zero errors). A per-PR smoke (5 hosts x 5s) at `test/scale/scale_test.go` proves the harness itself does
-not rot. The 30-minute baseline is captured manually and committed to `test/scale/baselines/baseline.json`. Queue-depth
+(`p99 < 250ms`, zero errors). A per-PR smoke (5 hosts x 5s) at `test/scale/scale_test.go` runs on every push via the
+`./test/scale/...` glob in the server-test job (`task test:go:server:coverage`) and proves the harness itself does not
+rot. The 30-minute baseline is captured manually and committed to `test/scale/baselines/baseline.json`. Queue-depth
 probes and SigNoz cross-checks (see the M12 row in `ai/uat/plan.md`) are explicitly deferred to a follow-up.
 
 ## Reusable artefacts

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/fleetdm/edr/tools/comment-wrap-check/lint v0.0.0-00010101000000-000000000000
 	github.com/go-sql-driver/mysql v1.9.3
 	github.com/go-webauthn/webauthn v0.17.2
+	github.com/google/uuid v1.6.0
 	github.com/jmoiron/sqlx v1.4.0
 	github.com/open-policy-agent/opa v1.16.1
 	github.com/stretchr/testify v1.11.1
@@ -26,6 +27,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.43.0
 	golang.org/x/crypto v0.50.0
 	golang.org/x/oauth2 v0.36.0
+	golang.org/x/sync v0.20.0
 	golang.org/x/time v0.15.0
 	golang.org/x/tools v0.44.0
 	modernc.org/sqlite v1.49.1
@@ -54,7 +56,6 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/golangci/plugin-module-register v0.1.2 // indirect
 	github.com/google/go-tpm v0.9.8 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
 	github.com/klauspost/compress v1.18.5 // indirect
 	github.com/lestrrat-go/blackmagic v1.0.4 // indirect
@@ -89,7 +90,6 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/mod v0.35.0 // indirect
 	golang.org/x/net v0.53.0 // indirect
-	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/telemetry v0.0.0-20260409153401-be6f6cb8b1fa // indirect
 	golang.org/x/text v0.36.0 // indirect

--- a/test/fakeagent/feeder.go
+++ b/test/fakeagent/feeder.go
@@ -88,7 +88,10 @@ func (s *Scenario) PostDirect(ctx context.Context, baseURL, token string, opts .
 	if err != nil {
 		return err
 	}
-	client := defaultHTTPClient()
+	client := cfg.httpClient
+	if client == nil {
+		client = defaultHTTPClient()
+	}
 	url := baseURL + "/api/events"
 
 	for start := 0; start < len(envelopes); start += cfg.batchSize {

--- a/test/fakeagent/option.go
+++ b/test/fakeagent/option.go
@@ -3,6 +3,7 @@ package fakeagent
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"net/http"
 	"time"
 )
 
@@ -14,6 +15,7 @@ type runConfig struct {
 	speedMultiplier float64
 	batchSize       int
 	idGenerator     func() string
+	httpClient      *http.Client
 }
 
 // Option is the functional-option type for FeedControlPlane, PostDirect, and Envelopes. Use With* helpers to construct values.
@@ -55,6 +57,18 @@ func WithIDGenerator(f func() string) Option {
 		panic("fakeagent: WithIDGenerator requires a non-nil function")
 	}
 	return func(c *runConfig) { c.idGenerator = f }
+}
+
+// WithHTTPClient overrides the *http.Client PostDirect uses for POSTs to /api/events. The default builds a client with the
+// project's postDirectHTTPTimeout and stock TLS verification; callers that need shared connection pools (e.g. fan-out load
+// generators) or a custom TLS config (e.g. dev:server's mkcert-signed cert when the system trust store has not been primed)
+// pass their own client here. Has no effect on FeedControlPlane, which dials a unix socket. Panics on a nil client so the
+// failure surfaces at the call site rather than later in PostDirect when client.Do() dereferences nil.
+func WithHTTPClient(c *http.Client) Option {
+	if c == nil {
+		panic("fakeagent: WithHTTPClient requires a non-nil client")
+	}
+	return func(cfg *runConfig) { cfg.httpClient = c }
 }
 
 // newRunConfig builds the resolved config, applies any options, then returns it.

--- a/test/scale/README.md
+++ b/test/scale/README.md
@@ -7,7 +7,7 @@ The harness exists in two shapes:
 
 | Shape | Where | When |
 |---|---|---|
-| Per-PR smoke (5 hosts x 5s) | `scale_test.go` (`-tags=integration`) | every PR via the existing server-test job |
+| Per-PR smoke (5 hosts x 5s) | `scale_test.go` (`-tags=integration`) | every PR via `task test:go:server:coverage`'s `./test/scale/...` glob |
 | Opt-in long-form run | `scaledriver/` (`go run` via `task uat:scale`) | manual; baseline capture; release-candidate |
 
 Both share the runner at `runner.go` so the smoke test exercises the same code path the long-form lane uses.
@@ -31,12 +31,18 @@ systemic regression.
 task db:up
 task dev:server
 
-# In another shell, capture a baseline.
-export EDR_ENROLL_SECRET=$(grep EDR_ENROLL_SECRET ~/.zshrc | head -1 | cut -d= -f2-)
-task uat:scale -- --hosts=10 --duration=30s     # smoke (~30s wall clock)
-task uat:scale                                  # default: 100 hosts x 5 min
-task uat:scale -- --duration=30m \
-    --output=test/scale/baselines/baseline.json  # plan's full 30 min baseline
+# In another shell, export EDR_ENROLL_SECRET from your current session (or
+# from a secret manager such as `op read ...`). Avoid scraping shell profile
+# files: the secret should live in your session env, not in a checked-in
+# rcfile path you can be parsed later.
+export EDR_ENROLL_SECRET=...   # paste from your secret source
+
+# dev:server uses mkcert; either trust the cert system-wide (`task dev:certs`)
+# OR opt in to TLS skip via `-- --insecure-tls=true`. The default is to verify.
+task uat:scale -- --hosts=10 --duration=30s --insecure-tls=true     # smoke
+task uat:scale -- --insecure-tls=true                               # 100 hosts x 5 min
+task uat:scale -- --duration=30m --insecure-tls=true \
+    --output=test/scale/baselines/baseline.json                     # full 30 min baseline
 ```
 
 The driver inherits `EDR_ENROLL_SECRET` from the environment so the same value the server reads at boot drives the test

--- a/test/scale/README.md
+++ b/test/scale/README.md
@@ -1,0 +1,88 @@
+# M12 scale-test harness
+
+UAT plan milestone M12 (see `ai/uat/plan.md` and `docs/testing-strategy.md`). Fans out N simulated EDR hosts against one
+server for D wall-clock duration, records client-observed POST /api/events latency, and asserts the documented pass criteria.
+
+The harness exists in two shapes:
+
+| Shape | Where | When |
+|---|---|---|
+| Per-PR smoke (5 hosts x 5s) | `scale_test.go` (`-tags=integration`) | every PR via the existing server-test job |
+| Opt-in long-form run | `scaledriver/` (`go run` via `task uat:scale`) | manual; baseline capture; release-candidate |
+
+Both share the runner at `runner.go` so the smoke test exercises the same code path the long-form lane uses.
+
+## Pass criteria
+
+Per the plan's M12 row:
+
+- `latency_p99 < 250ms` against the developer machine baseline run.
+- `error_count == 0` (no HTTP 4xx/5xx, no client-side timeouts).
+- `observation_count > 0` (the lane actually ran).
+
+If any criterion fails, the driver exits 2 and the JSON report's `pass` field is `false`. Per-host breakdowns (last error,
+per-host observation count, per-host p99) are preserved under `per_host` so a single bad node does not look identical to a
+systemic regression.
+
+## Quick start
+
+```bash
+# Start the server and a fresh MySQL.
+task db:up
+task dev:server
+
+# In another shell, capture a baseline.
+export EDR_ENROLL_SECRET=$(grep EDR_ENROLL_SECRET ~/.zshrc | head -1 | cut -d= -f2-)
+task uat:scale -- --hosts=10 --duration=30s     # smoke (~30s wall clock)
+task uat:scale                                  # default: 100 hosts x 5 min
+task uat:scale -- --duration=30m \
+    --output=test/scale/baselines/baseline.json  # plan's full 30 min baseline
+```
+
+The driver inherits `EDR_ENROLL_SECRET` from the environment so the same value the server reads at boot drives the test
+agents. If the secret is missing the driver exits 1 with a clear error.
+
+## Scenario mix
+
+- 80% of hosts run `test/fakeagent/scenarios/quiet-host.yaml` on a 5-second jittered cadence (noise floor).
+- 20% of hosts round-robin across a curated subset of the L6 corpus (`test/efficacy/corpus/T*/scenario.yaml`) on a
+  1-second jittered cadence. Currently `T1059-suspicious-exec`, `T1543.001-launchagent-persistence`,
+  `T1548.003-sudoers-tamper`, `T1555.001-keychain-dump`.
+
+Both ratios and the scenario lists are flags (`--quiet-ratio`, `--active-scenarios`); the defaults match the M12 plan
+exactly. The +/- 25% jitter applied to each gap de-synchronises hosts so the server does not see a heartbeat-shaped fan-in.
+
+## Output
+
+The report on stdout is JSON-encoded `scale.Report` (see `runner.go`). Key fields:
+
+```json
+{
+  "start_time": "...", "end_time": "...", "duration": "5m0s",
+  "host_count": 100, "quiet_host_count": 80, "active_host_count": 20,
+  "observation_count": 32140, "error_count": 0,
+  "latency_p50": "12ms", "latency_p95": "38ms", "latency_p99": "61ms",
+  "latency_max": "412ms", "observations_per_sec": 107.13,
+  "pass": true, "pass_p99": "250ms",
+  "per_host": [{ "host_id": "...", "scenario": "...", "observation_count": ..., "latency_p99": "..." }]
+}
+```
+
+Per-host scenarios show the YAML file path so a regression localised to one scenario family is easy to spot.
+
+## Baseline files
+
+`test/scale/baselines/baseline.json` is the canonical baseline a contributor captures on a representative developer machine.
+The plan's pass-criteria-tightening loop is: capture baseline -> compare against last commit -> file a follow-up when the
+p99 drifts > 10% upward. The baseline is hand-committed; the driver does not auto-update it.
+
+## What this layer does NOT do
+
+- **Queue depth on the agent**: v1 bypasses the M2 queue + uploader entirely by using `fakeagent.PostDirect`. A v2 lane
+  that drives `headless.Run` per host and polls `/state` for queue depth is a future iteration; the v1 measurement target
+  is the server's ingest p99 under fan-in, which the direct POST path measures honestly.
+- **MySQL CPU / row count growth**: the plan calls for these as observability outputs. They are not gates today;
+  capturing them is an operator job during the baseline run (a SigNoz dashboard or `mysqladmin extended-status` snapshot).
+  Promote to gates when a regression case justifies them.
+- **SigNoz cross-check**: client-observed latency is the gate. A future enhancement can pull server-side
+  `http.server.duration` p99 from SigNoz via its query API and compare.

--- a/test/scale/baselines/README.md
+++ b/test/scale/baselines/README.md
@@ -1,0 +1,18 @@
+# Scale-test baselines
+
+`baseline.json` is the canonical M12 scale-test baseline captured on a representative developer machine. Treat it as a
+hand-edited contract: regenerate by running
+
+    task uat:scale -- --duration=30m --output=test/scale/baselines/baseline.json
+
+against an idle dev:server, then `git diff` to confirm the change is intentional before committing.
+
+Each baseline file is a `scale.Report` (see `test/scale/runner.go`); the `per_host` array is dropped from committed
+baselines because it changes every run (random host UUIDs). Strip it manually before committing:
+
+    jq 'del(.per_host)' test/scale/baselines/baseline.json > /tmp/b.json && mv /tmp/b.json test/scale/baselines/baseline.json
+
+The plan's pass criteria (p99 < 250ms, zero errors) apply at the aggregate level; per-host latencies live in the JSON
+report on disk during triage but not in the committed baseline.
+
+Initial baseline: not yet captured. Run the command above to create `baseline.json`.

--- a/test/scale/runner.go
+++ b/test/scale/runner.go
@@ -177,6 +177,11 @@ func Run(ctx context.Context, opts Options) (Report, error) {
 			st.gap = opts.ActiveIterationGap
 			rep.ActiveHostCount++
 		}
+		// Pre-allocate the latency slice to the expected observation count (Duration / gap, padded by 2 for jitter +
+		// startup variance). Grow-by-double append in the hot loop is otherwise the largest allocator in a long run and
+		// can skew percentile measurements on GC-busy CI runners.
+		expectedObs := int(opts.Duration/st.gap) + 2
+		st.latencies = make([]time.Duration, 0, expectedObs)
 		hosts[i] = st
 	}
 
@@ -231,12 +236,30 @@ func (h *hostState) run(ctx context.Context, serverURL, enrollSecret string, cli
 		// Thread the runner's shared http.Client through PostDirect via WithHTTPClient so the optional --insecure-tls
 		// configuration applies to /api/events POSTs (not just /api/enroll). Without this option, fakeagent's PostDirect
 		// would build its own default *http.Client and lose the TLS skip required for dev:server's mkcert-signed cert.
+		//
+		// Latency caveat (Gemini's medium-priority note on M12 v1): the wall-clock measured here covers ONE PostDirect call,
+		// which may issue multiple HTTP POSTs if the scenario's envelope count exceeds fakeagent's batchSize (default 100).
+		// Every M10 corpus + fakeagent starter scenario produces fewer than 100 envelopes, so today a PostDirect call =
+		// one HTTP request and this measurement is per-request. If a future scenario crosses the batchSize boundary, the
+		// captured latency becomes an aggregate across batches and the runner's p99 stops corresponding to server-side
+		// http.server.duration p99. Either keep scenarios under one batch, raise the batchSize via WithBatchSize, or
+		// instrument per-request timing through a fakeagent observer hook.
 		err := h.scenario.PostDirect(ctx, serverURL, token,
 			fakeagent.WithHostID(h.hostID),
 			fakeagent.WithStartTime(start),
 			fakeagent.WithHTTPClient(client),
 		)
 		latency := time.Since(start)
+
+		// If the context cancelled while the POST was in flight, the resulting error is the runner's own shutdown signal,
+		// not a server-side problem. Exit cooperatively without counting it; otherwise tight CI timing where the lane
+		// deadline can fire mid-request would inflate error_count and flake the pass gate. The check uses ctx.Err()
+		// rather than errors.Is(err, context.Canceled) so context.DeadlineExceeded (the typical shape when the lane's
+		// own context.WithTimeout fires) is caught alongside parent-cancel propagations.
+		if err != nil && ctx.Err() != nil {
+			return
+		}
+
 		h.mu.Lock()
 		if err != nil {
 			h.errorCount++
@@ -246,9 +269,7 @@ func (h *hostState) run(ctx context.Context, serverURL, enrollSecret string, cli
 			h.postedCount++
 		}
 		h.mu.Unlock()
-		if err != nil && errors.Is(err, context.Canceled) {
-			return
-		}
+
 		// Jittered gap: gap * [jitterFloor, jitterFloor+jitterRange]. De-synchronises hosts so the server does not see a
 		// heartbeat-shaped fan-in spike.
 		jittered := time.Duration(float64(h.gap) * (jitterFloor + jitterRange*rng.Float64()))
@@ -268,7 +289,16 @@ func (h *hostState) recordErr(msg string) {
 // aggregate folds per-host latencies into the Report's percentile fields and computes pass/fail. Latencies are concatenated then
 // sorted once; with ~100 hosts and ~hundreds of observations each, an O(n log n) sort over the union is well under a millisecond.
 func aggregate(rep *Report, hosts []*hostState, opts Options) {
-	all := make([]time.Duration, 0, len(hosts)*16)
+	// Pre-size the aggregate latency slice to the exact total observation count. The per-host postedCount is already known
+	// here so the previous `len(hosts)*16` guess is replaced with the precise value; in a 100-host x 5-min x 1s lane the
+	// guess was ~20x low and forced grow-by-double reallocations.
+	totalObs := 0
+	for _, h := range hosts {
+		h.mu.Lock()
+		totalObs += h.postedCount
+		h.mu.Unlock()
+	}
+	all := make([]time.Duration, 0, totalObs)
 	for i, h := range hosts {
 		h.mu.Lock()
 		hostP99 := percentile(h.latencies, percentileP99)

--- a/test/scale/runner.go
+++ b/test/scale/runner.go
@@ -1,0 +1,475 @@
+// Package scale is UAT plan milestone M12: fan out N simulated EDR hosts against one server for D duration, record client-observed
+// ingest latency, exit non-zero if the documented pass criteria are breached (default p99 < 250ms, zero errors). The driver binary
+// at scaledriver/ wraps Run for opt-in long-form runs (e.g. 100 hosts x 30 min on a representative dev box); a per-PR smoke test
+// at scale_test.go wires Run to integration.Setup for a sub-second sanity check on every push so the harness itself does not rot.
+//
+// Direct-POST-to-/api/events is the load shape used here rather than driving the queue + uploader through the M2 headless binary.
+// The plan's "queue depth on the agents" probe is deferred to a follow-up: M12 v1's job is to baseline server-side ingest under
+// fan-in. The fakeagent library generates wire envelopes identical to what the production agent would emit, so the server side
+// of the contract is fully exercised.
+package scale
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/rand"
+	"net/http"
+	"slices"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/fleetdm/edr/test/fakeagent"
+)
+
+// Named constants for what would otherwise be magic numbers in defaults + tuning knobs. Grouped here so the lint-rule
+// objection lands once and the runtime values stay reviewable in one place. None of these are security-sensitive; they are
+// load-shape choices a contributor will want to tweak for local experiments.
+const (
+	defaultHostCount          = 100
+	defaultQuietRatio         = 0.8
+	defaultDuration           = 5 * time.Minute
+	defaultQuietIterationGap  = 5 * time.Second
+	defaultActiveIterationGap = 1 * time.Second
+	defaultPassP99            = 250 * time.Millisecond
+
+	jitterFloor        = 0.75 // multiplier floor for the per-host iteration gap; pairs with jitterRange below.
+	jitterRange        = 0.5  // multiplier added on top of floor (so the range is [floor, floor+range]).
+	enrollRetries      = 3
+	enrollRetryConnGap = 200 * time.Millisecond
+	enrollRetry429Gap  = 500 * time.Millisecond
+	httpClientTimeout  = 30 * time.Second
+	httpMaxIdle        = 1024
+	httpIdleTimeout    = 90 * time.Second
+
+	percentileP50 = 50
+	percentileP95 = 95
+	percentileP99 = 99
+)
+
+// Options configures a Run. ServerURL and EnrollSecret are required; everything else has a defaulted zero value that produces a
+// useful run.
+type Options struct {
+	// ServerURL is the base URL of the EDR server under test (e.g. "https://localhost:8088"). No trailing slash.
+	ServerURL string
+
+	// EnrollSecret is the shared secret POSTed to /api/enroll. For local dev:server, the same value the server reads from
+	// EDR_ENROLL_SECRET. For an integration.Setup Stack, integration.EnrollSecret.
+	EnrollSecret string
+
+	// HostCount is the number of simulated agents. Defaults to 100.
+	HostCount int
+
+	// QuietRatio is the fraction of hosts assigned the "quiet" scenario; the rest cycle through ActiveScenarios. Defaults to 0.8
+	// per the plan (80 quiet, 20 active).
+	QuietRatio float64
+
+	// Duration is the wall-clock the load lane runs for. Defaults to 5 minutes (the developer-machine default; the plan's 30-min
+	// baseline run is invoked explicitly).
+	Duration time.Duration
+
+	// QuietScenarioPath is the YAML file each quiet host loops. Required when HostCount > 0 and QuietRatio > 0.
+	QuietScenarioPath string
+
+	// ActiveScenarioPaths is the round-robin pool active hosts pick from. Required when QuietRatio < 1.
+	ActiveScenarioPaths []string
+
+	// IterationGap is the sleep between scenario iterations per host. Defaults to 5s for quiet, 1s for active. Jittered +/- 25%
+	// at run time so all hosts do not synchronise.
+	QuietIterationGap  time.Duration
+	ActiveIterationGap time.Duration
+
+	// AllowInsecureTLS skips the server cert check. Needed for dev:server's mkcert-signed cert when the system trust store has
+	// not been primed. The integration.Setup Stack uses plain HTTP; that path ignores this knob.
+	AllowInsecureTLS bool
+
+	// PassP99 is the latency ceiling for the p99 ingest assertion. Defaults to 250ms per the plan.
+	PassP99 time.Duration
+}
+
+// Report is the aggregate output of a Run. Every numeric field is computed across all simulated hosts; PerHost preserves the
+// per-host breakdown for triage when an aggregate gate fails.
+type Report struct {
+	StartTime          time.Time     `json:"start_time"`
+	EndTime            time.Time     `json:"end_time"`
+	Duration           time.Duration `json:"duration"`
+	HostCount          int           `json:"host_count"`
+	QuietHostCount     int           `json:"quiet_host_count"`
+	ActiveHostCount    int           `json:"active_host_count"`
+	ObservationCount   int           `json:"observation_count"`
+	ErrorCount         int           `json:"error_count"`
+	LatencyP50         time.Duration `json:"latency_p50"`
+	LatencyP95         time.Duration `json:"latency_p95"`
+	LatencyP99         time.Duration `json:"latency_p99"`
+	LatencyMax         time.Duration `json:"latency_max"`
+	ObservationsPerSec float64       `json:"observations_per_sec"`
+	Pass               bool          `json:"pass"`
+	PassP99            time.Duration `json:"pass_p99"`
+	FailReasons        []string      `json:"fail_reasons,omitempty"`
+	PerHost            []HostReport  `json:"per_host"`
+}
+
+// HostReport is one simulated host's contribution to the aggregate Report.
+type HostReport struct {
+	HostID           string        `json:"host_id"`
+	Scenario         string        `json:"scenario"`
+	ObservationCount int           `json:"observation_count"`
+	ErrorCount       int           `json:"error_count"`
+	LastError        string        `json:"last_error,omitempty"`
+	LatencyP99       time.Duration `json:"latency_p99"`
+}
+
+// Run executes the scale load lane against opts.ServerURL for opts.Duration and returns an aggregate Report. ctx is the parent
+// cancellation context; if cancelled, Run returns the partial report it has accumulated plus ctx.Err(). Errors from individual
+// host goroutines are recorded into the Report (HostReport.LastError + Report.ErrorCount); they do NOT abort the lane, so a
+// transient server hiccup does not collapse the whole observation set.
+func Run(ctx context.Context, opts Options) (Report, error) {
+	if opts.ServerURL == "" {
+		return Report{}, errors.New("scale: ServerURL is required")
+	}
+	if opts.EnrollSecret == "" {
+		return Report{}, errors.New("scale: EnrollSecret is required")
+	}
+	opts = defaultOptions(opts)
+	if opts.QuietRatio > 0 && opts.QuietScenarioPath == "" {
+		return Report{}, errors.New("scale: QuietScenarioPath is required when QuietRatio > 0")
+	}
+	if opts.QuietRatio < 1 && len(opts.ActiveScenarioPaths) == 0 {
+		return Report{}, errors.New("scale: ActiveScenarioPaths is required when QuietRatio < 1")
+	}
+
+	quiet, active, err := loadScenarios(opts)
+	if err != nil {
+		return Report{}, err
+	}
+
+	httpClient := buildHTTPClient(opts.AllowInsecureTLS)
+	rep := Report{
+		StartTime: time.Now(),
+		HostCount: opts.HostCount,
+		PassP99:   opts.PassP99,
+		PerHost:   make([]HostReport, opts.HostCount),
+	}
+	hosts := make([]*hostState, opts.HostCount)
+	quietCutoff := int(float64(opts.HostCount) * opts.QuietRatio)
+	for i := range hosts {
+		st := &hostState{
+			index:  i,
+			hostID: uuid.NewString(),
+		}
+		if i < quietCutoff {
+			st.scenario = quiet
+			st.scenarioName = opts.QuietScenarioPath
+			st.gap = opts.QuietIterationGap
+			rep.QuietHostCount++
+		} else {
+			st.scenario = active[i%len(active)]
+			st.scenarioName = opts.ActiveScenarioPaths[i%len(active)]
+			st.gap = opts.ActiveIterationGap
+			rep.ActiveHostCount++
+		}
+		hosts[i] = st
+	}
+
+	runCtx, cancel := context.WithTimeout(ctx, opts.Duration)
+	defer cancel()
+
+	g, runCtx := errgroup.WithContext(runCtx)
+	for _, h := range hosts {
+		g.Go(func() error {
+			h.run(runCtx, opts.ServerURL, opts.EnrollSecret, httpClient)
+			return nil
+		})
+	}
+	_ = g.Wait()
+
+	rep.EndTime = time.Now()
+	rep.Duration = rep.EndTime.Sub(rep.StartTime)
+	aggregate(&rep, hosts, opts)
+	return rep, ctx.Err()
+}
+
+// hostState is the per-goroutine state: scenario + RNG + observation slice. Latencies accumulate locally to avoid lock contention;
+// aggregate() merges them after Run returns.
+type hostState struct {
+	index        int
+	hostID       string
+	scenario     *fakeagent.Scenario
+	scenarioName string
+	gap          time.Duration
+
+	mu          sync.Mutex
+	latencies   []time.Duration
+	errorCount  int
+	lastErr     string
+	postedCount int
+}
+
+// run drives one simulated host: enroll once, then loop PostDirect + sleep until ctx cancels. Errors are recorded into hostState
+// but do not abort the loop; a per-host backoff would smooth retries but adds complexity disproportionate to v1's goals.
+func (h *hostState) run(ctx context.Context, serverURL, enrollSecret string, client *http.Client) {
+	token, err := enrollOne(ctx, client, serverURL, enrollSecret, h.hostID)
+	if err != nil {
+		h.recordErr("enroll: " + err.Error())
+		return
+	}
+
+	// Per-host PRNG seeded from hostID so the jitter pattern is deterministic per host but uncorrelated across hosts.
+	rng := rand.New(rand.NewSource(hashSeed(h.hostID))) //nolint:gosec // jitter randomness, not security
+
+	for ctx.Err() == nil {
+		start := time.Now()
+		err := h.scenario.PostDirect(ctx, serverURL, token,
+			fakeagent.WithHostID(h.hostID),
+			fakeagent.WithStartTime(start),
+		)
+		latency := time.Since(start)
+		h.mu.Lock()
+		if err != nil {
+			h.errorCount++
+			h.lastErr = err.Error()
+		} else {
+			h.latencies = append(h.latencies, latency)
+			h.postedCount++
+		}
+		h.mu.Unlock()
+		if err != nil && errors.Is(err, context.Canceled) {
+			return
+		}
+		// Jittered gap: gap * [jitterFloor, jitterFloor+jitterRange]. De-synchronises hosts so the server does not see a
+		// heartbeat-shaped fan-in spike.
+		jittered := time.Duration(float64(h.gap) * (jitterFloor + jitterRange*rng.Float64()))
+		if err := sleepCtx(ctx, jittered); err != nil {
+			return
+		}
+	}
+}
+
+func (h *hostState) recordErr(msg string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.errorCount++
+	h.lastErr = msg
+}
+
+// aggregate folds per-host latencies into the Report's percentile fields and computes pass/fail. Latencies are concatenated then
+// sorted once; with ~100 hosts and ~hundreds of observations each, an O(n log n) sort over the union is well under a millisecond.
+func aggregate(rep *Report, hosts []*hostState, opts Options) {
+	all := make([]time.Duration, 0, len(hosts)*16)
+	for i, h := range hosts {
+		h.mu.Lock()
+		hostP99 := percentile(h.latencies, percentileP99)
+		hr := HostReport{
+			HostID:           h.hostID,
+			Scenario:         h.scenarioName,
+			ObservationCount: h.postedCount,
+			ErrorCount:       h.errorCount,
+			LastError:        h.lastErr,
+			LatencyP99:       hostP99,
+		}
+		rep.PerHost[i] = hr
+		rep.ObservationCount += h.postedCount
+		rep.ErrorCount += h.errorCount
+		all = append(all, h.latencies...)
+		h.mu.Unlock()
+	}
+	slices.Sort(all)
+	rep.LatencyP50 = percentileSorted(all, percentileP50)
+	rep.LatencyP95 = percentileSorted(all, percentileP95)
+	rep.LatencyP99 = percentileSorted(all, percentileP99)
+	if len(all) > 0 {
+		rep.LatencyMax = all[len(all)-1]
+	}
+	if rep.Duration > 0 {
+		rep.ObservationsPerSec = float64(rep.ObservationCount) / rep.Duration.Seconds()
+	}
+	rep.Pass = true
+	if rep.ErrorCount > 0 {
+		rep.Pass = false
+		rep.FailReasons = append(rep.FailReasons, fmt.Sprintf("error_count > 0 (got %d)", rep.ErrorCount))
+	}
+	if rep.LatencyP99 > opts.PassP99 {
+		rep.Pass = false
+		rep.FailReasons = append(rep.FailReasons,
+			fmt.Sprintf("latency_p99 %s exceeds budget %s", rep.LatencyP99, opts.PassP99))
+	}
+	if rep.ObservationCount == 0 {
+		rep.Pass = false
+		rep.FailReasons = append(rep.FailReasons, "observation_count is zero")
+	}
+}
+
+// percentile sorts a copy of the slice and returns the requested percentile. Used for per-host p99 where mutating the host's
+// latency slice would force locking semantics across read paths.
+func percentile(samples []time.Duration, p float64) time.Duration {
+	if len(samples) == 0 {
+		return 0
+	}
+	dup := append([]time.Duration(nil), samples...)
+	slices.Sort(dup)
+	return percentileSorted(dup, p)
+}
+
+func percentileSorted(sorted []time.Duration, p float64) time.Duration {
+	if len(sorted) == 0 {
+		return 0
+	}
+	if p <= 0 {
+		return sorted[0]
+	}
+	if p >= 100 {
+		return sorted[len(sorted)-1]
+	}
+	// Nearest-rank method: rank index = ceil(p/100 * N) - 1, clamped to [0, N-1]. Matches the convention used by Prometheus
+	// histogram_quantile for under-resolution buckets and produces stable values for small N. The 0.5 + truncation produces
+	// banker's-style rounding without pulling in math.Round.
+	const halfStep = 0.5
+	const percentageScale = 100.0
+	rank := int((p/percentageScale)*float64(len(sorted)) + halfStep)
+	if rank >= len(sorted) {
+		rank = len(sorted) - 1
+	}
+	return sorted[rank]
+}
+
+// enrollOne hits /api/enroll for a single host_id and returns the issued host_token. Bounded retry: enrollment under fan-in can
+// temporarily 429 if many hosts arrive in the same second; one short backoff covers that without papering over real failures.
+func enrollOne(ctx context.Context, client *http.Client, serverURL, enrollSecret, hostID string) (string, error) {
+	body, _ := json.Marshal(map[string]string{
+		"enroll_secret": enrollSecret,
+		"hardware_uuid": hostID,
+		"hostname":      "scale-" + hostID + ".local",
+		"agent_version": "scale-driver",
+		"os_version":    "macOS 14.0",
+	})
+	var lastErr error
+	for range enrollRetries {
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, serverURL+"/api/enroll",
+			bytes.NewReader(body))
+		if err != nil {
+			return "", err
+		}
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := client.Do(req)
+		if err != nil {
+			lastErr = err
+			if err := sleepCtx(ctx, enrollRetryConnGap); err != nil {
+				return "", err
+			}
+			continue
+		}
+		if resp.StatusCode == http.StatusTooManyRequests {
+			_ = resp.Body.Close()
+			lastErr = errors.New("HTTP 429 from /api/enroll")
+			if err := sleepCtx(ctx, enrollRetry429Gap); err != nil {
+				return "", err
+			}
+			continue
+		}
+		if resp.StatusCode != http.StatusOK {
+			_ = resp.Body.Close()
+			return "", fmt.Errorf("/api/enroll HTTP %d", resp.StatusCode)
+		}
+		var er struct {
+			HostID    string `json:"host_id"`
+			HostToken string `json:"host_token"`
+		}
+		err = json.NewDecoder(resp.Body).Decode(&er)
+		_ = resp.Body.Close()
+		if err != nil {
+			return "", fmt.Errorf("decode enroll response: %w", err)
+		}
+		if er.HostToken == "" {
+			return "", errors.New("enroll response missing host_token")
+		}
+		return er.HostToken, nil
+	}
+	return "", lastErr
+}
+
+func defaultOptions(o Options) Options {
+	if o.HostCount == 0 {
+		o.HostCount = defaultHostCount
+	}
+	if o.QuietRatio == 0 {
+		o.QuietRatio = defaultQuietRatio
+	}
+	if o.Duration == 0 {
+		o.Duration = defaultDuration
+	}
+	if o.QuietIterationGap == 0 {
+		o.QuietIterationGap = defaultQuietIterationGap
+	}
+	if o.ActiveIterationGap == 0 {
+		o.ActiveIterationGap = defaultActiveIterationGap
+	}
+	if o.PassP99 == 0 {
+		o.PassP99 = defaultPassP99
+	}
+	return o
+}
+
+func loadScenarios(opts Options) (*fakeagent.Scenario, []*fakeagent.Scenario, error) {
+	var quiet *fakeagent.Scenario
+	if opts.QuietRatio > 0 {
+		s, err := fakeagent.LoadScenario(opts.QuietScenarioPath)
+		if err != nil {
+			return nil, nil, fmt.Errorf("load quiet scenario: %w", err)
+		}
+		quiet = s
+	}
+	active := make([]*fakeagent.Scenario, 0, len(opts.ActiveScenarioPaths))
+	for _, p := range opts.ActiveScenarioPaths {
+		s, err := fakeagent.LoadScenario(p)
+		if err != nil {
+			return nil, nil, fmt.Errorf("load active scenario %s: %w", p, err)
+		}
+		active = append(active, s)
+	}
+	return quiet, active, nil
+}
+
+// buildHTTPClient returns a client tuned for parallel small-batch POSTs: tight per-request timeout, no idle-connection ceiling
+// (every host keeps its own keep-alive open), and optional self-signed TLS skip for dev:server.
+func buildHTTPClient(insecure bool) *http.Client {
+	tr := &http.Transport{
+		MaxIdleConns:        httpMaxIdle,
+		MaxIdleConnsPerHost: httpMaxIdle,
+		IdleConnTimeout:     httpIdleTimeout,
+	}
+	if insecure {
+		tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} //nolint:gosec // dev:server mkcert path; opt-in via flag
+	}
+	return &http.Client{Timeout: httpClientTimeout, Transport: tr}
+}
+
+func sleepCtx(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return nil
+	}
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-t.C:
+		return nil
+	}
+}
+
+// hashSeed is a tiny FNV-1a-ish hash over the hostID so each host gets a deterministic but distinct PRNG seed without pulling in
+// hash/fnv (the seed has no security value; collisions are not catastrophic).
+func hashSeed(s string) int64 {
+	var h int64 = 1469598103934665603
+	for _, c := range []byte(s) {
+		h ^= int64(c)
+		h *= 1099511628211
+	}
+	return h
+}

--- a/test/scale/runner.go
+++ b/test/scale/runner.go
@@ -137,6 +137,9 @@ func Run(ctx context.Context, opts Options) (Report, error) {
 		return Report{}, errors.New("scale: EnrollSecret is required")
 	}
 	opts = defaultOptions(opts)
+	if opts.QuietRatio < 0 || opts.QuietRatio > 1 {
+		return Report{}, fmt.Errorf("scale: QuietRatio must be in [0,1], got %v", opts.QuietRatio)
+	}
 	if opts.QuietRatio > 0 && opts.QuietScenarioPath == "" {
 		return Report{}, errors.New("scale: QuietScenarioPath is required when QuietRatio > 0")
 	}
@@ -225,9 +228,13 @@ func (h *hostState) run(ctx context.Context, serverURL, enrollSecret string, cli
 
 	for ctx.Err() == nil {
 		start := time.Now()
+		// Thread the runner's shared http.Client through PostDirect via WithHTTPClient so the optional --insecure-tls
+		// configuration applies to /api/events POSTs (not just /api/enroll). Without this option, fakeagent's PostDirect
+		// would build its own default *http.Client and lose the TLS skip required for dev:server's mkcert-signed cert.
 		err := h.scenario.PostDirect(ctx, serverURL, token,
 			fakeagent.WithHostID(h.hostID),
 			fakeagent.WithStartTime(start),
+			fakeagent.WithHTTPClient(client),
 		)
 		latency := time.Since(start)
 		h.mu.Lock()
@@ -340,6 +347,7 @@ func percentileSorted(sorted []time.Duration, p float64) time.Duration {
 
 // enrollOne hits /api/enroll for a single host_id and returns the issued host_token. Bounded retry: enrollment under fan-in can
 // temporarily 429 if many hosts arrive in the same second; one short backoff covers that without papering over real failures.
+// The retry-vs-terminal classification is delegated to enrollAttempt so this loop stays under the cognitive-complexity budget.
 func enrollOne(ctx context.Context, client *http.Client, serverURL, enrollSecret, hostID string) (string, error) {
 	body, _ := json.Marshal(map[string]string{
 		"enroll_secret": enrollSecret,
@@ -350,47 +358,52 @@ func enrollOne(ctx context.Context, client *http.Client, serverURL, enrollSecret
 	})
 	var lastErr error
 	for range enrollRetries {
-		req, err := http.NewRequestWithContext(ctx, http.MethodPost, serverURL+"/api/enroll",
-			bytes.NewReader(body))
-		if err != nil {
+		token, retryGap, err := enrollAttempt(ctx, client, serverURL, body)
+		if err == nil {
+			return token, nil
+		}
+		lastErr = err
+		if retryGap <= 0 {
+			// enrollAttempt classified this as terminal (4xx other than 429, decode failure, missing token, request build error).
 			return "", err
 		}
-		req.Header.Set("Content-Type", "application/json")
-		resp, err := client.Do(req)
-		if err != nil {
-			lastErr = err
-			if err := sleepCtx(ctx, enrollRetryConnGap); err != nil {
-				return "", err
-			}
-			continue
+		if err := sleepCtx(ctx, retryGap); err != nil {
+			return "", err
 		}
-		if resp.StatusCode == http.StatusTooManyRequests {
-			_ = resp.Body.Close()
-			lastErr = errors.New("HTTP 429 from /api/enroll")
-			if err := sleepCtx(ctx, enrollRetry429Gap); err != nil {
-				return "", err
-			}
-			continue
-		}
-		if resp.StatusCode != http.StatusOK {
-			_ = resp.Body.Close()
-			return "", fmt.Errorf("/api/enroll HTTP %d", resp.StatusCode)
-		}
-		var er struct {
-			HostID    string `json:"host_id"`
-			HostToken string `json:"host_token"`
-		}
-		err = json.NewDecoder(resp.Body).Decode(&er)
-		_ = resp.Body.Close()
-		if err != nil {
-			return "", fmt.Errorf("decode enroll response: %w", err)
-		}
-		if er.HostToken == "" {
-			return "", errors.New("enroll response missing host_token")
-		}
-		return er.HostToken, nil
 	}
 	return "", lastErr
+}
+
+// enrollAttempt runs a single /api/enroll POST. Returns (token, 0, nil) on success; (_, retryGap > 0, err) when the caller
+// should sleep retryGap and retry (transport error or 429); (_, 0, err) on terminal failure.
+func enrollAttempt(ctx context.Context, client *http.Client, serverURL string, body []byte) (string, time.Duration, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, serverURL+"/api/enroll", bytes.NewReader(body))
+	if err != nil {
+		return "", 0, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", enrollRetryConnGap, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusTooManyRequests {
+		return "", enrollRetry429Gap, errors.New("HTTP 429 from /api/enroll")
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", 0, fmt.Errorf("/api/enroll HTTP %d", resp.StatusCode)
+	}
+	var er struct {
+		HostID    string `json:"host_id"`
+		HostToken string `json:"host_token"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&er); err != nil {
+		return "", 0, fmt.Errorf("decode enroll response: %w", err)
+	}
+	if er.HostToken == "" {
+		return "", 0, errors.New("enroll response missing host_token")
+	}
+	return er.HostToken, 0, nil
 }
 
 func defaultOptions(o Options) Options {
@@ -437,6 +450,11 @@ func loadScenarios(opts Options) (*fakeagent.Scenario, []*fakeagent.Scenario, er
 
 // buildHTTPClient returns a client tuned for parallel small-batch POSTs: tight per-request timeout, no idle-connection ceiling
 // (every host keeps its own keep-alive open), and optional self-signed TLS skip for dev:server.
+//
+// The TLS-skip branch trips three Sonar/CodeQL rules (go:S4830 server-cert validation, go:S5527 hostname verification, gosec
+// G402). They are intentional and opt-in: the scaledriver CLI default is `--insecure-tls=false`, and the only documented
+// use case is talking to a local dev:server whose cert is signed by mkcert and not yet in the system trust store. A real
+// scale run against a production server passes the default (`false`) and the InsecureSkipVerify=true branch never executes.
 func buildHTTPClient(insecure bool) *http.Client {
 	tr := &http.Transport{
 		MaxIdleConns:        httpMaxIdle,
@@ -444,7 +462,7 @@ func buildHTTPClient(insecure bool) *http.Client {
 		IdleConnTimeout:     httpIdleTimeout,
 	}
 	if insecure {
-		tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} //nolint:gosec // dev:server mkcert path; opt-in via flag
+		tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} //nolint:gosec // documented opt-in for dev:server mkcert cert; NOSONAR
 	}
 	return &http.Client{Timeout: httpClientTimeout, Transport: tr}
 }

--- a/test/scale/scale_test.go
+++ b/test/scale/scale_test.go
@@ -4,8 +4,8 @@
 // and asserts that observations land without errors and the latency budget holds. The full 100-host x 30-min baseline run lives
 // in test/scale/baselines/ and is invoked manually via `task uat:scale`; this test exists to prove the harness itself does not rot.
 //
-// Build tag: `integration` matches the existing test/integration suite gate. CI's server-test job picks this up automatically via
-// `./test/integration/...` plus `./test/scale/...` globs.
+// Build tag: `integration` matches the existing test/integration suite gate. The CI server-test job picks this up via the
+// `./test/scale/...` glob in Taskfile.yml's test:go:server:coverage target.
 package scale_test
 
 import (
@@ -21,44 +21,64 @@ import (
 	"github.com/fleetdm/edr/test/scale"
 )
 
-func TestM12_SmokeFiveHostsFiveSeconds(t *testing.T) {
-	if testing.Short() {
-		t.Skip("scale smoke skipped under -short")
+// Table-driven shape per CLAUDE.md's repo testing convention; even with one case today it gives an obvious extension point for
+// variant smoke profiles (e.g. quiet-only, active-only, larger fan-out) without duplicating setup or assertions.
+func TestM12_Smoke(t *testing.T) {
+	repoRoot := filepath.Join("..", "..")
+	cases := []struct {
+		name             string
+		opts             scale.Options
+		expectQuietHosts int
+		expectActive     int
+		minObservations  int
+	}{
+		{
+			name: "five hosts five seconds: mixed quiet + active",
+			opts: scale.Options{
+				HostCount:  5,
+				QuietRatio: 0.6, // 3 quiet, 2 active
+				Duration:   5 * time.Second,
+				QuietScenarioPath: filepath.Join(repoRoot,
+					"test", "fakeagent", "scenarios", "quiet-host.yaml"),
+				ActiveScenarioPaths: []string{
+					filepath.Join(repoRoot, "test", "efficacy", "corpus", "T1059-suspicious-exec", "scenario.yaml"),
+					filepath.Join(repoRoot, "test", "efficacy", "corpus", "T1543.001-launchagent-persistence", "scenario.yaml"),
+				},
+				QuietIterationGap:  500 * time.Millisecond,
+				ActiveIterationGap: 200 * time.Millisecond,
+				// Smoke runs against an in-process httptest server; budget is generous because the per-test MySQL container
+				// can be slow under suite-wide load. The plan's 250ms budget applies only to the dedicated dev-box run.
+				PassP99: 2 * time.Second,
+			},
+			expectQuietHosts: 3,
+			expectActive:     2,
+			minObservations:  5, // every host posts at least once in 5s
+		},
 	}
 
-	stack := integration.Setup(t)
-	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
-	defer cancel()
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			stack := integration.Setup(t)
+			ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+			defer cancel()
 
-	// Repo-relative paths resolved from this file's location (test/scale/). Pre-existing scenarios; no duplication.
-	repoRoot := filepath.Join("..", "..")
-	rep, err := scale.Run(ctx, scale.Options{
-		ServerURL:    stack.Server.URL,
-		EnrollSecret: integration.EnrollSecret,
-		HostCount:    5,
-		QuietRatio:   0.6, // 3 quiet, 2 active
-		Duration:     5 * time.Second,
-		QuietScenarioPath: filepath.Join(repoRoot,
-			"test", "fakeagent", "scenarios", "quiet-host.yaml"),
-		ActiveScenarioPaths: []string{
-			filepath.Join(repoRoot, "test", "efficacy", "corpus", "T1059-suspicious-exec", "scenario.yaml"),
-			filepath.Join(repoRoot, "test", "efficacy", "corpus", "T1543.001-launchagent-persistence", "scenario.yaml"),
-		},
-		QuietIterationGap:  500 * time.Millisecond,
-		ActiveIterationGap: 200 * time.Millisecond,
-		// Smoke runs against an in-process httptest server; budget is generous because the per-test MySQL container can be slow
-		// under suite-wide load. The plan's 250ms budget applies only to the dedicated dev-box baseline run.
-		PassP99: 2 * time.Second,
-	})
-	require.NoError(t, err, "scale.Run smoke")
+			opts := tc.opts
+			opts.ServerURL = stack.Server.URL
+			opts.EnrollSecret = integration.EnrollSecret
 
-	t.Logf("smoke: %d hosts, %d observations, p50=%s p95=%s p99=%s errors=%d",
-		rep.HostCount, rep.ObservationCount, rep.LatencyP50, rep.LatencyP95, rep.LatencyP99, rep.ErrorCount)
-	assert.Equal(t, 5, rep.HostCount, "host count mirrored into report")
-	assert.Equal(t, 3, rep.QuietHostCount)
-	assert.Equal(t, 2, rep.ActiveHostCount)
-	assert.Zero(t, rep.ErrorCount, "no errors under smoke load; last error per host in PerHost")
-	assert.GreaterOrEqual(t, rep.ObservationCount, 5, "every host posts at least once in 5s")
-	assert.True(t, rep.Pass, "smoke must pass; FailReasons=%v", rep.FailReasons)
-	assert.LessOrEqual(t, rep.LatencyP99, 2*time.Second, "smoke p99 must fit the generous budget")
+			rep, err := scale.Run(ctx, opts)
+			require.NoError(t, err, "scale.Run smoke")
+
+			t.Logf("smoke: %d hosts, %d observations, p50=%s p95=%s p99=%s errors=%d",
+				rep.HostCount, rep.ObservationCount, rep.LatencyP50, rep.LatencyP95, rep.LatencyP99, rep.ErrorCount)
+			assert.Equal(t, opts.HostCount, rep.HostCount, "host count mirrored into report")
+			assert.Equal(t, tc.expectQuietHosts, rep.QuietHostCount)
+			assert.Equal(t, tc.expectActive, rep.ActiveHostCount)
+			assert.Zero(t, rep.ErrorCount, "no errors under smoke load; last error per host is in PerHost")
+			assert.GreaterOrEqual(t, rep.ObservationCount, tc.minObservations,
+				"every host should post at least once within the lane")
+			assert.True(t, rep.Pass, "smoke must pass; FailReasons=%v", rep.FailReasons)
+			assert.LessOrEqual(t, rep.LatencyP99, opts.PassP99, "smoke p99 must fit the generous budget")
+		})
+	}
 }

--- a/test/scale/scale_test.go
+++ b/test/scale/scale_test.go
@@ -1,0 +1,64 @@
+//go:build integration
+
+// Per-PR smoke of the M12 scale runner. Boots an integration.Setup Stack, fans out a small number of hosts for a short duration,
+// and asserts that observations land without errors and the latency budget holds. The full 100-host x 30-min baseline run lives
+// in test/scale/baselines/ and is invoked manually via `task uat:scale`; this test exists to prove the harness itself does not rot.
+//
+// Build tag: `integration` matches the existing test/integration suite gate. CI's server-test job picks this up automatically via
+// `./test/integration/...` plus `./test/scale/...` globs.
+package scale_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fleetdm/edr/test/integration"
+	"github.com/fleetdm/edr/test/scale"
+)
+
+func TestM12_SmokeFiveHostsFiveSeconds(t *testing.T) {
+	if testing.Short() {
+		t.Skip("scale smoke skipped under -short")
+	}
+
+	stack := integration.Setup(t)
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+
+	// Repo-relative paths resolved from this file's location (test/scale/). Pre-existing scenarios; no duplication.
+	repoRoot := filepath.Join("..", "..")
+	rep, err := scale.Run(ctx, scale.Options{
+		ServerURL:    stack.Server.URL,
+		EnrollSecret: integration.EnrollSecret,
+		HostCount:    5,
+		QuietRatio:   0.6, // 3 quiet, 2 active
+		Duration:     5 * time.Second,
+		QuietScenarioPath: filepath.Join(repoRoot,
+			"test", "fakeagent", "scenarios", "quiet-host.yaml"),
+		ActiveScenarioPaths: []string{
+			filepath.Join(repoRoot, "test", "efficacy", "corpus", "T1059-suspicious-exec", "scenario.yaml"),
+			filepath.Join(repoRoot, "test", "efficacy", "corpus", "T1543.001-launchagent-persistence", "scenario.yaml"),
+		},
+		QuietIterationGap:  500 * time.Millisecond,
+		ActiveIterationGap: 200 * time.Millisecond,
+		// Smoke runs against an in-process httptest server; budget is generous because the per-test MySQL container can be slow
+		// under suite-wide load. The plan's 250ms budget applies only to the dedicated dev-box baseline run.
+		PassP99: 2 * time.Second,
+	})
+	require.NoError(t, err, "scale.Run smoke")
+
+	t.Logf("smoke: %d hosts, %d observations, p50=%s p95=%s p99=%s errors=%d",
+		rep.HostCount, rep.ObservationCount, rep.LatencyP50, rep.LatencyP95, rep.LatencyP99, rep.ErrorCount)
+	assert.Equal(t, 5, rep.HostCount, "host count mirrored into report")
+	assert.Equal(t, 3, rep.QuietHostCount)
+	assert.Equal(t, 2, rep.ActiveHostCount)
+	assert.Zero(t, rep.ErrorCount, "no errors under smoke load; last error per host in PerHost")
+	assert.GreaterOrEqual(t, rep.ObservationCount, 5, "every host posts at least once in 5s")
+	assert.True(t, rep.Pass, "smoke must pass; FailReasons=%v", rep.FailReasons)
+	assert.LessOrEqual(t, rep.LatencyP99, 2*time.Second, "smoke p99 must fit the generous budget")
+}

--- a/test/scale/scaledriver/main.go
+++ b/test/scale/scaledriver/main.go
@@ -1,0 +1,154 @@
+// Command scaledriver runs the M12 scale-test harness against an existing server. Boots no infrastructure of its own: the caller
+// stands up the server (task dev:server or a release-candidate container), and this binary fans out N simulated hosts against
+// the URL. Outputs a JSON report on stdout and (optionally) writes the same JSON to --output. Exit code is 0 on pass, 2 on fail.
+//
+// Defaults match the v0.1.0 baseline target: 100 hosts, 80/20 quiet/active mix, 5 minutes wall clock, p99 budget 250ms. The
+// 30-minute baseline run the plan calls out is invoked via --duration=30m.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/fleetdm/edr/test/scale"
+)
+
+// Defaults pulled out as named constants so the mnd linter's blanket objection lands once and the CLI flag block stays
+// concise. None are security-sensitive; tweak via flags at the call site.
+const (
+	defaultHosts      = 100
+	defaultQuietRatio = 0.8
+	defaultDuration   = 5 * time.Minute
+	defaultQuietGap   = 5 * time.Second
+	defaultActiveGap  = 1 * time.Second
+	defaultPassP99    = 250 * time.Millisecond
+	exitFail          = 2
+)
+
+func main() {
+	err := run()
+	switch {
+	case err == nil:
+		return
+	case errors.Is(err, errFail):
+		os.Exit(exitFail)
+	default:
+		fmt.Fprintln(os.Stderr, "scaledriver:", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	envEnrollSecret := os.Getenv("EDR_ENROLL_SECRET") //nolint:forbidigo // approved CLI-binary wiring boundary; see issue #172
+	serverURL := flag.String("server-url", "https://localhost:8088", "EDR server base URL (no trailing slash)")
+	enrollSecret := flag.String("enroll-secret", envEnrollSecret,
+		"shared enroll secret (default from EDR_ENROLL_SECRET)")
+	hostCount := flag.Int("hosts", defaultHosts, "number of simulated hosts")
+	quietRatio := flag.Float64("quiet-ratio", defaultQuietRatio,
+		"fraction of hosts assigned the quiet scenario; rest cycle active scenarios")
+	duration := flag.Duration("duration", defaultDuration, "wall-clock duration of the load lane")
+	quietGap := flag.Duration("quiet-gap", defaultQuietGap,
+		"sleep between scenario iterations on quiet hosts (jittered +/- 25%)")
+	activeGap := flag.Duration("active-gap", defaultActiveGap,
+		"sleep between scenario iterations on active hosts (jittered +/- 25%)")
+	passP99 := flag.Duration("pass-p99", defaultPassP99, "p99 ingest latency budget; exit 2 if exceeded")
+	allowInsecure := flag.Bool("insecure-tls", true, "skip TLS verification (default true for dev:server's mkcert path)")
+	scenarioDir := flag.String("scenario-dir", "", "root of scenario tree (defaults to repo-relative paths)")
+	quietScenario := flag.String("quiet-scenario", "test/fakeagent/scenarios/quiet-host.yaml", "path to quiet-host scenario")
+	activeScenarios := flag.String("active-scenarios", strings.Join([]string{
+		"test/efficacy/corpus/T1059-suspicious-exec/scenario.yaml",
+		"test/efficacy/corpus/T1543.001-launchagent-persistence/scenario.yaml",
+		"test/efficacy/corpus/T1548.003-sudoers-tamper/scenario.yaml",
+		"test/efficacy/corpus/T1555.001-keychain-dump/scenario.yaml",
+	}, ","), "comma-separated active scenario paths cycled across active hosts")
+	output := flag.String("output", "", "write the JSON report to this file in addition to stdout")
+	flag.Parse()
+
+	if *enrollSecret == "" {
+		return errors.New("--enroll-secret (or EDR_ENROLL_SECRET) is required")
+	}
+
+	quietPath := *quietScenario
+	if *scenarioDir != "" {
+		quietPath = filepath.Join(*scenarioDir, quietPath)
+	}
+	activePaths := strings.Split(*activeScenarios, ",")
+	for i, p := range activePaths {
+		activePaths[i] = strings.TrimSpace(p)
+		if *scenarioDir != "" {
+			activePaths[i] = filepath.Join(*scenarioDir, activePaths[i])
+		}
+	}
+
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
+	fmt.Fprintf(os.Stderr, "scaledriver: %d hosts (%.0f%% quiet), %s, p99 budget %s vs %s\n",
+		*hostCount, *quietRatio*100, *duration, *passP99, *serverURL)
+
+	rep, err := scale.Run(ctx, scale.Options{
+		ServerURL:           *serverURL,
+		EnrollSecret:        *enrollSecret,
+		HostCount:           *hostCount,
+		QuietRatio:          *quietRatio,
+		Duration:            *duration,
+		QuietScenarioPath:   quietPath,
+		ActiveScenarioPaths: activePaths,
+		QuietIterationGap:   *quietGap,
+		ActiveIterationGap:  *activeGap,
+		AllowInsecureTLS:    *allowInsecure,
+		PassP99:             *passP99,
+	})
+	if err != nil && !errors.Is(err, context.Canceled) {
+		return err
+	}
+
+	if err := writeReport(os.Stdout, rep); err != nil {
+		return err
+	}
+	if *output != "" {
+		f, err := os.Create(*output) //nolint:gosec // output is a CLI-controlled path
+		if err != nil {
+			return fmt.Errorf("open --output: %w", err)
+		}
+		if err := writeReport(f, rep); err != nil {
+			_ = f.Close()
+			return err
+		}
+		if err := f.Close(); err != nil {
+			return fmt.Errorf("close --output: %w", err)
+		}
+	}
+
+	fmt.Fprintf(os.Stderr, "scaledriver: pass=%t p50=%s p95=%s p99=%s max=%s obs=%d errors=%d obs/sec=%.1f\n",
+		rep.Pass, rep.LatencyP50, rep.LatencyP95, rep.LatencyP99, rep.LatencyMax,
+		rep.ObservationCount, rep.ErrorCount, rep.ObservationsPerSec)
+	if !rep.Pass {
+		fmt.Fprintln(os.Stderr, "scaledriver: FAIL")
+		for _, r := range rep.FailReasons {
+			fmt.Fprintln(os.Stderr, "  -", r)
+		}
+		return errFail
+	}
+	return nil
+}
+
+// errFail is the sentinel returned for a clean fail-criteria breach. main() maps it to exit code 2 so the gocritic
+// exitAfterDefer warning doesn't fire on an os.Exit() inline (defer cancel() in run() would otherwise be skipped).
+var errFail = errors.New("scale criteria breached")
+
+func writeReport(w io.Writer, rep scale.Report) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(rep)
+}

--- a/test/scale/scaledriver/main.go
+++ b/test/scale/scaledriver/main.go
@@ -35,6 +35,24 @@ const (
 	exitFail          = 2
 )
 
+// flagSet is the resolved CLI flag values + the runtime-only env-derived defaults. Parsing into a struct keeps run() under
+// the cognitive-complexity budget: flag boilerplate moves to parseFlags, run() becomes orchestration.
+type flagSet struct {
+	serverURL       string
+	enrollSecret    string
+	hostCount       int
+	quietRatio      float64
+	duration        time.Duration
+	quietGap        time.Duration
+	activeGap       time.Duration
+	passP99         time.Duration
+	allowInsecure   bool
+	scenarioDir     string
+	quietScenario   string
+	activeScenarios string
+	output          string
+}
+
 func main() {
 	err := run()
 	switch {
@@ -49,85 +67,40 @@ func main() {
 }
 
 func run() error {
-	envEnrollSecret := os.Getenv("EDR_ENROLL_SECRET") //nolint:forbidigo // approved CLI-binary wiring boundary; see issue #172
-	serverURL := flag.String("server-url", "https://localhost:8088", "EDR server base URL (no trailing slash)")
-	enrollSecret := flag.String("enroll-secret", envEnrollSecret,
-		"shared enroll secret (default from EDR_ENROLL_SECRET)")
-	hostCount := flag.Int("hosts", defaultHosts, "number of simulated hosts")
-	quietRatio := flag.Float64("quiet-ratio", defaultQuietRatio,
-		"fraction of hosts assigned the quiet scenario; rest cycle active scenarios")
-	duration := flag.Duration("duration", defaultDuration, "wall-clock duration of the load lane")
-	quietGap := flag.Duration("quiet-gap", defaultQuietGap,
-		"sleep between scenario iterations on quiet hosts (jittered +/- 25%)")
-	activeGap := flag.Duration("active-gap", defaultActiveGap,
-		"sleep between scenario iterations on active hosts (jittered +/- 25%)")
-	passP99 := flag.Duration("pass-p99", defaultPassP99, "p99 ingest latency budget; exit 2 if exceeded")
-	allowInsecure := flag.Bool("insecure-tls", true, "skip TLS verification (default true for dev:server's mkcert path)")
-	scenarioDir := flag.String("scenario-dir", "", "root of scenario tree (defaults to repo-relative paths)")
-	quietScenario := flag.String("quiet-scenario", "test/fakeagent/scenarios/quiet-host.yaml", "path to quiet-host scenario")
-	activeScenarios := flag.String("active-scenarios", strings.Join([]string{
-		"test/efficacy/corpus/T1059-suspicious-exec/scenario.yaml",
-		"test/efficacy/corpus/T1543.001-launchagent-persistence/scenario.yaml",
-		"test/efficacy/corpus/T1548.003-sudoers-tamper/scenario.yaml",
-		"test/efficacy/corpus/T1555.001-keychain-dump/scenario.yaml",
-	}, ","), "comma-separated active scenario paths cycled across active hosts")
-	output := flag.String("output", "", "write the JSON report to this file in addition to stdout")
-	flag.Parse()
-
-	if *enrollSecret == "" {
+	fs := parseFlags()
+	if fs.enrollSecret == "" {
 		return errors.New("--enroll-secret (or EDR_ENROLL_SECRET) is required")
 	}
-
-	quietPath := *quietScenario
-	if *scenarioDir != "" {
-		quietPath = filepath.Join(*scenarioDir, quietPath)
-	}
-	activePaths := strings.Split(*activeScenarios, ",")
-	for i, p := range activePaths {
-		activePaths[i] = strings.TrimSpace(p)
-		if *scenarioDir != "" {
-			activePaths[i] = filepath.Join(*scenarioDir, activePaths[i])
-		}
+	quietPath, activePaths, err := resolveScenarioPaths(fs)
+	if err != nil {
+		return err
 	}
 
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
 
 	fmt.Fprintf(os.Stderr, "scaledriver: %d hosts (%.0f%% quiet), %s, p99 budget %s vs %s\n",
-		*hostCount, *quietRatio*100, *duration, *passP99, *serverURL)
+		fs.hostCount, fs.quietRatio*100, fs.duration, fs.passP99, fs.serverURL)
 
 	rep, err := scale.Run(ctx, scale.Options{
-		ServerURL:           *serverURL,
-		EnrollSecret:        *enrollSecret,
-		HostCount:           *hostCount,
-		QuietRatio:          *quietRatio,
-		Duration:            *duration,
+		ServerURL:           fs.serverURL,
+		EnrollSecret:        fs.enrollSecret,
+		HostCount:           fs.hostCount,
+		QuietRatio:          fs.quietRatio,
+		Duration:            fs.duration,
 		QuietScenarioPath:   quietPath,
 		ActiveScenarioPaths: activePaths,
-		QuietIterationGap:   *quietGap,
-		ActiveIterationGap:  *activeGap,
-		AllowInsecureTLS:    *allowInsecure,
-		PassP99:             *passP99,
+		QuietIterationGap:   fs.quietGap,
+		ActiveIterationGap:  fs.activeGap,
+		AllowInsecureTLS:    fs.allowInsecure,
+		PassP99:             fs.passP99,
 	})
 	if err != nil && !errors.Is(err, context.Canceled) {
 		return err
 	}
 
-	if err := writeReport(os.Stdout, rep); err != nil {
+	if err := emitReport(rep, fs.output); err != nil {
 		return err
-	}
-	if *output != "" {
-		f, err := os.Create(*output) //nolint:gosec // output is a CLI-controlled path
-		if err != nil {
-			return fmt.Errorf("open --output: %w", err)
-		}
-		if err := writeReport(f, rep); err != nil {
-			_ = f.Close()
-			return err
-		}
-		if err := f.Close(); err != nil {
-			return fmt.Errorf("close --output: %w", err)
-		}
 	}
 
 	fmt.Fprintf(os.Stderr, "scaledriver: pass=%t p50=%s p95=%s p99=%s max=%s obs=%d errors=%d obs/sec=%.1f\n",
@@ -139,6 +112,89 @@ func run() error {
 			fmt.Fprintln(os.Stderr, "  -", r)
 		}
 		return errFail
+	}
+	return nil
+}
+
+// parseFlags wires every CLI flag onto a flagSet and calls flag.Parse(). Lives as its own helper so run() stays under the
+// cognitive-complexity budget; the env-default fallback for EDR_ENROLL_SECRET also lives here for the same reason.
+func parseFlags() flagSet {
+	var fs flagSet
+	envSecret := os.Getenv("EDR_ENROLL_SECRET") //nolint:forbidigo // approved CLI-binary wiring boundary; see issue #172
+	flag.StringVar(&fs.serverURL, "server-url", "https://localhost:8088", "EDR server base URL (no trailing slash)")
+	flag.StringVar(&fs.enrollSecret, "enroll-secret", envSecret, "shared enroll secret (default from EDR_ENROLL_SECRET)")
+	flag.IntVar(&fs.hostCount, "hosts", defaultHosts, "number of simulated hosts")
+	flag.Float64Var(&fs.quietRatio, "quiet-ratio", defaultQuietRatio,
+		"fraction of hosts assigned the quiet scenario; rest cycle active scenarios")
+	flag.DurationVar(&fs.duration, "duration", defaultDuration, "wall-clock duration of the load lane")
+	flag.DurationVar(&fs.quietGap, "quiet-gap", defaultQuietGap,
+		"sleep between scenario iterations on quiet hosts (jittered +/- 25%)")
+	flag.DurationVar(&fs.activeGap, "active-gap", defaultActiveGap,
+		"sleep between scenario iterations on active hosts (jittered +/- 25%)")
+	flag.DurationVar(&fs.passP99, "pass-p99", defaultPassP99, "p99 ingest latency budget; exit 2 if exceeded")
+	// Default to verifying TLS so a misconfigured caller cannot silently MITM a real server. Opt in only when targeting
+	// dev:server's mkcert cert and the cert is NOT in the system trust store. CodeRabbit + Sonar both objected to the old
+	// default-true behaviour; this flip is the resolution.
+	flag.BoolVar(&fs.allowInsecure, "insecure-tls", false,
+		"skip TLS verification (default false; opt-in for dev:server's mkcert path)")
+	flag.StringVar(&fs.scenarioDir, "scenario-dir", "", "root of scenario tree (defaults to repo-relative paths)")
+	flag.StringVar(&fs.quietScenario, "quiet-scenario", "test/fakeagent/scenarios/quiet-host.yaml",
+		"path to quiet-host scenario")
+	flag.StringVar(&fs.activeScenarios, "active-scenarios", strings.Join([]string{
+		"test/efficacy/corpus/T1059-suspicious-exec/scenario.yaml",
+		"test/efficacy/corpus/T1543.001-launchagent-persistence/scenario.yaml",
+		"test/efficacy/corpus/T1548.003-sudoers-tamper/scenario.yaml",
+		"test/efficacy/corpus/T1555.001-keychain-dump/scenario.yaml",
+	}, ","), "comma-separated active scenario paths cycled across active hosts")
+	flag.StringVar(&fs.output, "output", "", "write the JSON report to this file in addition to stdout")
+	flag.Parse()
+	return fs
+}
+
+// resolveScenarioPaths trims and prefixes scenario paths against the optional --scenario-dir root, dropping empty entries
+// from the active-scenarios comma list (a trailing comma is otherwise expanded into an empty path and failed later with a
+// less-clear error). Returns the quiet path plus a non-empty list of active paths.
+func resolveScenarioPaths(fs flagSet) (string, []string, error) {
+	quiet := fs.quietScenario
+	if fs.scenarioDir != "" {
+		quiet = filepath.Join(fs.scenarioDir, quiet)
+	}
+	raw := strings.Split(fs.activeScenarios, ",")
+	active := make([]string, 0, len(raw))
+	for _, p := range raw {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		if fs.scenarioDir != "" {
+			p = filepath.Join(fs.scenarioDir, p)
+		}
+		active = append(active, p)
+	}
+	if fs.quietRatio < 1 && len(active) == 0 {
+		return "", nil, errors.New("--active-scenarios must contain at least one path when quiet-ratio < 1")
+	}
+	return quiet, active, nil
+}
+
+// emitReport writes the JSON report to stdout and (optionally) the --output file. Split out so run()'s body stays linear.
+func emitReport(rep scale.Report, outPath string) error {
+	if err := writeReport(os.Stdout, rep); err != nil {
+		return err
+	}
+	if outPath == "" {
+		return nil
+	}
+	f, err := os.Create(outPath) //nolint:gosec // output is a CLI-controlled path
+	if err != nil {
+		return fmt.Errorf("open --output: %w", err)
+	}
+	if err := writeReport(f, rep); err != nil {
+		_ = f.Close()
+		return err
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("close --output: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
UAT plan milestone M12 first cut. Adds test/scale/, a scale lane that fans out N simulated EDR hosts against one server for D wall-clock duration, records client-observed POST /api/events p50/p95/p99, and asserts the documented gate (p99 < 250ms, zero errors).

Lives as a Go package + binary + integration test:

  test/scale/runner.go             scale.Run(ctx, Options) -> Report
  test/scale/scaledriver/main.go   binary; flags map onto runner.Options
  test/scale/scale_test.go         per-PR smoke (5 hosts x 5s, integration tag)
  test/scale/README.md             how to run, defaults, what's deferred
  test/scale/baselines/README.md   baseline capture procedure (jq strip per_host)

Wiring: `task uat:scale` is a Taskfile pass-through to `go run scaledriver`; default 100 hosts x 5 min against https://localhost:8088, plan's 30-min baseline run via --duration=30m. The driver inherits EDR_ENROLL_SECRET from the env (with the standard wiring-boundary nolint:forbidigo).

Load shape per the plan: 80% quiet hosts cycling fakeagent/scenarios/quiet-host on a jittered 5s cadence, 20% active hosts round-robining a curated L6 corpus subset (T1059-suspicious-exec, T1543.001-launchagent-persistence, T1548.003-sudoers-tamper, T1555.001-keychain-dump) on a jittered 1s cadence. The +/- 25% jitter de-syncs hosts so the server does not see a heartbeat-shaped fan-in spike.

Smoke verified locally: 5 hosts x 5s on an in-process integration.Setup Stack produces 78 observations, p99=22ms, 0 errors, detection pipeline fires alerts end-to-end. The smoke's PassP99 budget is loosened to 2s because the per-test MySQL container variance makes the 250ms plan budget unstable under suite-wide parallel load.

Explicitly deferred to a follow-up (noted in README + the M12 plan row):

  - Queue-depth on agents: v1 bypasses the M2 queue + uploader via PostDirect so we measure ingest fan-in cleanly; a v2 lane that drives headless.Run per host and polls /state can layer on top.
  - SigNoz server-side latency cross-check: client-observed is the gate today.
  - MySQL CPU / row count growth: operator observation during baseline capture; promote to gate when a regression case justifies them.

Goes off-piste from the plan's literal wording on one architectural choice: the plan said "--simulate-hosts=100 on the headless binary"; the implementation ships as a sibling binary at test/scale/scaledriver instead. The headless binary's main.go reads config from env, which doesn't compose with N hosts in one process; the sibling binary calls fakeagent.PostDirect directly per host so each goroutine carries its own host_id + token without per-host config threading. The fakeagent library is the shared substrate either way.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added UAT scale-testing harness with latency monitoring (p99 < 250ms enforcement) and command-line tool for running load tests against EDR servers.
  * Added integration smoke test for scale runner validation.

* **Documentation**
  * Added comprehensive scale-test documentation covering test strategy, execution modes, pass/fail criteria, scenario configuration, and baseline management.

* **Chores**
  * Updated dependencies to promote google/uuid and golang.org/x/sync to direct requirements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/getvictor/fleet-edr/pull/228?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->