### PR TITLE
UI test backfill: auth.ts + reauth hook + Login + BreakGlassLogin + R…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,8 @@ When adding tests, pick the style that matches the property under test:
 | **Property-based (PBT)** | Algebraic invariants over an input space larger than a table can reasonably cover | `pgregory.net/rapid` |
 | Fuzz | Untrusted input parsing (event JSON, policy diff, agent HTTP bodies) | `go test -fuzz` |
 | Integration | DB-backed behaviour, multi-step workflows | `testdb/full.Open` + a real MySQL via docker-compose |
+| **UI unit + component** | React component rendering, hooks, browser-facing logic (URL builders, fetch wrappers, state machines) | `vitest` + `@testing-library/react` + `@testing-library/jest-dom`, files at `ui/src/**/*.test.{ts,tsx}` |
+| UI end-to-end | Spec-level user journeys (login + dashboard + policy editor flows) | `@playwright/test` at `test/e2e/tests/**/*.spec.ts`, `task uat:e2e` |
 
 ### When to reach for PBT
 
@@ -38,6 +40,24 @@ in this codebase that already use or should use PBT:
   exactly the input minus the snapshot:true exec events, in the same order.
 - **Re-exec chain**: walking `previous_exec_id` from any leaf reaches the
   chain root in ≤ chain length steps without revisiting nodes.
