### PR TITLE
spectrace v2

### DIFF
--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -334,17 +334,26 @@ func test_spec_extension_xpc_server_peer_validation_signing_required() throws { 
 `### Requirement:` whose body contains SHALL or MUST, then walks the codebase for matching markers. By default the
 check exits 0 unless a reference points to a non-existent canonical ID (which catches drift after a spec rename); with
 `--strict` it also fails when a SHALL / MUST scenario has zero references. The CI workflow at
-`.github/workflows/spectrace.yml` ships in advisory mode (no `--strict`); flip the gate when the marker backlog is
-closed. `tools/spectrace list-ids [--normative-only]` prints every canonical scenario ID so contributors can copy a
-marker without typing the slug.
+`.github/workflows/spectrace.yml` runs `check --strict` on every PR.
 
-`tools/spectrace report --format=md` (a Markdown coverage matrix with one row per scenario and one column per layer)
-is deferred to a follow-up: it is a presentation layer over the same data `check` already collects, and the M13 budget
-was the linter itself. The same applies to per-layer breakdown in the gap output.
+`tools/spectrace list-ids [--normative-only]` prints every canonical scenario ID so contributors can copy a marker
+without typing the slug.
 
-Rollout is phased so the gate never goes red on day one: advisory first (M13 v1 today), then "new code" gate (every
-scenario added or modified in a PR must be covered), then full gate via `--strict`. The same "new code" framing that
-SonarCloud uses.
+`tools/spectrace report --format=md [--output FILE]` (M13 v2, issue #233) renders the Markdown coverage matrix: one
+row per scenario, one column per layer (L0..L6), each cell linking to every marker that covers the scenario at that
+layer. An `Other` column appears when at least one row has a non-test enforcement marker (workflow YAML, packaging
+shell). `report` never gates; it is for humans and PR comments.
+
+`check --by-layer` annotates the gap report with the layer coverage profile per scenario; `check --new-code` scopes
+the gate to scenarios added or modified in the current PR (diff against the merge base, default `origin/main`),
+matching SonarCloud's "new code" framing.
+
+Rollout sequence (delivered):
+
+- M13 v1: advisory `check`, then `check --strict` once the marker backlog closed on main.
+- M13 v2: `report --format=md`, `check --by-layer`, `check --new-code`. `--new-code` is the recommended fallback if
+  a future spec restructure briefly inflates the uncovered set: it preserves the gate signal on the delta without
+  blocking the broader work.
 
 ## Minimum requirements per PR
 

--- a/server/detection/internal/tests/integration_test.go
+++ b/server/detection/internal/tests/integration_test.go
@@ -2062,11 +2062,21 @@ func TestGraph_SnapshotHeartbeatNoOps(t *testing.T) {
 				readTime = forkTime + 100 // = exit timestamp; inclusive read
 			}
 
-			// Wait for the initial events to land.
+			// Wait for ALL initial events to drain through the processor before snapshotting the row. The earlier shape
+			// only waited for GetProcessDetail to return non-nil, which fires as soon as the exec row exists; if the
+			// exit event hasn't been processed yet, `before` ends up with ExitTimeNs=nil and the post-heartbeat snapshot
+			// (taken after the processor catches up) shows ExitTimeNs set, which then trips the "heartbeat MUST NOT
+			// change exit_time_ns" assertion against the heartbeat for an exit the heartbeat had nothing to do with.
+			// Gating on CountUnprocessed==0 ensures both the exec and the exit (when there is one) are durably reflected
+			// in the read model before the snapshot. Pre-existing race surfaced on PR #281.
 			require.Eventually(t, func() bool {
+				n, err := d.Store().CountUnprocessed(ctx)
+				if err != nil || n != 0 {
+					return false
+				}
 				p, err := d.Service().GetProcessDetail(ctx, hostID, 3030, readTime)
 				return err == nil && p != nil
-			}, 5*time.Second, 50*time.Millisecond)
+			}, 5*time.Second, 25*time.Millisecond, "initial events must drain and the row must be visible before snapshot")
 
 			// Snapshot the row's pre-heartbeat state.
 			before, err := d.Service().GetProcessDetail(ctx, hostID, 3030, readTime)

--- a/tools/spectrace/README.md
+++ b/tools/spectrace/README.md
@@ -6,17 +6,50 @@ the codebase via the canonical-ID marker contract documented in `docs/testing-st
 ## Subcommands
 
 ```text
-spectrace check      [--specs-dir DIR] [--root DIR] [--strict]
-spectrace list-ids   [--specs-dir DIR] [--normative-only]
+spectrace check    [--specs-dir DIR] [--root DIR] [--strict] [--by-layer] [--new-code] [--base-ref REF]
+spectrace list-ids [--specs-dir DIR] [--normative-only]
+spectrace report   [--specs-dir DIR] [--root DIR] [--format md] [--output FILE] [--normative-only]
 ```
 
 - `check` walks every `#### Scenario:` under a `### Requirement:` whose body contains the RFC 2119 keywords SHALL or
   MUST, computes the canonical ID, and scans `*.go`, `*.ts`, `*.tsx`, `*.swift`, `*.yml`, `*.yaml`, and `*.sh` for
   matching markers. Prints the coverage delta to stdout and the gap list to stderr. Exit code is 0 unless an invalid
-  reference is present, or `--strict` is set and at least one normative scenario is uncovered.
+  reference is present, or `--strict` is set and at least one normative scenario in the gated set is uncovered.
+  - `--by-layer` annotates the gap report with the layer coverage profile (L0..L6, Other) for each scenario so a
+    contributor reading the list can see "covered at L1 but missing L4." For the full per-cell detail with file:line
+    links, use `spectrace report` instead.
+  - `--new-code` restricts the gate to scenarios added or modified in the current branch relative to `--base-ref`
+    (default `origin/main`). The diff is taken against the merge base, mirroring SonarCloud's "new code on this PR"
+    framing: an existing legacy gap doesn't block a PR that doesn't touch it, but a new gap added by the PR does.
+    Modifying the SHALL/MUST text in a requirement body promotes every scenario under that requirement into the
+    new-code set, so tightening a requirement forces its covering tests to be re-considered.
 
 - `list-ids` prints the canonical scenario IDs, one per line, so contributors can copy a marker without typing the slug.
   `--normative-only` restricts the output to SHALL / MUST scenarios (the gateable set).
+
+- `report` renders the Markdown coverage matrix: one row per scenario, one column per layer (L0..L6, plus an `Other`
+  column for non-test enforcement markers such as workflow YAML or packaging shell scripts, rendered only when needed).
+  Each cell is a comma-separated list of `[basename:line](path#Lline)` Markdown links pointing at every marker that
+  covers the scenario at that layer. `--output FILE` writes the matrix to a file instead of stdout. The subcommand
+  never gates; CI can grep the rendered matrix for empty cells if a presentation-layer gate is wanted later.
+
+### Layer classifier
+
+The layer assigned to a marker is derived from its repo-relative file path by `tools/spectrace/layer.go`:
+
+| Path prefix | Layer |
+|---|---|
+| `test/efficacy/...` | L6 (Detection efficacy) |
+| `test/e2e/tests/...` | L4 (Browser E2E) |
+| `test/integration/agentserver/...` | L3 (Headless agent + server) |
+| `test/integration/...` | L2 (Cross-context integration) |
+| `server/<context>/internal/tests/...` | L1 (Per-context integration) |
+| `**/*_test.go`, `*.test.ts(x)`, `**/Tests/*.swift` | L0 (Unit) |
+| Everything else (workflow YAML, packaging shell) | Other |
+
+L5 (System / VM) is intentionally not auto-detected: there is no path prefix that uniquely identifies an L5 test in
+this repo (the VM driver lives under `scripts/uat/` and runs scenarios out of `test/efficacy/corpus/.../attack.sh`). If
+a future L5 harness lands with its own path prefix, add the case to `ClassifyLayer` in `layer.go`.
 
 ## Phased rollout
 
@@ -60,16 +93,6 @@ segments of lowercase alphanumerics + dashes). Markdown files are intentionally 
 work syntactically: `docs/testing-strategy.md` carries illustrative marker examples that would inflate the coverage
 count if scanned. Add `.md` to the ext gate alongside a `docs/testing-strategy.md` skip-rule if that boundary ever
 needs to move.
-
-## What this tool does NOT do (v1)
-
-- **`report --format=md` coverage matrix.** Mentioned in `docs/testing-strategy.md` as a future shape; deferred to a
-  follow-up so the M13 budget stays on the linter. The same data the `check` command collects already feeds the gate.
-- **Per-layer columns** in the gap list (L0 vs L1 vs L4 etc). Today the marker location is reported as a file path;
-  classifying by layer would require either path heuristics or per-marker metadata. Not worth the complexity until the
-  backlog is small enough that a person reads the list.
-- **New-code gate semantics** (fail only on scenarios touched in the current PR). The `--strict` flag is the full-gate
-  toggle; a follow-up can add a `--new-code` flag once main has a non-trivial number of markers landed.
 
 ## Exclusion
 

--- a/tools/spectrace/README.md
+++ b/tools/spectrace/README.md
@@ -18,11 +18,16 @@ spectrace report   [--specs-dir DIR] [--root DIR] [--format md] [--output FILE] 
   - `--by-layer` annotates the gap report with the layer coverage profile (L0..L6, Other) for each scenario so a
     contributor reading the list can see "covered at L1 but missing L4." For the full per-cell detail with file:line
     links, use `spectrace report` instead.
-  - `--new-code` restricts the gate to scenarios added or modified in the current branch relative to `--base-ref`
-    (default `origin/main`). The diff is taken against the merge base, mirroring SonarCloud's "new code on this PR"
-    framing: an existing legacy gap doesn't block a PR that doesn't touch it, but a new gap added by the PR does.
-    Modifying the SHALL/MUST text in a requirement body promotes every scenario under that requirement into the
-    new-code set, so tightening a requirement forces its covering tests to be re-considered.
+  - `--new-code` restricts the gate to scenarios whose `spec.md` lines (heading or enclosing requirement body) changed
+    in the current branch relative to `--base-ref` (default `origin/main`). The diff is taken against the merge base,
+    mirroring SonarCloud's "new code on this PR" framing: an existing legacy gap doesn't block a PR that doesn't touch
+    it, but a new gap added by the PR does. Modifying the SHALL/MUST text in a requirement body promotes every
+    scenario under that requirement into the new-code set, so tightening a requirement forces its covering tests to be
+    re-considered. Scope is intentionally **spec-diff only**: a PR that deletes a marker in code without touching the
+    spec does NOT cause `--strict --new-code` to fire on the now-uncovered scenario. Use plain `--strict` to gate on
+    that shape; the rationale for the narrower scope is that a marker delete is usually intentional (the test moved or
+    the scenario merged) and a contributor renaming code paths shouldn't be forced to re-mark every scenario the file
+    touched.
 
 - `list-ids` prints the canonical scenario IDs, one per line, so contributors can copy a marker without typing the slug.
   `--normative-only` restricts the output to SHALL / MUST scenarios (the gateable set).

