### PR TITLE
M13 markers server event ingestion

### DIFF
--- a/openspec/specs/server-event-ingestion/spec.md
+++ b/openspec/specs/server-event-ingestion/spec.md
@@ -65,15 +65,21 @@ A compromised or misbehaving agent MUST NOT be able to submit events that claim 
 ### Requirement: Body size limit
 
 The system SHALL cap the bytes it reads from the request body of `POST /api/events` at 10 MB. Bodies that exceed the
-cap MUST result in HTTP 400 with a typed body-read diagnostic, and no events from that batch are persisted. A well-
-behaved agent is expected to split larger telemetry into multiple batches under the cap rather than rely on the server
-to reject oversized bodies.
+cap MUST result in HTTP 413 with a typed `body_too_large` diagnostic, and no events from that batch are persisted. The
+413 status (RFC 9110 §15.5.14) is the canonical "your body exceeded the limit" signal and matches the shape Elastic
+Fleet, Datadog, Splunk HEC, and CrowdStrike's ingestion endpoints all use; an agent that sees 413 SHOULD split larger
+telemetry into multiple batches under the cap rather than retry the same body.
+
+The system MUST enforce the cap before allocating a buffer for the body so a malicious or misconfigured caller cannot
+trigger an arbitrary-size allocation. When the request advertises `Content-Length` greater than 10 MB the system MUST
+respond with 413 without reading any of the body; when the request uses chunked transfer-encoding the system MUST
+enforce the cap via a streaming reader and respond with 413 as soon as the cap is crossed.
 
 #### Scenario: An oversized request body is rejected
 
 - **GIVEN** an authenticated agent
 - **WHEN** the request body exceeds 10 MB
-- **THEN** the system responds with HTTP 400 and a typed body-read diagnostic
+- **THEN** the system responds with HTTP 413 and the body is `{"error":"body_too_large"}`
 - **AND** no events from that batch are persisted
 
 #### Scenario: A right-at-cap body is accepted

--- a/server/detection/internal/intake/handler.go
+++ b/server/detection/internal/intake/handler.go
@@ -3,6 +3,7 @@ package intake
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"log/slog"
 	"net/http"
@@ -14,6 +15,11 @@ import (
 	endpointapi "github.com/fleetdm/edr/server/endpoint/api"
 	"github.com/fleetdm/edr/server/httpserver"
 )
+
+// MaxIngestBodyBytes is the per-request body cap on POST /api/events. The contract is documented in openspec/specs/
+// server-event-ingestion/spec.md (Body size limit requirement); see the comment on handleIngest for the enforcement shape.
+// Exported for tests that need to compose right-at-cap and over-cap bodies without duplicating the magic number.
+const MaxIngestBodyBytes = 10 * 1024 * 1024
 
 // BuildInfo is injected at startup so the readiness endpoint
 // advertises version + commit.
@@ -74,8 +80,30 @@ func (h *Handler) handleIngest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	body, err := io.ReadAll(io.LimitReader(r.Body, 10*1024*1024)) // 10 MB limit
+	// Body-size enforcement happens in two stages to match the top-EDR shape and the openspec contract:
+	//
+	//  1. Content-Length fast-path. If the client advertised a length beyond the cap, reject with HTTP 413 BEFORE
+	//     allocating any buffer. This is the cheap defence against a malicious or misconfigured caller that would
+	//     otherwise trigger a 100+ MB allocation per request.
+	//  2. Streaming enforce. For chunked transfer-encoding (no Content-Length) or a lying Content-Length header, wrap
+	//     r.Body in http.MaxBytesReader which returns a typed *http.MaxBytesError once the cap is crossed mid-stream.
+	//     The previous shape used io.LimitReader, which silently truncates: a truncated body would then fail
+	//     json.Unmarshal and surface as `invalid_json`, hiding the real cause. MaxBytesReader's distinguished error is
+	//     what makes the 413-vs-400 split honest.
+	//
+	// 413 (RFC 9110 §15.5.14) is the canonical status; matches Elastic Fleet, Datadog, Splunk HEC, CrowdStrike Falcon.
+	if r.ContentLength > MaxIngestBodyBytes {
+		writeErr(ctx, h.logger, w, http.StatusRequestEntityTooLarge, "body_too_large")
+		return
+	}
+	r.Body = http.MaxBytesReader(w, r.Body, MaxIngestBodyBytes)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			writeErr(ctx, h.logger, w, http.StatusRequestEntityTooLarge, "body_too_large")
+			return
+		}
 		writeErr(ctx, h.logger, w, http.StatusBadRequest, "read_body")
 		return
 	}

