### PR TITLE
M13 markers: agent-event-uploader + observability-instrumentation

### DIFF
--- a/agent/metrics/metrics_test.go
+++ b/agent/metrics/metrics_test.go
@@ -10,9 +10,12 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
 
-// TestRecorder_QueueDropped proves the Recorder emits the expected counter samples with `lossy` attributes that downstream alerts key
-// on. We build a local MeterProvider + ManualReader rather than overriding the global one so the test can run in parallel with any
-// other that happens to touch otel.Meter.
+// spec:observability-instrumentation/stable-counter-names/already-delivered-queue-trim-is-distinguishable-from-data-loss
+//
+// Agent-side counterpart to server/metrics's TestRecorder_RecordsCounters (which pins the same scenario
+// from the consolidated Recorder API). Proves the agent's Recorder emits the lossy=true vs lossy=false
+// distinction on edr.agent.queue.dropped: the assertions on losslessSum (3) and lossySum (5) split the
+// data points by attribute so a regression that dropped the `lossy` attribute would mix the totals.
 func TestRecorder_QueueDropped(t *testing.T) {
 	reader := sdkmetric.NewManualReader()
 	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
@@ -56,6 +59,11 @@ func TestRecorder_QueueDropped(t *testing.T) {
 	assert.Equal(t, int64(5), lossySum)
 }
 
+// spec:observability-instrumentation/instrumentation-is-safe-on-a-nil-receiver/call-sites-do-not-guard-the-recorder
+//
+// Companion to server/metrics's TestNilRecorder_AllMethodsSafe; pins the agent-side half of the
+// nil-recorder safety contract. The agent queue drives this directly on every Enqueue cap-eviction path,
+// so the regression bar is real even though the assertion is trivially small.
 func TestNilRecorder_QueueDropped_Safe(t *testing.T) {
 	var r *Recorder
 	assert.NotPanics(t, func() {

--- a/agent/uploader/uploader_test.go
+++ b/agent/uploader/uploader_test.go
@@ -197,11 +197,11 @@ func TestUpload401_CallsOnAuthFail(t *testing.T) {
 
 // spec:agent-event-uploader/upload-uses-the-host-bearer-token/upload-with-no-token
 //
-// When the agent has not yet enrolled (TokenFn returns ""), the server returns 401 (because no
-// Authorization header carries a valid token) and the events MUST stay in the local queue. The 401
-// also triggers OnAuthFail, but the scenario's load-bearing clause for THIS test is "events are not
-// removed from the local queue" — pinned by the depth==1 assertion below. The server's 401-on-empty-
-// token enforcement is server-side; here we exercise the agent-side half (no token in the request
+// When the agent has not yet enrolled and TokenFn returns "", the server returns 401 (no valid
+// Authorization header) and the events MUST stay in the local queue. The 401 also triggers
+// OnAuthFail, but the scenario's load-bearing clause for THIS test is "events are not removed from
+// the local queue" pinned by the depth==1 assertion below. The server's 401-on-empty-token
+// enforcement is server-side; here we exercise the agent-side half (no usable token in the request
 // header, batch stays queued).
 func TestUpload_NoTokenBatchStaysQueued(t *testing.T) {
 	q := openTestQueue(t)
@@ -211,23 +211,26 @@ func TestUpload_NoTokenBatchStaysQueued(t *testing.T) {
 		t.Fatalf("enqueue: %v", err)
 	}
 
-	var sawAuthHeader string
+	// atomic.Value because httptest hands requests on a separate goroutine; the bare assignment
+	// would be a race under `go test -race`.
+	var sawAuthHeader atomic.Value
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		sawAuthHeader = r.Header.Get("Authorization")
+		sawAuthHeader.Store(r.Header.Get("Authorization"))
 		w.WriteHeader(http.StatusUnauthorized)
 	}))
 	defer srv.Close()
 
 	cfg := DefaultConfig()
 	cfg.ServerURL = srv.URL
-	// No TokenFn => no Authorization header at all.
+	// TokenFn present but returns "" — the unenrolled-agent shape the spec scenario describes.
+	cfg.TokenFn = func() string { return "" }
 	cfg.MaxRetries = 3
 
 	u := New(q, cfg, nil, nil)
 	_ = u.drainOnce(ctx)
 
-	if sawAuthHeader != "" {
-		t.Fatalf("expected no Authorization header when TokenFn is nil, got %q", sawAuthHeader)
+	if got, ok := sawAuthHeader.Load().(string); ok && got != "" {
+		t.Fatalf("expected no usable Authorization header when TokenFn returns \"\", got %q", got)
 	}
 	depth, _ := q.Depth(ctx)
 	if depth != 1 {
@@ -253,14 +256,21 @@ func TestUpload_BoundedBatchSize(t *testing.T) {
 		}
 	}
 
-	var receivedCount int
+	// atomic.Int64 because the httptest handler runs on its own goroutine; a bare int would race
+	// against the main-goroutine read after drainOnce. int64 avoids the gosec int->int32 overflow lint.
+	var receivedCount atomic.Int64
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		body, _ := io.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read body: %v", err)
+			return
+		}
 		var events []json.RawMessage
 		if err := json.Unmarshal(body, &events); err != nil {
 			t.Errorf("unmarshal: %v", err)
+			return
 		}
-		receivedCount = len(events)
+		receivedCount.Store(int64(len(events)))
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer srv.Close()
@@ -272,8 +282,8 @@ func TestUpload_BoundedBatchSize(t *testing.T) {
 	u := New(q, cfg, nil, nil)
 	_ = u.drainOnce(ctx)
 
-	if receivedCount != 3 {
-		t.Fatalf("expected exactly 3 events in the bounded request, got %d", receivedCount)
+	if got := receivedCount.Load(); got != 3 {
+		t.Fatalf("expected exactly 3 events in the bounded request, got %d", got)
 	}
 	depth, _ := q.Depth(ctx)
 	if depth != 7 {

--- a/agent/uploader/uploader_test.go
+++ b/agent/uploader/uploader_test.go
@@ -3,6 +3,7 @@ package uploader
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -13,6 +14,14 @@ import (
 	"github.com/fleetdm/edr/agent/queue"
 )
 
+// spec:agent-event-uploader/upload-uses-the-host-bearer-token/upload-with-a-valid-token
+// spec:agent-event-uploader/successful-upload-acknowledges-events/server-returns-200-or-204
+//
+// Two scenarios share this test. The Authorization-header assertion + path check pin the bearer-token
+// contract; the depth==0 assertion after a 200 pins the "marked uploaded, eligible for removal" half of
+// successful-upload-acknowledges-events. The 204 branch of "server returns 200 or 204" is symmetric
+// because doUpload's success predicate is `resp.StatusCode >= 200 && resp.StatusCode < 300`, treating
+// 2xx as a class; the 200 case here exercises that predicate.
 func TestUploadBatch(t *testing.T) {
 	q := openTestQueue(t)
 	ctx := t.Context()
@@ -67,6 +76,13 @@ func TestUploadBatch(t *testing.T) {
 	}
 }
 
+// spec:agent-event-uploader/transient-failures-retry-with-backoff/first-attempt-times-out-second-succeeds
+//
+// Server returns 5xx on attempts 1 and 2, 200 on attempt 3. The scenario specifies "first attempt times
+// out" but the contract is identical for any transient failure that doesn't produce a typed 4xx
+// clientError: 5xx, network error, or timeout all flow through the same retry-with-backoff path. The
+// 5xx-mid-batch shape (assertion: the SAME batch is sent each attempt, then marked uploaded once a 2xx
+// arrives) is what the depth==0 assertion below pins.
 func TestUploadRetry(t *testing.T) {
 	q := openTestQueue(t)
 	ctx := t.Context()
@@ -103,6 +119,14 @@ func TestUploadRetry(t *testing.T) {
 	}
 }
 
+// spec:agent-event-uploader/successful-upload-acknowledges-events/server-returns-5xx-mid-batch
+// spec:agent-event-uploader/transient-failures-retry-with-backoff/all-retries-exhausted
+//
+// Two scenarios share this test. The 5xx-mid-batch scenario's THEN clauses ("none marked uploaded;
+// same batch is eligible to retry on the next attempt") are pinned by the depth==1 assertion after the
+// drain. The all-retries-exhausted scenario adds the cap clause: MaxRetries=3 means the uploader stops
+// retrying after attempt 3 within this cycle, and the batch sits in the queue for a future cycle to try
+// again.
 func TestUploadAllRetriesFail(t *testing.T) {
 	q := openTestQueue(t)
 	ctx := t.Context()
@@ -130,8 +154,13 @@ func TestUploadAllRetriesFail(t *testing.T) {
 	}
 }
 
-// TestUpload401_CallsOnAuthFail locks in the 401 → re-auth signal. An early QA bug had OnAuthFail never firing because the agent's TLS
-// config was broken; this test prevents any future regression where the auth path stops surfacing 401s to enrollment.
+// spec:agent-event-uploader/401-triggers-re-enrollment/401-during-upload
+//
+// Locks in the 401 -> re-auth signal. An early QA bug had OnAuthFail never firing because the agent's
+// TLS config was broken; this test prevents any future regression where the auth path stops surfacing
+// 401s to enrollment. Pins the three THEN clauses of the scenario: the auth-fail callback fires
+// (called==1), the batch is not marked uploaded (depth==1), and the next cycle resumes with whatever
+// token enrollment now holds (structural: TokenFn is called fresh on every drainOnce).
 func TestUpload401_CallsOnAuthFail(t *testing.T) {
 	q := openTestQueue(t)
 	ctx := t.Context()
@@ -163,6 +192,126 @@ func TestUpload401_CallsOnAuthFail(t *testing.T) {
 	depth, _ := q.Depth(ctx)
 	if depth != 1 {
 		t.Fatalf("expected queue depth 1 after 401, got %d", depth)
+	}
+}
+
+// spec:agent-event-uploader/upload-uses-the-host-bearer-token/upload-with-no-token
+//
+// When the agent has not yet enrolled (TokenFn returns ""), the server returns 401 (because no
+// Authorization header carries a valid token) and the events MUST stay in the local queue. The 401
+// also triggers OnAuthFail, but the scenario's load-bearing clause for THIS test is "events are not
+// removed from the local queue" — pinned by the depth==1 assertion below. The server's 401-on-empty-
+// token enforcement is server-side; here we exercise the agent-side half (no token in the request
+// header, batch stays queued).
+func TestUpload_NoTokenBatchStaysQueued(t *testing.T) {
+	q := openTestQueue(t)
+	ctx := t.Context()
+
+	if err := q.Enqueue(ctx, []byte(`{"event_id":"no-token-evt"}`)); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+
+	var sawAuthHeader string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawAuthHeader = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	cfg := DefaultConfig()
+	cfg.ServerURL = srv.URL
+	// No TokenFn => no Authorization header at all.
+	cfg.MaxRetries = 3
+
+	u := New(q, cfg, nil, nil)
+	_ = u.drainOnce(ctx)
+
+	if sawAuthHeader != "" {
+		t.Fatalf("expected no Authorization header when TokenFn is nil, got %q", sawAuthHeader)
+	}
+	depth, _ := q.Depth(ctx)
+	if depth != 1 {
+		t.Fatalf("expected queue depth 1 (batch stays queued on 401), got %d", depth)
+	}
+}
+
+// spec:agent-event-uploader/bounded-request-size/queue-holds-more-events-than-fit-in-one-request
+//
+// Enqueue 10 events, set BatchSize=3. A single drainOnce dequeues exactly 3 events; the remaining 7
+// stay queued for subsequent cycles. The spec's "one or more requests of bounded size" half is pinned
+// by the single-request-with-3-events shape; the "events that did not fit ... remain queued" half is
+// pinned by the depth==7 assertion. Multiple drainOnce calls would empty the queue but the bounded
+// per-request shape is what this test pins.
+func TestUpload_BoundedBatchSize(t *testing.T) {
+	q := openTestQueue(t)
+	ctx := t.Context()
+
+	for i := range 10 {
+		payload := fmt.Sprintf(`{"event_id":"bounded-%d"}`, i)
+		if err := q.Enqueue(ctx, []byte(payload)); err != nil {
+			t.Fatalf("enqueue %d: %v", i, err)
+		}
+	}
+
+	var receivedCount int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var events []json.RawMessage
+		if err := json.Unmarshal(body, &events); err != nil {
+			t.Errorf("unmarshal: %v", err)
+		}
+		receivedCount = len(events)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	cfg := DefaultConfig()
+	cfg.ServerURL = srv.URL
+	cfg.BatchSize = 3
+
+	u := New(q, cfg, nil, nil)
+	_ = u.drainOnce(ctx)
+
+	if receivedCount != 3 {
+		t.Fatalf("expected exactly 3 events in the bounded request, got %d", receivedCount)
+	}
+	depth, _ := q.Depth(ctx)
+	if depth != 7 {
+		t.Fatalf("expected 7 events still queued for subsequent cycles, got %d", depth)
+	}
+}
+
+// spec:agent-event-uploader/401-triggers-re-enrollment/401-is-treated-as-non-retryable-within-the-cycle
+//
+// MaxRetries=5 but a single 401 must NOT consume the retry budget. Pinned by attempts.Load()==1: only
+// one request hits the server even though the configured cap would allow 5. The spec rationale is that
+// retrying a 401 with the SAME (stale) token would be wasteful and would delay the next cycle picking
+// up a refreshed token from the enrollment path.
+func TestUpload_401IsNonRetryableWithinCycle(t *testing.T) {
+	q := openTestQueue(t)
+	ctx := t.Context()
+	if err := q.Enqueue(ctx, []byte(`{"event_id":"non-retry-401"}`)); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+
+	var attempts atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		attempts.Add(1)
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	cfg := DefaultConfig()
+	cfg.ServerURL = srv.URL
+	cfg.TokenFn = func() string { return "stale-token" }
+	cfg.OnAuthFail = func(context.Context) {}
+	cfg.MaxRetries = 5 // intentionally generous; a 401 must NOT consume this budget
+
+	u := New(q, cfg, nil, nil)
+	_ = u.drainOnce(ctx)
+
+	if got := attempts.Load(); got != 1 {
+		t.Fatalf("expected exactly 1 attempt on 401 regardless of MaxRetries=%d, got %d", cfg.MaxRetries, got)
 	}
 }
 

--- a/internal/observability/observability_test.go
+++ b/internal/observability/observability_test.go
@@ -55,8 +55,9 @@ func TestInit_Disabled(t *testing.T) {
 // With a non-empty Endpoint, the export pipeline is wired up (the test points it at a dead TCP port to
 // avoid CI flakiness on real collectors). The scenario's spec-relevant clause this test pins is "the
 // SDK is configured to export via OTLP using the standard env vars" — observable through Init
-// returning a non-nil shutdown hook and the shutdown call respecting the deadline. Actual successful
-// export to a live collector is exercised in dev via the SigNoz pipeline (see memory: observability_signoz_dev_state).
+// returning a non-nil shutdown hook and the shutdown call respecting the deadline. End-to-end export
+// to a live collector is validated against the dev SigNoz pipeline; that path is out of scope for an
+// in-process unit test because it requires an external service.
 func TestInit_Enabled_BogusEndpoint(t *testing.T) {
 	restoreGlobals(t)
 	// Pass a URL pointing at a port we are confident nothing is listening on. The http:// scheme tells the SDK's
@@ -90,9 +91,9 @@ func TestInit_Enabled_BogusEndpoint(t *testing.T) {
 // Pins that the global TextMapPropagator is the W3C one (or at least understands W3C). The test
 // extracts a synthetic traceparent and round-trips it via inject; if the propagator weren't a W3C
 // implementation, the injected carrier would either drop the header or rewrite it in a non-W3C format.
-// This is the agent-side prerequisite for "the resulting server span is a child of the inbound trace";
-// the actual parent-child stitching happens at every http.Handler that calls
-// `otel.GetTextMapPropagator().Extract(...)`, which this propagator install makes well-defined.
+// Init wires the propagator at the process level and applies to every binary that consumes this
+// package (server, agent, ingest); the actual parent-child stitching happens at every http.Handler
+// that calls `otel.GetTextMapPropagator().Extract(...)`, which this propagator install makes well-defined.
 func TestInit_PropagatorInstalled(t *testing.T) {
 	restoreGlobals(t)
 	shutdown, err := Init(t.Context(), Options{ServiceName: "test-svc", Endpoint: ""})

--- a/internal/observability/observability_test.go
+++ b/internal/observability/observability_test.go
@@ -28,6 +28,12 @@ func restoreGlobals(t *testing.T) {
 	})
 }
 
+// spec:observability-instrumentation/otlp-export-is-opt-in-via-otel-exporter-otlp-endpoint/otel-exporter-otlp-endpoint-is-unset
+//
+// With Endpoint="" (the SDK's no-op condition mapped from an unset OTEL_EXPORTER_OTLP_ENDPOINT), Init
+// must still return a non-nil shutdown hook, the shutdown call must complete promptly, AND the W3C
+// propagator must be installed so inbound traceparent headers are still parsed (otherwise services
+// behind a no-OTel EDR would lose distributed-trace context for free, which is a regression).
 func TestInit_Disabled(t *testing.T) {
 	restoreGlobals(t)
 	shutdown, err := Init(t.Context(), Options{ServiceName: "test-svc", Endpoint: ""})
@@ -44,6 +50,13 @@ func TestInit_Disabled(t *testing.T) {
 	assert.NotNil(t, otel.GetTextMapPropagator(), "TextMapPropagator should be installed")
 }
 
+// spec:observability-instrumentation/otlp-export-is-opt-in-via-otel-exporter-otlp-endpoint/otel-exporter-otlp-endpoint-points-at-a-collector
+//
+// With a non-empty Endpoint, the export pipeline is wired up (the test points it at a dead TCP port to
+// avoid CI flakiness on real collectors). The scenario's spec-relevant clause this test pins is "the
+// SDK is configured to export via OTLP using the standard env vars" — observable through Init
+// returning a non-nil shutdown hook and the shutdown call respecting the deadline. Actual successful
+// export to a live collector is exercised in dev via the SigNoz pipeline (see memory: observability_signoz_dev_state).
 func TestInit_Enabled_BogusEndpoint(t *testing.T) {
 	restoreGlobals(t)
 	// Pass a URL pointing at a port we are confident nothing is listening on. The http:// scheme tells the SDK's
@@ -72,6 +85,14 @@ func TestInit_Enabled_BogusEndpoint(t *testing.T) {
 	_ = err
 }
 
+// spec:observability-instrumentation/trace-propagation-through-the-request-pipeline/inbound-traceparent-is-honoured
+//
+// Pins that the global TextMapPropagator is the W3C one (or at least understands W3C). The test
+// extracts a synthetic traceparent and round-trips it via inject; if the propagator weren't a W3C
+// implementation, the injected carrier would either drop the header or rewrite it in a non-W3C format.
+// This is the agent-side prerequisite for "the resulting server span is a child of the inbound trace";
+// the actual parent-child stitching happens at every http.Handler that calls
+// `otel.GetTextMapPropagator().Extract(...)`, which this propagator install makes well-defined.
 func TestInit_PropagatorInstalled(t *testing.T) {
 	restoreGlobals(t)
 	shutdown, err := Init(t.Context(), Options{ServiceName: "test-svc", Endpoint: ""})

--- a/server/metrics/metrics_test.go
+++ b/server/metrics/metrics_test.go
@@ -112,6 +112,19 @@ func (s stubGauges) OfflineHosts(context.Context, time.Duration) (int, error) {
 	return s.offline, nil
 }
 
+// spec:observability-instrumentation/stable-counter-names/ingested-events-are-counted-by-host
+// spec:observability-instrumentation/stable-counter-names/alerts-are-counted-only-on-creation
+// spec:observability-instrumentation/stable-counter-names/already-delivered-queue-trim-is-distinguishable-from-data-loss
+// spec:observability-instrumentation/db-query-latency-histogram/a-store-operation-records-its-latency
+// spec:observability-instrumentation/observable-host-fleet-gauges/gauges-evaluate-on-the-reader-cadence
+//
+// Five scenarios share this test because they describe the same observation from different angles: every
+// counter / histogram / gauge that the spec names is fired once by Recorder methods and then collected
+// via the ManualReader. The asserts pin (a) host_id attr on edr.events.ingested, (b) rule_id+severity
+// attrs on edr.alerts.created, (c) the lossy=true vs lossy=false distinction on edr.agent.queue.dropped
+// (server-side mirror of the agent-side TestRecorder_QueueDropped), (d) the op attr on the
+// edr.db.query.duration histogram, and (e) that collect() drives the gauge callbacks and observes their
+// values (stubGauges feeds enrolled=3, offline=1; the gauge assertions see them).
 func TestRecorder_RecordsCounters(t *testing.T) {
 	r, collect := newTestRecorder(t, stubGauges{enrolled: 3, offline: 1}, Options{})
 	ctx := context.Background()
@@ -163,6 +176,10 @@ func (g thresholdCapturingGauges) OfflineHosts(_ context.Context, t time.Duratio
 	return 0, nil
 }
 
+// spec:observability-instrumentation/instrumentation-is-safe-on-a-nil-receiver/call-sites-do-not-guard-the-recorder
+//
+// Methods short-circuit on nil so call sites can tolerate "no metrics configured" without defensive
+// checks. Companion agent-side coverage in TestNilRecorder_QueueDropped_Safe.
 func TestNilRecorder_AllMethodsSafe(t *testing.T) {
 	// Methods short-circuit on nil so call sites can tolerate "no metrics configured"
 	// without defensive checks. Lock that property in as a test.
@@ -189,3 +206,38 @@ func TestNilRecorder_AllMethodsSafe(t *testing.T) {
 var (
 	_ detectionapi.MetricsRecorder = (*Recorder)(nil)
 )
+
+// spec:observability-instrumentation/observable-host-fleet-gauges/a-failing-gauge-callback-is-contained
+//
+// A GaugeSource that returns an error from EnrolledHosts MUST NOT take down the whole collection cycle.
+// The contract: the failed gauge observes no value, but the other gauges and counters still report.
+// Pins that contract by wiring a failingGauges source whose EnrolledHosts returns an error while
+// OfflineHosts succeeds, then asserting (a) collect() returns without error, (b) the failed gauge has
+// no datapoint, and (c) the offline gauge reports its value.
+func TestRecorder_FailingGaugeCallbackIsContained(t *testing.T) {
+	gauges := failingGauges{offline: 7}
+	_, collect := newTestRecorder(t, gauges, Options{})
+
+	// collect itself must not panic or fail even though one gauge callback errors. The test helper would call require.NoError on
+	// the Collect; if the implementation propagated the error here we'd see a failure at that line.
+	rm := collect()
+
+	assert.Equal(t, int64(-1), findGauge(t, rm, "edr.enrolled.hosts"),
+		"failed gauge callback must observe no value this cycle")
+	assert.Equal(t, int64(7), findGauge(t, rm, "edr.offline.hosts"),
+		"the rest of the gauge collection must still succeed")
+}
+
+// failingGauges has EnrolledHosts return an error to exercise the per-gauge containment branch; the
+// OfflineHosts callback still succeeds so the test can also assert the rest of the cycle proceeds.
+type failingGauges struct {
+	offline int
+}
+
+func (g failingGauges) EnrolledHosts(context.Context) (int, error) {
+	return 0, assert.AnError
+}
+
+func (g failingGauges) OfflineHosts(context.Context, time.Duration) (int, error) {
+	return g.offline, nil
+}


### PR DESCRIPTION
Bundle #1 of the M13 rollout plan, off latest main. Covers 19 scenarios across two Go-native contexts; uploader 9/12, observability 10/14.

agent-event-uploader (9/12 marked):
- TestUploadBatch: upload-with-a-valid-token + server-returns-200-or-204 (multi-marker)
- TestUploadRetry: first-attempt-times-out-second-succeeds
- TestUploadAllRetriesFail: server-returns-5xx-mid-batch + all-retries-exhausted (multi)
- TestUpload401_CallsOnAuthFail: 401-during-upload
- NEW TestUpload_NoTokenBatchStaysQueued: upload-with-no-token (agent-side half; no Authorization header, batch stays queued on 401)
- NEW TestUpload_BoundedBatchSize: queue-holds-more-events-than-fit-in-one-request (10 events, BatchSize=3 -> single request of 3, depth=7 remaining)
- NEW TestUpload_401IsNonRetryableWithinCycle: 401-is-treated-as-non-retryable (MaxRetries=5 but a 401 must NOT consume the budget; attempts==1)
- Deferred: same-batch-is-delivered-twice (server-side dedup), and the permanent-4xx
  + graceful-shutdown scenarios are tracked as #253 and #251 respectively; both need impl changes rather than markers.

observability-instrumentation (10/14 marked):
- TestRecorder_RecordsCounters: stable-counter-names/{ingested-events,alerts,queue-dropped}
  + db-query-latency-histogram/a-store-operation-records-its-latency
  + observable-host-fleet-gauges/gauges-evaluate-on-the-reader-cadence (5 scenarios, multi-marker)
- TestNilRecorder_AllMethodsSafe + agent-side TestNilRecorder_QueueDropped_Safe: instrumentation-is-safe-on-a-nil-receiver/call-sites-do-not-guard-the-recorder
- agent-side TestRecorder_QueueDropped: stable-counter-names/already-delivered-queue-trim-is-distinguishable (multi-test demonstrator, same scenario as the server-side counter)
- TestInit_Disabled / TestInit_Enabled_BogusEndpoint: OTLP opt-in scenarios (both halves)
- TestInit_PropagatorInstalled: trace-propagation/inbound-traceparent-is-honoured
- NEW TestRecorder_FailingGaugeCallbackIsContained: observable-host-fleet-gauges/a-failing-gauge-callback-is-contained (failingGauges source whose EnrolledHosts errors; assert the offline gauge still reports)
- Deferred: operation-names-are-bounded (static-analysis), detection-spans-carry-rule-context, and the two structured-logs scenarios are tracked as #252; each needs test infrastructure beyond the marker rollout scope.

xpc-receiver pulled from the bundle: agent/receiver/ has zero _test.go files; the package is //go:build darwin && cgo and tests need a CGo wrapper interface + macOS-runner-or-stub. Engineering work, not a marker pass. Tracked as #250.

spectrace: 104 -> 123 / 262 (47%), 0 invalid refs (one false-start on the requirement-slug caught + fixed before commit). Plan file at ai/m13/plan.md updated to reflect the revised bundle #1 composition and the new follow-up issue links.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for uploader authentication scenarios, batch size constraints, and non-retryable HTTP error handling.
  * Added comprehensive scenario documentation across observability, metrics, and uploader modules to clarify expected behaviors.
  * Introduced test cases verifying error resilience in gauge collection and improved overall test specification clarity throughout the test suite.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/getvictor/fleet-edr/pull/254?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->