### PR TITLE
UAT: add L5 app-control-block scenario (active-blocking coverage)

### DIFF
--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -134,9 +134,10 @@ A run at any layer implies all lower layers have already passed; CI gates enforc
   within the per-rule SLA. UAT plan milestone **M9** delivered the driver plus one starter scenario,
   `attack-runbook`, which asserts six rule_ids fire from the dogfood runbook. The scenario is a thin wrapper
   around `scripts/qa/attack-runbook.sh`; the dogfood script stays the interactive demo, M9 adds the asserted
-  automation layer on top. App Control gets its own UAT scenario tracked separately against the per-policy
-  `/api/v1/app-control/*` surface. Driver supports `--dry-run` for orchestration smoke-tests without driving
-  real infrastructure. See `scripts/uat/README.md` for the schema - capture procedure.
+  automation layer on top. App Control active blocking has its own scenario, `app-control-block`, which posts a
+  BINARY BLOCK rule via the per-policy `/api/v1/app-control/*` surface, confirms the extension denies the matching
+  exec on the VM, and asserts the resulting `application_control_block` alert. Driver supports `--dry-run` for
+  orchestration smoke-tests without driving real infrastructure. See `scripts/uat/README.md` for the schema - capture procedure.
 - Runs on a real Mac with a SIP-enabled guest (GitHub-hosted macOS runners do not allow nested virtualisation
   or expose the ESF entitlement). Never per PR. UAT plan milestone **M11** ships the local-execution flavour:
   `task uat:l5 -- attack-runbook ...` (or `scripts/uat/system-test.sh attack-runbook ...` direct) runs the

--- a/scripts/qa/README.md
+++ b/scripts/qa/README.md
@@ -14,8 +14,11 @@ A fourth script (`e2-policy-roundtrip.sh`) used to exercise the blocklist
 policy round-trip via `GET/PUT /api/policy`. The server's blocklist admin
 endpoint has been replaced by the per-policy app-control surface
 (`/api/v1/app-control/policies/*` etc), which is a fundamentally different
-shape; the old script was removed rather than ported. A new round-trip
-script over the app-control admin API is tracked separately.
+shape; the old script was removed rather than ported. Its replacement over the
+app-control admin API is the asserted L5 scenario
+`scripts/uat/scenarios/app-control-block/` (it posts a BINARY BLOCK rule,
+confirms the extension denies the matching exec, and asserts the
+`application_control_block` alert), rather than another interactive `qa/` script.
 
 ## Prerequisites
 

--- a/scripts/uat/README.md
+++ b/scripts/uat/README.md
@@ -39,16 +39,21 @@ M9's assertion layer picks the change up automatically.
       lib/
         common.sh            -- shared SSH + REST + polling helpers
       scenarios/
+        app-control-block/   -- App Control active blocking (deny + alert)
+          README.md
+          attack.sh
+          expected.yaml
         attack-runbook/      -- fires every shipped detection rule
           README.md
           attack.sh
           expected.yaml
 
-A blocklist policy-roundtrip scenario used to live here; it has been
-dropped because the underlying server endpoint (`/api/policy`) is gone --
-the replacement is the per-policy app-control admin surface at
-`/api/v1/app-control/*`. A fresh scenario over the new API is tracked
-separately.
+A blocklist policy-roundtrip scenario used to live here; it was dropped when the
+`/api/policy` endpoint gave way to the per-policy app-control admin surface at
+`/api/v1/app-control/*`. Its replacement is the `app-control-block` scenario
+below, which posts a BINARY BLOCK rule over the new API, confirms the extension
+denies the matching exec on the VM, and asserts the `application_control_block`
+alert -- L5 coverage for Application Control active blocking.
 
 ## Quick start (local execution)
 