--- a/server/detection/internal/intake/handler.go
+++ b/server/detection/internal/intake/handler.go
@@ -80,31 +80,8 @@ func (h *Handler) handleIngest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Body-size enforcement happens in two stages to match the top-EDR shape and the openspec contract:
-	//
-	//  1. Content-Length fast-path. If the client advertised a length beyond the cap, reject with HTTP 413 BEFORE
-	//     allocating any buffer. This is the cheap defence against a malicious or misconfigured caller that would
-	//     otherwise trigger a 100+ MB allocation per request.
-	//  2. Streaming enforce. For chunked transfer-encoding (no Content-Length) or a lying Content-Length header, wrap
-	//     r.Body in http.MaxBytesReader which returns a typed *http.MaxBytesError once the cap is crossed mid-stream.
-	//     The previous shape used io.LimitReader, which silently truncates: a truncated body would then fail
-	//     json.Unmarshal and surface as `invalid_json`, hiding the real cause. MaxBytesReader's distinguished error is
-	//     what makes the 413-vs-400 split honest.
-	//
-	// 413 (RFC 9110 §15.5.14) is the canonical status; matches Elastic Fleet, Datadog, Splunk HEC, CrowdStrike Falcon.
-	if r.ContentLength > MaxIngestBodyBytes {
-		writeErr(ctx, h.logger, w, http.StatusRequestEntityTooLarge, "body_too_large")
-		return
-	}
-	r.Body = http.MaxBytesReader(w, r.Body, MaxIngestBodyBytes)
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		var maxErr *http.MaxBytesError
-		if errors.As(err, &maxErr) {
-			writeErr(ctx, h.logger, w, http.StatusRequestEntityTooLarge, "body_too_large")
-			return
-		}
-		writeErr(ctx, h.logger, w, http.StatusBadRequest, "read_body")
+	body, ok := h.readBodyWithCap(w, r)
+	if !ok {
 		return
 	}
 
