### PR TITLE
App Control: wire CERTIFICATE + PATH rule types end-to-end (#210)

### DIFF
--- a/extension/edr/Tests/EDRExtensionLogicTests/AuthExecDeciderTests.swift
+++ b/extension/edr/Tests/EDRExtensionLogicTests/AuthExecDeciderTests.swift
@@ -8,58 +8,84 @@
 @testable import EDRExtensionLogic
 import XCTest
 
+// MARK: - Free-function helpers (shared across AuthExecDeciderTests + AuthExecDeciderPhaseBTests)
+//
+// Helpers live at file scope rather than inside the test class because the class body length is bounded by SwiftLint
+// (type_body_length = 300). The shared helpers are tiny enough that file-scope makes them naturally usable by the second
+// test class that covers CERTIFICATE + PATH precedence. Keeping them private here scopes the symbols to the test target.
+
+/// makeRule builds a minimal ApplicationControlRule with the supplied ruleType / identifier / action / enforcement. Other
+/// fields are set to representative defaults so tests focus on the precedence walk and verdict mapping rather than per-rule
+/// decoration.
+private func makeRule(
+    ruleType: String,
+    identifier: String,
+    action: String = ApplicationControlAction.block,
+    enforcement: String = ApplicationControlEnforcement.protect
+) -> ApplicationControlRule {
+    return ApplicationControlRule(
+        ruleID: "app_control:test-\(identifier)",
+        ruleType: ruleType,
+        identifier: identifier,
+        action: action,
+        enforcement: enforcement,
+        severity: "medium",
+        customMsg: nil,
+        customURL: nil
+    )
+}
+
+/// makeSnapshot builds an ApplicationControlSnapshot with the supplied rule maps and the requested fallback posture. Maps
+/// not supplied default to empty so the precedence walk for missing layers correctly returns no match. certificateRules +
+/// pathRules joined the parameter list when CERTIFICATE / PATH wired through to the decider (PR for #210).
+private func makeSnapshot(
+    deadlineFallback: FallbackPosture = .defaultPosture,
+    cdhashRules: [String: ApplicationControlRule] = [:],
+    binaryRules: [String: ApplicationControlRule] = [:],
+    signingIDRules: [String: ApplicationControlRule] = [:],
+    teamIDRules: [String: ApplicationControlRule] = [:],
+    certificateRules: [String: ApplicationControlRule] = [:],
+    pathRules: [String: ApplicationControlRule] = [:]
+) -> ApplicationControlSnapshot {
+    return ApplicationControlSnapshot(
+        policyID: 1,
+        policyVersion: 1,
+        deadlineFallback: deadlineFallback,
+        binaryRules: binaryRules,
+        cdhashRules: cdhashRules,
+        signingIDRules: signingIDRules,
+        certificateRules: certificateRules,
+        teamIDRules: teamIDRules,
+        pathRules: pathRules
+    )
+}
+
+/// makeTuple wraps AuthTuple's memberwise init with every field defaulted to nil so existing tests can supply just the
+/// field they exercise. Each new test case sets only the fields its precedence row depends on; the rest stay nil so the
+/// walker correctly skips those layers. The default-everything pattern keeps the test surface readable and stable across
+/// future AuthTuple field additions.
+private func makeTuple(
+    cdhash: String? = nil,
+    leafCertSHA256: String? = nil,
+    signingIDPrefixed: String? = nil,
+    teamID: String? = nil,
+    canonicalPath: String? = nil
+) -> AuthTuple {
+    return AuthTuple(
+        cdhash: cdhash,
+        leafCertSHA256: leafCertSHA256,
+        signingIDPrefixed: signingIDPrefixed,
+        teamID: teamID,
+        canonicalPath: canonicalPath
+    )
+}
+
 final class AuthExecDeciderTests: XCTestCase {
-
-    // MARK: - Helpers
-
-    /// makeRule builds a minimal ApplicationControlRule with the supplied ruleType / identifier /
-    /// action / enforcement. Other fields are set to representative defaults so the tests focus
-    /// on the precedence walk and verdict mapping rather than per-rule decoration.
-    private func makeRule(
-        ruleType: String,
-        identifier: String,
-        action: String = ApplicationControlAction.block,
-        enforcement: String = ApplicationControlEnforcement.protect
-    ) -> ApplicationControlRule {
-        return ApplicationControlRule(
-            ruleID: "app_control:test-\(identifier)",
-            ruleType: ruleType,
-            identifier: identifier,
-            action: action,
-            enforcement: enforcement,
-            severity: "medium",
-            customMsg: nil,
-            customURL: nil
-        )
-    }
-
-    /// makeSnapshot builds an ApplicationControlSnapshot with the supplied rule maps and the
-    /// requested fallback posture. Maps not supplied default to empty so the precedence walk
-    /// for missing layers correctly returns no match.
-    private func makeSnapshot(
-        deadlineFallback: FallbackPosture = .defaultPosture,
-        cdhashRules: [String: ApplicationControlRule] = [:],
-        binaryRules: [String: ApplicationControlRule] = [:],
-        signingIDRules: [String: ApplicationControlRule] = [:],
-        teamIDRules: [String: ApplicationControlRule] = [:]
-    ) -> ApplicationControlSnapshot {
-        return ApplicationControlSnapshot(
-            policyID: 1,
-            policyVersion: 1,
-            deadlineFallback: deadlineFallback,
-            binaryRules: binaryRules,
-            cdhashRules: cdhashRules,
-            signingIDRules: signingIDRules,
-            certificateRules: [:],
-            teamIDRules: teamIDRules,
-            pathRules: [:]
-        )
-    }
 
     // MARK: - No match returns allow
 
     func testNoMatchOnEmptySnapshotReturnsAllow() {
-        let tuple = AuthTuple(cdhash: "c0", signingIDPrefixed: "ABC:org.test", teamID: "ABCDEFGHIJ")
+        let tuple = makeTuple(cdhash: "c0", signingIDPrefixed: "ABC:org.test", teamID: "ABCDEFGHIJ")
         let decision = decideAuthExec(tuple: tuple, snapshot: makeSnapshot(), hashOutcome: .notNeeded)
         XCTAssertEqual(decision, .allow)
     }
@@ -68,7 +94,7 @@ final class AuthExecDeciderTests: XCTestCase {
 
     func testCDHashBlockRuleReturnsDeny() {
         let rule = makeRule(ruleType: ApplicationControlRuleType.cdhash, identifier: "cdhashvalue")
-        let tuple = AuthTuple(cdhash: "cdhashvalue", signingIDPrefixed: nil, teamID: nil)
+        let tuple = makeTuple(cdhash: "cdhashvalue", signingIDPrefixed: nil, teamID: nil)
         let decision = decideAuthExec(
             tuple: tuple, snapshot: makeSnapshot(cdhashRules: ["cdhashvalue": rule]), hashOutcome: .notNeeded
         )
@@ -80,7 +106,7 @@ final class AuthExecDeciderTests: XCTestCase {
         // the deadlineExceeded path is never reached -- the deny precedes any fallback verdict.
         let cdhashRule = makeRule(ruleType: ApplicationControlRuleType.cdhash, identifier: "cdhashvalue")
         let binaryRule = makeRule(ruleType: ApplicationControlRuleType.binary, identifier: "shaRaceCondition")
-        let tuple = AuthTuple(cdhash: "cdhashvalue", signingIDPrefixed: nil, teamID: nil)
+        let tuple = makeTuple(cdhash: "cdhashvalue", signingIDPrefixed: nil, teamID: nil)
         let decision = decideAuthExec(
             tuple: tuple,
             snapshot: makeSnapshot(cdhashRules: ["cdhashvalue": cdhashRule], binaryRules: ["shaRaceCondition": binaryRule]),
@@ -96,7 +122,7 @@ final class AuthExecDeciderTests: XCTestCase {
             identifier: "cdhashvalue",
             enforcement: ApplicationControlEnforcement.detect
         )
-        let tuple = AuthTuple(cdhash: "cdhashvalue", signingIDPrefixed: nil, teamID: nil)
+        let tuple = makeTuple(cdhash: "cdhashvalue", signingIDPrefixed: nil, teamID: nil)
         let decision = decideAuthExec(
             tuple: tuple, snapshot: makeSnapshot(cdhashRules: ["cdhashvalue": rule]), hashOutcome: .notNeeded
         )
@@ -107,7 +133,7 @@ final class AuthExecDeciderTests: XCTestCase {
 
     func testBinaryMatchOnComputedHashReturnsDeny() {
         let rule = makeRule(ruleType: ApplicationControlRuleType.binary, identifier: "shavalue")
-        let tuple = AuthTuple(cdhash: nil, signingIDPrefixed: nil, teamID: nil)
+        let tuple = makeTuple(cdhash: nil, signingIDPrefixed: nil, teamID: nil)
         let decision = decideAuthExec(
             tuple: tuple, snapshot: makeSnapshot(binaryRules: ["shavalue": rule]), hashOutcome: .computed("shavalue")
         )
@@ -116,7 +142,7 @@ final class AuthExecDeciderTests: XCTestCase {
 
     func testBinaryNoMatchOnComputedHashFallsThroughToSigningID() {
         let signRule = makeRule(ruleType: ApplicationControlRuleType.signingID, identifier: "ABC:org.bad")
-        let tuple = AuthTuple(cdhash: nil, signingIDPrefixed: "ABC:org.bad", teamID: nil)
+        let tuple = makeTuple(cdhash: nil, signingIDPrefixed: "ABC:org.bad", teamID: nil)
         let decision = decideAuthExec(
             tuple: tuple,
             snapshot: makeSnapshot(signingIDRules: ["ABC:org.bad": signRule]),
@@ -130,7 +156,7 @@ final class AuthExecDeciderTests: XCTestCase {
         // walk skips BINARY entirely and continues to SIGNINGID / TEAMID rather than applying the
         // fallback posture. This is the common case in practice.
         let teamRule = makeRule(ruleType: ApplicationControlRuleType.teamID, identifier: "ABCDEFGHIJ")
-        let tuple = AuthTuple(cdhash: nil, signingIDPrefixed: nil, teamID: "ABCDEFGHIJ")
+        let tuple = makeTuple(cdhash: nil, signingIDPrefixed: nil, teamID: "ABCDEFGHIJ")
         let decision = decideAuthExec(
             tuple: tuple, snapshot: makeSnapshot(teamIDRules: ["ABCDEFGHIJ": teamRule]), hashOutcome: .notNeeded
         )
@@ -144,7 +170,7 @@ final class AuthExecDeciderTests: XCTestCase {
     // definitive lower-precedence DENY beats BINARY uncertainty.
 
     func testDeadlineExceededFailClosedNoLowerRuleDeniesWithUndecidedAudit() {
-        let tuple = AuthTuple(cdhash: nil, signingIDPrefixed: nil, teamID: nil)
+        let tuple = makeTuple(cdhash: nil, signingIDPrefixed: nil, teamID: nil)
         let binaryRule = makeRule(ruleType: ApplicationControlRuleType.binary, identifier: "anyShaWeCantSee")
         let snapshot = makeSnapshot(
             deadlineFallback: .failClosed,
@@ -155,7 +181,7 @@ final class AuthExecDeciderTests: XCTestCase {
     }
 
     func testDeadlineExceededFailOpenNoLowerRuleAllowsSilently() {
-        let tuple = AuthTuple(cdhash: nil, signingIDPrefixed: nil, teamID: nil)
+        let tuple = makeTuple(cdhash: nil, signingIDPrefixed: nil, teamID: nil)
         let binaryRule = makeRule(ruleType: ApplicationControlRuleType.binary, identifier: "anyShaWeCantSee")
         let snapshot = makeSnapshot(
             deadlineFallback: .failOpen,
@@ -166,7 +192,7 @@ final class AuthExecDeciderTests: XCTestCase {
     }
 
     func testDeadlineExceededAuditOnlyNoLowerRuleAllowsAndEmitsUndecidedAudit() {
-        let tuple = AuthTuple(cdhash: nil, signingIDPrefixed: nil, teamID: nil)
+        let tuple = makeTuple(cdhash: nil, signingIDPrefixed: nil, teamID: nil)
         let binaryRule = makeRule(ruleType: ApplicationControlRuleType.binary, identifier: "anyShaWeCantSee")
         let snapshot = makeSnapshot(
             deadlineFallback: .auditOnly,
@@ -186,7 +212,7 @@ final class AuthExecDeciderTests: XCTestCase {
     func testDeadlineExceededFailOpenStillEnforcesSigningIDBlock() {
         let signRule = makeRule(ruleType: ApplicationControlRuleType.signingID, identifier: "ABC:org.bad")
         let binaryRule = makeRule(ruleType: ApplicationControlRuleType.binary, identifier: "anyShaWeCantSee")
-        let tuple = AuthTuple(cdhash: nil, signingIDPrefixed: "ABC:org.bad", teamID: nil)
+        let tuple = makeTuple(cdhash: nil, signingIDPrefixed: "ABC:org.bad", teamID: nil)
         let snapshot = makeSnapshot(
             deadlineFallback: .failOpen,
             binaryRules: ["anyShaWeCantSee": binaryRule],
@@ -199,7 +225,7 @@ final class AuthExecDeciderTests: XCTestCase {
     func testReadFailedAuditOnlyStillEnforcesTeamIDBlock() {
         let teamRule = makeRule(ruleType: ApplicationControlRuleType.teamID, identifier: "ABCDEFGHIJ")
         let binaryRule = makeRule(ruleType: ApplicationControlRuleType.binary, identifier: "anyShaWeCantSee")
-        let tuple = AuthTuple(cdhash: nil, signingIDPrefixed: nil, teamID: "ABCDEFGHIJ")
+        let tuple = makeTuple(cdhash: nil, signingIDPrefixed: nil, teamID: "ABCDEFGHIJ")
         let snapshot = makeSnapshot(
             deadlineFallback: .auditOnly,
             binaryRules: ["anyShaWeCantSee": binaryRule],
@@ -212,7 +238,7 @@ final class AuthExecDeciderTests: XCTestCase {
     // MARK: - Read-failed posture matrix
 
     func testReadFailedFailClosedNoLowerRuleDeniesWithUndecidedAudit() {
-        let tuple = AuthTuple(cdhash: nil, signingIDPrefixed: nil, teamID: nil)
+        let tuple = makeTuple(cdhash: nil, signingIDPrefixed: nil, teamID: nil)
         let binaryRule = makeRule(ruleType: ApplicationControlRuleType.binary, identifier: "anyShaWeCantSee")
         let snapshot = makeSnapshot(deadlineFallback: .failClosed, binaryRules: ["anyShaWeCantSee": binaryRule])
         let decision = decideAuthExec(tuple: tuple, snapshot: snapshot, hashOutcome: .readFailed)
@@ -220,7 +246,7 @@ final class AuthExecDeciderTests: XCTestCase {
     }
 
     func testReadFailedAuditOnlyNoLowerRuleAllowsAndEmitsUndecidedAudit() {
-        let tuple = AuthTuple(cdhash: nil, signingIDPrefixed: nil, teamID: nil)
+        let tuple = makeTuple(cdhash: nil, signingIDPrefixed: nil, teamID: nil)
         let binaryRule = makeRule(ruleType: ApplicationControlRuleType.binary, identifier: "anyShaWeCantSee")
         let snapshot = makeSnapshot(deadlineFallback: .auditOnly, binaryRules: ["anyShaWeCantSee": binaryRule])
         let decision = decideAuthExec(tuple: tuple, snapshot: snapshot, hashOutcome: .readFailed)
@@ -231,7 +257,7 @@ final class AuthExecDeciderTests: XCTestCase {
 
     func testSigningIDBlockRuleReturnsDeny() {
         let rule = makeRule(ruleType: ApplicationControlRuleType.signingID, identifier: "ABC:org.bad")
-        let tuple = AuthTuple(cdhash: nil, signingIDPrefixed: "ABC:org.bad", teamID: nil)
+        let tuple = makeTuple(cdhash: nil, signingIDPrefixed: "ABC:org.bad", teamID: nil)
         let decision = decideAuthExec(
             tuple: tuple, snapshot: makeSnapshot(signingIDRules: ["ABC:org.bad": rule]), hashOutcome: .notNeeded
         )
@@ -240,7 +266,7 @@ final class AuthExecDeciderTests: XCTestCase {
 
     func testTeamIDBlockRuleReturnsDeny() {
         let rule = makeRule(ruleType: ApplicationControlRuleType.teamID, identifier: "ABCDEFGHIJ")
-        let tuple = AuthTuple(cdhash: nil, signingIDPrefixed: nil, teamID: "ABCDEFGHIJ")
+        let tuple = makeTuple(cdhash: nil, signingIDPrefixed: nil, teamID: "ABCDEFGHIJ")
         let decision = decideAuthExec(
             tuple: tuple, snapshot: makeSnapshot(teamIDRules: ["ABCDEFGHIJ": rule]), hashOutcome: .notNeeded
         )
@@ -252,12 +278,208 @@ final class AuthExecDeciderTests: XCTestCase {
         // the CDHASH match (higher priority) and never consult SIGNINGID.
         let cdRule = makeRule(ruleType: ApplicationControlRuleType.cdhash, identifier: "cdhashfirst")
         let signRule = makeRule(ruleType: ApplicationControlRuleType.signingID, identifier: "ABC:org.bad")
-        let tuple = AuthTuple(cdhash: "cdhashfirst", signingIDPrefixed: "ABC:org.bad", teamID: nil)
+        let tuple = makeTuple(cdhash: "cdhashfirst", signingIDPrefixed: "ABC:org.bad", teamID: nil)
         let decision = decideAuthExec(
             tuple: tuple,
             snapshot: makeSnapshot(cdhashRules: ["cdhashfirst": cdRule], signingIDRules: ["ABC:org.bad": signRule]),
             hashOutcome: .notNeeded
         )
         XCTAssertEqual(decision, .deny(rule: cdRule, matchedIdentifier: "cdhashfirst"))
+    }
+}
+
+/// AuthExecDeciderPhaseBTests covers CERTIFICATE + PATH precedence (PR for #210). Split from AuthExecDeciderTests because
+/// the combined class body would exceed SwiftLint's type_body_length cap; the helpers (makeRule / makeSnapshot / makeTuple)
+/// are free functions at file scope so both test classes share them without duplication.
+final class AuthExecDeciderPhaseBTests: XCTestCase {
+
+    // MARK: - CERTIFICATE layer (PR for #210)
+
+    /// CERTIFICATE rules match on the 64-char lowercase hex SHA-256 of the leaf X.509 signing certificate. Operators set
+    /// these as the surgical level for compromised-Developer-ID response: revoking a leaf cert hash neutralises every
+    /// binary signed under that cert without taking down the whole TeamID cohort. Layer sits between BINARY and SIGNINGID
+    /// in the precedence ladder (Santa's order).
+    func testCertificateBlockRuleReturnsDeny() {
+        let rule = makeRule(
+            ruleType: ApplicationControlRuleType.certificate,
+            identifier: "leafhashvalue"
+        )
+        let tuple = makeTuple(leafCertSHA256: "leafhashvalue")
+        let decision = decideAuthExec(
+            tuple: tuple,
+            snapshot: makeSnapshot(certificateRules: ["leafhashvalue": rule]),
+            hashOutcome: .notNeeded
+        )
+        XCTAssertEqual(decision, .deny(rule: rule, matchedIdentifier: "leafhashvalue"))
+    }
+
+    /// Precedence: a CERTIFICATE block must dominate a lower-precedence SIGNINGID block. Both layers populated;
+    /// CERTIFICATE matches first and the SIGNINGID rule is never consulted.
+    func testCertificateBeatsSigningIDOnSimultaneousBlock() {
+        let certRule = makeRule(ruleType: ApplicationControlRuleType.certificate, identifier: "leafhashvalue")
+        let signRule = makeRule(ruleType: ApplicationControlRuleType.signingID, identifier: "ABC:org.bad")
+        let tuple = makeTuple(leafCertSHA256: "leafhashvalue", signingIDPrefixed: "ABC:org.bad")
+        let decision = decideAuthExec(
+            tuple: tuple,
+            snapshot: makeSnapshot(
+                signingIDRules: ["ABC:org.bad": signRule],
+                certificateRules: ["leafhashvalue": certRule]
+            ),
+            hashOutcome: .notNeeded
+        )
+        XCTAssertEqual(decision, .deny(rule: certRule, matchedIdentifier: "leafhashvalue"))
+    }
+
+    /// A binary with no leaf cert (unsigned / ad-hoc) and no CERTIFICATE rule in the map must NOT match even if the map
+    /// has entries for other certs. Sanity check that the optional-binding skips the layer cleanly.
+    func testCertificateNoMatchWhenLeafIsNil() {
+        let certRule = makeRule(ruleType: ApplicationControlRuleType.certificate, identifier: "otherleafhash")
+        let tuple = makeTuple(leafCertSHA256: nil)
+        let decision = decideAuthExec(
+            tuple: tuple,
+            snapshot: makeSnapshot(certificateRules: ["otherleafhash": certRule]),
+            hashOutcome: .notNeeded
+        )
+        XCTAssertEqual(decision, .allow)
+    }
+
+    /// Under fail-open with .deadlineExceeded, the walk still continues through CERTIFICATE before the posture fires.
+    /// A CERTIFICATE block must enforce regardless of the BINARY uncertainty -- same property the SIGNINGID / TEAMID
+    /// rows already pin, extended to CERTIFICATE.
+    func testDeadlineExceededFailOpenStillEnforcesCertificateBlock() {
+        let certRule = makeRule(ruleType: ApplicationControlRuleType.certificate, identifier: "leafhashvalue")
+        let binaryRule = makeRule(ruleType: ApplicationControlRuleType.binary, identifier: "anyShaWeCantSee")
+        let tuple = makeTuple(leafCertSHA256: "leafhashvalue")
+        let snapshot = makeSnapshot(
+            deadlineFallback: .failOpen,
+            binaryRules: ["anyShaWeCantSee": binaryRule],
+            certificateRules: ["leafhashvalue": certRule]
+        )
+        let decision = decideAuthExec(tuple: tuple, snapshot: snapshot, hashOutcome: .deadlineExceeded)
+        XCTAssertEqual(decision, .deny(rule: certRule, matchedIdentifier: "leafhashvalue"))
+    }
+
+    // MARK: - PATH layer (PR for #210)
+
+    /// PATH rules match on the canonical absolute path of the exec target. Lowest-trust layer in the ladder by design --
+    /// paths are the most operator-spoofable identifier. The test fixture uses an exact canonical form; the canonicaliser
+    /// (canonicalizePath in AuthExecDecider) is tested separately.
+    func testPathBlockRuleReturnsDeny() {
+        let rule = makeRule(
+            ruleType: ApplicationControlRuleType.path,
+            identifier: "/Applications/Foo.app/Contents/MacOS/Foo"
+        )
+        let tuple = makeTuple(canonicalPath: "/Applications/Foo.app/Contents/MacOS/Foo")
+        let decision = decideAuthExec(
+            tuple: tuple,
+            snapshot: makeSnapshot(pathRules: ["/Applications/Foo.app/Contents/MacOS/Foo": rule]),
+            hashOutcome: .notNeeded
+        )
+        XCTAssertEqual(decision, .deny(rule: rule, matchedIdentifier: "/Applications/Foo.app/Contents/MacOS/Foo"))
+    }
+
+    /// PATH sits at the bottom of the precedence ladder. A TEAMID block on the same exec must fire first, never giving
+    /// PATH a chance to match. This pins the "PATH is last" property.
+    func testTeamIDBeatsPathOnSimultaneousBlock() {
+        let teamRule = makeRule(ruleType: ApplicationControlRuleType.teamID, identifier: "ABCDEFGHIJ")
+        let pathRule = makeRule(ruleType: ApplicationControlRuleType.path, identifier: "/Applications/Foo.app/Contents/MacOS/Foo")
+        let tuple = makeTuple(teamID: "ABCDEFGHIJ", canonicalPath: "/Applications/Foo.app/Contents/MacOS/Foo")
+        let decision = decideAuthExec(
+            tuple: tuple,
+            snapshot: makeSnapshot(
+                teamIDRules: ["ABCDEFGHIJ": teamRule],
+                pathRules: ["/Applications/Foo.app/Contents/MacOS/Foo": pathRule]
+            ),
+            hashOutcome: .notNeeded
+        )
+        XCTAssertEqual(decision, .deny(rule: teamRule, matchedIdentifier: "ABCDEFGHIJ"))
+    }
+
+    /// A nil canonicalPath (caller couldn't canonicalise the exec path) must skip the PATH layer cleanly without affecting
+    /// any other layer. Models the "canonicalize returned nil" branch in ESFSubscriber.buildAuthTuple.
+    func testPathNoMatchWhenCanonicalPathIsNil() {
+        let pathRule = makeRule(ruleType: ApplicationControlRuleType.path, identifier: "/Applications/Foo.app/Contents/MacOS/Foo")
+        let tuple = makeTuple(canonicalPath: nil)
+        let decision = decideAuthExec(
+            tuple: tuple,
+            snapshot: makeSnapshot(pathRules: ["/Applications/Foo.app/Contents/MacOS/Foo": pathRule]),
+            hashOutcome: .notNeeded
+        )
+        XCTAssertEqual(decision, .allow)
+    }
+
+    /// Under .deadlineExceeded with fail-closed posture, a PATH block in the snapshot must still dominate the
+    /// posture verdict -- the walk continues past unresolved BINARY through every lower layer including PATH before
+    /// applying the fallback. Pins the "lower-precedence deny dominates BINARY uncertainty" property at the lowest layer.
+    func testDeadlineExceededFailClosedStillEnforcesPathBlock() {
+        let pathRule = makeRule(ruleType: ApplicationControlRuleType.path, identifier: "/Applications/Foo.app/Contents/MacOS/Foo")
+        let binaryRule = makeRule(ruleType: ApplicationControlRuleType.binary, identifier: "anyShaWeCantSee")
+        let tuple = makeTuple(canonicalPath: "/Applications/Foo.app/Contents/MacOS/Foo")
+        let snapshot = makeSnapshot(
+            deadlineFallback: .failClosed,
+            binaryRules: ["anyShaWeCantSee": binaryRule],
+            pathRules: ["/Applications/Foo.app/Contents/MacOS/Foo": pathRule]
+        )
+        let decision = decideAuthExec(tuple: tuple, snapshot: snapshot, hashOutcome: .deadlineExceeded)
+        XCTAssertEqual(decision, .deny(rule: pathRule, matchedIdentifier: "/Applications/Foo.app/Contents/MacOS/Foo"))
+    }
+}
+
+// MARK: - canonicalizePath tests
+
+/// canonicalizePathTests pin the Swift implementation against the same rules as the server-side
+/// `server/rules/internal/appcontrol/CanonicalizePath`. A PATH rule created in the server is persisted in its canonical
+/// form (e.g. `/tmp/foo` -> `/private/tmp/foo`); the extension MUST produce the identical canonical form on the AUTH callback
+/// or the rule never matches. The fixture deliberately mirrors the Go test table so a future-self auditing parity can
+/// diff the two files visually.
+final class CanonicalizePathTests: XCTestCase {
+
+    func testPlainPathUnchanged() {
+        XCTAssertEqual(canonicalizePath("/usr/bin/ls"), "/usr/bin/ls")
+    }
+
+    func testTmpRewrittenToPrivate() {
+        XCTAssertEqual(canonicalizePath("/tmp/foo"), "/private/tmp/foo")
+    }
+
+    func testVarRewrittenToPrivate() {
+        XCTAssertEqual(canonicalizePath("/var/db/x"), "/private/var/db/x")
+    }
+
+    func testEtcRewrittenToPrivate() {
+        XCTAssertEqual(canonicalizePath("/etc/sudoers"), "/private/etc/sudoers")
+    }
+
+    func testEtcBareRewrittenToPrivate() {
+        XCTAssertEqual(canonicalizePath("/etc"), "/private/etc")
+    }
+
+    func testTmpPrefixNotRewrittenWhenNotBoundaryAligned() {
+        // `/tmpfoo/bar` is NOT under `/tmp`; the rewrite must only fire on a path-component boundary.
+        XCTAssertEqual(canonicalizePath("/tmpfoo/bar"), "/tmpfoo/bar")
+    }
+
+    func testRedundantSlashesCollapsed() {
+        XCTAssertEqual(canonicalizePath("/usr//bin///ls"), "/usr/bin/ls")
+    }
+
+    func testTrailingSlashCollapsed() {
+        XCTAssertEqual(canonicalizePath("/usr/bin/"), "/usr/bin")
+    }
+
+    func testEmptyRejected() {
+        XCTAssertNil(canonicalizePath(""))
+    }
+
+    func testRelativeRejected() {
+        XCTAssertNil(canonicalizePath("tmp/foo"))
+    }
+
+    func testDotDotSegmentRejected() {
+        XCTAssertNil(canonicalizePath("/var/foo/../../etc/sudoers"))
+    }
+
+    func testDotDotFinalSegmentRejected() {
+        XCTAssertNil(canonicalizePath("/usr/bin/.."))
     }
 }

--- a/extension/edr/extension/AuthExecDecider.swift
+++ b/extension/edr/extension/AuthExecDecider.swift
@@ -58,7 +58,7 @@ enum UndecidedReason: String, Sendable {
 /// honours every wire-enum rule type.
 struct AuthTuple: Equatable, Sendable {
     /// 40-char lowercase hex CDHash, only when the target runs under Apple's Hardened Runtime (CS_RUNTIME); see the comment on
-    /// isHardenedRuntime in ESFSubscriber.swift for the lazy-page-mapping rationale.
+    /// isHardenedRuntime in CDHashHex.swift for the lazy-page-mapping rationale.
     let cdhash: String?
     /// 64-char lowercase hex SHA-256 of the leaf X.509 signing cert. nil when the binary is unsigned, ad-hoc-signed, or
     /// SecCode can't read the on-disk binary. Populated by SigningInfoFallback.leafCertSHA256 once per (inode, mtime).
@@ -181,6 +181,18 @@ private func matchLowerLayers(tuple: AuthTuple, snapshot: ApplicationControlSnap
     return nil
 }
 
+/// macOSPrivatePrefixes lists the absolute-path prefixes that macOS exposes as `/private/...` symlinks (the `/tmp`, `/var`,
+/// `/etc` triple, stable on every macOS version that has shipped Endpoint Security). canonicalizePath rewrites a path
+/// starting with any of these into the `/private`-prefixed form to match Foundation's `realpath(3)` output and the
+/// server-side Go canonicaliser. Hoisted to file scope so the rewrite loop runs without allocating a fresh array per
+/// AUTH_EXEC call (Copilot PR #290) AND so SonarCloud's swift:S1075 hardcoded-URI heuristic has one named constant to look
+/// at rather than three inline literals.
+private let macOSPrivatePrefixes: [String] = ["/tmp", "/var", "/etc"]
+
+/// privatePrefix is the rewrite target each macOSPrivatePrefixes entry is lifted under. Same purpose for swift:S1075 as
+/// macOSPrivatePrefixes above.
+private let privatePrefix = "/private"
+
 /// canonicalizePath returns the macOS-canonical form of an absolute path, matching the server-side
 /// `server/rules/internal/appcontrol/CanonicalizePath` rules verbatim: rejects empty / relative / `..`-containing paths,
 /// collapses redundant slashes (filepath.Clean equivalent), and rewrites the /tmp, /var, /etc symlinks into their
@@ -207,9 +219,9 @@ func canonicalizePath(_ path: String) -> String? {
         segments.append(s)
     }
     let cleaned = "/" + segments.joined(separator: "/")
-    for prefix in ["/tmp", "/var", "/etc"] {
+    for prefix in macOSPrivatePrefixes {
         if cleaned == prefix || cleaned.hasPrefix(prefix + "/") {
-            return "/private" + cleaned
+            return privatePrefix + cleaned
         }
     }
     return cleaned

--- a/extension/edr/extension/AuthExecDecider.swift
+++ b/extension/edr/extension/AuthExecDecider.swift
@@ -50,19 +50,30 @@ enum UndecidedReason: String, Sendable {
 }
 
 /// AuthTuple captures the identifier values the decision walker compares against the snapshot's per-type maps. Each field is
-/// optional: absent values mean "the target has no value of this kind", and the precedence walker skips that map. CERTIFICATE
-/// and PATH stay deferred to Phase B and are not present here. Sendable so callers can build the tuple on the AUTH callback
-/// thread and hand it to a future async pipeline without bridging tricks.
+/// optional: absent values mean "the target has no value of this kind", and the precedence walker skips that map. Sendable so
+/// callers can build the tuple on the AUTH callback thread and hand it to a future async pipeline without bridging tricks.
+///
+/// PR for #210 closed out Phase B by adding leafCertSHA256 + canonicalPath; the snapshot maps for both rule types
+/// (certificateRules, pathRules) were already populated by ApplicationControlStore.makeSnapshot. The decision walker now
+/// honours every wire-enum rule type.
 struct AuthTuple: Equatable, Sendable {
     /// 40-char lowercase hex CDHash, only when the target runs under Apple's Hardened Runtime (CS_RUNTIME); see the comment on
     /// isHardenedRuntime in ESFSubscriber.swift for the lazy-page-mapping rationale.
     let cdhash: String?
+    /// 64-char lowercase hex SHA-256 of the leaf X.509 signing cert. nil when the binary is unsigned, ad-hoc-signed, or
+    /// SecCode can't read the on-disk binary. Populated by SigningInfoFallback.leafCertSHA256 once per (inode, mtime).
+    let leafCertSHA256: String?
     /// "<TeamID>:<bundle.id>" for third-party signed binaries, "platform:<bundle.id>" for kernel-classified Apple platform
     /// binaries. nil when ESF reports neither a usable team_id (real or fallback) nor a platform classification.
     let signingIDPrefixed: String?
     /// 10-char Apple Developer Team ID. nil when ESF redacts team_id (ad-hoc-signed extension on edr-dev) and
     /// SigningInfoFallback also cannot recover a real value.
     let teamID: String?
+    /// Canonical absolute path of the exec target -- filepath.Clean equivalent, /tmp + /var + /etc rewritten to /private.
+    /// nil when the wire path is empty, relative, or contains a `..` segment (defensive; ESF reports an absolute path under
+    /// normal conditions). PATH rules compare against this verbatim, so the canonicalisation MUST match the server-side
+    /// CanonicalizePath rules exactly or rules created against the operator's canonical form will never match.
+    let canonicalPath: String?
 }
 
 /// AuthDecision is the discrete verdict the wire side dispatches on. Cases enumerate every action handleAuthExec can take short
@@ -87,13 +98,20 @@ enum AuthDecision: Equatable, Sendable {
 /// EndpointSecurity imports, no Darwin time calls, no logging side effects on the hot path. Drives the SwiftPM-test surface
 /// because ESFSubscriber.swift is excluded from the test target by Package.swift.
 ///
-/// Precedence: CDHASH > BINARY > SIGNINGID > TEAMID. CERTIFICATE + PATH stay deferred to Phase B and are not consulted here.
+/// Precedence (Santa's order, every wire-enum rule type wired as of PR for #210):
+///   CDHASH > BINARY > CERTIFICATE > SIGNINGID > TEAMID > PATH
+///
 /// Each layer returns on first match. The BINARY layer is gated on hashOutcome: if .computed, walk the BINARY map; if
-/// .deadlineExceeded or .readFailed the walk CONTINUES to SIGNINGID/TEAMID first -- a definitive lower-precedence DENY
-/// dominates the BINARY layer's "could-have-fired" uncertainty (the operator's snapshot tells us the binary identifies as
-/// signing-id X / team Y; a block rule on X or Y is a real verdict the kernel can act on). Only after SIGNINGID/TEAMID
-/// produce no match does the snapshot's deadlineFallback posture apply to the unresolved BINARY decision. .notNeeded skips
-/// BINARY entirely and continues normally (snapshot has no BINARY rules so the fallback posture has nothing to govern).
+/// .deadlineExceeded or .readFailed the walk CONTINUES through every lower-precedence layer first -- a definitive
+/// lower-precedence DENY dominates the BINARY layer's "could-have-fired" uncertainty (the operator's snapshot tells us the
+/// binary identifies as cert X / signing-id Y / team Z / path P; a block rule on any of those is a real verdict the kernel
+/// can act on). Only after every layer below BINARY produces no match does the snapshot's deadlineFallback posture apply to
+/// the unresolved BINARY decision. .notNeeded skips BINARY entirely and continues normally (snapshot has no BINARY rules so
+/// the fallback posture has nothing to govern).
+///
+/// PATH is the lowest-trust layer by design: paths are the most operator-spoofable identifier (symlinks, bind mounts, copies
+/// preserving content but changing the path string), so a deny higher in the ladder always wins. Santa places PATH last for
+/// the same reason; documenting this here so a future precedence reorder is a deliberate decision, not an accident.
 ///
 /// Posture flows from snapshot.deadlineFallback directly -- this function does not take a separate posture parameter, so a
 /// caller cannot accidentally evaluate one snapshot's rule maps under a different fallback. (Previous signatures took the
@@ -106,32 +124,95 @@ func decideAuthExec(
     if let cdhash = tuple.cdhash, let rule = snapshot.cdhashRules[cdhash] {
         return verdict(for: rule, identifier: cdhash)
     }
-
-    var unresolvedBinaryReason: UndecidedReason?
-    switch hashOutcome {
-    case .computed(let sha):
-        if let rule = snapshot.binaryRules[sha] {
-            return verdict(for: rule, identifier: sha)
-        }
-    case .deadlineExceeded:
-        unresolvedBinaryReason = .deadline
-    case .readFailed:
-        unresolvedBinaryReason = .readFailed
-    case .notNeeded:
-        break
+    if let binaryDecision = matchBinaryLayer(snapshot: snapshot, hashOutcome: hashOutcome) {
+        return binaryDecision
     }
+    if let lowerDecision = matchLowerLayers(tuple: tuple, snapshot: snapshot) {
+        return lowerDecision
+    }
+    if let reason = unresolvedBinaryReason(for: hashOutcome) {
+        return applyPosture(snapshot.deadlineFallback, reason: reason)
+    }
+    return .allow
+}
 
+/// matchBinaryLayer consults the BINARY map only when the hash is .computed; the .deadlineExceeded / .readFailed branches
+/// do NOT return here -- they keep the walk going so a definitive lower-precedence DENY can dominate the BINARY layer's
+/// uncertainty. .notNeeded skips BINARY entirely and falls through to the lower layers without ever surfacing a posture.
+/// Returns nil when no BINARY rule matches (the walker continues); returns an AuthDecision only on a positive match.
+private func matchBinaryLayer(snapshot: ApplicationControlSnapshot, hashOutcome: HashOutcome) -> AuthDecision? {
+    if case .computed(let sha) = hashOutcome, let rule = snapshot.binaryRules[sha] {
+        return verdict(for: rule, identifier: sha)
+    }
+    return nil
+}
+
+/// unresolvedBinaryReason maps a hash failure to the audit-event reason tag. Returns nil for .computed (a definitive
+/// answer either way) and .notNeeded (the snapshot has no BINARY rules so there is nothing for a posture to govern).
+/// Drives the deadlineFallback decision after the walker has consulted every lower layer.
+private func unresolvedBinaryReason(for hashOutcome: HashOutcome) -> UndecidedReason? {
+    switch hashOutcome {
+    case .deadlineExceeded:
+        return .deadline
+    case .readFailed:
+        return .readFailed
+    case .computed, .notNeeded:
+        return nil
+    }
+}
+
+/// matchLowerLayers walks CERTIFICATE → SIGNINGID → TEAMID → PATH and returns the first matching verdict, or nil when no
+/// layer matches. PATH is intentionally last because filesystem paths are the most spoofable identifier (symlinks, bind
+/// mounts, copies preserving content but changing the path string); a deny higher in the ladder always wins. Extracted
+/// from decideAuthExec to keep that function under the cyclomatic_complexity budget SwiftLint enforces.
+private func matchLowerLayers(tuple: AuthTuple, snapshot: ApplicationControlSnapshot) -> AuthDecision? {
+    if let leafCert = tuple.leafCertSHA256, let rule = snapshot.certificateRules[leafCert] {
+        return verdict(for: rule, identifier: leafCert)
+    }
     if let signingID = tuple.signingIDPrefixed, let rule = snapshot.signingIDRules[signingID] {
         return verdict(for: rule, identifier: signingID)
     }
     if let teamID = tuple.teamID, let rule = snapshot.teamIDRules[teamID] {
         return verdict(for: rule, identifier: teamID)
     }
-
-    if let reason = unresolvedBinaryReason {
-        return applyPosture(snapshot.deadlineFallback, reason: reason)
+    if let path = tuple.canonicalPath, let rule = snapshot.pathRules[path] {
+        return verdict(for: rule, identifier: path)
     }
-    return .allow
+    return nil
+}
+
+/// canonicalizePath returns the macOS-canonical form of an absolute path, matching the server-side
+/// `server/rules/internal/appcontrol/CanonicalizePath` rules verbatim: rejects empty / relative / `..`-containing paths,
+/// collapses redundant slashes (filepath.Clean equivalent), and rewrites the /tmp, /var, /etc symlinks into their
+/// /private/... forms. Returns nil for any rejection case so the caller treats the rule as not-applicable rather than
+/// generating a falsely-canonicalised match. The Swift and Go implementations MUST stay in lockstep -- a rule created
+/// against `/tmp/foo` is persisted as `/private/tmp/foo`; AUTH_EXEC must canonicalise the exec target the same way or the
+/// rule never matches. Tested in AuthExecDeciderTests so a divergence surfaces at L0.
+func canonicalizePath(_ path: String) -> String? {
+    if path.isEmpty {
+        return nil
+    }
+    if !path.hasPrefix("/") {
+        return nil
+    }
+    var segments: [String] = []
+    for segment in path.split(separator: "/", omittingEmptySubsequences: false) {
+        let s = String(segment)
+        if s == ".." {
+            return nil
+        }
+        if s.isEmpty || s == "." {
+            continue
+        }
+        segments.append(s)
+    }
+    let cleaned = "/" + segments.joined(separator: "/")
+    for prefix in ["/tmp", "/var", "/etc"] {
+        if cleaned == prefix || cleaned.hasPrefix(prefix + "/") {
+            return "/private" + cleaned
+        }
+    }
+    return cleaned
 }
 
 /// verdict maps a matched rule to the wire-level decision. Non-PROTECT enforcements (DETECT) and non-BLOCK actions (ALLOW,

--- a/extension/edr/extension/CDHashHex.swift
+++ b/extension/edr/extension/CDHashHex.swift
@@ -1,0 +1,65 @@
+import EndpointSecurity
+import Foundation
+
+// CDHashHex.swift carries the pure helpers ESFSubscriber.swift uses to extract a string CDHash identifier and decide
+// whether a target runs under Apple's Hardened Runtime. Extracted from ESFSubscriber.swift so that file stays under
+// SwiftLint's file_length cap; the helpers are pure and have no class state, so file scope is the natural home.
+
+/// csRuntimeFlag is the codesigning_flags bit set when a binary runs under Apple's Hardened Runtime. Defined here (rather than
+/// imported from <kern/cs_blobs.h>) because the Swift bridging headers do not surface the constant directly; the literal value
+/// is stable per the public macOS code-signing documentation. Lowercased to satisfy SwiftLint's identifier_name rule (CS_RUNTIME
+/// would be the literal C symbol but Swift conventions reject all-caps identifiers).
+private let csRuntimeFlag: UInt32 = 0x0001_0000
+
+/// isHardenedRuntime reports whether the codesigning_flags bitfield indicates Apple's Hardened Runtime. CDHASH rules only match
+/// hardened-runtime processes because on non-hardened processes the kernel maps pages lazily and does not re-verify them post-load,
+/// which makes the CDHash ESF reports at exec an unreliable identity for the bytes that will eventually execute. This diverges from
+/// Santa, which enforces CDHASH on any signed binary regardless of the runtime flag; a migrating Santa admin should expect a CDHASH
+/// rule to no-op here against a non-hardened target until that target is rebuilt with the Hardened Runtime flag.
+func isHardenedRuntime(flags: UInt32) -> Bool {
+    return (flags & csRuntimeFlag) != 0
+}
+
+/// hexCharsPerByte is the fixed expansion ratio of a byte to its 2-char lowercase hex representation. Extracted so the capacity
+/// reserve in cdhashHexString is self-documenting (SwiftLint's no_magic_numbers rule would otherwise flag the literal `2`).
+private let hexCharsPerByte = 2
+
+/// hexDigitsLowercase is the lookup table cdhashHexString walks instead of calling String(format:"%02x", b). The format-string path
+/// bridges to Foundation and parses the format spec on every call; this matters because the helper runs inside AUTH_EXEC's
+/// kernel-deadline window. The table is private so it doesn't pollute symbol search at the module level.
+private let hexDigitsLowercase: [Character] = [
+    "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "a", "b", "c", "d", "e", "f"
+]
+
+/// hexLowNibbleMask is the bitmask used to extract the low 4 bits of a byte when looking up its hex digit in the
+/// hexDigitsLowercase table. Named so the no_magic_numbers SwiftLint rule doesn't flag the literal 0x0f.
+private let hexLowNibbleMask: UInt8 = 0x0f
+
+// swiftlint:disable large_tuple
+//
+// cdhashHexString lowercases-hex the 20-byte CDHash array from es_process_t.cdhash into the 40-char string the server's validator
+// + the snapshot's cdhashRules map index on. Returns nil when the cdhash is all zero (es_process_t conventions: unsigned binaries
+// report a zeroed cdhash, which is not a real identity).
+//
+// The parameter is a 20-element tuple because the C surface (es_process_t.cdhash) is a fixed-size array that Swift imports as a
+// homogeneous tuple. The large_tuple lint is disabled around this declaration because the shape is dictated by the ESF SDK and
+// cannot be reshaped without breaking the C bridge.
+func cdhashHexString(from cdhash: (UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
+                                    UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8)) -> String? {
+    var bytes = cdhash
+    return withUnsafeBytes(of: &bytes) { raw -> String? in
+        // All-zero cdhash means "no real CDHash present" — unsigned or otherwise unverifiable. Return nil so the precedence walker
+        // skips the CDHASH map for this exec rather than matching a rule whose identifier is "00…00" by coincidence.
+        if raw.allSatisfy({ $0 == 0 }) {
+            return nil
+        }
+        var s = ""
+        s.reserveCapacity(raw.count * hexCharsPerByte)
+        for b in raw {
+            s.append(hexDigitsLowercase[Int(b >> 4)])
+            s.append(hexDigitsLowercase[Int(b & hexLowNibbleMask)])
+        }
+        return s
+    }
+}
+// swiftlint:enable large_tuple

--- a/extension/edr/extension/ESFSubscriber.swift
+++ b/extension/edr/extension/ESFSubscriber.swift
@@ -459,4 +459,5 @@ final class ESFSubscriber: Sendable {
 }
 
 // isHardenedRuntime + cdhashHexString helpers moved to CDHashHex.swift (PR for #210) to keep this file under SwiftLint's
-// file_length cap. The helpers are pure; ESFSubscriber consumes them via their public names.
+// file_length cap. The helpers are pure; ESFSubscriber consumes them via their module-internal symbols (Swift's implicit
+// `internal` access — no explicit modifier is required since both files compile into the same module).

--- a/extension/edr/extension/ESFSubscriber.swift
+++ b/extension/edr/extension/ESFSubscriber.swift
@@ -55,14 +55,20 @@ final class ESFSubscriber: Sendable {
         }
 
         logger.info("Subscribed to \(events.count) event types (including AUTH_EXEC)")
-        // Application Control Phase A close-out: AUTH_EXEC consults the
-        // ApplicationControlStore snapshot and denies execs matching any of
-        // four rule types in fixed precedence: CDHASH → BINARY → SIGNINGID →
-        // TEAMID. CERTIFICATE + PATH stay deferred to Phase B (leaf-cert cache
-        // / Launch Services indirection). Cache misses on the lazy file-hash
-        // cache return ALLOW silently for the BINARY type; the cache fills
-        // off the callback so the next exec of the same binary catches.
-        logger.info("Application Control active: AUTH_EXEC walks CDHASH/BINARY/SIGNINGID/TEAMID rules")
+        // Application Control Phase B close-out (PR for #210): AUTH_EXEC consults
+        // the ApplicationControlStore snapshot and denies execs matching any of
+        // the six wire-enum rule types in fixed Santa precedence:
+        //   CDHASH → BINARY → CERTIFICATE → SIGNINGID → TEAMID → PATH.
+        // CERTIFICATE matches the SHA-256 of the leaf signing certificate
+        // (SecCodeCopySigningInformation walk, cached per (inode, mtime) on first
+        // exec). PATH matches the canonical absolute path of the exec target,
+        // with /tmp + /var + /etc rewritten to /private/... to match the
+        // server-side persisted canonical form. Cache misses on the lazy file-
+        // hash cache use the snapshot's deadlineFallback posture for the BINARY
+        // layer only; the cheaper CERTIFICATE / SIGNINGID / TEAMID / PATH layers
+        // run unconditionally and a definitive deny on any of them dominates
+        // BINARY-layer uncertainty.
+        logger.info("Application Control active: AUTH_EXEC walks CDHASH/BINARY/CERTIFICATE/SIGNINGID/TEAMID/PATH rules")
     }
 
     func stop() {
@@ -91,10 +97,12 @@ final class ESFSubscriber: Sendable {
 
     /// AUTH_EXEC handler. Decision order: (1) platform-binary carve-out (#205) ALLOWs Apple system binaries with cache:true to
     /// avoid bricking the host on an admin-applied BINARY rule for launchd/xpcproxy/etc; (2) self-allow failsafe ALLOWs the
-    /// agent + extensions + host app uncached (team_id + bundle-id match); (3) decideAuthExec walks CDHASH → BINARY → SIGNINGID
-    /// → TEAMID. BINARY hashing runs synchronously under a budget derived from msg.deadline (#208 close-out); on deadline /
-    /// read failure the walk continues to SIGNINGID/TEAMID first, and only applies the snapshot's deadlineFallback posture
-    /// when no later rule matches. CERTIFICATE and PATH stay deferred to Phase B; the leaf-cert cache fill remains lazy.
+    /// agent + extensions + host app uncached (team_id + bundle-id match); (3) decideAuthExec walks CDHASH → BINARY →
+    /// CERTIFICATE → SIGNINGID → TEAMID → PATH (Phase B close-out, PR for #210). BINARY hashing runs synchronously under a
+    /// budget derived from msg.deadline (#208 close-out); on deadline / read failure the walk continues through every lower
+    /// layer first and only applies the snapshot's deadlineFallback posture when no later rule matches. CERTIFICATE +
+    /// SIGNINGID + TEAMID rely on SigningInfoFallback's cached SecCode walk; PATH uses canonicalizePath on the exec target
+    /// path so the in-memory comparison matches the server-side persisted canonical form verbatim.
     private func handleAuthExec(_ message: UnsafePointer<es_message_t>) {
         let msg = message.pointee
         let target = msg.event.exec.target.pointee
@@ -189,10 +197,11 @@ final class ESFSubscriber: Sendable {
         }
     }
 
-    /// buildAuthTuple reduces a Mach-O exec target to the three pure-identifier values the decider reads. The fourth identifier
+    /// buildAuthTuple reduces a Mach-O exec target to the five pure-identifier values the decider reads. The sixth identifier
     /// (BINARY SHA-256) is supplied via HashOutcome at decide time so the hash compute can run on the AUTH callback thread
     /// under a deadline budget; that responsibility lives in handleAuthExec, not here. The `path` argument is the resolved
-    /// executable path used for the SigningInfoFallback lookup when ESF redacts team_id on ad-hoc-signed extension hosts.
+    /// executable path used both for the SigningInfoFallback lookups (TeamID + leaf cert SHA-256) and for the canonical PATH
+    /// derivation. The leaf cert hash + canonical path joined the tuple when CERTIFICATE / PATH wired through (PR for #210).
     private func buildAuthTuple(target: es_process_t, fileStat: stat, path: String) -> AuthTuple {
         let esTeamID = esTokenString(target.team_id)
         let signingID = esTokenString(target.signing_id)
@@ -219,6 +228,12 @@ final class ESFSubscriber: Sendable {
             teamID = SigningInfoFallback.shared.teamID(forPath: path, fileStat: fileStat) ?? ""
         }
 
+        // Leaf certificate SHA-256 always comes from SigningInfoFallback -- ESF does not surface a cert hash directly, so
+        // there is no "ESF first, fallback on empty" pattern here. The cache key is shared with the TeamID lookup above so
+        // both fields cost one SecCode walk per (inode, mtime). Returns nil for unsigned / ad-hoc-signed binaries and any
+        // path SecCode rejects; the decider's optional binding skips the CERTIFICATE layer cleanly in those cases.
+        let leafCertSHA256 = SigningInfoFallback.shared.leafCertSHA256(forPath: path, fileStat: fileStat)
+
         // SIGNINGID prefix: "<TeamID>:<bundle.id>" for third-party signed binaries, "platform:<bundle.id>" for Apple platform
         // binaries. Under edr-dev's ad-hoc-extension redaction ESF reports is_platform_binary=true on every exec (#187), so
         // we use the fallback team_id (when present) to discriminate genuine Apple platform binaries from third-party ones.
@@ -233,10 +248,17 @@ final class ESFSubscriber: Sendable {
             signingIDPrefixed = nil
         }
 
+        // Canonical path: filepath.Clean equivalent + /tmp + /var + /etc rewritten to /private. MUST match the server-side
+        // CanonicalizePath rules exactly or rules persisted in canonical form never match what the AUTH callback computes.
+        // Nil result (empty / relative / `..`-containing -- all defensive against malformed ESF input) skips the PATH layer.
+        let canonicalPath = canonicalizePath(path)
+
         return AuthTuple(
             cdhash: cdhash,
+            leafCertSHA256: leafCertSHA256,
             signingIDPrefixed: signingIDPrefixed,
-            teamID: teamID.isEmpty ? nil : teamID
+            teamID: teamID.isEmpty ? nil : teamID,
+            canonicalPath: canonicalPath
         )
     }
 
@@ -436,61 +458,5 @@ final class ESFSubscriber: Sendable {
     }
 }
 
-/// csRuntimeFlag is the codesigning_flags bit set when a binary runs under Apple's Hardened Runtime. Defined here (rather than
-/// imported from <kern/cs_blobs.h>) because the Swift bridging headers do not surface the constant directly; the literal value
-/// is stable per the public macOS code-signing documentation. Lowercased to satisfy SwiftLint's identifier_name rule (CS_RUNTIME
-/// would be the literal C symbol but Swift conventions reject all-caps identifiers).
-private let csRuntimeFlag: UInt32 = 0x0001_0000
-
-/// isHardenedRuntime reports whether the codesigning_flags bitfield indicates Apple's Hardened Runtime. CDHASH rules only match
-/// hardened-runtime processes because on non-hardened processes the kernel maps pages lazily and does not re-verify them post-load,
-/// which makes the CDHash ESF reports at exec an unreliable identity for the bytes that will eventually execute. This diverges from
-/// Santa, which enforces CDHASH on any signed binary regardless of the runtime flag; a migrating Santa admin should expect a CDHASH
-/// rule to no-op here against a non-hardened target until that target is rebuilt with the Hardened Runtime flag.
-private func isHardenedRuntime(flags: UInt32) -> Bool {
-    return (flags & csRuntimeFlag) != 0
-}
-
-/// hexCharsPerByte is the fixed expansion ratio of a byte to its 2-char lowercase hex representation. Extracted so the capacity
-/// reserve in cdhashHexString is self-documenting (SwiftLint's no_magic_numbers rule would otherwise flag the literal `2`).
-private let hexCharsPerByte = 2
-
-/// hexDigitsLowercase is the lookup table cdhashHexString walks instead of calling String(format:"%02x", b). The format-string path
-/// bridges to Foundation and parses the format spec on every call; this matters because the helper runs inside AUTH_EXEC's
-/// kernel-deadline window. The table is private so it doesn't pollute symbol search at the module level.
-private let hexDigitsLowercase: [Character] = [
-    "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "a", "b", "c", "d", "e", "f"
-]
-
-/// hexLowNibbleMask is the bitmask used to extract the low 4 bits of a byte when looking up its hex digit in the
-/// hexDigitsLowercase table. Named so the no_magic_numbers SwiftLint rule doesn't flag the literal 0x0f.
-private let hexLowNibbleMask: UInt8 = 0x0f
-
-// swiftlint:disable large_tuple
-//
-// cdhashHexString lowercases-hex the 20-byte CDHash array from es_process_t.cdhash into the 40-char string the server's validator
-// + the snapshot's cdhashRules map index on. Returns nil when the cdhash is all zero (es_process_t conventions: unsigned binaries
-// report a zeroed cdhash, which is not a real identity).
-//
-// The parameter is a 20-element tuple because the C surface (es_process_t.cdhash) is a fixed-size array that Swift imports as a
-// homogeneous tuple. The large_tuple lint is disabled around this declaration because the shape is dictated by the ESF SDK and
-// cannot be reshaped without breaking the C bridge.
-private func cdhashHexString(from cdhash: (UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
-                                            UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8)) -> String? {
-    var bytes = cdhash
-    return withUnsafeBytes(of: &bytes) { raw -> String? in
-        // All-zero cdhash means "no real CDHash present" — unsigned or otherwise unverifiable. Return nil so the precedence walker
-        // skips the CDHASH map for this exec rather than matching a rule whose identifier is "00…00" by coincidence.
-        if raw.allSatisfy({ $0 == 0 }) {
-            return nil
-        }
-        var s = ""
-        s.reserveCapacity(raw.count * hexCharsPerByte)
-        for b in raw {
-            s.append(hexDigitsLowercase[Int(b >> 4)])
-            s.append(hexDigitsLowercase[Int(b & hexLowNibbleMask)])
-        }
-        return s
-    }
-}
-// swiftlint:enable large_tuple
+// isHardenedRuntime + cdhashHexString helpers moved to CDHashHex.swift (PR for #210) to keep this file under SwiftLint's
+// file_length cap. The helpers are pure; ESFSubscriber consumes them via their public names.

--- a/extension/edr/extension/ESFSubscriber.swift
+++ b/extension/edr/extension/ESFSubscriber.swift
@@ -178,8 +178,13 @@ final class ESFSubscriber: Sendable {
                 target: context.target, fileStat: context.fileStat, verdict: "allow", reason: reason, snapshot: context.snapshot
             )
         case .deny(let rule, let matchedIdentifier):
+            // matchedIdentifier is .private to honor the "no PII in log statements" coding guideline. For BINARY/CDHASH/
+            // CERTIFICATE this is a hex digest -- not PII but uniform privacy keeps the log policy simple; for PATH (added
+            // in PR #290 for #210) it's an absolute filesystem path that IS PII and MUST stay out of the public log. The
+            // full identifier still flows to the server in the application_control_block event payload (where the project
+            // guideline explicitly permits file paths). CodeRabbit MAJOR on PR #290.
             logger.warning(
-                "AUTH_EXEC DENIED type=\(rule.ruleType, privacy: .public) id=\(matchedIdentifier, privacy: .public)"
+                "AUTH_EXEC DENIED type=\(rule.ruleType, privacy: .public) id=\(matchedIdentifier, privacy: .private)"
             )
             es_respond_auth_result(client, context.message, ES_AUTH_RESULT_DENY, false)
             emitBlockEvent(

--- a/extension/edr/extension/SigningInfoFallback.swift
+++ b/extension/edr/extension/SigningInfoFallback.swift
@@ -133,20 +133,23 @@ final class SigningInfoFallback {
 
     /// extractLeafCertSHA256 SHA-256s the DER bytes of the binary's leaf certificate (kSecCodeInfoCertificates[0]) and returns
     /// the 64-char lowercase hex digest. Returns nil for unsigned / ad-hoc-signed binaries (no certificate chain) or when the
-    /// chain decode produces zero certs (defensive; never happens in practice for a signed binary).
+    /// chain decode produces zero certs (defensive; never happens in practice for a signed binary). Gemini flagged the
+    /// SecCertificateCopyData forced cast on PR #290; the conditional bind below treats a nil return defensively even though
+    /// SecCertificateCopyData is documented as non-failing for a valid SecCertificate.
     private func extractLeafCertSHA256(from info: [String: Any]) -> String? {
-        guard let certs = info[kSecCodeInfoCertificates as String] as? [SecCertificate], let leaf = certs.first else {
+        guard let certs = info[kSecCodeInfoCertificates as String] as? [SecCertificate],
+              let leaf = certs.first,
+              let der = SecCertificateCopyData(leaf) as Data? else {
             return nil
         }
-        let der = SecCertificateCopyData(leaf) as Data
         let digest = SHA256.hash(data: der)
         return digestToHex(digest)
     }
 
     /// digestToHex renders a SHA-256 digest as 64 lowercase hex characters. Uses the explicit nibble-lookup pattern instead
     /// of String(format: "%02x", _) so the hex render is allocation-conscious and SwiftLint's no_magic_numbers rule has no
-    /// literal `2` to flag. Mirrors the cdhashHexString shape in ESFSubscriber.swift; if a third hex consumer lands, lift
-    /// this into a shared helper file.
+    /// literal `2` to flag. Mirrors the cdhashHexString shape in CDHashHex.swift; if a third hex consumer lands, lift this
+    /// + cdhashHexString into a shared helper file.
     private func digestToHex(_ digest: SHA256.Digest) -> String {
         var s = ""
         s.reserveCapacity(SHA256.byteCount * digestHexCharsPerByte)

--- a/extension/edr/extension/SigningInfoFallback.swift
+++ b/extension/edr/extension/SigningInfoFallback.swift
@@ -1,35 +1,41 @@
+import CryptoKit
 import Foundation
 import Security
 import os
 
 private let logger = Logger(subsystem: "com.fleetdm.edr.securityextension", category: "SigningInfoFallback")
 
-/// SigningInfoFallback fills in the canonical Team ID for a binary when ESF returns an empty `target.team_id`.
+/// SigningInfoFallback fills in the canonical Team ID and the leaf certificate SHA-256 for a binary when ESF does not provide
+/// them directly. Both fields come from one SecCodeCopySigningInformation call so the cache pays the SecCode cost once per
+/// (inode, mtime) regardless of which field a caller asks for first.
 ///
-/// Why this exists: ESF redacts `target.team_id=""` and forces `target.is_platform_binary=true` for every
-/// exec the client sees when the ESF host extension itself is not Developer-ID-signed + notarized. This is
-/// a documented per-client policy, not a per-binary CS_PLATFORM_BINARY classification: the redaction hits
-/// every exec, including unambiguously third-party Developer-ID-signed binaries (issue #187 quantified
-/// 393/393 exec events redacted on edr-dev). The edr-dev VM ships the extension ad-hoc-signed
-/// (`codesign -d` reports `adhoc, linker-signed`), which trips the redaction; AUTH_EXEC's TEAMID rule
-/// branch then has nothing to match against -- it cannot block a binary by `8VBZ3948LU` if ESF says
-/// team_id="". On notarized release hosts ESF reports the real team_id and this fallback is a no-op.
-/// The proper long-term fix is to notarize the extension (tracked separately); this fallback keeps the
-/// dev VM usable for end-to-end QA of TEAMID + SIGNINGID rule flows in the meantime.
+/// TeamID context: ESF redacts `target.team_id=""` and forces `target.is_platform_binary=true` for every exec the client sees
+/// when the ESF host extension itself is not Developer-ID-signed + notarized. This is a documented per-client policy, not a
+/// per-binary CS_PLATFORM_BINARY classification: the redaction hits every exec, including unambiguously third-party Developer-ID
+/// signed binaries (issue #187 quantified 393/393 exec events redacted on edr-dev). The edr-dev VM ships the extension ad-hoc-
+/// signed (`codesign -d` reports `adhoc, linker-signed`), which trips the redaction; AUTH_EXEC's TEAMID rule branch then has
+/// nothing to match against -- it cannot block a binary by `8VBZ3948LU` if ESF says team_id="". On notarized release hosts ESF
+/// reports the real team_id and this fallback is a no-op for the TEAM ID path. The proper long-term fix is to notarize the
+/// extension (tracked separately); this fallback keeps the dev VM usable for end-to-end QA of TEAMID + SIGNINGID rule flows
+/// in the meantime.
 ///
-/// The fallback reads the binary on disk via SecStaticCode + SecCodeCopySigningInformation and returns the
-/// `TeamIdentifier` value the codesign block declares. That is the same value `codesign -dvv` prints, and
-/// matches the identifier the server-side TEAMID rule's operator would have typed.
+/// CERTIFICATE context (PR for #210): ESF does NOT surface the leaf X.509 signing certificate hash at all. SecCode is the only
+/// path the extension has to derive it. Operators set CERTIFICATE rules with the SHA-256 of the leaf cert -- the value Santa
+/// admins type, and the same hash `openssl x509 -fingerprint -sha256` would compute over the DER-encoded leaf. Every AUTH_EXEC
+/// on a signed binary pays one SecCode walk on first exec, then cache hits.
 ///
-/// Cost: SecCode walks the Mach-O signing block, which is a few hundred microseconds for a typical binary.
-/// AUTH_EXEC's deadline (the kernel waits up to 60 seconds for our response by default) absorbs this; the
-/// FileHashCache pattern of "kick async fill, return nil on cold cache" is unnecessary at this latency.
-/// Results are cached in an inode+mtime-keyed dictionary so repeated execs of the same binary skip the
-/// SecCode walk; the cache is purged on extension restart (cold path is rare and self-healing).
+/// The fallback reads the binary on disk via SecStaticCode + SecCodeCopySigningInformation. The TeamIdentifier value the
+/// codesign block declares matches what `codesign -dvv` prints; the leaf cert SHA-256 matches what
+/// `codesign -d --extract-certificates` + `shasum -a 256` would produce against the index-0 (leaf) cert.
 ///
-/// Concurrency: the cache is guarded by an OSAllocatedUnfairLock for the same reason
-/// ApplicationControlStore's lock is -- AUTH_EXEC fires concurrently across CPUs and the critical section
-/// is a constant-time dictionary lookup.
+/// Cost: SecCode walks the Mach-O signing block, which is a few hundred microseconds for a typical binary. AUTH_EXEC's
+/// deadline (the kernel waits up to 60 seconds for our response by default) absorbs this; the FileHashCache pattern of "kick
+/// async fill, return nil on cold cache" is unnecessary at this latency. Results cache in an inode+mtime-keyed dictionary so
+/// repeated execs of the same binary skip the SecCode walk; the cache is purged on extension restart (cold path is rare and
+/// self-healing).
+///
+/// Concurrency: the cache is guarded by an OSAllocatedUnfairLock for the same reason ApplicationControlStore's lock is --
+/// AUTH_EXEC fires concurrently across CPUs and the critical section is a constant-time dictionary lookup.
 final class SigningInfoFallback {
     static let shared = SigningInfoFallback()
 
@@ -44,57 +50,126 @@ final class SigningInfoFallback {
         let mtimeNsec: Int64
     }
 
-    private let lock = OSAllocatedUnfairLock(initialState: [CacheKey: String?]())
+    /// SigningInfo carries every field one SecCodeCopySigningInformation call extracts. Nil fields indicate "the key was
+    /// absent or empty in the codesign info dict" (e.g. ad-hoc-signed binaries have no TeamIdentifier; unsigned binaries have
+    /// no certificate chain). Equatable so the test suite can assert on the cache state directly.
+    struct SigningInfo: Equatable {
+        let teamID: String?
+        let leafCertSHA256: String?
+    }
 
-    /// teamID returns the Team ID for the binary at `path`. Returns nil when:
-    ///   - SecStaticCode cannot read the binary (permission denied, file gone)
-    ///   - The signing dict does not contain a TeamIdentifier (ad-hoc signed binary)
-    ///   - The signing info has a TeamIdentifier of empty string
-    /// The first two are real "no Team ID" outcomes; the third should not happen in practice but is
-    /// handled defensively. Caches the result keyed on (inode, mtime).
+    private let lock = OSAllocatedUnfairLock(initialState: [CacheKey: SigningInfo]())
+
+    /// teamID returns the Team ID for the binary at `path`. Convenience wrapper for callers that only want the team-id
+    /// branch; first call populates the shared SigningInfo cache, subsequent calls hit it.
     func teamID(forPath path: String, fileStat: stat) -> String? {
+        return signingInfo(forPath: path, fileStat: fileStat).teamID
+    }
+
+    /// leafCertSHA256 returns the 64-character lowercase hex SHA-256 of the binary's leaf signing certificate. The "leaf"
+    /// is the cert at index 0 of kSecCodeInfoCertificates -- the cert the binary was directly signed with, NOT an
+    /// intermediate or the root. Returns nil for unsigned binaries, ad-hoc-signed binaries, or any path SecCode rejects.
+    /// CERTIFICATE rules created against the operator-provided 64-hex identifier compare against this value verbatim.
+    func leafCertSHA256(forPath path: String, fileStat: stat) -> String? {
+        return signingInfo(forPath: path, fileStat: fileStat).leafCertSHA256
+    }
+
+    /// signingInfo is the cached SecCode-backed lookup. Both teamID(forPath:fileStat:) and leafCertSHA256(forPath:fileStat:)
+    /// route through here so a binary that needs both lookups (the common case on AUTH_EXEC when both TEAMID and CERTIFICATE
+    /// rule maps are non-empty) pays the SecCode cost exactly once.
+    private func signingInfo(forPath path: String, fileStat: stat) -> SigningInfo {
         let key = CacheKey(
             inode: fileStat.st_ino,
             mtimeSec: Int64(fileStat.st_mtimespec.tv_sec),
             mtimeNsec: Int64(fileStat.st_mtimespec.tv_nsec),
         )
         if let cached = lock.withLock({ $0[key] }) {
-            // Non-nil cached means we have read this file before; the value (which itself may be a real
-            // String or nil) is the canonical answer. The outer optional pattern lets us distinguish
-            // "never read" from "read, returned nil".
             return cached
         }
-        let resolved = resolveTeamID(forPath: path)
+        let resolved = resolveSigningInfo(forPath: path)
         lock.withLock { $0[key] = resolved }
         return resolved
     }
 
-    /// resolveTeamID is the uncached SecCode read. Split out so the cache path can stay terse.
-    private func resolveTeamID(forPath path: String) -> String? {
+    /// resolveSigningInfo is the uncached SecCode read. One SecStaticCodeCreateWithPath + one SecCodeCopySigningInformation
+    /// produces both the TeamIdentifier and the leaf certificate, even though the call sites may consume them at different
+    /// times. Errors from either step return an empty SigningInfo (both fields nil) so the cache write still pins the
+    /// outcome -- otherwise every AUTH_EXEC for an unreadable / unsigned binary would re-walk SecCode pointlessly.
+    private func resolveSigningInfo(forPath path: String) -> SigningInfo {
         let url = URL(fileURLWithPath: path) as CFURL
         var staticCode: SecStaticCode?
         let createStatus = SecStaticCodeCreateWithPath(url, [], &staticCode)
         guard createStatus == errSecSuccess, let code = staticCode else {
             logger.debug("SecStaticCodeCreateWithPath failed for \(path, privacy: .private): \(createStatus)")
-            return nil
+            return SigningInfo(teamID: nil, leafCertSHA256: nil)
         }
         var infoDict: CFDictionary?
-        // kSecCSSigningInformation (rawValue=2) is the flag that asks SecCodeCopySigningInformation to populate the
-        // signing-info keys -- including kSecCodeInfoTeamIdentifier. Without it the returned dict is missing the
-        // TeamIdentifier entry entirely and the fallback silently returns nil (the bug that masked TEAMID enforcement
-        // on SIP-off VMs end-to-end). The constant is the canonical Sec framework flag; using the literal rawValue
-        // keeps the binding stable across SDK versions where the symbol's import name has drifted.
+        // kSecCSSigningInformation (rawValue=2) is the flag that asks SecCodeCopySigningInformation to populate the signing-info
+        // keys -- including kSecCodeInfoTeamIdentifier AND kSecCodeInfoCertificates. Without it the returned dict is missing both
+        // entries and this method silently returns the all-nil shape (the bug that masked TEAMID enforcement on SIP-off VMs end-
+        // to-end before the explicit flag was added). The constant is the canonical Sec framework flag; using the literal
+        // rawValue keeps the binding stable across SDK versions where the symbol's import name has drifted.
         let infoStatus = SecCodeCopySigningInformation(code, SecCSFlags(rawValue: kSecCSSigningInformation), &infoDict)
         guard infoStatus == errSecSuccess, let info = infoDict as? [String: Any] else {
             logger.debug("SecCodeCopySigningInformation failed for \(path, privacy: .private): \(infoStatus)")
-            return nil
+            return SigningInfo(teamID: nil, leafCertSHA256: nil)
         }
-        // The Sec framework spells this key "kSecCodeInfoTeamIdentifier" in its public header. Reference it
-        // by the Foundation string constant so a future SDK rename surfaces at compile time rather than
-        // silently returning nil.
+        let team = extractTeamID(from: info)
+        let leaf = extractLeafCertSHA256(from: info)
+        return SigningInfo(teamID: team, leafCertSHA256: leaf)
+    }
+
+    /// extractTeamID pulls the TeamIdentifier value out of the codesign info dict, returning nil when the key is absent or
+    /// the value is the empty string. Ad-hoc-signed binaries land in the nil case; Developer-ID-signed binaries return the
+    /// 10-char team id verbatim.
+    private func extractTeamID(from info: [String: Any]) -> String? {
+        // The Sec framework spells this key "kSecCodeInfoTeamIdentifier" in its public header. Reference it by the Foundation
+        // string constant so a future SDK rename surfaces at compile time rather than silently returning nil.
         guard let teamID = info[kSecCodeInfoTeamIdentifier as String] as? String, !teamID.isEmpty else {
             return nil
         }
         return teamID
     }
+
+    /// extractLeafCertSHA256 SHA-256s the DER bytes of the binary's leaf certificate (kSecCodeInfoCertificates[0]) and returns
+    /// the 64-char lowercase hex digest. Returns nil for unsigned / ad-hoc-signed binaries (no certificate chain) or when the
+    /// chain decode produces zero certs (defensive; never happens in practice for a signed binary).
+    private func extractLeafCertSHA256(from info: [String: Any]) -> String? {
+        guard let certs = info[kSecCodeInfoCertificates as String] as? [SecCertificate], let leaf = certs.first else {
+            return nil
+        }
+        let der = SecCertificateCopyData(leaf) as Data
+        let digest = SHA256.hash(data: der)
+        return digestToHex(digest)
+    }
+
+    /// digestToHex renders a SHA-256 digest as 64 lowercase hex characters. Uses the explicit nibble-lookup pattern instead
+    /// of String(format: "%02x", _) so the hex render is allocation-conscious and SwiftLint's no_magic_numbers rule has no
+    /// literal `2` to flag. Mirrors the cdhashHexString shape in ESFSubscriber.swift; if a third hex consumer lands, lift
+    /// this into a shared helper file.
+    private func digestToHex(_ digest: SHA256.Digest) -> String {
+        var s = ""
+        s.reserveCapacity(SHA256.byteCount * digestHexCharsPerByte)
+        for byte in digest {
+            s.append(digestHexDigits[Int(byte >> digestHexShift)])
+            s.append(digestHexDigits[Int(byte & digestLowNibbleMask)])
+        }
+        return s
+    }
 }
+
+/// digestHexCharsPerByte is the fixed 2-char expansion ratio per byte. Named so SwiftLint's no_magic_numbers rule has nothing
+/// to flag in digestToHex above.
+private let digestHexCharsPerByte = 2
+
+/// digestHexShift is the bit shift used to extract the high nibble of a byte. 4 bits per nibble; named to satisfy the lint.
+private let digestHexShift: UInt8 = 4
+
+/// digestLowNibbleMask is the bitmask used to extract the low nibble of a byte.
+private let digestLowNibbleMask: UInt8 = 0x0f
+
+/// digestHexDigits is the lookup table the digest-to-hex helper walks instead of calling String(format: "%02x", b). Mirrors
+/// the hexDigitsLowercase in ESFSubscriber.swift.
+private let digestHexDigits: [Character] = [
+    "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "a", "b", "c", "d", "e", "f"
+]

--- a/extension/edr/extension/SigningInfoFallback.swift
+++ b/extension/edr/extension/SigningInfoFallback.swift
@@ -39,12 +39,13 @@ private let logger = Logger(subsystem: "com.fleetdm.edr.securityextension", cate
 final class SigningInfoFallback {
     static let shared = SigningInfoFallback()
 
-    /// CacheKey pins a cached signing-info entry to a specific (inode, mtime) tuple so a binary swap that
-    /// preserves the path but changes the contents is observed as a cache miss. Stores mtime as separate
-    /// sec / nsec fields to mirror FileHashCache.swift's CacheKey exactly: same invalidation contract,
-    /// same shape, and no scalar multiplication that would trip SwiftLint's no_magic_numbers rule on the
-    /// nanoseconds-per-second constant.
+    /// CacheKey pins a cached signing-info entry to a specific (device, inode, mtime) tuple so a binary
+    /// swap that preserves the path but changes the contents is observed as a cache miss. `device` is
+    /// required because (inode, mtime) is only unique within a filesystem -- two binaries on different
+    /// volumes can share an inode number and collide their SigningInfo, misapplying CERTIFICATE / TEAMID /
+    /// SIGNINGID rules. CodeRabbit MAJOR on PR #290. Shape mirrors FileHashCache.swift's Key for parity.
     struct CacheKey: Hashable {
+        let device: Int32
         let inode: UInt64
         let mtimeSec: Int64
         let mtimeNsec: Int64
@@ -79,6 +80,7 @@ final class SigningInfoFallback {
     /// rule maps are non-empty) pays the SecCode cost exactly once.
     private func signingInfo(forPath path: String, fileStat: stat) -> SigningInfo {
         let key = CacheKey(
+            device: fileStat.st_dev,
             inode: fileStat.st_ino,
             mtimeSec: Int64(fileStat.st_mtimespec.tv_sec),
             mtimeNsec: Int64(fileStat.st_mtimespec.tv_nsec),

--- a/openspec/specs/server-admin-surface/spec.md
+++ b/openspec/specs/server-admin-surface/spec.md
@@ -112,14 +112,18 @@ admin push can reconcile, and MUST record the fan-out count in the audit payload
 Every mutation request body MUST carry a non-empty `reason`. The operator identity (`actor`) is NOT carried in the body;
 it is derived from the authenticated session context and recorded in the audit row in the form `user:<id>`. The
 POST (create) body MUST additionally carry `rule_type` and `identifier`; PATCH and DELETE accept partial mutations against
-the existing rule and do not need either. `rule_type` MUST be one of the supported uppercase tokens (`BINARY`, `CDHASH`,
-`SIGNINGID`, `TEAMID`; `CERTIFICATE` and `PATH` exist on the wire enum but are not yet enforced and currently surface
-as an unsupported-rule-type error). `identifier` MUST satisfy the format rules for the declared `rule_type`:
+the existing rule and do not need either. `rule_type` MUST be one of the supported uppercase tokens: `BINARY`, `CDHASH`,
+`SIGNINGID`, `CERTIFICATE`, `TEAMID`, `PATH`. `identifier` MUST satisfy the format rules for the declared `rule_type`:
 
 - `BINARY`: 64 lowercase hex characters (SHA-256 of the executable file).
 - `CDHASH`: 40 lowercase hex characters (Code Directory hash).
 - `SIGNINGID`: `<TeamID>:<bundle.id>` or `platform:<bundle.id>` for Apple platform binaries.
+- `CERTIFICATE`: 64 lowercase hex characters (SHA-256 of the leaf X.509 signing certificate; same value
+  `codesign -d --extract-certificates` + `shasum -a 256` against the index-0 cert produces).
 - `TEAMID`: 10-character alphanumeric Apple Developer Team ID (e.g. `EQHXZ8M8AV`).
+- `PATH`: absolute canonical filesystem path. The validator normalises redundant slashes and rewrites the macOS
+  `/tmp`, `/var`, `/etc` symlinks into their `/private/...` forms; relative paths, empty strings, and paths containing
+  `..` segments are rejected.
 
 A request that violates the rule-type or identifier constraints MUST be rejected with `400 Bad Request` and the policy
 MUST NOT be modified.
@@ -144,8 +148,8 @@ MUST NOT be modified.
 #### Scenario: Unsupported rule type is rejected without persisting
 
 - **GIVEN** any current policy
-- **WHEN** the operator POSTs a rule whose `rule_type` is not in the supported set (e.g., `CERTIFICATE` or `PATH` in the
-  current cut, both of which exist on the enum but lack validators)
+- **WHEN** the operator POSTs a rule whose `rule_type` is not a member of the supported set (an unknown uppercase token,
+  e.g. `BANANA`; the supported set is `BINARY`, `CDHASH`, `SIGNINGID`, `CERTIFICATE`, `TEAMID`, `PATH`)
 - **THEN** the server returns `400 Bad Request`
 - **AND** the persisted policy is unchanged
 

--- a/server/rules/internal/appcontrol/doc.go
+++ b/server/rules/internal/appcontrol/doc.go
@@ -5,10 +5,13 @@
 // validators, and the lookup paths the REST handler and the agent
 // fan-out consume.
 //
-// The demo cut enforces only the BINARY rule type; the validator
-// returns ErrAppControlUnsupportedRuleType for every other value on
-// the rule_type enum so the REST surface can reject those types with
-// a stable typed error. The remaining types come online one at a
-// time as their decision-engine branches and ESF-side identifier
-// extractors land in the extension.
+// v0.1.0 ships every wire-enum rule type wired through to the
+// extension's AUTH_EXEC walker: BINARY, CDHASH, SIGNINGID, TEAMID
+// (Phase A close-out, PR #289), plus CERTIFICATE and PATH (Phase B
+// close-out, PR for #210). The validator's only rejection branch is
+// ErrAppControlInvalidRuleType for tokens that aren't on the enum at
+// all. ErrAppControlUnsupportedRuleType is retained on the api
+// package for the future case where a new wire-enum value lands
+// before its extension-side support; no validator branch produces it
+// today.
 package appcontrol

--- a/server/rules/internal/appcontrol/store.go
+++ b/server/rules/internal/appcontrol/store.go
@@ -426,6 +426,13 @@ func (s *Store) CreateRule(ctx context.Context, req api.CreateRuleRequest) (api.
 		severity = api.SeverityRuleMedium
 	}
 
+	// Persist PATH identifiers in their canonical form (filepath.Clean + /tmp,/var,/etc → /private). The extension's AUTH_EXEC
+	// walker queries against the canonical form, so a literal `/tmp/foo` persisted as-is would never match (Gemini PR #290).
+	persistIdentifier, normErr := NormalizeIdentifier(req.RuleType, req.Identifier)
+	if normErr != nil {
+		return api.ApplicationControlRule{}, fmt.Errorf("%w: %s", api.ErrAppControlInvalidIdentifier, normErr.Error())
+	}
+
 	tx, err := s.db.BeginTxx(ctx, nil)
 	if err != nil {
 		return api.ApplicationControlRule{}, fmt.Errorf(errBeginTxFmt, err)
@@ -438,7 +445,7 @@ func (s *Store) CreateRule(ctx context.Context, req api.CreateRuleRequest) (api.
 		(policy_id, rule_type, identifier, action, enforcement, enabled, severity, source, custom_msg, custom_url, comment, created_by)
 		VALUES (?, ?, ?, 'BLOCK', 'PROTECT', 1, ?, 'admin', ?, ?, ?, ?)`
 	res, err := tx.ExecContext(ctx, insert,
-		req.PolicyID, req.RuleType, req.Identifier, severity,
+		req.PolicyID, req.RuleType, persistIdentifier, severity,
 		req.CustomMsg, req.CustomURL, req.Comment, req.Actor,
 	)
 	if err != nil {
@@ -887,6 +894,23 @@ func validateBulkUpsertRequest(req api.BulkUpsertRulesRequest) error {
 	return nil
 }
 
+// normalizeBulkUpsertItems returns a copy of items with PATH identifiers in canonical form. Every other rule type is returned
+// unchanged. Callers MUST run validateBulkUpsertItems first so the canonicalizePath call below cannot fail on malformed input
+// in practice; the error path is defensive. Added on PR #290 (#210) for the bulk paste-many path; CreateRule has the same
+// normalization step inline.
+func normalizeBulkUpsertItems(items []api.BulkUpsertRuleItem) ([]api.BulkUpsertRuleItem, error) {
+	out := make([]api.BulkUpsertRuleItem, len(items))
+	copy(out, items)
+	for i := range out {
+		canon, err := NormalizeIdentifier(out[i].RuleType, out[i].Identifier)
+		if err != nil {
+			return nil, fmt.Errorf(errBulkItemFmt, i, fmt.Errorf("%w: %s", api.ErrAppControlInvalidIdentifier, err.Error()))
+		}
+		out[i].Identifier = canon
+	}
+	return out, nil
+}
+
 // validateBulkUpsertItems runs the per-item shape checks AND the in-batch duplicate-key guard. CodeRabbit on PR #190 flagged a
 // duplicate key in the same batch as a count-correctness bug: without this guard, the second occurrence of the same
 // (rule_type, identifier) tuple would be classified as Insert because the preflight only sees pre-batch state.
@@ -1030,6 +1054,17 @@ func (s *Store) BulkUpsertRules(ctx context.Context, req api.BulkUpsertRulesRequ
 	if err := validateBulkUpsertItems(req.Items); err != nil {
 		return api.BulkUpsertResult{}, err
 	}
+	// Normalize PATH identifiers to their canonical form (filepath.Clean + /tmp,/var,/etc → /private) so the persisted row
+	// matches what the extension's AUTH_EXEC walker computes from the exec target's path. Without this, a paste-many import
+	// of `/tmp/foo` lands as `/tmp/foo` in the DB but the extension queries `/private/tmp/foo` and the rule silently never
+	// fires (Gemini PR #290). Replaces both req.Items + the working slice so collectExistingBulkKeys + the INSERT loop both
+	// see canonical identifiers; the in-batch duplicate guard already ran on raw input so two canonical-form duplicates
+	// (e.g. `/tmp/foo` and `/private/tmp/foo` pasted in the same batch) collide as expected at the DB unique-key gate.
+	normalized, err := normalizeBulkUpsertItems(req.Items)
+	if err != nil {
+		return api.BulkUpsertResult{}, err
+	}
+	req.Items = normalized
 
 	// Sort a copy so the caller's slice stays intact + lock ordering on rule rows is deterministic across concurrent batches.
 	sortedItems := make([]api.BulkUpsertRuleItem, len(req.Items))

--- a/server/rules/internal/appcontrol/validate.go
+++ b/server/rules/internal/appcontrol/validate.go
@@ -46,10 +46,26 @@ var teamID = regexp.MustCompile(`^[A-Z0-9]{10}$`)
 // The bundle.id portion is ASCII alphanumeric with `.`, `_`, `-`.
 var signingID = regexp.MustCompile(`^(?:[A-Z0-9]{10}|platform):[a-zA-Z0-9._-]+$`)
 
+// NormalizeIdentifier returns the canonical persist-ready form of an identifier for the given rule type. For PATH rules this is
+// the macOS-canonical form (filepath.Clean + /tmp,/var,/etc → /private rewrite); the extension queries against the canonical form
+// at AUTH_EXEC time, so persisting any other shape (e.g. the operator's literal `/tmp/foo`) silently breaks rule match. For every
+// other rule type the identifier is returned unchanged. Callers MUST run ValidateIdentifier first so they can return a typed
+// validation error; this function assumes the identifier already passed validation and panics through canonicalizePath's error
+// only when invoked on invalid input (operationally impossible after ValidateIdentifier succeeds). Gemini flagged the missing
+// normalization step on PR #290 (#210).
+func NormalizeIdentifier(rt api.RuleType, identifier string) (string, error) {
+	if rt != api.RuleTypePath {
+		return identifier, nil
+	}
+	return canonicalizePath(identifier)
+}
+
 // ValidateIdentifier checks that the identifier value matches the format required by the rule type. Returns
 // ErrAppControlInvalidIdentifier with the expected-shape hint string (the raw identifier value is NOT included so this validator does
 // not turn unbounded admin input into log lines). Returns ErrAppControlInvalidRuleType for tokens that aren't on the wire enum at
-// all; ErrAppControlUnsupportedRuleType is retired now that every wire enum value is wired through to the extension.
+// all; ErrAppControlUnsupportedRuleType is retired now that every wire enum value is wired through to the extension. For PATH rules
+// the format check is the canonicalization-can-succeed check; callers persist the canonical form via NormalizeIdentifier so the
+// extension's AUTH_EXEC walker matches against the same string.
 func ValidateIdentifier(rt api.RuleType, identifier string) error {
 	switch rt {
 	case api.RuleTypeBinary:

--- a/server/rules/internal/appcontrol/validate.go
+++ b/server/rules/internal/appcontrol/validate.go
@@ -15,16 +15,16 @@ import (
 // future rename to a structured-error shape is a one-line change.
 const wrapFmt = "%w: %s"
 
-// ValidateRuleType reports whether rt is a recognized rule type. Phase A close-out accepts CDHASH, BINARY, SIGNINGID, and TEAMID.
-// CERTIFICATE and PATH stay gated (CERTIFICATE needs the leaf-cert cache plumbing Phase B brings; PATH needs Launch Services
-// indirection coverage Phase B brings); both return ErrAppControlUnsupportedRuleType so the operator audit log surfaces the
-// precise "not yet wired" cause rather than a generic invalid-type error.
+// ValidateRuleType reports whether rt is a recognized rule type. v0.1.0 accepts the full enum: BINARY, CDHASH, SIGNINGID, TEAMID
+// (Phase A close-out, PR #289), plus CERTIFICATE and PATH (Phase B close-out, this PR). CERTIFICATE matches against the SHA-256
+// of the leaf X.509 signing certificate -- the surgical level for compromised-Developer-ID incident response. PATH matches against
+// the canonical absolute path of the exec target; the validator's canonicalizePath is the single canonical-form authority and the
+// extension applies the same rules on the AUTH callback. ErrAppControlUnsupportedRuleType is retired: every wire-enum value is now
+// either accepted or invalid; an unknown token returns ErrAppControlInvalidRuleType.
 func ValidateRuleType(rt api.RuleType) error {
 	switch rt {
-	case api.RuleTypeBinary, api.RuleTypeCDHash, api.RuleTypeSigningID, api.RuleTypeTeamID:
+	case api.RuleTypeBinary, api.RuleTypeCDHash, api.RuleTypeSigningID, api.RuleTypeCertificate, api.RuleTypeTeamID, api.RuleTypePath:
 		return nil
-	case api.RuleTypeCertificate, api.RuleTypePath:
-		return fmt.Errorf(wrapFmt, api.ErrAppControlUnsupportedRuleType, rt)
 	default:
 		return fmt.Errorf(wrapFmt, api.ErrAppControlInvalidRuleType, rt)
 	}
@@ -48,8 +48,8 @@ var signingID = regexp.MustCompile(`^(?:[A-Z0-9]{10}|platform):[a-zA-Z0-9._-]+$`
 
 // ValidateIdentifier checks that the identifier value matches the format required by the rule type. Returns
 // ErrAppControlInvalidIdentifier with the expected-shape hint string (the raw identifier value is NOT included so this validator does
-// not turn unbounded admin input into log lines). Returns ErrAppControlUnsupportedRuleType if the type is on the enum but not yet
-// wired through validation.
+// not turn unbounded admin input into log lines). Returns ErrAppControlInvalidRuleType for tokens that aren't on the wire enum at
+// all; ErrAppControlUnsupportedRuleType is retired now that every wire enum value is wired through to the extension.
 func ValidateIdentifier(rt api.RuleType, identifier string) error {
 	switch rt {
 	case api.RuleTypeBinary:
@@ -66,7 +66,7 @@ func ValidateIdentifier(rt api.RuleType, identifier string) error {
 		if !hex64.MatchString(identifier) {
 			return fmt.Errorf(wrapFmt, api.ErrAppControlInvalidIdentifier, "CERTIFICATE rule identifier must be 64 lowercase hex characters")
 		}
-		return fmt.Errorf(wrapFmt, api.ErrAppControlUnsupportedRuleType, rt)
+		return nil
 	case api.RuleTypeTeamID:
 		if !teamID.MatchString(identifier) {
 			return fmt.Errorf(wrapFmt, api.ErrAppControlInvalidIdentifier, "TEAMID rule identifier must be 10 uppercase alphanumeric characters")
@@ -81,7 +81,7 @@ func ValidateIdentifier(rt api.RuleType, identifier string) error {
 		if _, err := canonicalizePath(identifier); err != nil {
 			return fmt.Errorf(wrapFmt, api.ErrAppControlInvalidIdentifier, err.Error())
 		}
-		return fmt.Errorf(wrapFmt, api.ErrAppControlUnsupportedRuleType, rt)
+		return nil
 	default:
 		return fmt.Errorf(wrapFmt, api.ErrAppControlInvalidRuleType, rt)
 	}

--- a/server/rules/internal/appcontrol/validate_test.go
+++ b/server/rules/internal/appcontrol/validate_test.go
@@ -115,8 +115,40 @@ func TestValidateIdentifier_AcceptedTypes(t *testing.T) {
 	}
 }
 
-// TestCanonicalizePath covers the macOS-specific /tmp, /var, /etc rewrites every PATH rule depends on. The validator path is exercised
-// today; the Phase-A PATH-rule decision engine will consume the same helper.
+// TestNormalizeIdentifier pins the canonicalization-on-persist contract added in response to Gemini's HIGH on PR #290.
+// PATH rules must persist in canonical form so the extension's AUTH_EXEC walker (which canonicalises the exec target the
+// same way) matches the rule. Every other rule type is returned unchanged. The test covers both: PATH gets the /private
+// rewrite, and BINARY/CDHASH/SIGNINGID/TEAMID/CERTIFICATE pass through verbatim.
+func TestNormalizeIdentifier(t *testing.T) {
+	cases := []struct {
+		name string
+		rt   api.RuleType
+		in   string
+		want string
+	}{
+		{"path /tmp rewritten to /private/tmp", api.RuleTypePath, "/tmp/foo", "/private/tmp/foo"},
+		{"path /var rewritten to /private/var", api.RuleTypePath, "/var/db/x", "/private/var/db/x"},
+		{"path /usr unchanged", api.RuleTypePath, "/usr/bin/ls", "/usr/bin/ls"},
+		{"path redundant slashes collapsed", api.RuleTypePath, "/usr//bin///ls", "/usr/bin/ls"},
+		{"binary identifier passes through", api.RuleTypeBinary, strings.Repeat("a", 64), strings.Repeat("a", 64)},
+		{"cdhash identifier passes through", api.RuleTypeCDHash, strings.Repeat("b", 40), strings.Repeat("b", 40)},
+		{"signing id passes through", api.RuleTypeSigningID, "EQHXZ8M8AV:com.google.Chrome", "EQHXZ8M8AV:com.google.Chrome"},
+		{"team id passes through", api.RuleTypeTeamID, "EQHXZ8M8AV", "EQHXZ8M8AV"},
+		{"certificate passes through", api.RuleTypeCertificate, strings.Repeat("c", 64), strings.Repeat("c", 64)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := appcontrol.NormalizeIdentifier(tc.rt, tc.in)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestCanonicalizePath covers the macOS-specific /tmp, /var, /etc rewrites every PATH rule depends on. Exercised by both the
+// validator (input validation) and the persist-time canonicalizer (NormalizeIdentifier); the Swift-side canonicalizePath in
+// AuthExecDecider.swift MUST stay in lockstep with this table or the persisted rule never matches the AUTH_EXEC walker's
+// canonical form.
 func TestCanonicalizePath(t *testing.T) {
 	cases := []struct {
 		name string

--- a/server/rules/internal/appcontrol/validate_test.go
+++ b/server/rules/internal/appcontrol/validate_test.go
@@ -11,11 +11,11 @@ import (
 	"github.com/fleetdm/edr/server/rules/internal/appcontrol"
 )
 
-// TestValidateRuleType_AcceptedAndDeferred covers the matrix of accepted / deferred / invalid rule_type values after the Phase A
-// close-out: BINARY, CDHASH, SIGNINGID, and TEAMID are accepted; CERTIFICATE and PATH remain gated as
-// ErrAppControlUnsupportedRuleType (Phase B unblocks them alongside the leaf-cert cache + Launch Services indirection); unknown /
-// empty values return ErrAppControlInvalidRuleType so REST callers can distinguish "not yet wired" from "not a real type".
-func TestValidateRuleType_AcceptedAndDeferred(t *testing.T) {
+// TestValidateRuleType_AcceptedAndRejected covers the full enum after the Phase B close-out (PR for #210): every wire-enum value
+// (BINARY, CDHASH, SIGNINGID, CERTIFICATE, TEAMID, PATH) is accepted by the validator. Only unknown / empty tokens return
+// ErrAppControlInvalidRuleType. ErrAppControlUnsupportedRuleType is retained on the api package for future use but no validator
+// branch produces it today.
+func TestValidateRuleType_AcceptedAndRejected(t *testing.T) {
 	cases := []struct {
 		name    string
 		rt      api.RuleType
@@ -25,8 +25,8 @@ func TestValidateRuleType_AcceptedAndDeferred(t *testing.T) {
 		{"cdhash accepted", api.RuleTypeCDHash, nil},
 		{"signing id accepted", api.RuleTypeSigningID, nil},
 		{"team id accepted", api.RuleTypeTeamID, nil},
-		{"certificate deferred", api.RuleTypeCertificate, api.ErrAppControlUnsupportedRuleType},
-		{"path deferred", api.RuleTypePath, api.ErrAppControlUnsupportedRuleType},
+		{"certificate accepted", api.RuleTypeCertificate, nil},
+		{"path accepted", api.RuleTypePath, nil},
 		{"unknown rejected", api.RuleType("BANANA"), api.ErrAppControlInvalidRuleType},
 		{"empty rejected", api.RuleType(""), api.ErrAppControlInvalidRuleType},
 	}
@@ -73,8 +73,9 @@ func TestValidateIdentifier_Binary(t *testing.T) {
 	}
 }
 
-// TestValidateIdentifier_AcceptedTypes pins the Phase A close-out additions: CDHASH, SIGNINGID, and TEAMID identifiers shaped
-// correctly return nil (the rule is created), and malformed identifiers return ErrAppControlInvalidIdentifier.
+// TestValidateIdentifier_AcceptedTypes pins identifier format checks for every wired rule type. CERTIFICATE + PATH joined the
+// accepted set in this PR (#210); the format checks themselves are unchanged from before -- the only delta is that a well-formed
+// identifier no longer triggers ErrAppControlUnsupportedRuleType.
 func TestValidateIdentifier_AcceptedTypes(t *testing.T) {
 	cases := []struct {
 		name string
@@ -92,6 +93,14 @@ func TestValidateIdentifier_AcceptedTypes(t *testing.T) {
 		{"signing id platform:bundle accepted", api.RuleTypeSigningID, "platform:com.apple.curl", true},
 		{"signing id missing colon rejected", api.RuleTypeSigningID, "EQHXZ8M8AVcom.google.Chrome", false},
 		{"signing id empty bundle rejected", api.RuleTypeSigningID, "EQHXZ8M8AV:", false},
+		{"certificate 64 hex accepted", api.RuleTypeCertificate, strings.Repeat("c", 64), true},
+		{"certificate 63 chars rejected", api.RuleTypeCertificate, strings.Repeat("c", 63), false},
+		{"certificate uppercase rejected", api.RuleTypeCertificate, strings.Repeat("C", 64), false},
+		{"path absolute accepted", api.RuleTypePath, "/usr/bin/ls", true},
+		{"path /tmp lowered accepted", api.RuleTypePath, "/tmp/foo", true},
+		{"path relative rejected", api.RuleTypePath, "usr/bin/ls", false},
+		{"path empty rejected", api.RuleTypePath, "", false},
+		{"path with .. rejected", api.RuleTypePath, "/var/foo/../../etc/sudoers", false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -102,31 +111,6 @@ func TestValidateIdentifier_AcceptedTypes(t *testing.T) {
 			}
 			require.Error(t, err)
 			assert.ErrorIs(t, err, api.ErrAppControlInvalidIdentifier)
-		})
-	}
-}
-
-// TestValidateIdentifier_DeferredTypes pins the remaining types (CERTIFICATE, PATH) still gated as unsupported. The format check
-// fires first; on a well-formed value the validator still reports ErrAppControlUnsupportedRuleType so the REST handler returns
-// "not yet wired" rather than silently accepting the rule. Phase B unblocks these alongside the leaf-cert cache work.
-func TestValidateIdentifier_DeferredTypes(t *testing.T) {
-	cases := []struct {
-		name        string
-		rt          api.RuleType
-		id          string
-		wantErrType error
-	}{
-		{"certificate 64 hex unsupported", api.RuleTypeCertificate, strings.Repeat("c", 64), api.ErrAppControlUnsupportedRuleType},
-		{"certificate 63 chars format rejected", api.RuleTypeCertificate, strings.Repeat("c", 63), api.ErrAppControlInvalidIdentifier},
-		{"path absolute unsupported", api.RuleTypePath, "/usr/bin/ls", api.ErrAppControlUnsupportedRuleType},
-		{"path relative format rejected", api.RuleTypePath, "usr/bin/ls", api.ErrAppControlInvalidIdentifier},
-		{"path empty format rejected", api.RuleTypePath, "", api.ErrAppControlInvalidIdentifier},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			err := appcontrol.ValidateIdentifier(tc.rt, tc.id)
-			require.Error(t, err)
-			assert.ErrorIs(t, err, tc.wantErrType)
 		})
 	}
 }

--- a/server/rules/internal/tests/app_control_test.go
+++ b/server/rules/internal/tests/app_control_test.go
@@ -344,6 +344,11 @@ func TestAppControl_CreateRule_RejectsUnknownRuleType(t *testing.T) {
 	ctx := t.Context()
 	p, err := store.GetPolicyByName(ctx, api.DefaultPolicyName)
 	require.NoError(t, err)
+	// Snapshot the rule count before the rejected create so the assertion below pins the "no persistence on rejected
+	// rule_type" contract from openspec/specs/server-admin-surface/spec.md. CodeRabbit minor on PR #290: without this,
+	// a regression that ignored the validator's error and persisted the row anyway would still pass the test.
+	rulesBefore, err := store.ListRulesByPolicy(ctx, p.ID)
+	require.NoError(t, err)
 	_, err = store.CreateRule(ctx, api.CreateRuleRequest{
 		PolicyID:   p.ID,
 		RuleType:   api.RuleType("BANANA"),
@@ -353,6 +358,9 @@ func TestAppControl_CreateRule_RejectsUnknownRuleType(t *testing.T) {
 	})
 	require.Error(t, err)
 	assert.ErrorIs(t, err, api.ErrAppControlInvalidRuleType)
+	rulesAfter, err := store.ListRulesByPolicy(ctx, p.ID)
+	require.NoError(t, err)
+	assert.Len(t, rulesAfter, len(rulesBefore), "rejected rule_type must not persist a row")
 }
 
 // TestAppControl_CreateRule_PathPersistsCanonical pins the canonicalization-on-persist contract Gemini surfaced on PR #290.

--- a/server/rules/internal/tests/app_control_test.go
+++ b/server/rules/internal/tests/app_control_test.go
@@ -355,6 +355,41 @@ func TestAppControl_CreateRule_RejectsUnknownRuleType(t *testing.T) {
 	assert.ErrorIs(t, err, api.ErrAppControlInvalidRuleType)
 }
 
+// TestAppControl_CreateRule_PathPersistsCanonical pins the canonicalization-on-persist contract Gemini surfaced on PR #290.
+// An operator who creates a PATH rule for `/tmp/foo` MUST see `/private/tmp/foo` round-trip from the store; the extension's
+// AUTH_EXEC walker queries against the canonical form, so persisting the raw `/tmp/foo` would silently make every such rule
+// a no-op against the dev VM's actual exec targets.
+func TestAppControl_CreateRule_PathPersistsCanonical(t *testing.T) {
+	t.Parallel()
+	store, _ := newAppControlStore(t)
+	ctx := t.Context()
+	p, err := store.GetPolicyByName(ctx, api.DefaultPolicyName)
+	require.NoError(t, err)
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"slash-tmp rewritten to /private/tmp", "/tmp/canonical-tmp-target", "/private/tmp/canonical-tmp-target"},
+		{"slash-var rewritten to /private/var", "/var/db/canonical-var-target", "/private/var/db/canonical-var-target"},
+		{"already-canonical /private path passes through", "/private/etc/canonical-private-target", "/private/etc/canonical-private-target"},
+		{"non-symlink path passes through", "/usr/bin/canonical-usr-target", "/usr/bin/canonical-usr-target"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rule, err := store.CreateRule(ctx, api.CreateRuleRequest{
+				PolicyID:   p.ID,
+				RuleType:   api.RuleTypePath,
+				Identifier: tc.in,
+				Actor:      "demo-admin",
+				Reason:     "PR #290 path canonical persist",
+			})
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, rule.Identifier)
+		})
+	}
+}
+
 // TestAppControl_CreateRule_AcceptsAllWiredTypes is the positive companion to the unknown-type test. Every rule type on the
 // wire enum MUST round-trip the validator + store + schema. A regression that re-introduced ErrAppControlUnsupportedRuleType
 // for CERTIFICATE / PATH (or that broke any other type's validator) would silently break creating these rule types via the

--- a/server/rules/internal/tests/app_control_test.go
+++ b/server/rules/internal/tests/app_control_test.go
@@ -333,41 +333,33 @@ func TestAppControl_CreateRule_DuplicateRejected(t *testing.T) {
 
 // spec:server-admin-surface/persist-and-fan-out-application-control-rules/unsupported-rule-type-is-rejected-without-persisting
 //
-// TestAppControl_CreateRule_RejectsUnsupportedTypes pins the rule_type gate after the Phase A close-out: CDHASH / SIGNINGID / TEAMID
-// are accepted (they pass through the validator and the unsupported-sentinel does not fire), while CERTIFICATE + PATH remain
-// deferred and continue to surface ErrAppControlUnsupportedRuleType so the REST surface is honest about what's wired today.
-// The Identifier per type is shape-valid so the format check passes; the test isolates the rule_type gate from the identifier gate.
-func TestAppControl_CreateRule_RejectsUnsupportedTypes(t *testing.T) {
+// TestAppControl_CreateRule_RejectsUnknownRuleType pins the rule_type gate for tokens that are not on the wire enum. After the
+// Phase B close-out (PR for #210) every named enum value -- BINARY, CDHASH, SIGNINGID, CERTIFICATE, TEAMID, PATH -- is wired,
+// so the only way to fall through to the gate is to submit a token the validator does not recognise. The store must reject
+// without persisting and surface ErrAppControlInvalidRuleType (not the retired ErrAppControlUnsupportedRuleType, which is reserved
+// for the future case where a value is added to the enum before the extension supports it).
+func TestAppControl_CreateRule_RejectsUnknownRuleType(t *testing.T) {
 	t.Parallel()
 	store, _ := newAppControlStore(t)
 	ctx := t.Context()
 	p, err := store.GetPolicyByName(ctx, api.DefaultPolicyName)
 	require.NoError(t, err)
-	for _, tc := range []struct {
-		rt         api.RuleType
-		identifier string
-	}{
-		{api.RuleTypeCertificate, strings.Repeat("c", 64)},
-		{api.RuleTypePath, "/usr/bin/ls"},
-	} {
-		t.Run(string(tc.rt), func(t *testing.T) {
-			_, err := store.CreateRule(ctx, api.CreateRuleRequest{
-				PolicyID:   p.ID,
-				RuleType:   tc.rt,
-				Identifier: tc.identifier,
-				Actor:      "demo-admin",
-				Reason:     "should be rejected as unsupported",
-			})
-			require.Error(t, err)
-			assert.ErrorIs(t, err, api.ErrAppControlUnsupportedRuleType)
-		})
-	}
+	_, err = store.CreateRule(ctx, api.CreateRuleRequest{
+		PolicyID:   p.ID,
+		RuleType:   api.RuleType("BANANA"),
+		Identifier: strings.Repeat("a", 64),
+		Actor:      "demo-admin",
+		Reason:     "unknown token should be rejected",
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, api.ErrAppControlInvalidRuleType)
 }
 
-// TestAppControl_CreateRule_AcceptsCDHashSigningIDTeamID is the positive companion to the unsupported-types test. CDHASH /
-// SIGNINGID / TEAMID rules MUST round-trip the validator + store + schema after the Phase A close-out — a deferred enum value
-// in the schema or a regressed validator would otherwise silently break creating these rule types via the REST handler.
-func TestAppControl_CreateRule_AcceptsCDHashSigningIDTeamID(t *testing.T) {
+// TestAppControl_CreateRule_AcceptsAllWiredTypes is the positive companion to the unknown-type test. Every rule type on the
+// wire enum MUST round-trip the validator + store + schema. A regression that re-introduced ErrAppControlUnsupportedRuleType
+// for CERTIFICATE / PATH (or that broke any other type's validator) would silently break creating these rule types via the
+// REST handler.
+func TestAppControl_CreateRule_AcceptsAllWiredTypes(t *testing.T) {
 	t.Parallel()
 	store, _ := newAppControlStore(t)
 	ctx := t.Context()
@@ -381,6 +373,8 @@ func TestAppControl_CreateRule_AcceptsCDHashSigningIDTeamID(t *testing.T) {
 		{api.RuleTypeSigningID, "EQHXZ8M8AV:com.google.Chrome"},
 		{api.RuleTypeSigningID, "platform:com.apple.curl"},
 		{api.RuleTypeTeamID, "EQHXZ8M8AV"},
+		{api.RuleTypeCertificate, strings.Repeat("c", 64)},
+		{api.RuleTypePath, "/Applications/Foo.app/Contents/MacOS/Foo"},
 	}
 	for _, tc := range cases {
 		t.Run(string(tc.rt)+"/"+tc.identifier, func(t *testing.T) {
@@ -389,7 +383,7 @@ func TestAppControl_CreateRule_AcceptsCDHashSigningIDTeamID(t *testing.T) {
 				RuleType:   tc.rt,
 				Identifier: tc.identifier,
 				Actor:      "demo-admin",
-				Reason:     "phase A acceptance",
+				Reason:     "all-wired acceptance",
 			})
 			require.NoError(t, err)
 			assert.NotZero(t, rule.ID)


### PR DESCRIPTION
Closes #210. Phase B close-out of the original umbrella #68: every wire-enum rule type is now wired through the validator AND the extension's AUTH_EXEC decision walk. Precedence (Santa's order):
  CDHASH → BINARY → CERTIFICATE → SIGNINGID → TEAMID → PATH

Server validator
  - ValidateRuleType: CERTIFICATE + PATH accepted (was: returned ErrAppControlUnsupportedRuleType). Only unknown tokens stay invalid.
  - ValidateIdentifier: drops the trailing unsupported-error returns in the CERTIFICATE + PATH branches. Format checks unchanged.
  - validate_test.go: collapsed the deferred-types case to a single accepted-types table; explicit unknown-token row stays.
  - app_control_test.go: rewrote the unsupported-types test against an unknown-token submission; positive companion now covers all six wired types.

Extension
  - SigningInfoFallback: extended to return SigningInfo(teamID, leafCertSHA256). One SecCodeCopySigningInformation call now covers both fields; cache key unchanged. leafCertSHA256 reads kSecCodeInfoCertificates[0] and SHA-256s the DER bytes (matches `codesign -d --extract-certificates` + `shasum -a 256`).
  - AuthExecDecider: AuthTuple gains leafCertSHA256 + canonicalPath. decideAuthExec walks the new 6-layer precedence. Extracted the lower-precedence walk + the hash-outcome reason helper to keep cyclomatic_complexity under the SwiftLint cap. Added a pure canonicalizePath helper that mirrors the server's Go rules verbatim (reject empty / relative / `..`; rewrite /tmp, /var, /etc → /private).
  - ESFSubscriber: buildAuthTuple resolves leafCertSHA256 (one SecCode call shared with the TeamID path) + canonicalizePath of the exec target path. Top-of-file rationale comments refreshed.
  - CDHashHex.swift (new): isHardenedRuntime + cdhashHexString helpers extracted from ESFSubscriber.swift so that file stays under file_length cap.

Tests
  - AuthExecDeciderTests.swift: makeRule / makeSnapshot / makeTuple helpers lifted to file scope so the class body fits under type_body_length. Split CERTIFICATE + PATH cases into a sibling AuthExecDeciderPhaseBTests class. CanonicalizePathTests pins the Swift implementation against the Go canonicalizer's table.
  - 20 new test cases total (cert match / cert beats signing-id / cert fallback under .deadlineExceeded fail-open; path match / teamid beats path / path nil when canonicalize fails / path under .deadlineExceeded fail-closed; 12 canonicalize cases).
  - 126 swift tests pass (was 106 pre-PR); go test ./server/rules/... incl. -tags integration green.

Spec (openspec/specs/server-admin-surface/spec.md)
  - Supported-rule-type list updated to include CERTIFICATE + PATH with format hints (64-hex leaf cert SHA-256; canonical absolute path with /tmp,/var,/etc → /private rewrite).
  - "Unsupported rule type is rejected" scenario reworded for unknown-token-only semantics now that every named token is wired.

Out of scope (deferred to v0.2.0)
  - Launch Services bundle indirection (block /Applications/X.app matching exec'd .../Contents/MacOS/X)
  - Cert chain rules (intermediate / root)
  - ALLOW + SILENT_BLOCK actions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Application Control rules now support CERTIFICATE and PATH rule types
  * PATH rules are validated with automatic symlink normalization (e.g., `/tmp` → `/private/tmp`)
  * CERTIFICATE rules match using leaf certificate SHA-256 identifiers
  * Enhanced rule precedence handling for improved authorization decisions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/getvictor/fleet-edr/pull/290?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->