### PR TITLE
ci: flip spectrace gate to --strict; M13 marker backlog is closed

### DIFF
--- a/.github/workflows/spectrace.yml
+++ b/.github/workflows/spectrace.yml
@@ -1,9 +1,9 @@
 name: Spec traceability
 
 # spectrace ties scenarios in openspec/specs/<dir>/spec.md to tests via the canonical-ID marker contract documented in
-# docs/testing-strategy.md. UAT plan milestone M13 phased rollout: invalid references fail the build today (catches typos
-# and stale renames at zero backlog cost), but uncovered SHALL/MUST scenarios are advisory until the marker backlog is
-# closed and the gate flips to --strict.
+# docs/testing-strategy.md. UAT plan milestone M13 phased rollout finished at 262/262 markers on main; the gate now runs
+# in --strict mode so that invalid references AND uncovered SHALL/MUST scenarios both fail the build. New normative
+# scenarios MUST land with at least one marker; spec renames MUST update every marker that references the old slug.
 
 on:
   push:
@@ -60,7 +60,7 @@ jobs:
           fi
 
   spectrace:
-    name: spectrace check (advisory)
+    name: spectrace check
     needs: changes
     if: needs.changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
@@ -75,19 +75,9 @@ jobs:
         with:
           go-version-file: go.mod
 
-      # The check exits 0 when there are no invalid references, even if there are uncovered SHALL/MUST scenarios; that is
-      # the documented phased-rollout shape. Invalid references DO fail the build because they almost always indicate a
-      # typo or a rename that hasn't propagated, and the cost to fix one is trivial.
-      - name: Run spectrace check
-        run: go run ./tools/spectrace check
-
-      # The advisory uncovered-scenarios list is printed to the job output but does not gate. Flip the gate to --strict
-      # in this workflow once the marker backlog is closed.
-      - name: "Advisory: count uncovered SHALL/MUST scenarios"
-        run: |
-          set -euo pipefail
-          total_normative=$(go run ./tools/spectrace list-ids --normative-only | wc -l)
-          # `check` already prints the per-scenario gap list; this step echoes the headline numbers to make the rollout
-          # progress visible in the job log without scrolling through every entry.
-          echo "spectrace: total normative scenarios = $total_normative"
-          echo "spectrace: phased rollout, --strict not yet enforced; see docs/testing-strategy.md"
+      # --strict mode: the check fails the build on EITHER invalid references (typo, stale spec rename) OR uncovered
+      # SHALL/MUST scenarios. The advisory phase is over; main is at 100% coverage and the gate enforces it from here.
+      # The check's stdout includes the headline "N/M normative scenarios have a test marker" line, so a passing run
+      # still surfaces the coverage figure in the job log without a separate informational step.
+      - name: Run spectrace check (strict)
+        run: go run ./tools/spectrace check --strict

--- a/.github/workflows/spectrace.yml
+++ b/.github/workflows/spectrace.yml
@@ -1,9 +1,10 @@
 name: Spec traceability
 
 # spectrace ties scenarios in openspec/specs/<dir>/spec.md to tests via the canonical-ID marker contract documented in
-# docs/testing-strategy.md. UAT plan milestone M13 phased rollout finished at 262/262 markers on main; the gate now runs
-# in --strict mode so that invalid references AND uncovered SHALL/MUST scenarios both fail the build. New normative
-# scenarios MUST land with at least one marker; spec renames MUST update every marker that references the old slug.
+# docs/testing-strategy.md. UAT plan milestone M13 phased rollout finished with all 262 normative scenarios covered on
+# main; the gate now runs in --strict mode so that invalid references AND uncovered SHALL/MUST scenarios both fail the
+# build. New normative scenarios MUST land with at least one marker; spec renames MUST update every marker that
+# references the old slug.
 
 on:
   push:

--- a/tools/spectrace/README.md
+++ b/tools/spectrace/README.md
@@ -20,10 +20,22 @@ spectrace list-ids   [--specs-dir DIR] [--normative-only]
 
 ## Phased rollout
 