@@ -152,6 +129,40 @@ func (h *Handler) handleIngest(w http.ResponseWriter, r *http.Request) {
 	if err := json.NewEncoder(w).Encode(map[string]int{"accepted": len(events)}); err != nil {
 		h.logger.ErrorContext(ctx, "encode response", "err", err)
 	}
+}
+
+// readBodyWithCap enforces the per-request body cap in two stages and writes the appropriate error response if either
+// stage rejects. Returns (body, true) on success or (nil, false) when the caller should return without further work.
+// Split out of handleIngest so the latter stays under the cognitive-complexity budget (go:S3776).
+//
+//  1. Content-Length fast-path. If the client advertised a length beyond the cap, reject with HTTP 413 BEFORE
+//     allocating any buffer. Cheap defense against a malicious or misconfigured caller that would otherwise trigger
+//     a 100+ MB allocation per request.
+//  2. Streaming enforce via http.MaxBytesReader. For chunked transfer-encoding (no Content-Length) or a lying
+//     Content-Length, MaxBytesReader returns a typed *http.MaxBytesError once the cap is crossed mid-stream.
+//     The previous shape used io.LimitReader, which silently truncates: a truncated body would then fail
+//     json.Unmarshal and surface as `invalid_json`, hiding the real cause. MaxBytesReader's distinguished error is
+//     what makes the 413-vs-400 split honest.
+//
+// HTTP 413 (RFC 9110 §15.5.14) is the canonical status; matches Elastic Fleet, Datadog, Splunk HEC, CrowdStrike.
+func (h *Handler) readBodyWithCap(w http.ResponseWriter, r *http.Request) ([]byte, bool) {
+	ctx := r.Context()
+	if r.ContentLength > MaxIngestBodyBytes {
+		writeErr(ctx, h.logger, w, http.StatusRequestEntityTooLarge, "body_too_large")
+		return nil, false
+	}
+	r.Body = http.MaxBytesReader(w, r.Body, MaxIngestBodyBytes)
+	body, err := io.ReadAll(r.Body)
+	if err == nil {
+		return body, true
+	}
+	var maxErr *http.MaxBytesError
+	if errors.As(err, &maxErr) {
+		writeErr(ctx, h.logger, w, http.StatusRequestEntityTooLarge, "body_too_large")
+		return nil, false
+	}
+	writeErr(ctx, h.logger, w, http.StatusBadRequest, "read_body")
+	return nil, false
 }
 
 type livezResponse struct {

--- a/server/detection/internal/mysql/store_test.go
+++ b/server/detection/internal/mysql/store_test.go
@@ -3,6 +3,9 @@ package mysql_test
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"strconv"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -111,6 +114,88 @@ func TestStore_InsertEvents_ClosedDBReturnsError(t *testing.T) {
 	err := s.InsertEvents(t.Context(), events)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "begin tx", "begin tx failures must propagate, not be swallowed by the retry loop")
+}
+
+// spec:server-event-ingestion/horizontally-scalable-ingestion-service/two-ingestion-replicas-run-against-the-same-database
+//
+// Concurrent-InsertEvents stress test. Spawns N goroutines that each call InsertEvents with overlapping batches against
+// the SAME *mysql.Store (which models two ingestion replicas pointing at one shared MySQL backend, since the handler is
+// stateless apart from its store handle and both replicas would dial the same DB). Half the batches share event_ids
+// with each other and with the other half, exercising both the INSERT IGNORE deduplication path and the M10 deadlock-
+// retry wrapper under contention.
+//
+// Assertions:
+//
+//   - Every goroutine completes without error. The M10 retry budget is 5 attempts; if a deadlock window cannot resolve
+//     in that budget, the goroutine returns the wrapped 1213 and the test fails loudly rather than silently dropping
+//     events.
+//   - The events table's final cardinality equals the count of distinct event_ids across all batches (not the SUM of
+//     batch lengths). This pins both the dedup semantic AND the "no spurious deletes / rollbacks" property — a buggy
+//     concurrent path that lost rows would show up as a low cardinality count here.
+//
+// The architectural property being pinned is the spec's "Multiple replicas of the ingestion service MUST be able to
+// accept agent traffic concurrently against the same database without coordinating with each other." A literal two-
+// process test (two scaledriver binaries against one server) belongs at the M12 scale layer (#232); this in-process
+// stress test pins the wire-level concurrency-safety property that makes the multi-process shape work.
+func TestStore_InsertEvents_ConcurrentReplicaShape(t *testing.T) {
+	t.Parallel()
+	s := newTestStore(t)
+	ctx := t.Context()
+
+	const goroutines = 16
+	const eventsPerBatch = 20
+	const sharedEventCount = 8 // first 8 events overlap across every batch; remaining 12 are unique per goroutine
+
+	// Build the shared (overlap) event slice once. Every goroutine reuses these event_ids, so concurrent inserts of the
+	// same row exercise INSERT IGNORE under contention. Their host_ids match across goroutines too because in
+	// production multiple replicas commonly receive batches from the same host on different connections.
+	shared := make([]api.Event, sharedEventCount)
+	for i := range shared {
+		shared[i] = api.Event{
+			EventID:     "shared-" + strconv.Itoa(i),
+			HostID:      "host-shared",
+			TimestampNs: int64(i + 1),
+			EventType:   "fork",
+			Payload:     json.RawMessage(`{}`),
+		}
+	}
+
+	var wg sync.WaitGroup
+	errs := make(chan error, goroutines)
+	for g := range goroutines {
+		wg.Add(1)
+		go func(replicaIdx int) {
+			defer wg.Done()
+			batch := append([]api.Event(nil), shared...)
+			for i := sharedEventCount; i < eventsPerBatch; i++ {
+				batch = append(batch, api.Event{
+					EventID:     "rep-" + strconv.Itoa(replicaIdx) + "-evt-" + strconv.Itoa(i),
+					HostID:      "host-rep-" + strconv.Itoa(replicaIdx),
+					TimestampNs: int64(i + 1),
+					EventType:   "fork",
+					Payload:     json.RawMessage(`{}`),
+				})
+			}
+			if err := s.InsertEvents(ctx, batch); err != nil {
+				errs <- fmt.Errorf("replica %d: %w", replicaIdx, err)
+			}
+		}(g)
+	}
+	wg.Wait()
+	close(errs)
+
+	var collected []error
+	for err := range errs {
+		collected = append(collected, err)
+	}
+	require.Empty(t, collected, "no replica goroutine may surface an unretried deadlock or insert error")
+
+	got, err := s.CountEvents(ctx)
+	require.NoError(t, err)
+	// Distinct event_ids = sharedEventCount + (eventsPerBatch - sharedEventCount) * goroutines.
+	wantDistinct := int64(sharedEventCount + (eventsPerBatch-sharedEventCount)*goroutines)
+	assert.Equal(t, wantDistinct, got,
+		"final events table cardinality must equal the distinct-event-id union across replicas")
 }
 
 func TestStore_FetchUnprocessedAndUnclaim(t *testing.T) {

--- a/server/detection/internal/tests/integration_test.go
+++ b/server/detection/internal/tests/integration_test.go
@@ -276,10 +276,12 @@ func TestIngest_RequiresHostContext(t *testing.T) {
 // spec:server-event-ingestion/required-field-validation/a-batch-contains-an-event-with-a-missing-field
 //
 // Table-driven across the four required fields. Each subtest omits exactly one (event_id, host_id, event_type,
-// timestamp_ns) on an otherwise valid envelope, posts the batch, asserts HTTP 400 with a diagnostic identifying
-// the failing field's position, and confirms ListHosts is empty so the spec's "no events from that batch are
-// persisted" clause holds. The handler's validation lives at server/detection/internal/intake/handler.go's
-// per-event loop; a regression that drops the check on any one field would surface here.
+// timestamp_ns) on an otherwise valid envelope, posts the batch, asserts HTTP 400 with the typed
+// `missing_fields_at_<index>` error code identifying the failing field's position, and confirms ListHosts is empty
+// so the spec's "no events from that batch are persisted" clause holds. The handler's validation lives at
+// server/detection/internal/intake/handler.go's per-event loop; a regression that drops the check on any one field
+// would surface here. Pinning the error code (not just the status) also prevents a regression where the handler
+// returns 400 with a generic body and contributors silently accept it.
 func TestIngest_MissingFieldRejected(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
@@ -307,6 +309,15 @@ func TestIngest_MissingFieldRejected(t *testing.T) {
 			defer resp.Body.Close()
 			assert.Equal(t, http.StatusBadRequest, resp.StatusCode, "missing field must return 400")
 
+			respBody, _ := io.ReadAll(resp.Body)
+			var parsed map[string]string
+			require.NoError(t, json.Unmarshal(respBody, &parsed))
+			// The handler emits `missing_fields_at_<idx>` where idx is the position of the offending event in the
+			// batch. Every fixture above has the bad event at index 0, so we pin the exact code rather than just
+			// the prefix.
+			assert.Equal(t, "missing_fields_at_0", parsed["error"],
+				"typed diagnostic identifying the failing event's position")
+
 			hosts, err := d.Service().ListHosts(ctx)
 			require.NoError(t, err)
 			assert.Empty(t, hosts, "no events persisted when validation fails")
@@ -317,9 +328,10 @@ func TestIngest_MissingFieldRejected(t *testing.T) {
 // spec:server-event-ingestion/required-field-validation/a-batch-body-is-not-valid-json
 //
 // The handler runs io.ReadAll on the body then json.Unmarshal into []api.Event. A non-array body (here, a JSON
-// object) fails Unmarshal and the handler returns 400 with `invalid_json`. The spec's "no events persisted"
-// clause is satisfied trivially because we never reach the insert path; the test still asserts ListHosts is
-// empty to pin the behaviour against a future refactor that might short-circuit differently.
+// object) fails Unmarshal and the handler returns 400 with the typed `invalid_json` error code. The spec's "no
+// events persisted" clause is satisfied trivially because we never reach the insert path; the test still asserts
+// ListHosts is empty to pin the behaviour against a future refactor that might short-circuit differently. Pinning
+// the typed error code (not just the status) prevents a regression where the handler returns a generic 400.
 func TestIngest_InvalidJSONRejected(t *testing.T) {
 	t.Parallel()
 	d := newDetection(t, detectionOpts{mode: bootstrap.ModeFull})
@@ -334,6 +346,11 @@ func TestIngest_InvalidJSONRejected(t *testing.T) {
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+
+	respBody, _ := io.ReadAll(resp.Body)
+	var parsed map[string]string
+	require.NoError(t, json.Unmarshal(respBody, &parsed))
+	assert.Equal(t, "invalid_json", parsed["error"], "typed diagnostic per the spec")
 
 	hosts, err := d.Service().ListHosts(ctx)
 	require.NoError(t, err)

--- a/server/detection/internal/tests/integration_test.go
+++ b/server/detection/internal/tests/integration_test.go
@@ -12,6 +12,7 @@ package tests
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"slices"
@@ -27,6 +28,7 @@ import (
 
 	"github.com/fleetdm/edr/server/detection/api"
 	"github.com/fleetdm/edr/server/detection/bootstrap"
+	"github.com/fleetdm/edr/server/detection/internal/intake"
 	endpointapi "github.com/fleetdm/edr/server/endpoint/api"
 	identityapi "github.com/fleetdm/edr/server/identity/api"
 	rulesapi "github.com/fleetdm/edr/server/rules/api"
@@ -440,6 +442,100 @@ func TestIngest_DBErrorReturns5xx(t *testing.T) {
 	defer resp.Body.Close()
 	assert.GreaterOrEqual(t, resp.StatusCode, 500, "DB failure must surface as a 5xx so the agent retries")
 	assert.Less(t, resp.StatusCode, 600)
+}
+
+// spec:server-event-ingestion/body-size-limit/an-oversized-request-body-is-rejected
+//
+// Two over-cap shapes are exercised so the test pins both enforcement stages of the handler:
+//
+//   - Content-Length fast-path: send a body whose declared Content-Length exceeds MaxIngestBodyBytes. The handler must
+//     reject with 413 BEFORE reading any of the body.
+//   - Streaming MaxBytesReader path: send a chunked body that crosses the cap mid-read. The previous io.LimitReader
+//     shape silently truncated and surfaced as `invalid_json`; this case is the regression test for that bug.
+//
+// Pass: 413 + JSON body {"error":"body_too_large"}. No host appears in ListHosts because no events were persisted.
+func TestIngest_OversizedBodyRejected(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		chunked bool
+	}{
+		{"content-length advertises oversize", false},
+		{"chunked body crosses cap mid-stream", true},
+	}
+	// One event with a 12 MB payload field; the array brackets + envelope overhead push the total over the 10 MB cap.
+	bigPayload := strings.Repeat("A", 12*1024*1024)
+	body := `[{"event_id":"e-big","host_id":"host-a","timestamp_ns":1,"event_type":"fork","payload":{"data":"` +
+		bigPayload + `"}}]`
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			d := newDetection(t, detectionOpts{mode: bootstrap.ModeFull})
+			ctx := t.Context()
+			srv := httptest.NewServer(withHostID(d.Service().IngestHandler(), "host-a"))
+			t.Cleanup(srv.Close)
+
+			req, err := http.NewRequestWithContext(ctx, http.MethodPost, srv.URL, strings.NewReader(body))
+			require.NoError(t, err)
+			req.Header.Set("Content-Type", "application/json")
+			if tc.chunked {
+				// Forcing chunked encoding requires the client to NOT know the body length up front. http.NewRequest
+				// computes ContentLength from the strings.Reader; setting it to -1 makes Go's transport switch to
+				// Transfer-Encoding: chunked, which is exactly the path MaxBytesReader catches.
+				req.ContentLength = -1
+				req.Header.Set("Transfer-Encoding", "chunked")
+			}
+			resp, err := srv.Client().Do(req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+			assert.Equal(t, http.StatusRequestEntityTooLarge, resp.StatusCode, "413 per RFC 9110 §15.5.14")
+			respBody, _ := io.ReadAll(resp.Body)
+			var parsed map[string]string
+			require.NoError(t, json.Unmarshal(respBody, &parsed))
+			assert.Equal(t, "body_too_large", parsed["error"], "typed diagnostic per the spec")
+
+			hosts, err := d.Service().ListHosts(ctx)
+			require.NoError(t, err)
+			assert.Empty(t, hosts, "no events persisted when the body is rejected")
+		})
+	}
+}
+
+// spec:server-event-ingestion/body-size-limit/a-right-at-cap-body-is-accepted
+//
+// Boundary test: construct a body whose serialized length is just under MaxIngestBodyBytes and assert the handler reads
+// the entire payload, validates every event, and returns 200. The test pads ONE event's payload field with ASCII bytes
+// to drive the total body length close to the cap; the JSON wrapper overhead means the actual payload string is the
+// cap minus the envelope shape. Wall-clock cost is ~100ms for the 10 MB allocation + parse + insert; well under
+// suite-wide test budgets.
+func TestIngest_RightAtCapAccepted(t *testing.T) {
+	t.Parallel()
+	d := newDetection(t, detectionOpts{mode: bootstrap.ModeFull})
+	ctx := t.Context()
+	srv := httptest.NewServer(withHostID(d.Service().IngestHandler(), "host-a"))
+	t.Cleanup(srv.Close)
+
+	// Compute the maximum payload-data length that keeps the total body at or below the cap. The envelope structure is
+	// fixed; everything beyond the data string is constant overhead we can subtract from the cap.
+	envelope := `[{"event_id":"e-cap","host_id":"host-a","timestamp_ns":1,"event_type":"fork","payload":{"data":""}}]`
+	overhead := len(envelope)
+	dataLen := intake.MaxIngestBodyBytes - overhead - 32 // 32-byte safety margin for JSON escaping / encoding
+	body := `[{"event_id":"e-cap","host_id":"host-a","timestamp_ns":1,"event_type":"fork","payload":{"data":"` +
+		strings.Repeat("A", dataLen) + `"}}]`
+	require.LessOrEqual(t, len(body), intake.MaxIngestBodyBytes, "test fixture must fit under the cap")
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, srv.URL, strings.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := srv.Client().Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode, "right-at-cap body must be accepted")
+
+	count, err := d.Store().CountEvents(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), count, "the single right-at-cap event was persisted")
 }
 
 // ---- Engine + processor tests ----------------------------------------------

--- a/server/detection/internal/tests/integration_test.go
+++ b/server/detection/internal/tests/integration_test.go
@@ -202,6 +202,15 @@ func withHostID(next http.Handler, hostID string) http.Handler {
 
 // ---- Ingest tests -----------------------------------------------------------
 
+// spec:server-event-ingestion/authenticated-batch-event-submission/a-valid-agent-posts-a-batch
+// spec:server-event-ingestion/decoupled-processing-pipeline/ingestion-accepts-events-while-the-processor-is-busy
+//
+// One test, two scenarios. The double-marker is honest because the test (a) posts a valid batch via the
+// host-token-wrapped IngestHandler, asserts HTTP 200 + the host shows up via the read API with the event count
+// the spec requires; (b) runs in detectionOpts{mode: ModeFull} which means the processor goroutine is live
+// during the ingest, so the test simultaneously demonstrates that the ingestion path does not block on or
+// fail because of downstream processing work. If a future refactor unwires either property, this is the test
+// that must be updated.
 func TestIngest_PersistsEvents(t *testing.T) {
 	t.Parallel()
 	d := newDetection(t, detectionOpts{mode: bootstrap.ModeFull})
@@ -226,6 +235,7 @@ func TestIngest_PersistsEvents(t *testing.T) {
 	assert.Equal(t, int64(1), hosts[0].EventCount)
 }
 
+// spec:server-event-ingestion/host-identity-pinning/a-batch-contains-a-foreign-host-id
 func TestIngest_HostIDMismatchRejected(t *testing.T) {
 	t.Parallel()
 	d := newDetection(t, detectionOpts{mode: bootstrap.ModeFull})
@@ -259,6 +269,177 @@ func TestIngest_RequiresHostContext(t *testing.T) {
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+}
+
+// spec:server-event-ingestion/required-field-validation/a-batch-contains-an-event-with-a-missing-field
+//
+// Table-driven across the four required fields. Each subtest omits exactly one (event_id, host_id, event_type,
+// timestamp_ns) on an otherwise valid envelope, posts the batch, asserts HTTP 400 with a diagnostic identifying
+// the failing field's position, and confirms ListHosts is empty so the spec's "no events from that batch are
+// persisted" clause holds. The handler's validation lives at server/detection/internal/intake/handler.go's
+// per-event loop; a regression that drops the check on any one field would surface here.
+func TestIngest_MissingFieldRejected(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"missing event_id", `[{"event_id":"","host_id":"host-a","timestamp_ns":1,"event_type":"fork","payload":{}}]`},
+		{"missing host_id", `[{"event_id":"e1","host_id":"","timestamp_ns":1,"event_type":"fork","payload":{}}]`},
+		{"missing event_type", `[{"event_id":"e1","host_id":"host-a","timestamp_ns":1,"event_type":"","payload":{}}]`},
+		{"missing timestamp_ns", `[{"event_id":"e1","host_id":"host-a","timestamp_ns":0,"event_type":"fork","payload":{}}]`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			d := newDetection(t, detectionOpts{mode: bootstrap.ModeFull})
+			ctx := t.Context()
+			srv := httptest.NewServer(withHostID(d.Service().IngestHandler(), "host-a"))
+			t.Cleanup(srv.Close)
+
+			req, err := http.NewRequestWithContext(ctx, http.MethodPost, srv.URL, strings.NewReader(tc.body))
+			require.NoError(t, err)
+			req.Header.Set("Content-Type", "application/json")
+			resp, err := srv.Client().Do(req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+			assert.Equal(t, http.StatusBadRequest, resp.StatusCode, "missing field must return 400")
+
+			hosts, err := d.Service().ListHosts(ctx)
+			require.NoError(t, err)
+			assert.Empty(t, hosts, "no events persisted when validation fails")
+		})
+	}
+}
+
+// spec:server-event-ingestion/required-field-validation/a-batch-body-is-not-valid-json
+//
+// The handler runs io.ReadAll on the body then json.Unmarshal into []api.Event. A non-array body (here, a JSON
+// object) fails Unmarshal and the handler returns 400 with `invalid_json`. The spec's "no events persisted"
+// clause is satisfied trivially because we never reach the insert path; the test still asserts ListHosts is
+// empty to pin the behaviour against a future refactor that might short-circuit differently.
+func TestIngest_InvalidJSONRejected(t *testing.T) {
+	t.Parallel()
+	d := newDetection(t, detectionOpts{mode: bootstrap.ModeFull})
+	ctx := t.Context()
+	srv := httptest.NewServer(withHostID(d.Service().IngestHandler(), "host-a"))
+	t.Cleanup(srv.Close)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, srv.URL, strings.NewReader(`{"not":"an array"}`))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := srv.Client().Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+
+	hosts, err := d.Service().ListHosts(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, hosts)
+}
+
+// spec:server-event-ingestion/idempotent-submission-by-event-id/an-agent-retries-a-batch-after-a-network-failure
+//
+// The store's InsertEvents uses INSERT IGNORE so duplicate event_id collisions are dropped silently at the
+// events table. This test posts the same single-event batch twice and asserts the second response is still 200
+// and that the events table has exactly one row afterwards. CountEvents (the events table cardinality) is the
+// authoritative probe; hosts.event_count is a per-batch arrival counter that increments on every POST including
+// duplicates by design (see server/detection/internal/mysql/perf_test.go:59) and is NOT what the idempotency
+// spec scenario constrains.
+func TestIngest_DuplicateEventIDIsIdempotent(t *testing.T) {
+	t.Parallel()
+	d := newDetection(t, detectionOpts{mode: bootstrap.ModeFull})
+	ctx := t.Context()
+	srv := httptest.NewServer(withHostID(d.Service().IngestHandler(), "host-a"))
+	t.Cleanup(srv.Close)
+
+	body := `[{"event_id":"e-dup-1","host_id":"host-a","timestamp_ns":1000,"event_type":"fork","payload":{"child_pid":42,"parent_pid":1}}]`
+	post := func() *http.Response {
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, srv.URL, strings.NewReader(body))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := srv.Client().Do(req)
+		require.NoError(t, err)
+		return resp
+	}
+
+	resp1 := post()
+	require.Equal(t, http.StatusOK, resp1.StatusCode)
+	resp1.Body.Close()
+
+	resp2 := post()
+	assert.Equal(t, http.StatusOK, resp2.StatusCode, "retry of an already-persisted batch must succeed")
+	resp2.Body.Close()
+
+	count, err := d.Store().CountEvents(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), count, "duplicate event_id must not produce a duplicate row in the events table")
+}
+
+// spec:server-event-ingestion/idempotent-submission-by-event-id/a-batch-mixes-new-and-previously-seen-events
+//
+// First batch persists one event; second batch contains the same event plus a new one. The expected post-state
+// in the events table is two rows: the original (untouched) and the new one. This pins the per-row INSERT
+// IGNORE behaviour against a regression that would either reject the whole batch on the first duplicate or
+// overwrite the original row. See the comment on TestIngest_DuplicateEventIDIsIdempotent for why CountEvents is
+// the right probe rather than hosts.event_count.
+func TestIngest_MixedNewAndSeen(t *testing.T) {
+	t.Parallel()
+	d := newDetection(t, detectionOpts{mode: bootstrap.ModeFull})
+	ctx := t.Context()
+	srv := httptest.NewServer(withHostID(d.Service().IngestHandler(), "host-a"))
+	t.Cleanup(srv.Close)
+
+	first := `[{"event_id":"e-seen","host_id":"host-a","timestamp_ns":1000,"event_type":"fork","payload":{"child_pid":1,"parent_pid":0}}]`
+	mixed := `[` +
+		`{"event_id":"e-seen","host_id":"host-a","timestamp_ns":1000,"event_type":"fork","payload":{"child_pid":1,"parent_pid":0}},` +
+		`{"event_id":"e-new","host_id":"host-a","timestamp_ns":2000,"event_type":"fork","payload":{"child_pid":2,"parent_pid":1}}` +
+		`]`
+	post := func(body string) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, srv.URL, strings.NewReader(body))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := srv.Client().Do(req)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		resp.Body.Close()
+	}
+
+	post(first)
+	post(mixed)
+
+	count, err := d.Store().CountEvents(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), count,
+		"mixed batch: the previously-seen event is deduped, the new event is appended; events table = 2 rows")
+}
+
+// spec:server-event-ingestion/transparent-persistence-failure-reporting/the-database-is-temporarily-unavailable
+//
+// Closes the per-test MySQL handle out from under the handler, then posts a valid batch. The store's
+// InsertEvents path returns the wrapped sql error; the handler maps that to HTTP 500 with `internal` per the
+// "MUST NOT acknowledge a batch that was not durably persisted" clause. Each test gets its own testdb so closing
+// the pool here does not affect parallel tests.
+func TestIngest_DBErrorReturns5xx(t *testing.T) {
+	t.Parallel()
+	d := newDetection(t, detectionOpts{mode: bootstrap.ModeFull})
+	srv := httptest.NewServer(withHostID(d.Service().IngestHandler(), "host-a"))
+	t.Cleanup(srv.Close)
+
+	// Close the pool so the next InsertEvents fails with "sql: database is closed". This is the same shape
+	// TestStore_InsertEvents_ClosedDBReturnsError uses in the mysql package; here we assert the handler-side
+	// 5xx translation, not the store error itself.
+	require.NoError(t, d.Store().DB().Close(), "close pool to force the insert error path")
+
+	body := `[{"event_id":"e-db-down","host_id":"host-a","timestamp_ns":1,"event_type":"fork","payload":{}}]`
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, srv.URL, strings.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := srv.Client().Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.GreaterOrEqual(t, resp.StatusCode, 500, "DB failure must surface as a 5xx so the agent retries")
+	assert.Less(t, resp.StatusCode, 600)
 }
 
 // ---- Engine + processor tests ----------------------------------------------