--- a/tools/spectrace/layer.go
+++ b/tools/spectrace/layer.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// Layer is the test-pyramid rung defined in docs/testing-strategy.md. The integer values are stable: report column ordering,
+// the gap output, and the --by-layer flag all assume L0..L6 ordering. LayerOther is sentinel -1 for markers on enforcement
+// surfaces that are not themselves a test layer (workflow YAML, packaging shell scripts, etc.); the report renders an
+// `Other` column for these only when at least one scenario has such a marker so the standard matrix stays compact.
+//
+// L5 (System / VM) is intentionally not auto-detected: there is no path prefix that uniquely identifies an L5 test in this
+// repo (the VM driver lives under `scripts/uat/` and runs scenarios out of `test/efficacy/corpus/.../attack.sh`). Adding
+// an L5 marker today requires a Go test or similar surface inside `test/integration/` that explicitly drives the VM. If a
+// future L5 harness lands with its own path prefix, add the case to ClassifyLayer.
+type Layer int
+
+const (
+	LayerOther         Layer = -1
+	LayerUnit          Layer = 0
+	LayerPerContext    Layer = 1
+	LayerCrossContext  Layer = 2
+	LayerHeadlessAgent Layer = 3
+	LayerBrowserE2E    Layer = 4
+	LayerSystemVM      Layer = 5
+	LayerEfficacy      Layer = 6
+)
+
+// allTestLayers is the ordered set of L0..L6 columns the report renders by default. LayerOther is excluded; the report
+// renderer adds it on demand.
+var allTestLayers = [...]Layer{
+	LayerUnit, LayerPerContext, LayerCrossContext, LayerHeadlessAgent,
+	LayerBrowserE2E, LayerSystemVM, LayerEfficacy,
+}
+
+// Label is the short header used in report columns and the gap output (L0..L6 / Other).
+func (l Layer) Label() string {
+	switch l {
+	case LayerUnit:
+		return "L0"
+	case LayerPerContext:
+		return "L1"
+	case LayerCrossContext:
+		return "L2"
+	case LayerHeadlessAgent:
+		return "L3"
+	case LayerBrowserE2E:
+		return "L4"
+	case LayerSystemVM:
+		return "L5"
+	case LayerEfficacy:
+		return "L6"
+	case LayerOther:
+		return "Other"
+	default:
+		return "Other"
+	}
+}
+
+// ClassifyLayer maps a forward-slash repo-relative path to a Layer per the heuristics in issue #233 + docs/testing-strategy.md.
+// The check order is deepest-prefix-first because `test/integration/agentserver/` is a sub-prefix of `test/integration/` and
+// would otherwise classify as L2. Inputs are normalised to forward slashes; callers that pass an OS-native path do not need
+// to convert.
+func ClassifyLayer(path string) Layer {
+	p := filepath.ToSlash(path)
+	switch {
+	case strings.HasPrefix(p, "test/efficacy/"):
+		return LayerEfficacy
+	case strings.HasPrefix(p, "test/e2e/tests/"):
+		return LayerBrowserE2E
+	case strings.HasPrefix(p, "test/integration/agentserver/"):
+		return LayerHeadlessAgent
+	case strings.HasPrefix(p, "test/integration/"):
+		return LayerCrossContext
+	case isPerContextTestPath(p):
+		return LayerPerContext
+	case isUnitTestPath(p):
+		return LayerUnit
+	default:
+		return LayerOther
+	}
+}
+
+// isPerContextTestPath matches `server/<context>/internal/tests/...` (the L1 home documented in docs/testing-strategy.md).
+// Per-context tests at any deeper path under `internal/tests/` (e.g. `server/identity/internal/tests/journeys/foo_test.go`)
+// also count as L1; the prefix check has no depth cap.
+func isPerContextTestPath(p string) bool {
+	if !strings.HasPrefix(p, "server/") {
+		return false
+	}
+	parts := strings.Split(p, "/")
+	// server / <context> / internal / tests / ...
+	return len(parts) >= 5 && parts[2] == "internal" && parts[3] == "tests"
+}
+
+// isUnitTestPath catches anything that looks like a unit test: Go `_test.go`, vitest `.test.ts(x)`, and Swift sources living
+// under a `Tests/` directory (the SwiftPM convention used in extension/edr/Tests/). The Swift case is a containment check
+// rather than a prefix because the package root is `extension/edr/Tests/...` but a future repo layout could place tests
+// elsewhere. Markers in non-test Swift sources fall through to LayerOther.
+func isUnitTestPath(p string) bool {
+	switch {
+	case strings.HasSuffix(p, "_test.go"):
+		return true
+	case strings.HasSuffix(p, ".test.ts"), strings.HasSuffix(p, ".test.tsx"):
+		return true
+	case strings.HasSuffix(p, ".swift") && strings.Contains(p, "/Tests/"):
+		return true
+	default:
+		return false
+	}
+}

--- a/tools/spectrace/layer_test.go
+++ b/tools/spectrace/layer_test.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestClassifyLayer pins the path-prefix rules in issue #233. Each case names the layer it exercises so a future reader
+// debugging an "unexpected layer" finding goes straight to the row, not the function. The deepest-prefix-first ordering
+// inside ClassifyLayer is what makes `test/integration/agentserver/...` resolve to L3 rather than L2; the two rows that
+// share that prefix are kept adjacent so a reordering bug is immediately visible.
+func TestClassifyLayer(t *testing.T) {
+	cases := []struct {
+		name string
+		path string
+		want Layer
+	}{
+		{"L0 go unit test under package root", "agent/queue/queue_test.go", LayerUnit},
+		{"L0 go unit test under internal package", "internal/observability/observability_test.go", LayerUnit},
+		{"L0 vitest .test.ts", "ui/src/auth.test.ts", LayerUnit},
+		{"L0 vitest .test.tsx", "ui/src/components/Login.test.tsx", LayerUnit},
+		{"L0 swift XCTest under SwiftPM Tests root", "extension/edr/Tests/EDRExtensionLogicTests/DNSParserTests.swift", LayerUnit},
+
+		{"L1 per-context test (response context)", "server/response/internal/tests/handler_test.go", LayerPerContext},
+		{"L1 per-context test nested directory", "server/identity/internal/tests/journeys/login_test.go", LayerPerContext},
+		{"server unit test is L0, not L1 (no internal/tests prefix)", "server/metrics/metrics_test.go", LayerUnit},
+
+		{"L2 cross-context test", "test/integration/full_path_test.go", LayerCrossContext},
+		{"L2 cross-context test deeper", "test/integration/authz_journey_test.go", LayerCrossContext},
+
+		{"L3 headless agent integration", "test/integration/agentserver/agentserver_test.go", LayerHeadlessAgent},
+
+		{"L4 playwright auth spec", "test/e2e/tests/auth/oidc-login.spec.ts", LayerBrowserE2E},
+		{"L4 playwright qa spec", "test/e2e/tests/qa/host-list-and-process-tree.spec.ts", LayerBrowserE2E},
+
+		{"L6 efficacy harness", "test/efficacy/efficacy_test.go", LayerEfficacy},
+		{"L6 efficacy corpus yaml", "test/efficacy/corpus/T1059/scenario.yaml", LayerEfficacy},
+
+		{"Other: release-packaging workflow yaml", ".github/workflows/release.yml", LayerOther},
+		{"Other: release-packaging shell script", "packaging/pkg/build.sh", LayerOther},
+		{"Other: production Go source (no _test.go suffix)", "agent/uploader/uploader.go", LayerOther},
+		{"Other: production Swift source (no /Tests/ in path)", "extension/edr/main.swift", LayerOther},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, ClassifyLayer(tc.path), "ClassifyLayer(%q)", tc.path)
+		})
+	}
+}
+
+// TestLayerLabel pins the column-header strings the report renderer uses. The Label() output is part of the report contract;
+// if a future PR renames any of these strings, the Markdown matrix shape changes and downstream tooling (PR summaries, dash-
+// boards that grep `L0` etc.) breaks. Treat any change here as a contract change, not an implementation detail.
+func TestLayerLabel(t *testing.T) {
+	cases := []struct {
+		l    Layer
+		want string
+	}{
+		{LayerUnit, "L0"},
+		{LayerPerContext, "L1"},
+		{LayerCrossContext, "L2"},
+		{LayerHeadlessAgent, "L3"},
+		{LayerBrowserE2E, "L4"},
+		{LayerSystemVM, "L5"},
+		{LayerEfficacy, "L6"},
+		{LayerOther, "Other"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.want, func(t *testing.T) {
+			assert.Equal(t, tc.want, tc.l.Label())
+		})
+	}
+}

--- a/tools/spectrace/main.go
+++ b/tools/spectrace/main.go
@@ -102,6 +102,13 @@ func runCheck(args []string) int {
 		return 2
 	}
 
