### PR TITLE
Address SonarCloud global findings (21 issues triaged)

### DIFF
--- a/agent/cmd/fleet-edr-agent-headless/headless/control.go
+++ b/agent/cmd/fleet-edr-agent-headless/headless/control.go
@@ -37,6 +37,11 @@ const (
 	// controlSocketMode locks the unix socket to the running user only. The headless binary is single-user dev/test tooling; a more
 	// permissive mode would let any process on the host inject events.
 	controlSocketMode os.FileMode = 0o600
+
+	// HTTP header names + content types centralised so Sonar's S1192 (duplicated literal) doesn't trip across the three
+	// inject + state + error response paths. None of these are wire contracts that vary per call site.
+	contentTypeHeader = "Content-Type"
+	contentTypeJSON   = "application/json"
 )
 
 // startControlPlane binds a unix socket at socketPath and serves the control-plane HTTP API on it. Returns a shutdown function the
@@ -138,7 +143,7 @@ func handlePostEvent(
 	n := cnt.eventsInjected.Add(1)
 	cnt.lastInjectAtUnix.Store(time.Now().Unix())
 	logger.DebugContext(r.Context(), "control plane injected event", "events_injected", n)
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(contentTypeHeader, contentTypeJSON)
 	w.WriteHeader(http.StatusAccepted)
 	_ = json.NewEncoder(w).Encode(map[string]any{"events_injected": n})
 }
@@ -170,13 +175,13 @@ func handleGetState(
 		LastInjectAtUnix: cnt.lastInjectAtUnix.Load(),
 		QueueDepth:       depth,
 	}
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(contentTypeHeader, contentTypeJSON)
 	_ = json.NewEncoder(w).Encode(resp)
 }
 
 // writeJSONError emits a small JSON error body so a client parsing the response can read .error without sniffing the body type.
 func writeJSONError(w http.ResponseWriter, status int, msg string) {
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(contentTypeHeader, contentTypeJSON)
 	w.WriteHeader(status)
 	_ = json.NewEncoder(w).Encode(map[string]string{"error": msg})
 }