+
+### UI testing convention
+
+UI tests live under `ui/src/**` as `*.test.{ts,tsx}` files co-located with the source. Run via `cd ui && npm test` (or
+`npm run test:coverage` for the LCOV that Sonar + codecov read). The conventions:
+
+- **Components**: `@testing-library/react`'s `render` + `screen` + user-event idioms. Mock the API layer via `vi.spyOn(api,
+  ...)` rather than stubbing global `fetch` — keeps the test scoped to the component's behaviour, not the HTTP wire shape.
+- **Hooks**: `renderHook` from `@testing-library/react`. The `act()` wrapper is required around state-setter calls.
+- **Pure-logic modules** (URL builders, parsers, validators): plain vitest `describe` / `it` with no React dependency.
+- **WebAuthn / browser globals**: stub via `vi.stubGlobal("navigator", { credentials: { create / get } })` or
+  `vi.spyOn(globalThis.location, "assign")`. Tear down in `afterEach(vi.restoreAllMocks)`.
+
+`ui/src/**` was excluded from Sonar's new-code coverage gate until vitest tests landed. The exclusion is now lifted; every
+new UI file must carry a `*.test.{ts,tsx}` sibling that exercises the non-trivial branches. The 80% new-code gate applies
+identically to UI + server code. Coverage is captured by V8 via vitest's coverage provider (`@vitest/coverage-v8`); the
+Playwright E2E run captures complementary V8 coverage of the running React bundle via `monocart-coverage-reports`, and
+Codecov takes the union.
 
 PBT does NOT replace example-based tests when:
 

--- a/ui/src/auth.test.ts
+++ b/ui/src/auth.test.ts
@@ -1,0 +1,358 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  BreakglassError,
+  oidcLoginUrl,
+  breakglassBeginSetup,
+  breakglassFinishSetup,
+  breakglassBeginLogin,
+  breakglassFinishLogin,
+  reauthBreakglass,
+  reauthOIDC,
+} from "./auth";
+
+// The auth.ts surface covers the pre-auth break-glass + OIDC redirect helpers shipped in Phase 4c. These tests pin the
+// observable contract of each helper: URL shape, fetch wire shape (method + headers + body + credentials), error mapping
+// (BreakglassError carries the X-Edr-Auth-Reason header verbatim or the http_<status> fallback), and the post-call
+// navigation side effects (reauthOIDC's globalThis.location.assign). The WebAuthn-ceremony calls into
+// @simplewebauthn/browser are stubbed via vi.mock so the tests don't depend on a real navigator.credentials surface.
+//
+// Test conventions match ui/src/api.test.ts:
+// - stubFetch builds a typed fake Response so the helper's res.json() / res.headers.get() / res.status calls all work.
+// - afterEach restores all mocks so test order doesn't matter.
+// - One describe per exported symbol; one it per documented branch.
+
+vi.mock("@simplewebauthn/browser", () => ({
+  startRegistration: vi.fn(),
+  startAuthentication: vi.fn(),
+}));
+
+// Re-import the stubbed module so individual tests can assert on the spy calls.
+import {
+  startRegistration as mockedStartRegistration,
+  startAuthentication as mockedStartAuthentication,
+} from "@simplewebauthn/browser";
+
+interface FakeResponse {
+  ok: boolean;
+  status: number;
+  statusText: string;
+  headers: { get(name: string): string | null };
+  json(): Promise<unknown>;
+}
+
+function stubFetch(
+  body: unknown,
+  status = 200,
+  reason?: string,
+  contentType: string | null = "application/json",
+): ReturnType<typeof vi.fn> {
+  const headerMap = new Map<string, string>();
+  if (reason !== undefined) headerMap.set("X-Edr-Auth-Reason", reason);
+  if (contentType !== null) headerMap.set("Content-Type", contentType);
+  const fake: FakeResponse = {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: "",
+    headers: {
+      get: (n: string) => headerMap.get(n) ?? null,
+    },
+    json: () => Promise.resolve(body),
+  };
+  return vi.fn().mockResolvedValue(fake);
+}
+
+afterEach(() => {
+  // restoreAllMocks resets vi.spyOn spies; clearAllMocks resets the call history on vi.fn() / vi.mock() module mocks
+  // (without it, `toHaveBeenCalled` assertions accumulate across tests and a "should not have been called" assertion
+  // false-positives on a prior test's call).
+  vi.restoreAllMocks();
+  vi.clearAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("BreakglassError", () => {
+  it("stores status + reason and carries the canonical name", () => {
+    const e = new BreakglassError(429, "rate_limited");
+    expect(e).toBeInstanceOf(Error);
+    expect(e.name).toBe("BreakglassError");
+    expect(e.status).toBe(429);
+    expect(e.reason).toBe("rate_limited");
+    expect(e.message).toContain("rate_limited");
+    expect(e.message).toContain("429");
+  });
+});
+
+describe("oidcLoginUrl", () => {
+  it("returns the bare /api/auth/login when next is undefined", () => {
+    expect(oidcLoginUrl()).toBe("/api/auth/login");
+  });
+
+  it("returns the bare URL when next is the empty string", () => {
+    expect(oidcLoginUrl("")).toBe("/api/auth/login");
+  });
+
+  it("appends a same-origin path next=", () => {
+    expect(oidcLoginUrl("/ui/alerts")).toBe("/api/auth/login?next=%2Fui%2Falerts");
+  });
+
+  it("encodes special characters in the next path", () => {
+    expect(oidcLoginUrl("/ui/hosts/abc?foo=bar")).toBe("/api/auth/login?next=%2Fui%2Fhosts%2Fabc%3Ffoo%3Dbar");
+  });
+
+  it("drops a next that doesn't start with /", () => {
+    expect(oidcLoginUrl("ui/alerts")).toBe("/api/auth/login");
+  });
+
+  it("drops a protocol-relative // next (open-redirect defence)", () => {
+    expect(oidcLoginUrl("//evil.example.com")).toBe("/api/auth/login");
+  });
+
+  it("drops a next longer than the 256-char cap", () => {
+    const long = "/ui/" + "a".repeat(260);
+    expect(oidcLoginUrl(long)).toBe("/api/auth/login");
+  });
+
+  it("drops a next containing characters outside the allowlist", () => {
+    // Spaces (encoded or otherwise) aren't in the regex; the helper rejects them.
+    expect(oidcLoginUrl("/ui/alerts page")).toBe("/api/auth/login");
+  });
+});
+
+describe("breakglassBeginSetup", () => {
+  it("POSTs to the challenge endpoint with the token and runs startRegistration", async () => {
+    const publicKey = { challenge: "c", rp: { id: "x", name: "x" }, user: { id: "u", name: "u", displayName: "u" } };
+    const fetchSpy = stubFetch({ publicKey });
+    vi.stubGlobal("fetch", fetchSpy);
+    vi.mocked(mockedStartRegistration).mockResolvedValue({ id: "att-1" } as unknown as never);
+
+    const result = await breakglassBeginSetup("redeem-tok");
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const req = fetchSpy.mock.calls[0]?.[1] as RequestInit;
+    expect(req.method).toBe("POST");
+    expect(req.credentials).toBe("include");
+    expect(String(fetchSpy.mock.calls[0]?.[0])).toContain("/admin/break-glass/setup/challenge?token=redeem-tok");
+    expect(mockedStartRegistration).toHaveBeenCalledWith({ optionsJSON: publicKey });
+    expect(result).toEqual({ id: "att-1" });
+  });
+
+  it("URL-encodes the redemption token", async () => {
+    const fetchSpy = stubFetch({ publicKey: {} });
+    vi.stubGlobal("fetch", fetchSpy);
+    vi.mocked(mockedStartRegistration).mockResolvedValue({} as unknown as never);
+    await breakglassBeginSetup("a b/c?d");
+    expect(String(fetchSpy.mock.calls[0]?.[0])).toContain("token=a%20b%2Fc%3Fd");
+  });
+
+  it("throws BreakglassError carrying the wire reason on 4xx", async () => {
+    const fetchSpy = stubFetch({}, 410, "token_gone");
+    vi.stubGlobal("fetch", fetchSpy);
+    await expect(breakglassBeginSetup("expired")).rejects.toMatchObject({
+      name: "BreakglassError",
+      status: 410,
+      reason: "token_gone",
+    });
+  });
+
+  it("falls back to http_<status> when X-Edr-Auth-Reason is missing", async () => {
+    const fetchSpy = stubFetch({}, 500);
+    vi.stubGlobal("fetch", fetchSpy);
+    await expect(breakglassBeginSetup("t")).rejects.toMatchObject({ reason: "http_500" });
+  });
+});
+
+describe("breakglassFinishSetup", () => {
+  it("POSTs the password + credentialName + attestation as JSON", async () => {
+    const fetchSpy = stubFetch({ redirect: "/ui/" });
+    vi.stubGlobal("fetch", fetchSpy);
+    const att = { id: "att" };
+    const result = await breakglassFinishSetup("tok", "secret", "Yubikey", att);
+    expect(result).toEqual({ redirect: "/ui/" });
+    const req = fetchSpy.mock.calls[0]?.[1] as RequestInit;
+    expect(req.method).toBe("POST");
+    expect(JSON.parse(req.body as string)).toEqual({
+      password: "secret",
+      credential_name: "Yubikey",
+      attestation: att,
+    });
+  });
+
+  it("returns undefined for a 204 No Content response", async () => {
+    const fetchSpy = stubFetch(null, 204, undefined, null);
+    vi.stubGlobal("fetch", fetchSpy);
+    const result = await breakglassFinishSetup("t", "p", "n", {});
+    expect(result).toBeUndefined();
+  });
+});
+
+describe("breakglassBeginLogin", () => {
+  it("POSTs the email and forwards the publicKey to startAuthentication", async () => {
+    const publicKey = { challenge: "c" };
+    const fetchSpy = stubFetch({ publicKey });
+    vi.stubGlobal("fetch", fetchSpy);
+    vi.mocked(mockedStartAuthentication).mockResolvedValue({ id: "assert" } as unknown as never);
+
+    const result = await breakglassBeginLogin("ops@example.com");
+
+    const req = fetchSpy.mock.calls[0]?.[1] as RequestInit;
+    expect(JSON.parse(req.body as string)).toEqual({ email: "ops@example.com" });
+    expect(String(fetchSpy.mock.calls[0]?.[0])).toContain("/admin/break-glass/challenge");
+    expect(mockedStartAuthentication).toHaveBeenCalledWith({ optionsJSON: publicKey });
+    expect(result).toEqual({ id: "assert" });
+  });
+});
+
+describe("breakglassFinishLogin", () => {
+  it("POSTs email + password + assertion and returns the redirect", async () => {
+    const fetchSpy = stubFetch({ redirect: "/ui/alerts" });
+    vi.stubGlobal("fetch", fetchSpy);
+    const assertion = { id: "asrt" };
+    const result = await breakglassFinishLogin("ops@example.com", "pw", assertion);
+    expect(result).toEqual({ redirect: "/ui/alerts" });
+    const req = fetchSpy.mock.calls[0]?.[1] as RequestInit;
+    expect(JSON.parse(req.body as string)).toEqual({
+      email: "ops@example.com",
+      password: "pw",
+      assertion,
+    });
+  });
+
+  it("surfaces the server reason on 401", async () => {
+    const fetchSpy = stubFetch({}, 401, "invalid_credentials");
+    vi.stubGlobal("fetch", fetchSpy);
+    await expect(breakglassFinishLogin("o", "p", {})).rejects.toMatchObject({
+      status: 401,
+      reason: "invalid_credentials",
+    });
+  });
+});
+
+describe("reauthBreakglass", () => {
+  it("runs challenge → startAuthentication → submit and resolves on 2xx", async () => {
+    const publicKey = { challenge: "c" };
+    // Two sequential fetches: first the challenge endpoint, then the reauth POST. mockResolvedValueOnce stacks them.
+    const fetchSpy = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: "",
+        headers: { get: (n: string) => (n === "Content-Type" ? "application/json" : null) },
+        json: () => Promise.resolve({ publicKey }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: "",
+        headers: { get: (n: string) => (n === "Content-Type" ? "application/json" : null) },
+        json: () => Promise.resolve({ ok: true }),
+      });
+    vi.stubGlobal("fetch", fetchSpy);
+    vi.mocked(mockedStartAuthentication).mockResolvedValue({ id: "as" } as unknown as never);
+
+    await expect(reauthBreakglass("pw")).resolves.toBeUndefined();
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(String(fetchSpy.mock.calls[0]?.[0])).toContain("/api/auth/reauth/challenge");
+    expect(String(fetchSpy.mock.calls[1]?.[0])).toContain("/api/auth/reauth");
+    const body = JSON.parse((fetchSpy.mock.calls[1]?.[1] as RequestInit).body as string) as {
+      password: string;
+      assertion: { id: string };
+    };
+    expect(body).toEqual({ password: "pw", assertion: { id: "as" } });
+  });
+
+  it("rejects with BreakglassError if the challenge endpoint returns 429", async () => {
+    const fetchSpy = stubFetch({}, 429, "rate_limited");
+    vi.stubGlobal("fetch", fetchSpy);
+    await expect(reauthBreakglass("pw")).rejects.toMatchObject({
+      name: "BreakglassError",
+      status: 429,
+      reason: "rate_limited",
+    });
+    // Should NOT have run startAuthentication when the challenge call itself rejected.
+    expect(mockedStartAuthentication).not.toHaveBeenCalled();
+  });
+});
+
+describe("reauthOIDC", () => {
+  it("redirects to the baseURL with next=<current path> when on a same-origin path", () => {
+    const assignSpy = vi.fn();
+    vi.stubGlobal("location", {
+      origin: "https://edr.test",
+      pathname: "/ui/alerts/42",
+      search: "?status=open",
+      hash: "",
+      assign: assignSpy,
+    });
+    reauthOIDC("/api/auth/login?reauth=1");
+    expect(assignSpy).toHaveBeenCalledTimes(1);
+    const url = String(assignSpy.mock.calls[0]?.[0]);
+    expect(url).toContain("/api/auth/login?reauth=1&next=");
+    expect(url).toContain(encodeURIComponent("/ui/alerts/42?status=open"));
+  });
+
+  it("falls back to the default /api/auth/login?reauth=1 when baseURL is off-shape", () => {
+    const assignSpy = vi.fn();
+    vi.stubGlobal("location", {
+      origin: "https://edr.test",
+      pathname: "/ui/",
+      search: "",
+      hash: "",
+      assign: assignSpy,
+    });
+    // Off-shape baseURL: missing leading slash, would otherwise let a hostile server steer the redirect.
+    reauthOIDC("https://evil.example.com/login");
+    expect(String(assignSpy.mock.calls[0]?.[0])).toContain("/api/auth/login?reauth=1");
+    expect(String(assignSpy.mock.calls[0]?.[0])).not.toContain("evil.example.com");
+  });
+
+  it("omits next= when the current path itself fails the allowlist", () => {
+    const assignSpy = vi.fn();
+    vi.stubGlobal("location", {
+      origin: "https://edr.test",
+      // Pathname with a character outside the regex's allowlist - exercises the safeNext === "" branch.
+      pathname: "/ui/with space",
+      search: "",
+      hash: "",
+      assign: assignSpy,
+    });
+    reauthOIDC("/api/auth/login?reauth=1");
+    expect(String(assignSpy.mock.calls[0]?.[0])).toBe("/api/auth/login?reauth=1");
+  });
+});
+
+describe("requestJSON behaviour via the wrappers", () => {
+  // requestJSON itself is internal; the wrapped exports exercise its behaviour. The remaining branches not covered above:
+  //   - non-JSON 2xx body (Content-Type != application/json) returns undefined to typed callers.
+  //   - 4xx without X-Edr-Auth-Reason falls back to http_<status>.
+  //   - Content-Length: 0 short-circuits the JSON parse.
+  beforeEach(() => {
+    vi.mocked(mockedStartAuthentication).mockResolvedValue({ id: "a" } as unknown as never);
+    vi.mocked(mockedStartRegistration).mockResolvedValue({ id: "r" } as unknown as never);
+  });
+
+  it("returns undefined for a 2xx with a non-JSON Content-Type", async () => {
+    // breakglassFinishSetup's redirect type is { redirect: string }; the helper sees an empty body and resolves undefined
+    // rather than throwing on the json() parse of the empty body.
+    const fetchSpy = stubFetch(null, 200, undefined, "text/plain");
+    vi.stubGlobal("fetch", fetchSpy);
+    const result = await breakglassFinishSetup("t", "p", "n", {});
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined when Content-Length is 0 even with a JSON Content-Type", async () => {
+    const headerMap = new Map<string, string>();
+    headerMap.set("Content-Type", "application/json");
+    headerMap.set("Content-Length", "0");
+    const fake = {
+      ok: true,
+      status: 200,
+      statusText: "",
+      headers: { get: (n: string) => headerMap.get(n) ?? null },
+      json: () => Promise.reject(new Error("should not be called")),
+    };
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(fake));
+    const result = await breakglassFinishSetup("t", "p", "n", {});
+    expect(result).toBeUndefined();
+  });
+});

--- a/ui/src/auth.test.ts
+++ b/ui/src/auth.test.ts
@@ -274,16 +274,26 @@ describe("reauthBreakglass", () => {
   });
 });
 
+// stubLocation replaces window.location with a synthetic object exposing only the fields reauthOIDC reads. We use
+// vi.stubGlobal rather than vi.spyOn(location, "assign") because jsdom's location.assign is non-configurable and spyOn
+// throws "Cannot redefine property: assign" (the CodeRabbit + Gemini #278 suggestion was tested and produces that
+// error). Replacing the whole location object DOES work in this jsdom because window.location itself is configurable;
+// afterEach -> vi.unstubAllGlobals() restores the original on teardown.
+function stubLocation(pathname: string, search = "", hash = ""): ReturnType<typeof vi.fn> {
+  const assignSpy = vi.fn();
+  vi.stubGlobal("location", {
+    origin: "https://edr.test",
+    pathname,
+    search,
+    hash,
+    assign: assignSpy,
+  });
+  return assignSpy;
+}
+
 describe("reauthOIDC", () => {
   it("redirects to the baseURL with next=<current path> when on a same-origin path", () => {
-    const assignSpy = vi.fn();
-    vi.stubGlobal("location", {
-      origin: "https://edr.test",
-      pathname: "/ui/alerts/42",
-      search: "?status=open",
-      hash: "",
-      assign: assignSpy,
-    });
+    const assignSpy = stubLocation("/ui/alerts/42", "?status=open");
     reauthOIDC("/api/auth/login?reauth=1");
     expect(assignSpy).toHaveBeenCalledTimes(1);
     const url = String(assignSpy.mock.calls[0]?.[0]);
@@ -292,30 +302,16 @@ describe("reauthOIDC", () => {
   });
 
   it("falls back to the default /api/auth/login?reauth=1 when baseURL is off-shape", () => {
-    const assignSpy = vi.fn();
-    vi.stubGlobal("location", {
-      origin: "https://edr.test",
-      pathname: "/ui/",
-      search: "",
-      hash: "",
-      assign: assignSpy,
-    });
-    // Off-shape baseURL: missing leading slash, would otherwise let a hostile server steer the redirect.
+    const assignSpy = stubLocation("/ui/");
+    // Off-shape baseURL: doesn't start with /, would otherwise let a hostile server steer the redirect.
     reauthOIDC("https://evil.example.com/login");
     expect(String(assignSpy.mock.calls[0]?.[0])).toContain("/api/auth/login?reauth=1");
     expect(String(assignSpy.mock.calls[0]?.[0])).not.toContain("evil.example.com");
   });
 
   it("omits next= when the current path itself fails the allowlist", () => {
-    const assignSpy = vi.fn();
-    vi.stubGlobal("location", {
-      origin: "https://edr.test",
-      // Pathname with a character outside the regex's allowlist - exercises the safeNext === "" branch.
-      pathname: "/ui/with space",
-      search: "",
-      hash: "",
-      assign: assignSpy,
-    });
+    // Pathname with a character outside the regex's allowlist - exercises the safeNext === "" branch.
+    const assignSpy = stubLocation("/ui/with space");
     reauthOIDC("/api/auth/login?reauth=1");
     expect(String(assignSpy.mock.calls[0]?.[0])).toBe("/api/auth/login?reauth=1");
   });

--- a/ui/src/components/BreakGlassLogin.test.tsx
+++ b/ui/src/components/BreakGlassLogin.test.tsx
@@ -63,7 +63,10 @@ describe("BreakGlassLogin form", () => {
 
 describe("BreakGlassLogin submit happy path", () => {
   it("calls breakglassBeginLogin → breakglassFinishLogin → navigates to the redirect", async () => {
-    const finishSpy = vi.spyOn(auth, "breakglassFinishLogin").mockResolvedValue({ redirect: "/ui/alerts" });
+    // Reconfigure the existing spy from beforeEach rather than re-installing it (Copilot #278: layered vi.spyOn on the
+    // same target can throw "already spied upon" on some vitest versions). vi.mocked is the standard handle.
+    const finishSpy = vi.mocked(auth.breakglassFinishLogin);
+    finishSpy.mockResolvedValue({ redirect: "/ui/alerts" });
     renderAt();
 
     fireEvent.change(screen.getByLabelText(/email/i), { target: { value: "  ops@example.com  " } });
@@ -77,7 +80,7 @@ describe("BreakGlassLogin submit happy path", () => {
   });
 
   it("strips just /ui when the redirect is exactly /ui (no trailing slash)", async () => {
-    vi.spyOn(auth, "breakglassFinishLogin").mockResolvedValue({ redirect: "/ui" });
+    vi.mocked(auth.breakglassFinishLogin).mockResolvedValue({ redirect: "/ui" });
     renderAt();
     fireEvent.change(screen.getByLabelText(/email/i), { target: { value: "ops@example.com" } });
     fireEvent.change(screen.getByLabelText(/password/i), { target: { value: "pw" } });
@@ -87,7 +90,7 @@ describe("BreakGlassLogin submit happy path", () => {
   });
 
   it("does NOT strip a redirect that isn't /ui-prefixed (e.g. /uipreview)", async () => {
-    vi.spyOn(auth, "breakglassFinishLogin").mockResolvedValue({ redirect: "/uipreview" });
+    vi.mocked(auth.breakglassFinishLogin).mockResolvedValue({ redirect: "/uipreview" });
     renderAt();
     fireEvent.change(screen.getByLabelText(/email/i), { target: { value: "ops@example.com" } });
     fireEvent.change(screen.getByLabelText(/password/i), { target: { value: "pw" } });
@@ -107,7 +110,7 @@ describe("BreakGlassLogin error mapping", () => {
     ["email_rate_limited", /too many failed attempts for this email/i],
     ["assertion_parse_failed", /couldn't read your security-key response/i],
   ])("renders the directed copy for %s", async (reason, copyPattern) => {
-    vi.spyOn(auth, "breakglassBeginLogin").mockRejectedValue(
+    vi.mocked(auth.breakglassBeginLogin).mockRejectedValue(
       new auth.BreakglassError(401, reason),
     );
     renderAt();
@@ -118,7 +121,7 @@ describe("BreakGlassLogin error mapping", () => {
   });
 
   it("falls through to the generic message for an unmapped reason", async () => {
-    vi.spyOn(auth, "breakglassBeginLogin").mockRejectedValue(
+    vi.mocked(auth.breakglassBeginLogin).mockRejectedValue(
       new auth.BreakglassError(500, "some_unmapped_reason"),
     );
     renderAt();
@@ -129,7 +132,7 @@ describe("BreakGlassLogin error mapping", () => {
   });
 
   it("renders the WebAuthn-cancelled copy when startAuthentication throws NotAllowedError", async () => {
-    vi.spyOn(auth, "breakglassBeginLogin").mockRejectedValue(
+    vi.mocked(auth.breakglassBeginLogin).mockRejectedValue(
       new DOMException("user cancelled", "NotAllowedError"),
     );
     renderAt();
@@ -140,7 +143,7 @@ describe("BreakGlassLogin error mapping", () => {
   });
 
   it("renders the generic message for a non-BreakglassError non-NotAllowedError throw", async () => {
-    vi.spyOn(auth, "breakglassBeginLogin").mockRejectedValue(new Error("network gone"));
+    vi.mocked(auth.breakglassBeginLogin).mockRejectedValue(new Error("network gone"));
     renderAt();
     fireEvent.change(screen.getByLabelText(/email/i), { target: { value: "ops@example.com" } });
     fireEvent.change(screen.getByLabelText(/password/i), { target: { value: "pw" } });

--- a/ui/src/components/BreakGlassLogin.test.tsx
+++ b/ui/src/components/BreakGlassLogin.test.tsx
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+import { BreakGlassLogin } from "./BreakGlassLogin";
+import * as auth from "../auth";
+
+// BreakGlassLogin pins the recovery-sign-in flow: email + password + WebAuthn assertion → POST /admin/break-glass.
+// Tests cover form rendering, the happy-path submit chain, each documented error reason → operator copy, WebAuthn cancel,
+// the redirect path-stripping logic (the helper strips "/ui" prefix so React Router navigates correctly), and the
+// submit-disabled guard against empty inputs.
+
+function renderAt(initialPath = "/admin/break-glass") {
+  return render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <Routes>
+        <Route path="/admin/break-glass" element={<BreakGlassLogin />} />
+        {/* Sink routes so the post-login navigate doesn't blow up under the test router. */}
+        <Route path="/" element={<div>HOME</div>} />
+        <Route path="/alerts" element={<div>ALERTS</div>} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  // Default happy-path stubs; individual tests override via mockImplementation / mockRejectedValue.
+  vi.spyOn(auth, "breakglassBeginLogin").mockResolvedValue({ id: "asrt" });
+  vi.spyOn(auth, "breakglassFinishLogin").mockResolvedValue({ redirect: "/ui/" });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("BreakGlassLogin form", () => {
+  it("renders email + password + submit + back-link", () => {
+    renderAt();
+    expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/password/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /sign in with security key/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /back to single sign-on/i })).toHaveAttribute("href", "/login");
+  });
+
+  it("submit is disabled until both email + password are entered", () => {
+    renderAt();
+    const submit = screen.getByRole("button", { name: /sign in with security key/i });
+    expect(submit).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText(/email/i), { target: { value: "ops@example.com" } });
+    expect(submit).toBeDisabled(); // still missing password
+
+    fireEvent.change(screen.getByLabelText(/password/i), { target: { value: "pw" } });
+    expect(submit).not.toBeDisabled();
+  });
+
+  it("trims the email before submission (a leading space shouldn't enable submit prematurely)", () => {
+    renderAt();
+    fireEvent.change(screen.getByLabelText(/email/i), { target: { value: "   " } });
+    fireEvent.change(screen.getByLabelText(/password/i), { target: { value: "pw" } });
+    expect(screen.getByRole("button", { name: /sign in with security key/i })).toBeDisabled();
+  });
+});
+
+describe("BreakGlassLogin submit happy path", () => {
+  it("calls breakglassBeginLogin → breakglassFinishLogin → navigates to the redirect", async () => {
+    const finishSpy = vi.spyOn(auth, "breakglassFinishLogin").mockResolvedValue({ redirect: "/ui/alerts" });
+    renderAt();
+
+    fireEvent.change(screen.getByLabelText(/email/i), { target: { value: "  ops@example.com  " } });
+    fireEvent.change(screen.getByLabelText(/password/i), { target: { value: "pw" } });
+    fireEvent.click(screen.getByRole("button", { name: /sign in with security key/i }));
+
+    await waitFor(() => { expect(auth.breakglassBeginLogin).toHaveBeenCalledWith("ops@example.com"); });
+    await waitFor(() => { expect(finishSpy).toHaveBeenCalledWith("ops@example.com", "pw", { id: "asrt" }); });
+    // /ui/alerts → /alerts (the basename strip; the sink route is at /alerts).
+    await waitFor(() => expect(screen.getByText("ALERTS")).toBeInTheDocument());
+  });
+
+  it("strips just /ui when the redirect is exactly /ui (no trailing slash)", async () => {
+    vi.spyOn(auth, "breakglassFinishLogin").mockResolvedValue({ redirect: "/ui" });
+    renderAt();
+    fireEvent.change(screen.getByLabelText(/email/i), { target: { value: "ops@example.com" } });
+    fireEvent.change(screen.getByLabelText(/password/i), { target: { value: "pw" } });
+    fireEvent.click(screen.getByRole("button", { name: /sign in with security key/i }));
+    // /ui → "/" (slice("/ui".length) is empty; fallback to "/")
+    await waitFor(() => expect(screen.getByText("HOME")).toBeInTheDocument());
+  });
+
+  it("does NOT strip a redirect that isn't /ui-prefixed (e.g. /uipreview)", async () => {
+    vi.spyOn(auth, "breakglassFinishLogin").mockResolvedValue({ redirect: "/uipreview" });
+    renderAt();
+    fireEvent.change(screen.getByLabelText(/email/i), { target: { value: "ops@example.com" } });
+    fireEvent.change(screen.getByLabelText(/password/i), { target: { value: "pw" } });
+    fireEvent.click(screen.getByRole("button", { name: /sign in with security key/i }));
+    // /uipreview stays /uipreview. There's no sink route so the test just verifies no crash + we land on a navigated path
+    // (no longer the break-glass form). The router's catch-all returns an empty render, so we look for the absence of the
+    // form's heading.
+    await waitFor(() => expect(screen.queryByText(/break-glass/i)).not.toBeInTheDocument());
+  });
+});
+
+describe("BreakGlassLogin error mapping", () => {
+  it.each([
+    ["invalid_credentials", /invalid email, password, or security key/i],
+    ["no_credentials", /no security key is registered/i],
+    ["rate_limited", /too many attempts from this address/i],
+    ["email_rate_limited", /too many failed attempts for this email/i],
+    ["assertion_parse_failed", /couldn't read your security-key response/i],
+  ])("renders the directed copy for %s", async (reason, copyPattern) => {
+    vi.spyOn(auth, "breakglassBeginLogin").mockRejectedValue(
+      new auth.BreakglassError(401, reason),
+    );
+    renderAt();
+    fireEvent.change(screen.getByLabelText(/email/i), { target: { value: "ops@example.com" } });
+    fireEvent.change(screen.getByLabelText(/password/i), { target: { value: "pw" } });
+    fireEvent.click(screen.getByRole("button", { name: /sign in with security key/i }));
+    await waitFor(() => expect(screen.getByRole("alert")).toHaveTextContent(copyPattern));
+  });
+
+  it("falls through to the generic message for an unmapped reason", async () => {
+    vi.spyOn(auth, "breakglassBeginLogin").mockRejectedValue(
+      new auth.BreakglassError(500, "some_unmapped_reason"),
+    );
+    renderAt();
+    fireEvent.change(screen.getByLabelText(/email/i), { target: { value: "ops@example.com" } });
+    fireEvent.change(screen.getByLabelText(/password/i), { target: { value: "pw" } });
+    fireEvent.click(screen.getByRole("button", { name: /sign in with security key/i }));
+    await waitFor(() => expect(screen.getByRole("alert")).toHaveTextContent(/sign-in failed/i));
+  });
+
+  it("renders the WebAuthn-cancelled copy when startAuthentication throws NotAllowedError", async () => {
+    vi.spyOn(auth, "breakglassBeginLogin").mockRejectedValue(
+      new DOMException("user cancelled", "NotAllowedError"),
+    );
+    renderAt();
+    fireEvent.change(screen.getByLabelText(/email/i), { target: { value: "ops@example.com" } });
+    fireEvent.change(screen.getByLabelText(/password/i), { target: { value: "pw" } });
+    fireEvent.click(screen.getByRole("button", { name: /sign in with security key/i }));
+    await waitFor(() => expect(screen.getByRole("alert")).toHaveTextContent(/security-key sign-in was cancelled/i));
+  });
+
+  it("renders the generic message for a non-BreakglassError non-NotAllowedError throw", async () => {
+    vi.spyOn(auth, "breakglassBeginLogin").mockRejectedValue(new Error("network gone"));
+    renderAt();
+    fireEvent.change(screen.getByLabelText(/email/i), { target: { value: "ops@example.com" } });
+    fireEvent.change(screen.getByLabelText(/password/i), { target: { value: "pw" } });
+    fireEvent.click(screen.getByRole("button", { name: /sign in with security key/i }));
+    await waitFor(() => expect(screen.getByRole("alert")).toHaveTextContent(/sign-in failed/i));
+  });
+});

--- a/ui/src/components/Login.test.tsx
+++ b/ui/src/components/Login.test.tsx
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { Login } from "./Login";
+
+// Login renders the post-Phase-4c single-CTA login page: "Continue with single sign-on" + a break-glass footer link.
+// Tests pin the wire-derived error-message map (each documented reason renders the right copy; unknown falls through to
+// the generic message), the next-param resolution order (prop > URL ?next > default), and the click → location.assign
+// dispatch.
+
+function renderAt(searchParams: Record<string, string>, props: { next?: string } = {}) {
+  const search = new URLSearchParams(searchParams).toString();
+  return render(
+    <MemoryRouter initialEntries={[`/admin?${search}`]}>
+      <Login {...props} />
+    </MemoryRouter>,
+  );
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("Login error block", () => {
+  it("renders no error block when ?error= is absent", () => {
+    renderAt({});
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  // Spot-check the high-traffic mapped reasons rather than every entry; the Map itself is data, not logic.
+  it.each([
+    ["invalid_state", /sign-in session expired before you returned/i],
+    ["unknown_subject", /isn't authorised for this server/i],
+    ["exchange_failed", /couldn't reach the identity provider/i],
+    ["session_create_failed", /couldn't start your session/i],
+  ])("renders the directed copy for %s", (reason, copyPattern) => {
+    renderAt({ error: reason });
+    expect(screen.getByRole("alert")).toHaveTextContent(copyPattern);
+  });
+
+  it("falls through to the generic message for an unmapped reason", () => {
+    renderAt({ error: "some_unmapped_reason" });
+    expect(screen.getByRole("alert")).toHaveTextContent(/sign-in failed/i);
+  });
+});
+
+describe("Login next-param resolution", () => {
+  it("uses the next prop when one is provided", () => {
+    renderAt({}, { next: "/ui/alerts" });
+    const cta = screen.getByRole("button", { name: /continue with single sign-on/i });
+    expect(cta).toBeInTheDocument();
+    // The href is bound on click; we verify by clicking and inspecting the assign call below in a sibling test.
+  });
+
+  it("clicking Continue with the next prop hits /api/auth/login?next=<prop>", () => {
+    const assignSpy = vi.fn();
+    vi.stubGlobal("location", { assign: assignSpy });
+    renderAt({}, { next: "/ui/hosts/abc" });
+    fireEvent.click(screen.getByRole("button", { name: /continue with single sign-on/i }));
+    expect(assignSpy).toHaveBeenCalledWith("/api/auth/login?next=%2Fui%2Fhosts%2Fabc");
+  });
+
+  it("falls back to the URL ?next when no prop is provided", () => {
+    const assignSpy = vi.fn();
+    vi.stubGlobal("location", { assign: assignSpy });
+    renderAt({ next: "/ui/alerts" });
+    fireEvent.click(screen.getByRole("button", { name: /continue with single sign-on/i }));
+    expect(assignSpy).toHaveBeenCalledWith("/api/auth/login?next=%2Fui%2Falerts");
+  });
+
+  it("falls back to the default /ui/ when neither is provided", () => {
+    const assignSpy = vi.fn();
+    vi.stubGlobal("location", { assign: assignSpy });
+    renderAt({});
+    fireEvent.click(screen.getByRole("button", { name: /continue with single sign-on/i }));
+    expect(assignSpy).toHaveBeenCalledWith("/api/auth/login?next=%2Fui%2F");
+  });
+
+  it("drops an off-shape URL ?next (open-redirect defence)", () => {
+    const assignSpy = vi.fn();
+    vi.stubGlobal("location", { assign: assignSpy });
+    renderAt({ next: "//evil.example.com" });
+    fireEvent.click(screen.getByRole("button", { name: /continue with single sign-on/i }));
+    // oidcLoginUrl rejected the bad next and returned the bare endpoint.
+    expect(assignSpy).toHaveBeenCalledWith("/api/auth/login");
+  });
+});
+
+describe("Login break-glass link", () => {
+  it("renders a link to /admin/break-glass", () => {
+    renderAt({});
+    const link = screen.getByRole("link", { name: /break-glass login/i });
+    expect(link).toHaveAttribute("href", "/admin/break-glass");
+  });
+});
+
+describe("Login navigating state", () => {
+  it("transitions the button to loading on click", () => {
+    const assignSpy = vi.fn();
+    vi.stubGlobal("location", { assign: assignSpy });
+    renderAt({});
+    const cta = screen.getByRole("button", { name: /continue with single sign-on/i });
+    expect(cta).not.toBeDisabled();
+    fireEvent.click(cta);
+    // The Button primitive renders isLoading by adding aria-busy or a class; assert via aria-busy if present, else just
+    // verify the click landed (assign was called). The loading state is a UX nicety, not a correctness contract.
+    expect(assignSpy).toHaveBeenCalled();
+  });
+});

--- a/ui/src/components/Login.test.tsx
+++ b/ui/src/components/Login.test.tsx
@@ -54,6 +54,10 @@ describe("Login next-param resolution", () => {
   });
 
   it("clicking Continue with the next prop hits /api/auth/login?next=<prop>", () => {
+    // vi.stubGlobal("location", { assign }) is used here (NOT vi.spyOn(location, "assign")) because in this jsdom version
+    // location.assign is a non-configurable property: vi.spyOn -> Object.defineProperty throws "Cannot redefine property:
+    // assign". The bots' #278 suggestion to switch to spyOn was tested and produces that error; the whole-location-replace
+    // approach is what actually works here. afterEach calls vi.unstubAllGlobals() so the stub doesn't leak.
     const assignSpy = vi.fn();
     vi.stubGlobal("location", { assign: assignSpy });
     renderAt({}, { next: "/ui/hosts/abc" });
@@ -62,6 +66,10 @@ describe("Login next-param resolution", () => {
   });
 
   it("falls back to the URL ?next when no prop is provided", () => {
+    // vi.stubGlobal("location", { assign }) is used here (NOT vi.spyOn(location, "assign")) because in this jsdom version
+    // location.assign is a non-configurable property: vi.spyOn -> Object.defineProperty throws "Cannot redefine property:
+    // assign". The bots' #278 suggestion to switch to spyOn was tested and produces that error; the whole-location-replace
+    // approach is what actually works here. afterEach calls vi.unstubAllGlobals() so the stub doesn't leak.
     const assignSpy = vi.fn();
     vi.stubGlobal("location", { assign: assignSpy });
     renderAt({ next: "/ui/alerts" });
@@ -70,6 +78,10 @@ describe("Login next-param resolution", () => {
   });
 
   it("falls back to the default /ui/ when neither is provided", () => {
+    // vi.stubGlobal("location", { assign }) is used here (NOT vi.spyOn(location, "assign")) because in this jsdom version
+    // location.assign is a non-configurable property: vi.spyOn -> Object.defineProperty throws "Cannot redefine property:
+    // assign". The bots' #278 suggestion to switch to spyOn was tested and produces that error; the whole-location-replace
+    // approach is what actually works here. afterEach calls vi.unstubAllGlobals() so the stub doesn't leak.
     const assignSpy = vi.fn();
     vi.stubGlobal("location", { assign: assignSpy });
     renderAt({});
@@ -78,6 +90,10 @@ describe("Login next-param resolution", () => {
   });
 
   it("drops an off-shape URL ?next (open-redirect defence)", () => {
+    // vi.stubGlobal("location", { assign }) is used here (NOT vi.spyOn(location, "assign")) because in this jsdom version
+    // location.assign is a non-configurable property: vi.spyOn -> Object.defineProperty throws "Cannot redefine property:
+    // assign". The bots' #278 suggestion to switch to spyOn was tested and produces that error; the whole-location-replace
+    // approach is what actually works here. afterEach calls vi.unstubAllGlobals() so the stub doesn't leak.
     const assignSpy = vi.fn();
     vi.stubGlobal("location", { assign: assignSpy });
     renderAt({ next: "//evil.example.com" });
@@ -97,6 +113,10 @@ describe("Login break-glass link", () => {
 
 describe("Login navigating state", () => {
   it("transitions the button to loading on click", () => {
+    // vi.stubGlobal("location", { assign }) is used here (NOT vi.spyOn(location, "assign")) because in this jsdom version
+    // location.assign is a non-configurable property: vi.spyOn -> Object.defineProperty throws "Cannot redefine property:
+    // assign". The bots' #278 suggestion to switch to spyOn was tested and produces that error; the whole-location-replace
+    // approach is what actually works here. afterEach calls vi.unstubAllGlobals() so the stub doesn't leak.
     const assignSpy = vi.fn();
     vi.stubGlobal("location", { assign: assignSpy });
     renderAt({});

--- a/ui/src/components/ReauthModal.test.tsx
+++ b/ui/src/components/ReauthModal.test.tsx
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { ReauthModal } from "./ReauthModal";
+import * as auth from "../auth";
+import type { ReauthChallenge } from "../api";
+
+// ReauthModal renders the per-flow reauth prompt and dispatches to either an OIDC redirect or the WebAuthn break-glass
+// ceremony depending on challenge.authMethod. Tests cover:
+//   - null challenge → renders nothing (early-return branch)
+//   - OIDC flow: renders the right copy + button; click → reauthOIDC; Cancel → resolve(false)
+//   - break-glass flow: renders password input + submit; submit happy-path calls reauthBreakglass + resolve(true);
+//     each documented BreakglassError reason renders the right operator copy; WebAuthn NotAllowedError renders
+//     the right copy; non-mapped error falls through to the generic message.
+//
+// JSDOM ships HTMLDialogElement but its showModal()/close() are stubs that don't bubble events the same way as a real
+// browser; the test only inspects what's rendered, not the dialog's modal-ness.
+
+const oidcChallenge: ReauthChallenge = {
+  authMethod: "oidc",
+  reauthURL: "/api/auth/login?reauth=1",
+};
+
+const breakglassChallenge: ReauthChallenge = {
+  authMethod: "local_password",
+  reauthURL: "/api/auth/reauth",
+};
+
+beforeEach(() => {
+  // showModal/close in jsdom default to throwing; provide stubs that match the real behaviour testing-library needs: the
+  // `open` attribute MUST be set/unset so getByRole queries treat the dialog's children as accessible. Without that the
+  // role-based queries fail with "no accessible roles" because a non-`open` dialog is treated as inert.
+  HTMLDialogElement.prototype.showModal = function () {
+    this.setAttribute("open", "");
+  };
+  HTMLDialogElement.prototype.close = function () {
+    this.removeAttribute("open");
+  };
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("ReauthModal", () => {
+  it("renders nothing when challenge is null", () => {
+    const { container } = render(<ReauthModal open={false} challenge={null} resolve={vi.fn()} />);
+    expect(container.querySelector("dialog")).toBeNull();
+  });
+
+  it("renders the OIDC flow's copy when authMethod is 'oidc'", () => {
+    render(<ReauthModal open={true} challenge={oidcChallenge} resolve={vi.fn()} />);
+    expect(screen.getByRole("heading", { name: /confirm your identity/i })).toBeInTheDocument();
+    expect(screen.getByText(/identity provider/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /continue with single sign-on/i })).toBeInTheDocument();
+  });
+
+  it("OIDC Continue triggers reauthOIDC with the server-supplied reauthURL", () => {
+    const reauthSpy = vi.spyOn(auth, "reauthOIDC").mockImplementation(() => undefined);
+    render(<ReauthModal open={true} challenge={oidcChallenge} resolve={vi.fn()} />);
+    fireEvent.click(screen.getByRole("button", { name: /continue with single sign-on/i }));
+    expect(reauthSpy).toHaveBeenCalledWith("/api/auth/login?reauth=1");
+  });
+
+  it("OIDC Cancel calls resolve(false) without redirecting", () => {
+    const resolve = vi.fn();
+    const reauthSpy = vi.spyOn(auth, "reauthOIDC").mockImplementation(() => undefined);
+    render(<ReauthModal open={true} challenge={oidcChallenge} resolve={resolve} />);
+    fireEvent.click(screen.getByRole("button", { name: /^cancel$/i }));
+    expect(resolve).toHaveBeenCalledWith(false);
+    expect(reauthSpy).not.toHaveBeenCalled();
+  });
+
+  it("renders the break-glass form when authMethod is 'local_password'", () => {
+    render(<ReauthModal open={true} challenge={breakglassChallenge} resolve={vi.fn()} />);
+    expect(screen.getByLabelText(/password/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /confirm with security key/i })).toBeInTheDocument();
+  });
+
+  it("break-glass submit happy path calls reauthBreakglass + resolve(true)", async () => {
+    const reauthSpy = vi.spyOn(auth, "reauthBreakglass").mockResolvedValue(undefined);
+    const resolve = vi.fn();
+    render(<ReauthModal open={true} challenge={breakglassChallenge} resolve={resolve} />);
+
+    const passwordInput = screen.getByLabelText(/password/i);
+    fireEvent.change(passwordInput, { target: { value: "ops-password" } });
+    fireEvent.click(screen.getByRole("button", { name: /confirm with security key/i }));
+
+    await waitFor(() => { expect(reauthSpy).toHaveBeenCalledWith("ops-password"); });
+    await waitFor(() => { expect(resolve).toHaveBeenCalledWith(true); });
+  });
+
+  it("break-glass invalid_credentials renders the directed message", async () => {
+    vi.spyOn(auth, "reauthBreakglass").mockRejectedValue(
+      new auth.BreakglassError(401, "invalid_credentials"),
+    );
+    const resolve = vi.fn();
+    render(<ReauthModal open={true} challenge={breakglassChallenge} resolve={resolve} />);
+
+    fireEvent.change(screen.getByLabelText(/password/i), { target: { value: "wrong" } });
+    fireEvent.click(screen.getByRole("button", { name: /confirm with security key/i }));
+
+    await waitFor(() => expect(screen.getByRole("alert")).toHaveTextContent(/invalid password or security key/i));
+    expect(resolve).not.toHaveBeenCalled();
+  });
+
+  it("break-glass rate_limited renders the directed message", async () => {
+    vi.spyOn(auth, "reauthBreakglass").mockRejectedValue(
+      new auth.BreakglassError(429, "rate_limited"),
+    );
+    render(<ReauthModal open={true} challenge={breakglassChallenge} resolve={vi.fn()} />);
+
+    fireEvent.change(screen.getByLabelText(/password/i), { target: { value: "pw" } });
+    fireEvent.click(screen.getByRole("button", { name: /confirm with security key/i }));
+
+    await waitFor(() => expect(screen.getByRole("alert")).toHaveTextContent(/too many attempts/i));
+  });
+
+  it("break-glass unknown reason falls through to the generic message", async () => {
+    vi.spyOn(auth, "reauthBreakglass").mockRejectedValue(
+      new auth.BreakglassError(500, "some_unmapped_reason"),
+    );
+    render(<ReauthModal open={true} challenge={breakglassChallenge} resolve={vi.fn()} />);
+
+    fireEvent.change(screen.getByLabelText(/password/i), { target: { value: "pw" } });
+    fireEvent.click(screen.getByRole("button", { name: /confirm with security key/i }));
+
+    await waitFor(() => expect(screen.getByRole("alert")).toHaveTextContent(/reauth failed/i));
+  });
+
+  it("break-glass WebAuthn NotAllowedError renders the security-key cancelled message", async () => {
+    const webauthnCancel = new DOMException("user cancelled", "NotAllowedError");
+    vi.spyOn(auth, "reauthBreakglass").mockRejectedValue(webauthnCancel);
+    render(<ReauthModal open={true} challenge={breakglassChallenge} resolve={vi.fn()} />);
+
+    fireEvent.change(screen.getByLabelText(/password/i), { target: { value: "pw" } });
+    fireEvent.click(screen.getByRole("button", { name: /confirm with security key/i }));
+
+    await waitFor(() => expect(screen.getByRole("alert")).toHaveTextContent(/security-key prompt was cancelled/i));
+  });
+
+  it("break-glass Cancel button calls resolve(false)", () => {
+    const resolve = vi.fn();
+    render(<ReauthModal open={true} challenge={breakglassChallenge} resolve={resolve} />);
+    fireEvent.click(screen.getByRole("button", { name: /^cancel$/i }));
+    expect(resolve).toHaveBeenCalledWith(false);
+  });
+
+  it("break-glass submit is disabled until a password is entered", () => {
+    render(<ReauthModal open={true} challenge={breakglassChallenge} resolve={vi.fn()} />);
+    const submit = screen.getByRole("button", { name: /confirm with security key/i });
+    expect(submit).toBeDisabled();
+    fireEvent.change(screen.getByLabelText(/password/i), { target: { value: "p" } });
+    expect(submit).not.toBeDisabled();
+  });
+});

--- a/ui/src/components/ReauthModal.test.tsx
+++ b/ui/src/components/ReauthModal.test.tsx
@@ -25,8 +25,17 @@ const breakglassChallenge: ReauthChallenge = {
   reauthURL: "/api/auth/reauth",
 };
 
+// Save the originals once so afterEach can put them back. Without this, the prototype mutation below leaks across test
+// files in the same vitest worker and changes ReauthModal's render behaviour anywhere else HTMLDialogElement is used
+// (Copilot + CodeRabbit + Gemini #278). The eslint-disable-next-line silences @typescript-eslint/unbound-method: we're
+// not calling these references directly, just storing them for later prototype reassignment.
+// eslint-disable-next-line @typescript-eslint/unbound-method
+const originalShowModal = HTMLDialogElement.prototype.showModal;
+// eslint-disable-next-line @typescript-eslint/unbound-method
+const originalClose = HTMLDialogElement.prototype.close;
+
 beforeEach(() => {
-  // showModal/close in jsdom default to throwing; provide stubs that match the real behaviour testing-library needs: the
+  // showModal/close in jsdom default to throwing; install stubs that match the real behaviour testing-library needs: the
   // `open` attribute MUST be set/unset so getByRole queries treat the dialog's children as accessible. Without that the
   // role-based queries fail with "no accessible roles" because a non-`open` dialog is treated as inert.
   HTMLDialogElement.prototype.showModal = function () {
@@ -39,6 +48,10 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.restoreAllMocks();
+  // Put back the originals so this file's prototype mutation doesn't bleed into other test files running in the same
+  // vitest worker. vi.restoreAllMocks() handles vi.spyOn spies but doesn't touch direct prototype assignments.
+  HTMLDialogElement.prototype.showModal = originalShowModal;
+  HTMLDialogElement.prototype.close = originalClose;
 });
 
 describe("ReauthModal", () => {

--- a/ui/src/hooks/useReauthRetry.test.ts
+++ b/ui/src/hooks/useReauthRetry.test.ts
@@ -41,10 +41,17 @@ afterEach(() => {
 
 describe("useReauthRetry", () => {
   it("returns the wrapped result on success without opening the modal", async () => {
+    // Explicit <[], string> on useReauthRetry so result.current.call() returns Promise<string> rather than Promise<unknown>;
+    // without it, TypeScript can't narrow vi.fn().mockResolvedValue("ok") to a string-returning callable.
     const fn = vi.fn().mockResolvedValue("ok");
-    const { result } = renderHook(() => useReauthRetry(fn));
+    const { result } = renderHook(() => useReauthRetry<[], string>(fn));
 
-    const value = await act(async () => result.current.call());
+    // act(async () => ...) resolves to void; the async callback's return value is NOT propagated (Copilot #278). Capture
+    // the call's resolved value INSIDE the act callback so the assertion below reads the real value, not undefined.
+    let value: string | undefined;
+    await act(async () => {
+      value = await result.current.call();
+    });
     expect(value).toBe("ok");
     expect(fn).toHaveBeenCalledTimes(1);
     expect(result.current.modal.open).toBe(false);
@@ -136,7 +143,10 @@ describe("useReauthRetry", () => {
     });
 
     const [vA, vB] = await Promise.all([pA, pB]);
-    expect([vA, vB]).toEqual(["attempt-3", "attempt-4"]);
+    // Microtask order between pA's retry and pB's retry isn't guaranteed; the contract is that BOTH retries land and
+    // observe distinct attempt counts. Sort so a future scheduler change doesn't flip [vA, vB] order and flake the test
+    // (CodeRabbit #278).
+    expect([vA, vB].slice().sort()).toEqual(["attempt-3", "attempt-4"]);
     // fn ran 4 times total: 2 initial deny + 2 retries.
     expect(fn).toHaveBeenCalledTimes(4);
   });
@@ -146,7 +156,17 @@ describe("useReauthRetry", () => {
     const fn = vi.fn().mockRejectedValue(otherErr);
     const { result } = renderHook(() => useReauthRetry(fn));
 
-    await expect(act(async () => result.current.call())).rejects.toBe(otherErr);
+    // Capture the rejection inside act() so the assertion targets the call's promise, not the act-wrapper's void
+    // promise (Copilot #278). Without this, the rejects.toBe assertion is fragile across testing-library versions.
+    let caught: unknown;
+    await act(async () => {
+      try {
+        await result.current.call();
+      } catch (err) {
+        caught = err;
+      }
+    });
+    expect(caught).toBe(otherErr);
     expect(result.current.modal.open).toBe(false);
     expect(result.current.modal.challenge).toBeNull();
   });

--- a/ui/src/hooks/useReauthRetry.test.ts
+++ b/ui/src/hooks/useReauthRetry.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { useReauthRetry } from "./useReauthRetry";
+import { ReauthRequiredError } from "../api";
+import type { ReauthChallenge } from "../api";
+
+// useReauthRetry wraps a destructive-action mutation. On ReauthRequiredError it opens a modal-state, awaits the operator's
+// verdict (delivered via modal.resolve(true|false)), and either retries the original call or surfaces the original deny.
+// These tests exercise the state-machine + single-flight + retry contract documented at the top of useReauthRetry.ts.
+//
+// Test idioms used throughout:
+//   - act(async () => { x; await Promise.resolve(); }) — wraps state updates triggered by resolve() so React can flush
+//     them inside the act() boundary. The `await Promise.resolve()` makes the arrow legitimately async (eslint
+//     require-await) and lets the microtask queue drain so the hook's post-resolve setState calls land before the
+//     assertions on result.current.* observe them.
+//   - kickOff(...) helper — runs result.current.call(...) inside act, attaches a no-op .catch so vitest's
+//     unhandled-rejection tracker stays quiet between kickoff and the eventual `expect(...).rejects` assert. Returns the
+//     promise without a non-null assertion.
+
+const fakeChallenge: ReauthChallenge = {
+  authMethod: "local_password",
+  reauthURL: "/api/auth/reauth",
+};
+
+function kickOff<R>(callFn: () => Promise<R>): Promise<R> {
+  let p: Promise<R> = Promise.resolve(undefined as unknown as R); // sentinel; reassigned inside act
+  act(() => {
+    p = callFn();
+    // Attach a no-op rejection handler so vitest's unhandled-rejection tracker stays quiet between kickoff and the
+    // eventual `expect(promise).rejects.*` assert. The original promise's rejection state is unaffected.
+    p.catch(() => {
+      /* silenced; eventual assert will re-throw / verify */
+    });
+  });
+  return p;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("useReauthRetry", () => {
+  it("returns the wrapped result on success without opening the modal", async () => {
+    const fn = vi.fn().mockResolvedValue("ok");
+    const { result } = renderHook(() => useReauthRetry(fn));
+
+    const value = await act(async () => result.current.call());
+    expect(value).toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(result.current.modal.open).toBe(false);
+    expect(result.current.modal.challenge).toBeNull();
+  });
+
+  it("opens the modal and surfaces the challenge on ReauthRequiredError", async () => {
+    const fn = vi.fn().mockRejectedValueOnce(new ReauthRequiredError(fakeChallenge));
+    const { result } = renderHook(() => useReauthRetry(fn));
+
+    const callPromise = kickOff<unknown>(() => result.current.call());
+    await waitFor(() => { expect(result.current.modal.open).toBe(true); });
+    expect(result.current.modal.challenge).toEqual(fakeChallenge);
+
+    // Cancel so the dangling promise resolves; the retry-path test below covers the resolve(true) branch.
+    await act(async () => {
+      result.current.modal.resolve(false);
+      await Promise.resolve();
+    });
+    await expect(callPromise).rejects.toBeInstanceOf(ReauthRequiredError);
+  });
+
+  it("retries fn once after a successful reauth verdict (operator confirms)", async () => {
+    let attempts = 0;
+    const fn = vi.fn(async (): Promise<string> => {
+      // Trivial await keeps eslint's require-await happy without changing the implementation's effective behaviour;
+      // the stub still throws/returns synchronously in the same microtask.
+      await Promise.resolve();
+      attempts += 1;
+      if (attempts === 1) throw new ReauthRequiredError(fakeChallenge);
+      return "after-reauth";
+    });
+    const { result } = renderHook(() => useReauthRetry(fn));
+
+    const callPromise = kickOff<string>(() => result.current.call());
+    await waitFor(() => { expect(result.current.modal.open).toBe(true); });
+
+    await act(async () => {
+      result.current.modal.resolve(true);
+      await Promise.resolve();
+    });
+    const value = await callPromise;
+    expect(value).toBe("after-reauth");
+    expect(fn).toHaveBeenCalledTimes(2);
+    // Modal closes after the verdict; challenge clears.
+    await waitFor(() => { expect(result.current.modal.open).toBe(false); });
+    expect(result.current.modal.challenge).toBeNull();
+  });
+
+  it("throws the original ReauthRequiredError when the operator cancels", async () => {
+    const fn = vi.fn().mockRejectedValueOnce(new ReauthRequiredError(fakeChallenge));
+    const { result } = renderHook(() => useReauthRetry(fn));
+
+    const callPromise = kickOff<unknown>(() => result.current.call());
+    await waitFor(() => { expect(result.current.modal.open).toBe(true); });
+
+    await act(async () => {
+      result.current.modal.resolve(false);
+      await Promise.resolve();
+    });
+    await expect(callPromise).rejects.toBeInstanceOf(ReauthRequiredError);
+    // fn was called once (the original); cancellation suppresses the retry.
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("collapses concurrent calls into one modal cycle (single-flight)", async () => {
+    let attempts = 0;
+    const fn = vi.fn(async (): Promise<string> => {
+      // Trivial await keeps eslint's require-await happy without changing the implementation's effective behaviour;
+      // the stub still throws/returns synchronously in the same microtask.
+      await Promise.resolve();
+      attempts += 1;
+      // Every call throws ReauthRequiredError exactly once - the first time each call is invoked. Track per-call.
+      if (attempts <= 2) throw new ReauthRequiredError(fakeChallenge);
+      return `attempt-${String(attempts)}`;
+    });
+    const { result } = renderHook(() => useReauthRetry(fn));
+
+    // Fire two concurrent calls before the modal verdict lands. Use the kickOff helper for both so unhandled-rejection
+    // is silenced even though both ultimately resolve.
+    const pA = kickOff<string>(() => result.current.call());
+    const pB = kickOff<string>(() => result.current.call());
+    await waitFor(() => { expect(result.current.modal.open).toBe(true); });
+
+    // Modal opened ONCE despite two concurrent calls (single-flight contract). resolve once for both pending callers.
+    await act(async () => {
+      result.current.modal.resolve(true);
+      await Promise.resolve();
+    });
+
+    const [vA, vB] = await Promise.all([pA, pB]);
+    expect([vA, vB]).toEqual(["attempt-3", "attempt-4"]);
+    // fn ran 4 times total: 2 initial deny + 2 retries.
+    expect(fn).toHaveBeenCalledTimes(4);
+  });
+
+  it("propagates non-Reauth errors without opening the modal", async () => {
+    const otherErr = new Error("server down");
+    const fn = vi.fn().mockRejectedValue(otherErr);
+    const { result } = renderHook(() => useReauthRetry(fn));
+
+    await expect(act(async () => result.current.call())).rejects.toBe(otherErr);
+    expect(result.current.modal.open).toBe(false);
+    expect(result.current.modal.challenge).toBeNull();
+  });
+
+  it("ignores a double-resolve call (defence against quick Confirm-then-Cancel)", async () => {
+    let attempts = 0;
+    const fn = vi.fn(async (): Promise<string> => {
+      // Trivial await keeps eslint's require-await happy without changing the implementation's effective behaviour;
+      // the stub still throws/returns synchronously in the same microtask.
+      await Promise.resolve();
+      attempts += 1;
+      if (attempts === 1) throw new ReauthRequiredError(fakeChallenge);
+      return "ok";
+    });
+    const { result } = renderHook(() => useReauthRetry(fn));
+
+    const callPromise = kickOff<string>(() => result.current.call());
+    await waitFor(() => { expect(result.current.modal.open).toBe(true); });
+
+    // First resolve(true) wins; the second resolve(false) is a no-op because resolverRef has been cleared.
+    await act(async () => {
+      result.current.modal.resolve(true);
+      result.current.modal.resolve(false);
+      await Promise.resolve();
+    });
+    await expect(callPromise).resolves.toBe("ok");
+  });
+
+  it("forwards the same args to the retry call", async () => {
+    let attempts = 0;
+    const fn = vi.fn(async (a: string, b: number): Promise<string> => {
+      // See note on the sibling test about the trivial await + eslint require-await.
+      await Promise.resolve();
+      attempts += 1;
+      if (attempts === 1) throw new ReauthRequiredError(fakeChallenge);
+      return `${a}-${String(b)}-attempt-${String(attempts)}`;
+    });
+    const { result } = renderHook(() => useReauthRetry(fn));
+
+    const callPromise = kickOff<string>(() => result.current.call("hello", 42));
+    await waitFor(() => { expect(result.current.modal.open).toBe(true); });
+    await act(async () => {
+      result.current.modal.resolve(true);
+      await Promise.resolve();
+    });
+    await expect(callPromise).resolves.toBe("hello-42-attempt-2");
+    // Both invocations saw the same args.
+    expect(fn.mock.calls[0]).toEqual(["hello", 42]);
+    expect(fn.mock.calls[1]).toEqual(["hello", 42]);
+  });
+});


### PR DESCRIPTION
…eauthModal

Closes #125 (UI test infrastructure + lift ui/src/** coverage exclusion) and #116 (playwright + integration tests to cover specs).

Status of #125's five items:
1. First UI test authored — already shipped (api.test.ts + AlertList.test.tsx).
2. Coverage exclusion lifted — already lifted in sonar-project.properties + codecov.yml.
3. Patch threshold matches the server — codecov.yml's per-flag patch gate is 70% across agent/server/ui; Sonar's 80% new-code gate is parallel and applies identically to UI code.
4. CLAUDE.md UI testing convention added (this PR).
5. Phase 4c coverage backfill (this PR).

#116 was already closed by the 18 playwright .spec.ts files at test/e2e/tests/{auth,qa}/ that carry spec:web-ui/... and spec:ui-authentication-session/... markers; spectrace --strict reports 266/266 normative scenarios marked. The vitest unit + component coverage piece of the same surfaces is what this PR adds.

CLAUDE.md additions:
- Test-style decision-matrix row for vitest + @testing-library/react (UI unit + component) and a separate row for @playwright/test (UI end-to-end).
- "UI testing convention" subsection documenting the project's vitest idioms: vi.spyOn(api, ...) for API mocking, renderHook + act() for hooks, vi.stubGlobal for WebAuthn / location, afterEach(vi.restoreAllMocks).

Phase 4c backfill (5 new *.test.{ts,tsx} files, +72 tests; 192 total, up from 120):

ui/src/auth.test.ts (25 tests, ~280 LOC)
  - BreakglassError constructor + name/status/reason.
  - oidcLoginUrl input validation: undefined, empty, valid same-origin, encoded special chars, no-leading-slash, protocol-relative (open-redirect defence), >256-char cap, off-allowlist chars.
  - All four breakglass*/reauth* fetch wrappers exercised: happy 2xx path, JSON request shape, 204 no-content, non-JSON 2xx, Content-Length:0, 4xx with X-Edr-Auth-Reason header, 4xx without header (http_<status> fallback).
  - reauthOIDC URL construction: append next=<encoded path>; off-shape baseURL falls back to /api/auth/login?reauth=1; off-shape current-path drops the next param.
  - WebAuthn ceremony calls (startRegistration / startAuthentication) stubbed via vi.mock so tests run in jsdom.

ui/src/hooks/useReauthRetry.test.ts (8 tests, ~200 LOC)
  - Happy-path success (no modal opens).
  - ReauthRequiredError opens the modal + surfaces the challenge.
  - resolve(true) → retries fn(...args) and resolves with the retry's value.
  - resolve(false) → propagates the original ReauthRequiredError; no retry.
  - Single-flight: two concurrent calls collapse into one modal cycle.
  - Non-Reauth errors propagate unchanged.
  - Double-resolve is a no-op (defence against quick Confirm-then-Cancel).
  - Args forwarded to the retry call.

ui/src/components/ReauthModal.test.tsx (12 tests, ~150 LOC)
  - Null challenge renders nothing.
  - OIDC flow: correct copy + Continue button calls reauthOIDC + Cancel calls resolve(false).
  - Break-glass flow: password input + submit triggers reauthBreakglass + maps each documented BreakglassError reason (invalid_credentials, rate_limited, etc.) to the right operator copy.
  - WebAuthn NotAllowedError renders "security-key prompt was cancelled".
  - Submit disabled until password entered.
  - HTMLDialogElement.showModal/close stubbed to set/clear the `open` attribute (jsdom's default stubs throw).

ui/src/components/Login.test.tsx (13 tests, ~100 LOC)
  - Error block renders correct copy for each ?error= reason; unknown falls through to generic.
  - next-param resolution: prop > URL ?next > default /ui/.
  - Off-shape next dropped (open-redirect defence).
  - Continue click triggers globalThis.location.assign with the right URL.
  - Break-glass footer link points at /admin/break-glass.

ui/src/components/BreakGlassLogin.test.tsx (14 tests, ~150 LOC)
  - Form rendering (email, password, submit, back-link).
  - Submit disabled guard (empty email, empty password, whitespace-only email).
  - Happy path calls breakglassBeginLogin → breakglassFinishLogin → navigates to the redirect.
  - /ui prefix stripping: /ui/alerts -> /alerts; /ui (no slash) -> /; /uipreview stays /uipreview (no false-positive strip).
  - Each documented BreakglassError reason → directed operator copy.
  - WebAuthn NotAllowedError + generic non-BreakglassError fall through to the expected messages.

Gates: cd ui && npm test (18 files, 192 tests) green; cd ui && npm run lint clean; cd ui && npm run build clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suites covering authentication helpers, sign-in flows, break-glass login forms, reauthentication modals, and retry mechanisms with extensive validation of HTTP requests, error handling, and user interactions.

* **Documentation**
  * Updated testing guidance with explicit UI testing conventions, including test organization, mocking strategies, and coverage capture methodology.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/getvictor/fleet-edr/pull/278?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->