### PR TITLE
test+ci: fuzz POST /api/events + POST /api/enroll body; demote codeco…

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -9,22 +9,32 @@ coverage:
   status:
     project:
       default:
-        # Tracks reality on main (today ~73.1% per codecov). Sonar's per-PR new-code gate at
-        # 80% (configured in the SonarCloud UI) is the authoritative bar for what each change
-        # must meet; this project rollup just tracks the trend. Lowered from 80% to 75% per
-        # issue #124, then to 70% after main drifted below the 75% floor and the gate began
-        # failing on every PR regardless of patch coverage.
+        # PROJECT-LEVEL ROLLUP IS INFORMATIONAL, NOT GATING (#227).
+        #
+        # Codecov's project rollup has repeatedly reported numbers that don't match reality on this repo: PR #224 (head
+        # bd59ef76) showed project/server at 37.9% and project/ui at 42.3% while the per-package go-test runs were
+        # producing 70%+ coverage and the per-PR Sonar new-code gate was passing at >80%. Two earlier rounds (#124, then
+        # again at #227) responded by dropping the threshold (80 → 75 → 70). Main drifted below the floor each time and
+        # the gate became a chronic-flake red check that every PR in the M13 stack carried a "documented skip reason" for.
+        #
+        # `informational: true` makes the project rollup visible in the codecov dashboard without failing the PR check.
+        # Sonar's per-PR "Coverage on New Code" gate (configured in the SonarCloud UI at 80%) remains the authoritative
+        # bar for what each PR must meet; codecov's per-PATCH gate below still gates on new-code coverage, just like
+        # Sonar does. Demoting the project rollup means we stop chasing the codecov-vs-reality discrepancy on every PR
+        # and let Sonar's machinery (which has been reliable) carry the new-code coverage contract.
+        #
+        # If a real coverage cliff lands on main, the trend will show up in the project rollup's number; an operator
+        # noticing a regression flips informational back to false and tightens the target. The path back is short.
+        informational: true
         target: 70%
-        # Allow a 1% drift before failing the project status; smaller deltas are
-        # noise from coverage tool reordering, not regressions.
         threshold: 1%
-        if_ci_failed: error
         only_pulls: false
     patch:
       default:
-        # Sonar's per-PR "Coverage on New Code" gate is 80%, but codecov's patch coverage tends to be stricter in practice (the
-        # uploaded LCOV is per-language and per-flag, and codecov's branch-counting differs from sonar's). Held at 70% so codecov
-        # doesn't gate-out PRs that sonar already accepts; sonar remains the authoritative new-code bar.
+        # PATCH-LEVEL GATE STAYS ENFORCING. The chronic flake was the project rollup, not the patch coverage — patch
+        # gates have consistently passed in the M13 stack. Per-PR new-code coverage is what we actually want to gate on,
+        # and the patch gate enforces that here. Sonar's 80% new-code gate is parallel; codecov is held at 70% so it
+        # doesn't gate-out PRs that Sonar already accepts.
         target: 70%
         threshold: 0%
         if_ci_failed: error
@@ -37,13 +47,16 @@ flag_management:
     carryforward: true
     statuses:
       - type: project
-        # Per-flag project target. Held at a fixed 70% rather than `auto` so the gate stops failing on small trend drifts (a flag
-        # going from 78% to 76% would otherwise breach the prior auto+1%-threshold setup). The patch gate below keeps regressions
-        # on new code visible; sonar's per-PR 80% new-code gate remains the authoritative bar.
+        # Per-flag project rollups (agent / server / ui) are informational for the same reason the overall project
+        # rollup is — codecov's per-flag numbers have been unreliable on this repo and were the most frequent chronic
+        # flake in the M13 stack ("codecov/project/ui at 14.4% vs 70% target" on Go-only PRs that didn't touch the UI
+        # tree at all). Demote to informational; sonar's per-PR new-code gate remains the authoritative bar.
+        informational: true
         target: 70%
       - type: patch
-        # Per-flag patch target. Mirrors the project-wide patch target above; see the note there for why codecov is held one notch
-        # below sonar's 80% new-code gate.
+        # Per-flag patch target stays enforcing. The chronic flake was the rollup, not the patch — patch gates pin
+        # new-code coverage per PR and have been consistently honest. Held at 70%; sonar's 80% new-code gate is
+        # parallel.
         target: 70%
   individual_flags:
     - name: agent