--- a/server/endpoint/internal/middleware/hosttoken_test.go
+++ b/server/endpoint/internal/middleware/hosttoken_test.go
@@ -132,6 +132,13 @@ func TestHostToken_EmptyBearerSuffixRejected(t *testing.T) {
 	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
 }
 
+// spec:server-event-ingestion/authenticated-batch-event-submission/a-request-without-a-host-token-is-rejected
+//
+// The spec scenario covers two cases: "omits or supplies an unrecognized bearer token". The omit case is
+// covered by TestHostToken_MissingBearer above (this same file); the unrecognized-token case is below. One
+// marker per scenario is enough to satisfy the gate, and "unrecognized" is the meatier case so the marker
+// lands here. The middleware is what the spec's "system MUST reject" clause materialises as; the detection
+// IngestHandler runs only after this middleware has resolved the bearer to a host_id.
 func TestHostToken_InvalidToken(t *testing.T) {
 	svc := fakeService{
 		verifyToken: func(context.Context, string) (string, error) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Event ingestion requests exceeding 10 MB now return HTTP 413 with proper error response, preventing silent truncation.
  * Event deduplication via event ID ensures idempotent ingestion behavior.
  * Improved request validation and error handling for malformed payloads.

* **Tests**
  * Added comprehensive test coverage for event ingestion validation, deduplication, concurrent operations, and size limit enforcement.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/getvictor/fleet-edr/pull/235?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->