### PR TITLE
Detection: surface file creates so LaunchDaemon/sudoers drops fire (#…

### DIFF
--- a/extension/edr/extension/ESFSubscriber+FileEvents.swift
+++ b/extension/edr/extension/ESFSubscriber+FileEvents.swift
@@ -1,0 +1,57 @@
+import EndpointSecurity
+import Foundation
+import os.log
+
+// File-event handlers split out of ESFSubscriber.swift to keep that file under SwiftLint's file_length /
+// type_body_length caps (same rationale as the CDHashHex.swift split). They run in the ES message-handler context and
+// reach ESFSubscriber's module-internal `serializer` + `onEvent`; `serializer` is declared internal (not private) for
+// this reason.
+private let logger = Logger(subsystem: "com.fleetdm.edr.securityextension", category: "ESFFileEvents")
+
+extension ESFSubscriber {
+    func handleOpen(_ msg: es_message_t) {
+        let pid = audit_token_to_pid(msg.process.pointee.audit_token)
+        let path = String(cString: msg.event.open.file.pointee.path.data)
+        let flags = msg.event.open.fflag
+
+        let payload = OpenPayload(pid: pid, path: path, flags: Int(flags))
+
+        if let data = serializer.serialize(eventType: "open", payload: payload) {
+            logger.debug("open pid=\(pid) path=\(path)")
+            onEvent?(data)
+        }
+    }
+
+    /// handleCreate surfaces file creation. ES delivers NOTIFY_CREATE (not NOTIFY_OPEN) when a process creates a NEW
+    /// file, so write-to-sensitive-path rules keyed on `open` events (privilege_launchd_plist_write, sudoers_tamper)
+    /// miss the canonical "drop a new file" attack without it. We re-emit it as an `open` event with synthetic
+    /// write-mode flags so those rules fire unchanged and the server keeps the path filtering -- the same division of
+    /// labour as handleOpen (the extension forwards everything; the rules decide). NOTIFY_CREATE is high-volume like
+    /// NOTIFY_OPEN; extension-side es_mute_path muting for both is tracked as a follow-up.
+    func handleCreate(_ msg: es_message_t) {
+        let pid = audit_token_to_pid(msg.process.pointee.audit_token)
+        let create = msg.event.create
+        let path: String
+        switch create.destination_type {
+        case ES_DESTINATION_TYPE_NEW_PATH:
+            // New file: ES reports the parent directory and the new filename separately; join them.
+            let dir = String(cString: create.destination.new_path.dir.pointee.path.data)
+            let filename = esTokenString(create.destination.new_path.filename)
+            path = dir.hasSuffix("/") ? dir + filename : dir + "/" + filename
+        case ES_DESTINATION_TYPE_EXISTING_FILE:
+            // Pre-existing file clobbered via O_CREAT; ES resolves the full path directly.
+            path = String(cString: create.destination.existing_file.pointee.path.data)
+        default:
+            return
+        }
+
+        // Synthetic write-mode flags (O_WRONLY|O_CREAT|O_TRUNC): a create is a write, and the `open` consumers key on
+        // the access-mode bits. Reusing the `open` event type means no server-side or wire-format change.
+        let payload = OpenPayload(pid: pid, path: path, flags: Int(O_WRONLY | O_CREAT | O_TRUNC))
+
+        if let data = serializer.serialize(eventType: "open", payload: payload) {
+            logger.debug("create pid=\(pid) path=\(path)")
+            onEvent?(data)
+        }
+    }
+}

--- a/extension/edr/extension/ESFSubscriber+FileEvents.swift
+++ b/extension/edr/extension/ESFSubscriber+FileEvents.swift
@@ -11,7 +11,7 @@ private let logger = Logger(subsystem: "com.fleetdm.edr.securityextension", cate
 extension ESFSubscriber {
     func handleOpen(_ msg: es_message_t) {
         let pid = audit_token_to_pid(msg.process.pointee.audit_token)
-        let path = String(cString: msg.event.open.file.pointee.path.data)
+        let path = esTokenString(msg.event.open.file.pointee.path)
         let flags = msg.event.open.fflag
 
         let payload = OpenPayload(pid: pid, path: path, flags: Int(flags))
@@ -35,12 +35,12 @@ extension ESFSubscriber {
         switch create.destination_type {
         case ES_DESTINATION_TYPE_NEW_PATH:
             // New file: ES reports the parent directory and the new filename separately; join them.
-            let dir = String(cString: create.destination.new_path.dir.pointee.path.data)
+            let dir = esTokenString(create.destination.new_path.dir.pointee.path)
             let filename = esTokenString(create.destination.new_path.filename)
             path = dir.hasSuffix("/") ? dir + filename : dir + "/" + filename
         case ES_DESTINATION_TYPE_EXISTING_FILE:
             // Pre-existing file clobbered via O_CREAT; ES resolves the full path directly.
-            path = String(cString: create.destination.existing_file.pointee.path.data)
+            path = esTokenString(create.destination.existing_file.pointee.path)
         default:
             return
         }

--- a/extension/edr/extension/ESFSubscriber+FileEvents.swift
+++ b/extension/edr/extension/ESFSubscriber+FileEvents.swift
@@ -27,7 +27,7 @@ extension ESFSubscriber {
     /// miss the canonical "drop a new file" attack without it. We re-emit it as an `open` event with synthetic
     /// write-mode flags so those rules fire unchanged and the server keeps the path filtering -- the same division of
     /// labour as handleOpen (the extension forwards everything; the rules decide). NOTIFY_CREATE is high-volume like
-    /// NOTIFY_OPEN; extension-side es_mute_path muting for both is tracked as a follow-up.
+    /// NOTIFY_OPEN; extension-side es_mute_path muting for both is tracked as a follow-up (#301).
     func handleCreate(_ msg: es_message_t) {
         let pid = audit_token_to_pid(msg.process.pointee.audit_token)
         let create = msg.event.create

--- a/extension/edr/extension/ESFSubscriber.swift
+++ b/extension/edr/extension/ESFSubscriber.swift
@@ -21,7 +21,9 @@ private let fleetSelfAllowSigningIDs: Set<String> = [
 final class ESFSubscriber: Sendable {
     // swiftlint:disable:next implicitly_unwrapped_optional
     private nonisolated(unsafe) var client: OpaquePointer!
-    private let serializer = EventSerializer()
+    // Internal (not private) so the file-event handlers split into ESFSubscriber+FileEvents.swift can reach it; that
+    // split keeps this file under SwiftLint's file_length / type_body_length caps (same rationale as CDHashHex.swift).
+    let serializer = EventSerializer()
     nonisolated(unsafe) var onEvent: ((Data) -> Void)?
 
     init() {
@@ -45,7 +47,11 @@ final class ESFSubscriber: Sendable {
             ES_EVENT_TYPE_NOTIFY_EXEC,  // notification: records allowed execs (fires after AUTH allows)
             ES_EVENT_TYPE_NOTIFY_FORK,
             ES_EVENT_TYPE_NOTIFY_EXIT,
-            ES_EVENT_TYPE_NOTIFY_OPEN
+            ES_EVENT_TYPE_NOTIFY_OPEN,
+            // Creating a NEW file fires NOTIFY_CREATE, not NOTIFY_OPEN, so write-to-sensitive-path rules keyed on
+            // `open` events (privilege_launchd_plist_write, sudoers_tamper) miss the canonical "drop a new file"
+            // attack without this. See handleCreate.
+            ES_EVENT_TYPE_NOTIFY_CREATE
         ]
 
         let subResult = es_subscribe(client, events, UInt32(events.count))
@@ -90,6 +96,8 @@ final class ESFSubscriber: Sendable {
             handleExit(msg)
         case ES_EVENT_TYPE_NOTIFY_OPEN:
             handleOpen(msg)
+        case ES_EVENT_TYPE_NOTIFY_CREATE:
+            handleCreate(msg)
         default:
             break
         }
@@ -419,19 +427,6 @@ final class ESFSubscriber: Sendable {
 
         if let data = serializer.serialize(eventType: "exit", payload: payload) {
             logger.debug("exit pid=\(pid) code=\(exitCode)")
-            onEvent?(data)
-        }
-    }
-
-    private func handleOpen(_ msg: es_message_t) {
-        let pid = audit_token_to_pid(msg.process.pointee.audit_token)
-        let path = String(cString: msg.event.open.file.pointee.path.data)
-        let flags = msg.event.open.fflag
-
-        let payload = OpenPayload(pid: pid, path: path, flags: Int(flags))
-
-        if let data = serializer.serialize(eventType: "open", payload: payload) {
-            logger.debug("open pid=\(pid) path=\(path)")
             onEvent?(data)
         }
     }


### PR DESCRIPTION
…299)

Subscribe to ES_EVENT_TYPE_NOTIFY_CREATE and re-emit it as an `open` event with synthetic write-mode flags. Creating a NEW file fires NOTIFY_CREATE, not NOTIFY_OPEN, so write-to-sensitive-path rules (privilege_launchd_plist_write, sudoers_tamper) previously missed the canonical new-file-drop attack end-to-end -- the rule + unit tests were correct, but the event never reached the server. Reusing the `open` type means no server/wire change and future write-rules need no extension re-release.

Split handleOpen + handleCreate into ESFSubscriber+FileEvents.swift to keep ESFSubscriber.swift under SwiftLint's file_length/type_body_length caps (same pattern as CDHashHex.swift); serializer is now internal.

Touches ESF subscriptions: must be VM-validated (L5 attack-runbook rule 6) before RC.