+	// Promote --specs-dir / --root to their repo-root-relative form so spectrace works whether invoked from the repo
+	// top-level (CI shape) or a nested package (Copilot's PR #281 concern). Defaults bind to the repo root unconditionally
+	// because their literal cwd-relative meaning is rarely the intent; explicit values keep cwd-first semantics.
+	setFlags := userSetFlagNames(fs)
+	*specsDir = resolvePathFlag(*specsDir, setFlags["specs-dir"])
+	*rootDir = resolvePathFlag(*rootDir, setFlags["root"])
+
 	scenarios, markers, exitCode := loadScenariosAndMarkers(*specsDir, *rootDir)
 	if exitCode != 0 {
 		return exitCode
@@ -275,6 +282,7 @@ func runListIDs(args []string) int {
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
+	*specsDir = resolvePathFlag(*specsDir, userSetFlagNames(fs)["specs-dir"])
 	scenarios, err := ParseAllSpecs(*specsDir)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "spectrace: parse specs:", err)

--- a/tools/spectrace/main.go
+++ b/tools/spectrace/main.go
@@ -2,22 +2,26 @@
 // SHALL / MUST `### Requirement:` in openspec/specs/<dir>/spec.md to a test marker somewhere in the codebase. The marker
 // syntax and the canonical-ID slug rule are documented in docs/testing-strategy.md.
 //
-// Two subcommands ship in v1:
+// Three subcommands ship:
 //
 //	tools/spectrace check         walks specs + sources, prints a coverage gap report, exits 1 on INVALID references and
-//	                              (with --strict) on uncovered SHALL / MUST scenarios.
+//	                              (with --strict) on uncovered SHALL / MUST scenarios. --new-code scopes the gate to
+//	                              scenarios added or modified in the current PR (via git diff against the merge base).
+//	                              --by-layer expands the gap output with the per-layer coverage profile so contributors
+//	                              can see which test rung is missing.
 //	tools/spectrace list-ids      prints every canonical scenario ID, one per line. Useful when authoring a test marker
 //	                              without typing the slug by hand.
-//
-// The `report --format=md` coverage matrix mentioned in docs/testing-strategy.md is intentionally deferred to a follow-up:
-// it's a presentation layer over the same data the check command already collects, and the M13 budget is the linter.
+//	tools/spectrace report        renders a Markdown coverage matrix (one row per scenario, one column per layer L0..L6
+//	                              and an optional Other column for non-test enforcement markers) to stdout or --output.
+//	                              No gating; the matrix is for humans + PR comments.
 //
 // Phased rollout matches the plan's "never goes red on day one" guidance: the CI workflow this binary feeds is advisory by
-// default (exit code is 0 when there are uncovered SHALL / MUST scenarios but no invalid references), and the --strict flag
-// is the future "full gate" toggle.
+// default (exit code is 0 when there are uncovered SHALL / MUST scenarios but no invalid references), --strict is the
+// "full gate" toggle, and --new-code is the SonarCloud-style "fail only on the delta this PR introduced" intermediate.
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"os"
@@ -42,6 +46,8 @@ func main() {
 		os.Exit(runCheck(rest))
 	case "list-ids":
 		os.Exit(runListIDs(rest))
+	case "report":
+		os.Exit(runReport(rest))
 	case "-h", "--help", "help":
 		usage()
 		os.Exit(0)
@@ -56,13 +62,19 @@ func usage() {
 	fmt.Fprint(os.Stderr, `spectrace - openspec spec-to-test traceability linter
 
 Usage:
-  spectrace check      [--specs-dir DIR] [--root DIR] [--strict]
-  spectrace list-ids   [--specs-dir DIR] [--normative-only]
+  spectrace check    [--specs-dir DIR] [--root DIR] [--strict] [--by-layer] [--new-code] [--base-ref REF]
+  spectrace list-ids [--specs-dir DIR] [--normative-only]
+  spectrace report   [--specs-dir DIR] [--root DIR] [--format md] [--output FILE] [--normative-only]
 
 Subcommands:
-  check       Walk specs and codebase; report uncovered scenarios and invalid references.
-              Exit code 0 unless --strict is set or invalid references are present.
-  list-ids    Print canonical scenario IDs, one per line.
+  check     Walk specs and codebase; report uncovered scenarios and invalid references.
+            Exit code 0 unless --strict is set or invalid references are present.
+            --by-layer  Annotate the gap report with per-layer coverage (L0..L6).
+            --new-code  Gate only on scenarios added or modified in the current PR (diff against --base-ref).
+            --base-ref  Git revision the merge base is computed against (default: origin/main).
+  list-ids  Print canonical scenario IDs, one per line.
+  report    Render the Markdown coverage matrix (one row per scenario, one column per layer).
+            Exit code 0 on a clean render; the subcommand never gates.
 
 See docs/testing-strategy.md for the marker syntax and rollout plan.
 `)
@@ -71,31 +83,32 @@ See docs/testing-strategy.md for the marker syntax and rollout plan.
 // runCheck loads every scenario from --specs-dir, every marker from --root, and reports the coverage diff. Exit codes:
 //
 //	0 = clean (or only advisory issues without --strict)
-//	1 = invalid references present, OR --strict and uncovered SHALL/MUST scenarios present
+//	1 = invalid references present, OR --strict and uncovered SHALL/MUST scenarios in the gated set
 //	2 = usage / IO error
+//
+// --new-code restricts the gated SHALL/MUST set to scenarios added or modified in the current branch relative to
+// --base-ref (default origin/main). The framing matches SonarCloud's "new code" gate: an unfixed legacy gap doesn't
+// block a PR that doesn't touch it, but a new gap added by the PR does. --by-layer expands the gap output with the
+// per-layer coverage profile per scenario so contributors can see which test rung is missing.
 func runCheck(args []string) int {
 	fs := flag.NewFlagSet("check", flag.ContinueOnError)
 	specsDir := fs.String("specs-dir", defaultSpecsDir, "root of the openspec/specs tree")
 	rootDir := fs.String("root", defaultRootDir, "root of the source tree to scan for markers")
 	strict := fs.Bool("strict", false, "exit non-zero if any SHALL/MUST scenario is uncovered")
+	byLayer := fs.Bool("by-layer", false, "annotate the gap report with per-layer coverage (L0..L6)")
+	newCode := fs.Bool("new-code", false, "gate only on scenarios added or modified in the current branch")
+	baseRef := fs.String("base-ref", defaultBaseRef, "git revision the merge base is computed against (for --new-code)")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
 
-	scenarios, err := ParseAllSpecs(*specsDir)
-	if err != nil {
-		fmt.Fprintln(os.Stderr, "spectrace: parse specs:", err)
-		return 2
+	scenarios, markers, exitCode := loadScenariosAndMarkers(*specsDir, *rootDir)
+	if exitCode != 0 {
+		return exitCode
 	}
-	canonical, dupErr := buildCanonicalSet(scenarios)
-	if dupErr != nil {
-		fmt.Fprintln(os.Stderr, "spectrace:", dupErr)
-		return 2
-	}
-	markers, err := ScanMarkers(*rootDir, canonical)
-	if err != nil {
-		fmt.Fprintln(os.Stderr, "spectrace: scan markers:", err)
-		return 2
+	canonical := make(map[string]struct{}, len(scenarios))
+	for _, s := range scenarios {
+		canonical[s.ID] = struct{}{}
 	}
 
 	covered := make(map[string][]Marker, len(markers))
@@ -110,16 +123,75 @@ func runCheck(args []string) int {
 
 	uncoveredNormative, uncoveredAdvisory := splitUncovered(scenarios, covered)
 
+	gatedNormative := uncoveredNormative
+	if *newCode {
+		newCodeIDs, err := computeNewCodeScenarioIDs(context.Background(), *specsDir, *baseRef)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "spectrace --new-code:", err)
+			return 2
+		}
+		gatedNormative = filterByIDSet(uncoveredNormative, newCodeIDs)
+		fmt.Printf("spectrace: --new-code scope: %d scenarios touched in branch (vs %s)\n",
+			len(newCodeIDs), *baseRef)
+	}
+
 	printReport(scenarios, uncoveredNormative, uncoveredAdvisory, invalid)
+	if *byLayer {
+		printByLayer(scenarios, covered)
+	}
 
 	switch {
 	case len(invalid) > 0:
 		return 1
-	case *strict && len(uncoveredNormative) > 0:
+	case *strict && len(gatedNormative) > 0:
 		return 1
 	default:
 		return 0
 	}
+}
+
+// filterByIDSet keeps only scenarios whose ID is in the set. Used by --new-code to scope the gate to scenarios touched
+// by the current branch.
+func filterByIDSet(in []Scenario, ids map[string]struct{}) []Scenario {
+	if len(ids) == 0 {
+		return nil
+	}
+	out := in[:0:0]
+	for _, s := range in {
+		if _, ok := ids[s.ID]; ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// printByLayer writes a per-scenario layer coverage map to stderr. Each line is `<id> [L0,L4]` listing the labels of the
+// layers that cover the scenario; empty brackets mean the scenario is uncovered. The output is intentionally compact so a
+// human skimming a 200-scenario report can scan it; for the full detail (with file:line links per cell), use
+// `spectrace report --format=md`.
+func printByLayer(scenarios []Scenario, covered map[string][]Marker) {
+	fmt.Fprintln(os.Stderr, "\nPer-layer coverage (--by-layer):")
+	for _, s := range scenarios {
+		fmt.Fprintf(os.Stderr, "  %s [%s]\n", s.ID, layerLabelsFor(covered[s.ID]))
+	}
+}
+
+// layerLabelsFor returns a comma-separated list of the unique layer labels that cover the scenario. Empty if no markers.
+func layerLabelsFor(markers []Marker) string {
+	seen := make(map[Layer]struct{}, len(markers))
+	for _, m := range markers {
+		seen[m.Layer] = struct{}{}
+	}
+	var labels []string
+	for _, l := range allTestLayers {
+		if _, ok := seen[l]; ok {
+			labels = append(labels, l.Label())
+		}
+	}
+	if _, ok := seen[LayerOther]; ok {
+		labels = append(labels, LayerOther.Label())
+	}
+	return strings.Join(labels, ",")
 }
 
 // buildCanonicalSet builds the lookup map used to validate marker references AND fails fast if two scenarios slug to the

--- a/tools/spectrace/marker.go
+++ b/tools/spectrace/marker.go
@@ -12,11 +12,14 @@ import (
 
 // Marker is one reference to a spec ID found in the codebase. SourcePath is normalised to a forward-slash repo-relative
 // path (e.g. `test/scale/scale_test.go`) so report output is the same whether the caller invoked `spectrace check` with
-// `--root=.` or an absolute path.
+// `--root=.` or an absolute path. Layer is the test-pyramid rung the marker belongs to (see layer.go); it's populated by
+// ClassifyLayer at scan time so downstream consumers (the coverage matrix, the --by-layer gap output, the --new-code
+// filter) do not re-derive it.
 type Marker struct {
 	ID         string
 	SourcePath string
 	SourceLine int
+	Layer      Layer
 }
 
 // markerRE captures candidate IDs after the literal `spec:` prefix. The capture allows uppercase, underscores, and
@@ -145,16 +148,17 @@ func scanFile(r io.Reader, path string, isSwift bool, canonicalIDs map[string]st
 	var out []Marker
 	scanner := bufio.NewScanner(r)
 	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	layer := ClassifyLayer(path)
 	lineNo := 0
 	for scanner.Scan() {
 		lineNo++
 		line := scanner.Text()
 		for _, m := range markerRE.FindAllStringSubmatch(line, -1) {
-			out = append(out, Marker{ID: m[1], SourcePath: path, SourceLine: lineNo})
+			out = append(out, Marker{ID: m[1], SourcePath: path, SourceLine: lineNo, Layer: layer})
 		}
 		if isSwift {
 			for _, m := range swiftMarkerRE.FindAllStringSubmatch(line, -1) {
-				out = append(out, resolveSwiftMarker(m[1], path, lineNo, swiftIndex))
+				out = append(out, resolveSwiftMarker(m[1], path, lineNo, layer, swiftIndex))
 			}
 		}
 		_ = canonicalIDs // unused; reserved for future per-line validation hooks
@@ -170,15 +174,15 @@ func scanFile(r io.Reader, path string, isSwift bool, canonicalIDs map[string]st
 //	                                      is the failure shape when two canonical IDs share a Swift form (e.g. `foo-bar`
 //	                                      vs `foo/bar`); a non-deterministic "first match wins" would attribute coverage
 //	                                      to the wrong scenario across runs.
-func resolveSwiftMarker(body, path string, lineNo int, swiftIndex map[string][]string) Marker {
+func resolveSwiftMarker(body, path string, lineNo int, layer Layer, swiftIndex map[string][]string) Marker {
 	matches := swiftIndex[body]
 	switch len(matches) {
 	case 1:
-		return Marker{ID: matches[0], SourcePath: path, SourceLine: lineNo}
+		return Marker{ID: matches[0], SourcePath: path, SourceLine: lineNo, Layer: layer}
 	case 0:
-		return Marker{ID: "swift:" + body, SourcePath: path, SourceLine: lineNo}
+		return Marker{ID: "swift:" + body, SourcePath: path, SourceLine: lineNo, Layer: layer}
 	default:
-		return Marker{ID: "swift-ambiguous:" + body, SourcePath: path, SourceLine: lineNo}
+		return Marker{ID: "swift-ambiguous:" + body, SourcePath: path, SourceLine: lineNo, Layer: layer}
 	}
 }
 

--- a/tools/spectrace/newcode.go
+++ b/tools/spectrace/newcode.go
@@ -10,11 +10,18 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // defaultBaseRef is the merge-base parent the --new-code gate diffs against. `origin/main` mirrors how SonarCloud frames
 // "new code on this PR" against the target branch; for local runs without an origin remote, callers can pass --base-ref.
 const defaultBaseRef = "origin/main"
+
+// gitCommandTimeout caps every git subprocess this file spawns. CI typically completes git operations in well under a
+// second; the timeout exists so a misconfigured environment (credential prompt, hung network fetch, etc.) can't hang the
+// spectrace job indefinitely. Gemini called this out on PR #281; the cap is conservative so a legitimately slow `git diff`
+// on a very large spec.md still has plenty of headroom.
+const gitCommandTimeout = 30 * time.Second
 
 // scenarioRange records the line range a canonical scenario occupies in its spec.md, used to intersect against git-diff
 // hunks. The range is closed-closed in 1-based line numbers, matching git's `+a,b` hunk header convention. End is the line
@@ -37,11 +44,21 @@ func computeNewCodeScenarioIDs(ctx context.Context, specsDir, baseRef string) (m
 	if baseRef == "" {
 		baseRef = defaultBaseRef
 	}
-	mergeBase, err := gitMergeBase(ctx, baseRef)
+	if err := validateBaseRef(baseRef); err != nil {
+		return nil, err
+	}
+	ctx, cancel := context.WithTimeout(ctx, gitCommandTimeout)
+	defer cancel()
+
+	repoRoot, err := gitTopLevel(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("git rev-parse --show-toplevel: %w", err)
+	}
+	mergeBase, err := gitMergeBase(ctx, repoRoot, baseRef)
 	if err != nil {
 		return nil, fmt.Errorf("git merge-base HEAD %s: %w", baseRef, err)
 	}
-	changedFiles, err := gitChangedFiles(ctx, mergeBase, specsDir)
+	changedFiles, err := gitChangedFiles(ctx, repoRoot, mergeBase, specsDir)
 	if err != nil {
 		return nil, fmt.Errorf("git diff --name-only: %w", err)
 	}
@@ -50,11 +67,13 @@ func computeNewCodeScenarioIDs(ctx context.Context, specsDir, baseRef string) (m
 		if filepath.Base(file) != "spec.md" {
 			continue
 		}
-		hunks, err := gitDiffNewLineRanges(ctx, mergeBase, file)
+		hunks, err := gitDiffNewLineRanges(ctx, repoRoot, mergeBase, file)
 		if err != nil {
 			return nil, fmt.Errorf("git diff %s: %w", file, err)
 		}
-		ranges, err := parseSpecScenarioRanges(file)
+		// gitChangedFiles returns paths relative to the repo root; open from that root so spectrace works whether invoked
+		// from the repo top-level (CI shape) or a subdirectory (a contributor in their package).
+		ranges, err := parseSpecScenarioRanges(filepath.Join(repoRoot, file))
 		if err != nil {
 			return nil, fmt.Errorf("parse %s: %w", file, err)
 		}
@@ -65,6 +84,30 @@ func computeNewCodeScenarioIDs(ctx context.Context, specsDir, baseRef string) (m
 		}
 	}
 	return out, nil
+}
+
+// validateBaseRef rejects revisions that git would interpret as command-line options instead of a commit-ish reference.
+// `git merge-base HEAD --help` opens pager output and `--exec=...` style abuses become a remote-code-execution surface.
+// Refnames legitimately cannot start with `-` (git refuses them on creation), so this check has no false-positive
+// surface. Copilot flagged the option-injection risk on PR #281.
+func validateBaseRef(baseRef string) error {
+	if strings.HasPrefix(baseRef, "-") {
+		return fmt.Errorf("invalid --base-ref %q: revisions starting with '-' would be parsed as git options", baseRef)
+	}
+	return nil
+}
+
+// gitTopLevel resolves the working copy's root so subsequent git commands run with a stable Dir. Without this, running
+// spectrace from a subdirectory would pass `--specs-dir` relative to the subdirectory but `git diff -- <specsDir>` would
+// resolve <specsDir> relative to the subdirectory too, which usually works but breaks if --specs-dir is absolute or the
+// caller cd'd outside the worktree. Copilot called this out on PR #281.
+func gitTopLevel(ctx context.Context) (string, error) {
+	cmd := exec.CommandContext(ctx, "git", "rev-parse", "--show-toplevel") //nolint:gosec // args are literal
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("%w: %s", err, strings.TrimSpace(string(out)))
+	}
+	return strings.TrimSpace(string(out)), nil
 }
 
 // lineRange is a closed-closed range of new-side file lines (1-based).
@@ -83,24 +126,29 @@ func anyOverlap(start, end int, hunks []lineRange) bool {
 
 // gitMergeBase runs `git merge-base HEAD baseRef` and returns the resolved SHA. The merge-base is the right "branch point"
 // reference for a SonarCloud-style new-code diff: it excludes upstream changes that landed on baseRef after the branch
-// was cut, which would otherwise inflate the new-code set on a long-running branch.
-func gitMergeBase(ctx context.Context, baseRef string) (string, error) {
-	cmd := exec.CommandContext(ctx, "git", "merge-base", "HEAD", baseRef) //nolint:gosec // baseRef is a CLI flag the operator supplies
-	out, err := cmd.Output()
+// was cut, which would otherwise inflate the new-code set on a long-running branch. CombinedOutput captures stderr so a
+// failure (missing remote, shallow clone) carries the actionable git error message in the returned error instead of a
+// bare `exit status 1`; Gemini called this out on PR #281.
+func gitMergeBase(ctx context.Context, repoRoot, baseRef string) (string, error) {
+	cmd := exec.CommandContext(ctx, "git", "merge-base", "HEAD", baseRef) //nolint:gosec // baseRef passed validateBaseRef
+	cmd.Dir = repoRoot
+	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("%w: %s", err, strings.TrimSpace(string(out)))
 	}
 	return strings.TrimSpace(string(out)), nil
 }
 
 // gitChangedFiles returns the list of files changed between mergeBase and the working tree, filtered to those under
 // specsDir. We use `--diff-filter=ACMR` to drop deletions: a deleted scenario can't be uncovered because it's no longer
-// in the canonical set, so deletions don't contribute to the gate.
-func gitChangedFiles(ctx context.Context, mergeBase, specsDir string) ([]string, error) {
+// in the canonical set, so deletions don't contribute to the gate. cmd.Dir is the repo root so specsDir resolves
+// against the repo root regardless of where the caller invoked spectrace.
+func gitChangedFiles(ctx context.Context, repoRoot, mergeBase, specsDir string) ([]string, error) {
 	cmd := exec.CommandContext(ctx, "git", "diff", "--name-only", "--diff-filter=ACMR", mergeBase, "--", specsDir) //nolint:gosec // args bounded
-	out, err := cmd.Output()
+	cmd.Dir = repoRoot
+	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: %s", err, strings.TrimSpace(string(out)))
 	}
 	var files []string
 	for line := range strings.SplitSeq(strings.TrimSpace(string(out)), "\n") {
@@ -116,12 +164,13 @@ var hunkHeaderRE = regexp.MustCompile(`^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@`)
 
 // gitDiffNewLineRanges runs `git diff --unified=0 mergeBase -- file` and parses the @@ headers to return the changed
 // new-side line ranges. --unified=0 strips context so the ranges describe only added/modified lines, which is the precise
-// shape the gate needs.
-func gitDiffNewLineRanges(ctx context.Context, mergeBase, file string) ([]lineRange, error) {
+// shape the gate needs. cmd.Dir is the repo root so `file` resolves against the repo root regardless of cwd.
+func gitDiffNewLineRanges(ctx context.Context, repoRoot, mergeBase, file string) ([]lineRange, error) {
 	cmd := exec.CommandContext(ctx, "git", "diff", "--unified=0", mergeBase, "--", file) //nolint:gosec // args bounded
-	out, err := cmd.Output()
+	cmd.Dir = repoRoot
+	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: %s", err, strings.TrimSpace(string(out)))
 	}
 	return parseUnifiedDiffNewRanges(string(out)), nil
 }

--- a/tools/spectrace/newcode.go
+++ b/tools/spectrace/newcode.go
@@ -1,0 +1,225 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// defaultBaseRef is the merge-base parent the --new-code gate diffs against. `origin/main` mirrors how SonarCloud frames
+// "new code on this PR" against the target branch; for local runs without an origin remote, callers can pass --base-ref.
+const defaultBaseRef = "origin/main"
+
+// scenarioRange records the line range a canonical scenario occupies in its spec.md, used to intersect against git-diff
+// hunks. The range is closed-closed in 1-based line numbers, matching git's `+a,b` hunk header convention. End is the line
+// of the last body line before the next subheading or EOF; the scenario heading itself is at Start.
+type scenarioRange struct {
+	ID    string
+	Start int
+	End   int
+}
+
+// computeNewCodeScenarioIDs returns the set of canonical scenario IDs that were added or modified in the working branch
+// relative to baseRef. "Modified" means at least one new-side line of the scenario's range (heading or body) appears in a
+// diff hunk against the merge base of HEAD and baseRef. baseRef defaults to defaultBaseRef when empty.
+//
+// The returned map is empty when no spec.md file changed; that's an honest signal that --new-code has nothing to gate on
+// and the caller should pass the check. If the git plumbing fails (no merge base, no git, baseRef unknown), an error is
+// returned so the caller can decide whether to fail open or fail closed; runCheck fails closed (exit 2) because the
+// gate's correctness depends on having a merge base.
+func computeNewCodeScenarioIDs(ctx context.Context, specsDir, baseRef string) (map[string]struct{}, error) {
+	if baseRef == "" {
+		baseRef = defaultBaseRef
+	}
+	mergeBase, err := gitMergeBase(ctx, baseRef)
+	if err != nil {
+		return nil, fmt.Errorf("git merge-base HEAD %s: %w", baseRef, err)
+	}
+	changedFiles, err := gitChangedFiles(ctx, mergeBase, specsDir)
+	if err != nil {
+		return nil, fmt.Errorf("git diff --name-only: %w", err)
+	}
+	out := make(map[string]struct{})
+	for _, file := range changedFiles {
+		if filepath.Base(file) != "spec.md" {
+			continue
+		}
+		hunks, err := gitDiffNewLineRanges(ctx, mergeBase, file)
+		if err != nil {
+			return nil, fmt.Errorf("git diff %s: %w", file, err)
+		}
+		ranges, err := parseSpecScenarioRanges(file)
+		if err != nil {
+			return nil, fmt.Errorf("parse %s: %w", file, err)
+		}
+		for _, sr := range ranges {
+			if anyOverlap(sr.Start, sr.End, hunks) {
+				out[sr.ID] = struct{}{}
+			}
+		}
+	}
+	return out, nil
+}
+
+// lineRange is a closed-closed range of new-side file lines (1-based).
+type lineRange struct {
+	Start, End int
+}
+
+func anyOverlap(start, end int, hunks []lineRange) bool {
+	for _, h := range hunks {
+		if h.End >= start && h.Start <= end {
+			return true
+		}
+	}
+	return false
+}
+
+// gitMergeBase runs `git merge-base HEAD baseRef` and returns the resolved SHA. The merge-base is the right "branch point"
+// reference for a SonarCloud-style new-code diff: it excludes upstream changes that landed on baseRef after the branch
+// was cut, which would otherwise inflate the new-code set on a long-running branch.
+func gitMergeBase(ctx context.Context, baseRef string) (string, error) {
+	cmd := exec.CommandContext(ctx, "git", "merge-base", "HEAD", baseRef) //nolint:gosec // baseRef is a CLI flag the operator supplies
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// gitChangedFiles returns the list of files changed between mergeBase and the working tree, filtered to those under
+// specsDir. We use `--diff-filter=ACMR` to drop deletions: a deleted scenario can't be uncovered because it's no longer
+// in the canonical set, so deletions don't contribute to the gate.
+func gitChangedFiles(ctx context.Context, mergeBase, specsDir string) ([]string, error) {
+	cmd := exec.CommandContext(ctx, "git", "diff", "--name-only", "--diff-filter=ACMR", mergeBase, "--", specsDir) //nolint:gosec // args bounded
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+	var files []string
+	for line := range strings.SplitSeq(strings.TrimSpace(string(out)), "\n") {
+		if line == "" {
+			continue
+		}
+		files = append(files, line)
+	}
+	return files, nil
+}
+
+var hunkHeaderRE = regexp.MustCompile(`^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@`)
+
+// gitDiffNewLineRanges runs `git diff --unified=0 mergeBase -- file` and parses the @@ headers to return the changed
+// new-side line ranges. --unified=0 strips context so the ranges describe only added/modified lines, which is the precise
+// shape the gate needs.
+func gitDiffNewLineRanges(ctx context.Context, mergeBase, file string) ([]lineRange, error) {
+	cmd := exec.CommandContext(ctx, "git", "diff", "--unified=0", mergeBase, "--", file) //nolint:gosec // args bounded
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+	return parseUnifiedDiffNewRanges(string(out)), nil
+}
+
+// parseUnifiedDiffNewRanges extracts new-side line ranges from a unified diff. A hunk header
+// `@@ -<a>,<b> +<c>,<d> @@` yields the range [c, c+d-1]; missing `,d` means d=1. Hunks whose new-side count is 0 (pure
+// deletion) are skipped, as their c value names the line BEFORE the deletion and doesn't intersect any scenario range in
+// the new file.
+func parseUnifiedDiffNewRanges(diff string) []lineRange {
+	var out []lineRange
+	scanner := bufio.NewScanner(strings.NewReader(diff))
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		m := hunkHeaderRE.FindStringSubmatch(scanner.Text())
+		if m == nil {
+			continue
+		}
+		start, err := strconv.Atoi(m[1])
+		if err != nil {
+			continue
+		}
+		count := 1
+		if m[2] != "" {
+			count, err = strconv.Atoi(m[2])
+			if err != nil {
+				continue
+			}
+		}
+		if count == 0 {
+			continue
+		}
+		out = append(out, lineRange{Start: start, End: start + count - 1})
+	}
+	return out
+}
+
+// parseSpecScenarioRanges parses a spec.md and returns the line range each scenario occupies. The range starts at the
+// `#### Scenario:` heading line and ends at the line BEFORE the next subheading (or EOF). The implementation mirrors
+// parseSpec in spec.go but tracks Start/End instead of the Requirement/Title metadata that spec.go cares about; sharing
+// the same parser was rejected because the existing parser is in a hot path and growing it to emit ranges would
+// complicate the streaming flow for a feature only --new-code uses.
+//
+// One subtlety: the requirement-body lines BEFORE the first scenario heading need to attribute to "every scenario under
+// this requirement" so a SHALL/MUST edit upstream of any scenario heading promotes all the scenarios under that
+// requirement into the new-code set. We model this by extending each scenario's range BACKWARD to include the requirement
+// heading + body, which means a diff hunk anywhere from the requirement heading through the scenario body counts the
+// scenario as touched.
+func parseSpecScenarioRanges(path string) ([]scenarioRange, error) {
+	f, err := os.Open(path) //nolint:gosec // path comes from gitChangedFiles output
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	specDir := filepath.Base(filepath.Dir(path))
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+	var (
+		ranges          []scenarioRange
+		currentReqSlug  string
+		currentReqStart int  // line of the active `### Requirement:` heading
+		currentScenIdx  = -1 // index into ranges of the active scenario (so we can close it on the next subheading)
+		lineNo          int
+	)
+	closeScenario := func(line int) {
+		if currentScenIdx >= 0 {
+			ranges[currentScenIdx].End = line - 1
+			currentScenIdx = -1
+		}
+	}
+	for scanner.Scan() {
+		lineNo++
+		line := scanner.Text()
+		switch {
+		case strings.HasPrefix(line, "### Requirement:"):
+			closeScenario(lineNo)
+			title := strings.TrimSpace(strings.TrimPrefix(line, "### Requirement:"))
+			currentReqSlug = slugify(title)
+			currentReqStart = lineNo
+		case strings.HasPrefix(line, "#### Scenario:") && currentReqSlug != "":
+			closeScenario(lineNo)
+			title := strings.TrimSpace(strings.TrimPrefix(line, "#### Scenario:"))
+			ranges = append(ranges, scenarioRange{
+				ID:    specDir + "/" + currentReqSlug + "/" + slugify(title),
+				Start: currentReqStart, // extend backward to include requirement heading + body
+				End:   lineNo,          // tentative; updated when the next subheading or EOF is seen
+			})
+			currentScenIdx = len(ranges) - 1
+		case strings.HasPrefix(line, "### ") || strings.HasPrefix(line, "## "):
+			closeScenario(lineNo)
+			currentReqSlug = ""
+			currentReqStart = 0
+		case strings.HasPrefix(line, "#### "):
+			closeScenario(lineNo)
+		}
+	}
+	// Final close: any scenario open at EOF ends on the last line scanned.
+	closeScenario(lineNo + 1)
+	return ranges, scanner.Err()
+}

--- a/tools/spectrace/newcode_test.go
+++ b/tools/spectrace/newcode_test.go
@@ -130,6 +130,15 @@ The system MUST do Y.
 	assert.Equal(t, 17, got[2].Start, "Gamma starts at the Second req heading")
 }
 
+// TestComputeNewCodeScenarioIDs_RejectsDashBaseRef pins the early-exit when --base-ref would shell out as a git option.
+// The function must short-circuit before invoking git so an attacker controlling the flag can't force `git merge-base
+// HEAD --help` (which opens a pager and could hang CI) or `--exec=<command>`-style abuses.
+func TestComputeNewCodeScenarioIDs_RejectsDashBaseRef(t *testing.T) {
+	_, err := computeNewCodeScenarioIDs(context.Background(), "openspec/specs", "-help")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid --base-ref")
+}
+
 // TestComputeNewCodeScenarioIDs_E2E exercises the full git-diff path against a transient repo. We initialise a repo, commit
 // a baseline spec, then add one new requirement+scenario and modify a SHALL line under an existing requirement; the gate
 // must surface both the new scenario AND every scenario under the modified requirement (because a SHALL edit promotes the
@@ -213,6 +222,34 @@ func runGit(t *testing.T, dir string, args ...string) {
 	cmd.Dir = dir
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("git %s failed: %v\n%s", strings.Join(args, " "), err, out)
+	}
+}
+
+// TestValidateBaseRef pins the dash-prefix rejection added in response to Copilot's PR #281 review. The two legitimate-
+// looking refs (a branch name, a SHA) must pass; anything starting with `-` must be rejected because git would parse it
+// as an option flag. Git itself refuses to create refs starting with `-`, so this check has no false-positive surface.
+func TestValidateBaseRef(t *testing.T) {
+	cases := []struct {
+		name    string
+		baseRef string
+		wantErr bool
+	}{
+		{"origin/main passes", "origin/main", false},
+		{"branch name passes", "main", false},
+		{"sha passes", "abc1234567", false},
+		{"leading dash is rejected", "-help", true},
+		{"leading double-dash is rejected", "--all", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateBaseRef(tc.baseRef)
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "invalid --base-ref")
+			} else {
+				assert.NoError(t, err)
+			}
+		})
 	}
 }
 

--- a/tools/spectrace/newcode_test.go
+++ b/tools/spectrace/newcode_test.go
@@ -1,0 +1,233 @@
+package main
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestParseUnifiedDiffNewRanges pins the hunk-header parse. Each row exercises one shape the parser will see in the wild:
+// implicit count (just `+a`), explicit count (`+a,b`), pure-deletion (`+a,0` — skipped), and a multi-hunk diff.
+func TestParseUnifiedDiffNewRanges(t *testing.T) {
+	cases := []struct {
+		name string
+		diff string
+		want []lineRange
+	}{
+		{
+			name: "single hunk implicit count is treated as 1",
+			diff: "@@ -10 +12 @@\n+new line\n",
+			want: []lineRange{{Start: 12, End: 12}},
+		},
+		{
+			name: "single hunk explicit count",
+			diff: "@@ -10,2 +12,3 @@\n+a\n+b\n+c\n",
+			want: []lineRange{{Start: 12, End: 14}},
+		},
+		{
+			name: "pure deletion is skipped",
+			diff: "@@ -10,2 +12,0 @@\n-a\n-b\n",
+			want: nil,
+		},
+		{
+			name: "multiple hunks",
+			diff: "@@ -1,3 +1,2 @@\n line\n-old\n line\n@@ -10,0 +12,2 @@\n+new1\n+new2\n",
+			want: []lineRange{{Start: 1, End: 2}, {Start: 12, End: 13}},
+		},
+		{
+			name: "diff with no hunks returns nil",
+			diff: "diff --git a/x b/x\nindex abc..def 100644\n",
+			want: nil,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, parseUnifiedDiffNewRanges(tc.diff))
+		})
+	}
+}
+
+// TestAnyOverlap pins the inclusive-closed range intersection that computeNewCodeScenarioIDs uses to decide whether the scenario's
+// body overlaps any diff hunk. Adjacency-not-overlap is a separate case row because off-by-one bugs here would silently drop or
+// include scenarios at the boundary; the deepest-prefix ordering inside the renderer would not catch it.
+func TestAnyOverlap(t *testing.T) {
+	cases := []struct {
+		name               string
+		scenStart, scenEnd int
+		hunks              []lineRange
+		want               bool
+	}{
+		{"hunk inside scenario", 10, 20, []lineRange{{15, 16}}, true},
+		{"scenario inside hunk", 10, 20, []lineRange{{1, 100}}, true},
+		{"hunk touches scenario start", 10, 20, []lineRange{{1, 10}}, true},
+		{"hunk touches scenario end", 10, 20, []lineRange{{20, 30}}, true},
+		{"hunk before scenario, gap", 10, 20, []lineRange{{1, 9}}, false},
+		{"hunk after scenario, gap", 10, 20, []lineRange{{21, 30}}, false},
+		{"no hunks", 10, 20, nil, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, anyOverlap(tc.scenStart, tc.scenEnd, tc.hunks))
+		})
+	}
+}
+
+// TestParseSpecScenarioRanges covers the scenario-range parser against a synthetic spec.md. The scenarios' Start must point
+// to the parent requirement heading (so a SHALL edit upstream of the scenario heading promotes the scenario into the new-
+// code set), and End must extend to the line BEFORE the next subheading or EOF.
+func TestParseSpecScenarioRanges(t *testing.T) {
+	doc := `# Title
+
+## Requirements
+
+### Requirement: First req
+
+The system SHALL do X.
+
+#### Scenario: Alpha
+
+- WHEN x THEN y
+
+#### Scenario: Beta
+
+- WHEN y THEN z
+
+### Requirement: Second req
+
+The system MUST do Y.
+
+#### Scenario: Gamma
+
+- WHEN done
+`
+	dir := t.TempDir()
+	specDir := filepath.Join(dir, "openspec", "specs", "x")
+	require.NoError(t, os.MkdirAll(specDir, 0o750))
+	path := filepath.Join(specDir, "spec.md")
+	require.NoError(t, os.WriteFile(path, []byte(doc), 0o644))
+
+	got, err := parseSpecScenarioRanges(path)
+	require.NoError(t, err)
+	require.Len(t, got, 3)
+
+	// First scenario's Start should be the First-req heading line (line 5), End is the line before the Beta heading
+	// (Beta heading is at line 13, so Alpha ends at line 12).
+	assert.Equal(t, "x/first-req/alpha", got[0].ID)
+	assert.Equal(t, 5, got[0].Start, "scenario range should extend back to the requirement heading")
+	assert.Equal(t, 12, got[0].End, "scenario range should end on the line before the next subheading")
+
+	assert.Equal(t, "x/first-req/beta", got[1].ID)
+	assert.Equal(t, 5, got[1].Start, "Beta also lives under First req; range starts at the req heading")
+	assert.Equal(t, 16, got[1].End, "Beta ends on the line before the Second req heading")
+
+	assert.Equal(t, "x/second-req/gamma", got[2].ID)
+	assert.Equal(t, 17, got[2].Start, "Gamma starts at the Second req heading")
+}
+
+// TestComputeNewCodeScenarioIDs_E2E exercises the full git-diff path against a transient repo. We initialise a repo, commit
+// a baseline spec, then add one new requirement+scenario and modify a SHALL line under an existing requirement; the gate
+// must surface both the new scenario AND every scenario under the modified requirement (because a SHALL edit promotes the
+// entire requirement's scenario set).
+func TestComputeNewCodeScenarioIDs_E2E(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := t.TempDir()
+	runGit(t, dir, "init", "--quiet")
+	runGit(t, dir, "config", "user.email", "spectrace@example.test")
+	runGit(t, dir, "config", "user.name", "spectrace test")
+
+	specDir := filepath.Join(dir, "openspec", "specs", "alpha")
+	require.NoError(t, os.MkdirAll(specDir, 0o750))
+	specPath := filepath.Join(specDir, "spec.md")
+
+	baseline := strings.Join([]string{
+		"# Alpha",
+		"",
+		"## Requirements",
+		"",
+		"### Requirement: Existing req",
+		"",
+		"The system SHALL do legacy thing.",
+		"",
+		"#### Scenario: Legacy scenario",
+		"",
+		"- WHEN x THEN y",
+		"",
+	}, "\n")
+	require.NoError(t, os.WriteFile(specPath, []byte(baseline), 0o644))
+	runGit(t, dir, "add", ".")
+	runGit(t, dir, "commit", "--quiet", "-m", "baseline")
+	runGit(t, dir, "branch", "base") // baseRef will be `base`
+
+	// Now modify: tighten the SHALL wording (promotes Legacy scenario) AND add a new requirement+scenario at the end.
+	modified := strings.Join([]string{
+		"# Alpha",
+		"",
+		"## Requirements",
+		"",
+		"### Requirement: Existing req",
+		"",
+		"The system SHALL strictly do legacy thing.",
+		"",
+		"#### Scenario: Legacy scenario",
+		"",
+		"- WHEN x THEN y",
+		"",
+		"### Requirement: New req",
+		"",
+		"The system MUST do new thing.",
+		"",
+		"#### Scenario: New scenario",
+		"",
+		"- WHEN a THEN b",
+		"",
+	}, "\n")
+	require.NoError(t, os.WriteFile(specPath, []byte(modified), 0o644))
+	runGit(t, dir, "add", ".")
+	runGit(t, dir, "commit", "--quiet", "-m", "modify + add")
+
+	// Switch into the repo so the git plumbing reads the right working tree. t.Chdir restores the cwd at test end.
+	t.Chdir(dir)
+
+	got, err := computeNewCodeScenarioIDs(context.Background(), "openspec/specs", "base")
+	require.NoError(t, err)
+	assert.Contains(t, got, "alpha/existing-req/legacy-scenario",
+		"SHALL edit under Existing req must promote its scenario into new-code scope")
+	assert.Contains(t, got, "alpha/new-req/new-scenario",
+		"freshly-added scenario must be in new-code scope")
+	assert.Len(t, got, 2)
+}
+
+// runGit is a small helper that runs git in the test repo and fails fast with the combined output. Tests use this to keep
+// the e2e flow readable; production code uses exec.CommandContext directly.
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.CommandContext(t.Context(), "git", args...) //nolint:gosec // args are test-local literals
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %s failed: %v\n%s", strings.Join(args, " "), err, out)
+	}
+}
+
+// TestFilterByIDSet covers the small helper that scopes the gate's uncovered set to a subset by ID.
+func TestFilterByIDSet(t *testing.T) {
+	in := []Scenario{
+		{ID: "a/b/c"}, {ID: "d/e/f"}, {ID: "g/h/i"},
+	}
+	t.Run("empty set drops everything", func(t *testing.T) {
+		assert.Empty(t, filterByIDSet(in, map[string]struct{}{}))
+	})
+	t.Run("partial set keeps only matching ids", func(t *testing.T) {
+		got := filterByIDSet(in, map[string]struct{}{"a/b/c": {}, "g/h/i": {}})
+		require.Len(t, got, 2)
+		assert.Equal(t, "a/b/c", got[0].ID)
+		assert.Equal(t, "g/h/i", got[1].ID)
+	})
+}

--- a/tools/spectrace/paths.go
+++ b/tools/spectrace/paths.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"os"
+	"path/filepath"
+)
+
+// resolveRepoPath promotes a relative CLI path to its repo-root-relative form when cwd doesn't have it. The intent is
+// that `spectrace check` (with its `--specs-dir openspec/specs` and `--root .` defaults) keeps working when invoked
+// from a subdirectory like `tools/spectrace/` — Copilot raised the concern on PR #281. The resolution rules, in order:
+//
+//  1. Absolute path: returned verbatim. The user has been explicit, honour them.
+//  2. Path exists relative to cwd: returned verbatim. This preserves the historical behaviour for callers who pass
+//     `--specs-dir=../../openspec/specs` from inside a nested package; we don't second-guess paths that already work.
+//  3. We can find a repo top-level AND the path exists relative to it: return the joined `<repoRoot>/<path>`.
+//  4. Otherwise: return the original. The downstream ParseAllSpecs / ScanMarkers calls then produce a deterministic
+//     "no such file or directory" error pointed at the user's input, which is the right shape for diagnosing typos.
+//
+// The git subprocess inherits the same 30s cap as the --new-code path so a hung lookup can't stall the linter.
+func resolveRepoPath(p string) string {
+	if filepath.IsAbs(p) {
+		return p
+	}
+	if _, err := os.Stat(p); err == nil {
+		return p
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), gitCommandTimeout)
+	defer cancel()
+	root, err := gitTopLevel(ctx)
+	if err != nil {
+		return p
+	}
+	candidate := filepath.Join(root, p)
+	if _, err := os.Stat(candidate); err == nil {
+		return candidate
+	}
+	return p
+}
+
+// resolveDefaultRepoPath is the variant used for unset CLI flags. When a flag is at its default value, the user has not
+// asked for "literally cwd"; they've asked for "the natural location of this thing." For the `--root .` default that
+// means "the repo's source tree," not "this particular subdirectory I happen to be in." So we always try the repo top-
+// level first and only fall back to the cwd-relative form when no repo top-level can be found. This matters for the
+// `--root` default specifically (cwd-relative `.` exists, so resolveRepoPath would short-circuit at step 2 and leave
+// the scan scoped to a tools/ subdir, missing everything else).
+func resolveDefaultRepoPath(p string) string {
+	if filepath.IsAbs(p) {
+		return p
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), gitCommandTimeout)
+	defer cancel()
+	root, err := gitTopLevel(ctx)
+	if err == nil {
+		candidate := filepath.Join(root, p)
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate
+		}
+	}
+	return p
+}
+
+// resolvePathFlag picks the right resolver based on whether the operator supplied the flag explicitly. Explicit values stay
+// cwd-first (so `--specs-dir=./local-fixture` honours the literal `.`); default values bind to the repo root when one can be found.
+// The fs.Visit walk happens once per subcommand after Parse, so the caller passes the resulting set in here as isUserSet.
+func resolvePathFlag(value string, isUserSet bool) string {
+	if isUserSet {
+		return resolveRepoPath(value)
+	}
+	return resolveDefaultRepoPath(value)
+}
+
+// userSetFlagNames returns the names of every flag the operator supplied on the command line. flag.FlagSet.Visit walks only the set
+// flags, which is exactly the information resolvePathFlag needs to choose between cwd-relative and repo-root resolution.
+func userSetFlagNames(fs *flag.FlagSet) map[string]bool {
+	out := make(map[string]bool)
+	fs.Visit(func(f *flag.Flag) { out[f.Name] = true })
+	return out
+}