--- a/scripts/uat/scenarios/app-control-block/README.md
+++ b/scripts/uat/scenarios/app-control-block/README.md
@@ -1,0 +1,33 @@
+# app-control-block scenario
+
+L5 system/VM coverage for **Application Control active blocking** — the half of
+the App Control story that detection scenarios (attack-runbook) do not exercise.
+
+It is the replacement for the removed `e2-policy-roundtrip.sh` blocklist scenario
+(`scripts/qa/README.md` "Known gaps"): when the singleton `/api/policy` blocklist
+became the per-policy `/api/v1/app-control/*` surface (#289 / #290), the old L5
+scenario was deleted and its replacement was "tracked separately". This is it. It
+is also the missing half of the #301 acceptance gate ("Application Control still
+works", VM-validated on a SIP-on host).
+
+## What it does
+
+1. Stages a deterministic non-platform block target on the VM (a copy of
+   `/bin/echo`; copying drops the kernel `is_platform_binary` attribution so the
+   platform carve-out does not exempt it).
+2. Confirms the target runs + is allowed at baseline.
+3. POSTs a `BINARY` BLOCK rule on the copy's SHA-256 to the seeded Default policy.
+4. Polls until the snapshot fan-out reaches the host and the exec is **DENIED**
+   (host-side enforcement), then fires a couple more denied execs.
+5. The driver asserts the resulting `application_control_block` alert
+   (`expected.yaml`).
+
+Cleanup deletes the rule and the target on exit.
+
+## Run
+
+    task uat:l5 -- app-control-block --skip-install   # against an enrolled VM
+    task uat:l5 -- app-control-block                  # full install + scenario
+
+Same required env as attack-runbook (see `../../README.md`): `EDR_SERVER_URL`,
+`EDR_SESSION_COOKIE`, `VM_SSH_TARGET`, and `UAT_INSECURE=1` for the local dev cert.

--- a/scripts/uat/scenarios/app-control-block/README.md
+++ b/scripts/uat/scenarios/app-control-block/README.md
@@ -1,6 +1,6 @@
 # app-control-block scenario
 
-L5 system/VM coverage for **Application Control active blocking** — the half of
+L5 system/VM coverage for **Application Control active blocking** - the half of
 the App Control story that detection scenarios (attack-runbook) do not exercise.
 
 It is the replacement for the removed `e2-policy-roundtrip.sh` blocklist scenario
@@ -12,9 +12,10 @@ works", VM-validated on a SIP-on host).
 
 ## What it does
 
-1. Stages a deterministic non-platform block target on the VM (a copy of
-   `/bin/echo`; copying drops the kernel `is_platform_binary` attribution so the
-   platform carve-out does not exempt it).
+1. Builds a deterministic non-platform block target on the VM via `go build`
+   (a locally compiled binary lacks Apple's `is_platform_binary` flag, so the
+   platform carve-out does not exempt it; an ad-hoc-signed copy of a system
+   `arm64e` binary would instead be killed by AMFI under SIP).
 2. Confirms the target runs + is allowed at baseline.
 3. POSTs a `BINARY` BLOCK rule on the copy's SHA-256 to the seeded Default policy.
 4. Polls until the snapshot fan-out reaches the host and the exec is **DENIED**
@@ -23,6 +24,13 @@ works", VM-validated on a SIP-on host).
    (`expected.yaml`).
 
 Cleanup deletes the rule and the target on exit.
+
+## Prerequisites
+
+A working `go` toolchain on the VM (found on `PATH` or under `/usr/local/go/bin`),
+used to compile the non-platform block target. This matches the attack-runbook
+scenario, which also `go build`s its launchd dropper. If `go` is absent the
+scenario fails fast with a clear message rather than a cryptic build error.
 
 ## Run
 

--- a/scripts/uat/scenarios/app-control-block/attack.sh
+++ b/scripts/uat/scenarios/app-control-block/attack.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# L5 scenario: Application Control ACTIVE BLOCKING under SIP-on.
+#
+# Closes the coverage gap from the singleton-blocklist -> per-policy app-control
+# rework (#289 / #290): the old /api/policy round-trip L5 scenario was removed
+# and its replacement over /api/v1/app-control/* was "tracked separately". This
+# is that replacement, and the missing half of the #301 acceptance gate
+# ("Application Control still works", VM-validated).
+#
+# What it proves end to end on a real SIP + Gatekeeper VM:
+#   1. A BINARY BLOCK rule POSTed via the admin REST API reaches the host as an
+#      app-control snapshot (the agent /api/commands fan-out).
+#   2. The system extension's AUTH_EXEC handler DENIES the matching exec -- the
+#      binary that ran a moment ago now fails to exec (host-side enforcement).
+#   3. The denial emits an application_control_block event -> server alert, which
+#      the driver asserts via expected.yaml (rule_id=application_control_block).
+#
+# Receives from system-test.sh: UAT_VM_SSH_TARGET, UAT_HOST_ID, UAT_SCRIPT_DIR.
+set -euo pipefail
+
+# shellcheck source=/dev/null
+source "$UAT_SCRIPT_DIR/lib/common.sh"
+uat_server_warmup # populates UAT_COOKIE_HEADER + UAT_CSRF_TOKEN from EDR_SESSION_COOKIE
+uat_curl_args     # populates UAT_CURL_ARGS (adds -k under UAT_INSECURE)
+
+VM="$UAT_VM_SSH_TARGET"
+TARGET=/tmp/edr-acblock-target
+SRC=/tmp/edr-acblock-src
+SENTINEL="EDR_ACBLOCK_SENTINEL_RAN"
+RULE_ID=""
+
+# rest METHOD PATH [JSON_BODY] -- authenticated admin REST call.
+rest() {
+  local method="$1" path="$2" body="${3:-}"
+  # UAT_CURL_ARGS already carries --fail-with-body + -sS (+ -k under UAT_INSECURE);
+  # do NOT re-add -f/-s here (-f conflicts with --fail-with-body).
+  local args=("${UAT_CURL_ARGS[@]}" "${UAT_COOKIE_HEADER[@]}"
+    -H "X-Csrf-Token: $UAT_CSRF_TOKEN" -X "$method" "$EDR_SERVER_URL$path")
+  [[ -n "$body" ]] && args+=(-H "Content-Type: application/json" --data "$body")
+  curl "${args[@]}"
+}
+
+cleanup() {
+  # DeleteRule requires a reason in the JSON body (audit trail); a bodyless DELETE 400s.
+  [[ -n "$RULE_ID" ]] && rest DELETE "/api/v1/app-control/rules/$RULE_ID" '{"reason":"uat app-control-block cleanup"}' >/dev/null 2>&1 || true
+  uat_ssh "$VM" "rm -rf $TARGET $SRC" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+# 1. Build a deterministic, non-platform block target on the VM with `go build`
+#    (the same trick the attack-runbook uses for its launchd dropper: a locally
+#    compiled binary lacks Apple's is_platform_binary flag, so the unconditional
+#    platform carve-out does NOT exempt it and a BINARY rule on its hash bites).
+#    A copied system binary will not do: macOS binaries are arm64e, which AMFI
+#    kills when run ad-hoc-signed outside SIP. Source is base64'd to dodge SSH
+#    quoting. Hash the built binary -- that is the image that execs.
+uat_log app-control-block "building non-platform block target on VM (go build)"
+GO_SRC_B64=$(printf 'package main\nimport "fmt"\nfunc main(){ fmt.Println("%s") }\n' "$SENTINEL" | base64)
+uat_ssh "$VM" "export PATH=\$PATH:/usr/local/go/bin:\$HOME/go/bin
+  mkdir -p $SRC
+  echo '$GO_SRC_B64' | base64 -d > $SRC/main.go
+  cd $SRC && go build -o $TARGET main.go"
+HASH=$(uat_ssh "$VM" "shasum -a 256 $TARGET | awk '{print \$1}'")
+[[ "$HASH" =~ ^[0-9a-f]{64}$ ]] || uat_fail app-control-block "could not build/hash block target (got '$HASH')"
+
+# 2. Baseline: the target runs AND is allowed before the rule exists. Without
+#    this, a later "did not run" reading could be an environment fault, not a block.
+if ! uat_ssh "$VM" "$TARGET $SENTINEL" | grep -q "$SENTINEL"; then
+  uat_fail app-control-block "baseline exec did not run; cannot distinguish allow from block"
+fi
+uat_log app-control-block "baseline exec allowed (sentinel printed) hash=${HASH:0:12}"
+
+# 3. POST a BINARY BLOCK rule on that hash to the seeded Default policy.
+POLICY_ID=$(rest GET /api/v1/app-control/policies | jq -r '.policies[] | select(.name=="Default") | .id' | head -1)
+[[ -n "$POLICY_ID" && "$POLICY_ID" != "null" ]] || uat_fail app-control-block "could not resolve Default policy id"
+RULE_ID=$(rest POST "/api/v1/app-control/policies/$POLICY_ID/rules" \
+  "{\"rule_type\":\"BINARY\",\"identifier\":\"$HASH\",\"severity\":\"high\",\"custom_msg\":\"L5 app-control-block scenario\",\"reason\":\"uat app-control active-block coverage\"}" \
+  | jq -r '.id')
+[[ -n "$RULE_ID" && "$RULE_ID" != "null" ]] || uat_fail app-control-block "rule create did not return an id"
+uat_log app-control-block "posted BINARY block rule id=$RULE_ID policy=$POLICY_ID; waiting for snapshot fan-out"
+
+# 4. Poll: exec the target until the snapshot lands and the exec is DENIED. A
+#    denied AUTH_EXEC fails to run, so the sentinel stops printing. Each denied
+#    exec also emits an application_control_block event the driver asserts on.
+blocked=0
+for _ in $(seq 1 20); do # ~60s; fan-out is normally single-digit seconds
+  if ! uat_ssh "$VM" "$TARGET $SENTINEL 2>/dev/null" | grep -q "$SENTINEL"; then
+    blocked=1
+    break
+  fi
+  sleep 3
+done
+[[ "$blocked" == 1 ]] || uat_fail app-control-block "exec still ALLOWED after 60s; the BLOCK rule was not enforced"
+uat_log app-control-block "host-side enforcement confirmed: matching exec is now DENIED"
+
+# A couple more denied execs so the application_control_block alert is unambiguous.
+uat_ssh "$VM" "$TARGET $SENTINEL >/dev/null 2>&1 || true; $TARGET $SENTINEL >/dev/null 2>&1 || true"
+
+# 5. Server-side assertion. The denial must surface as an application_control_block
+#    alert. That alert's rule_id is app_control:<ruleId> -- DYNAMIC per run -- which
+#    the driver's static expected.yaml cannot match, so attack.sh asserts it here
+#    (the driver passes the scenario on attack.sh's exit 0; expected.yaml has no
+#    rules block). Matching the exact app_control:$RULE_ID we just created also
+#    rules out collapsing onto a stale alert from a prior run.
+uat_log app-control-block "asserting application_control_block alert (rule_id=app_control:$RULE_ID)"
+alert_seen=0
+for _ in $(seq 1 15); do # ~30s; event upload + detection is single-digit seconds
+  if rest GET "/api/alerts?host_id=$UAT_HOST_ID&limit=100" |
+    jq -e --arg rid "app_control:$RULE_ID" '.[]? | select(.rule_id==$rid and .source=="application_control")' >/dev/null 2>&1; then
+    alert_seen=1
+    break
+  fi
+  sleep 2
+done
+[[ "$alert_seen" == 1 ]] || uat_fail app-control-block "host blocked the exec but no application_control_block alert surfaced server-side"
+uat_log app-control-block "server-side alert confirmed: app_control:$RULE_ID (source=application_control)"
+uat_log app-control-block "PASS: host-side deny + server-side alert both confirmed"

--- a/scripts/uat/scenarios/app-control-block/attack.sh
+++ b/scripts/uat/scenarios/app-control-block/attack.sh
@@ -54,11 +54,20 @@ trap cleanup EXIT
 #    A copied system binary will not do: macOS binaries are arm64e, which AMFI
 #    kills when run ad-hoc-signed outside SIP. Source is base64'd to dodge SSH
 #    quoting. Hash the built binary -- that is the image that execs.
+#
+#    Go is a prerequisite on the VM (the attack-runbook scenario depends on it
+#    too); fail with a clear message rather than a cryptic build error if it is
+#    absent. See this scenario's README "Prerequisites".
 uat_log app-control-block "building non-platform block target on VM (go build)"
-GO_SRC_B64=$(printf 'package main\nimport "fmt"\nfunc main(){ fmt.Println("%s") }\n' "$SENTINEL" | base64)
+if ! uat_ssh "$VM" "export PATH=\$PATH:/usr/local/go/bin:\$HOME/go/bin; command -v go >/dev/null"; then
+  uat_fail app-control-block "go toolchain not found on the VM; this scenario needs it to build a non-platform block target (see README)"
+fi
+# Host base64 may line-wrap; tr strips that so the VM gets one token. Decode with
+# -D (BSD-canonical, accepted on every macOS) rather than -d.
+GO_SRC_B64=$(printf 'package main\nimport "fmt"\nfunc main(){ fmt.Println("%s") }\n' "$SENTINEL" | base64 | tr -d '\n')
 uat_ssh "$VM" "export PATH=\$PATH:/usr/local/go/bin:\$HOME/go/bin
   mkdir -p $SRC
-  echo '$GO_SRC_B64' | base64 -d > $SRC/main.go
+  echo '$GO_SRC_B64' | base64 -D > $SRC/main.go
   cd $SRC && go build -o $TARGET main.go"
 HASH=$(uat_ssh "$VM" "shasum -a 256 $TARGET | awk '{print \$1}'")
 [[ "$HASH" =~ ^[0-9a-f]{64}$ ]] || uat_fail app-control-block "could not build/hash block target (got '$HASH')"
@@ -83,7 +92,7 @@ uat_log app-control-block "posted BINARY block rule id=$RULE_ID policy=$POLICY_I
 #    denied AUTH_EXEC fails to run, so the sentinel stops printing. Each denied
 #    exec also emits an application_control_block event the driver asserts on.
 blocked=0
-for _ in $(seq 1 20); do # ~60s; fan-out is normally single-digit seconds
+for _ in {1..20}; do # ~60s; fan-out is normally single-digit seconds
   if ! uat_ssh "$VM" "$TARGET $SENTINEL 2>/dev/null" | grep -q "$SENTINEL"; then
     blocked=1
     break
@@ -104,7 +113,7 @@ uat_ssh "$VM" "$TARGET $SENTINEL >/dev/null 2>&1 || true; $TARGET $SENTINEL >/de
 #    rules out collapsing onto a stale alert from a prior run.
 uat_log app-control-block "asserting application_control_block alert (rule_id=app_control:$RULE_ID)"
 alert_seen=0
-for _ in $(seq 1 15); do # ~30s; event upload + detection is single-digit seconds
+for _ in {1..15}; do # ~30s; event upload + detection is single-digit seconds
   if rest GET "/api/alerts?host_id=$UAT_HOST_ID&limit=100" |
     jq -e --arg rid "app_control:$RULE_ID" '.[]? | select(.rule_id==$rid and .source=="application_control")' >/dev/null 2>&1; then
     alert_seen=1

--- a/scripts/uat/scenarios/app-control-block/expected.yaml
+++ b/scripts/uat/scenarios/app-control-block/expected.yaml
@@ -1,0 +1,18 @@
+# app-control-block scenario.
+#
+# This scenario exercises Application Control ACTIVE BLOCKING: attack.sh posts a
+# BINARY BLOCK rule via the admin API, confirms the system extension DENIES the
+# matching exec on a SIP-on VM (host-side enforcement), and asserts the resulting
+# application_control_block alert server-side.
+#
+# There is intentionally NO `rules:` block. The alert a block produces has a
+# DYNAMIC rule_id (app_control:<ruleId>, assigned per run), which the driver's
+# static rule_id match cannot express. attack.sh therefore asserts BOTH halves
+# itself (the host-side AUTH_EXEC deny AND the application_control_block alert for
+# the exact rule it created), and the driver passes the scenario on attack.sh's
+# exit 0 -- a mode it explicitly supports ("scenario passes on attack.sh exit 0
+# alone").
+
+scenario_id: app-control-block
+description: Posts a BINARY BLOCK rule via the app-control admin API, confirms the extension denies the matching exec on a SIP-on VM, and asserts the application_control_block alert. Assertions live in attack.sh (the alert rule_id is dynamic).
+within_seconds: 120


### PR DESCRIPTION
Closes the coverage gap that let App Control active blocking ship without L5 validation: when /api/policy became the per-policy /api/v1/app-control/* surface (#289 / #290), the old blocklist L5 scenario was deleted and its replacement was only "tracked separately" -- so enforcement lost system/VM coverage and nothing forced it back. This is that replacement, and the missing half of the #301 acceptance gate ("Application Control still works", VM-validated).

scripts/uat/scenarios/app-control-block/:
- Builds a non-platform block target on the VM with `go build` (a copied system binary is arm64e and AMFI-killed when run outside SIP; a Go binary is plain arm64 + non-platform, the same trick attack-runbook uses for its launchd drop).
- Confirms it runs at baseline, POSTs a BINARY BLOCK rule on its hash to the Default policy, then polls until the exec is DENIED (host-side enforcement).
- Asserts the application_control_block alert itself: the alert rule_id is dynamic (app_control:<ruleId>), which the driver's static rule_id match can't express, so the scenario carries no rules block and the driver passes it on attack.sh exit 0 (a mode it explicitly supports). Cleans up the rule + target.

Validated on edr-qa (SIP + Gatekeeper on) against v0.1.1-rc.8: baseline allowed -> rule posted -> exec DENIED -> app_control:<id> alert (source=application_control) -> PASS.

Also scrubs the now-resolved "tracked separately" notes in scripts/uat/README.md, scripts/qa/README.md, and docs/testing-strategy.md to point at this scenario.

<!-- Keep this short. Delete sections that do not apply. -->

## What & why



## Checklist

- [ ] **OpenSpec updated for behavior changes.** If this PR changes observable behavior (a detection rule, the event
      wire schema, persistence semantics, an API/wire shape, or an emitted event), `openspec/specs/**` is updated (and
      an `openspec/changes/` proposal added), with a `spec:<id>` test marker for any new/renamed scenario. Only if this
      PR changes NO observable behavior (a comment / refactor / gofmt / dep bump that happens to touch a scoped path)
      may you assert `no-behavior-change` (label or `[no-behavior-change]` in the title) to clear the OpenSpec-sync gate.
      That is an assertion a reviewer will check, not a way to skip the spec for a real behavior change.
- [ ] Tests added/updated for the change (unit / integration / efficacy / UI as applicable).
- [ ] Agent/extension change touching ESF, XPC, or the event wire format: exercised on a live macOS VM before RC
      (flagged below).

## VM / RC notes (if applicable)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated testing strategy documentation to clarify Application Control blocking scenario coverage and test automation procedures
  * Added new UAT scenario documentation for validating Application Control active blocking behavior with expected alert assertions
  * Refreshed QA and UAT procedures to reflect current test infrastructure for application control testing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->