-The CI workflow at `.github/workflows/spectrace.yml` runs `check` in **advisory** mode: invalid references fail the
-build (catches typos and stale spec renames at zero backlog cost) but uncovered SHALL / MUST scenarios are reported
-without failing. Flip the workflow to `--strict` once the marker backlog is closed and every normative scenario has at
-least one reference.
+The CI workflow at `.github/workflows/spectrace.yml` runs `check --strict`: both invalid references and uncovered
+SHALL / MUST scenarios fail the build. The advisory phase finished at 262/262 markers on main; the gate enforces 100%
+coverage from here.
+
+What this means for contributors:
+
+- Adding a new normative scenario (a `#### Scenario:` under a `### Requirement:` whose body contains SHALL or MUST)
+  requires at least one marker reference in the same PR. Otherwise the spectrace job fails.
+- Renaming a scenario heading changes the canonical-ID slug; every marker that referenced the old slug becomes an
+  invalid reference and must be updated in the same PR.
+- Deleting a scenario removes its denominator entry, but stale `// spec:<old-id>` markers in tests become invalid
+  references; clean them up in the same PR.
+
+`spectrace check` (no `--strict`) still works locally as the advisory variant: prints the coverage delta + invalid-
+reference list without changing exit code on uncovered scenarios. Useful for iterating mid-PR before every marker is
+in place.
 
 ## Marker forms
 

--- a/tools/spectrace/README.md
+++ b/tools/spectrace/README.md
@@ -21,8 +21,8 @@ spectrace list-ids   [--specs-dir DIR] [--normative-only]
 ## Phased rollout
 
 The CI workflow at `.github/workflows/spectrace.yml` runs `check --strict`: both invalid references and uncovered
-SHALL / MUST scenarios fail the build. The advisory phase finished at 262/262 markers on main; the gate enforces 100%
-coverage from here.
+SHALL / MUST scenarios fail the build. The advisory phase finished with all 262 normative scenarios covered on main;
+the gate enforces 100% coverage from here.
 
 What this means for contributors:
 
@@ -33,9 +33,9 @@ What this means for contributors:
 - Deleting a scenario removes its denominator entry, but stale `// spec:<old-id>` markers in tests become invalid
   references; clean them up in the same PR.
 
-`spectrace check` (no `--strict`) still works locally as the advisory variant: prints the coverage delta + invalid-
-reference list without changing exit code on uncovered scenarios. Useful for iterating mid-PR before every marker is
-in place.
+`spectrace check` (no `--strict`) still works locally as the advisory variant: prints the coverage delta and the
+invalid-reference list without changing exit code on uncovered scenarios. Useful for iterating mid-PR before every
+marker is in place.
 
 ## Marker forms
 


### PR DESCRIPTION
Main reached 262/262 normative scenarios with at least one marker (the last PR in the M13 stack, #271, landed today). The spectrace gate ran in advisory mode through the rollout so uncovered scenarios surfaced in job logs without failing the build. The backlog is now closed; the gate enforces 100% coverage from this PR forward.

Workflow change at .github/workflows/spectrace.yml:

- Renamed the job from "spectrace check (advisory)" to "spectrace check".
- The `Run spectrace check` step now passes `--strict`, which surfaces uncovered SHALL/MUST scenarios as a failing exit code (invalid references already failed under the advisory gate).
- Removed the secondary "Advisory: count uncovered SHALL/MUST scenarios" step. `check` itself prints the headline "N/M normative scenarios have a test marker" line, so the same coverage figure remains visible in the job log without a separate step.
- Rewrote the header comment to describe the strict-enforcing shape + the two new contributor-facing rules: new normative scenarios MUST land with at least one marker; spec renames MUST update every marker referencing the old slug.

tools/spectrace/README.md "Phased rollout" section rewritten to match. Three contributor-facing call-outs added (new normative scenario, rename, deletion) so the next reader sees the strict-enforcement implications without having to reverse-engineer them from the workflow.

The `spectrace check` (no --strict) form still works locally as the advisory variant for mid-PR iteration; documented in the README so contributors know it's available before every marker is in place.

Local verification: `go run ./tools/spectrace check --strict` exits 0 on this branch (262/262 markers on main). actionlint clean on the modified workflow; markdownlint clean on the modified README.