--- a/tools/spectrace/paths_test.go
+++ b/tools/spectrace/paths_test.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"flag"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestResolveRepoPath_AbsoluteIsVerbatim pins rule 1: an absolute path is returned unchanged. The function MUST NOT reach for git
+// at all in this case; we don't want a spectrace invocation against an absolute path to fail on a non-git directory or a hung
+// credential prompt that the underlying git rev-parse subprocess would otherwise trigger.
+func TestResolveRepoPath_AbsoluteIsVerbatim(t *testing.T) {
+	abs := t.TempDir()
+	assert.Equal(t, abs, resolveRepoPath(abs))
+}
+
+// TestResolveRepoPath_CwdRelativeShortCircuits pins rule 2: when the path already resolves relative to cwd, the
+// function returns it verbatim. Doing this avoids second-guessing callers who supply `--specs-dir=./local-fixture` from
+// inside a nested package; their literal `./` is what they want, even if the same name also exists at the repo root.
+func TestResolveRepoPath_CwdRelativeShortCircuits(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "exists"), 0o750))
+	t.Chdir(dir)
+	assert.Equal(t, "exists", resolveRepoPath("exists"))
+}
+
+// TestResolveRepoPath_PromotesToRepoRoot pins rule 3: when the path doesn't resolve cwd-relative but exists relative to
+// the repo top-level, return the joined path. We model this by initialising a fake git repo, dropping a file at the
+// root, then cd'ing into a subdirectory and asking the resolver to find the file by its relative name.
+func TestResolveRepoPath_PromotesToRepoRoot(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	root := setupGitRepo(t)
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "openspec", "specs"), 0o750))
+	sub := filepath.Join(root, "tools", "spectrace")
+	require.NoError(t, os.MkdirAll(sub, 0o750))
+	t.Chdir(sub)
+	got := resolveRepoPath("openspec/specs")
+	want := filepath.Join(root, "openspec", "specs")
+	// macOS adds a /private prefix to t.TempDir results in some contexts; canonicalise both sides via filepath.EvalSymlinks.
+	gotReal, _ := filepath.EvalSymlinks(got)
+	wantReal, _ := filepath.EvalSymlinks(want)
+	assert.Equal(t, wantReal, gotReal)
+}
+
+// TestResolveRepoPath_UnresolvableReturnsOriginal pins rule 4: when the path doesn't resolve cwd-relative and the repo
+// root either can't be found or doesn't have the path either, the function returns the original. The downstream parser
+// then emits a deterministic "no such file" error against the user's input, which is the right shape for catching typos.
+func TestResolveRepoPath_UnresolvableReturnsOriginal(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	root := setupGitRepo(t)
+	t.Chdir(root)
+	assert.Equal(t, "definitely-not-here", resolveRepoPath("definitely-not-here"))
+}
+
+// TestResolveDefaultRepoPath_PromotesDotToRepoRoot pins the more aggressive behaviour for unset flags. The literal `.` trivially
+// resolves cwd-relative — resolveRepoPath would short-circuit at rule 2 and leave a default `--root .` scan scoped to the
+// tools/spectrace subdirectory. The default-only variant skips the cwd check so the scan widens to the whole repo, which is the
+// actual intent of running `spectrace check` from any directory.
+func TestResolveDefaultRepoPath_PromotesDotToRepoRoot(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	root := setupGitRepo(t)
+	sub := filepath.Join(root, "tools", "spectrace")
+	require.NoError(t, os.MkdirAll(sub, 0o750))
+	t.Chdir(sub)
+	got := resolveDefaultRepoPath(".")
+	gotReal, _ := filepath.EvalSymlinks(got)
+	rootReal, _ := filepath.EvalSymlinks(root)
+	assert.Equal(t, rootReal, gotReal,
+		"a `.` default from a subdirectory must widen to the repo root, not stay scoped to the subdir")
+}
+
+// TestResolvePathFlag_HonoursUserExplicitness pins the switch between the two resolvers based on whether the operator supplied the
+// flag. An explicit `--root .` from a subdirectory means "literally cwd" and must not be widened to the repo root; a default
+// `--root .` means "the natural scope" and gets widened.
+func TestResolvePathFlag_HonoursUserExplicitness(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	root := setupGitRepo(t)
+	sub := filepath.Join(root, "tools", "spectrace")
+	require.NoError(t, os.MkdirAll(sub, 0o750))
+	t.Chdir(sub)
+
+	t.Run("explicit value stays cwd-relative", func(t *testing.T) {
+		assert.Equal(t, ".", resolvePathFlag(".", true))
+	})
+	t.Run("default value widens to repo root", func(t *testing.T) {
+		got := resolvePathFlag(".", false)
+		gotReal, _ := filepath.EvalSymlinks(got)
+		rootReal, _ := filepath.EvalSymlinks(root)
+		assert.Equal(t, rootReal, gotReal)
+	})
+}
+
+// TestUserSetFlagNames covers the small helper that wraps fs.Visit. We supply one flag explicitly and confirm only that
+// name appears in the resulting set; the unset flags must NOT appear, which is the property resolvePathFlag depends on.
+func TestUserSetFlagNames(t *testing.T) {
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	fs.String("specs-dir", "default-a", "")
+	fs.String("root", "default-b", "")
+	require.NoError(t, fs.Parse([]string{"--specs-dir", "explicit-a"}))
+	got := userSetFlagNames(fs)
+	assert.True(t, got["specs-dir"])
+	assert.False(t, got["root"])
+}
+
+// setupGitRepo creates a transient git repo and returns its absolute root path. Tests use this when they need
+// gitTopLevel to succeed in isolation from the surrounding fleet-edr worktree.
+func setupGitRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	for _, args := range [][]string{
+		{"init", "--quiet"},
+		{"config", "user.email", "spectrace@example.test"},
+		{"config", "user.name", "spectrace test"},
+	} {
+		cmd := exec.CommandContext(t.Context(), "git", args...) //nolint:gosec // args are literal
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %s failed: %v\n%s", strings.Join(args, " "), err, out)
+		}
+	}
+	return dir
+}