--- a/agent/cmd/fleet-edr-agent-headless/headless/headless.go
+++ b/agent/cmd/fleet-edr-agent-headless/headless/headless.go
@@ -156,8 +156,11 @@ func Run(ctx context.Context, opts Options) error {
 
 	// Control plane: optional. When SocketPath is non-empty, start the server in a goroutine. Capture shutdown so we can call it
 	// explicitly between ctx.Done() and drainOnShutdown (see below); also keep a deferred call as a safety net in case Run returns
-	// before ctx.Done() fires. http.Server.Shutdown is idempotent so the double-call is safe.
-	shutdownControlPlane := func() {}
+	// before ctx.Done() fires. http.Server.Shutdown is idempotent so the double-call is safe. Default the closure to a no-op so
+	// the two call sites below don't have to nil-check (Sonar S1186 requires the comment INSIDE the body, not preceding).
+	shutdownControlPlane := func() {
+		// Intentional no-op default; replaced by startControlPlane's real shutdown closure when SocketPath is non-empty.
+	}
 	if opts.SocketPath != "" {
 		shutdown, err := startControlPlane(ctx, opts.SocketPath, recv, q, cnt, logger)
 		if err != nil {

--- a/agent/queue/queue_test.go
+++ b/agent/queue/queue_test.go
@@ -5,10 +5,10 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
 	"modernc.org/sqlite"
 )
 
@@ -493,31 +493,13 @@ func TestQueue_DuplicateEventIDIsAccepted(t *testing.T) {
 func TestQueue_CapEvictionRacesInflightUpload(t *testing.T) {
 	q := openCappedQueue(t, 32*1024)
 	ctx := t.Context()
-	payload := make([]byte, 1024)
-	for i := range payload {
-		payload[i] = 'x'
-	}
+	payload := capRaceTestPayload()
 
 	var stub stubMetrics
 	q.SetMetrics(&stub)
 
-	// Phase 1: enqueue a small initial batch and dequeue it so the uploader has captured these IDs as "in-flight".
-	for range 5 {
-		if err := q.Enqueue(ctx, payload); err != nil {
-			t.Fatalf("initial enqueue: %v", err)
-		}
-	}
-	inflight, err := q.DequeueBatch(ctx, 10)
-	if err != nil {
-		t.Fatalf("dequeue in-flight batch: %v", err)
-	}
-	if len(inflight) != 5 {
-		t.Fatalf("expected 5 in-flight rows, got %d", len(inflight))
-	}
-	inflightIDs := make([]int64, len(inflight))
-	for i, e := range inflight {
-		inflightIDs[i] = e.ID
-	}
+	// Phase 1: capture an in-flight batch (5 rows dequeued but not yet acked).
+	inflightIDs := capRaceEnqueueInflight(t, q, ctx, payload, 5)
 
 	// Phase 2: enqueue enough additional events to force the cap to lossy-drop pending rows. The in-flight rows
 	// (oldest) are the first to go because nothing is marked uploaded yet.
@@ -530,22 +512,8 @@ func TestQueue_CapEvictionRacesInflightUpload(t *testing.T) {
 		t.Fatalf("expected at least one lossy drop during cap pressure; metrics stub saw none")
 	}
 
-	// Prove the eviction actually touched the in-flight set rather than only dropping newer rows. Without this probe, a
-	// regression that flipped the eviction policy to drop newest-first would silently keep the test green - stub.hadLossy
-	// + Depth would both pass even though MarkUploaded's missing-row path is no longer exercised. The query has a fixed
-	// 5-placeholder shape because the test enqueues exactly 5 in-flight events; if that count ever changes, update the
-	// query alongside the loop above so the lint check below (require.Len matches the placeholder count) stays accurate.
-	require.Len(t, inflightIDs, 5, "in-flight ID count must match the hardcoded 5-placeholder query below")
-	var survivingInflight int
-	row := q.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM events WHERE id IN (?, ?, ?, ?, ?)",
-		inflightIDs[0], inflightIDs[1], inflightIDs[2], inflightIDs[3], inflightIDs[4])
-	if err := row.Scan(&survivingInflight); err != nil {
-		t.Fatalf("count surviving in-flight rows: %v", err)
-	}
-	if survivingInflight == len(inflightIDs) {
-		t.Fatalf("expected cap enforcement to evict at least one in-flight row before MarkUploaded; all %d survived",
-			len(inflightIDs))
-	}
+	// Verify the eviction actually touched the in-flight set rather than only dropping newer rows.
+	capRaceAssertInflightEvicted(t, q, ctx, inflightIDs)
 
 	// Phase 3: ack the originally-dequeued IDs. Some MUST already be gone (the cap evicted them); MarkUploaded MUST
 	// still return nil so the uploader's happy path doesn't surface a failure for events the queue has chosen to drop.
@@ -553,16 +521,70 @@ func TestQueue_CapEvictionRacesInflightUpload(t *testing.T) {
 		t.Fatalf("MarkUploaded on evicted-in-flight IDs MUST be a silent no-op, got: %v", err)
 	}
 
-	// Sanity check: at least one of the in-flight rows was evicted (verifies the test actually exercised the race
-	// rather than racing nobody). Counts both rows: the in-flight IDs that survived plus everything queued in Phase 2.
+	// 5 in-flight + 200 pressure = 205 rows enqueued. After lossy drops, depth MUST be strictly less than 205. If the
+	// cap didn't fire there's no race to test.
 	depth, err := q.Depth(ctx)
 	if err != nil {
 		t.Fatalf("depth: %v", err)
 	}
-	// 5 in-flight + 200 pressure = 205 rows enqueued. After lossy drops, depth MUST be strictly less than 205. If the
-	// cap didn't fire there's no race to test.
 	if depth >= 205 {
 		t.Fatalf("expected cap enforcement to drop rows; depth=%d still >= 205 enqueues", depth)
+	}
+}
+
+// capRaceTestPayload returns a 1 KiB payload of 'x' bytes the cap-eviction test enqueues at every level. Pulled out so
+// the test body stays under Sonar S3776's cognitive-complexity budget.
+func capRaceTestPayload() []byte {
+	payload := make([]byte, 1024)
+	for i := range payload {
+		payload[i] = 'x'
+	}
+	return payload
+}
+
+// capRaceEnqueueInflight enqueues `count` payload rows and immediately dequeues them so the test has a captured set of
+// "in-flight" IDs the uploader would still be working on when the cap fires. Returns the captured IDs.
+func capRaceEnqueueInflight(t *testing.T, q *Queue, ctx context.Context, payload []byte, count int) []int64 {
+	t.Helper()
+	for range count {
+		if err := q.Enqueue(ctx, payload); err != nil {
+			t.Fatalf("initial enqueue: %v", err)
+		}
+	}
+	inflight, err := q.DequeueBatch(ctx, count*2) // generous limit so partial returns surface as a test failure
+	if err != nil {
+		t.Fatalf("dequeue in-flight batch: %v", err)
+	}
+	if len(inflight) != count {
+		t.Fatalf("expected %d in-flight rows, got %d", count, len(inflight))
+	}
+	ids := make([]int64, len(inflight))
+	for i, e := range inflight {
+		ids[i] = e.ID
+	}
+	return ids
+}
+
+// capRaceAssertInflightEvicted verifies the cap's lossy-drop path touched the captured in-flight set rather than only dropping
+// newer rows. Without this probe, a regression that flipped the eviction policy to drop newest-first would silently keep the
+// test green: stub.hadLossy + Depth would both pass even though MarkUploaded's missing-row path is no longer exercised. The
+// IN-clause is composed dynamically so a future count change in the caller doesn't require a parallel SQL edit (the prior
+// hardcoded 5-placeholder shape was a footgun the require.Len lint check papered over).
+func capRaceAssertInflightEvicted(t *testing.T, q *Queue, ctx context.Context, inflightIDs []int64) {
+	t.Helper()
+	placeholders := strings.Repeat("?,", len(inflightIDs)-1) + "?"
+	args := make([]any, len(inflightIDs))
+	for i, id := range inflightIDs {
+		args[i] = id
+	}
+	var survivingInflight int
+	row := q.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM events WHERE id IN ("+placeholders+")", args...) //nolint:gosec
+	if err := row.Scan(&survivingInflight); err != nil {
+		t.Fatalf("count surviving in-flight rows: %v", err)
+	}
+	if survivingInflight == len(inflightIDs) {
+		t.Fatalf("expected cap enforcement to evict at least one in-flight row before MarkUploaded; all %d survived",
+			len(inflightIDs))
 	}
 }
 

--- a/extension/edr/extension/ApplicationControlStore.swift
+++ b/extension/edr/extension/ApplicationControlStore.swift
@@ -129,12 +129,18 @@ final class ApplicationControlStore {
     private let persistQueue = DispatchQueue(label: "com.fleetdm.edr.appcontrol.persist", qos: .utility)
     private let storagePath: String
 
+    /// defaultStoragePath is the on-disk policy file the production singleton uses. Extracted from the init's default
+    /// argument so Sonar S1075 (hardcoded URI in source) lands on the named constant rather than the function signature;
+    /// the constant is still in one place and the doc-comment on `.shared` continues to discourage production callers
+    /// from bypassing the singleton.
+    static let defaultStoragePath = "/var/db/com.fleetdm.edr/application-control.json"
+
     /// The `storagePath` argument exists for XCTest isolation -- production code uses `.shared`
     /// which initializes via the default value (the real on-disk policy file under /var/db).
     /// The init is internal (not private) because @testable code in the SwiftPM Tests target
     /// needs to call it; the doc comment on `.shared` discourages new production callers from
     /// bypassing the singleton.
-    init(storagePath: String = "/var/db/com.fleetdm.edr/application-control.json") {
+    init(storagePath: String = ApplicationControlStore.defaultStoragePath) {
         self.storagePath = storagePath
     }
 

--- a/scripts/uat/lib/common.sh
+++ b/scripts/uat/lib/common.sh
@@ -37,11 +37,13 @@ UAT_COMMON_SH_LOADED=1
 uat_log() {
   local tag="$1"; shift
   printf '[%s] [%s] %s\n' "$(date '+%H:%M:%S')" "$tag" "$*" >&2
+  return 0
 }
 
 # uat_fail <tag> <msg...>: log then exit 1.
 uat_fail() {
-  uat_log "$1" "FAIL: ${*:2}"
+  local tag="$1"
+  uat_log "$tag" "FAIL: ${*:2}"
   exit 1
 }
 
@@ -68,6 +70,7 @@ uat_ssh_args() {
     -o "UserKnownHostsFile=$known_hosts"
     -o ConnectTimeout=10
   )
+  return 0
 }
 
 # uat_ssh <target> <cmd...>: run cmd over ssh on target. Honors $UAT_DRY_RUN.

--- a/server/detection/internal/intake/handler.go
+++ b/server/detection/internal/intake/handler.go
@@ -48,22 +48,39 @@ const MaxIngestEventsPerRequest = 10_000
 // but it's bounded to MaxIngestEventsPerRequest+1, not the entire body's worth.
 func ParseAndValidateIngestBody(body []byte, pinnedHostID string) (events []api.Event, status int, errCode string) {
 	dec := json.NewDecoder(bytes.NewReader(body))
+	if !readArrayOpen(dec) {
+		return nil, http.StatusBadRequest, "invalid_json"
+	}
+	events, status, errCode = streamDecodeEvents(dec, pinnedHostID)
+	if status != http.StatusOK {
+		return nil, status, errCode
+	}
+	if !readArrayCloseAndEOF(dec) {
+		return nil, http.StatusBadRequest, "invalid_json"
+	}
+	return events, http.StatusOK, ""
+}
 
-	// Opening token must be `[`. Anything else (`{`, null, primitive, garbage, EOF) is invalid_json. This subsumes the
-	// previous explicit nil-check on the literal `null` body: json.Decoder.Token() for `null` returns the nil Token, which
-	// fails the json.Delim type-assert below, so the same input still returns invalid_json.
+// readArrayOpen consumes the opening `[` token. Returns false for anything else (`{`, null, primitive, garbage, EOF). Subsumes
+// the previous explicit nil-check on the literal `null` body: json.Decoder.Token() for `null` returns the nil Token, which
+// fails the json.Delim type-assert below, so the same input still returns invalid_json. Extracted from
+// ParseAndValidateIngestBody so the parent stays under Sonar's S3776 cognitive-complexity budget.
+func readArrayOpen(dec *json.Decoder) bool {
 	tok, err := dec.Token()
 	if err != nil {
-		return nil, http.StatusBadRequest, "invalid_json"
+		return false
 	}
-	if delim, ok := tok.(json.Delim); !ok || delim != '[' {
-		return nil, http.StatusBadRequest, "invalid_json"
-	}
+	delim, ok := tok.(json.Delim)
+	return ok && delim == '['
+}
 
+// streamDecodeEvents reads array elements one-at-a-time, applying the cap + per-event validation in a single pass. Returns
+// events on success or (status, errCode) on the first validation failure. The cap fires BEFORE the over-cap event is
+// allocated; the +1 conceptual margin (accept up to and including MaxIngestEventsPerRequest, reject the (Max+1)th before
+// decoding) keeps the heap-amplification path closed even on a body at the 10 MB upstream byte cap.
+func streamDecodeEvents(dec *json.Decoder, pinnedHostID string) ([]api.Event, int, string) {
+	var events []api.Event
 	for i := 0; dec.More(); i++ {
-		// Cap fires BEFORE the over-cap event is allocated. The +1 conceptual margin (we accept up to and including
-		// MaxIngestEventsPerRequest events, then reject the (Max+1)th before decoding) keeps the heap-amplification path
-		// closed even on a body whose byte count is at the 10 MB upstream cap.
 		if i >= MaxIngestEventsPerRequest {
 			return nil, http.StatusRequestEntityTooLarge, "too_many_events"
 		}
@@ -79,22 +96,23 @@ func ParseAndValidateIngestBody(body []byte, pinnedHostID string) (events []api.
 		}
 		events = append(events, e)
 	}
-
-	// Closing `]` must follow; anything else is malformed and surfaces as invalid_json. After the close, the decoder must
-	// reach io.EOF on the next token call - trailing bytes after the array are also invalid_json. The two checks together
-	// reject inputs like `[]extra` or `[][]` that json.Unmarshal would also reject.
-	tok, err = dec.Token()
-	if err != nil {
-		return nil, http.StatusBadRequest, "invalid_json"
-	}
-	if delim, ok := tok.(json.Delim); !ok || delim != ']' {
-		return nil, http.StatusBadRequest, "invalid_json"
-	}
-	if _, err := dec.Token(); !errors.Is(err, io.EOF) {
-		return nil, http.StatusBadRequest, "invalid_json"
-	}
-
 	return events, http.StatusOK, ""
+}
+
+// readArrayCloseAndEOF verifies the array closes with `]` AND the decoder reaches io.EOF on the next token call. Trailing
+// bytes after the array are invalid_json (matching json.Unmarshal's contract). The two checks together reject inputs like
+// `[]extra` or `[][]`.
+func readArrayCloseAndEOF(dec *json.Decoder) bool {
+	tok, err := dec.Token()
+	if err != nil {
+		return false
+	}
+	delim, ok := tok.(json.Delim)
+	if !ok || delim != ']' {
+		return false
+	}
+	_, err = dec.Token()
+	return errors.Is(err, io.EOF)
 }
 
 // BuildInfo is injected at startup so the readiness endpoint

--- a/server/detection/internal/intake/handler_fuzz_test.go
+++ b/server/detection/internal/intake/handler_fuzz_test.go
@@ -66,68 +66,75 @@ func FuzzParseAndValidateIngestBody(f *testing.F) {
 // against the validation logic, not just against the wire shape.
 func assertValidOutput(t *testing.T, body []byte, events []api.Event, status int, errCode string, pinnedHostID string) {
 	t.Helper()
-
 	switch status {
 	case http.StatusOK:
-		if errCode != "" {
-			t.Fatalf("status 200 returned with non-empty errCode %q for body %q", errCode, body)
-		}
-		// Sanity: a 200 result implies the body started with [ (a JSON array). An empty body or a non-array would not have
-		// reached the loop. The body may have leading/trailing whitespace; trim before the prefix check.
-		trimmed := bytes.TrimSpace(body)
-		if len(trimmed) > 0 && trimmed[0] != '[' {
-			t.Fatalf("status 200 but body is not a JSON array: %q", body)
-		}
-		// Per-event field-population + host_id pin. The validation loop in ParseAndValidateIngestBody enforces these on every
-		// event; a 200 that returns events failing either check would be a contract regression.
-		for i, e := range events {
-			if e.EventID == "" || e.HostID == "" || e.EventType == "" || e.TimestampNs == 0 {
-				t.Fatalf("status 200 returned event[%d] with empty required field (event_id=%q host_id=%q event_type=%q timestamp_ns=%d) for body %q",
-					i, e.EventID, e.HostID, e.EventType, e.TimestampNs, body)
-			}
-			if e.HostID != pinnedHostID {
-				t.Fatalf("status 200 returned event[%d] with host_id %q != pinned %q for body %q",
-					i, e.HostID, pinnedHostID, body)
-			}
-		}
-		if len(events) > MaxIngestEventsPerRequest {
-			t.Fatalf("status 200 returned %d events; exceeds MaxIngestEventsPerRequest=%d for body %q",
-				len(events), MaxIngestEventsPerRequest, body)
-		}
-		// Trailing-bytes pin: a 200 implies the body parses cleanly as []api.Event with no trailing content. json.Unmarshal
-		// rejects trailing bytes by contract (encoding/json package documentation), so using it as an independent oracle
-		// catches the case where the streaming decoder accepts content past the closing `]`. Without this check, the
-		// trailing-bytes seeds (`[]extra`, `[][]`, `[...]X`) silently pass because the events-slice contract on its own
-		// doesn't see the trailing material.
-		var reparsed []api.Event
-		if err := json.Unmarshal(body, &reparsed); err != nil {
-			t.Fatalf("status 200 but json.Unmarshal rejects the body: %v; body=%q", err, body)
-		}
-
+		assertOKContract(t, body, events, errCode, pinnedHostID)
 	case http.StatusBadRequest:
-		// Any of the documented 400 error codes is acceptable. The fuzz pins the SET of codes; a stray code is a finding.
-		switch {
-		case errCode == "invalid_json":
-			// Implies the JSON parse failed OR the body deserialized to nil (literal `null`, treated as a parse failure).
-		case errCode == "host_id_mismatch":
-			// Implies at least one event's host_id != pinnedHostID. We don't re-parse the body here to confirm — the parse
-			// produced events, then a validation step caught the mismatch. Trusting the function's own report.
-			_ = pinnedHostID
-		case strings.HasPrefix(errCode, "missing_fields_at_"):
-			// Implies an event at some index missed one of {event_id, host_id, event_type, timestamp_ns}.
-		default:
-			t.Fatalf("status 400 returned with undocumented errCode %q for body %q", errCode, body)
-		}
-
+		assertBadRequestErrCode(t, body, errCode, pinnedHostID)
 	case http.StatusRequestEntityTooLarge:
-		// The parse-helper emits 413 only for too_many_events; the 413 body_too_large path is upstream of this function in
-		// readBodyWithCap and never reaches the parse helper. A stray 413 errCode is a finding.
+		// 413 from the parse-helper is reserved for too_many_events; the body_too_large path is upstream and never reaches
+		// the parse helper. A stray 413 errCode is a finding.
 		if errCode != "too_many_events" {
 			t.Fatalf("status 413 returned with undocumented errCode %q for body %q", errCode, body)
 		}
-
 	default:
 		t.Fatalf("undocumented status %d (errCode %q) for body %q", status, errCode, body)
+	}
+}
+
+// assertOKContract pins the (200, "") contract: empty errCode, body starts with `[`, every event has its required fields
+// populated and host_id == pinnedHostID, count under the cap, and the body parses cleanly with json.Unmarshal (trailing-bytes
+// check; Unmarshal rejects content past the closing `]`). Extracted from assertValidOutput so the parent stays under Sonar
+// S3776's cognitive-complexity budget (assertValidOutput hit 23 vs 15 allowed pre-refactor).
+func assertOKContract(t *testing.T, body []byte, events []api.Event, errCode string, pinnedHostID string) {
+	t.Helper()
+	if errCode != "" {
+		t.Fatalf("status 200 returned with non-empty errCode %q for body %q", errCode, body)
+	}
+	// A 200 result implies the body started with [ (a JSON array). The body may have leading/trailing whitespace;
+	// trim before the prefix check.
+	trimmed := bytes.TrimSpace(body)
+	if len(trimmed) > 0 && trimmed[0] != '[' {
+		t.Fatalf("status 200 but body is not a JSON array: %q", body)
+	}
+	for i, e := range events {
+		if e.EventID == "" || e.HostID == "" || e.EventType == "" || e.TimestampNs == 0 {
+			t.Fatalf("status 200 returned event[%d] with empty required field (event_id=%q host_id=%q event_type=%q timestamp_ns=%d) for body %q",
+				i, e.EventID, e.HostID, e.EventType, e.TimestampNs, body)
+		}
+		if e.HostID != pinnedHostID {
+			t.Fatalf("status 200 returned event[%d] with host_id %q != pinned %q for body %q",
+				i, e.HostID, pinnedHostID, body)
+		}
+	}
+	if len(events) > MaxIngestEventsPerRequest {
+		t.Fatalf("status 200 returned %d events; exceeds MaxIngestEventsPerRequest=%d for body %q",
+			len(events), MaxIngestEventsPerRequest, body)
+	}
+	// Trailing-bytes pin: json.Unmarshal rejects content past the closing `]`, so using it as an independent oracle
+	// catches the case where the streaming decoder accepts trailing bytes. The trailing-bytes seeds (`[]extra`,
+	// `[][]`, `[...]X`) silently pass without this check.
+	var reparsed []api.Event
+	if err := json.Unmarshal(body, &reparsed); err != nil {
+		t.Fatalf("status 200 but json.Unmarshal rejects the body: %v; body=%q", err, body)
+	}
+}
+
+// assertBadRequestErrCode pins the 400-error-code vocabulary: only invalid_json, host_id_mismatch, and missing_fields_at_<i>
+// are acceptable codes; a stray errCode is a finding. The 4 documented branches are listed explicitly for clarity.
+func assertBadRequestErrCode(t *testing.T, body []byte, errCode string, pinnedHostID string) {
+	t.Helper()
+	switch {
+	case errCode == "invalid_json":
+		// Implies the JSON parse failed OR the body deserialized to nil (literal `null`, treated as a parse failure).
+	case errCode == "host_id_mismatch":
+		// Implies at least one event's host_id != pinnedHostID. We don't re-parse the body to confirm - the parse
+		// produced events, then a validation step caught the mismatch. Trusting the function's own report.
+		_ = pinnedHostID
+	case strings.HasPrefix(errCode, "missing_fields_at_"):
+		// Implies an event at some index missed one of {event_id, host_id, event_type, timestamp_ns}.
+	default:
+		t.Fatalf("status 400 returned with undocumented errCode %q for body %q", errCode, body)
 	}
 }
 

--- a/test/e2e/fixtures/auth.ts
+++ b/test/e2e/fixtures/auth.ts
@@ -5,7 +5,7 @@
 
 import { Page } from "@playwright/test";
 import { openDB, resetDB, mintBootstrapToken } from "./db";
-import { installVirtualAuthenticator, uninstallVirtualAuthenticator, VirtualAuthenticator } from "./webauthn";
+import { installVirtualAuthenticator, VirtualAuthenticator } from "./webauthn";
 
 /**
  * BG_PASSWORD is the password registered during break-glass setup. Any string >=12 chars works; this one is shared across the L4
@@ -84,4 +84,5 @@ export async function resetHostData(
   `);
 }
 
-export { uninstallVirtualAuthenticator };
+// Re-export from the source module (Sonar S7763: `export { X }` of an imported name should use `export { X } from`).
+export { uninstallVirtualAuthenticator } from "./webauthn";

--- a/test/e2e/tests/qa/agent-events-flow.spec.ts
+++ b/test/e2e/tests/qa/agent-events-flow.spec.ts
@@ -51,8 +51,8 @@ test.describe("L4 agent fixture: scenarios land in events table", () => {
         // Exact-set assertion: the event_types in the DB must equal exactly what the scenario declared - no missing types and no
         // surprises (extra inserts would suggest the fixture leaked through to a wrong host, or the server's ingest accepted a
         // mistyped event_type).
-        const dbTypes = rows.map((r) => r.event_type).sort();
-        expect(dbTypes).toEqual(Object.keys(sc.expectedCounts).sort());
+        const dbTypes = rows.map((r) => r.event_type).sort((a, b) => a.localeCompare(b));
+        expect(dbTypes).toEqual(Object.keys(sc.expectedCounts).sort((a, b) => a.localeCompare(b)));
 
         // Exact-count per event_type: catches partial-ingest cases the presence-only check used to miss.
         for (const row of rows) {

--- a/test/e2e/tests/qa/host-list-and-process-tree.spec.ts
+++ b/test/e2e/tests/qa/host-list-and-process-tree.spec.ts
@@ -132,7 +132,7 @@ test.describe.serial("L4 (M6): host list + process tree UI specs", () => {
             )) as [Array<{ host_id: string; event_count: number | string }>, unknown];
             return rows
               .map((r) => `${r.host_id}=${String(r.event_count)}`)
-              .sort()
+              .sort((a, b) => a.localeCompare(b))
               .join(",");
           },
           { timeout: 10_000, message: "hosts.event_count never converged to expected per-scenario counts" },
@@ -140,7 +140,7 @@ test.describe.serial("L4 (M6): host list + process tree UI specs", () => {
         .toBe(
           driven
             .map((d) => `${d.hostId}=${String(d.expected)}`)
-            .sort()
+            .sort((a, b) => a.localeCompare(b))
             .join(","),
         );
     } finally {

--- a/test/scale/runner_headless.go
+++ b/test/scale/runner_headless.go
@@ -362,8 +362,10 @@ func (s *scaleTokenProvider) HostID() string { return s.hostID }
 // OnUnauthorized is intentionally a no-op in scale runs: a 401 from the server in headless mode is a setup/test bug
 // (mismatched enroll secret, server-side token revoke), not a re-enroll trigger. The scale runner aborts the host on
 // any persistent error path through the uploader's quarantine; the per-host LastError captures the diagnostic and the
-// run's pass gate flips. Sonar S1186 fix - explicit no-op comment per the rule (#277).
-func (s *scaleTokenProvider) OnUnauthorized(_ context.Context) {}
+// run's pass gate flips.
+func (s *scaleTokenProvider) OnUnauthorized(_ context.Context) {
+	// Intentional no-op; see method doc comment. Sonar S1186 requires the comment INSIDE the body, not just preceding.
+}
 
 func (s *scaleTokenProvider) Rotate(_ context.Context, _ string) error { return nil }
 


### PR DESCRIPTION
17 fixed via code edits, 4 accepted via Sonar status change (intentional + matches existing convention or opt-in/test-only by design).

Code edits

agent/cmd/fleet-edr-agent-headless/headless/control.go (S1192 ×2): extracted "Content-Type" + "application/json" to contentTypeHeader + contentTypeJSON constants. Three call sites (POST /event ack, GET /state response, error envelope) all use the constants.

agent/cmd/fleet-edr-agent-headless/headless/headless.go (S1186): the `shutdownControlPlane := func() {}` default is now documented with an inline body comment explaining why the no-op exists (replaced by startControlPlane's real shutdown closure when SocketPath is non-empty).

agent/queue/queue_test.go (S3776): TestQueue_CapEvictionRacesInflightUpload had cognitive complexity 16 vs 15 allowed. Factored out capRaceTestPayload + capRaceEnqueueInflight + capRaceAssertInflightEvicted helpers. The IN-clause in the eviction probe is now composed dynamically from len(inflightIDs) so a future count change doesn't require a parallel SQL edit (the previous hardcoded 5-placeholder shape was a footgun the require.Len lint check papered over).

server/detection/internal/intake/handler.go (S3776): ParseAndValidateIngestBody complexity 17 vs 15. Extracted readArrayOpen + streamDecodeEvents + readArrayCloseAndEOF helpers; the parent function is now a 3-step orchestrator.

server/detection/internal/intake/handler_fuzz_test.go (S3776): assertValidOutput complexity 23 vs 15. Split the 200- branch into assertOKContract and the 400-branch into assertBadRequestErrCode; the parent switch is now linear.

test/scale/runner_headless.go (S1186): scaleTokenProvider.OnUnauthorized empty body now carries an inline comment inside the braces (the rule rejects a preceding doc comment alone).

scripts/uat/lib/common.sh (S7682 ×3 + S7679 ×1): added explicit `return 0` at the end of uat_log + uat_ssh_args; added `local tag` for the positional parameter in uat_fail rather than reading $1 directly. Bash syntax-checked clean.

extension/edr/extension/ApplicationControlStore.swift (S1075): extracted the hardcoded "/var/db/com.fleetdm.edr/application-control.json" URI into a `defaultStoragePath` static constant. The init's default argument now references the constant so the URI is named in one place + future Sonar S1075 hits on this surface land on the constant rather than the function signature.

test/e2e/fixtures/auth.ts (S7763): switched `export { uninstallVirtualAuthenticator }` to `export { uninstallVirtualAuthenticator } from "./webauthn"` (`export...from` style; dropped the dangling import).

test/e2e/tests/qa/host-list-and-process-tree.spec.ts (S2871 ×2) + test/e2e/tests/qa/agent-events-flow.spec.ts (S2871 ×2): replaced bare `.sort()` with `.sort((a, b) => a.localeCompare(b))` so the alphabetical comparison is locale-stable rather than relying on JavaScript's default UTF-16 code-unit ordering (which doesn't behave alphabetically for accented chars).

Accepted via Sonar status change (intentional, documented)

agent/metrics/metrics.go:31 godre:S8196 (QueueDepthSource interface naming) - matches the project's `<Subject>Source` convention for read-only callback contracts (precedent: server/metrics's GaugeSource). Renaming to `DepthReader` (the rule's preferred shape) would create a one-off inconsistency reviewers have to re-resolve every time they touch the metrics surface.

test/scale/runner.go:689 go:S4830 + go:S5527 (TLS server-cert + hostname verification disabled) - the `InsecureSkipVerify: true` branch is the documented opt-in for `task uat:scale --insecure-tls=true` against dev:server's mkcert cert. The default is `false`; production scale runs against a properly-certificated server never take this branch. The `//nolint:gosec` comment already documents this; Sonar's NOSONAR pragma wasn't recognised so explicit status change is the path that sticks.

test/e2e/fixtures/auth.ts:14 typescript:S2068 (hardcoded password) - BG_PASSWORD is a literal in a Playwright fixture, shared across L4 specs so test failures don't have to chase the password value across files. It's never used in production code; the file is build-tagged out of the production bundle. Pinning the literal to an env var would only relocate the data without changing its sensitivity.

Gates: go test ./agent/... ./server/... green; task lint:go clean; spectrace 266/266 strict; bash -n scripts/uat/lib/common.sh clean. Sonar global open-issue count drops from 21 → 0 after this PR's analysis lands (17 closed by code fix + 4 closed by accept).