--- a/server/detection/internal/intake/handler.go
+++ b/server/detection/internal/intake/handler.go
@@ -21,15 +21,32 @@ import (
 // Exported for tests that need to compose right-at-cap and over-cap bodies without duplicating the magic number.
 const MaxIngestBodyBytes = 10 * 1024 * 1024
 
+// MaxIngestEventsPerRequest caps the number of events the parser accepts in a single batch. Closes the memory-amplification angle that the 10 MB body cap doesn't on its own: a minimal event JSON is ~50 bytes on the wire but the in-memory api.Event representation (json.RawMessage payload + the four string headers) is several hundred bytes — so a 10 MB body of microscopic events could expand to ~140k entries and ~60-80 MB of heap before the downstream InsertEvents loop runs. The agent's defaultBatchSize is 100; 10k is two orders of magnitude of headroom for legitimate batching while capping the blast radius of a hostile or buggy peer.
+const MaxIngestEventsPerRequest = 10_000
+
 // ParseAndValidateIngestBody is the parse + per-event validation half of POST /api/events, lifted out of handleIngest so the
 // fuzz harness can drive it without a full HTTP server + Detection store. Returns (events, http.StatusOK, "") on success, or
 // (nil, 4xx, errCode) on parse / validation failure. The error codes are the same stable set the HTTP handler emits:
-// "invalid_json", "missing_fields_at_<i>", "host_id_mismatch". The body-cap (413) check is upstream of this function (in
-// readBodyWithCap); the store-insert (5xx) is downstream of it. The fuzz contract is therefore: every output MUST be one of
-// {(200, ""), (400, "invalid_json"), (400, "missing_fields_at_<i>"), (400, "host_id_mismatch")} — anything else is a finding.
+// "invalid_json", "missing_fields_at_<i>", "host_id_mismatch", "too_many_events". The body-cap (413) check is upstream of
+// this function (in readBodyWithCap); the store-insert (5xx) is downstream of it. The fuzz contract is therefore: every
+// output MUST be one of {(200, ""), (400, "invalid_json"), (400, "missing_fields_at_<i>"), (400, "host_id_mismatch"),
+// (400, "too_many_events")} — anything else is a finding.
 func ParseAndValidateIngestBody(body []byte, pinnedHostID string) (events []api.Event, status int, errCode string) {
 	if err := json.Unmarshal(body, &events); err != nil {
 		return nil, http.StatusBadRequest, "invalid_json"
+	}
+	// json.Unmarshal of the literal `null` succeeds with events=nil. Treat that as a parse-failure shape rather than as a
+	// valid empty batch — a caller that genuinely means "empty batch" sends `[]`, not `null`. Without this check the
+	// function would return 200 OK for a body that is not a JSON array, breaking the fuzz invariant "status 200 implies a
+	// JSON-array body" (Gemini #275).
+	if events == nil {
+		return nil, http.StatusBadRequest, "invalid_json"
+	}
+	// Per-batch event-count cap: defense against a body-cap-respecting attacker who packs the 10 MB body with thousands
+	// of microscopic events. The 10 MB byte cap doesn't bound the in-memory expansion (api.Event with its string headers
+	// is larger per-event than the JSON form), so this cap is what closes the memory-amplification path (CodeRabbit #275).
+	if len(events) > MaxIngestEventsPerRequest {
+		return nil, http.StatusBadRequest, "too_many_events"
 	}
 	for i, e := range events {
 		if e.EventID == "" || e.HostID == "" || e.EventType == "" || e.TimestampNs == 0 {

--- a/server/detection/internal/intake/handler.go
+++ b/server/detection/internal/intake/handler.go
@@ -21,6 +21,27 @@ import (
 // Exported for tests that need to compose right-at-cap and over-cap bodies without duplicating the magic number.
 const MaxIngestBodyBytes = 10 * 1024 * 1024
 
+// ParseAndValidateIngestBody is the parse + per-event validation half of POST /api/events, lifted out of handleIngest so the
+// fuzz harness can drive it without a full HTTP server + Detection store. Returns (events, http.StatusOK, "") on success, or
+// (nil, 4xx, errCode) on parse / validation failure. The error codes are the same stable set the HTTP handler emits:
+// "invalid_json", "missing_fields_at_<i>", "host_id_mismatch". The body-cap (413) check is upstream of this function (in
+// readBodyWithCap); the store-insert (5xx) is downstream of it. The fuzz contract is therefore: every output MUST be one of
+// {(200, ""), (400, "invalid_json"), (400, "missing_fields_at_<i>"), (400, "host_id_mismatch")} — anything else is a finding.
+func ParseAndValidateIngestBody(body []byte, pinnedHostID string) (events []api.Event, status int, errCode string) {
+	if err := json.Unmarshal(body, &events); err != nil {
+		return nil, http.StatusBadRequest, "invalid_json"
+	}
+	for i, e := range events {
+		if e.EventID == "" || e.HostID == "" || e.EventType == "" || e.TimestampNs == 0 {
+			return nil, http.StatusBadRequest, "missing_fields_at_" + strconv.Itoa(i)
+		}
+		if e.HostID != pinnedHostID {
+			return nil, http.StatusBadRequest, "host_id_mismatch"
+		}
+	}
+	return events, http.StatusOK, ""
+}
+
 // BuildInfo is injected at startup so the readiness endpoint
 // advertises version + commit.
 type BuildInfo struct {
@@ -85,21 +106,10 @@ func (h *Handler) handleIngest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var events []api.Event
-	if err := json.Unmarshal(body, &events); err != nil {
-		writeErr(ctx, h.logger, w, http.StatusBadRequest, "invalid_json")
+	events, status, errCode := ParseAndValidateIngestBody(body, pinnedHostID)
+	if status != http.StatusOK {
+		writeErr(ctx, h.logger, w, status, errCode)
 		return
-	}
-
-	for i, e := range events {
-		if e.EventID == "" || e.HostID == "" || e.EventType == "" || e.TimestampNs == 0 {
-			writeErr(ctx, h.logger, w, http.StatusBadRequest, "missing_fields_at_"+strconv.Itoa(i))
-			return
-		}
-		if e.HostID != pinnedHostID {
-			writeErr(ctx, h.logger, w, http.StatusBadRequest, "host_id_mismatch")
-			return
-		}
 	}
 
 	insertStart := time.Now()

--- a/server/detection/internal/intake/handler_fuzz_test.go
+++ b/server/detection/internal/intake/handler_fuzz_test.go
@@ -77,11 +77,14 @@ func assertValidOutput(t *testing.T, body []byte, events []api.Event, status int
 		// Any of the documented 400 error codes is acceptable. The fuzz pins the SET of codes; a stray code is a finding.
 		switch {
 		case errCode == "invalid_json":
-			// Implies the JSON parse failed. The body either isn't well-formed JSON OR doesn't deserialize into []api.Event.
+			// Implies the JSON parse failed OR the body deserialized to nil (literal `null`, treated as a parse failure).
 		case errCode == "host_id_mismatch":
 			// Implies at least one event's host_id != pinnedHostID. We don't re-parse the body here to confirm — the parse
 			// produced events, then a validation step caught the mismatch. Trusting the function's own report.
 			_ = pinnedHostID
+		case errCode == "too_many_events":
+			// Implies the parsed array exceeded MaxIngestEventsPerRequest. Memory-amplification defense; the cap fires
+			// before the per-event validation loop.
 		case strings.HasPrefix(errCode, "missing_fields_at_"):
 			// Implies an event at some index missed one of {event_id, host_id, event_type, timestamp_ns}.
 		default:
@@ -133,14 +136,20 @@ func seedCorpus(f *testing.F) {
     ]`))
 
 	// Adversarial / pathological shapes the fuzz engine might not synthesize on its own.
-	f.Add(deepNestedArray(64))                      // deeply-nested JSON arrays — JSON decoder stack
-	f.Add(bytes.Repeat([]byte{0}, 256))             // a NULL-byte block
-	f.Add([]byte(`["\xff"]`))                       // invalid UTF-8 inside a JSON string (\xff is not legal UTF-8)
+	f.Add(deepNestedArray(64))          // deeply-nested JSON arrays — JSON decoder stack
+	f.Add(bytes.Repeat([]byte{0}, 256)) // a NULL-byte block
+	// `["\xff"]` literal: the bytes on disk are the 8 ASCII characters [ " \ x f f " ]. Valid UTF-8 (no 0xFF byte ever
+	// hits the parser); the JSON decoder rejects the input because `\xff` is not a recognized JSON escape sequence. This
+	// seed exercises the escape-handling path, not the UTF-8-validity path.
+	f.Add([]byte(`["\xff"]`))
+	// Raw 0xFF byte inside the JSON string — actual invalid UTF-8 on the wire. The decoder's UTF-8 validity check
+	// catches this one (distinct path from the escape-sequence rejection above).
+	f.Add([]byte("[\"" + string([]byte{0xff}) + "\"]"))
 	f.Add([]byte("[\"\x00\"]"))                     // U+0000 in a JSON string — historically a parser footgun
 	f.Add([]byte("[{\"event_id\":\"e\x00nuls\"}]")) // NULs inside required-string field — exercise len()-vs-empty check
 	// Long string field (~64 KiB event_id) to exercise large-value paths within the body cap.
 	long := bytes.Repeat([]byte("a"), 64*1024)
-	f.Add([]byte(fmt.Sprintf(`[{"event_id":%q,"host_id":"fuzz-pinned-host","event_type":"exec","timestamp_ns":1,"payload":{}}]`, long)))
+	f.Add(fmt.Appendf(nil, `[{"event_id":%q,"host_id":"fuzz-pinned-host","event_type":"exec","timestamp_ns":1,"payload":{}}]`, long))
 	// Mixed-validity ASCII + UTF-8 in a host_id (assert the comparator handles non-ASCII without crashing).
 	if utf8.ValidString("ñöß-host") {
 		f.Add([]byte(`[{"event_id":"e1","host_id":"ñöß-host","event_type":"exec","timestamp_ns":1,"payload":{}}]`))

--- a/server/detection/internal/intake/handler_fuzz_test.go
+++ b/server/detection/internal/intake/handler_fuzz_test.go
@@ -1,0 +1,161 @@
+package intake
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/fleetdm/edr/server/detection/api"
+)
+
+// FuzzParseAndValidateIngestBody drives the parse + per-event validation half of POST /api/events with random body bytes.
+// The fuzz target asserts two invariants the spec contract makes on this surface:
+//
+//  1. Liveness: no input causes a panic, an unbounded allocation, or any other unrecoverable behavior. The harness wraps the
+//     call in a defer/recover sanity net so a panic surfaces as a test failure with the offending input attached.
+//  2. Contract: every (status, errCode) tuple is one of the documented set:
+//     {(200, ""), (400, "invalid_json"), (400, "missing_fields_at_<i>"), (400, "host_id_mismatch")}.
+//     Anything else (an undocumented status, a stray errCode, a 200 returned for a body that obviously isn't a well-formed
+//     []api.Event) is a finding. The 413 body-cap and the 500 store-insert paths are upstream / downstream of this function
+//     and are tested elsewhere; the fuzz keeps its blast radius to the parse + validate surface so the harness needs no DB.
+//
+// Why the pinnedHostID is a fixed sentinel: the production middleware threads the token-bound HostID through context; the
+// fuzz only needs ONE host ID to exercise both the matching and the mismatching code paths (a fuzz-generated body's
+// embedded host_id may or may not match this sentinel). Two distinct sentinels would double the search space without
+// changing what's reachable.
+//
+// CLAUDE.md test-style decision matrix:
+//
+//	"Use Go's native go test -fuzz for untrusted input parsing including event JSON, policy diff, and agent HTTP bodies"
+//
+// This target closes the "event JSON" row.
+func FuzzParseAndValidateIngestBody(f *testing.F) {
+	seedCorpus(f)
+
+	const pinnedHostID = "fuzz-pinned-host"
+	f.Fuzz(func(t *testing.T, body []byte) {
+		// Outer recover so a real panic surfaces as a clean test failure with the offending input attached. The fuzz engine
+		// would catch the panic anyway, but the explicit %q'd input makes the failure log self-contained for reproducing.
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("ParseAndValidateIngestBody panicked on input %q: %v", body, r)
+			}
+		}()
+
+		events, status, errCode := ParseAndValidateIngestBody(body, pinnedHostID)
+		assertValidOutput(t, body, events, status, errCode, pinnedHostID)
+	})
+}
+
+// assertValidOutput pins the (status, errCode) -> shape contract documented on ParseAndValidateIngestBody. Pulled out of
+// the FuzzFunc body so the test failure message can include the exact tuple AND so a future contract addition (new error
+// code) is a one-line edit here, not in the fuzz function.
+func assertValidOutput(t *testing.T, body []byte, events []api.Event, status int, errCode string, pinnedHostID string) {
+	t.Helper()
+	_ = events // events shape is implicit in the success-vs-failure split below; per-event field assertions are tested separately
+
+	switch status {
+	case http.StatusOK:
+		// Success means the body parsed AND every event passed the per-event validation. A 200 on a body that's obviously not
+		// a JSON array of well-formed events would be a real finding; the fuzz cheaply guards against that by requiring an
+		// empty errCode on success and re-checking the body parses as a JSON array (the json.Unmarshal failure path is what
+		// emits invalid_json, so a 200 implies the unmarshal succeeded).
+		if errCode != "" {
+			t.Fatalf("status 200 returned with non-empty errCode %q for body %q", errCode, body)
+		}
+		// Sanity: a 200 result implies the body started with [ (a JSON array). An empty body or a non-array would not have
+		// reached the loop. The body may have leading/trailing whitespace; trim before the prefix check.
+		trimmed := bytes.TrimSpace(body)
+		if len(trimmed) > 0 && trimmed[0] != '[' {
+			t.Fatalf("status 200 but body is not a JSON array: %q", body)
+		}
+
+	case http.StatusBadRequest:
+		// Any of the documented 400 error codes is acceptable. The fuzz pins the SET of codes; a stray code is a finding.
+		switch {
+		case errCode == "invalid_json":
+			// Implies the JSON parse failed. The body either isn't well-formed JSON OR doesn't deserialize into []api.Event.
+		case errCode == "host_id_mismatch":
+			// Implies at least one event's host_id != pinnedHostID. We don't re-parse the body here to confirm — the parse
+			// produced events, then a validation step caught the mismatch. Trusting the function's own report.
+			_ = pinnedHostID
+		case strings.HasPrefix(errCode, "missing_fields_at_"):
+			// Implies an event at some index missed one of {event_id, host_id, event_type, timestamp_ns}.
+		default:
+			t.Fatalf("status 400 returned with undocumented errCode %q for body %q", errCode, body)
+		}
+
+	default:
+		t.Fatalf("undocumented status %d (errCode %q) for body %q", status, errCode, body)
+	}
+}
+
+// seedCorpus loads the curated entry set. Each entry exercises a distinct decision point in ParseAndValidateIngestBody;
+// the fuzz engine extends from there via byte-flip / insert mutations.
+func seedCorpus(f *testing.F) {
+	f.Helper()
+	// Happy path: an empty array (no events to validate; parses cleanly to []api.Event{} -> status 200).
+	f.Add([]byte(`[]`))
+	// One well-formed event matching the pinned host id. The TimestampNs must be non-zero per the validation rule.
+	f.Add([]byte(`[{"event_id":"e1","host_id":"fuzz-pinned-host","event_type":"exec","timestamp_ns":1,"payload":{}}]`))
+	// Two well-formed events, both pinned.
+	f.Add([]byte(`[
+        {"event_id":"e1","host_id":"fuzz-pinned-host","event_type":"exec","timestamp_ns":1,"payload":{}},
+        {"event_id":"e2","host_id":"fuzz-pinned-host","event_type":"fork","timestamp_ns":2,"payload":{}}
+    ]`))
+
+	// invalid_json shapes.
+	f.Add([]byte{})                         // empty body
+	f.Add([]byte(`not json at all`))        // raw text
+	f.Add([]byte(`[`))                      // unterminated array
+	f.Add([]byte(`{"event_id":"e1"}`))      // object, not array
+	f.Add([]byte(`[{`))                     // unterminated object inside array
+	f.Add([]byte(`[null]`))                 // null instead of an event object
+	f.Add([]byte(`[1,2,3]`))                // numbers instead of objects
+	f.Add([]byte(`[{"event_id":1}]`))       // event_id wrong type (int instead of string) — json strict?
+	f.Add([]byte(`[{"timestamp_ns":"x"}]`)) // timestamp_ns wrong type (string instead of int)
+
+	// missing_fields shapes.
+	f.Add([]byte(`[{}]`))                                                                                  // every required field missing
+	f.Add([]byte(`[{"event_id":"e1"}]`))                                                                   // only event_id
+	f.Add([]byte(`[{"event_id":"e1","host_id":"fuzz-pinned-host"}]`))                                      // missing event_type + timestamp_ns
+	f.Add([]byte(`[{"event_id":"e1","host_id":"fuzz-pinned-host","event_type":"exec","timestamp_ns":0}]`)) // timestamp_ns zero is a miss
+
+	// host_id_mismatch shapes.
+	f.Add([]byte(`[{"event_id":"e1","host_id":"other-host","event_type":"exec","timestamp_ns":1,"payload":{}}]`))
+	// First event matches pinned, second doesn't — exercises the loop's per-event check.
+	f.Add([]byte(`[
+        {"event_id":"e1","host_id":"fuzz-pinned-host","event_type":"exec","timestamp_ns":1,"payload":{}},
+        {"event_id":"e2","host_id":"other-host","event_type":"exec","timestamp_ns":2,"payload":{}}
+    ]`))
+
+	// Adversarial / pathological shapes the fuzz engine might not synthesize on its own.
+	f.Add(deepNestedArray(64))                      // deeply-nested JSON arrays — JSON decoder stack
+	f.Add(bytes.Repeat([]byte{0}, 256))             // a NULL-byte block
+	f.Add([]byte(`["\xff"]`))                       // invalid UTF-8 inside a JSON string (\xff is not legal UTF-8)
+	f.Add([]byte("[\"\x00\"]"))                     // U+0000 in a JSON string — historically a parser footgun
+	f.Add([]byte("[{\"event_id\":\"e\x00nuls\"}]")) // NULs inside required-string field — exercise len()-vs-empty check
+	// Long string field (~64 KiB event_id) to exercise large-value paths within the body cap.
+	long := bytes.Repeat([]byte("a"), 64*1024)
+	f.Add([]byte(fmt.Sprintf(`[{"event_id":%q,"host_id":"fuzz-pinned-host","event_type":"exec","timestamp_ns":1,"payload":{}}]`, long)))
+	// Mixed-validity ASCII + UTF-8 in a host_id (assert the comparator handles non-ASCII without crashing).
+	if utf8.ValidString("ñöß-host") {
+		f.Add([]byte(`[{"event_id":"e1","host_id":"ñöß-host","event_type":"exec","timestamp_ns":1,"payload":{}}]`))
+	}
+}
+
+// deepNestedArray returns a JSON body that nests n levels of `[`s before closing with n `]`s. Probes the decoder's
+// recursion depth handling without going so deep that the test itself OOMs.
+func deepNestedArray(n int) []byte {
+	var b bytes.Buffer
+	for range n {
+		b.WriteByte('[')
+	}
+	for range n {
+		b.WriteByte(']')
+	}
+	return b.Bytes()
+}

--- a/server/endpoint/internal/enroll/handler_fuzz_test.go
+++ b/server/endpoint/internal/enroll/handler_fuzz_test.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -48,7 +49,8 @@ import (
 func FuzzEnrollBody(f *testing.F) {
 	seedEnrollCorpus(f)
 
-	srv, client := sharedEnrollServer(f)
+	srv := sharedEnrollServer()
+	client := srv.Client()
 	url := srv.URL + "/api/enroll"
 
 	f.Fuzz(func(t *testing.T, body []byte) {
@@ -82,67 +84,51 @@ func FuzzEnrollBody(f *testing.F) {
 	})
 }
 
-// assertEnrollOutputContract pins the (status, errCode) -> envelope contract for every documented enroll outcome.
-// Pulled out so a future contract change (new error code) is one edit here, not in the fuzz function body.
+// assertEnrollOutputContract pins the (status, errCode) -> envelope contract for every documented enroll outcome. The switch dispatches to per-status helpers; the helpers do the JSON parse + error-code check so this function stays linear (cognitive complexity ≤ 15 per Sonar S3776).
 func assertEnrollOutputContract(t *testing.T, body []byte, status int, retryAfter string, respBody []byte) {
 	t.Helper()
 	switch status {
 	case http.StatusOK:
-		// Success implies the body parsed cleanly + every required field was populated + Service.Enroll returned
-		// a valid response. The response body is the enrollResponse JSON: {host_id, host_token, enrolled_at}.
-		var ok enrollResponse
-		if err := json.Unmarshal(respBody, &ok); err != nil {
-			t.Fatalf("200 response is not enrollResponse JSON: %v; body=%q", err, respBody)
-		}
-		if ok.HostID == "" || ok.HostToken == "" {
-			t.Fatalf("200 response has empty required field; body=%q", respBody)
-		}
-
+		assertEnroll200(t, respBody)
 	case http.StatusBadRequest:
-		// Any 400 must carry a documented error code in the JSON envelope. The handler only emits two 400 codes:
-		// bad_body (parse/missing-fields) and hardware_uuid_invalid (Service-level UUID validation).
-		var env errBody
-		if err := json.Unmarshal(respBody, &env); err != nil {
-			t.Fatalf("400 response is not errBody JSON: %v; body=%q", err, respBody)
-		}
-		switch env.Error {
-		case "bad_body", "hardware_uuid_invalid":
-			// expected codes
-		default:
-			t.Fatalf("400 response has undocumented errCode %q for input %q", env.Error, body)
-		}
-
+		assertEnrollErrBody(t, body, respBody, http.StatusBadRequest, "bad_body", "hardware_uuid_invalid")
 	case http.StatusUnauthorized:
-		// The only 401 path emits secret_mismatch.
-		var env errBody
-		if err := json.Unmarshal(respBody, &env); err != nil {
-			t.Fatalf("401 response is not errBody JSON: %v; body=%q", err, respBody)
-		}
-		if env.Error != "secret_mismatch" {
-			t.Fatalf("401 response has undocumented errCode %q for input %q", env.Error, body)
-		}
-
+		assertEnrollErrBody(t, body, respBody, http.StatusUnauthorized, "secret_mismatch")
 	case http.StatusTooManyRequests:
-		// The 429 path emits rate_limited AND the Retry-After header. The fuzz uses RatePerMinute=60_000 which makes
-		// 429s effectively unreachable, but if one ever fires here, the envelope + header must still satisfy the spec.
 		if retryAfter == "" {
 			t.Fatalf("429 returned without Retry-After header for input %q", body)
 		}
-		var env errBody
-		if err := json.Unmarshal(respBody, &env); err != nil || env.Error != "rate_limited" {
-			t.Fatalf("429 envelope mismatch: err=%v code=%q for input %q", err, env.Error, body)
-		}
-
+		assertEnrollErrBody(t, body, respBody, http.StatusTooManyRequests, "rate_limited")
 	case http.StatusInternalServerError:
-		// Internal errors map to errCode "internal".
-		var env errBody
-		if err := json.Unmarshal(respBody, &env); err != nil || env.Error != "internal" {
-			t.Fatalf("500 envelope mismatch: err=%v code=%q for input %q", err, env.Error, body)
-		}
-
+		assertEnrollErrBody(t, body, respBody, http.StatusInternalServerError, "internal")
 	default:
 		t.Fatalf("undocumented status %d (body=%q) for input %q", status, respBody, body)
 	}
+}
+
+// assertEnroll200 pins the success-response shape. Success implies the body parsed cleanly + every required field was populated + Service.Enroll returned a valid response. The response body is the enrollResponse JSON: {host_id, host_token, enrolled_at}.
+func assertEnroll200(t *testing.T, respBody []byte) {
+	t.Helper()
+	var ok enrollResponse
+	if err := json.Unmarshal(respBody, &ok); err != nil {
+		t.Fatalf("200 response is not enrollResponse JSON: %v; body=%q", err, respBody)
+	}
+	if ok.HostID == "" || ok.HostToken == "" {
+		t.Fatalf("200 response has empty required field; body=%q", respBody)
+	}
+}
+
+// assertEnrollErrBody pins the error-envelope contract: every non-200 response is `{"error": "<code>"}` JSON and the code is in the allow-list the caller passed. allowed is variadic so each status' set of codes is documented at the call site.
+func assertEnrollErrBody(t *testing.T, body, respBody []byte, status int, allowed ...string) {
+	t.Helper()
+	var env errBody
+	if err := json.Unmarshal(respBody, &env); err != nil {
+		t.Fatalf("%d response is not errBody JSON: %v; body=%q", status, err, respBody)
+	}
+	if slices.Contains(allowed, env.Error) {
+		return
+	}
+	t.Fatalf("%d response has undocumented errCode %q (allowed=%v) for input %q", status, env.Error, allowed, body)
 }
 
 // sharedEnrollServer constructs ONE httptest server + reusable client for the whole fuzz run. One server avoids
@@ -153,36 +139,35 @@ func assertEnrollOutputContract(t *testing.T, body []byte, status int, retryAfte
 // The limiter is set to a huge per-minute rate so 429s don't accumulate across iterations — but the iteration order +
 // the limiter's internal token-bucket state still mean the very first few iterations can drain the burst; the fuzz
 // must tolerate 429s with the proper envelope (assertEnrollOutputContract handles that case explicitly).
-var sharedEnrollServerOnce sync.Once
-var sharedEnrollServerSrv *httptest.Server
+//
+// sync.OnceValue (Go 1.21+) gives a non-nilable return without the global-variable indirection that the older
+// sync.Once+global pattern needs. nilaway can prove the returned *httptest.Server is non-nil because newSharedEnrollServer
+// always constructs and returns a value, whereas the older pattern hid the assignment inside a closure that nilaway's
+// dataflow couldn't follow.
+var sharedEnrollServer = sync.OnceValue(newSharedEnrollServer)
 
-func sharedEnrollServer(f *testing.F) (*httptest.Server, *http.Client) {
-	f.Helper()
-	sharedEnrollServerOnce.Do(func() {
-		now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
-		svc := fakeService{
-			enroll: func(_ context.Context, _ api.EnrollRequest, _ string) (api.EnrollResponse, error) {
-				return api.EnrollResponse{HostID: "fuzz-host", HostToken: "fuzz-tok", EnrolledAt: now}, nil
-			},
-		}
-		h := New(svc, Options{RatePerMinute: 60_000, Logger: slog.New(slog.DiscardHandler)})
-		mux := http.NewServeMux()
-		h.RegisterRoutes(mux)
-		sharedEnrollServerSrv = httptest.NewServer(mux)
-	})
-	return sharedEnrollServerSrv, sharedEnrollServerSrv.Client()
+func newSharedEnrollServer() *httptest.Server {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	svc := fakeService{
+		enroll: func(_ context.Context, _ api.EnrollRequest, _ string) (api.EnrollResponse, error) {
+			return api.EnrollResponse{HostID: "fuzz-host", HostToken: "fuzz-tok", EnrolledAt: now}, nil
+		},
+	}
+	h := New(svc, Options{RatePerMinute: 60_000, Logger: slog.New(slog.DiscardHandler)})
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+	return httptest.NewServer(mux)
 }
 
-// seedEnrollCorpus loads curated entries that hit every decision point in the enroll handler. The fuzz engine extends from
-// these via byte-flip / insert mutations.
+// seedEnrollCorpus loads curated entries that hit every decision point in the enroll handler. The fuzz engine extends
+// from these via byte-flip / insert mutations.
 func seedEnrollCorpus(f *testing.F) {
 	f.Helper()
 
-	// Happy-path bodies. The stub's first-byte=0 branch returns success; these inputs start with `{` (byte 0x7B = 123),
-	// 123 % 4 = 3 -> internal. So they actually exercise the synthetic-error path. The mutator quickly synthesizes
-	// happy-path-shape bodies that start with bytes mapping to firstByte%4==0 too.
+	// Happy-path-shape bodies. All required fields populated; the stub returns success.
 	f.Add([]byte(`{"enroll_secret":"s","hardware_uuid":"93DFC6F5-763D-5075-B305-8AC145D12F96","hostname":"h","os_version":"o","agent_version":"v"}`))
-	f.Add([]byte(`{"enroll_secret":"","hardware_uuid":"u","hostname":"h","os_version":"o","agent_version":"v"}`)) // empty secret -> missing field
+	// Empty secret — all-fields-required gate rejects with bad_body before Service.Enroll is called.
+	f.Add([]byte(`{"enroll_secret":"","hardware_uuid":"u","hostname":"h","os_version":"o","agent_version":"v"}`))
 
 	// bad_body shapes.
 	f.Add([]byte{})                                        // empty body
@@ -195,10 +180,9 @@ func seedEnrollCorpus(f *testing.F) {
 	f.Add([]byte(strings.Repeat("{", 100)))                // deeply truncated JSON
 	f.Add(bytes.Repeat([]byte("a"), maxEnrollBodyBytes+1)) // over the body cap; cap-trip path
 
-	// Inputs that should reach the Service-error mapping. First-byte mod 4 picks which Service-error branch fires; the
-	// JSON shape must still pass the required-fields gate to reach the Service call. So we need bodies whose JSON parses
-	// cleanly AND whose first byte maps to each stub branch.
-	// firstByte = '{' (0x7B = 123); 123 % 4 = 3 -> internal-error branch.
+	// A second happy-path-shape body for the mutator to anchor mutations on. With the always-success stub this exercises
+	// the same Service.Enroll → 200 path as the first happy-path seed; redundant on the seed list but a useful anchor for
+	// the mutator's byte-flip generations.
 	f.Add([]byte(`{"enroll_secret":"s","hardware_uuid":"u","hostname":"h","os_version":"o","agent_version":"v"}`))
 
 	// Adversarial / pathological. The fuzz engine probes the parser; these seeds explicitly add shapes that historically

--- a/server/endpoint/internal/enroll/handler_fuzz_test.go
+++ b/server/endpoint/internal/enroll/handler_fuzz_test.go
@@ -1,0 +1,210 @@
+package enroll
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/fleetdm/edr/server/endpoint/api"
+)
+
+// FuzzEnrollBody drives the full POST /api/enroll handler with random body bytes. Parallel to FuzzParseAndValidateIngestBody
+// in server/detection/internal/intake/: same untrusted-public-input boundary, same shape, same liveness + contract
+// invariants. /api/enroll is unauthenticated (rate-limited per source IP); the body must survive every fuzzer-synthesized
+// shape without panicking, and every (status, errCode) tuple must be one of the documented set.
+//
+// Documented set on the enroll handler (per server/endpoint/internal/enroll/handler.go):
+//
+//	(200, "")                    success — Service.Enroll returned a token
+//	(400, "bad_body")            body parse failure OR missing required field
+//	(400, "hardware_uuid_invalid") Service returned api.ErrInvalidHardwareUUID
+//	(401, "secret_mismatch")     Service returned api.ErrInvalidSecret
+//	(429, "rate_limited")        per-IP rate limit (with Retry-After header)
+//	(500, "internal")            Service returned any other error
+//
+// The fuzz drives the full handler (not a refactored parse helper) because /api/enroll's body cap is integrated with the
+// per-IP rate limiter and the Service-injection seam: the handler wraps r.Body in MaxBytesReader and decodes via
+// json.NewDecoder, so the cap-vs-parse interaction matters. The fakeService stub avoids a real DB.
+//
+// Service stub strategy: the stub returns success on every call. The fuzz's job is to verify the parse + body-cap +
+// required-fields path; the Service-error mapping branches (secret_mismatch, hardware_uuid_invalid, internal) are
+// table-tested in handler_test.go. Folding the error-mapping into the fuzz would require per-request port allocation
+// (one server per stub behavior), which exhausts ephemeral ports during a high-throughput fuzz. One shared server is the
+// trade-off that lets the fuzz hit 1k+ execs/sec without TCP-port-pool starvation.
+//
+// CLAUDE.md test-style decision matrix:
+//
+//	"Use Go's native go test -fuzz for untrusted input parsing including event JSON, policy diff, and agent HTTP bodies"
+//
+// This closes the "agent HTTP bodies" row for the enroll surface — the other public agent body path.
+func FuzzEnrollBody(f *testing.F) {
+	seedEnrollCorpus(f)
+
+	srv, client := sharedEnrollServer(f)
+	url := srv.URL + "/api/enroll"
+
+	f.Fuzz(func(t *testing.T, body []byte) {
+		// Outer recover so a panic surfaces with the offending input attached. The fuzz engine catches panics anyway; the
+		// explicit %q'd input makes the failure log self-contained for reproduction.
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("enroll handler panicked on input %q: %v", body, r)
+			}
+		}()
+
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, url, bytes.NewReader(body))
+		if err != nil {
+			t.Fatalf("build request: %v", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatalf("send request: %v", err)
+		}
+		defer resp.Body.Close()
+
+		// Read the body so we can pin the error envelope's shape on every non-200 response. Cap the read at 4 KiB; the
+		// handler writes a tiny JSON object, anything larger is itself a finding.
+		respBody, err := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		if err != nil {
+			t.Fatalf("read response body: %v", err)
+		}
+
+		assertEnrollOutputContract(t, body, resp.StatusCode, resp.Header.Get("Retry-After"), respBody)
+	})
+}
+
+// assertEnrollOutputContract pins the (status, errCode) -> envelope contract for every documented enroll outcome.
+// Pulled out so a future contract change (new error code) is one edit here, not in the fuzz function body.
+func assertEnrollOutputContract(t *testing.T, body []byte, status int, retryAfter string, respBody []byte) {
+	t.Helper()
+	switch status {
+	case http.StatusOK:
+		// Success implies the body parsed cleanly + every required field was populated + Service.Enroll returned
+		// a valid response. The response body is the enrollResponse JSON: {host_id, host_token, enrolled_at}.
+		var ok enrollResponse
+		if err := json.Unmarshal(respBody, &ok); err != nil {
+			t.Fatalf("200 response is not enrollResponse JSON: %v; body=%q", err, respBody)
+		}
+		if ok.HostID == "" || ok.HostToken == "" {
+			t.Fatalf("200 response has empty required field; body=%q", respBody)
+		}
+
+	case http.StatusBadRequest:
+		// Any 400 must carry a documented error code in the JSON envelope. The handler only emits two 400 codes:
+		// bad_body (parse/missing-fields) and hardware_uuid_invalid (Service-level UUID validation).
+		var env errBody
+		if err := json.Unmarshal(respBody, &env); err != nil {
+			t.Fatalf("400 response is not errBody JSON: %v; body=%q", err, respBody)
+		}
+		switch env.Error {
+		case "bad_body", "hardware_uuid_invalid":
+			// expected codes
+		default:
+			t.Fatalf("400 response has undocumented errCode %q for input %q", env.Error, body)
+		}
+
+	case http.StatusUnauthorized:
+		// The only 401 path emits secret_mismatch.
+		var env errBody
+		if err := json.Unmarshal(respBody, &env); err != nil {
+			t.Fatalf("401 response is not errBody JSON: %v; body=%q", err, respBody)
+		}
+		if env.Error != "secret_mismatch" {
+			t.Fatalf("401 response has undocumented errCode %q for input %q", env.Error, body)
+		}
+
+	case http.StatusTooManyRequests:
+		// The 429 path emits rate_limited AND the Retry-After header. The fuzz uses RatePerMinute=60_000 which makes
+		// 429s effectively unreachable, but if one ever fires here, the envelope + header must still satisfy the spec.
+		if retryAfter == "" {
+			t.Fatalf("429 returned without Retry-After header for input %q", body)
+		}
+		var env errBody
+		if err := json.Unmarshal(respBody, &env); err != nil || env.Error != "rate_limited" {
+			t.Fatalf("429 envelope mismatch: err=%v code=%q for input %q", err, env.Error, body)
+		}
+
+	case http.StatusInternalServerError:
+		// Internal errors map to errCode "internal".
+		var env errBody
+		if err := json.Unmarshal(respBody, &env); err != nil || env.Error != "internal" {
+			t.Fatalf("500 envelope mismatch: err=%v code=%q for input %q", err, env.Error, body)
+		}
+
+	default:
+		t.Fatalf("undocumented status %d (body=%q) for input %q", status, respBody, body)
+	}
+}
+
+// sharedEnrollServer constructs ONE httptest server + reusable client for the whole fuzz run. One server avoids
+// ephemeral-port exhaustion under high-throughput fuzz (16 workers × ~1k execs/sec quickly drain a /29 of free ports).
+// The Service stub returns success on every call; per-error-mapping branches are covered by handler_test.go's table
+// tests, not by the fuzz.
+//
+// The limiter is set to a huge per-minute rate so 429s don't accumulate across iterations — but the iteration order +
+// the limiter's internal token-bucket state still mean the very first few iterations can drain the burst; the fuzz
+// must tolerate 429s with the proper envelope (assertEnrollOutputContract handles that case explicitly).
+var sharedEnrollServerOnce sync.Once
+var sharedEnrollServerSrv *httptest.Server
+
+func sharedEnrollServer(f *testing.F) (*httptest.Server, *http.Client) {
+	f.Helper()
+	sharedEnrollServerOnce.Do(func() {
+		now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+		svc := fakeService{
+			enroll: func(_ context.Context, _ api.EnrollRequest, _ string) (api.EnrollResponse, error) {
+				return api.EnrollResponse{HostID: "fuzz-host", HostToken: "fuzz-tok", EnrolledAt: now}, nil
+			},
+		}
+		h := New(svc, Options{RatePerMinute: 60_000, Logger: slog.New(slog.DiscardHandler)})
+		mux := http.NewServeMux()
+		h.RegisterRoutes(mux)
+		sharedEnrollServerSrv = httptest.NewServer(mux)
+	})
+	return sharedEnrollServerSrv, sharedEnrollServerSrv.Client()
+}
+
+// seedEnrollCorpus loads curated entries that hit every decision point in the enroll handler. The fuzz engine extends from
+// these via byte-flip / insert mutations.
+func seedEnrollCorpus(f *testing.F) {
+	f.Helper()
+
+	// Happy-path bodies. The stub's first-byte=0 branch returns success; these inputs start with `{` (byte 0x7B = 123),
+	// 123 % 4 = 3 -> internal. So they actually exercise the synthetic-error path. The mutator quickly synthesizes
+	// happy-path-shape bodies that start with bytes mapping to firstByte%4==0 too.
+	f.Add([]byte(`{"enroll_secret":"s","hardware_uuid":"93DFC6F5-763D-5075-B305-8AC145D12F96","hostname":"h","os_version":"o","agent_version":"v"}`))
+	f.Add([]byte(`{"enroll_secret":"","hardware_uuid":"u","hostname":"h","os_version":"o","agent_version":"v"}`)) // empty secret -> missing field
+
+	// bad_body shapes.
+	f.Add([]byte{})                                        // empty body
+	f.Add([]byte(`not json`))                              // raw text
+	f.Add([]byte(`{`))                                     // unterminated object
+	f.Add([]byte(`{"enroll_secret":"s"}`))                 // missing other required fields
+	f.Add([]byte(`null`))                                  // top-level null
+	f.Add([]byte(`[]`))                                    // top-level array (struct decoder rejects)
+	f.Add([]byte(`{"enroll_secret":1}`))                   // wrong type for string field
+	f.Add([]byte(strings.Repeat("{", 100)))                // deeply truncated JSON
+	f.Add(bytes.Repeat([]byte("a"), maxEnrollBodyBytes+1)) // over the body cap; cap-trip path
+
+	// Inputs that should reach the Service-error mapping. First-byte mod 4 picks which Service-error branch fires; the
+	// JSON shape must still pass the required-fields gate to reach the Service call. So we need bodies whose JSON parses
+	// cleanly AND whose first byte maps to each stub branch.
+	// firstByte = '{' (0x7B = 123); 123 % 4 = 3 -> internal-error branch.
+	f.Add([]byte(`{"enroll_secret":"s","hardware_uuid":"u","hostname":"h","os_version":"o","agent_version":"v"}`))
+
+	// Adversarial / pathological. The fuzz engine probes the parser; these seeds explicitly add shapes that historically
+	// trip JSON decoders.
+	f.Add(bytes.Repeat([]byte{0}, 256))                                                                                   // NULL-byte block
+	f.Add([]byte(`{"enroll_secret":"` + strings.Repeat("a", 8192) + `"}`))                                                // very long secret string
+	f.Add([]byte(`{"enroll_secret":"\uD83D"}`))                                                                           // unpaired surrogate
+	f.Add([]byte(`{"hardware_uuid":"ñöß-uuid","enroll_secret":"s","hostname":"h","os_version":"o","agent_version":"v"}`)) // non-ASCII UUID
+}


### PR DESCRIPTION
…v project rollups to informational

Two changes, both pre-v0.1.0 test hardening + CI noise removal.

# Fuzz coverage on untrusted public-input bodies (#236 + parallel enroll work)

CLAUDE.md's test-style decision matrix calls for fuzz coverage on "event JSON, policy diff, and agent HTTP bodies." Two of those three surfaces are public agent inputs hit by every enrolled host on every event upload; neither had a fuzz target before this PR.

- FuzzParseAndValidateIngestBody at server/detection/internal/intake/ drives the parse + per-event validation half of POST /api/events. Refactored handler.go to extract ParseAndValidateIngestBody as a pure function so the harness doesn't need a Detection store. The contract assertion pins every output to one of the documented (status, errCode) tuples; an undocumented status or stray errCode is a finding. 1.8M execs / 6s on the curated corpus, no findings.

- FuzzEnrollBody at server/endpoint/internal/enroll/ drives the full POST /api/enroll handler via httptest. One shared server + client avoids ephemeral-port exhaustion under 16-worker fuzz throughput. Service stub returns success on every call; per-Service-error branches are table-tested in handler_test.go. Output contract pins the (status, errCode) tuple AND the response envelope shape AND (for 429) the Retry-After header. 154k execs / 6s, no findings.

Both targets feed the standard `go test` run via the seed-corpus-as- table-test path; `-fuzz=Fuzz<Name>` extends them for nightly runs.

# Codecov project rollup demoted to informational (#227)

Three M13 stack PRs in a row carried a "documented skip reason" for codecov/project/ui failing at 14.4% vs 70% on Go-only PRs. Earlier rounds (#124, then #227) responded by dropping the threshold; main kept drifting below the floor and the gate became a chronic-flake red check on every PR.

informational: true on the project + per-flag project rollups demotes the gate without removing the dashboard signal. The per-PR patch gates stay enforcing — those pin new-code coverage and have been consistently honest in the M13 stack. Sonar's per-PR new-code gate (80% in the SonarCloud UI) is the authoritative bar.

If a real coverage cliff lands on main, the trend will show up in the rollup's number; an operator flips informational back to false and tightens the target. The path back is short.

# PR scope honest about what M13 already closed

The original bundle was scoped to include #243 (queue cap-eviction + disk-full), #242 (operator JSON error envelope), #246 (server-side command scope), and #247 (server-side enroll boundaries). Inventory revealed all four were already addressed during the M13 marker stack — markers + tests exist for every deferred scenario. They've been closed in separate `gh issue close` commands with verification comments rather than carried as PR work. The remaining honestly- needed work landed at ~400 LOC: one new fuzz target on each public agent body endpoint + the codecov gate fix.

# Verification

- go test on touched packages: pass.
- FuzzParseAndValidateIngestBody seed corpus (24 entries): pass.
- FuzzEnrollBody seed corpus (16 entries): pass.
- spectrace check --strict: 263/263 (100%), exit 0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive fuzzing tests to validate event intake endpoint handling with diverse JSON inputs
  * Added fuzzing tests for enrollment endpoint request validation and error handling

* **Chores**
  * Updated code coverage tracking configuration to treat project-level metrics as informational

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/getvictor/fleet-edr/pull/275?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->