--- a/tools/spectrace/report.go
+++ b/tools/spectrace/report.go
@@ -33,6 +33,11 @@ func runReport(args []string) int {
 		return 2
 	}
 
+	// Promote --specs-dir / --root to repo-root-relative when cwd doesn't have them; matches the runCheck shape.
+	setFlags := userSetFlagNames(fs)
+	*specsDir = resolvePathFlag(*specsDir, setFlags["specs-dir"])
+	*rootDir = resolvePathFlag(*rootDir, setFlags["root"])
+
 	scenarios, markers, exitCode := loadScenariosAndMarkers(*specsDir, *rootDir)
 	if exitCode != 0 {
 		return exitCode

--- a/tools/spectrace/report.go
+++ b/tools/spectrace/report.go
@@ -1,0 +1,260 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+)
+
+// runReport implements `spectrace report --format=md [--output FILE]`. The Markdown coverage matrix has one row per scenario
+// and one column per test layer (L0..L6), with each cell listing the markers (file:line links) that cover the scenario at
+// that layer. The matrix is the v2 deliverable from issue #233; the data it presents is the same canonical+markers set the
+// check subcommand already loads, so this function is a pure presentation layer with no spec-parsing or marker-scanning
+// duplication. Exit codes: 0 on a clean render, 2 on IO / usage error. The subcommand does NOT gate (unlike check
+// --strict); it is a reporting tool for humans + PR comments. CI can grep the rendered matrix for "uncovered" rows if a
+// gate is needed.
+func runReport(args []string) int {
+	fs := flag.NewFlagSet("report", flag.ContinueOnError)
+	specsDir := fs.String("specs-dir", defaultSpecsDir, "root of the openspec/specs tree")
+	rootDir := fs.String("root", defaultRootDir, "root of the source tree to scan for markers")
+	format := fs.String("format", "md", "output format (currently only `md` is supported)")
+	output := fs.String("output", "", "write to FILE instead of stdout")
+	normativeOnly := fs.Bool("normative-only", false,
+		"restrict the matrix to scenarios whose parent requirement contains SHALL or MUST")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if *format != "md" {
+		fmt.Fprintf(os.Stderr, "spectrace report: unsupported --format %q (only `md` is supported)\n", *format)
+		return 2
+	}
+
+	scenarios, markers, exitCode := loadScenariosAndMarkers(*specsDir, *rootDir)
+	if exitCode != 0 {
+		return exitCode
+	}
+
+	w, closer, err := openReportWriter(*output)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "spectrace report: %v\n", err)
+		return 2
+	}
+	defer closer()
+
+	renderMarkdownMatrix(w, scenarios, markers, *normativeOnly)
+	return 0
+}
+
+// loadScenariosAndMarkers is the shared specs+markers load path used by report and (in --new-code mode) check. Returns
+// (scenarios, markers, exitCode); when exitCode != 0 the error has already been written to stderr and the caller should
+// return it directly. Kept here rather than in main.go because report.go is the first consumer; check predates this and
+// inlines the same three calls. A future refactor could fold them, but the diff would be wider than the deduplication.
+func loadScenariosAndMarkers(specsDir, rootDir string) ([]Scenario, []Marker, int) {
+	scenarios, err := ParseAllSpecs(specsDir)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "spectrace: parse specs:", err)
+		return nil, nil, 2
+	}
+	canonical, dupErr := buildCanonicalSet(scenarios)
+	if dupErr != nil {
+		fmt.Fprintln(os.Stderr, "spectrace:", dupErr)
+		return nil, nil, 2
+	}
+	markers, err := ScanMarkers(rootDir, canonical)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "spectrace: scan markers:", err)
+		return nil, nil, 2
+	}
+	return scenarios, markers, 0
+}
+
+// openReportWriter returns (writer, cleanup, error). When path is empty the writer is stdout and the cleanup is a no-op.
+// When path is non-empty the writer is a newly-created file whose cleanup closes it. Errors from Close are reported via
+// stderr at cleanup time because the report renderer has already returned by then.
+func openReportWriter(path string) (io.Writer, func(), error) {
+	if path == "" {
+		return os.Stdout, func() {}, nil
+	}
+	f, err := os.Create(path) //nolint:gosec // path comes from a --output flag the operator supplies
+	if err != nil {
+		return nil, nil, fmt.Errorf("open --output %s: %w", path, err)
+	}
+	cleanup := func() {
+		if cerr := f.Close(); cerr != nil {
+			fmt.Fprintf(os.Stderr, "spectrace report: close %s: %v\n", path, cerr)
+		}
+	}
+	return f, cleanup, nil
+}
+
+// renderMarkdownMatrix writes a single Markdown table to w with one row per scenario and one column per layer. The columns
+// are L0..L6 always, plus an "Other" column at the right when at least one marker classifies as LayerOther. Cell content
+// is a comma-separated list of `[basename:line](path)` Markdown links pointing at the marker source. The header summarises
+// total scenarios, normative count, and the per-layer marker totals so a reader skimming the file gets the gestalt before
+// scanning rows.
+func renderMarkdownMatrix(w io.Writer, scenarios []Scenario, markers []Marker, normativeOnly bool) {
+	coverage := indexMarkersByScenario(markers)
+	includeOther := matrixHasOtherMarkers(scenarios, coverage, normativeOnly)
+	cols := matrixColumns(includeOther)
+
+	writeMatrixHeader(w, scenarios, markers, normativeOnly)
+	writeColumnHeaders(w, cols)
+	writeMatrixRows(w, scenarios, coverage, cols, normativeOnly)
+}
+
+// matrixHasOtherMarkers reports whether the LayerOther column needs to render. We omit it when no scenario has a non-test
+// marker so the standard matrix stays compact for the bulk of specs. The normativeOnly filter is honoured so the column
+// decision matches the row set.
+func matrixHasOtherMarkers(scenarios []Scenario, coverage map[string][]Marker, normativeOnly bool) bool {
+	for _, s := range scenarios {
+		if normativeOnly && !s.Normative {
+			continue
+		}
+		for _, m := range coverage[s.ID] {
+			if m.Layer == LayerOther {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// matrixColumns returns the layer set rendered as columns, in stable left-to-right order. When includeOther is true the
+// LayerOther column is appended at the right.
+func matrixColumns(includeOther bool) []Layer {
+	cols := append([]Layer(nil), allTestLayers[:]...)
+	if includeOther {
+		cols = append(cols, LayerOther)
+	}
+	return cols
+}
+
+// writeMatrixHeader writes the title + summary block above the table. The per-layer marker totals are derived from the full
+// marker slice (not the coverage map) so invalid-reference markers also contribute, giving an honest "where do the markers
+// live" view independent of whether they line up with a canonical ID.
+func writeMatrixHeader(w io.Writer, scenarios []Scenario, markers []Marker, normativeOnly bool) {
+	totalNormative := 0
+	for _, s := range scenarios {
+		if s.Normative {
+			totalNormative++
+		}
+	}
+	fmt.Fprintln(w, "# spectrace coverage matrix")
+	fmt.Fprintln(w)
+	fmt.Fprintf(w, "- Scenarios total: %d (%d normative, %d advisory)\n",
+		len(scenarios), totalNormative, len(scenarios)-totalNormative)
+	if normativeOnly {
+		fmt.Fprintln(w, "- Filter: `--normative-only` (advisory scenarios omitted)")
+	}
+	fmt.Fprintln(w, "- Markers by layer:")
+	for _, l := range allTestLayers {
+		fmt.Fprintf(w, "  - %s: %d\n", l.Label(), countMarkersAtLayer(markers, l))
+	}
+	if otherCount := countMarkersAtLayer(markers, LayerOther); otherCount > 0 {
+		fmt.Fprintf(w, "  - Other: %d\n", otherCount)
+	}
+	fmt.Fprintln(w)
+}
+
+func countMarkersAtLayer(markers []Marker, l Layer) int {
+	n := 0
+	for _, m := range markers {
+		if m.Layer == l {
+			n++
+		}
+	}
+	return n
+}
+
+func writeColumnHeaders(w io.Writer, cols []Layer) {
+	headers := make([]string, 0, len(cols)+1)
+	headers = append(headers, "Scenario")
+	for _, l := range cols {
+		headers = append(headers, l.Label())
+	}
+	fmt.Fprintln(w, "| "+strings.Join(headers, " | ")+" |")
+	dividers := make([]string, len(headers))
+	for i := range dividers {
+		dividers[i] = "---"
+	}
+	fmt.Fprintln(w, "|"+strings.Join(dividers, "|")+"|")
+}
+
+func writeMatrixRows(w io.Writer, scenarios []Scenario, coverage map[string][]Marker,
+	cols []Layer, normativeOnly bool,
+) {
+	for _, s := range scenarios {
+		if normativeOnly && !s.Normative {
+			continue
+		}
+		cells := make([]string, 0, len(cols)+1)
+		cells = append(cells, escapeMarkdownPipe(s.ID))
+		for _, l := range cols {
+			cells = append(cells, renderCell(coverage[s.ID], l))
+		}
+		fmt.Fprintln(w, "| "+strings.Join(cells, " | ")+" |")
+	}
+}
+
+// indexMarkersByScenario groups markers by their canonical ID. Markers whose ID is not a canonical scenario (invalid refs,
+// `swift:` / `swift-ambiguous:` synthetic IDs) are dropped; they are reported by check, not by report. Within a group,
+// markers are sorted by (Layer, SourcePath, SourceLine) so cell rendering is deterministic.
+func indexMarkersByScenario(markers []Marker) map[string][]Marker {
+	out := make(map[string][]Marker)
+	for _, m := range markers {
+		if strings.HasPrefix(m.ID, "swift:") || strings.HasPrefix(m.ID, "swift-ambiguous:") {
+			continue
+		}
+		out[m.ID] = append(out[m.ID], m)
+	}
+	for id := range out {
+		sort.Slice(out[id], func(i, j int) bool {
+			a, b := out[id][i], out[id][j]
+			if a.Layer != b.Layer {
+				return a.Layer < b.Layer
+			}
+			if a.SourcePath != b.SourcePath {
+				return a.SourcePath < b.SourcePath
+			}
+			return a.SourceLine < b.SourceLine
+		})
+	}
+	return out
+}
+
+// renderCell formats every marker covering the scenario at the given layer as a comma-separated list of Markdown links.
+// Empty cells render as an empty string; the table row uses ` | ` separators so a missing entry is visually distinct.
+func renderCell(markers []Marker, l Layer) string {
+	var links []string
+	for _, m := range markers {
+		if m.Layer != l {
+			continue
+		}
+		links = append(links, formatMarkerLink(m))
+	}
+	if len(links) == 0 {
+		return ""
+	}
+	return strings.Join(links, ", ")
+}
+
+// formatMarkerLink builds `[basename:line](path)` for a marker. The path is the same forward-slash repo-relative form
+// stored on the Marker, which Markdown renderers on GitHub resolve relative to the file containing the table; for stdout
+// previews the link is still a clickable hint for IDE users.
+func formatMarkerLink(m Marker) string {
+	base := m.SourcePath
+	if idx := strings.LastIndex(base, "/"); idx >= 0 {
+		base = base[idx+1:]
+	}
+	return fmt.Sprintf("[%s:%d](%s#L%d)", base, m.SourceLine, m.SourcePath, m.SourceLine)
+}
+
+// escapeMarkdownPipe replaces literal `|` with the HTML entity so a pipe character inside a scenario ID does not break the
+// table row. Canonical IDs are slug-only so this is defensive; if a non-canonical row ever gets rendered (e.g. a future
+// `--include-invalid` flag), the escape keeps the table well-formed.
+func escapeMarkdownPipe(s string) string {
+	return strings.ReplaceAll(s, "|", "&#124;")
+}

--- a/tools/spectrace/report.go
+++ b/tools/spectrace/report.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"flag"
 	"fmt"
 	"io"
@@ -44,7 +45,15 @@ func runReport(args []string) int {
 	}
 	defer closer()
 
-	renderMarkdownMatrix(w, scenarios, markers, *normativeOnly)
+	// Buffer the writer so a single Flush surfaces any IO error (broken pipe, disk full) instead of silently truncating
+	// the matrix. CodeRabbit flagged the unchecked write on PR #281: with raw os.Stdout, `spectrace report | head` would
+	// SIGPIPE mid-stream and exit 0; the buffered Flush returns the EPIPE so the caller sees exit 2.
+	bw := bufio.NewWriter(w)
+	renderMarkdownMatrix(bw, scenarios, markers, *normativeOnly)
+	if err := bw.Flush(); err != nil {
+		fmt.Fprintf(os.Stderr, "spectrace report: write output: %v\n", err)
+		return 2
+	}
 	return 0
 }
 
@@ -199,9 +208,13 @@ func writeMatrixRows(w io.Writer, scenarios []Scenario, coverage map[string][]Ma
 	}
 }
 
-// indexMarkersByScenario groups markers by their canonical ID. Markers whose ID is not a canonical scenario (invalid refs,
-// `swift:` / `swift-ambiguous:` synthetic IDs) are dropped; they are reported by check, not by report. Within a group,
-// markers are sorted by (Layer, SourcePath, SourceLine) so cell rendering is deterministic.
+// indexMarkersByScenario groups markers by their canonical ID. Synthetic Swift IDs (`swift:` / `swift-ambiguous:` from
+// resolveSwiftMarker) are dropped because they cannot match any scenario row. Other invalid references (a typo'd ID, a
+// stale slug after a spec rename) are still indexed under their literal ID — they don't render because the row iteration
+// uses the canonical scenario list, not this map's key set. The check subcommand reports those typo'd markers separately
+// as invalid references, so leaving them in the map here is harmless and avoids re-threading the canonical set through
+// the report path. Within a group, markers are sorted by (Layer, SourcePath, SourceLine) so cell rendering is
+// deterministic. Copilot's comment-vs-behavior nit on PR #281.
 func indexMarkersByScenario(markers []Marker) map[string][]Marker {
 	out := make(map[string][]Marker)
 	for _, m := range markers {

--- a/tools/spectrace/report_test.go
+++ b/tools/spectrace/report_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -170,6 +171,15 @@ func TestFormatMarkerLink(t *testing.T) {
 func TestRunReport_UnsupportedFormat(t *testing.T) {
 	code := runReport([]string{"--format", "json"})
 	assert.Equal(t, 2, code)
+}
+
+// TestRunReport_WriteErrorReturnsExitCodeTwo exercises the bufio flush check added in response to CodeRabbit's PR #281 review.
+// We point --output at a path inside a NOT-existing directory; os.Create fails, openReportWriter returns the error, and
+// runReport must exit 2. Without the flush check the prior shape returned 0 on any IO failure during render or close.
+func TestRunReport_WriteErrorReturnsExitCodeTwo(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist-dir", "matrix.md")
+	code := runReport([]string{"--output", missing, "--specs-dir", "openspec/specs", "--root", "."})
+	assert.Equal(t, 2, code, "open --output under a missing directory must exit non-zero")
 }
 
 // TestMatrixHasOtherMarkers covers the column-on-demand decision. Cases drive both directions: an empty marker set, a set

--- a/tools/spectrace/report_test.go
+++ b/tools/spectrace/report_test.go
@@ -1,0 +1,208 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fixtureScenarios is the shared scenario set the report tests render against. Two normative scenarios + one advisory so the
+// --normative-only filter has something to drop, two distinct spec dirs so the row sort is observable. The IDs match the
+// canonical-slug rule (lowercase, dash-separated) so the test exercises the same shape main.go produces in the real run.
+func fixtureScenarios() []Scenario {
+	return []Scenario{
+		{
+			ID:        "agent-event-uploader/upload-uses-the-host-bearer-token/upload-with-a-valid-token",
+			Normative: true,
+		},
+		{
+			ID:        "agent-event-uploader/upload-uses-the-host-bearer-token/upload-with-an-expired-token",
+			Normative: true,
+		},
+		{
+			ID:        "release-packaging/dry-run-build-on-any-macos-runner/pull-request-runs-the-dry-run",
+			Normative: false,
+		},
+	}
+}
+
+// fixtureMarkers wires one marker per layer L0/L1/L4 and one Other-layer marker so the renderer must lay them out across the
+// matrix columns AND emit the Other column. Two L0 markers on the same scenario exercise the comma-separated-cell branch;
+// they sit on different files so the renderer's marker sort by (path, line) is observable.
+func fixtureMarkers() []Marker {
+	return []Marker{
+		{
+			ID:         "agent-event-uploader/upload-uses-the-host-bearer-token/upload-with-a-valid-token",
+			SourcePath: "agent/uploader/uploader_test.go",
+			SourceLine: 42,
+			Layer:      LayerUnit,
+		},
+		{
+			ID:         "agent-event-uploader/upload-uses-the-host-bearer-token/upload-with-a-valid-token",
+			SourcePath: "server/endpoint/internal/tests/upload_test.go",
+			SourceLine: 73,
+			Layer:      LayerPerContext,
+		},
+		{
+			ID:         "agent-event-uploader/upload-uses-the-host-bearer-token/upload-with-an-expired-token",
+			SourcePath: "test/e2e/tests/qa/upload-with-bad-token.spec.ts",
+			SourceLine: 12,
+			Layer:      LayerBrowserE2E,
+		},
+		{
+			ID:         "release-packaging/dry-run-build-on-any-macos-runner/pull-request-runs-the-dry-run",
+			SourcePath: ".github/workflows/pkg-dryrun.yml",
+			SourceLine: 19,
+			Layer:      LayerOther,
+		},
+	}
+}
+
+// TestRenderMarkdownMatrix covers the happy-path render: header summary, column headers, per-row content, and the on-demand
+// Other column. The assertion uses contains-substring matches rather than full equality because the precise whitespace +
+// summary numbers are content-tested by other cases; this case is about structure.
+func TestRenderMarkdownMatrix(t *testing.T) {
+	var buf bytes.Buffer
+	renderMarkdownMatrix(&buf, fixtureScenarios(), fixtureMarkers(), false)
+	out := buf.String()
+
+	assert.Contains(t, out, "# spectrace coverage matrix")
+	assert.Contains(t, out, "Scenarios total: 3 (2 normative, 1 advisory)")
+	assert.Contains(t, out, "| Scenario | L0 | L1 | L2 | L3 | L4 | L5 | L6 | Other |")
+
+	// L0 cell carries the marker link; L1 column on the same row also has its marker.
+	assert.Contains(t, out,
+		"[uploader_test.go:42](agent/uploader/uploader_test.go#L42)")
+	assert.Contains(t, out,
+		"[upload_test.go:73](server/endpoint/internal/tests/upload_test.go#L73)")
+	// L4 marker on the second scenario.
+	assert.Contains(t, out, "[upload-with-bad-token.spec.ts:12](test/e2e/tests/qa/upload-with-bad-token.spec.ts#L12)")
+	// Other marker on the advisory scenario.
+	assert.Contains(t, out, "[pkg-dryrun.yml:19](.github/workflows/pkg-dryrun.yml#L19)")
+}
+
+// TestRenderMarkdownMatrix_NormativeOnlyFilter pins the row filter: with --normative-only the advisory scenario is dropped
+// from the row set AND the Other column is dropped because its only marker was on that scenario. This is the property the
+// matrixHasOtherMarkers helper guards.
+func TestRenderMarkdownMatrix_NormativeOnlyFilter(t *testing.T) {
+	var buf bytes.Buffer
+	renderMarkdownMatrix(&buf, fixtureScenarios(), fixtureMarkers(), true)
+	out := buf.String()
+
+	assert.Contains(t, out, "Filter: `--normative-only`")
+	assert.NotContains(t, out, "release-packaging/dry-run-build-on-any-macos-runner",
+		"advisory scenario row must be omitted with --normative-only")
+	assert.NotContains(t, out, "| Other |",
+		"Other column must drop when no rendered row has an Other marker")
+	assert.Contains(t, out, "| Scenario | L0 | L1 | L2 | L3 | L4 | L5 | L6 |",
+		"standard 7-column header must still render")
+}
+
+// TestRenderMarkdownMatrix_MultipleMarkersInCell pins the comma-separated cell rendering when two markers land in the same
+// (scenario, layer) cell.
+func TestRenderMarkdownMatrix_MultipleMarkersInCell(t *testing.T) {
+	scenarios := []Scenario{
+		{ID: "x/y/z", Normative: true},
+	}
+	markers := []Marker{
+		{ID: "x/y/z", SourcePath: "a_test.go", SourceLine: 10, Layer: LayerUnit},
+		{ID: "x/y/z", SourcePath: "b_test.go", SourceLine: 20, Layer: LayerUnit},
+	}
+	var buf bytes.Buffer
+	renderMarkdownMatrix(&buf, scenarios, markers, false)
+	out := buf.String()
+	assert.Contains(t, out, "[a_test.go:10](a_test.go#L10), [b_test.go:20](b_test.go#L20)")
+}
+
+// TestRenderMarkdownMatrix_SwiftInvalidMarkersAreSkipped guards a property of indexMarkersByScenario: markers with synthetic
+// `swift:` or `swift-ambiguous:` IDs are reported by check, not by report. They must not appear in any matrix cell because
+// they don't belong to any canonical scenario.
+func TestRenderMarkdownMatrix_SwiftInvalidMarkersAreSkipped(t *testing.T) {
+	scenarios := []Scenario{
+		{ID: "x/y/z", Normative: true},
+	}
+	markers := []Marker{
+		{ID: "swift:does_not_exist", SourcePath: "Tests/X.swift", SourceLine: 1, Layer: LayerUnit},
+		{ID: "swift-ambiguous:foo_bar", SourcePath: "Tests/Y.swift", SourceLine: 2, Layer: LayerUnit},
+	}
+	var buf bytes.Buffer
+	renderMarkdownMatrix(&buf, scenarios, markers, false)
+	out := buf.String()
+	assert.NotContains(t, out, "swift:")
+	assert.NotContains(t, out, "swift-ambiguous:")
+	// The row exists but every cell is empty.
+	require.Contains(t, out, "| x/y/z |")
+}
+
+// TestEscapeMarkdownPipe pins the pipe-escape behaviour. A pipe inside a scenario ID would otherwise close the table cell
+// and break the row. Canonical IDs never contain pipes today, but the escape is defensive against future shapes.
+func TestEscapeMarkdownPipe(t *testing.T) {
+	assert.Equal(t, "a&#124;b", escapeMarkdownPipe("a|b"))
+	assert.Equal(t, "noop", escapeMarkdownPipe("noop"))
+}
+
+// TestFormatMarkerLink pins the link shape: `[basename:line](path#Lline)`.
+func TestFormatMarkerLink(t *testing.T) {
+	cases := []struct {
+		name string
+		m    Marker
+		want string
+	}{
+		{"deeply nested path uses basename in label", Marker{
+			SourcePath: "server/identity/internal/tests/journeys/login_test.go", SourceLine: 12,
+		}, "[login_test.go:12](server/identity/internal/tests/journeys/login_test.go#L12)"},
+		{"top-level path uses the same name in both spots", Marker{
+			SourcePath: "main_test.go", SourceLine: 7,
+		}, "[main_test.go:7](main_test.go#L7)"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, formatMarkerLink(tc.m))
+		})
+	}
+}
+
+// TestRunReport_UnsupportedFormat pins the only failure path that runReport returns without delegating to the loader. A
+// future `--format=json` will need a corresponding test row.
+func TestRunReport_UnsupportedFormat(t *testing.T) {
+	code := runReport([]string{"--format", "json"})
+	assert.Equal(t, 2, code)
+}
+
+// TestMatrixHasOtherMarkers covers the column-on-demand decision. Cases drive both directions: an empty marker set, a set
+// with only test markers, and a set with a single Other marker on a row included by the filter.
+func TestMatrixHasOtherMarkers(t *testing.T) {
+	scenarios := fixtureScenarios()
+	markers := fixtureMarkers()
+	coverage := indexMarkersByScenario(markers)
+
+	assert.True(t, matrixHasOtherMarkers(scenarios, coverage, false),
+		"unfiltered set includes the advisory scenario whose marker is LayerOther")
+	assert.False(t, matrixHasOtherMarkers(scenarios, coverage, true),
+		"normative-only filter drops the row that owned the Other marker")
+}
+
+// TestRenderMarkdownMatrix_EmptyScenarios pins the degenerate render: the header still emits, the table has only the column
+// header + divider rows, and no panic.
+func TestRenderMarkdownMatrix_EmptyScenarios(t *testing.T) {
+	var buf bytes.Buffer
+	renderMarkdownMatrix(&buf, nil, nil, false)
+	out := buf.String()
+	assert.Contains(t, out, "Scenarios total: 0")
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+	// Header block + column header + divider = no data rows. Find the column header line and assert nothing follows.
+	headerIdx := -1
+	for i, line := range lines {
+		if strings.HasPrefix(line, "| Scenario | L0 |") {
+			headerIdx = i
+			break
+		}
+	}
+	require.NotEqual(t, -1, headerIdx, "expected column header in output")
+	require.GreaterOrEqual(t, len(lines), headerIdx+2, "expected divider row after header")
+	assert.True(t, strings.HasPrefix(lines[headerIdx+1], "|---|"))
+	assert.Equal(t, headerIdx+1, len(lines)-1, "no data rows should follow the divider when scenarios is empty")
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `report` command to generate Markdown coverage matrices showing test scenario coverage across classification layers.
  * Enhanced `check` command with `--by-layer`, `--new-code`, and `--base-ref` flags for layer-specific validation and scoped gating to modified scenarios.

* **Documentation**
  * Updated testing-strategy and tool documentation with concrete rollout sequence, new command behaviors, and layer classification details.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/getvictor/fleet-edr/pull/281?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->