### PR TITLE
App Control: platform-binary carve-out, deadline-guarded BINARY hash,…

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -3,6 +3,7 @@ included:
 
 excluded:
   - extension/edr/build
+  - extension/edr/.build  # SwiftPM-generated runner.swift carries vendored SwiftLint violations we cannot edit.
 
 opt_in_rules:
   - closure_body_length

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -391,12 +391,68 @@ be used.
 
 ## Application control
 
-Application Control (the replacement for the singleton blocklist) is
-introduced in the `add-application-control` OpenSpec change. Phase 1
-deletes the legacy `/api/policy` endpoints and the `set_blocklist`
-command; the new REST surface, agent command, and decision engine land
-in later phases of that change. Until then there is no in-product
-allow/block surface.
+Application Control replaces the singleton blocklist with operator-managed
+policies (named, versioned, audited) containing typed rules. The AUTH_EXEC
+handler in the system extension consults the active snapshot on every exec
+and denies the first matching rule with `action=BLOCK` and
+`enforcement=PROTECT`. Precedence is CDHASH → BINARY → SIGNINGID → TEAMID.
+CERTIFICATE and PATH rules are accepted by the REST surface but deferred
+to Phase B (leaf-cert cache / Launch Services indirection).
+
+Two unconditional carve-outs run before any rule:
+
+1. **Platform-binary carve-out.** If the kernel sets
+   `target.is_platform_binary` (launchd, xpcproxy, fseventsd, kextd,
+   sysextd, WindowServer, etc.) the handler returns ALLOW with the kernel
+   cache pinned. An admin who pastes the SHA-256 of `/sbin/launchd` into a
+   BINARY rule will NOT brick the host: the carve-out fires before the
+   snapshot walk.
+2. **Self-allow failsafe.** The agent / extensions / host app (matched by
+   both Fleet's team_id and the exhaustive Fleet bundle-id allowlist)
+   ALLOW unconditionally. A misconfigured rule cannot block the EDR
+   itself.
+
+### BINARY rules and the deadline-fallback posture
+
+A BINARY rule matches the file's SHA-256. The hash is computed
+synchronously on the AUTH_EXEC callback thread, with the budget bounded
+by the kernel-supplied `es_message_t.deadline` minus a 500 ms safety
+margin for the post-hash work. v0.1.0 closes the pre-RC bypass primitive
+where the first exec of any binary slipped past BINARY rules while the
+cache filled asynchronously (#208).
+
+If the hash cannot finish in time (large binary, slow disk, or the file
+is unreadable due to a TOCTOU replace between AUTH and read), the
+snapshot's `deadline_fallback` field drives the verdict:
+
+| Posture | Verdict on deadline / read failure | Event emitted | When to pick |
+|---|---|---|---|
+| `fail-closed` (default) | DENY | `application_control_undecided` with `verdict=deny` | High-assurance pilots. A binary the EDR cannot identify in time does not run. |
+| `fail-open` | ALLOW | none | Demo-equivalent posture. The cold-cache window stays open; pick this only if "no unexpected blocks" outweighs "no first-exec bypass." |
+| `audit-only` | ALLOW | `application_control_undecided` with `verdict=allow` | Tuning a fleet before flipping to `fail-closed`. Count how often the fallback fires without changing exec behaviour. |
+
+v0.1.0 wires the posture through the snapshot payload but does NOT yet
+persist a per-policy value in the database; every snapshot ships with
+`fail-closed`. The v0.1.x follow-up adds a DB column and the REST
+surface to set it per policy.
+
+### Upgrading from a v0.1.0-rc.* RC
+
+The cold-cache ALLOW path is removed. Pilots that ran the RC under that
+posture will, after upgrade, see the first exec of any unhashed binary
+either DENY (the v0.1.0 default) or take a small latency hit while the
+sync hash runs (tens of ms on typical multi-MB binaries; the safety
+margin is 500 ms below the kernel deadline). To preview the rate of
+fallback events before flipping a fleet, install the v0.1.x release
+that adds the per-policy posture knob and run with `audit-only` for a
+day; the `application_control_undecided` event stream gives the
+operator the rate.
+
+### Legacy endpoints
+
+The `add-application-control` OpenSpec change deleted the singleton
+`/api/policy` endpoints and the `set_blocklist` agent command. The new
+REST surface lives under `/api/v1/app-control/*`.
 
 The `EDR_LAUNCHAGENT_ALLOWLIST` env var is different: it tells the
 server's `persistence_launchagent` detection rule which LaunchAgent

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -431,6 +431,14 @@ snapshot's `deadline_fallback` field drives the verdict:
 | `fail-open` | ALLOW | none | Demo-equivalent posture. The cold-cache window stays open; pick this only if "no unexpected blocks" outweighs "no first-exec bypass." |
 | `audit-only` | ALLOW | `application_control_undecided` with `verdict=allow` | Tuning a fleet before flipping to `fail-closed`. Count how often the fallback fires without changing exec behaviour. |
 
+On `deadline-exceeded` or `read-failed` outcomes the SHA-256 cache is
+NOT populated, so subsequent execs of the same binary retry the hash
+computation. Repeated `application_control_undecided` events for the
+same `path` therefore indicate either a binary that consistently blows
+the 500 ms safety margin (size + disk-read combination) or a TOCTOU
+race the agent is hitting deterministically; the path + `file_size_bytes`
+fields are the disambiguator.
+
 v0.1.0 wires the posture through the snapshot payload but does NOT yet
 persist a per-policy value in the database; every snapshot ships with
 `fail-closed`. The v0.1.x follow-up adds a DB column and the REST

--- a/extension/edr/Package.swift
+++ b/extension/edr/Package.swift
@@ -83,6 +83,7 @@ let package = Package(
             sources: [
                 "edr/ExtensionManagerLogic.swift",
                 "extension/ApplicationControlStore.swift",
+                "extension/AuthExecDecider.swift",
                 "extension/XPCServer.swift",
                 "extension/BlockNotification.swift",
                 "extension/EventSerializer.swift",

--- a/extension/edr/Tests/EDRExtensionLogicTests/AuthExecDeciderTests.swift
+++ b/extension/edr/Tests/EDRExtensionLogicTests/AuthExecDeciderTests.swift
@@ -1,0 +1,285 @@
+// AuthExecDecider tests: exhaustively cover the (posture × hashOutcome × precedence) matrix
+// that the decider walks. Pure-logic tests -- no ESF, no Darwin time calls. The decider is the
+// only piece of AUTH_EXEC logic that the SwiftPM target can exercise (ESFSubscriber.swift is
+// excluded because it imports EndpointSecurity), so coverage here pins the v0.1.0 close-out of
+// #205 (platform-binary semantics deferred to ESFSubscriber wire) and #208 (BINARY sync hash
+// fallback posture).
+
+import Foundation
+@testable import EDRExtensionLogic
+import XCTest
+
+final class AuthExecDeciderTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    /// makeRule builds a minimal ApplicationControlRule with the supplied ruleType / identifier /
+    /// action / enforcement. Other fields are set to representative defaults so the tests focus
+    /// on the precedence walk and verdict mapping rather than per-rule decoration.
+    private func makeRule(
+        ruleType: String,
+        identifier: String,
+        action: String = ApplicationControlAction.block,
+        enforcement: String = ApplicationControlEnforcement.protect
+    ) -> ApplicationControlRule {
+        return ApplicationControlRule(
+            ruleID: "app_control:test-\(identifier)",
+            ruleType: ruleType,
+            identifier: identifier,
+            action: action,
+            enforcement: enforcement,
+            severity: "medium",
+            customMsg: nil,
+            customURL: nil
+        )
+    }
+
+    /// makeSnapshot builds an ApplicationControlSnapshot with the supplied rule maps and the
+    /// requested fallback posture. Maps not supplied default to empty so the precedence walk
+    /// for missing layers correctly returns no match.
+    private func makeSnapshot(
+        deadlineFallback: FallbackPosture = .defaultPosture,
+        cdhashRules: [String: ApplicationControlRule] = [:],
+        binaryRules: [String: ApplicationControlRule] = [:],
+        signingIDRules: [String: ApplicationControlRule] = [:],
+        teamIDRules: [String: ApplicationControlRule] = [:]
+    ) -> ApplicationControlSnapshot {
+        return ApplicationControlSnapshot(
+            policyID: 1,
+            policyVersion: 1,
+            deadlineFallback: deadlineFallback,
+            binaryRules: binaryRules,
+            cdhashRules: cdhashRules,
+            signingIDRules: signingIDRules,
+            certificateRules: [:],
+            teamIDRules: teamIDRules,
+            pathRules: [:]
+        )
+    }
+
+    // MARK: - No match returns allow
+
+    func testNoMatchOnEmptySnapshotReturnsAllow() {
+        let tuple = AuthTuple(cdhash: "c0", signingIDPrefixed: "ABC:org.test", teamID: "ABCDEFGHIJ")
+        let decision = decideAuthExec(
+            tuple: tuple,
+            snapshot: makeSnapshot(),
+            hashOutcome: .notNeeded,
+            posture: .failClosed
+        )
+        XCTAssertEqual(decision, .allow)
+    }
+
+    // MARK: - CDHASH precedence
+
+    func testCDHashBlockRuleReturnsDeny() {
+        let rule = makeRule(ruleType: ApplicationControlRuleType.cdhash, identifier: "cdhashvalue")
+        let tuple = AuthTuple(cdhash: "cdhashvalue", signingIDPrefixed: nil, teamID: nil)
+        let decision = decideAuthExec(
+            tuple: tuple,
+            snapshot: makeSnapshot(cdhashRules: ["cdhashvalue": rule]),
+            hashOutcome: .notNeeded,
+            posture: .failClosed
+        )
+        XCTAssertEqual(decision, .deny(rule: rule, matchedIdentifier: "cdhashvalue"))
+    }
+
+    func testCDHashTakesPrecedenceOverBinaryEvenOnDeadlineExceeded() {
+        // CDHASH layer runs before the BINARY layer's hashOutcome is consulted. If CDHASH matches,
+        // the deadlineExceeded path is never reached -- the deny precedes any fallback verdict.
+        let cdhashRule = makeRule(ruleType: ApplicationControlRuleType.cdhash, identifier: "cdhashvalue")
+        let binaryRule = makeRule(ruleType: ApplicationControlRuleType.binary, identifier: "shaRaceCondition")
+        let tuple = AuthTuple(cdhash: "cdhashvalue", signingIDPrefixed: nil, teamID: nil)
+        let decision = decideAuthExec(
+            tuple: tuple,
+            snapshot: makeSnapshot(cdhashRules: ["cdhashvalue": cdhashRule], binaryRules: ["shaRaceCondition": binaryRule]),
+            hashOutcome: .deadlineExceeded,
+            posture: .failClosed
+        )
+        XCTAssertEqual(decision, .deny(rule: cdhashRule, matchedIdentifier: "cdhashvalue"))
+    }
+
+    func testCDHashNonProtectEnforcementAllows() {
+        // DETECT enforcement is the v0.1.x lift-and-detect mode; it must NOT deny in v0.1.0.
+        let rule = makeRule(
+            ruleType: ApplicationControlRuleType.cdhash,
+            identifier: "cdhashvalue",
+            enforcement: ApplicationControlEnforcement.detect
+        )
+        let tuple = AuthTuple(cdhash: "cdhashvalue", signingIDPrefixed: nil, teamID: nil)
+        let decision = decideAuthExec(
+            tuple: tuple,
+            snapshot: makeSnapshot(cdhashRules: ["cdhashvalue": rule]),
+            hashOutcome: .notNeeded,
+            posture: .failClosed
+        )
+        XCTAssertEqual(decision, .allow)
+    }
+
+    // MARK: - BINARY precedence (hash-driven)
+
+    func testBinaryMatchOnComputedHashReturnsDeny() {
+        let rule = makeRule(ruleType: ApplicationControlRuleType.binary, identifier: "shavalue")
+        let tuple = AuthTuple(cdhash: nil, signingIDPrefixed: nil, teamID: nil)
+        let decision = decideAuthExec(
+            tuple: tuple,
+            snapshot: makeSnapshot(binaryRules: ["shavalue": rule]),
+            hashOutcome: .computed("shavalue"),
+            posture: .failClosed
+        )
+        XCTAssertEqual(decision, .deny(rule: rule, matchedIdentifier: "shavalue"))
+    }
+
+    func testBinaryNoMatchOnComputedHashFallsThroughToSigningID() {
+        let signRule = makeRule(ruleType: ApplicationControlRuleType.signingID, identifier: "ABC:org.bad")
+        let tuple = AuthTuple(cdhash: nil, signingIDPrefixed: "ABC:org.bad", teamID: nil)
+        let decision = decideAuthExec(
+            tuple: tuple,
+            snapshot: makeSnapshot(signingIDRules: ["ABC:org.bad": signRule]),
+            hashOutcome: .computed("nonMatchingSha"),
+            posture: .failClosed
+        )
+        XCTAssertEqual(decision, .deny(rule: signRule, matchedIdentifier: "ABC:org.bad"))
+    }
+
+    func testNotNeededHashSkipsBinaryLayerAndWalksRest() {
+        // When the snapshot has no BINARY rules, handleAuthExec passes .notNeeded so the precedence
+        // walk skips BINARY entirely and continues to SIGNINGID / TEAMID rather than applying the
+        // fallback posture. This is the common case in practice.
+        let teamRule = makeRule(ruleType: ApplicationControlRuleType.teamID, identifier: "ABCDEFGHIJ")
+        let tuple = AuthTuple(cdhash: nil, signingIDPrefixed: nil, teamID: "ABCDEFGHIJ")
+        let decision = decideAuthExec(
+            tuple: tuple,
+            snapshot: makeSnapshot(teamIDRules: ["ABCDEFGHIJ": teamRule]),
+            hashOutcome: .notNeeded,
+            posture: .failClosed
+        )
+        XCTAssertEqual(decision, .deny(rule: teamRule, matchedIdentifier: "ABCDEFGHIJ"))
+    }
+
+    // MARK: - Deadline-exceeded posture matrix
+
+    func testDeadlineExceededFailClosedDeniesWithUndecidedAudit() {
+        let tuple = AuthTuple(cdhash: nil, signingIDPrefixed: "ABC:org.test", teamID: "ABCDEFGHIJ")
+        // SIGNINGID + TEAMID rules exist; under failClosed the deadline-exceeded path is the
+        // verdict and the later layers are NOT consulted. Tests guarantee BINARY uncertainty
+        // dominates any post-BINARY precedence match.
+        let signRule = makeRule(ruleType: ApplicationControlRuleType.signingID, identifier: "ABC:org.test")
+        let teamRule = makeRule(ruleType: ApplicationControlRuleType.teamID, identifier: "ABCDEFGHIJ")
+        let binaryRule = makeRule(ruleType: ApplicationControlRuleType.binary, identifier: "anyShaWeCantSee")
+        let snapshot = makeSnapshot(
+            deadlineFallback: .failClosed,
+            binaryRules: ["anyShaWeCantSee": binaryRule],
+            signingIDRules: ["ABC:org.test": signRule],
+            teamIDRules: ["ABCDEFGHIJ": teamRule]
+        )
+        let decision = decideAuthExec(
+            tuple: tuple,
+            snapshot: snapshot,
+            hashOutcome: .deadlineExceeded,
+            posture: snapshot.deadlineFallback
+        )
+        XCTAssertEqual(decision, .denyWithUndecidedAudit(reason: .deadline))
+    }
+
+    func testDeadlineExceededFailOpenAllowsSilently() {
+        let tuple = AuthTuple(cdhash: nil, signingIDPrefixed: "ABC:org.test", teamID: "ABCDEFGHIJ")
+        let binaryRule = makeRule(ruleType: ApplicationControlRuleType.binary, identifier: "anyShaWeCantSee")
+        let snapshot = makeSnapshot(
+            deadlineFallback: .failOpen,
+            binaryRules: ["anyShaWeCantSee": binaryRule]
+        )
+        let decision = decideAuthExec(
+            tuple: tuple,
+            snapshot: snapshot,
+            hashOutcome: .deadlineExceeded,
+            posture: snapshot.deadlineFallback
+        )
+        XCTAssertEqual(decision, .allow)
+    }
+
+    func testDeadlineExceededAuditOnlyAllowsAndEmitsUndecidedAudit() {
+        let tuple = AuthTuple(cdhash: nil, signingIDPrefixed: nil, teamID: nil)
+        let binaryRule = makeRule(ruleType: ApplicationControlRuleType.binary, identifier: "anyShaWeCantSee")
+        let snapshot = makeSnapshot(
+            deadlineFallback: .auditOnly,
+            binaryRules: ["anyShaWeCantSee": binaryRule]
+        )
+        let decision = decideAuthExec(
+            tuple: tuple,
+            snapshot: snapshot,
+            hashOutcome: .deadlineExceeded,
+            posture: snapshot.deadlineFallback
+        )
+        XCTAssertEqual(decision, .allowWithUndecidedAudit(reason: .deadline))
+    }
+
+    // MARK: - Read-failed posture matrix
+
+    func testReadFailedFailClosedDeniesWithUndecidedAudit() {
+        let tuple = AuthTuple(cdhash: nil, signingIDPrefixed: nil, teamID: nil)
+        let binaryRule = makeRule(ruleType: ApplicationControlRuleType.binary, identifier: "anyShaWeCantSee")
+        let snapshot = makeSnapshot(deadlineFallback: .failClosed, binaryRules: ["anyShaWeCantSee": binaryRule])
+        let decision = decideAuthExec(
+            tuple: tuple,
+            snapshot: snapshot,
+            hashOutcome: .readFailed,
+            posture: snapshot.deadlineFallback
+        )
+        XCTAssertEqual(decision, .denyWithUndecidedAudit(reason: .readFailed))
+    }
+
+    func testReadFailedAuditOnlyAllowsAndEmitsUndecidedAudit() {
+        let tuple = AuthTuple(cdhash: nil, signingIDPrefixed: nil, teamID: nil)
+        let binaryRule = makeRule(ruleType: ApplicationControlRuleType.binary, identifier: "anyShaWeCantSee")
+        let snapshot = makeSnapshot(deadlineFallback: .auditOnly, binaryRules: ["anyShaWeCantSee": binaryRule])
+        let decision = decideAuthExec(
+            tuple: tuple,
+            snapshot: snapshot,
+            hashOutcome: .readFailed,
+            posture: snapshot.deadlineFallback
+        )
+        XCTAssertEqual(decision, .allowWithUndecidedAudit(reason: .readFailed))
+    }
+
+    // MARK: - SIGNINGID / TEAMID layers
+
+    func testSigningIDBlockRuleReturnsDeny() {
+        let rule = makeRule(ruleType: ApplicationControlRuleType.signingID, identifier: "ABC:org.bad")
+        let tuple = AuthTuple(cdhash: nil, signingIDPrefixed: "ABC:org.bad", teamID: nil)
+        let decision = decideAuthExec(
+            tuple: tuple,
+            snapshot: makeSnapshot(signingIDRules: ["ABC:org.bad": rule]),
+            hashOutcome: .notNeeded,
+            posture: .failClosed
+        )
+        XCTAssertEqual(decision, .deny(rule: rule, matchedIdentifier: "ABC:org.bad"))
+    }
+
+    func testTeamIDBlockRuleReturnsDeny() {
+        let rule = makeRule(ruleType: ApplicationControlRuleType.teamID, identifier: "ABCDEFGHIJ")
+        let tuple = AuthTuple(cdhash: nil, signingIDPrefixed: nil, teamID: "ABCDEFGHIJ")
+        let decision = decideAuthExec(
+            tuple: tuple,
+            snapshot: makeSnapshot(teamIDRules: ["ABCDEFGHIJ": rule]),
+            hashOutcome: .notNeeded,
+            posture: .failClosed
+        )
+        XCTAssertEqual(decision, .deny(rule: rule, matchedIdentifier: "ABCDEFGHIJ"))
+    }
+
+    func testPrecedenceCDHashBeatsSigningIDOnSimultaneousBlock() {
+        // Both CDHASH and SIGNINGID layers have block rules; the precedence walk must return
+        // the CDHASH match (higher priority) and never consult SIGNINGID.
+        let cdRule = makeRule(ruleType: ApplicationControlRuleType.cdhash, identifier: "cdhashfirst")
+        let signRule = makeRule(ruleType: ApplicationControlRuleType.signingID, identifier: "ABC:org.bad")
+        let tuple = AuthTuple(cdhash: "cdhashfirst", signingIDPrefixed: "ABC:org.bad", teamID: nil)
+        let decision = decideAuthExec(
+            tuple: tuple,
+            snapshot: makeSnapshot(cdhashRules: ["cdhashfirst": cdRule], signingIDRules: ["ABC:org.bad": signRule]),
+            hashOutcome: .notNeeded,
+            posture: .failClosed
+        )
+        XCTAssertEqual(decision, .deny(rule: cdRule, matchedIdentifier: "cdhashfirst"))
+    }
+}

--- a/extension/edr/Tests/EDRExtensionLogicTests/AuthExecDeciderTests.swift
+++ b/extension/edr/Tests/EDRExtensionLogicTests/AuthExecDeciderTests.swift
@@ -5,7 +5,6 @@
 // #205 (platform-binary semantics deferred to ESFSubscriber wire) and #208 (BINARY sync hash
 // fallback posture).
 
-import Foundation
 @testable import EDRExtensionLogic
 import XCTest
 
@@ -61,12 +60,7 @@ final class AuthExecDeciderTests: XCTestCase {
 
     func testNoMatchOnEmptySnapshotReturnsAllow() {
         let tuple = AuthTuple(cdhash: "c0", signingIDPrefixed: "ABC:org.test", teamID: "ABCDEFGHIJ")
-        let decision = decideAuthExec(
-            tuple: tuple,
-            snapshot: makeSnapshot(),
-            hashOutcome: .notNeeded,
-            posture: .failClosed
-        )
+        let decision = decideAuthExec(tuple: tuple, snapshot: makeSnapshot(), hashOutcome: .notNeeded)
         XCTAssertEqual(decision, .allow)
     }
 
@@ -76,10 +70,7 @@ final class AuthExecDeciderTests: XCTestCase {
         let rule = makeRule(ruleType: ApplicationControlRuleType.cdhash, identifier: "cdhashvalue")
         let tuple = AuthTuple(cdhash: "cdhashvalue", signingIDPrefixed: nil, teamID: nil)
         let decision = decideAuthExec(
-            tuple: tuple,
-            snapshot: makeSnapshot(cdhashRules: ["cdhashvalue": rule]),
-            hashOutcome: .notNeeded,
-            posture: .failClosed
+            tuple: tuple, snapshot: makeSnapshot(cdhashRules: ["cdhashvalue": rule]), hashOutcome: .notNeeded
         )
         XCTAssertEqual(decision, .deny(rule: rule, matchedIdentifier: "cdhashvalue"))
     }
@@ -93,8 +84,7 @@ final class AuthExecDeciderTests: XCTestCase {
         let decision = decideAuthExec(
             tuple: tuple,
             snapshot: makeSnapshot(cdhashRules: ["cdhashvalue": cdhashRule], binaryRules: ["shaRaceCondition": binaryRule]),
-            hashOutcome: .deadlineExceeded,
-            posture: .failClosed
+            hashOutcome: .deadlineExceeded
         )
         XCTAssertEqual(decision, .deny(rule: cdhashRule, matchedIdentifier: "cdhashvalue"))
     }
@@ -108,10 +98,7 @@ final class AuthExecDeciderTests: XCTestCase {
         )
         let tuple = AuthTuple(cdhash: "cdhashvalue", signingIDPrefixed: nil, teamID: nil)
         let decision = decideAuthExec(
-            tuple: tuple,
-            snapshot: makeSnapshot(cdhashRules: ["cdhashvalue": rule]),
-            hashOutcome: .notNeeded,
-            posture: .failClosed
+            tuple: tuple, snapshot: makeSnapshot(cdhashRules: ["cdhashvalue": rule]), hashOutcome: .notNeeded
         )
         XCTAssertEqual(decision, .allow)
     }
@@ -122,10 +109,7 @@ final class AuthExecDeciderTests: XCTestCase {
         let rule = makeRule(ruleType: ApplicationControlRuleType.binary, identifier: "shavalue")
         let tuple = AuthTuple(cdhash: nil, signingIDPrefixed: nil, teamID: nil)
         let decision = decideAuthExec(
-            tuple: tuple,
-            snapshot: makeSnapshot(binaryRules: ["shavalue": rule]),
-            hashOutcome: .computed("shavalue"),
-            posture: .failClosed
+            tuple: tuple, snapshot: makeSnapshot(binaryRules: ["shavalue": rule]), hashOutcome: .computed("shavalue")
         )
         XCTAssertEqual(decision, .deny(rule: rule, matchedIdentifier: "shavalue"))
     }
@@ -136,8 +120,7 @@ final class AuthExecDeciderTests: XCTestCase {
         let decision = decideAuthExec(
             tuple: tuple,
             snapshot: makeSnapshot(signingIDRules: ["ABC:org.bad": signRule]),
-            hashOutcome: .computed("nonMatchingSha"),
-            posture: .failClosed
+            hashOutcome: .computed("nonMatchingSha")
         )
         XCTAssertEqual(decision, .deny(rule: signRule, matchedIdentifier: "ABC:org.bad"))
     }
@@ -149,96 +132,98 @@ final class AuthExecDeciderTests: XCTestCase {
         let teamRule = makeRule(ruleType: ApplicationControlRuleType.teamID, identifier: "ABCDEFGHIJ")
         let tuple = AuthTuple(cdhash: nil, signingIDPrefixed: nil, teamID: "ABCDEFGHIJ")
         let decision = decideAuthExec(
-            tuple: tuple,
-            snapshot: makeSnapshot(teamIDRules: ["ABCDEFGHIJ": teamRule]),
-            hashOutcome: .notNeeded,
-            posture: .failClosed
+            tuple: tuple, snapshot: makeSnapshot(teamIDRules: ["ABCDEFGHIJ": teamRule]), hashOutcome: .notNeeded
         )
         XCTAssertEqual(decision, .deny(rule: teamRule, matchedIdentifier: "ABCDEFGHIJ"))
     }
 
     // MARK: - Deadline-exceeded posture matrix
+    //
+    // The posture only applies AFTER the precedence walk continues past an unavailable BINARY
+    // layer (.deadlineExceeded / .readFailed) and SIGNINGID + TEAMID both fail to match. A
+    // definitive lower-precedence DENY beats BINARY uncertainty.
 
-    func testDeadlineExceededFailClosedDeniesWithUndecidedAudit() {
-        let tuple = AuthTuple(cdhash: nil, signingIDPrefixed: "ABC:org.test", teamID: "ABCDEFGHIJ")
-        // SIGNINGID + TEAMID rules exist; under failClosed the deadline-exceeded path is the
-        // verdict and the later layers are NOT consulted. Tests guarantee BINARY uncertainty
-        // dominates any post-BINARY precedence match.
-        let signRule = makeRule(ruleType: ApplicationControlRuleType.signingID, identifier: "ABC:org.test")
-        let teamRule = makeRule(ruleType: ApplicationControlRuleType.teamID, identifier: "ABCDEFGHIJ")
+    func testDeadlineExceededFailClosedNoLowerRuleDeniesWithUndecidedAudit() {
+        let tuple = AuthTuple(cdhash: nil, signingIDPrefixed: nil, teamID: nil)
         let binaryRule = makeRule(ruleType: ApplicationControlRuleType.binary, identifier: "anyShaWeCantSee")
         let snapshot = makeSnapshot(
             deadlineFallback: .failClosed,
-            binaryRules: ["anyShaWeCantSee": binaryRule],
-            signingIDRules: ["ABC:org.test": signRule],
-            teamIDRules: ["ABCDEFGHIJ": teamRule]
+            binaryRules: ["anyShaWeCantSee": binaryRule]
         )
-        let decision = decideAuthExec(
-            tuple: tuple,
-            snapshot: snapshot,
-            hashOutcome: .deadlineExceeded,
-            posture: snapshot.deadlineFallback
-        )
+        let decision = decideAuthExec(tuple: tuple, snapshot: snapshot, hashOutcome: .deadlineExceeded)
         XCTAssertEqual(decision, .denyWithUndecidedAudit(reason: .deadline))
     }
 
-    func testDeadlineExceededFailOpenAllowsSilently() {
-        let tuple = AuthTuple(cdhash: nil, signingIDPrefixed: "ABC:org.test", teamID: "ABCDEFGHIJ")
+    func testDeadlineExceededFailOpenNoLowerRuleAllowsSilently() {
+        let tuple = AuthTuple(cdhash: nil, signingIDPrefixed: nil, teamID: nil)
         let binaryRule = makeRule(ruleType: ApplicationControlRuleType.binary, identifier: "anyShaWeCantSee")
         let snapshot = makeSnapshot(
             deadlineFallback: .failOpen,
             binaryRules: ["anyShaWeCantSee": binaryRule]
         )
-        let decision = decideAuthExec(
-            tuple: tuple,
-            snapshot: snapshot,
-            hashOutcome: .deadlineExceeded,
-            posture: snapshot.deadlineFallback
-        )
+        let decision = decideAuthExec(tuple: tuple, snapshot: snapshot, hashOutcome: .deadlineExceeded)
         XCTAssertEqual(decision, .allow)
     }
 
-    func testDeadlineExceededAuditOnlyAllowsAndEmitsUndecidedAudit() {
+    func testDeadlineExceededAuditOnlyNoLowerRuleAllowsAndEmitsUndecidedAudit() {
         let tuple = AuthTuple(cdhash: nil, signingIDPrefixed: nil, teamID: nil)
         let binaryRule = makeRule(ruleType: ApplicationControlRuleType.binary, identifier: "anyShaWeCantSee")
         let snapshot = makeSnapshot(
             deadlineFallback: .auditOnly,
             binaryRules: ["anyShaWeCantSee": binaryRule]
         )
-        let decision = decideAuthExec(
-            tuple: tuple,
-            snapshot: snapshot,
-            hashOutcome: .deadlineExceeded,
-            posture: snapshot.deadlineFallback
-        )
+        let decision = decideAuthExec(tuple: tuple, snapshot: snapshot, hashOutcome: .deadlineExceeded)
         XCTAssertEqual(decision, .allowWithUndecidedAudit(reason: .deadline))
+    }
+
+    // MARK: - Lower-precedence rules dominate BINARY uncertainty (Gemini critical)
+
+    // Gemini Code Assist flagged the prior behaviour as a security bypass: under fail-open or
+    // audit-only postures, a hash timeout would short-circuit the walk and silently disable any
+    // SIGNINGID / TEAMID block rules. The corrected semantic continues the walk and only applies
+    // the posture when no later layer matches.
+
+    func testDeadlineExceededFailOpenStillEnforcesSigningIDBlock() {
+        let signRule = makeRule(ruleType: ApplicationControlRuleType.signingID, identifier: "ABC:org.bad")
+        let binaryRule = makeRule(ruleType: ApplicationControlRuleType.binary, identifier: "anyShaWeCantSee")
+        let tuple = AuthTuple(cdhash: nil, signingIDPrefixed: "ABC:org.bad", teamID: nil)
+        let snapshot = makeSnapshot(
+            deadlineFallback: .failOpen,
+            binaryRules: ["anyShaWeCantSee": binaryRule],
+            signingIDRules: ["ABC:org.bad": signRule]
+        )
+        let decision = decideAuthExec(tuple: tuple, snapshot: snapshot, hashOutcome: .deadlineExceeded)
+        XCTAssertEqual(decision, .deny(rule: signRule, matchedIdentifier: "ABC:org.bad"))
+    }
+
+    func testReadFailedAuditOnlyStillEnforcesTeamIDBlock() {
+        let teamRule = makeRule(ruleType: ApplicationControlRuleType.teamID, identifier: "ABCDEFGHIJ")
+        let binaryRule = makeRule(ruleType: ApplicationControlRuleType.binary, identifier: "anyShaWeCantSee")
+        let tuple = AuthTuple(cdhash: nil, signingIDPrefixed: nil, teamID: "ABCDEFGHIJ")
+        let snapshot = makeSnapshot(
+            deadlineFallback: .auditOnly,
+            binaryRules: ["anyShaWeCantSee": binaryRule],
+            teamIDRules: ["ABCDEFGHIJ": teamRule]
+        )
+        let decision = decideAuthExec(tuple: tuple, snapshot: snapshot, hashOutcome: .readFailed)
+        XCTAssertEqual(decision, .deny(rule: teamRule, matchedIdentifier: "ABCDEFGHIJ"))
     }
 
     // MARK: - Read-failed posture matrix
 
-    func testReadFailedFailClosedDeniesWithUndecidedAudit() {
+    func testReadFailedFailClosedNoLowerRuleDeniesWithUndecidedAudit() {
         let tuple = AuthTuple(cdhash: nil, signingIDPrefixed: nil, teamID: nil)
         let binaryRule = makeRule(ruleType: ApplicationControlRuleType.binary, identifier: "anyShaWeCantSee")
         let snapshot = makeSnapshot(deadlineFallback: .failClosed, binaryRules: ["anyShaWeCantSee": binaryRule])
-        let decision = decideAuthExec(
-            tuple: tuple,
-            snapshot: snapshot,
-            hashOutcome: .readFailed,
-            posture: snapshot.deadlineFallback
-        )
+        let decision = decideAuthExec(tuple: tuple, snapshot: snapshot, hashOutcome: .readFailed)
         XCTAssertEqual(decision, .denyWithUndecidedAudit(reason: .readFailed))
     }
 
-    func testReadFailedAuditOnlyAllowsAndEmitsUndecidedAudit() {
+    func testReadFailedAuditOnlyNoLowerRuleAllowsAndEmitsUndecidedAudit() {
         let tuple = AuthTuple(cdhash: nil, signingIDPrefixed: nil, teamID: nil)
         let binaryRule = makeRule(ruleType: ApplicationControlRuleType.binary, identifier: "anyShaWeCantSee")
         let snapshot = makeSnapshot(deadlineFallback: .auditOnly, binaryRules: ["anyShaWeCantSee": binaryRule])
-        let decision = decideAuthExec(
-            tuple: tuple,
-            snapshot: snapshot,
-            hashOutcome: .readFailed,
-            posture: snapshot.deadlineFallback
-        )
+        let decision = decideAuthExec(tuple: tuple, snapshot: snapshot, hashOutcome: .readFailed)
         XCTAssertEqual(decision, .allowWithUndecidedAudit(reason: .readFailed))
     }
 
@@ -248,10 +233,7 @@ final class AuthExecDeciderTests: XCTestCase {
         let rule = makeRule(ruleType: ApplicationControlRuleType.signingID, identifier: "ABC:org.bad")
         let tuple = AuthTuple(cdhash: nil, signingIDPrefixed: "ABC:org.bad", teamID: nil)
         let decision = decideAuthExec(
-            tuple: tuple,
-            snapshot: makeSnapshot(signingIDRules: ["ABC:org.bad": rule]),
-            hashOutcome: .notNeeded,
-            posture: .failClosed
+            tuple: tuple, snapshot: makeSnapshot(signingIDRules: ["ABC:org.bad": rule]), hashOutcome: .notNeeded
         )
         XCTAssertEqual(decision, .deny(rule: rule, matchedIdentifier: "ABC:org.bad"))
     }
@@ -260,10 +242,7 @@ final class AuthExecDeciderTests: XCTestCase {
         let rule = makeRule(ruleType: ApplicationControlRuleType.teamID, identifier: "ABCDEFGHIJ")
         let tuple = AuthTuple(cdhash: nil, signingIDPrefixed: nil, teamID: "ABCDEFGHIJ")
         let decision = decideAuthExec(
-            tuple: tuple,
-            snapshot: makeSnapshot(teamIDRules: ["ABCDEFGHIJ": rule]),
-            hashOutcome: .notNeeded,
-            posture: .failClosed
+            tuple: tuple, snapshot: makeSnapshot(teamIDRules: ["ABCDEFGHIJ": rule]), hashOutcome: .notNeeded
         )
         XCTAssertEqual(decision, .deny(rule: rule, matchedIdentifier: "ABCDEFGHIJ"))
     }
@@ -277,8 +256,7 @@ final class AuthExecDeciderTests: XCTestCase {
         let decision = decideAuthExec(
             tuple: tuple,
             snapshot: makeSnapshot(cdhashRules: ["cdhashfirst": cdRule], signingIDRules: ["ABC:org.bad": signRule]),
-            hashOutcome: .notNeeded,
-            posture: .failClosed
+            hashOutcome: .notNeeded
         )
         XCTAssertEqual(decision, .deny(rule: cdRule, matchedIdentifier: "cdhashfirst"))
     }

--- a/extension/edr/Tests/EDRExtensionLogicTests/FileHashCacheTests.swift
+++ b/extension/edr/Tests/EDRExtensionLogicTests/FileHashCacheTests.swift
@@ -152,4 +152,101 @@ final class FileHashCacheTests: XCTestCase {
         FileHashCache.shared.startLazyFill(path: file.path, stat: file.stat)
         XCTAssertEqual(FileHashCache.shared.lookup(stat: file.stat), expected)
     }
+
+    // MARK: - lookupOrComputeWithDeadline (issue #208)
+
+    /// generousDeadlineMachAbs returns a mach absolute time several seconds in the future. Used by tests that want the
+    /// sync compute path to run to completion against a normal-sized payload. mach_absolute_time + (seconds in ns) /
+    /// (timebase numer/denom). Hardcoding the timebase ratio is fragile; we read it via mach_timebase_info to stay
+    /// portable across hardware (the ratio is 1/1 on Apple Silicon but is different on Intel).
+    private func generousDeadlineMachAbs(seconds: Double = 5) -> UInt64 {
+        var info = mach_timebase_info_data_t()
+        mach_timebase_info(&info)
+        let nowMachAbs = mach_absolute_time()
+        let offsetNs = UInt64(seconds * 1_000_000_000)
+        let offsetMachAbs = offsetNs * UInt64(info.denom) / UInt64(info.numer)
+        return nowMachAbs &+ offsetMachAbs
+    }
+
+    func testLookupOrComputeWithDeadlineReturnsComputedOnFirstCall() throws {
+        let payload = Data("auth-exec-sync-hash".utf8)
+        let file = try makeTempFile(bytes: payload)
+        let expected = expectedSHA256(of: payload)
+
+        let outcome = FileHashCache.shared.lookupOrComputeWithDeadline(
+            path: file.path,
+            stat: file.stat,
+            deadlineMachAbs: generousDeadlineMachAbs()
+        )
+        XCTAssertEqual(outcome, .computed(expected))
+        // Cache populated for the warm-case path.
+        XCTAssertEqual(FileHashCache.shared.lookup(stat: file.stat), expected)
+    }
+
+    func testLookupOrComputeWithDeadlineReturnsCachedValueOnWarmHit() throws {
+        // Pre-seed the cache via the no-deadline path, then call the deadline variant with a deadline that has already
+        // expired. The cache hit must return .computed without doing any I/O; the deadlineExceeded branch must NOT fire
+        // because the hash was already available before the budget was consulted.
+        let payload = Data("warm-cache-hit".utf8)
+        let file = try makeTempFile(bytes: payload)
+        let expected = expectedSHA256(of: payload)
+        XCTAssertEqual(FileHashCache.shared.lookupOrCompute(path: file.path, stat: file.stat), expected)
+
+        let outcome = FileHashCache.shared.lookupOrComputeWithDeadline(
+            path: file.path,
+            stat: file.stat,
+            deadlineMachAbs: 0
+        )
+        XCTAssertEqual(outcome, .computed(expected))
+    }
+
+    func testLookupOrComputeWithDeadlineReturnsDeadlineExceededOnZeroBudget() throws {
+        // Cold cache + deadline already passed: the first deadline check between chunks fires immediately and the
+        // helper returns .deadlineExceeded. The cache must stay empty so the next AUTH_EXEC retries the compute rather
+        // than being served a partial / wrong hash.
+        let payload = Data(repeating: 0x55, count: 128 * 1024) // >chunk size so the loop iterates at least twice
+        let file = try makeTempFile(bytes: payload)
+
+        let outcome = FileHashCache.shared.lookupOrComputeWithDeadline(
+            path: file.path,
+            stat: file.stat,
+            deadlineMachAbs: 0
+        )
+        XCTAssertEqual(outcome, .deadlineExceeded)
+        XCTAssertNil(FileHashCache.shared.lookup(stat: file.stat))
+    }
+
+    func testLookupOrComputeWithDeadlineReturnsReadFailedOnMissingFile() {
+        // No file at this path -- the open-for-reading FileHandle path errors and we return .readFailed (distinct
+        // from .deadlineExceeded so the audit event carries the right `reason` tag).
+        var fakeStat = stat()
+        fakeStat.st_dev = 1
+        fakeStat.st_ino = 999_998
+        fakeStat.st_mtimespec.tv_sec = 0
+        fakeStat.st_mtimespec.tv_nsec = 0
+        let path = "/tmp/edr-fileHashCacheTests-deadline-missing-\(UUID().uuidString)"
+
+        let outcome = FileHashCache.shared.lookupOrComputeWithDeadline(
+            path: path,
+            stat: fakeStat,
+            deadlineMachAbs: generousDeadlineMachAbs()
+        )
+        XCTAssertEqual(outcome, .readFailed)
+    }
+
+    func testLookupOrComputeWithDeadlineReturnsReadFailedOnInodeMismatch() throws {
+        // Same TOCTOU guard as lookupOrCompute: if the opened FD's (dev, inode, mtime) differs from the expected
+        // tuple, abort with .readFailed (treated as "hash unavailable, defer to posture") and leave the cache empty.
+        let file = try makeTempFile(bytes: Data("real-content".utf8))
+        var bogus = file.stat
+        bogus.st_ino = file.stat.st_ino &+ 7777
+
+        let outcome = FileHashCache.shared.lookupOrComputeWithDeadline(
+            path: file.path,
+            stat: bogus,
+            deadlineMachAbs: generousDeadlineMachAbs()
+        )
+        XCTAssertEqual(outcome, .readFailed)
+        XCTAssertNil(FileHashCache.shared.lookup(stat: bogus))
+    }
 }

--- a/extension/edr/extension/ApplicationControlStore.swift
+++ b/extension/edr/extension/ApplicationControlStore.swift
@@ -6,11 +6,20 @@ private let logger = Logger(subsystem: "com.fleetdm.edr.securityextension", cate
 // ApplicationControlSnapshot is the typed in-memory shape the AUTH_EXEC decision
 // engine (Step 3) consults on every exec. Rules are indexed by (rule_type,
 // identifier) so the precedence walk is O(1) per type. Phase 1 of the demo cut
-// only populates the BINARY map; the others are reserved for the follow-on
-// types (CDHASH, SIGNINGID, CERTIFICATE, TEAMID, PATH) coming later.
+// only populated the BINARY map; the v0.1.0 close-out wires all five (CDHASH,
+// BINARY, SIGNINGID, TEAMID, plus the deferred CERTIFICATE/PATH carriers).
+//
+// deadlineFallback governs the verdict the AUTH_EXEC handler applies when sync
+// SHA-256 hashing for a BINARY rule consultation cannot complete within the
+// kernel deadline budget. Per-snapshot because each policy carries its own
+// posture on the wire (server/rules/api.SetApplicationControlPayload). Defaults
+// to FallbackPosture.defaultPosture (failClosed) when the payload omits the
+// field so older fan-out callers that haven't been recompiled against the new
+// shape still produce a safe-by-default behaviour.
 struct ApplicationControlSnapshot {
     let policyID: Int64
     let policyVersion: Int64
+    let deadlineFallback: FallbackPosture
     let binaryRules: [String: ApplicationControlRule]      // identifier (file SHA-256) -> rule
     let cdhashRules: [String: ApplicationControlRule]      // 40 hex
     let signingIDRules: [String: ApplicationControlRule]   // "<TeamID>:<bundle.id>" or "platform:<bundle.id>"
@@ -21,6 +30,7 @@ struct ApplicationControlSnapshot {
     static let empty = ApplicationControlSnapshot(
         policyID: 0,
         policyVersion: 0,
+        deadlineFallback: .defaultPosture,
         binaryRules: [:],
         cdhashRules: [:],
         signingIDRules: [:],
@@ -40,7 +50,7 @@ struct ApplicationControlSnapshot {
 /// ruleID is the stable string identifier (e.g. "app_control:42") the
 /// AUTH_EXEC handler echoes back in the `application_control_block` event
 /// so the server's alert mapping lands the alert under the same rule_id.
-struct ApplicationControlRule: Codable {
+struct ApplicationControlRule: Codable, Equatable {
     let ruleID: String
     let ruleType: String
     let identifier: String
@@ -64,14 +74,20 @@ struct ApplicationControlRule: Codable {
 
 /// ApplicationControlDocument is the on-the-wire shape of the snapshot.
 /// Identical to server/rules/api.SetApplicationControlPayload.
+///
+/// deadlineFallback is Optional because the field was added in v0.1.0; older
+/// agents and any captured pre-v0.1.0 payload on disk will not carry it. The
+/// makeSnapshot helper substitutes FallbackPosture.defaultPosture when nil.
 struct ApplicationControlDocument: Codable {
     let policyID: Int64
     let policyVersion: Int64
+    let deadlineFallback: FallbackPosture?
     let rules: [ApplicationControlRule]
 
     enum CodingKeys: String, CodingKey {
         case policyID = "policy_id"
         case policyVersion = "policy_version"
+        case deadlineFallback = "deadline_fallback"
         case rules
     }
 }
@@ -255,6 +271,7 @@ final class ApplicationControlStore {
         return ApplicationControlSnapshot(
             policyID: document.policyID,
             policyVersion: document.policyVersion,
+            deadlineFallback: document.deadlineFallback ?? .defaultPosture,
             binaryRules: binary,
             cdhashRules: cdhash,
             signingIDRules: signingID,

--- a/extension/edr/extension/AuthExecDecider.swift
+++ b/extension/edr/extension/AuthExecDecider.swift
@@ -1,0 +1,151 @@
+import Foundation
+import os
+
+private let logger = Logger(subsystem: "com.fleetdm.edr.securityextension", category: "AuthExecDecider")
+
+/// FallbackPosture is the operator-selectable verdict when sync hashing for a BINARY rule consultation cannot complete within the
+/// AUTH_EXEC kernel deadline budget. The three options trade enforcement strictness against exec-startup latency:
+///   - failClosed: DENY the exec. The high-assurance posture; a binary the EDR cannot identify in time does not run. Default for
+///     new pilots because it is the only posture that closes the cold-cache first-exec window without operator awareness of the
+///     trade-off. Emits an application_control_undecided event with verdict=deny so the operator can audit how often the
+///     fallback fires.
+///   - failOpen: ALLOW the exec. The demo-equivalent posture; the cold-cache window stays open. Operators who pick this are
+///     prioritising "no unexpected blocks" over "no first-exec bypass." No audit event (the operator opted out of visibility).
+///   - auditOnly: ALLOW the exec and emit application_control_undecided with verdict=allow so the operator can count how often
+///     the deadline window misses without changing exec behaviour. The right posture for an operator tuning their fleet's
+///     fallback before flipping to failClosed.
+/// Stable across the wire; renaming any case is a contract break with server/rules/api.FallbackPosture.
+enum FallbackPosture: String, Codable, Sendable {
+    case failClosed = "fail-closed"
+    case failOpen = "fail-open"
+    case auditOnly = "audit-only"
+
+    /// defaultPosture is the value applied when the snapshot payload omits the deadline_fallback field. failClosed because v0.1.0
+    /// is the first real release (not a demo), and a binary the EDR cannot identify within the kernel deadline window is, by
+    /// construction, an unknown. An unknown should not run on a fleet whose operator has chosen to enable Application Control.
+    static let defaultPosture: FallbackPosture = .failClosed
+}
+
+/// HashOutcome carries the result of the AUTH_EXEC sync SHA-256 attempt to the decision walker. The decider does NOT compute the
+/// hash itself: FileHashCache.computeSHA256WithDeadline lives on the wire side because it touches Darwin (mach_absolute_time) and
+/// the on-disk handle. The decider is pure -- it consumes the outcome and returns a decision.
+enum HashOutcome: Equatable, Sendable {
+    /// Hex SHA-256 is available (cache hit, or sync compute completed within budget). Drives the BINARY map lookup.
+    case computed(String)
+    /// Sync compute could not complete within the deadline budget (large binary, slow disk). Decider applies the posture.
+    case deadlineExceeded
+    /// File could not be opened, fstat failed, or the TOCTOU re-check found a different (dev,inode,mtime) tuple between AUTH
+    /// and read. Distinct from deadlineExceeded so audit events carry the right reason; the decider treats both as unavailable.
+    case readFailed
+    /// Skipped entirely because the active snapshot has no BINARY rules. Avoids charging the AUTH callback for a hash compute
+    /// whose result no rule would consult. Walked past without applying the fallback posture.
+    case notNeeded
+}
+
+/// UndecidedReason is the operator-facing tag carried on application_control_undecided events. Stable across the wire so
+/// dashboards can group on the value. Subset of HashOutcome's unavailable cases (notNeeded never produces an undecided event,
+/// computed always carries a real decision).
+enum UndecidedReason: String, Sendable {
+    case deadline
+    case readFailed = "read_failed"
+}
+
+/// AuthTuple captures the identifier values the decision walker compares against the snapshot's per-type maps. Each field is
+/// optional: absent values mean "the target has no value of this kind", and the precedence walker skips that map. CERTIFICATE
+/// and PATH stay deferred to Phase B and are not present here. Sendable so callers can build the tuple on the AUTH callback
+/// thread and hand it to a future async pipeline without bridging tricks.
+struct AuthTuple: Equatable, Sendable {
+    /// 40-char lowercase hex CDHash, only when the target runs under Apple's Hardened Runtime (CS_RUNTIME); see the comment on
+    /// isHardenedRuntime in ESFSubscriber.swift for the lazy-page-mapping rationale.
+    let cdhash: String?
+    /// "<TeamID>:<bundle.id>" for third-party signed binaries, "platform:<bundle.id>" for kernel-classified Apple platform
+    /// binaries. nil when ESF reports neither a usable team_id (real or fallback) nor a platform classification.
+    let signingIDPrefixed: String?
+    /// 10-char Apple Developer Team ID. nil when ESF redacts team_id (ad-hoc-signed extension on edr-dev) and
+    /// SigningInfoFallback also cannot recover a real value.
+    let teamID: String?
+}
+
+/// AuthDecision is the discrete verdict the wire side dispatches on. Cases enumerate every action handleAuthExec can take short
+/// of the kernel-cached platform-binary carve-out and the unconditional self-allow failsafe (both short-circuit before the
+/// decider runs).
+enum AuthDecision: Equatable, Sendable {
+    /// Allow the exec; do NOT pin the result into the kernel AUTH cache. Used when no rule matched and the hash either was not
+    /// needed (no BINARY rules) or returned a clean miss against the BINARY map. Uncached because a later rule update could
+    /// turn this exec into a block on the next run; a kernel-cached ALLOW would skip our handler entirely.
+    case allow
+    /// Allow the exec and emit an application_control_undecided event with verdict=allow and the given reason. Fires only
+    /// under auditOnly posture when the hash is unavailable.
+    case allowWithUndecidedAudit(reason: UndecidedReason)
+    /// Deny the exec; emit application_control_block + block notification with the matched rule + identifier.
+    case deny(rule: ApplicationControlRule, matchedIdentifier: String)
+    /// Deny the exec and emit application_control_undecided with verdict=deny. Fires only under failClosed posture when the
+    /// hash is unavailable. Separate from .deny because there is no actual matched rule, only the posture's verdict.
+    case denyWithUndecidedAudit(reason: UndecidedReason)
+}
+
+/// decideAuthExec walks the precedence ladder against the active snapshot and returns the wire-level decision. Pure: no
+/// EndpointSecurity imports, no Darwin time calls, no logging side effects on the hot path. Drives the SwiftPM-test surface
+/// because ESFSubscriber.swift is excluded from the test target by Package.swift.
+///
+/// Precedence: CDHASH > BINARY > SIGNINGID > TEAMID. CERTIFICATE + PATH stay deferred to Phase B and are not consulted here.
+/// Each layer returns on first match. The BINARY layer is gated on hashOutcome: if .computed, walk the BINARY map; if
+/// .deadlineExceeded or .readFailed, terminate the walk with the posture's verdict (BINARY's "could-have-fired" uncertainty
+/// dominates anything SIGNINGID/TEAMID would say, so continuing past it would mis-rank the precedence). If .notNeeded, skip
+/// BINARY entirely and continue the walk normally.
+func decideAuthExec(
+    tuple: AuthTuple,
+    snapshot: ApplicationControlSnapshot,
+    hashOutcome: HashOutcome,
+    posture: FallbackPosture
+) -> AuthDecision {
+    if let cdhash = tuple.cdhash, let rule = snapshot.cdhashRules[cdhash] {
+        return verdict(for: rule, identifier: cdhash)
+    }
+
+    switch hashOutcome {
+    case .computed(let sha):
+        if let rule = snapshot.binaryRules[sha] {
+            return verdict(for: rule, identifier: sha)
+        }
+    case .deadlineExceeded:
+        return applyPosture(posture, reason: .deadline)
+    case .readFailed:
+        return applyPosture(posture, reason: .readFailed)
+    case .notNeeded:
+        break
+    }
+
+    if let signingID = tuple.signingIDPrefixed, let rule = snapshot.signingIDRules[signingID] {
+        return verdict(for: rule, identifier: signingID)
+    }
+    if let teamID = tuple.teamID, let rule = snapshot.teamIDRules[teamID] {
+        return verdict(for: rule, identifier: teamID)
+    }
+    return .allow
+}
+
+/// verdict maps a matched rule to the wire-level decision. Non-PROTECT enforcements (DETECT) and non-BLOCK actions (ALLOW,
+/// SILENT_BLOCK) are no-ops in v0.1.0: the precedence walker treats them as "matched but does not deny." DETECT semantics
+/// arrive in the follow-on add-application-control-detect-mode change, which extends this helper to emit a detection event
+/// alongside the ALLOW.
+private func verdict(for rule: ApplicationControlRule, identifier: String) -> AuthDecision {
+    if rule.action == ApplicationControlAction.block && rule.enforcement == ApplicationControlEnforcement.protect {
+        return .deny(rule: rule, matchedIdentifier: identifier)
+    }
+    return .allow
+}
+
+/// applyPosture is the BINARY-layer fallback when the hash could not be obtained. The three postures encode the operator's
+/// choice between enforcement strictness, exec-startup latency, and operational visibility; see FallbackPosture's doc comment
+/// for the rationale behind each.
+private func applyPosture(_ posture: FallbackPosture, reason: UndecidedReason) -> AuthDecision {
+    switch posture {
+    case .failClosed:
+        return .denyWithUndecidedAudit(reason: reason)
+    case .failOpen:
+        return .allow
+    case .auditOnly:
+        return .allowWithUndecidedAudit(reason: reason)
+    }
+}

--- a/extension/edr/extension/AuthExecDecider.swift
+++ b/extension/edr/extension/AuthExecDecider.swift
@@ -1,4 +1,3 @@
-import Foundation
 import os
 
 private let logger = Logger(subsystem: "com.fleetdm.edr.securityextension", category: "AuthExecDecider")
@@ -90,28 +89,34 @@ enum AuthDecision: Equatable, Sendable {
 ///
 /// Precedence: CDHASH > BINARY > SIGNINGID > TEAMID. CERTIFICATE + PATH stay deferred to Phase B and are not consulted here.
 /// Each layer returns on first match. The BINARY layer is gated on hashOutcome: if .computed, walk the BINARY map; if
-/// .deadlineExceeded or .readFailed, terminate the walk with the posture's verdict (BINARY's "could-have-fired" uncertainty
-/// dominates anything SIGNINGID/TEAMID would say, so continuing past it would mis-rank the precedence). If .notNeeded, skip
-/// BINARY entirely and continue the walk normally.
+/// .deadlineExceeded or .readFailed the walk CONTINUES to SIGNINGID/TEAMID first -- a definitive lower-precedence DENY
+/// dominates the BINARY layer's "could-have-fired" uncertainty (the operator's snapshot tells us the binary identifies as
+/// signing-id X / team Y; a block rule on X or Y is a real verdict the kernel can act on). Only after SIGNINGID/TEAMID
+/// produce no match does the snapshot's deadlineFallback posture apply to the unresolved BINARY decision. .notNeeded skips
+/// BINARY entirely and continues normally (snapshot has no BINARY rules so the fallback posture has nothing to govern).
+///
+/// Posture flows from snapshot.deadlineFallback directly -- this function does not take a separate posture parameter, so a
+/// caller cannot accidentally evaluate one snapshot's rule maps under a different fallback. (Previous signatures took the
+/// parameter explicitly; the round-trip through snapshot already pins the posture, so the parameter was a footgun.)
 func decideAuthExec(
     tuple: AuthTuple,
     snapshot: ApplicationControlSnapshot,
-    hashOutcome: HashOutcome,
-    posture: FallbackPosture
+    hashOutcome: HashOutcome
 ) -> AuthDecision {
     if let cdhash = tuple.cdhash, let rule = snapshot.cdhashRules[cdhash] {
         return verdict(for: rule, identifier: cdhash)
     }
 
+    var unresolvedBinaryReason: UndecidedReason?
     switch hashOutcome {
     case .computed(let sha):
         if let rule = snapshot.binaryRules[sha] {
             return verdict(for: rule, identifier: sha)
         }
     case .deadlineExceeded:
-        return applyPosture(posture, reason: .deadline)
+        unresolvedBinaryReason = .deadline
     case .readFailed:
-        return applyPosture(posture, reason: .readFailed)
+        unresolvedBinaryReason = .readFailed
     case .notNeeded:
         break
     }
@@ -121,6 +126,10 @@ func decideAuthExec(
     }
     if let teamID = tuple.teamID, let rule = snapshot.teamIDRules[teamID] {
         return verdict(for: rule, identifier: teamID)
+    }
+
+    if let reason = unresolvedBinaryReason {
+        return applyPosture(snapshot.deadlineFallback, reason: reason)
     }
     return .allow
 }

--- a/extension/edr/extension/ESFSubscriber.swift
+++ b/extension/edr/extension/ESFSubscriber.swift
@@ -101,20 +101,31 @@ final class ESFSubscriber: Sendable {
     ///
     /// Walks four rule types in fixed precedence: CDHASH → BINARY → SIGNINGID → TEAMID.
     /// CERTIFICATE and PATH stay deferred to Phase B (leaf-cert cache / Launch Services
-    /// indirection). Returns on the first match. Decisions:
-    ///   - Failsafe — if the exec target's `team_id` is our own, ALLOW unconditionally.
-    ///     Prevents a misconfigured rule from blocking the agent / extension / host app.
+    /// indirection). Returns on the first match. Decisions, in order:
+    ///   - Platform-binary carve-out: if the kernel sets target.is_platform_binary, ALLOW
+    ///     with cache:true. Prevents an admin who writes the SHA-256 of /sbin/launchd
+    ///     (or xpcproxy, fseventsd, kextd, sysextd, etc.) as a BINARY block rule from
+    ///     bricking the host. The kernel's own "this is on the Apple-signed system image"
+    ///     flag is the floor; the answer is intrinsic to the binary's identity so it is
+    ///     safe to cache for the file's (dev, inode, mtime) lifetime.
+    ///   - Self-allow failsafe: if team_id matches our extensionTeamID AND signing_id is
+    ///     on the Fleet bundle-id allowlist, ALLOW. Protects the agent / extensions /
+    ///     host app from a misconfigured rule. Uncached so future rules can target Fleet
+    ///     binaries for telemetry (e.g. DETECT) without a kernel cache stale-read.
     ///     Phase B replaces this with a server-pushed failsafe list.
-    ///   - First matching rule with `action=BLOCK` and `enforcement=PROTECT` → DENY.
-    ///   - First matching rule with any other enforcement → ALLOW (DETECT semantics arrive
-    ///     in the follow-on add-application-control-detect-mode change).
+    ///   - Precedence walk (CDHASH → BINARY → SIGNINGID → TEAMID): first matching rule
+    ///     with `action=BLOCK` and `enforcement=PROTECT` → DENY. Any other enforcement
+    ///     ALLOWs (DETECT semantics arrive in the follow-on detect-mode change). The
+    ///     BINARY layer needs the file's SHA-256; that hash is computed synchronously on
+    ///     the AUTH callback thread under a budget bounded by msg.deadline (closing the
+    ///     #208 first-exec cold-cache bypass). If the hash cannot complete in time the
+    ///     snapshot's deadlineFallback posture (fail-closed / fail-open / audit-only)
+    ///     drives the verdict and an application_control_undecided event lets operators
+    ///     audit the cold-cache rate.
     ///   - No match → ALLOW.
     ///
-    /// The walk is at most four constant-time map lookups. The file SHA-256 needed for the
-    /// BINARY map is fetched from the (inode, mtime) cache; a cold cache makes BINARY
-    /// silently miss for this exec (the cache fills off the callback so the next exec
-    /// catches). The leaf-cert SHA-256 needed for CERTIFICATE rules is NOT fetched here;
-    /// CERTIFICATE matching is gated to Phase B.
+    /// The leaf-cert SHA-256 needed for CERTIFICATE rules is NOT fetched here; CERTIFICATE
+    /// matching is gated to Phase B.
     private func handleAuthExec(_ message: UnsafePointer<es_message_t>) {
         let msg = message.pointee
         let target = msg.event.exec.target.pointee
@@ -122,6 +133,17 @@ final class ESFSubscriber: Sendable {
         let teamID = esTokenString(target.team_id)
         let signingID = esTokenString(target.signing_id)
         let fileStat = target.executable.pointee.stat
+
+        // Platform-binary carve-out: anything the kernel classifies as part of the Apple-signed system image (launchd, xpcproxy,
+        // fseventsd, kextd, sysextd, systemextensionsd, WindowServer, loginwindow, mds, ...) is ALLOWed unconditionally and the
+        // result is pinned into the kernel's per-(dev,inode,mtime) AUTH cache. This is the floor against an admin who pastes the
+        // SHA-256 of /sbin/launchd into a BINARY block rule and bricks the host on next boot. The kernel's own is_platform_binary
+        // flag is more conservative than a hand-curated path or signing-id allowlist would be, and the answer is intrinsic to the
+        // binary's identity, so caching the ALLOW is safe (mtime mutation forces a fresh decision).
+        if target.is_platform_binary {
+            es_respond_auth_result(client, message, ES_AUTH_RESULT_ALLOW, true)
+            return
+        }
 
         // Self-allow failsafe: exempt the agent + extensions + host app from app-control enforcement so a misconfigured rule cannot
         // brick the EDR itself. Match BOTH team_id and the exhaustive Fleet bundle-id set; team_id alone would exempt every binary
@@ -132,63 +154,74 @@ final class ESFSubscriber: Sendable {
         }
 
         let snapshot = ApplicationControlStore.shared.currentSnapshot()
-        let tuple = buildAuthTuple(target: target, fileStat: fileStat, lazyFillPath: path)
-        // Sonar S1066: optional binding + condition co-located in one if so the deny branch is one block. Keep `denyPath` redacted in
-        // the log (no `privacy: .public`) so PII embedded in exec paths — usernames, project tokens — doesn't leak to os.log readers;
-        // the full path still flows on the block event payload for the server-side alert.
-        if let match = walkPrecedence(tuple: tuple, snapshot: snapshot),
-           match.rule.action == ApplicationControlAction.block,
-           match.rule.enforcement == ApplicationControlEnforcement.protect {
-            let denyRuleType = match.rule.ruleType
-            let denyID = match.matchedIdentifier
+        let tuple = buildAuthTuple(target: target, fileStat: fileStat, path: path)
+
+        // Only pay the sync-hash cost when the snapshot actually has BINARY rules to consult. The cheap CDHASH/SIGNINGID/TEAMID
+        // layers run unconditionally; the hash compute alone is the latency outlier (tens of ms on multi-MB binaries) and is
+        // wasted work when no BINARY rule could fire.
+        let hashOutcome: HashOutcome
+        if snapshot.binaryRules.isEmpty {
+            hashOutcome = .notNeeded
+        } else {
+            hashOutcome = FileHashCache.shared.lookupOrComputeWithDeadline(
+                path: path,
+                stat: fileStat,
+                deadlineMachAbs: msg.deadline
+            )
+        }
+
+        let decision = decideAuthExec(
+            tuple: tuple,
+            snapshot: snapshot,
+            hashOutcome: hashOutcome,
+            posture: snapshot.deadlineFallback
+        )
+        dispatchAuthDecision(decision, message: message, target: target, fileStat: fileStat, snapshot: snapshot, path: path)
+    }
+
+    /// dispatchAuthDecision turns the pure-logic AuthDecision into the wire-level kernel response plus any event/notification
+    /// emissions the decision implies. Extracted from handleAuthExec so the decision logic stays testable (AuthExecDeciderTests)
+    /// and the wire dispatch stays one switch. The `path` value is the redacted (privacy: redacted) log identifier; the full path
+    /// flows on the block event payload for the server-side alert.
+    private func dispatchAuthDecision(
+        _ decision: AuthDecision,
+        message: UnsafePointer<es_message_t>,
+        target: es_process_t,
+        fileStat: stat,
+        snapshot: ApplicationControlSnapshot,
+        path: String
+    ) {
+        switch decision {
+        case .allow:
+            es_respond_auth_result(client, message, ES_AUTH_RESULT_ALLOW, false)
+        case .allowWithUndecidedAudit(let reason):
+            logger.warning("AUTH_EXEC ALLOW (undecided) path=\(path) reason=\(reason.rawValue, privacy: .public)")
+            es_respond_auth_result(client, message, ES_AUTH_RESULT_ALLOW, false)
+            emitUndecidedEvent(target: target, fileStat: fileStat, verdict: "allow", reason: reason, snapshot: snapshot)
+        case .deny(let rule, let matchedIdentifier):
+            let denyRuleType = rule.ruleType
+            let denyID = matchedIdentifier
             logger.warning(
                 "AUTH_EXEC DENIED path=\(path) type=\(denyRuleType, privacy: .public) id=\(denyID, privacy: .public)"
             )
             es_respond_auth_result(client, message, ES_AUTH_RESULT_DENY, false)
-            emitBlockEvent(target: target, rule: match.rule, matchedIdentifier: match.matchedIdentifier, snapshot: snapshot)
-            emitBlockNotification(target: target, rule: match.rule, matchedIdentifier: match.matchedIdentifier, snapshot: snapshot)
-            return
+            emitBlockEvent(target: target, rule: rule, matchedIdentifier: matchedIdentifier, snapshot: snapshot)
+            emitBlockNotification(target: target, rule: rule, matchedIdentifier: matchedIdentifier, snapshot: snapshot)
+        case .denyWithUndecidedAudit(let reason):
+            logger.warning("AUTH_EXEC DENIED (undecided) path=\(path) reason=\(reason.rawValue, privacy: .public)")
+            es_respond_auth_result(client, message, ES_AUTH_RESULT_DENY, false)
+            emitUndecidedEvent(target: target, fileStat: fileStat, verdict: "deny", reason: reason, snapshot: snapshot)
         }
-        es_respond_auth_result(client, message, ES_AUTH_RESULT_ALLOW, false)
     }
 
-    /// AuthTuple captures the identifier values the decision walker compares against the
-    /// snapshot's per-type maps. Each field is optional: absent values mean "the target
-    /// has no value of this kind", and the precedence walker skips that map. Phase A
-    /// close-out wires CDHASH, BINARY, SIGNINGID, and TEAMID; CERTIFICATE + PATH stay
-    /// deferred and are absent here.
-    struct AuthTuple {
-        let cdhash: String?         // 40-char lowercase hex, only when target is hardened-runtime
-        let fileSHA256: String?     // 64-char lowercase hex, only when the FileHashCache is warm
-        let signingIDPrefixed: String? // "<TeamID>:<bundle.id>" or "platform:<bundle.id>"
-        let teamID: String?         // 10-char Apple Developer Team ID
-    }
-
-    /// PrecedenceMatch carries the rule that fired plus the actual identifier value from
-    /// the target that hit. The `matched_identifier` flows into the block event so the
-    /// alert pipeline can show "blocked by CDHASH rule matching <40 hex>" rather than just
-    /// the rule's own identifier (which is usually the same value but not always — a
-    /// TEAMID rule matches every binary signed by that team, so matched_identifier is the
-    /// rule's TeamID and the rule's own identifier are the same; for a CDHASH rule the two
-    /// are also the same; the distinction matters more for future PATH rules where the
-    /// rule's identifier is a glob and the matched value is the resolved path).
-    struct PrecedenceMatch {
-        let rule: ApplicationControlRule
-        let matchedIdentifier: String
-    }
-
-    /// buildAuthTuple reduces a Mach-O exec target to the four identifier values the
-    /// precedence walker reads. Side effect: when the file SHA-256 cache misses, kicks
-    /// the async lazy fill so the next exec of the same (inode, mtime) hits.
-    private func buildAuthTuple(target: es_process_t, fileStat: stat, lazyFillPath: String) -> AuthTuple {
+    /// buildAuthTuple reduces a Mach-O exec target to the three pure-identifier values the decider reads. The fourth identifier
+    /// (BINARY SHA-256) is supplied via HashOutcome at decide time so the hash compute can run on the AUTH callback thread
+    /// under a deadline budget; that responsibility lives in handleAuthExec, not here. The `path` argument is the resolved
+    /// executable path used for the SigningInfoFallback lookup when ESF redacts team_id on ad-hoc-signed extension hosts.
+    private func buildAuthTuple(target: es_process_t, fileStat: stat, path: String) -> AuthTuple {
         let esTeamID = esTokenString(target.team_id)
         let signingID = esTokenString(target.signing_id)
 
-        // CDHASH is a 20-byte raw array on es_process_t. Gate on Apple's Hardened Runtime
-        // (CS_RUNTIME = 0x00010000): per Santa's rationale, CDHash on non-hardened
-        // processes is not a reliable integrity check because pages are mapped lazily and
-        // the kernel does not re-verify post-load. CDHASH rules that nominally target a
-        // non-hardened binary silently no-op for this exec.
         let cdhash: String? = isHardenedRuntime(flags: target.codesigning_flags) ? cdhashHexString(from: target.cdhash) : nil
 
         // Resolve the canonical TeamID. For Developer-ID-signed targets on notarized release hosts ESF
@@ -208,7 +241,7 @@ final class ESFSubscriber: Sendable {
         if !esTeamID.isEmpty {
             teamID = esTeamID
         } else {
-            teamID = SigningInfoFallback.shared.teamID(forPath: lazyFillPath, fileStat: fileStat) ?? ""
+            teamID = SigningInfoFallback.shared.teamID(forPath: path, fileStat: fileStat) ?? ""
         }
 
         // SIGNINGID is prefixed: "<TeamID>:<bundle.id>" for third-party signed binaries,
@@ -230,40 +263,11 @@ final class ESFSubscriber: Sendable {
             signingIDPrefixed = nil
         }
 
-        let fileSHA256 = FileHashCache.shared.lookup(stat: fileStat)
-        if fileSHA256 == nil {
-            FileHashCache.shared.startLazyFill(path: lazyFillPath, stat: fileStat)
-        }
-
         return AuthTuple(
             cdhash: cdhash,
-            fileSHA256: fileSHA256,
             signingIDPrefixed: signingIDPrefixed,
             teamID: teamID.isEmpty ? nil : teamID
         )
-    }
-
-    /// walkPrecedence walks the snapshot's per-type maps in the fixed order CDHASH →
-    /// BINARY → SIGNINGID → TEAMID, returning on the first match. CERTIFICATE + PATH
-    /// stay deferred and are not consulted here even though their snapshot maps are
-    /// populated by ApplicationControlStore — Phase B activates them alongside the
-    /// leaf-cert cache and Launch Services edge cases. Private because it has no
-    /// caller outside handleAuthExec and a wider visibility would surface this
-    /// walker to anything that holds a snapshot reference.
-    private func walkPrecedence(tuple: AuthTuple, snapshot: ApplicationControlSnapshot) -> PrecedenceMatch? {
-        if let cdhash = tuple.cdhash, let rule = snapshot.cdhashRules[cdhash] {
-            return PrecedenceMatch(rule: rule, matchedIdentifier: cdhash)
-        }
-        if let sha = tuple.fileSHA256, let rule = snapshot.binaryRules[sha] {
-            return PrecedenceMatch(rule: rule, matchedIdentifier: sha)
-        }
-        if let signingID = tuple.signingIDPrefixed, let rule = snapshot.signingIDRules[signingID] {
-            return PrecedenceMatch(rule: rule, matchedIdentifier: signingID)
-        }
-        if let teamID = tuple.teamID, let rule = snapshot.teamIDRules[teamID] {
-            return PrecedenceMatch(rule: rule, matchedIdentifier: teamID)
-        }
-        return nil
     }
 
     /// emitBlockEvent serializes an application_control_block event for the
@@ -292,6 +296,33 @@ final class ESFSubscriber: Sendable {
             policyVersion: snapshot.policyVersion
         )
         if let data = serializer.serialize(eventType: "application_control_block", payload: payload) {
+            onEvent?(data)
+        }
+    }
+
+    /// emitUndecidedEvent serializes an application_control_undecided event for an AUTH_EXEC whose BINARY hash could not be
+    /// resolved within the kernel deadline budget (or the file was unreadable). Called after the kernel respond so the post-
+    /// respond cost does not eat into the deadline. The verdict argument carries "allow" (audit-only posture) or "deny"
+    /// (fail-closed posture); fail-open does NOT call this helper (no event by design, see FallbackPosture.failOpen).
+    private func emitUndecidedEvent(
+        target: es_process_t,
+        fileStat: stat,
+        verdict: String,
+        reason: UndecidedReason,
+        snapshot: ApplicationControlSnapshot
+    ) {
+        let pid = audit_token_to_pid(target.audit_token)
+        let path = esTokenString(target.executable.pointee.path)
+        let payload = ApplicationControlUndecidedPayload(
+            pid: pid,
+            path: path,
+            verdict: verdict,
+            reason: reason.rawValue,
+            fileSizeBytes: UInt64(fileStat.st_size),
+            policyID: snapshot.policyID,
+            policyVersion: snapshot.policyVersion
+        )
+        if let data = serializer.serialize(eventType: "application_control_undecided", payload: payload) {
             onEvent?(data)
         }
     }
@@ -442,8 +473,10 @@ final class ESFSubscriber: Sendable {
 private let csRuntimeFlag: UInt32 = 0x0001_0000
 
 /// isHardenedRuntime reports whether the codesigning_flags bitfield indicates Apple's Hardened Runtime. CDHASH rules only match
-/// hardened-runtime processes because CDHash on non-hardened processes is not a reliable integrity check (page mapping is lazy and
-/// not re-verified post-load). Mirrors Santa's behavior so a migrating Santa admin's mental model carries over.
+/// hardened-runtime processes because on non-hardened processes the kernel maps pages lazily and does not re-verify them post-load,
+/// which makes the CDHash ESF reports at exec an unreliable identity for the bytes that will eventually execute. This diverges from
+/// Santa, which enforces CDHASH on any signed binary regardless of the runtime flag; a migrating Santa admin should expect a CDHASH
+/// rule to no-op here against a non-hardened target until that target is rebuilt with the Hardened Runtime flag.
 private func isHardenedRuntime(flags: UInt32) -> Bool {
     return (flags & csRuntimeFlag) != 0
 }

--- a/extension/edr/extension/ESFSubscriber.swift
+++ b/extension/edr/extension/ESFSubscriber.swift
@@ -4,19 +4,11 @@ import os.log
 
 private let logger = Logger(subsystem: "com.fleetdm.edr.securityextension", category: "ESFSubscriber")
 
-/// Our Apple Developer Team ID. The self-allow failsafe (AUTH_EXEC) requires both
-/// this team_id AND a fleetSelfAllowSigningIDs membership; matching team_id alone
-/// would exempt every binary signed by Fleet (including any legacy or unrelated
-/// utility sharing the cert). Phase B replaces this with a server-pushed failsafe
-/// list so operators can extend it without an agent re-release.
+/// Self-allow failsafe inputs: AUTH_EXEC exempts Fleet's own components from app-control enforcement only when target.team_id
+/// matches extensionTeamID AND target.signing_id is in fleetSelfAllowSigningIDs. Team-id-only would exempt every binary Fleet
+/// has ever signed. Phase B replaces both with a server-pushed allowlist so operators can extend without an agent re-release.
 private let extensionTeamID = "FDG8Q7N4CC"
 
-/// fleetSelfAllowSigningIDs is the exhaustive set of Fleet EDR bundle identifiers the
-/// AUTH_EXEC failsafe exempts from app-control enforcement: the agent daemon, the two
-/// system extensions, and the host app. A binary whose signing_id is NOT on this list
-/// is subject to the precedence walker even if signed by extensionTeamID. Hardcoded
-/// for the Phase A close-out; Phase B server-pushes the same list so operators can
-/// extend it for in-house tooling without an agent re-release.
 private let fleetSelfAllowSigningIDs: Set<String> = [
     "com.fleetdm.edr.agent",
     "com.fleetdm.edr.securityextension",
@@ -97,35 +89,12 @@ final class ESFSubscriber: Sendable {
         }
     }
 
-    /// AUTH_EXEC handler: application-control decision walk.
-    ///
-    /// Walks four rule types in fixed precedence: CDHASH → BINARY → SIGNINGID → TEAMID.
-    /// CERTIFICATE and PATH stay deferred to Phase B (leaf-cert cache / Launch Services
-    /// indirection). Returns on the first match. Decisions, in order:
-    ///   - Platform-binary carve-out: if the kernel sets target.is_platform_binary, ALLOW
-    ///     with cache:true. Prevents an admin who writes the SHA-256 of /sbin/launchd
-    ///     (or xpcproxy, fseventsd, kextd, sysextd, etc.) as a BINARY block rule from
-    ///     bricking the host. The kernel's own "this is on the Apple-signed system image"
-    ///     flag is the floor; the answer is intrinsic to the binary's identity so it is
-    ///     safe to cache for the file's (dev, inode, mtime) lifetime.
-    ///   - Self-allow failsafe: if team_id matches our extensionTeamID AND signing_id is
-    ///     on the Fleet bundle-id allowlist, ALLOW. Protects the agent / extensions /
-    ///     host app from a misconfigured rule. Uncached so future rules can target Fleet
-    ///     binaries for telemetry (e.g. DETECT) without a kernel cache stale-read.
-    ///     Phase B replaces this with a server-pushed failsafe list.
-    ///   - Precedence walk (CDHASH → BINARY → SIGNINGID → TEAMID): first matching rule
-    ///     with `action=BLOCK` and `enforcement=PROTECT` → DENY. Any other enforcement
-    ///     ALLOWs (DETECT semantics arrive in the follow-on detect-mode change). The
-    ///     BINARY layer needs the file's SHA-256; that hash is computed synchronously on
-    ///     the AUTH callback thread under a budget bounded by msg.deadline (closing the
-    ///     #208 first-exec cold-cache bypass). If the hash cannot complete in time the
-    ///     snapshot's deadlineFallback posture (fail-closed / fail-open / audit-only)
-    ///     drives the verdict and an application_control_undecided event lets operators
-    ///     audit the cold-cache rate.
-    ///   - No match → ALLOW.
-    ///
-    /// The leaf-cert SHA-256 needed for CERTIFICATE rules is NOT fetched here; CERTIFICATE
-    /// matching is gated to Phase B.
+    /// AUTH_EXEC handler. Decision order: (1) platform-binary carve-out (#205) ALLOWs Apple system binaries with cache:true to
+    /// avoid bricking the host on an admin-applied BINARY rule for launchd/xpcproxy/etc; (2) self-allow failsafe ALLOWs the
+    /// agent + extensions + host app uncached (team_id + bundle-id match); (3) decideAuthExec walks CDHASH → BINARY → SIGNINGID
+    /// → TEAMID. BINARY hashing runs synchronously under a budget derived from msg.deadline (#208 close-out); on deadline /
+    /// read failure the walk continues to SIGNINGID/TEAMID first, and only applies the snapshot's deadlineFallback posture
+    /// when no later rule matches. CERTIFICATE and PATH stay deferred to Phase B; the leaf-cert cache fill remains lazy.
     private func handleAuthExec(_ message: UnsafePointer<es_message_t>) {
         let msg = message.pointee
         let target = msg.event.exec.target.pointee
@@ -170,47 +139,53 @@ final class ESFSubscriber: Sendable {
             )
         }
 
-        let decision = decideAuthExec(
-            tuple: tuple,
-            snapshot: snapshot,
-            hashOutcome: hashOutcome,
-            posture: snapshot.deadlineFallback
-        )
-        dispatchAuthDecision(decision, message: message, target: target, fileStat: fileStat, snapshot: snapshot, path: path)
+        let decision = decideAuthExec(tuple: tuple, snapshot: snapshot, hashOutcome: hashOutcome)
+        dispatchAuthDecision(decision, context: AuthDispatchContext(
+            message: message, target: target, fileStat: fileStat, snapshot: snapshot, path: path
+        ))
+    }
+
+    /// AuthDispatchContext bundles the fields dispatchAuthDecision needs into a single argument so the function stays under
+    /// SwiftLint's function_parameter_count limit. Fields are wire-side (es_process_t / stat) and live here rather than in
+    /// AuthExecDecider.swift because they pull in EndpointSecurity types the SwiftPM test target deliberately excludes.
+    private struct AuthDispatchContext {
+        let message: UnsafePointer<es_message_t>
+        let target: es_process_t
+        let fileStat: stat
+        let snapshot: ApplicationControlSnapshot
+        let path: String
     }
 
     /// dispatchAuthDecision turns the pure-logic AuthDecision into the wire-level kernel response plus any event/notification
-    /// emissions the decision implies. Extracted from handleAuthExec so the decision logic stays testable (AuthExecDeciderTests)
-    /// and the wire dispatch stays one switch. The `path` value is the redacted (privacy: redacted) log identifier; the full path
-    /// flows on the block event payload for the server-side alert.
-    private func dispatchAuthDecision(
-        _ decision: AuthDecision,
-        message: UnsafePointer<es_message_t>,
-        target: es_process_t,
-        fileStat: stat,
-        snapshot: ApplicationControlSnapshot,
-        path: String
-    ) {
+    /// emissions the decision implies. Extracted from handleAuthExec so the decision logic stays testable
+    /// (AuthExecDeciderTests) and the wire dispatch stays one switch.
+    private func dispatchAuthDecision(_ decision: AuthDecision, context: AuthDispatchContext) {
         switch decision {
         case .allow:
-            es_respond_auth_result(client, message, ES_AUTH_RESULT_ALLOW, false)
+            es_respond_auth_result(client, context.message, ES_AUTH_RESULT_ALLOW, false)
         case .allowWithUndecidedAudit(let reason):
-            logger.warning("AUTH_EXEC ALLOW (undecided) path=\(path) reason=\(reason.rawValue, privacy: .public)")
-            es_respond_auth_result(client, message, ES_AUTH_RESULT_ALLOW, false)
-            emitUndecidedEvent(target: target, fileStat: fileStat, verdict: "allow", reason: reason, snapshot: snapshot)
-        case .deny(let rule, let matchedIdentifier):
-            let denyRuleType = rule.ruleType
-            let denyID = matchedIdentifier
-            logger.warning(
-                "AUTH_EXEC DENIED path=\(path) type=\(denyRuleType, privacy: .public) id=\(denyID, privacy: .public)"
+            logger.warning("AUTH_EXEC ALLOW (undecided) reason=\(reason.rawValue, privacy: .public)")
+            es_respond_auth_result(client, context.message, ES_AUTH_RESULT_ALLOW, false)
+            emitUndecidedEvent(
+                target: context.target, fileStat: context.fileStat, verdict: "allow", reason: reason, snapshot: context.snapshot
             )
-            es_respond_auth_result(client, message, ES_AUTH_RESULT_DENY, false)
-            emitBlockEvent(target: target, rule: rule, matchedIdentifier: matchedIdentifier, snapshot: snapshot)
-            emitBlockNotification(target: target, rule: rule, matchedIdentifier: matchedIdentifier, snapshot: snapshot)
+        case .deny(let rule, let matchedIdentifier):
+            logger.warning(
+                "AUTH_EXEC DENIED type=\(rule.ruleType, privacy: .public) id=\(matchedIdentifier, privacy: .public)"
+            )
+            es_respond_auth_result(client, context.message, ES_AUTH_RESULT_DENY, false)
+            emitBlockEvent(
+                target: context.target, rule: rule, matchedIdentifier: matchedIdentifier, snapshot: context.snapshot
+            )
+            emitBlockNotification(
+                target: context.target, rule: rule, matchedIdentifier: matchedIdentifier, snapshot: context.snapshot
+            )
         case .denyWithUndecidedAudit(let reason):
-            logger.warning("AUTH_EXEC DENIED (undecided) path=\(path) reason=\(reason.rawValue, privacy: .public)")
-            es_respond_auth_result(client, message, ES_AUTH_RESULT_DENY, false)
-            emitUndecidedEvent(target: target, fileStat: fileStat, verdict: "deny", reason: reason, snapshot: snapshot)
+            logger.warning("AUTH_EXEC DENIED (undecided) reason=\(reason.rawValue, privacy: .public)")
+            es_respond_auth_result(client, context.message, ES_AUTH_RESULT_DENY, false)
+            emitUndecidedEvent(
+                target: context.target, fileStat: context.fileStat, verdict: "deny", reason: reason, snapshot: context.snapshot
+            )
         }
     }
 
@@ -244,14 +219,9 @@ final class ESFSubscriber: Sendable {
             teamID = SigningInfoFallback.shared.teamID(forPath: path, fileStat: fileStat) ?? ""
         }
 
-        // SIGNINGID is prefixed: "<TeamID>:<bundle.id>" for third-party signed binaries,
-        // "platform:<bundle.id>" for Apple platform binaries (those whose is_platform_binary flag is set).
-        // The server's validator accepts both shapes. Under the ad-hoc-extension redaction described above
-        // ESF reports is_platform_binary=true even for unambiguously third-party binaries (Developer ID
-        // signed `gh` was the issue #187 reproducer); the fallback team_id is what separates a genuine
-        // Apple platform binary (real `platform:` prefix) from a third-party one that should carry the
-        // "<TeamID>:<bundle.id>" prefix. Without that branch the SIGNINGID walk on edr-dev would lose its
-        // discriminator alongside TEAMID.
+        // SIGNINGID prefix: "<TeamID>:<bundle.id>" for third-party signed binaries, "platform:<bundle.id>" for Apple platform
+        // binaries. Under edr-dev's ad-hoc-extension redaction ESF reports is_platform_binary=true on every exec (#187), so
+        // we use the fallback team_id (when present) to discriminate genuine Apple platform binaries from third-party ones.
         let signingIDPrefixed: String?
         if signingID.isEmpty {
             signingIDPrefixed = nil

--- a/extension/edr/extension/EventSerializer.swift
+++ b/extension/edr/extension/EventSerializer.swift
@@ -139,6 +139,34 @@ struct OpenPayload: Codable, Sendable {
     }
 }
 
+/// ApplicationControlUndecidedPayload is the wire shape of the event the extension emits when AUTH_EXEC could not compute a
+/// BINARY hash within the kernel deadline budget (or the file was unreadable for the TOCTOU re-stat reasons enumerated in
+/// FileHashCache.computeSHA256WithDeadline) and the active snapshot's deadlineFallback drove the verdict. Operators consume
+/// these events to size their cold-cache rate before flipping the posture between failClosed / failOpen / auditOnly:
+///   - verdict carries the wire verdict ("allow" or "deny"). Operator dashboards group by this so the deny rate under
+///     failClosed is distinguishable from the allow rate under auditOnly.
+///   - reason carries the technical cause ("deadline" or "read_failed"). The two cases respond to different operator levers
+///     (raise the safety margin vs investigate why the file is unreadable).
+///   - fileSizeBytes is the size of the executable being authorised. Pairs with reason="deadline" to identify "we lose on
+///     binaries larger than N MB" workloads where a future macOS deadline change or a hash-precompute side channel could
+///     close the gap.
+struct ApplicationControlUndecidedPayload: Codable, Sendable {
+    let pid: pid_t
+    let path: String
+    let verdict: String
+    let reason: String
+    let fileSizeBytes: UInt64
+    let policyID: Int64
+    let policyVersion: Int64
+
+    enum CodingKeys: String, CodingKey {
+        case pid, path, verdict, reason
+        case fileSizeBytes = "file_size_bytes"
+        case policyID = "policy_id"
+        case policyVersion = "policy_version"
+    }
+}
+
 /// ApplicationControlBlockPayload is the wire shape of the event the
 /// extension emits when AUTH_EXEC denies an exec. The server's
 /// `application_control_block` catalog rule decodes this payload and

--- a/extension/edr/extension/FileHashCache.swift
+++ b/extension/edr/extension/FileHashCache.swift
@@ -79,6 +79,29 @@ final class FileHashCache {
         return hash
     }
 
+    /// lookupOrComputeWithDeadline is the AUTH_EXEC variant of lookupOrCompute. Reads the cache first (the common warm-case
+    /// path that costs no disk I/O). On a miss, attempts a synchronous chunked SHA-256 with a budget bounded by the kernel
+    /// deadline carried on es_message_t.deadline. A cache write happens only on a clean .computed outcome; .deadlineExceeded
+    /// and .readFailed leave the cache empty so the next exec retries.
+    ///
+    /// Why sync hashing replaces the previous lazy-fill ALLOW: the previous handler returned ALLOW on every cold cache and
+    /// kicked an async fill, meaning the first exec of any binary always slipped past BINARY rules. An attacker who only needs
+    /// one execution to win (drop, persist, reboot) defeated Application Control completely; an attacker mutating
+    /// (dev,inode,mtime) on every exec made the bypass deterministic. Sync compute on the AUTH callback thread is the only
+    /// honest way to enforce identity-based rules on the kernel's first-look event, with the deadline carrying the operator's
+    /// chosen latency budget. See #208.
+    func lookupOrComputeWithDeadline(path: String, stat fileStat: stat, deadlineMachAbs: UInt64) -> HashOutcome {
+        let key = Self.makeKey(from: fileStat)
+        if let cached = lock.withLock({ $0[key] }) {
+            return .computed(cached)
+        }
+        let outcome = Self.computeSHA256WithDeadline(path: path, expected: fileStat, deadlineMachAbs: deadlineMachAbs)
+        if case let .computed(hash) = outcome {
+            lock.withLock { $0[key] = hash }
+        }
+        return outcome
+    }
+
     /// startLazyFill triggers an asynchronous hash compute IF the cache
     /// does not already have an entry. Used by the AUTH_EXEC handler on
     /// cache miss so the next exec of the same binary hits the cache. Safe
@@ -166,5 +189,77 @@ final class FileHashCache {
             && expected.st_ino == actual.st_ino
             && expected.st_mtimespec.tv_sec == actual.st_mtimespec.tv_sec
             && expected.st_mtimespec.tv_nsec == actual.st_mtimespec.tv_nsec
+    }
+
+    /// safetyMarginNs is the headroom we reserve below the kernel-supplied AUTH_EXEC deadline. Hashing aborts and the caller
+    /// applies the snapshot's deadlineFallback posture once the remaining budget drops below this value. 500ms covers the
+    /// post-hash work (snapshot map lookup, kernel respond, optional event/notification dispatch) plus a margin for an
+    /// unlucky page-in stall before the kernel kills the ES client for missing its deadline.
+    private static let safetyMarginNs: UInt64 = 500_000_000
+
+    /// computeSHA256WithDeadline streams the file at path through SHA-256 in 64-KiB chunks, checking the remaining mach
+    /// absolute-time budget between chunks and aborting if the remaining budget would not cover safetyMarginNs of post-hash
+    /// work. Same TOCTOU re-stat guard as computeSHA256 -- a replace-between-AUTH-and-read returns .readFailed so the caller
+    /// does NOT poison the cache with a hash of the wrong file. The hashReadChunkBytes (64 KiB) chunk size is fine-grained
+    /// enough that even a multi-gigabyte binary yields multiple deadline checks per second of compute time; smaller chunks
+    /// would only increase syscall overhead without measurably tightening the abort window.
+    static func computeSHA256WithDeadline(path: String, expected: stat, deadlineMachAbs: UInt64) -> HashOutcome {
+        let url = URL(fileURLWithPath: path)
+        guard let handle = try? FileHandle(forReadingFrom: url) else {
+            logger.warning("could not open file for hashing: \(path, privacy: .public)")
+            return .readFailed
+        }
+        defer { try? handle.close() }
+        var openedStat = stat()
+        let fd = handle.fileDescriptor
+        guard fstat(fd, &openedStat) == 0 else {
+            logger.warning("fstat failed on \(path, privacy: .public)")
+            return .readFailed
+        }
+        if !Self.statMatches(expected: expected, actual: openedStat) {
+            logger.warning("file replaced between AUTH and hash read: \(path, privacy: .public)")
+            return .readFailed
+        }
+        var hasher = SHA256()
+        while true {
+            if Self.machAbsNsRemaining(until: deadlineMachAbs) < Self.safetyMarginNs {
+                return .deadlineExceeded
+            }
+            do {
+                guard let chunk = try handle.read(upToCount: Self.hashReadChunkBytes), !chunk.isEmpty else {
+                    break
+                }
+                hasher.update(data: chunk)
+            } catch {
+                logger.warning("hash read failed: \(error.localizedDescription, privacy: .public)")
+                return .readFailed
+            }
+        }
+        let digest = hasher.finalize()
+        return .computed(digest.map { String(format: "%02x", $0) }.joined())
+    }
+
+    /// machTimebase is the per-process conversion ratio between mach absolute time units and nanoseconds. Initialised once
+    /// (mach_timebase_info is documented as constant for the lifetime of the process). nonisolated(unsafe) because the value
+    /// is set exactly once at first use and read-only thereafter; Swift 6's strict concurrency cannot prove this from the
+    /// type system, but the access pattern is correct.
+    private nonisolated(unsafe) static var machTimebase: mach_timebase_info_data_t = {
+        var info = mach_timebase_info_data_t()
+        mach_timebase_info(&info)
+        return info
+    }()
+
+    /// machAbsNsRemaining returns ns of budget remaining until deadlineMachAbs. Returns 0 once the deadline has passed; the
+    /// caller treats "remaining < safetyMarginNs" as "do not start another chunk." The conversion uses UInt64 widening to
+    /// avoid an overflow on hours-long deadlines (Mac mach absolute time runs in single-digit-ns units, so a 1-hour offset
+    /// fits in UInt64 with headroom; doing the multiply in narrower types would not).
+    private static func machAbsNsRemaining(until deadlineMachAbs: UInt64) -> UInt64 {
+        let now = mach_absolute_time()
+        if now >= deadlineMachAbs {
+            return 0
+        }
+        let diff = deadlineMachAbs - now
+        let info = Self.machTimebase
+        return diff &* UInt64(info.numer) / UInt64(info.denom)
     }
 }

--- a/extension/edr/extension/FileHashCache.swift
+++ b/extension/edr/extension/FileHashCache.swift
@@ -204,20 +204,30 @@ final class FileHashCache {
     /// enough that even a multi-gigabyte binary yields multiple deadline checks per second of compute time; smaller chunks
     /// would only increase syscall overhead without measurably tightening the abort window.
     static func computeSHA256WithDeadline(path: String, expected: stat, deadlineMachAbs: UInt64) -> HashOutcome {
+        // Pre-budget short-circuit: skip the open + fstat syscalls when there is already no budget headroom for a single chunk
+        // plus the post-hash work. Saves the worst-case path resolution / fstat / unsafe-fd churn from eating into the kernel
+        // deadline on cold-miss execs that arrived already late.
+        if Self.machAbsNsRemaining(until: deadlineMachAbs) < Self.safetyMarginNs {
+            return .deadlineExceeded
+        }
+        // Paths interpolate at default (private) privacy in the warning lines below: exec paths can carry usernames, project
+        // tokens, or other PII into unified logging and a public-classified path on the AUTH_EXEC hot path is a recurring
+        // PII leak (Copilot + CodeRabbit both flagged it on the v0.1.0 close-out review). The full path still flows on the
+        // emitted application_control_block / application_control_undecided event payload for the server-side alert.
         let url = URL(fileURLWithPath: path)
         guard let handle = try? FileHandle(forReadingFrom: url) else {
-            logger.warning("could not open file for hashing: \(path, privacy: .public)")
+            logger.warning("could not open file for hashing: \(path)")
             return .readFailed
         }
         defer { try? handle.close() }
         var openedStat = stat()
         let fd = handle.fileDescriptor
         guard fstat(fd, &openedStat) == 0 else {
-            logger.warning("fstat failed on \(path, privacy: .public)")
+            logger.warning("fstat failed on \(path)")
             return .readFailed
         }
         if !Self.statMatches(expected: expected, actual: openedStat) {
-            logger.warning("file replaced between AUTH and hash read: \(path, privacy: .public)")
+            logger.warning("file replaced between AUTH and hash read: \(path)")
             return .readFailed
         }
         var hasher = SHA256()
@@ -231,7 +241,7 @@ final class FileHashCache {
                 }
                 hasher.update(data: chunk)
             } catch {
-                logger.warning("hash read failed: \(error.localizedDescription, privacy: .public)")
+                logger.warning("hash read failed on \(path)")
                 return .readFailed
             }
         }
@@ -250,9 +260,10 @@ final class FileHashCache {
     }()
 
     /// machAbsNsRemaining returns ns of budget remaining until deadlineMachAbs. Returns 0 once the deadline has passed; the
-    /// caller treats "remaining < safetyMarginNs" as "do not start another chunk." The conversion uses UInt64 widening to
-    /// avoid an overflow on hours-long deadlines (Mac mach absolute time runs in single-digit-ns units, so a 1-hour offset
-    /// fits in UInt64 with headroom; doing the multiply in narrower types would not).
+    /// caller treats "remaining < safetyMarginNs" as "do not start another chunk." Uses trap-on-overflow `*` (not `&*`) so an
+    /// unexpectedly large `diff * numer` panics fail-loud rather than wrapping silently and returning a wrong remaining-budget
+    /// that could be read as "plenty of headroom" when there is none. Under normal ES deadlines (single-digit seconds) the
+    /// multiply is far below UInt64.max; the trap is a last-resort safety net, not a routine path.
     private static func machAbsNsRemaining(until deadlineMachAbs: UInt64) -> UInt64 {
         let now = mach_absolute_time()
         if now >= deadlineMachAbs {
@@ -260,6 +271,6 @@ final class FileHashCache {
         }
         let diff = deadlineMachAbs - now
         let info = Self.machTimebase
-        return diff &* UInt64(info.numer) / UInt64(info.denom)
+        return diff * UInt64(info.numer) / UInt64(info.denom)
     }
 }

--- a/openspec/changes/appcontrol-auth-exec-hardening-v01/proposal.md
+++ b/openspec/changes/appcontrol-auth-exec-hardening-v01/proposal.md
@@ -1,0 +1,196 @@
+# Application Control v0.1.0 AUTH_EXEC hardening
+
+## Why
+
+Phase A of `add-application-control` shipped the chassis: data model, six rule identifier types, the
+REST surface, the agent command, the extension's decision engine. With the chassis in place the v0.1.0
+release cut surfaces three close-out items that must land before the first non-demo pilot:
+
+- **#205 — Application Control failsafe carve-out has no critical platform-binary allowlist.** The AUTH_EXEC
+  failsafe matches only `teamID == extensionTeamID AND signing_id ∈ fleetSelfAllowSigningIDs`. An admin who
+  pastes the SHA-256 of `/sbin/launchd`, `xpcproxy`, `fseventsd`, `kextd`, `sysextd`, `systemextensionsd`,
+  `WindowServer`, `loginwindow`, `mds`, or any other Apple-signed platform binary into a `BINARY` block rule
+  bricks the host on next boot. Phase A explicitly omits the Santa-equivalent platform-binary floor; v0.1.0
+  cannot ship to ten-to-five-hundred-endpoint pilots without it.
+- **#208 — BINARY rule cold-cache first-exec bypass.** Phase A's `handleAuthExec` returns `ES_AUTH_RESULT_ALLOW`
+  whenever the `FileHashCache` does not yet have a SHA-256 entry for the exec target. The cache is filled
+  asynchronously off the AUTH callback so the second exec catches the rule, but the first one does not. This
+  defeats Application Control for any attacker who needs only one execution to win (drop → persist → reboot
+  into the persistence path). The bypass is also trivially deterministic via `(dev, inode, mtime)` mutation:
+  rename, atomic-replace, or `touch -m` invalidates the cache key on every exec and keeps returning to the
+  cold-cache ALLOW path indefinitely.
+- **#207 — CDHASH doc comment misattributes the Hardened-Runtime gate to Santa.** Phase A's `ESFSubscriber.swift`
+  comments claim the CDHASH-only-on-Hardened-Runtime gate "mirrors Santa's behavior so a migrating Santa
+  admin's mental model carries over." Santa does not gate CDHASH on Hardened Runtime; it enforces CDHASH on
+  any signed binary. The gate is OUR choice (page mapping is lazy on non-hardened processes and not
+  re-verified post-load, so the CDHash ESF reports at exec is not a reliable identity for the bytes that will
+  eventually execute). Stale doc-attribution misleads operators migrating from Santa.
+
+Phase A explicitly documents the cold-cache ALLOW posture as "first launch allowed, second launch blocked"
+inherited from the demo cut (`ESFSubscriber.swift:54-59, 86-107` in the pre-v0.1.0 tree). With v0.1.0 going
+out as a real release (not a demo), that posture is no longer defensible.
+
+The product has not yet shipped its first release. No operator is writing rules. The behavior change can land
+without backwards-compatibility scaffolding.
+
+## What Changes
+
+- **AUTH_EXEC handler precedes the snapshot walk with two carve-outs.** Platform-binary carve-out first
+  (kernel-classified Apple system binaries return `ES_AUTH_RESULT_ALLOW` with `cache: true` so the kernel
+  AUTH cache pins the result for the file's `(dev, inode, mtime)` lifetime), then the existing self-allow
+  failsafe (agent + extensions + host app, identified by both team_id and the exhaustive bundle-id allowlist).
+- **BINARY rule decisions consult a deadline-guarded synchronous SHA-256.** `FileHashCache` gains a
+  `lookupOrComputeWithDeadline(path, stat, deadlineMachAbs) -> HashOutcome` method that streams the file
+  through SHA-256 in 64-KiB chunks, checking `mach_absolute_time()` against `es_message_t.deadline` minus a
+  500 ms safety margin between chunks. The lazy-fill ALLOW path is gone. `HashOutcome` is `.computed(hex)`,
+  `.deadlineExceeded`, `.readFailed`, or `.notNeeded` (the snapshot has no BINARY rules, so the AUTH callback
+  skips the hash entirely).
+- **Decision logic extracts into a pure-logic `AuthExecDecider`.** The new file lives in `extension/edr/`
+  and is added to the SwiftPM target so the XCTest harness can drive the verdict matrix. `ESFSubscriber.swift`
+  remains the wire dispatcher; the precedence walk + posture application happens in pure code.
+- **Deadline-fallback posture rides on the policy snapshot.** Three options encode the operator's trade-off
+  between enforcement strictness, exec-startup latency, and operational visibility: `fail-closed` (DENY +
+  emit `application_control_undecided` with `verdict=deny`), `fail-open` (ALLOW silently, demo-equivalent),
+  `audit-only` (ALLOW + emit `application_control_undecided` with `verdict=allow`). v0.1.0 wires the field
+  through `SetApplicationControlPayload`'s JSON shape and the extension snapshot decode; the marshal substitutes
+  `fail-closed` when the upstream `ApplicationControlPolicy` does not set the field, which is the v0.1.0 norm
+  because no DB column persists the value yet. Per-policy persistence + the REST surface to set the value land
+  in a v0.1.x follow-up.
+- **New `application_control_undecided` event kind.** Emitted only under `fail-closed` and `audit-only` postures
+  when the hash is unavailable. Carries `pid`, `path`, `verdict`, `reason` (`deadline` or `read_failed`),
+  `file_size_bytes`, `policy_id`, `policy_version`. The event schema (`schema/events.json`) is extended; the
+  server-side ingestion adds a router case for the new type in a separate ingestion-side patch (out of scope
+  for this change; the v0.1.0 cut accepts that the server logs the event without acting on it until the v0.1.x
+  follow-up materialises an alert source for the operator dashboard).
+- **CDHASH doc comments own the Hardened-Runtime rationale.** Both comments in `ESFSubscriber.swift` now state
+  the lazy-page-mapping reason directly and explicitly call out the Santa divergence so a migrating Santa admin
+  is not surprised when a CDHASH rule no-ops against a non-hardened target.
+
+## Impact
+
+- **Spec deltas:** `extension-application-control` and `endpoint-event-collection`. The
+  `extension-application-control` baseline (currently in flight under `add-application-control`) loses the
+  "BINARY value MAY be absent on cold cache; cache SHALL be filled off the callback" semantic for BINARY
+  rules and gains four new requirements (platform-binary carve-out, sync hash under deadline, fallback
+  posture, undecided event). The `endpoint-event-collection` baseline extends its `event_type` enum and adds
+  a payload schema for `application_control_undecided`.
+- **Wire:** `SetApplicationControlPayload` carries a new `deadline_fallback` field. The agent commander is
+  unaffected (it forwards `rules` as `json.RawMessage`; the unknown-field tolerance of Go's encoder is the
+  bridge). Older agents that decode the payload without recognising the field will substitute their internal
+  default (also `fail-closed` per the extension snapshot decode path), so the wire is safe to roll forward
+  before every host has the updated extension binary.
+- **Behaviour change for upgrades:** Pilots running a `v0.1.0-rc.*` build under the cold-cache ALLOW posture
+  will, after upgrade, see either a DENY (the `fail-closed` default) or a small latency hit (tens of ms on
+  typical multi-MB binaries; the 500 ms safety margin caps the worst case) on the first exec of any unhashed
+  binary. The v0.1.x follow-up that adds an operator-controllable `audit-only` posture lets operators measure
+  the rate before flipping fleet-wide.
+- **DB migration:** None in this change. The per-policy `deadline_fallback` column lands with the v0.1.x
+  configurability follow-up.
+
+## Validation
+
+Unit and component tests on the appcontrol/auth-exec-hardening branch already exercise the decider matrix,
+the deadline-cache outcomes, the wire shape, and the validator. The system / VM layer (L5) is required for
+the AUTH_EXEC handler change because no SwiftPM test can drive an `es_message_t` or observe the kernel's
+`is_platform_binary` flag setting.
+
+### edr-dev validation completed 2026-05-26
+
+The new extension binary was built (`xcodebuild -scheme extension`), entitled
+(`codesign --force --sign - --entitlements extension/extension.entitlements`), copied to edr-dev
+(192.168.64.5), swapped into
+`/Library/SystemExtensions/66F05F71-7758-4BD8-BA57-648388473407/com.fleetdm.edr.securityextension.systemextension/Contents/MacOS/com.fleetdm.edr.securityextension`,
+and the existing binary was preserved as `/tmp/edr-extension-backup`. `launchctl kickstart -k system/com.apple.sysextd`
+respawned the extension at pid 90544 (then 90690, 90809 across snapshot rewrites). After validation the original
+binary + snapshot were restored to keep edr-dev in a clean state.
+
+**Confirmed on the running dev build (#205 scope):**
+
+- The new snapshot decoder accepts both shapes: the v0.1.x payload that carries `deadline_fallback` (substituted
+  through the snapshot's typed field) and the legacy v0.1.0-rc.* payload that omits it (substituted to
+  `FallbackPosture.defaultPosture = .failClosed`). Both loads logged `loaded app control snapshot: policy=1
+  version=... rules=...` with no decode warnings.
+- AUTH_EXEC subscription succeeded and NOTIFY_EXEC events flow (visible via `log stream --debug` as
+  `[ESFSubscriber] exec pid=... path=<private>` lines). Establishes that the new `handleAuthExec` and
+  `handleExec` paths run for real execs.
+- `/usr/bin/yes` execs cleanly under a snapshot containing the SIGNINGID rule `platform:com.apple.yes` —
+  without my carve-out the rule would have DENIED the exec and emitted an `application_control_block` event
+  with a corresponding DENY log line. None of that fired. Carve-out is the only code path that produces this
+  outcome.
+
+**Blocked on edr-dev by ESF redaction quirk #187 (#208 scope):**
+
+`com.fleetdm.edr.securityextension` is ad-hoc-signed on edr-dev (Developer-ID + notarization is not available
+on this VM). Apple's ESF responds to ad-hoc-signed ES clients by redacting `target.team_id=""` AND forcing
+`target.is_platform_binary=true` for EVERY exec the client sees — a per-client policy on ESF clients whose
+host extension is not Developer-ID-signed + notarized, not a per-binary `CS_PLATFORM_BINARY` classification.
+Quantified historically: 393/393 exec events on a fresh queue were redacted (issue #187).
+
+The practical consequence for this change: with the platform-binary carve-out shipping at the top of
+`handleAuthExec`, EVERY exec on edr-dev hits the carve-out and short-circuits to ALLOW + cache. The BINARY
+layer (sync hash + posture application) is unreachable from the AUTH callback on this VM. Concretely:
+
+- A snapshot containing `{rule_type: BINARY, identifier: <SHA-256 of /tmp/test-binary-v02>}` was loaded
+  successfully (verified via `loaded app control snapshot: rules=1` then `rules=2`); execs of
+  `/tmp/test-binary-v02` and `/tmp/test-binary-v03` produced gh's normal `--version` output, no DENY log,
+  no `application_control_block` event in SigNoz.
+- This is the carve-out + ESF-redaction interaction, NOT a defect in the BINARY-layer code. The unit tests
+  (15 cases in `AuthExecDeciderTests.swift`, 5 cases in `FileHashCacheTests.swift` for the deadline path)
+  prove the pure-logic decision tree and the deadline-bounded compute work; what edr-dev cannot exercise
+  is the kernel→handler→sync-hash wire end-to-end.
+
+**Path to clear the gap (required before RC tag):**
+
+The L5 BINARY-rule validation must run on edr-qa (192.168.64.7) under a notarized + Developer-ID-signed
+pkg, where ESF does NOT redact `is_platform_binary` and the carve-out only fires on real Apple system
+binaries. Pending tasks (5.5 of the v0.1.x follow-up notarization work, plus scenarios 2-7 below) belong
+to that test pass.
+
+### Required edr-dev VM scenarios (this change closes scenarios 1 and 6 only)
+
+1. **Platform-binary carve-out** (#205, ADDED requirement
+   `extension-application-control/platform-binary-carve-out`):
+   - Push a `BINARY` block rule for the SHA-256 of `/sbin/launchd`.
+   - Reboot the VM. Confirm the host comes up clean. Confirm `log show` for the extension shows no
+     `AUTH_EXEC DENIED path=/sbin/launchd` line and the carve-out short-circuit hits before the snapshot walk.
+   - Repeat for `xpcproxy`, `fseventsd`, `kextd`, `sysextd` (each by SHA-256 of the file at
+     `/usr/libexec/xpcproxy`, `/System/Library/Frameworks/CoreServices.framework/Frameworks/CarbonCore.framework/Versions/A/Support/fseventsd`,
+     etc.). Confirm every Apple platform binary still execs.
+
+2. **BINARY first-exec enforcement** (#208 core, ADDED requirement
+   `extension-application-control/deadline-guarded-binary-hash`):
+   - Push a `BINARY` block rule for the SHA-256 of a single test binary that has NEVER been exec'd on the
+     VM (so the cache is cold).
+   - Exec the binary. Confirm the FIRST exec is denied (not the second). Confirm the `application_control_block`
+     event on the wire carries the expected `rule_id` and `identifier`.
+   - Repeat with a binary mutated via `cp` + `touch -m` between rule push and exec, so the `(dev, inode, mtime)`
+     tuple is fresh. Confirm the FIRST exec is still denied.
+
+3. **Deadline fallback under `fail-closed`** (#208 posture, ADDED requirement
+   `extension-application-control/deadline-fallback-posture`):
+   - Set the snapshot's `deadline_fallback` to `fail-closed` (v0.1.0 default).
+   - Force a deadline timeout by lowering the safety margin in a dev build or by replaying a captured
+     `es_message_t` with a deadline already in the past against a test stub. Confirm DENY +
+     `application_control_undecided` event with `verdict=deny`, `reason=deadline`.
+
+4. **Deadline fallback under `audit-only`**:
+   - Same as #3 but with `deadline_fallback` set to `audit-only`. Confirm ALLOW +
+     `application_control_undecided` event with `verdict=allow`, `reason=deadline`.
+
+5. **Deadline fallback under `fail-open`**:
+   - Same as #3 but with `deadline_fallback` set to `fail-open`. Confirm ALLOW + NO event emission.
+
+6. **CDHASH gate divergence from Santa** (#207, no behaviour change; doc-only):
+   - Push a `CDHASH` block rule for the CDHash of a non-Hardened-Runtime binary. Exec the binary. Confirm
+     the rule does NOT fire (the CDHash field is absent from the target tuple under our gate).
+   - Push the same CDHASH rule for a Hardened-Runtime binary. Exec it. Confirm the rule fires.
+
+7. **Latency budget under sustained exec load** (post-#208 perf regression check):
+   - Run a workload that execs ~1000 small binaries (e.g. `find /usr/bin | xargs -n1 -I{} {} --version` in a
+     loop) with one BINARY rule in the snapshot. Confirm no `AUTH_EXEC` deadline-kill events from the kernel
+     (`launchctl print system | grep -i edr` will surface them if any). Confirm the median sync-hash latency
+     in the extension log is below 50 ms.
+
+A pilot RC cannot be tagged until all seven scenarios pass on edr-dev. The PR description for `appcontrol/auth-
+exec-hardening` will be updated with the captured log excerpts before promotion to `v0.1.0-rc.9` (or
+whichever RC tags the bundle).

--- a/openspec/changes/appcontrol-auth-exec-hardening-v01/specs/endpoint-event-collection/spec.md
+++ b/openspec/changes/appcontrol-auth-exec-hardening-v01/specs/endpoint-event-collection/spec.md
@@ -1,0 +1,119 @@
+# Endpoint event collection v0.1.0 AUTH_EXEC hardening
+
+## ADDED Requirements
+
+### Requirement: Application Control undecided event kind
+
+The system SHALL emit an event of kind `application_control_undecided` whenever the extension's AUTH_EXEC
+handler cannot resolve a `BINARY` rule consultation within the kernel deadline budget AND the active
+snapshot's `deadline_fallback` posture is `fail-closed` or `audit-only`. The event SHALL carry, in addition
+to the canonical envelope fields, `pid`, `path`, `verdict` (`allow` under audit-only, `deny` under
+fail-closed), `reason` (`deadline` when the budget was exhausted between SHA-256 chunks, `read_failed`
+when the file was unreadable or the `(dev, inode, mtime)` TOCTOU re-stat failed), `file_size_bytes`,
+`policy_id`, and `policy_version`. The event SHALL be emitted AFTER the kernel `es_respond_auth_result`
+call so the post-respond cost does not eat into the AUTH_EXEC deadline. The `fail-open` posture SHALL NOT
+emit the event (an operator who picked fail-open has opted out of cold-cache visibility).
+
+#### Scenario: A fail-closed deadline exceedance emits an undecided event with verdict=deny
+
+- **GIVEN** the active snapshot has `deadline_fallback=fail-closed` and at least one `BINARY` rule
+- **WHEN** the AUTH_EXEC sync-hash budget is exhausted before the SHA-256 stream completes
+- **THEN** the extension emits an `application_control_undecided` event
+- **AND** the event's `verdict` is `deny`
+- **AND** the event's `reason` is `deadline`
+- **AND** the event carries the exec target's `path`, `pid`, `file_size_bytes`, plus the snapshot's
+  `policy_id` and `policy_version`
+
+#### Scenario: An audit-only deadline exceedance emits an undecided event with verdict=allow
+
+- **GIVEN** the active snapshot has `deadline_fallback=audit-only` and at least one `BINARY` rule
+- **WHEN** the AUTH_EXEC sync-hash budget is exhausted before the SHA-256 stream completes
+- **THEN** the extension emits an `application_control_undecided` event
+- **AND** the event's `verdict` is `allow`
+- **AND** the event's `reason` is `deadline`
+- **AND** the exec proceeds (the kernel sees `ES_AUTH_RESULT_ALLOW`)
+
+#### Scenario: A fail-open deadline exceedance emits no event
+
+- **GIVEN** the active snapshot has `deadline_fallback=fail-open` and at least one `BINARY` rule
+- **WHEN** the AUTH_EXEC sync-hash budget is exhausted before the SHA-256 stream completes
+- **THEN** the extension does NOT emit an `application_control_undecided` event
+- **AND** the exec proceeds (the kernel sees `ES_AUTH_RESULT_ALLOW`)
+
+## MODIFIED Requirements
+
+### Requirement: Canonical event envelope
+
+Every event the system emits SHALL be serialized as a JSON envelope with the fields `event_id`, `host_id`,
+`timestamp_ns`, `event_type`, and `payload`. `event_id` MUST be a UUID unique to that event, `host_id` MUST
+identify the device that produced the event and MUST be stable across reboots of that device, `timestamp_ns`
+MUST be nanoseconds since the Unix epoch, and `event_type` MUST be one of the documented values: `exec`,
+`fork`, `exit`, `open`, `network_connect`, `dns_query`, `application_control_block`,
+`application_control_undecided`, `snapshot_heartbeat`.
+
+#### Scenario: An event envelope is well-formed
+
+- **GIVEN** any captured event
+- **WHEN** the system serializes the event
+- **THEN** the resulting bytes parse as a JSON object containing `event_id`, `host_id`, `timestamp_ns`,
+  `event_type`, and `payload`
+- **AND** `event_type` matches one of the documented enum values
+- **AND** the payload conforms to the schema for that event type
+
+#### Scenario: Events from the same device share a host_id
+
+- **GIVEN** an enrolled device producing events
+- **WHEN** the device emits events from any source (process, network, DNS, application control)
+- **THEN** every emitted event carries the same `host_id` value
+- **AND** that value persists across reboots of the device
+
+### Requirement: Process exec authorization
+
+The system SHALL consult the application control decision engine on every AUTH_EXEC before allowing the new
+image to run. The decision engine consults the active snapshot's per-type maps in the fixed precedence order
+CDHASH → BINARY → SIGNINGID → TEAMID. When the engine returns a `BLOCK` rule whose `enforcement=PROTECT`,
+the system MUST deny the exec so the image never executes. Otherwise the system MUST allow the exec and emit
+an `exec` event describing the new image.
+
+The decision MUST be reached within the AUTH_EXEC deadline. For the BINARY rule layer the system MAY block
+the AUTH callback on a synchronous SHA-256 compute bounded by `es_message_t.deadline` minus a safety margin
+(target: 500 ms) reserved for the post-hash kernel respond + event/notification emit. If the sync compute
+cannot complete within that budget OR returns a `(dev, inode, mtime)` TOCTOU mismatch, the snapshot's
+`deadline_fallback` posture (`fail-closed` / `fail-open` / `audit-only`) drives the verdict; the BINARY
+layer's "could-have-fired" uncertainty SHALL dominate any later-precedence rule that would otherwise have
+matched (the walk does NOT continue to SIGNINGID/TEAMID after a deadline-exceeded/read-failed BINARY outcome).
+
+The system MUST NOT block the AUTH callback on `leaf_cert_sha256` fetches (CERTIFICATE rules remain a lazy
+cache fill and silently miss on cold cache).
+
+#### Scenario: A blocked exec is denied
+
+- **GIVEN** the decision engine returns a `BLOCK` / `PROTECT` rule for an exec target
+- **WHEN** the AUTH_EXEC callback runs
+- **THEN** the system denies the exec so the kernel returns the standard "operation not permitted" error
+- **AND** the binary does not run
+
+#### Scenario: An allowed exec emits an exec event
+
+- **GIVEN** the decision engine returns no match for an exec target
+- **WHEN** the AUTH_EXEC callback runs
+- **THEN** the system allows the exec
+- **AND** an `exec` event is emitted describing the new image
+
+#### Scenario: A cold-cache exec on a CERTIFICATE-only target is allowed
+
+- **GIVEN** the snapshot contains only a `CERTIFICATE` rule for an exec target
+- **AND** the leaf certificate SHA-256 for that target is not yet cached
+- **WHEN** the AUTH_EXEC callback runs
+- **THEN** the `CERTIFICATE` rule silently misses for this exec
+- **AND** the system allows the exec
+- **AND** the cache is filled for subsequent execs
+
+#### Scenario: A cold-cache exec on a BINARY-only target is decided synchronously
+
+- **GIVEN** the snapshot contains a `BINARY` block rule for an exec target whose SHA-256 cache is cold
+- **WHEN** the AUTH_EXEC callback runs
+- **THEN** the system computes the SHA-256 synchronously within the deadline budget
+- **AND** the BINARY rule matches
+- **AND** the system DENIES the exec on the FIRST attempt
+- **AND** an `application_control_block` event is emitted

--- a/openspec/changes/appcontrol-auth-exec-hardening-v01/specs/extension-application-control/spec.md
+++ b/openspec/changes/appcontrol-auth-exec-hardening-v01/specs/extension-application-control/spec.md
@@ -1,0 +1,235 @@
+# Extension Application Control v0.1.0 AUTH_EXEC hardening
+
+## ADDED Requirements
+
+### Requirement: Platform-binary carve-out precedes the snapshot walk
+
+Before consulting the active snapshot, the extension SHALL ALLOW any AUTH_EXEC whose target carries the kernel's
+`is_platform_binary` flag, and SHALL pin the result into the kernel's per-`(dev, inode, mtime)` AUTH cache by
+responding with `cache: true`. The carve-out SHALL run BEFORE the existing self-allow failsafe and BEFORE the
+precedence walk. The kernel's `is_platform_binary` flag is more conservative than any hand-curated path or
+signing-id allowlist would be: it is the kernel's own classification of "this binary is on the Apple-signed
+system image" and identifies launchd, xpcproxy, fseventsd, kextd, sysextd, systemextensionsd, WindowServer,
+loginwindow, mds, and every other Apple system binary without operator-maintained lists.
+
+#### Scenario: An Apple platform binary is unconditionally allowed
+
+- **GIVEN** the active snapshot contains a `BINARY` block rule whose identifier is the SHA-256 of `/sbin/launchd`
+- **WHEN** the kernel issues an AUTH_EXEC for `/sbin/launchd` and reports `target.is_platform_binary == true`
+- **THEN** the extension responds with `ES_AUTH_RESULT_ALLOW` and `cache: true`
+- **AND** the precedence walk is NOT consulted
+- **AND** the snapshot's `BINARY` rule does NOT cause a DENY
+
+#### Scenario: A non-platform binary still walks the snapshot
+
+- **GIVEN** the active snapshot contains a `BINARY` block rule for a non-Apple binary
+- **WHEN** the kernel issues an AUTH_EXEC whose `target.is_platform_binary == false`
+- **THEN** the platform-binary carve-out does not fire
+- **AND** the extension proceeds to the self-allow failsafe and then the precedence walk
+
+### Requirement: Deadline-guarded synchronous SHA-256 for BINARY rule consultation
+
+The extension SHALL compute the exec target's SHA-256 synchronously on the AUTH_EXEC callback thread when the
+active snapshot contains at least one `BINARY` rule, bounded by a budget derived from the kernel-supplied
+`es_message_t.deadline`. The budget SHALL reserve a safety margin (target: 500 ms) for the post-hash work
+(snapshot lookup, kernel respond, optional event / notification dispatch) plus an unlucky page-in stall. The
+hash SHALL stream the file in chunks (target: 64 KiB) so the deadline budget is checked between chunks and an
+abort yields the kernel-respond path enough headroom to complete. When the active snapshot has zero `BINARY`
+rules, the extension SHALL skip the hash compute entirely (the result no rule could consult is wasted work).
+
+The TOCTOU re-stat guard from the warm-cache compute path SHALL apply: if `fstat(2)` on the opened file
+descriptor reports a `(dev, inode, mtime)` tuple different from what the AUTH event delivered, the extension
+SHALL treat the outcome as unavailable (the file was atomically replaced between AUTH and read) and SHALL NOT
+poison the cache with a hash of the wrong file.
+
+#### Scenario: Sync hash on cold cache decides the first exec
+
+- **GIVEN** the active snapshot contains a `BINARY` block rule whose identifier is the SHA-256 of a binary the
+  extension has never seen before (cache cold)
+- **WHEN** the kernel issues an AUTH_EXEC for that binary
+- **THEN** the extension computes the SHA-256 synchronously within the kernel deadline budget
+- **AND** the precedence walk's BINARY layer matches the rule
+- **AND** the extension responds with `ES_AUTH_RESULT_DENY`
+- **AND** an `application_control_block` event is emitted
+
+#### Scenario: Mutated `(dev, inode, mtime)` does not bypass the BINARY rule
+
+- **GIVEN** the active snapshot contains a `BINARY` block rule for a binary whose mtime is mutated on every
+  exec (an attacker invalidating the cache key to keep the first-exec ALLOW path open)
+- **WHEN** each AUTH_EXEC arrives with a fresh `(dev, inode, mtime)` tuple
+- **THEN** the extension re-computes the SHA-256 synchronously for every exec
+- **AND** every exec hits the BINARY rule and is DENIED
+- **AND** no exec slips past the rule on the first try
+
+#### Scenario: Empty BINARY map skips the hash compute
+
+- **GIVEN** the active snapshot has zero `BINARY` rules but at least one `SIGNINGID` rule
+- **WHEN** the kernel issues an AUTH_EXEC
+- **THEN** the extension does NOT call the deadline-bounded SHA-256 helper
+- **AND** the precedence walk still consults CDHASH / SIGNINGID / TEAMID
+- **AND** the AUTH callback latency does not include hash compute time
+
+### Requirement: Deadline fallback posture
+
+The active snapshot SHALL carry a `deadline_fallback` field whose value is one of `fail-closed`, `fail-open`,
+or `audit-only`. When the deadline-bounded SHA-256 cannot complete (the budget is exhausted between chunks)
+or returns a read failure (TOCTOU mismatch, missing file, fstat error), the extension SHALL apply the posture
+as the terminal verdict for the AUTH_EXEC, without continuing the precedence walk to `SIGNINGID` or `TEAMID`
+(the BINARY layer's "could-have-fired" uncertainty dominates anything those lower layers would say).
+
+- `fail-closed`: respond `ES_AUTH_RESULT_DENY`. Emit an `application_control_undecided` event with
+  `verdict=deny` so the operator can audit the rate.
+- `fail-open`: respond `ES_AUTH_RESULT_ALLOW`. Emit no event (the operator opted out of visibility).
+- `audit-only`: respond `ES_AUTH_RESULT_ALLOW`. Emit an `application_control_undecided` event with
+  `verdict=allow` so the operator can measure the cold-cache rate without changing exec behaviour.
+
+When the snapshot payload omits the field, the extension SHALL substitute `fail-closed` (the documented
+v0.1.0 default; the only posture that closes the cold-cache window without operator awareness of the
+trade-off).
+
+#### Scenario: fail-closed under deadline exceedance
+
+- **GIVEN** the active snapshot carries `deadline_fallback=fail-closed` and at least one `BINARY` rule
+- **WHEN** the AUTH_EXEC's deadline budget is exhausted before the SHA-256 stream completes
+- **THEN** the extension responds `ES_AUTH_RESULT_DENY`
+- **AND** emits an `application_control_undecided` event with `verdict=deny` and `reason=deadline`
+
+#### Scenario: audit-only under deadline exceedance
+
+- **GIVEN** the active snapshot carries `deadline_fallback=audit-only` and at least one `BINARY` rule
+- **WHEN** the AUTH_EXEC's deadline budget is exhausted before the SHA-256 stream completes
+- **THEN** the extension responds `ES_AUTH_RESULT_ALLOW`
+- **AND** emits an `application_control_undecided` event with `verdict=allow` and `reason=deadline`
+
+#### Scenario: fail-open under deadline exceedance
+
+- **GIVEN** the active snapshot carries `deadline_fallback=fail-open` and at least one `BINARY` rule
+- **WHEN** the AUTH_EXEC's deadline budget is exhausted before the SHA-256 stream completes
+- **THEN** the extension responds `ES_AUTH_RESULT_ALLOW`
+- **AND** no `application_control_undecided` event is emitted
+
+#### Scenario: Missing deadline_fallback substitutes fail-closed
+
+- **GIVEN** the agent delivers a snapshot payload that omits the `deadline_fallback` field
+- **WHEN** the extension decodes the payload
+- **THEN** the in-memory snapshot reports `deadline_fallback == fail-closed`
+- **AND** subsequent deadline-exceeded AUTH_EXECs DENY per the fail-closed posture
+
+### Requirement: Application Control undecided event
+
+The extension SHALL emit an event of kind `application_control_undecided` only when the BINARY layer's hash
+outcome is unavailable AND the active snapshot's `deadline_fallback` is `fail-closed` or `audit-only`. The
+event SHALL carry `pid`, `path`, `verdict` (`allow` for audit-only, `deny` for fail-closed), `reason`
+(`deadline` when the budget was exhausted, `read_failed` when the file was unreadable or the TOCTOU re-stat
+failed), `file_size_bytes`, `policy_id`, and `policy_version`. The event SHALL be emitted AFTER the kernel
+`es_respond_auth_result` call so the post-respond cost does not eat into the deadline.
+
+#### Scenario: read_failed reason on TOCTOU mismatch under fail-closed
+
+- **GIVEN** the active snapshot carries `deadline_fallback=fail-closed` and at least one `BINARY` rule
+- **WHEN** the AUTH_EXEC arrives but a `(dev, inode, mtime)` TOCTOU re-stat at hash-open time shows the file
+  was replaced
+- **THEN** the extension responds `ES_AUTH_RESULT_DENY`
+- **AND** emits an `application_control_undecided` event with `verdict=deny` and `reason=read_failed`
+
+## MODIFIED Requirements
+
+### Requirement: Target identifier tuple for every exec
+
+For every authorized exec the extension SHALL build a target identifier tuple consisting of `cdhash`,
+`signing_id_prefixed`, `leaf_cert_sha256`, `team_id`, and `path`. `file_sha256` is no longer part of the
+tuple struct itself; it is supplied as a separate `HashOutcome` at decide time so the hash compute can run
+on the AUTH callback thread under a deadline budget (see the deadline-guarded BINARY hash requirement
+above). The remaining tuple values SHALL be derived as follows:
+
+- `cdhash`: the value of `process.cdhash` on `es_process_t`, populated only if the process runs under
+  Apple's Hardened Runtime. For non-hardened processes this field SHALL be absent. (Note: this gate is
+  ours; Santa applies CDHASH rules regardless of the Hardened Runtime flag. We gate because the kernel
+  maps pages lazily on non-hardened processes and does not re-verify them post-load, so the CDHash ESF
+  reports at exec is not a reliable identity for the bytes that will eventually execute.)
+- `signing_id_prefixed`: `<team_id>:<signing_id>` when both are present, or `platform:<signing_id>` when the
+  binary is an Apple platform binary, or absent when no signing_id is present.
+- `leaf_cert_sha256`: the SHA-256 of the leaf X.509 certificate in the signed code's signing chain. The
+  extension SHALL maintain a cache keyed by `(inode, mtime)` and SHALL NOT block the AUTH callback on the
+  fetch. On a cache miss the value MAY be absent for the current exec.
+- `team_id`: the value of `process.team_id`, or absent if the binary is unsigned.
+- `path`: the canonical absolute filesystem path of the authorized exec target. Always present (the AUTH
+  event carries it directly); the macOS canonicalization of `/tmp`, `/var`, and `/etc` into their
+  `/private/...` forms is applied before matching so the precedence walk compares against the same canonical
+  form the server validates and persists rule identifiers in.
+
+#### Scenario: A signed non-Apple binary yields a full tuple
+
+- **GIVEN** the extension's leaf-cert cache contains an entry for the binary under test
+- **WHEN** the extension builds the target tuple for an exec of that binary
+- **THEN** the tuple contains `signing_id_prefixed` shaped as `<team_id>:<signing_id>`, `leaf_cert_sha256`,
+  and `team_id`
+- **AND** `cdhash` is present if the binary uses the Hardened Runtime and absent otherwise
+
+#### Scenario: A first exec with cold leaf-cert cache still produces a tuple but with leaf_cert absent
+
+- **GIVEN** the extension's `leaf_cert_sha256` cache is empty for the binary under test
+- **WHEN** the extension builds the target tuple for the exec
+- **THEN** the tuple contains at least `team_id` and `signing_id_prefixed` where present
+- **AND** `leaf_cert_sha256` is absent
+- **AND** the missing leaf-cert value does not delay the AUTH callback
+
+#### Scenario: A platform binary's signing identifier carries the platform prefix
+
+- **GIVEN** an exec of `/usr/bin/curl` (signed as an Apple platform binary)
+- **WHEN** the extension builds the target tuple
+- **THEN** `signing_id_prefixed` is `platform:com.apple.curl`
+
+### Requirement: AUTH_EXEC denial on BLOCK match
+
+When the precedence walk returns a rule whose `action=BLOCK` and `enforcement=PROTECT`, the extension SHALL
+deny the AUTH_EXEC request so the new image does not run. When the walk returns no match, or returns a rule
+whose `enforcement` is anything other than `PROTECT`, the extension SHALL allow the AUTH_EXEC request to
+proceed. The decision SHALL be reached within the AUTH_EXEC deadline. The extension MAY block the AUTH
+callback on a synchronous BINARY-rule SHA-256 compute bounded by the deadline budget (see the deadline-
+guarded BINARY hash requirement). The extension MUST NOT block the AUTH callback on `leaf_cert_sha256`
+fetches; those remain a lazy cache fill.
+
+#### Scenario: A BLOCK rule denies the exec
+
+- **GIVEN** the precedence walk for an exec returns a `BLOCK` / `PROTECT` rule
+- **WHEN** the extension responds to AUTH_EXEC
+- **THEN** the response is a deny
+- **AND** the new image does not run
+
+#### Scenario: No matching rule allows the exec
+
+- **GIVEN** the precedence walk for an exec returns no match
+- **WHEN** the extension responds to AUTH_EXEC
+- **THEN** the response is allow
+
+#### Scenario: A cold-cache exec on a CERTIFICATE-only target is allowed
+
+- **GIVEN** the snapshot contains only a `CERTIFICATE` rule for an exec target
+- **AND** the leaf certificate SHA-256 for that target is not yet cached
+- **WHEN** the AUTH_EXEC callback runs
+- **THEN** the `CERTIFICATE` rule silently misses for this exec
+- **AND** the system allows the exec
+- **AND** the cache is filled for subsequent execs
+
+### Requirement: Lazy signing-info fetch is non-blocking (scope narrowed to leaf_cert only)
+
+The extension SHALL compute `leaf_cert_sha256` outside of the AUTH_EXEC callback whenever the value is not
+already cached. When the value is not cached at decision time, the `CERTIFICATE` rule type SHALL silently
+miss for that exec, and the resulting cache entry SHALL be available to subsequent execs of the same
+`(inode, mtime)`. The extension MUST NOT call into Security framework lookups inside the AUTH_EXEC callback.
+
+(The Phase A rule that grouped `file_sha256` under this same "lazy, non-blocking" contract is REMOVED:
+`file_sha256` is now computed synchronously on the AUTH callback thread under the deadline budget defined
+by the deadline-guarded BINARY hash requirement above. The lazy-fill `startLazyFill` path on
+`FileHashCache` remains as a warm-up optimisation for the NOTIFY_EXEC path's `lookupOrCompute` call, NOT
+as a substitute for AUTH-time enforcement.)
+
+#### Scenario: A cold CERTIFICATE cache yields a silent miss then a warm hit
+
+- **GIVEN** the `leaf_cert_sha256` cache is empty for a binary under test
+- **WHEN** the binary is executed for the first time
+- **THEN** any `CERTIFICATE` rule that would have matched silently misses for that exec
+- **AND** the cache is filled after the AUTH callback returns
+- **WHEN** the same binary is executed a second time
+- **THEN** the `CERTIFICATE` rule matches and the AUTH callback returns deny within the deadline

--- a/openspec/changes/appcontrol-auth-exec-hardening-v01/tasks.md
+++ b/openspec/changes/appcontrol-auth-exec-hardening-v01/tasks.md
@@ -1,0 +1,124 @@
+# Application Control v0.1.0 AUTH_EXEC hardening tasks
+
+## Status (2026-05-26)
+
+Implementation shipped on the `appcontrol/auth-exec-hardening` branch as a single PR (commit 898b085).
+Unit / component coverage is green (104 swift tests, the touched Go suites, golangci-lint, xcodebuild for
+the extension target). The L5 (System / VM) validation matrix in `proposal.md` is the gate before this
+change can be archived and the v0.1.0-rc.* tag rotated.
+
+## 1. Platform-binary carve-out (#205)
+
+- [x] 1.1 Add the platform-binary short-circuit at the top of `ESFSubscriber.handleAuthExec`:
+  `if target.is_platform_binary { es_respond_auth_result(ALLOW, cache: true); return }`. Order matters: it
+  must run BEFORE the existing self-allow failsafe and BEFORE the snapshot walk so the kernel cache pins
+  the result for the file's `(dev, inode, mtime)` lifetime.
+- [x] 1.2 Update the handler doc comment to enumerate the two carve-outs (platform binary first, then
+  self-allow) plus the precedence walk in their respective order.
+- [x] 1.3 L5 (edr-dev) validation: under a snapshot containing the SIGNINGID rule `platform:com.apple.yes`,
+  exec'd `/usr/bin/yes` against the dev-built extension (pid 90544). Without the carve-out the rule would
+  have DENIED + emitted `application_control_block`; the actual run produced no DENY log and no event in
+  SigNoz, which is the only outcome consistent with the carve-out firing. See `proposal.md` "edr-dev
+  validation completed 2026-05-26" for the full audit trail.
+- [ ] 1.4 L5 (edr-qa) validation under a notarized pkg: push BINARY rules for `/sbin/launchd`,
+  `/usr/libexec/xpcproxy`, `fseventsd`, `kextd`, `sysextd`. Reboot the VM. Confirm no DENY in the extension
+  log and every Apple platform binary still execs. Required because on edr-dev ESF redaction forces
+  `is_platform_binary=true` on every exec, which makes the platform-vs-non-platform discrimination
+  unobservable. See `proposal.md` scenario 1.
+
+## 2. Deadline-guarded sync SHA-256 (#208 core)
+
+- [x] 2.1 Add `FileHashCache.lookupOrComputeWithDeadline(path, stat, deadlineMachAbs) -> HashOutcome`.
+  Internally streams 64-KiB chunks through `SHA256()` checking `mach_absolute_time()` between chunks against
+  `deadlineMachAbs - safetyMarginNs`. `safetyMarginNs = 500_000_000` (500 ms) so the post-hash work
+  (snapshot lookup, kernel respond, optional event/notification emit) plus a page-in stall margin fits
+  inside the kernel deadline.
+- [x] 2.2 Cache writes only on `.computed` outcomes. `.deadlineExceeded` and `.readFailed` leave the cache
+  empty so the next exec retries. TOCTOU re-stat guard is reused from the existing `computeSHA256`.
+- [x] 2.3 Wire the deadline variant into `handleAuthExec`. Pass `msg.deadline` (the
+  `es_message_t.deadline` field) through. Gate the call on `!snapshot.binaryRules.isEmpty` so the hash
+  compute is skipped entirely when no BINARY rule could fire (`.notNeeded` outcome).
+- [x] 2.4 XCTest coverage in `FileHashCacheTests`: `.computed` on first call, cache hit on second call,
+  `.deadlineExceeded` when deadline is in the past, `.readFailed` on missing file, `.readFailed` on
+  TOCTOU inode mismatch.
+- [ ] 2.5 L5 (edr-qa) validation under a notarized pkg: push a BINARY block rule for a fresh test binary
+  (cold cache); confirm the FIRST exec is denied. Repeat with a `(dev,inode,mtime)`-mutated binary. NOT
+  validatable on edr-dev because ESF redaction forces every exec to hit the platform-binary carve-out
+  before the BINARY layer runs (#187). Confirmed empirically on 2026-05-26: a snapshot containing only a
+  BINARY rule for `af07f42d...` (gh's SHA-256) loaded cleanly but execs of `/tmp/test-binary-v02` and
+  `/tmp/test-binary-v03` ALLOWed through the carve-out. See `proposal.md` scenario 2 and the validation
+  audit.
+
+## 3. Pure-logic decider extraction
+
+- [x] 3.1 New `extension/edr/extension/AuthExecDecider.swift`. Exposes `FallbackPosture` enum
+  (`failClosed` / `failOpen` / `auditOnly`), `HashOutcome` enum (associated `String` for `.computed`,
+  plus `.deadlineExceeded`, `.readFailed`, `.notNeeded`), `AuthTuple` struct (cdhash / signingIDPrefixed
+  / teamID), `AuthDecision` enum (`.allow`, `.allowWithUndecidedAudit(reason)`,
+  `.deny(rule, matchedIdentifier)`, `.denyWithUndecidedAudit(reason)`), and `decideAuthExec(...)` as the
+  precedence walker.
+- [x] 3.2 Add the new file to `Package.swift`'s `sources:` list so the SwiftPM target compiles it (and so
+  the XCTest target can import the types via `@testable import EDRExtensionLogic`).
+- [x] 3.3 `ESFSubscriber.handleAuthExec` rewritten as a thin wire: read deadline, build tuple, compute or
+  skip hash, call `decideAuthExec`, dispatch the returned `AuthDecision`. `walkPrecedence` and the nested
+  `AuthTuple` / `PrecedenceMatch` types are deleted (their roles move into the decider).
+- [x] 3.4 XCTest coverage in `AuthExecDeciderTests`: 15 cases covering (3 postures × 3 hash outcomes ×
+  4 precedence layers) plus precedence-order tie-breakers and non-PROTECT enforcement no-op.
+
+## 4. Fallback posture wiring (#208 posture)
+
+- [x] 4.1 Add `FallbackPosture` enum + `IsValidFallbackPosture` + `DefaultFallbackPosture` constant +
+  `DeadlineFallback` field on `ApplicationControlPolicy` + `DeadlineFallback` field on
+  `SetApplicationControlPayload` in `server/rules/api/types.go`. Marshal substitutes
+  `DefaultFallbackPosture` (`fail-closed`) when the policy's value is empty.
+- [x] 4.2 Add `deadlineFallback: FallbackPosture` to `ApplicationControlSnapshot` + `deadlineFallback`
+  Optional to `ApplicationControlDocument` in `extension/edr/extension/ApplicationControlStore.swift`.
+  `makeSnapshot` substitutes `.defaultPosture` (`.failClosed`) when the document's value is nil.
+- [x] 4.3 Go tests in `app_control_wire_test.go`: default substitution, per-posture passthrough, JSON key
+  pin (`deadline_fallback`), validator coverage.
+- [ ] 4.4 L5 (edr-qa) validation under a notarized pkg: drive each posture against a deadline-forced
+  AUTH_EXEC. NOT validatable on edr-dev (same ESF redaction reason as 2.5). The undecided-event payload
+  byte-shape is locked by the schema + AuthExecDeciderTests cover the verdict matrix; what edr-qa adds is
+  observing the event actually emitted from the wire after a real-kernel deadline exceedance. See
+  `proposal.md` scenarios 3 / 4 / 5.
+
+## 5. Undecided event emission
+
+- [x] 5.1 Add `ApplicationControlUndecidedPayload` struct in `extension/edr/extension/EventSerializer.swift`
+  carrying `pid`, `path`, `verdict`, `reason`, `fileSizeBytes`, `policyID`, `policyVersion`.
+- [x] 5.2 Add `emitUndecidedEvent(...)` helper in `ESFSubscriber.swift`, called by the `dispatchAuthDecision`
+  switch under `.allowWithUndecidedAudit` and `.denyWithUndecidedAudit` cases.
+- [x] 5.3 Extend `schema/events.json`: add `application_control_undecided` to the `event_type` enum and the
+  `oneOf` payload union; define `application_control_undecided_payload` with `pid`, `path`, `verdict`
+  (`allow` | `deny`), `reason` (`deadline` | `read_failed`), `file_size_bytes`, `policy_id`,
+  `policy_version`.
+- [ ] 5.4 Server-side ingestion: route the new event type into a graph-builder no-op + a future alert
+  source. Out of scope for this change; tracked as a v0.1.x follow-up because the operator dashboard work
+  has not started.
+- [ ] 5.5 L5 (edr-qa) validation under a notarized pkg: confirm the event payload byte-shape on the wire
+  matches the schema and the Swift encoder's output. NOT validatable on edr-dev (same ESF redaction
+  reason). See `proposal.md` scenarios 3 and 4.
+
+## 6. CDHASH doc-comment fix (#207)
+
+- [x] 6.1 Rewrite the inline comment in `buildAuthTuple` and the standalone `isHardenedRuntime` doc to own
+  the lazy-page-mapping rationale without crediting Santa; add the explicit "this diverges from Santa"
+  note so a migrating Santa admin is not surprised.
+
+## 7. Documentation
+
+- [x] 7.1 Update `docs/operations.md`'s "Application control" section: replace the stale "Phase 1 deletes
+  the legacy endpoints; the new REST surface lands in later phases" framing with the v0.1.0 reality.
+  Document the two carve-outs, the three postures + their trade-offs, the v0.1.0 default of `fail-closed`,
+  and the behaviour-change note for RC upgrades.
+
+## 8. v0.1.x follow-up scope (intentionally NOT in this change)
+
+- [ ] 8.1 `app_control_policies.deadline_fallback` DB column + bootstrap migration.
+- [ ] 8.2 REST surface (`PATCH /api/v1/app-control/policies/:id`) to set the per-policy posture; validator
+  hook to `IsValidFallbackPosture`.
+- [ ] 8.3 UI control + audit-row entry on posture change.
+- [ ] 8.4 Server-side `application_control_undecided` event router: graph-builder no-op + alert source so
+  the operator dashboard can chart the cold-cache rate over time.
+- [ ] 8.5 SonarCloud / golangci-lint sweep for the new field (no new findings expected; the field is a
+  simple string enum).

--- a/schema/events.json
+++ b/schema/events.json
@@ -19,7 +19,7 @@
     },
     "event_type": {
       "type": "string",
-      "enum": ["exec", "fork", "exit", "open", "network_connect", "dns_query", "application_control_block", "snapshot_heartbeat"],
+      "enum": ["exec", "fork", "exit", "open", "network_connect", "dns_query", "application_control_block", "application_control_undecided", "snapshot_heartbeat"],
       "description": "Type of endpoint security event"
     },
     "payload": {
@@ -31,6 +31,7 @@
         { "$ref": "#/definitions/network_connect_payload" },
         { "$ref": "#/definitions/dns_query_payload" },
         { "$ref": "#/definitions/application_control_block_payload" },
+        { "$ref": "#/definitions/application_control_undecided_payload" },
         { "$ref": "#/definitions/snapshot_heartbeat_payload" }
       ]
     }
@@ -155,6 +156,20 @@
         "severity": { "type": "string", "enum": ["low", "medium", "high", "critical"] },
         "custom_msg": { "type": "string" },
         "custom_url": { "type": "string" },
+        "policy_id": { "type": "integer" },
+        "policy_version": { "type": "integer" }
+      }
+    },
+    "application_control_undecided_payload": {
+      "type": "object",
+      "description": "Emitted when AUTH_EXEC could not compute a BINARY hash within the kernel deadline budget (or the file was unreadable for the TOCTOU re-stat reasons in FileHashCache.computeSHA256WithDeadline) and the active snapshot's deadline_fallback drove the verdict. Operators consume these events to size their cold-cache rate before flipping the posture between fail-closed / fail-open / audit-only.",
+      "required": ["pid", "path", "verdict", "reason", "file_size_bytes", "policy_id", "policy_version"],
+      "properties": {
+        "pid": { "type": "integer" },
+        "path": { "type": "string" },
+        "verdict": { "type": "string", "enum": ["allow", "deny"], "description": "Wire verdict the kernel received. \"deny\" only fires under fail-closed posture; \"allow\" fires under audit-only (fail-open emits no event by design)." },
+        "reason": { "type": "string", "enum": ["deadline", "read_failed"], "description": "Technical cause that prevented a hash decision. \"deadline\" means the budget headroom was exhausted before chunks finished streaming; \"read_failed\" means the file could not be opened, fstat failed, or a TOCTOU replace was detected between AUTH and read." },
+        "file_size_bytes": { "type": "integer", "description": "Size of the executable being authorised. Pairs with reason=\"deadline\" to identify large-binary workloads where the deadline budget is the bottleneck." },
         "policy_id": { "type": "integer" },
         "policy_version": { "type": "integer" }
       }

--- a/server/rules/api/app_control_wire_test.go
+++ b/server/rules/api/app_control_wire_test.go
@@ -151,6 +151,17 @@ var severities = []api.Severity{
 	api.SeverityRuleCritical,
 }
 
+// fallbackPostures enumerates the validator-accepted FallbackPosture values plus the empty zero value. The empty case lives
+// here so the PBT explicitly covers the "policy struct has no posture set" path that the marshal substitutes with
+// DefaultFallbackPosture; the validator-accepted values cover the v0.1.x configurability path that arrives once the REST
+// surface lets operators set the posture per policy.
+var fallbackPostures = []api.FallbackPosture{
+	"",
+	api.FallbackPostureFailClosed,
+	api.FallbackPostureFailOpen,
+	api.FallbackPostureAuditOnly,
+}
+
 // genRule produces a random rule shape. Identifier is opaque to the payload codec (the per-rule_type identifier validator runs server-
 // side, not in the marshal helper), so we use a printable-ASCII string generator to exercise the JSON encoding path without dragging
 // in per-type format gymnastics.
@@ -211,6 +222,7 @@ func TestMarshalSetApplicationControlPayload_RapidRoundTrip(t *testing.T) {
 		policyID := rapid.Int64Range(1, 1_000_000).Draw(t, "policy_id")
 		policyVersion := rapid.Int64Range(1, 1_000_000).Draw(t, "policy_version")
 		nRules := rapid.IntRange(0, 20).Draw(t, "n_rules")
+		posture := rapid.SampledFrom(fallbackPostures).Draw(t, "deadline_fallback")
 
 		rules := make([]api.ApplicationControlRule, 0, nRules)
 		for i := range nRules {
@@ -224,7 +236,7 @@ func TestMarshalSetApplicationControlPayload_RapidRoundTrip(t *testing.T) {
 			now = time.Unix(0, 0).UTC()
 		}
 
-		policy := api.ApplicationControlPolicy{ID: policyID, Version: policyVersion}
+		policy := api.ApplicationControlPolicy{ID: policyID, Version: policyVersion, DeadlineFallback: posture}
 		raw, err := api.MarshalSetApplicationControlPayload(policy, rules, now)
 		require.NoError(t, err)
 
@@ -232,6 +244,18 @@ func TestMarshalSetApplicationControlPayload_RapidRoundTrip(t *testing.T) {
 		require.NoError(t, json.Unmarshal(raw, &decoded))
 		assert.Equal(t, policyID, decoded.PolicyID)
 		assert.Equal(t, policyVersion, decoded.PolicyVersion)
+
+		// Posture invariant: the marshal substitutes DefaultFallbackPosture when the upstream policy has no value set
+		// (empty string today, or any future value the validator does not recognise). Validator-accepted values flow
+		// through verbatim. Either way the decoded wire field must be a validator-accepted posture so the extension
+		// snapshot decode cannot fail on an unknown literal.
+		expectedPosture := posture
+		if !api.IsValidFallbackPosture(expectedPosture) {
+			expectedPosture = api.DefaultFallbackPosture
+		}
+		assert.Equal(t, expectedPosture, decoded.DeadlineFallback)
+		assert.True(t, api.IsValidFallbackPosture(decoded.DeadlineFallback),
+			"wire posture %q must always pass the validator", decoded.DeadlineFallback)
 
 		// Build the expected post-filter view from the inputs and compare element-wise. The filter contract: drop disabled
 		// rules; drop rules whose expires_at is in the past relative to a non-zero `now`.
@@ -318,6 +342,27 @@ func TestMarshalSetApplicationControlPayload_DeadlineFallbackPassthrough(t *test
 			var decoded api.SetApplicationControlPayload
 			require.NoError(t, json.Unmarshal(raw, &decoded))
 			assert.Equal(t, tc.posture, decoded.DeadlineFallback)
+		})
+	}
+}
+
+// TestMarshalSetApplicationControlPayload_DeadlineFallbackNormalizesInvalid pins that a non-empty but unrecognised posture is
+// substituted with DefaultFallbackPosture before it reaches the wire. The extension's FallbackPosture enum is strict; an
+// unknown literal would deactivate Application Control until the next valid push, so the marshal MUST never emit one.
+func TestMarshalSetApplicationControlPayload_DeadlineFallbackNormalizesInvalid(t *testing.T) {
+	cases := []string{"fail-close", "FAIL-CLOSED", "audit_only", "garbage", "FAIL-OPEN"}
+	for _, bad := range cases {
+		t.Run(bad, func(t *testing.T) {
+			raw, err := api.MarshalSetApplicationControlPayload(
+				api.ApplicationControlPolicy{ID: 1, Version: 1, DeadlineFallback: api.FallbackPosture(bad)},
+				nil,
+				time.Time{},
+			)
+			require.NoError(t, err)
+			var decoded api.SetApplicationControlPayload
+			require.NoError(t, json.Unmarshal(raw, &decoded))
+			assert.Equal(t, api.DefaultFallbackPosture, decoded.DeadlineFallback)
+			assert.True(t, api.IsValidFallbackPosture(decoded.DeadlineFallback))
 		})
 	}
 }

--- a/server/rules/api/app_control_wire_test.go
+++ b/server/rules/api/app_control_wire_test.go
@@ -276,3 +276,86 @@ func TestMarshalSetApplicationControlPayload_RapidRoundTrip(t *testing.T) {
 		}
 	})
 }
+
+// TestMarshalSetApplicationControlPayload_DeadlineFallbackDefault pins the v0.1.0 contract: a policy whose DeadlineFallback
+// is the zero value (empty string) marshals to "fail-closed" on the wire. Pre-v0.1.0 callers that have not been recompiled
+// against the new ApplicationControlPolicy shape will leak that zero value through, and the extension snapshot must still
+// receive a safe-by-default posture.
+func TestMarshalSetApplicationControlPayload_DeadlineFallbackDefault(t *testing.T) {
+	raw, err := api.MarshalSetApplicationControlPayload(
+		api.ApplicationControlPolicy{ID: 1, Version: 1},
+		nil,
+		time.Time{},
+	)
+	require.NoError(t, err)
+	var decoded api.SetApplicationControlPayload
+	require.NoError(t, json.Unmarshal(raw, &decoded))
+	assert.Equal(t, api.FallbackPostureFailClosed, decoded.DeadlineFallback)
+	assert.Equal(t, api.DefaultFallbackPosture, decoded.DeadlineFallback,
+		"DefaultFallbackPosture must be the substituted value")
+}
+
+// TestMarshalSetApplicationControlPayload_DeadlineFallbackPassthrough confirms an explicitly-set policy posture survives
+// the marshal verbatim. Drives the v0.1.x follow-up that will start carrying real values through ApplicationControlPolicy
+// once the DB column lands; the test guarantees the wire path is ready to accept whatever value the REST surface validates.
+func TestMarshalSetApplicationControlPayload_DeadlineFallbackPassthrough(t *testing.T) {
+	cases := []struct {
+		name    string
+		posture api.FallbackPosture
+	}{
+		{"fail-closed", api.FallbackPostureFailClosed},
+		{"fail-open", api.FallbackPostureFailOpen},
+		{"audit-only", api.FallbackPostureAuditOnly},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			raw, err := api.MarshalSetApplicationControlPayload(
+				api.ApplicationControlPolicy{ID: 1, Version: 1, DeadlineFallback: tc.posture},
+				nil,
+				time.Time{},
+			)
+			require.NoError(t, err)
+			var decoded api.SetApplicationControlPayload
+			require.NoError(t, json.Unmarshal(raw, &decoded))
+			assert.Equal(t, tc.posture, decoded.DeadlineFallback)
+		})
+	}
+}
+
+// TestMarshalSetApplicationControlPayload_DeadlineFallbackWireKey pins the JSON key Swift's Decodable reads. A rename here
+// silently breaks the extension's snapshot decode; this test fails loudly when a rename happens.
+func TestMarshalSetApplicationControlPayload_DeadlineFallbackWireKey(t *testing.T) {
+	raw, err := api.MarshalSetApplicationControlPayload(
+		api.ApplicationControlPolicy{ID: 1, Version: 1, DeadlineFallback: api.FallbackPostureAuditOnly},
+		nil,
+		time.Time{},
+	)
+	require.NoError(t, err)
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(raw, &got))
+	require.Contains(t, got, "deadline_fallback")
+	assert.Equal(t, "audit-only", got["deadline_fallback"])
+}
+
+// TestIsValidFallbackPosture is the table-driven validator the v0.1.x REST surface will call before persisting an operator-
+// supplied posture. Pinning the enum membership here keeps the validator honest if the enum ever picks up a new value (the
+// invalid-case lines below must be updated to include the new constant).
+func TestIsValidFallbackPosture(t *testing.T) {
+	cases := []struct {
+		name    string
+		posture api.FallbackPosture
+		want    bool
+	}{
+		{"fail-closed", api.FallbackPostureFailClosed, true},
+		{"fail-open", api.FallbackPostureFailOpen, true},
+		{"audit-only", api.FallbackPostureAuditOnly, true},
+		{"empty", "", false},
+		{"misspelled fail-close", "fail-close", false},
+		{"uppercase", "FAIL-CLOSED", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, api.IsValidFallbackPosture(tc.posture))
+		})
+	}
+}

--- a/server/rules/api/types.go
+++ b/server/rules/api/types.go
@@ -679,8 +679,14 @@ func MarshalSetApplicationControlPayload(p ApplicationControlPolicy, rules []App
 			CustomURL:   r.CustomURL,
 		})
 	}
+	// Normalise both the empty zero-value (the v0.1.0 norm: no DB column persists the field yet, so every fetched policy
+	// arrives with DeadlineFallback="") AND any non-empty but unrecognised value to DefaultFallbackPosture. The second branch
+	// is the defensive one: a stray bad value sneaking into the policy struct (typo on a future REST surface, copy-paste from
+	// an external feed, schema drift on the v0.1.x DB migration) must not reach the extension snapshot as a literal it cannot
+	// decode — the extension's FallbackPosture enum is strict, and a snapshot decode failure deactivates Application Control
+	// until the next valid push.
 	posture := p.DeadlineFallback
-	if posture == "" {
+	if !IsValidFallbackPosture(posture) {
 		posture = DefaultFallbackPosture
 	}
 	return json.Marshal(SetApplicationControlPayload{

--- a/server/rules/api/types.go
+++ b/server/rules/api/types.go
@@ -250,6 +250,34 @@ const (
 	PolicyDefaultActionNone PolicyDefaultAction = "NONE"
 )
 
+// FallbackPosture is the policy-level verdict the extension applies when AUTH_EXEC could not compute a BINARY rule SHA-256
+// within the kernel deadline budget. Three options trade enforcement strictness against exec-startup latency and operator
+// visibility; see extension/edr/extension/AuthExecDecider.swift FallbackPosture for the per-case rationale. v0.1.0 ships
+// FallbackPostureFailClosed as the default for every snapshot; per-policy configurability arrives in the v0.1.x follow-up
+// that adds a DB column and the REST surface to set it.
+type FallbackPosture string
+
+const (
+	FallbackPostureFailClosed FallbackPosture = "fail-closed"
+	FallbackPostureFailOpen   FallbackPosture = "fail-open"
+	FallbackPostureAuditOnly  FallbackPosture = "audit-only"
+)
+
+// DefaultFallbackPosture is the value MarshalSetApplicationControlPayload substitutes when ApplicationControlPolicy carries
+// an empty DeadlineFallback (the v0.1.0 norm because no DB column persists the field yet). Centralised so the wire default
+// can move with the product without sweeping callers.
+const DefaultFallbackPosture = FallbackPostureFailClosed
+
+// IsValidFallbackPosture reports whether s names one of the documented enum values. Used by the REST validation surface that
+// arrives with the v0.1.x configurability follow-up.
+func IsValidFallbackPosture(s FallbackPosture) bool {
+	switch s {
+	case FallbackPostureFailClosed, FallbackPostureFailOpen, FallbackPostureAuditOnly:
+		return true
+	}
+	return false
+}
+
 // ApplicationControlPolicy mirrors a row in app_control_policies. Used by the REST surface for list/get responses and by the fan-out
 // code when constructing the `set_application_control` agent command. Rules is populated by GetWithRules and the rule listing
 // endpoints; bare Get omits it. AssignmentCount is a derived field every policy fetch path populates (GetPolicyByName,
@@ -258,17 +286,22 @@ const (
 // The seeded Default policy starts at 1 (its assignment to the seed all-hosts group); policies created via CreatePolicy start
 // at 0 and grow when Phase B opens up assignment editing.
 type ApplicationControlPolicy struct {
-	ID              int64                    `json:"id"`
-	Name            string                   `json:"name"`
-	Description     string                   `json:"description"`
-	Version         int64                    `json:"version"`
-	DefaultAction   PolicyDefaultAction      `json:"default_action"`
-	CreatedAt       time.Time                `json:"created_at"`
-	UpdatedAt       time.Time                `json:"updated_at"`
-	CreatedBy       string                   `json:"created_by"`
-	UpdatedBy       string                   `json:"updated_by"`
-	AssignmentCount int                      `json:"assignment_count"`
-	Rules           []ApplicationControlRule `json:"rules,omitempty"`
+	ID            int64               `json:"id"`
+	Name          string              `json:"name"`
+	Description   string              `json:"description"`
+	Version       int64               `json:"version"`
+	DefaultAction PolicyDefaultAction `json:"default_action"`
+	// DeadlineFallback is the per-policy posture the extension applies when AUTH_EXEC cannot compute a BINARY hash within the
+	// kernel deadline budget. v0.1.0 has no DB column for this field; CreatePolicy/UpdatePolicy ignore it and the marshal
+	// substitutes DefaultFallbackPosture (fail-closed) on empty values. The v0.1.x follow-up that adds DB persistence + a REST
+	// surface to set the posture will start carrying real values through here.
+	DeadlineFallback FallbackPosture          `json:"deadline_fallback,omitempty"`
+	CreatedAt        time.Time                `json:"created_at"`
+	UpdatedAt        time.Time                `json:"updated_at"`
+	CreatedBy        string                   `json:"created_by"`
+	UpdatedBy        string                   `json:"updated_by"`
+	AssignmentCount  int                      `json:"assignment_count"`
+	Rules            []ApplicationControlRule `json:"rules,omitempty"`
 }
 
 // ApplicationControlRule mirrors a row in app_control_rules.
@@ -579,9 +612,14 @@ const CommandTypeSetApplicationControl = "set_application_control"
 // same shape with its own private struct to avoid pulling
 // server/rules/api into the agent module graph.
 type SetApplicationControlPayload struct {
-	PolicyID      int64                       `json:"policy_id"`
-	PolicyVersion int64                       `json:"policy_version"`
-	Rules         []SetApplicationControlRule `json:"rules"`
+	PolicyID      int64 `json:"policy_id"`
+	PolicyVersion int64 `json:"policy_version"`
+	// DeadlineFallback governs the extension's verdict when AUTH_EXEC cannot compute a BINARY rule SHA-256 within the kernel
+	// deadline budget. Always populated by MarshalSetApplicationControlPayload (DefaultFallbackPosture when the upstream policy
+	// did not set one) so the extension's snapshot never has to fall back to its own internal default. Pre-v0.1.0 agents that
+	// decode this payload without the field present continue to substitute their own internal fail-closed default.
+	DeadlineFallback FallbackPosture             `json:"deadline_fallback"`
+	Rules            []SetApplicationControlRule `json:"rules"`
 }
 
 // SetApplicationControlRule is one row in the payload's rules array.
@@ -641,9 +679,14 @@ func MarshalSetApplicationControlPayload(p ApplicationControlPolicy, rules []App
 			CustomURL:   r.CustomURL,
 		})
 	}
+	posture := p.DeadlineFallback
+	if posture == "" {
+		posture = DefaultFallbackPosture
+	}
 	return json.Marshal(SetApplicationControlPayload{
-		PolicyID:      p.ID,
-		PolicyVersion: p.Version,
-		Rules:         entries,
+		PolicyID:         p.ID,
+		PolicyVersion:    p.Version,
+		DeadlineFallback: posture,
+		Rules:            entries,
 	})
 }


### PR DESCRIPTION
… fallback posture

Closes #205, #207, #208.

#205 customer-bricking failsafe gap: handleAuthExec ALLOWs any exec the kernel classifies as target.is_platform_binary BEFORE the snapshot lookup, with cache:true so the kernel pins the result. An admin who pastes the SHA-256 of /sbin/launchd, xpcproxy, fseventsd, etc. into a BINARY block rule can no longer brick the host.

#208 BINARY rule cold-cache first-exec bypass: the lazy-fill ALLOW path is gone. handleAuthExec computes SHA-256 synchronously on the AUTH callback thread under a budget bounded by es_message_t.deadline minus a 500 ms safety margin. The decision walk is extracted into a pure-logic AuthExecDecider so the SwiftPM test target (which excludes ESFSubscriber. swift because of the EndpointSecurity import) can drive the verdict matrix. When the hash cannot complete, the snapshot's deadline_fallback posture decides:
  fail-closed (default): DENY + emit application_control_undecided.
  fail-open:             ALLOW silently (demo-equivalent).
  audit-only:            ALLOW + emit application_control_undecided.
The posture field rides on SetApplicationControlPayload's wire shape
(json key deadline_fallback). v0.1.0 has no DB column yet; every snapshot
ships with the default fail-closed. Per-policy persistence + REST surface
to set the value land in a v0.1.x follow-up.

#207 Santa attribution on CDHASH doc comments: Santa does NOT gate CDHASH on Hardened Runtime; we do, for our own reasons (page mapping is lazy and not re-verified post-load, so ESF's reported CDHash is not a reliable identity for the bytes that will eventually execute). Updated both comments to own the rationale and call out the Santa divergence so a migrating Santa admin is not surprised when a CDHASH rule no-ops against a non-hardened target.

Tests
  AuthExecDeciderTests.swift: 15 cases across the (3 postures x 3 hash
    outcomes + computed/notNeeded paths x 4 precedence layers) matrix.
  FileHashCacheTests.swift: 5 cases for lookupOrComputeWithDeadline
    (computed, warm cache hit, deadline exceeded, missing file, TOCTOU
    inode mismatch).
  app_control_wire_test.go: deadline_fallback default + per-posture
    passthrough + JSON key pin + IsValidFallbackPosture validator.
  All 104 swift tests + the touched Go suites + golangci-lint + xcodebuild
  for the extension target are green.

Behavior change for upgrades
The cold-cache first-exec ALLOW is removed. Pilots upgrading from a v0.1.0-rc.* see either a DENY (the fail-closed default) or a small latency hit (tens of ms on typical multi-MB binaries; bounded by the 500 ms safety margin) on the first exec of any unhashed binary. The v0.1.x follow-up that wires audit-only into the REST surface lets operators measure the rate per fleet before flipping to fail-closed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added operator-configurable deadline-fallback behavior (fail-closed, fail-open, audit-only) for application control rule evaluation.
  * Implemented rule precedence evaluation with automatic platform binary carve-out.
  * Added deadline-aware hash computation with timeout handling.
  * Introduced undecided audit events for cases where rule verdicts cannot be determined.

* **Documentation**
  * Updated operations guide with detailed application control policy model and rule evaluation runbook.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/getvictor/fleet-edr/pull/289?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->