### PR TITLE
Capability based UI gating

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ task db:up
 # Build the UI (embedded in the server binary via server/ui/dist/)
 task build:ui
 
-# Run the server (HTTPS-only since #140; serves a local mkcert-trusted cert from tmp/dev.crt)
+# Run the server (HTTPS-only since #140; serves tmp/dev.crt: mkcert-trusted if mkcert is installed, else a self-signed cert)
 task dev:server
 # Then open https://localhost:8088/ui/
 ```

--- a/README.md
+++ b/README.md
@@ -135,10 +135,14 @@ task db:up
 # Build the UI (embedded in the server binary via server/ui/dist/)
 task build:ui
 
-# Run the server
+# Run the server (HTTPS-only since #140; serves a local mkcert-trusted cert from tmp/dev.crt)
 task dev:server
-# Then open http://localhost:8088/ui/
+# Then open https://localhost:8088/ui/
 ```
+
+`task dev:server` boots break-glass-only (no SSO). To exercise the SSO sign-in flow locally against the
+bundled dex IdP, run `task qa:up` then `task dev:server:qa-oidc`; see [`docs/okta-setup.md`](docs/okta-setup.md)
+for configuring a real OIDC tenant.
 
 ## Production deployment
 

--- a/docs/adr/0012-capability-based-ui-gating.md
+++ b/docs/adr/0012-capability-based-ui-gating.md
@@ -62,9 +62,11 @@ What becomes easier:
 
 What becomes harder, and the costs:
 
-- The permission set is a **session-lifetime snapshot**. A role change made mid-session is not
-  reflected until the next login or an explicit refetch - the same "takes effect on next sign-in"
-  semantics the chokepoint already exhibits, but now it must be documented as a UI property too.
+- The permission set is a **session-lifetime snapshot**, so server enforcement and UI display update
+  on different schedules: the chokepoint reads fresh bindings on the next request (enforced
+  immediately), while the UI keeps showing the cached snapshot until the next login or an explicit
+  refetch. That gap is the cost; it must be documented as a UI property and is mitigated by the
+  refetch-on-denial self-heal below.
 - The session response gains a field that must stay aligned with the action registry. The UI inherits
   correctness from the server because it only echoes server-computed data, but a new wire field is a
   new thing to keep honest.

--- a/docs/adr/0012-capability-based-ui-gating.md
+++ b/docs/adr/0012-capability-based-ui-gating.md
@@ -1,0 +1,110 @@
+# 0012. Capability-based UI gating from a server-provided permission set
+
+- Status: Proposed
+- Date: 2026-06-01
+- Deciders: getvictor
+
+## Context
+
+The wave-1 user-management work (issue #66) introduced an embedded OPA / Rego authorization
+chokepoint: every privileged UI/API handler calls the authorization decision before acting, and
+the seeded roles (`super_admin`, `admin`, `senior_analyst`, `analyst`, `auditor`) map to a fixed
+action registry. That boundary is sound, and it is the only thing that actually protects the
+system.
+
+The UI knows nothing about it. `GET /api/session` returns only the user identity, the CSRF token,
+and the auth method. The React app therefore renders every navigation tab and every action control
+unconditionally. An operator whose role lacks an action discovers this only by clicking: a
+JIT-provisioned `analyst` who opens Application control gets a raw `Error: API error: 403`, and the
+Kill process control is shown to roles that cannot use it. That is poor UX, and for a product whose
+competitive set (CrowdStrike Falcon, SentinelOne, Microsoft Defender) ships polished least-privilege
+consoles, a credibility gap.
+
+We want the UI to hide affordances an operator cannot use. To do that the frontend needs a reliable
+picture of the operator's effective permissions, and we must decide (a) how the frontend learns them
+and (b) whether to build a bespoke gating helper or adopt a client-side authorization library.
+
+Two forces constrain the answer. First, the server already owns the authoritative role→action
+mapping (Rego + the action registry); any second copy of that logic is a drift hazard, and for a
+security product two policy definitions that can disagree is a liability, not a feature. Second,
+ADR-0010 (stateless server) requires that no UI-specific cross-request state live in process —
+whatever we hand the UI must be derivable per request from the session's role bindings, which is
+exactly how the chokepoint already builds the request actor.
+
+## Decision
+
+1. The server computes the authenticated operator's **effective permission set** — the union of the
+   action grants across the session's role bindings, with the `super_admin` `*` wildcard expanded
+   against the action registry — and returns it in the session-probe response (`GET /api/session`)
+   as a flat list of action identifiers.
+2. The UI gates navigation entries and action controls through a single centralized capability seam
+   that reads that set. It ships **permissions (action identifiers), not role names**: the UI never
+   maps roles to features.
+3. We build that seam **bespoke** (a thin membership check over the permission set behind one
+   capability boundary). We do **not** adopt a client-side authorization library for wave 1.
+4. The Rego authorization chokepoint remains the **sole** security boundary. UI gating is a
+   usability layer only; the UI MUST still treat an unexpected `403` as a graceful no-access state,
+   never a raw error.
+
+## Consequences
+
+What becomes easier:
+
+- One vocabulary end to end. The action identifiers the UI checks are the same strings the
+  chokepoint enforces and the same strings the audit log records (`authz.<action>`), so a UI gate
+  maps 1:1 to a backend check and to an audit row. There is no role→feature translation table to
+  drift.
+- The raw-`403` UX defect is fixed by item 4 (graceful denial) independently of the hiding work.
+- The seam is tiny, dependency-free, and reversible. Centralizing behind one boundary means swapping
+  the implementation later — including adopting a library — is mechanical.
+- Consistent with ADR-0010: the permission set is derived per request from the session's bindings;
+  no new in-process shared state.
+
+What becomes harder, and the costs:
+
+- The permission set is a **session-lifetime snapshot**. A role change made mid-session is not
+  reflected until the next login or an explicit refetch — the same "takes effect on next sign-in"
+  semantics the chokepoint already exhibits, but now it must be documented as a UI property too.
+- The session response gains a field that must stay aligned with the action registry. The UI inherits
+  correctness from the server because it only echoes server-computed data, but a new wire field is a
+  new thing to keep honest.
+- Bespoke means we own the gating code. The burden is near zero precisely because the UI holds no
+  policy logic, but it is not zero.
+
+## Alternatives considered
+
+- **Ship the role name(s) and map role→features in the UI.** Attractive because the session already
+  knows the role. Rejected: it duplicates the role→action policy in TypeScript, so every `roles.json`
+  change needs a matching UI change or the two drift. Decision-as-data means shipping the computed
+  result, not the inputs.
+- **Coarse UI capability booleans** (`{canViewAppControl, canKillProcess, …}`). Attractive: smallest
+  payload, leaks no taxonomy. Rejected as the primary shape because it introduces a *second*
+  permission vocabulary the server must maintain alongside the action registry — another drift
+  surface — for no security benefit (our action catalog is checked into the repo and is not
+  sensitive). The flat action list reuses the vocabulary we already have.
+- **Adopt a client-side authorization library (e.g. CASL / `@casl/react`).** Attractive: ready-made
+  conditional-render components, isomorphic rules, a well-trodden path. Rejected for wave 1 because it
+  is a client-side *decision engine* and we already have one on the server (Rego). Using it for real
+  means reimplementing policy conditions in JS (drift; two engines that can disagree — unacceptable
+  for a security product); using it only as a conditional-render wrapper over a flat set exercises a
+  small fraction of the library that a thin bespoke check replaces. Revisit at wave-2 scoped bindings
+  (`host_group` / `host`) *only if* the UI must evaluate resource/attribute conditions client-side
+  without a server round-trip; the centralized seam makes that migration cheap.
+- **Per-affordance authorization probe** (ask the chokepoint "can I?" for each control). Attractive:
+  always fresh, no snapshot staleness. Rejected: chatty, and unnecessary for wave-1 deployment-wide
+  scopes where one session-bootstrap fetch covers every action. A probe pattern may return for
+  per-resource (`host`-scoped) checks in wave 2.
+
+## References
+
+- ADR-0010 (stateless server) — the permission set is per-request-derived session data, not
+  in-process state.
+- OpenSpec change `add-capability-based-ui-gating` — the behavioral spec deltas for this decision.
+- `docs/authz.md` — role / action matrix.
+  `server/identity/internal/authz/policy/data/{actions,roles}.json` — the authoritative action
+  registry and role grants.
+- User-management plan, issue #66 — the wave-1 identity boundary this builds on.
+- Frontend RBAC guidance ("expose permissions, keep enforcement server-side"): CASL
+  (https://github.com/stalniy/casl), LogRocket on access-control models for the frontend
+  (https://blog.logrocket.com/choosing-best-access-control-model-frontend/), Oso on RBAC
+  (https://www.osohq.com/learn/rbac-role-based-access-control).

--- a/docs/adr/0012-capability-based-ui-gating.md
+++ b/docs/adr/0012-capability-based-ui-gating.md
@@ -27,15 +27,15 @@ and (b) whether to build a bespoke gating helper or adopt a client-side authoriz
 Two forces constrain the answer. First, the server already owns the authoritative role→action
 mapping (Rego + the action registry); any second copy of that logic is a drift hazard, and for a
 security product two policy definitions that can disagree is a liability, not a feature. Second,
-ADR-0010 (stateless server) requires that no UI-specific cross-request state live in process —
-whatever we hand the UI must be derivable per request from the session's role bindings, which is
-exactly how the chokepoint already builds the request actor.
+ADR-0010 (stateless server) requires that no UI-specific cross-request state live in process - whatever
+we hand the UI must be derivable per request from the session's role bindings, which is exactly how the
+chokepoint already builds the request actor.
 
 ## Decision
 
-1. The server computes the authenticated operator's **effective permission set** — the union of the
+1. The server computes the authenticated operator's **effective permission set** - the union of the
    action grants across the session's role bindings, with the `super_admin` `*` wildcard expanded
-   against the action registry — and returns it in the session-probe response (`GET /api/session`)
+   against the action registry - and returns it in the session-probe response (`GET /api/session`)
    as a flat list of action identifiers.
 2. The UI gates navigation entries and action controls through a single centralized capability seam
    that reads that set. It ships **permissions (action identifiers), not role names**: the UI never
@@ -56,14 +56,14 @@ What becomes easier:
   drift.
 - The raw-`403` UX defect is fixed by item 4 (graceful denial) independently of the hiding work.
 - The seam is tiny, dependency-free, and reversible. Centralizing behind one boundary means swapping
-  the implementation later — including adopting a library — is mechanical.
+  the implementation later - including adopting a library - is mechanical.
 - Consistent with ADR-0010: the permission set is derived per request from the session's bindings;
   no new in-process shared state.
 
 What becomes harder, and the costs:
 
 - The permission set is a **session-lifetime snapshot**. A role change made mid-session is not
-  reflected until the next login or an explicit refetch — the same "takes effect on next sign-in"
+  reflected until the next login or an explicit refetch - the same "takes effect on next sign-in"
   semantics the chokepoint already exhibits, but now it must be documented as a UI property too.
 - The session response gains a field that must stay aligned with the action registry. The UI inherits
   correctness from the server because it only echoes server-computed data, but a new wire field is a
@@ -79,13 +79,13 @@ What becomes harder, and the costs:
   result, not the inputs.
 - **Coarse UI capability booleans** (`{canViewAppControl, canKillProcess, …}`). Attractive: smallest
   payload, leaks no taxonomy. Rejected as the primary shape because it introduces a *second*
-  permission vocabulary the server must maintain alongside the action registry — another drift
-  surface — for no security benefit (our action catalog is checked into the repo and is not
+  permission vocabulary the server must maintain alongside the action registry - another drift
+  surface - for no security benefit (our action catalog is checked into the repo and is not
   sensitive). The flat action list reuses the vocabulary we already have.
 - **Adopt a client-side authorization library (e.g. CASL / `@casl/react`).** Attractive: ready-made
   conditional-render components, isomorphic rules, a well-trodden path. Rejected for wave 1 because it
   is a client-side *decision engine* and we already have one on the server (Rego). Using it for real
-  means reimplementing policy conditions in JS (drift; two engines that can disagree — unacceptable
+  means reimplementing policy conditions in JS (drift; two engines that can disagree - unacceptable
   for a security product); using it only as a conditional-render wrapper over a flat set exercises a
   small fraction of the library that a thin bespoke check replaces. Revisit at wave-2 scoped bindings
   (`host_group` / `host`) *only if* the UI must evaluate resource/attribute conditions client-side
@@ -97,13 +97,13 @@ What becomes harder, and the costs:
 
 ## References
 
-- ADR-0010 (stateless server) — the permission set is per-request-derived session data, not
+- ADR-0010 (stateless server) - the permission set is per-request-derived session data, not
   in-process state.
-- OpenSpec change `add-capability-based-ui-gating` — the behavioral spec deltas for this decision.
-- `docs/authz.md` — role / action matrix.
-  `server/identity/internal/authz/policy/data/{actions,roles}.json` — the authoritative action
+- OpenSpec change `add-capability-based-ui-gating` - the behavioral spec deltas for this decision.
+- `docs/authz.md` - role / action matrix.
+  `server/identity/internal/authz/policy/data/{actions,roles}.json` - the authoritative action
   registry and role grants.
-- User-management plan, issue #66 — the wave-1 identity boundary this builds on.
+- User-management plan, issue #66 - the wave-1 identity boundary this builds on.
 - Frontend RBAC guidance ("expose permissions, keep enforcement server-side"): CASL
   (https://github.com/stalniy/casl), LogRocket on access-control models for the frontend
   (https://blog.logrocket.com/choosing-best-access-control-model-frontend/), Oso on RBAC

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -46,6 +46,7 @@ time, not a single mutable "current view".
 | [0009](0009-migrations-via-goose.md) | Versioned, forward-only, per-context schema migrations via goose | Accepted |
 | [0010](0010-stateless-server.md) | Stateless server: no in-process state survives a request | Accepted |
 | [0011](0011-ha-architecture.md) | High-availability architecture: multi-replica app tier with rolling upgrade | Accepted |
+| [0012](0012-capability-based-ui-gating.md) | Capability-based UI gating from a server-provided permission set | Proposed |
 
 ## Tooling
 

--- a/docs/authz.md
+++ b/docs/authz.md
@@ -144,15 +144,17 @@ wildcard expanded to the concrete action set; the wire never carries
 chokepoint check and to an `authz.<action>` audit row: one vocabulary
 end to end, no separate role-to-feature mapping in the frontend.
 
-The permission set is a session-lifetime snapshot. A role change made
-mid-session is not reflected in the UI until the operator's next sign-in
-or an explicit refresh, matching the chokepoint's own "takes effect on
-next sign-in" behaviour (binding changes do not bounce live sessions, as
-noted under "Binding a role to a user" above). As a self-heal, when the
-server denies an action the UI believed was permitted, the UI refetches
-the session permission set (deduplicated so a burst of denials collapses
-to a single request) and hides the now-stale affordance on the next
-render.
+The permission set the UI gates on is a session-lifetime snapshot, taken
+when the session probe runs. Server enforcement and UI display therefore
+update on different schedules, and this is not a contradiction: the
+chokepoint reads fresh bindings on the next request (see "Binding a role
+to a user" above), so a role change is enforced immediately server-side;
+but the UI keeps showing affordances from its cached snapshot until the
+operator's next sign-in or an explicit refresh. As a self-heal, when the
+server denies an action the UI believed was permitted (the snapshot was
+stale), the UI refetches the session permission set (deduplicated so a
+burst of denials collapses to a single request) and hides the now-stale
+affordance on the next render.
 
 ## Test coverage
 

--- a/docs/authz.md
+++ b/docs/authz.md
@@ -125,6 +125,35 @@ See `docs/architecture.md` for the bounded-context split and
 chokepoint sits inside the `identity` context but exposes a public
 `api.AuthZ` interface every other context calls.
 
+## UI capability gating
+
+The web UI hides navigation entries and action controls an operator's
+role does not confer, so an analyst never sees a Kill process button or
+an Application control tab they cannot use. This is a usability layer
+only: the chokepoint above remains the sole security boundary, and the
+UI keeps handling a `403` gracefully (it never relies on hiding as a
+control). See `docs/adr/0012-capability-based-ui-gating.md` for the
+decision and trade-offs.
+
+The UI learns what to show from the session probe. `GET /api/session`
+returns a `permissions` array: the flat set of action identifiers the
+operator's role bindings confer, computed server-side from the same
+`roles.json` grants the chokepoint evaluates (the `super_admin` `*`
+wildcard expanded to the concrete action set; the wire never carries
+`*`). The UI gates on those exact identifiers, so a gate maps 1:1 to a
+chokepoint check and to an `authz.<action>` audit row: one vocabulary
+end to end, no separate role-to-feature mapping in the frontend.
+
+The permission set is a session-lifetime snapshot. A role change made
+mid-session is not reflected in the UI until the operator's next sign-in
+or an explicit refresh, matching the chokepoint's own "takes effect on
+next sign-in" behaviour (binding changes do not bounce live sessions, as
+noted under "Binding a role to a user" above). As a self-heal, when the
+server denies an action the UI believed was permitted, the UI refetches
+the session permission set (deduplicated so a burst of denials collapses
+to a single request) and hides the now-stale affordance on the next
+render.
+
 ## Test coverage
 
 Three test layers protect the chokepoint contract:

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -334,6 +334,13 @@ check exits 0 unless a reference points to a non-existent canonical ID (which ca
 `--strict` it also fails when a SHALL / MUST scenario has zero references. The CI workflow at
 `.github/workflows/spectrace.yml` runs `check --strict` on every PR.
 
+Scenarios declared in in-flight change proposals (`openspec/changes/<change>/specs/<capability>/spec.md`, the
+`--changes-dir` tree, default `openspec/changes`) are also valid marker targets. This lets a PR add a `spec:<id>`
+marker for a scenario it is introducing before the change is archived into `openspec/specs/`, without `check` flagging
+the marker as a dangling reference. WIP scenarios only widen what a marker may point at; they impose no coverage
+obligation (they are not in the `--strict` denominator) until the change is archived and its delta merges into the live
+specs. A MODIFIED requirement that repeats a live scenario heading is expected and collapses harmlessly.
+
 `tools/spectrace list-ids [--normative-only]` prints every canonical scenario ID so contributors can copy a marker
 without typing the slug.
 

--- a/openspec/changes/add-capability-based-ui-gating/.openspec.yaml
+++ b/openspec/changes/add-capability-based-ui-gating/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-01

--- a/openspec/changes/add-capability-based-ui-gating/design.md
+++ b/openspec/changes/add-capability-based-ui-gating/design.md
@@ -57,9 +57,10 @@ wave-2 scoped grants ever require client-side conditional evaluation - mechanica
 
 ## Staleness and graceful denial
 
-The permission set is a snapshot taken at session bootstrap; its lifetime is the session's. A role
-change made mid-session is therefore not reflected until the next login or an explicit refetch. This
-matches the chokepoint's existing "takes effect on next sign-in" behavior.
+The permission set is a snapshot taken at session bootstrap; its lifetime is the session's. The
+chokepoint itself reads fresh bindings on every request, so a mid-session role change is enforced
+server-side immediately; only the UI's cached snapshot lags, staying stale until the next login or an
+explicit refetch.
 
 Two consequences are specified as behavior:
 

--- a/openspec/changes/add-capability-based-ui-gating/design.md
+++ b/openspec/changes/add-capability-based-ui-gating/design.md
@@ -1,0 +1,73 @@
+# Design: capability-based UI gating
+
+This note records the implementation-level shape that the behavioral spec deltas deliberately leave
+out. The build-versus-buy decision (bespoke seam vs a client authorization library) and the
+permissions-not-roles rationale live in ADR-0012; this document covers how the pieces fit.
+
+## Permission set shape
+
+The session-probe response gains one additive field: a flat array of action identifiers drawn from
+the existing action registry (`server/identity/internal/authz/policy/data/actions.json`). Example for
+an `analyst` session:
+
+```jsonc
+// GET /api/session
+{
+  "user": { "id": 2, "email": "analyst@qa.local" },
+  "csrf_token": "…",
+  "auth_method": "oidc",
+  "permissions": ["host.read", "process.read", "alert.read", "alert.comment"]
+}
+```
+
+The identifiers are the same strings the chokepoint enforces and the audit log records
+(`authz.<action>`), so a UI gate, a backend check, and an audit row all speak one vocabulary.
+
+## How the set is computed
+
+The set is the union of the action grants across the active session's role bindings, evaluated at the
+deployment-wide scope (the only scope enforced in wave 1). It is derived from the **same** role
+bindings the session middleware already loads to build the request actor, so no new persisted state
+and no new cross-request in-process state is introduced (ADR-0010).
+
+The `super_admin` role grants `*`. The server expands that wildcard against the action registry before
+serializing, so the wire never carries `*` and the UI never has to special-case it. Expanding
+server-side keeps the single source of truth on the server.
+
+## UI seam
+
+A single capability provider is seeded from the existing session bootstrap and exposes one check
+(conceptually `can(action)` / a `<Can action="…">` wrapper). Every gated affordance goes through it:
+
+- Navigation entries gate on the read action for their destination (Application control on
+  `application_control.read`, and so on).
+- Action controls gate on the action they perform (Kill process on `host.kill_process`; isolate on
+  `host.isolate`; run script on `host.run_script`; alert lifecycle controls on their respective
+  actions).
+
+Centralizing on one seam is the load-bearing decision: it keeps role→feature logic out of the UI
+entirely (the UI only ever reads the server-computed set) and makes a future swap to a library — should
+wave-2 scoped grants ever require client-side conditional evaluation — mechanical rather than a rewrite.
+
+## Staleness and graceful denial
+
+The permission set is a snapshot taken at session bootstrap; its lifetime is the session's. A role
+change made mid-session is therefore not reflected until the next login or an explicit refetch. This
+matches the chokepoint's existing "takes effect on next sign-in" behavior.
+
+Two consequences are specified as behavior:
+
+1. Any authorization denial the UI did not anticipate renders a friendly no-access state, never a raw
+   `API error: 403`.
+2. On such a denial the UI refetches the session permission set, self-healing the staleness window so
+   the stale affordance is hidden on subsequent renders.
+
+Because the server enforces every action regardless, an absent or stale permission set can only change
+what is shown, never what is allowed.
+
+## Non-goals
+
+- Per-resource (`host_group` / `host`) scoped gating — depends on wave-2 scoped role bindings.
+- Pushing permission changes to a live session without a refetch.
+- Any client-side evaluation of authorization conditions, or a client authorization library — see
+  ADR-0012 for the trigger that would reopen that choice.

--- a/openspec/changes/add-capability-based-ui-gating/design.md
+++ b/openspec/changes/add-capability-based-ui-gating/design.md
@@ -39,15 +39,21 @@ server-side keeps the single source of truth on the server.
 A single capability provider is seeded from the existing session bootstrap and exposes one check
 (conceptually `can(action)` / a `<Can action="…">` wrapper). Every gated affordance goes through it:
 
-- Navigation entries gate on the read action for their destination (Application control on
-  `application_control.read`, and so on).
+- Navigation entries gate on the read action for their destination. The full wave-1 mapping:
+  - Hosts (`/`) on `host.read`.
+  - Alerts (`/alerts`) on `alert.read`.
+  - Application control (`/app-control`) on `application_control.read`.
+  - Coverage (`/coverage`) and the per-rule documentation pages are not gated by a dedicated read
+    action in wave 1 (no `coverage.read` / `rule.read` exists in the action registry); they remain
+    visible to any authenticated operator. If a future wave adds such an action, this mapping grows
+    with it.
 - Action controls gate on the action they perform (Kill process on `host.kill_process`; isolate on
   `host.isolate`; run script on `host.run_script`; alert lifecycle controls on their respective
   actions).
 
 Centralizing on one seam is the load-bearing decision: it keeps role→feature logic out of the UI
-entirely (the UI only ever reads the server-computed set) and makes a future swap to a library — should
-wave-2 scoped grants ever require client-side conditional evaluation — mechanical rather than a rewrite.
+entirely (the UI only ever reads the server-computed set) and makes a future swap to a library - should
+wave-2 scoped grants ever require client-side conditional evaluation - mechanical rather than a rewrite.
 
 ## Staleness and graceful denial
 
@@ -67,7 +73,7 @@ what is shown, never what is allowed.
 
 ## Non-goals
 
-- Per-resource (`host_group` / `host`) scoped gating — depends on wave-2 scoped role bindings.
+- Per-resource (`host_group` / `host`) scoped gating - depends on wave-2 scoped role bindings.
 - Pushing permission changes to a live session without a refetch.
-- Any client-side evaluation of authorization conditions, or a client authorization library — see
+- Any client-side evaluation of authorization conditions, or a client authorization library - see
   ADR-0012 for the trigger that would reopen that choice.

--- a/openspec/changes/add-capability-based-ui-gating/proposal.md
+++ b/openspec/changes/add-capability-based-ui-gating/proposal.md
@@ -1,0 +1,77 @@
+## Why
+
+Today the UI renders every navigation tab and every action control to every authenticated operator,
+regardless of what their role permits. The wave-1 authorization chokepoint correctly denies an
+unpermitted action server-side, but the operator only finds out by clicking: a JIT-provisioned
+`analyst` who opens Application control sees a raw `Error: API error: 403`, and the Kill process /
+isolate / run-script controls are shown to roles that cannot use them. That is a least-privilege
+console that neither looks nor feels least-privilege — a UX and credibility gap against the
+security-console set (CrowdStrike Falcon, SentinelOne Singularity, Microsoft Defender for Endpoint),
+all of which hide what a role cannot do.
+
+The fix has two halves: (1) tell the UI what the operator is allowed to do, and (2) have the UI hide
+affordances it cannot use and degrade gracefully when the server denies anyway. The server stays the
+only enforcement point; this change is purely additive UX on top of the existing chokepoint. The
+build-versus-library decision and the rationale for shipping permissions rather than roles are
+recorded in ADR-0012.
+
+## What Changes
+
+- The session-probe response (`GET /api/session`) gains the operator's **effective permission set**:
+  the flat list of action identifiers the operator is permitted, computed server-side as the union of
+  the active session's role-binding grants with the `super_admin` wildcard expanded against the action
+  registry. SSO and break-glass sessions both carry it. The wire never ships a wildcard token.
+- The UI hides navigation entries whose gating read action is absent from the permission set (for
+  example, Application control is hidden without `application_control.read`) and hides action controls
+  whose action is not granted (for example, Kill process is hidden without `host.kill_process`). Gating
+  is derived solely from the server-provided set; the UI holds no role→action mapping of its own.
+- The UI treats an authorization denial it did not anticipate as a graceful no-access state — a
+  human-readable message plus a refetch of the permission set — never a raw `API error: 403`. This
+  covers the snapshot-staleness window (a role changed mid-session) and any affordance not yet gated.
+- No change to the authorization chokepoint, the role / action registry, or the persisted
+  authorization model. The permission set is advisory to the UI; the server remains authoritative for
+  every action.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `ui-authentication-session`: the current-user / session-probe response is extended to include the
+  operator's effective permission set, so the UI can discover not just *who* is logged in but *what
+  they may do*, without a per-affordance round trip. The set is advisory and is never authorization in
+  itself.
+- `web-ui`: navigation entries and action affordances become capability-gated — hidden when the
+  operator's permission set does not include the relevant action — and authorization denials degrade to
+  a graceful no-access state instead of a raw transport error.
+
+No new capabilities are introduced and no other context's behavior changes.
+
+## Impact
+
+**API surface:** one additive field on the `GET /api/session` response body (a list of action
+identifiers). No new endpoint; no change to request shapes, status codes, or the cookie / CSRF
+contract.
+
+**Server:** the effective permission set is computed from the same role bindings the authorization
+chokepoint already loads to build the request actor, so there is no new persisted state and no new
+cross-request in-process state (consistent with ADR-0010). The `*` wildcard is expanded against the
+existing action registry so the wire never carries `*`.
+
+**UI:** a single capability seam (a permission-set provider plus one check) consumed by the navigation
+and the affordance-bearing surfaces (host list navigation, process detail, alert lifecycle controls,
+application control). The implementation is bespoke and dependency-free per ADR-0012.
+
+**Security:** enforcement is unchanged. UI gating is non-authoritative; the chokepoint still denies
+every unpermitted action and the spec mandates the UI keep handling `403`. Hiding an affordance is
+never relied on as a control, so an absent or stale permission set can change only what is *shown*,
+never what is *allowed*.
+
+**Out of scope / deferred:** per-resource (`host_group` / `host`) scoped gating, which depends on
+wave-2 scoped role bindings; live mid-session permission push; any client-side evaluation of
+authorization conditions (ADR-0012 records the trigger for revisiting a client authorization library).
+
+**Rollback:** the change is additive and reversible. Reverting the UI restores unconditional rendering;
+reverting the server field leaves the UI to treat an absent permission set as "gate nothing", which is
+safe because the server still enforces — fail-open affects *visibility* only, never access. The agent
+protocol, the events schema, and the persisted host token are untouched, so no agent-side rollback
+steps apply.

--- a/openspec/changes/add-capability-based-ui-gating/proposal.md
+++ b/openspec/changes/add-capability-based-ui-gating/proposal.md
@@ -5,7 +5,7 @@ regardless of what their role permits. The wave-1 authorization chokepoint corre
 unpermitted action server-side, but the operator only finds out by clicking: a JIT-provisioned
 `analyst` who opens Application control sees a raw `Error: API error: 403`, and the Kill process /
 isolate / run-script controls are shown to roles that cannot use them. That is a least-privilege
-console that neither looks nor feels least-privilege — a UX and credibility gap against the
+console that neither looks nor feels least-privilege - a UX and credibility gap against the
 security-console set (CrowdStrike Falcon, SentinelOne Singularity, Microsoft Defender for Endpoint),
 all of which hide what a role cannot do.
 
@@ -25,8 +25,8 @@ recorded in ADR-0012.
   example, Application control is hidden without `application_control.read`) and hides action controls
   whose action is not granted (for example, Kill process is hidden without `host.kill_process`). Gating
   is derived solely from the server-provided set; the UI holds no role→action mapping of its own.
-- The UI treats an authorization denial it did not anticipate as a graceful no-access state — a
-  human-readable message plus a refetch of the permission set — never a raw `API error: 403`. This
+- The UI treats an authorization denial it did not anticipate as a graceful no-access state - a
+  human-readable message plus a refetch of the permission set - never a raw `API error: 403`. This
   covers the snapshot-staleness window (a role changed mid-session) and any affordance not yet gated.
 - No change to the authorization chokepoint, the role / action registry, or the persisted
   authorization model. The permission set is advisory to the UI; the server remains authoritative for
@@ -40,8 +40,8 @@ recorded in ADR-0012.
   operator's effective permission set, so the UI can discover not just *who* is logged in but *what
   they may do*, without a per-affordance round trip. The set is advisory and is never authorization in
   itself.
-- `web-ui`: navigation entries and action affordances become capability-gated — hidden when the
-  operator's permission set does not include the relevant action — and authorization denials degrade to
+- `web-ui`: navigation entries and action affordances become capability-gated - hidden when the
+  operator's permission set does not include the relevant action - and authorization denials degrade to
   a graceful no-access state instead of a raw transport error.
 
 No new capabilities are introduced and no other context's behavior changes.
@@ -72,6 +72,6 @@ authorization conditions (ADR-0012 records the trigger for revisiting a client a
 
 **Rollback:** the change is additive and reversible. Reverting the UI restores unconditional rendering;
 reverting the server field leaves the UI to treat an absent permission set as "gate nothing", which is
-safe because the server still enforces — fail-open affects *visibility* only, never access. The agent
+safe because the server still enforces - fail-open affects *visibility* only, never access. The agent
 protocol, the events schema, and the persisted host token are untouched, so no agent-side rollback
 steps apply.

--- a/openspec/changes/add-capability-based-ui-gating/specs/ui-authentication-session/spec.md
+++ b/openspec/changes/add-capability-based-ui-gating/specs/ui-authentication-session/spec.md
@@ -15,7 +15,7 @@ advisory to the UI for presentation only; no client SHALL treat it as authorizat
 SHALL continue to enforce every action at its authorization boundary independently of what the
 permission set contained.
 
-#### Scenario: Session probe returns identity and permissions while logged in
+#### Scenario: Session probe while logged in
 
 - **GIVEN** the client holds a valid session cookie for an operator bound to the `analyst` role
 - **WHEN** the client issues a GET to the session endpoint

--- a/openspec/changes/add-capability-based-ui-gating/specs/ui-authentication-session/spec.md
+++ b/openspec/changes/add-capability-based-ui-gating/specs/ui-authentication-session/spec.md
@@ -1,0 +1,45 @@
+## MODIFIED Requirements
+
+### Requirement: Current-user lookup
+
+The system SHALL expose a session-required GET that returns the currently authenticated operator's
+identity AND the operator's effective permission set, so the UI can discover whether it is logged in,
+which account is active, and which privileged actions the operator may perform, without re-prompting
+for credentials and without a per-action round trip. The effective permission set SHALL be the
+collection of action identifiers the operator is permitted under the active session's role bindings at
+the deployment-wide scope, evaluated consistently with the authorization decision the server enforces.
+A role that grants every action SHALL be expanded to the concrete action identifiers rather than
+returning a wildcard token. The permission set SHALL be present for every authenticated session
+regardless of whether it was established via SSO or via the break-glass surface. The permission set is
+advisory to the UI for presentation only; no client SHALL treat it as authorization, and the server
+SHALL continue to enforce every action at its authorization boundary independently of what the
+permission set contained.
+
+#### Scenario: Session probe returns identity and permissions while logged in
+
+- **GIVEN** the client holds a valid session cookie for an operator bound to the `analyst` role
+- **WHEN** the client issues a GET to the session endpoint
+- **THEN** the server returns 200 with the operator's identity, the session's CSRF token, and a
+  permission set containing the analyst actions (for example `host.read`, `process.read`,
+  `alert.read`, `alert.comment`)
+- **AND** the permission set does not contain `host.kill_process` or `application_control.read`
+
+#### Scenario: Higher-privilege role returns a superset
+
+- **GIVEN** the client holds a valid session for an operator bound to `senior_analyst`
+- **WHEN** the client issues a GET to the session endpoint
+- **THEN** the returned permission set additionally contains `host.kill_process`, `host.isolate`,
+  `host.run_script`, and `application_control.read`
+
+#### Scenario: All-actions role is expanded rather than wildcarded
+
+- **GIVEN** the client holds a valid session for an operator whose role grants every action
+- **WHEN** the client issues a GET to the session endpoint
+- **THEN** the returned permission set lists the concrete action identifiers from the action registry
+- **AND** it does not contain a wildcard token such as `*`
+
+#### Scenario: Session probe while logged out
+
+- **GIVEN** the client has no session cookie or the cookie is invalid
+- **WHEN** the client issues a GET to the session endpoint
+- **THEN** the server returns 401 and no permission set is returned

--- a/openspec/changes/add-capability-based-ui-gating/specs/web-ui/spec.md
+++ b/openspec/changes/add-capability-based-ui-gating/specs/web-ui/spec.md
@@ -1,0 +1,64 @@
+## ADDED Requirements
+
+### Requirement: Navigation and action affordances are capability-gated
+
+The UI SHALL hide navigation entries and action controls that the authenticated operator's effective
+permission set — obtained from the session probe — does not authorize, so an operator is not shown
+affordances they cannot use. A navigation entry SHALL be hidden when the permission set does not
+contain the read action that gates its destination surface. An action control SHALL be hidden when the
+permission set does not contain the action that the control performs. Gating SHALL be derived solely
+from the server-provided permission set; the UI SHALL NOT contain its own mapping from role names to
+permitted actions. Hiding an affordance is a usability measure only and SHALL NOT be relied upon as
+access control; the server remains authoritative for every action.
+
+#### Scenario: Application control entry hidden without read access
+
+- **GIVEN** an operator whose permission set does not contain `application_control.read`
+- **WHEN** the authenticated application renders its navigation
+- **THEN** the Application control navigation entry is not shown
+- **AND** navigating directly to the Application control route does not present the surface
+
+#### Scenario: Application control entry shown with read access
+
+- **GIVEN** an operator whose permission set contains `application_control.read`
+- **WHEN** the navigation renders
+- **THEN** the Application control navigation entry is shown
+
+#### Scenario: Kill process control hidden without the action
+
+- **GIVEN** an operator whose permission set does not contain `host.kill_process`
+- **WHEN** the operator opens a process's detail
+- **THEN** the Kill process control is not rendered
+
+#### Scenario: Kill process control shown with the action
+
+- **GIVEN** an operator whose permission set contains `host.kill_process`
+- **WHEN** the operator opens a process's detail
+- **THEN** the Kill process control is rendered and can be invoked
+
+### Requirement: Authorization denials degrade gracefully
+
+The UI SHALL present an authorization denial as a clear, human-readable no-access state and SHALL NOT
+surface a raw transport error such as `API error: 403`. When the server denies a request the UI
+believed was permitted — for example because the operator's role changed after the session permission
+set was fetched — the UI SHALL render the no-access state for that surface or action AND SHALL refresh
+the permission set from the session endpoint so subsequent rendering reflects the operator's current
+permissions. When the permission set is unavailable — for example an older server that does not return
+one — the UI MAY render affordances optimistically but MUST still degrade any resulting denial
+gracefully, so an absent permission set can never grant access; only the server can.
+
+#### Scenario: Deep-link to a gated surface shows a no-access state
+
+- **GIVEN** an operator whose permission set does not contain `application_control.read`
+- **WHEN** the operator navigates directly to the Application control route
+- **THEN** the UI shows a no-access message indicating the operator lacks access to that surface
+- **AND** the UI does not display a raw `API error: 403`
+
+#### Scenario: Mid-session revocation degrades and refetches
+
+- **GIVEN** an operator who held an action and whose role binding was revoked after their session
+  permission set was fetched
+- **WHEN** the operator invokes the affected action and the server responds 403
+- **THEN** the UI renders the no-access state for that action
+- **AND** the UI refetches the session permission set so the corresponding affordance is hidden on
+  subsequent renders

--- a/openspec/changes/add-capability-based-ui-gating/specs/web-ui/spec.md
+++ b/openspec/changes/add-capability-based-ui-gating/specs/web-ui/spec.md
@@ -3,7 +3,7 @@
 ### Requirement: Navigation and action affordances are capability-gated
 
 The UI SHALL hide navigation entries and action controls that the authenticated operator's effective
-permission set — obtained from the session probe — does not authorize, so an operator is not shown
+permission set - obtained from the session probe - does not authorize, so an operator is not shown
 affordances they cannot use. A navigation entry SHALL be hidden when the permission set does not
 contain the read action that gates its destination surface. An action control SHALL be hidden when the
 permission set does not contain the action that the control performs. Gating SHALL be derived solely
@@ -40,12 +40,14 @@ access control; the server remains authoritative for every action.
 
 The UI SHALL present an authorization denial as a clear, human-readable no-access state and SHALL NOT
 surface a raw transport error such as `API error: 403`. When the server denies a request the UI
-believed was permitted — for example because the operator's role changed after the session permission
-set was fetched — the UI SHALL render the no-access state for that surface or action AND SHALL refresh
+believed was permitted - for example because the operator's role changed after the session permission
+set was fetched - the UI SHALL render the no-access state for that surface or action AND SHALL refresh
 the permission set from the session endpoint so subsequent rendering reflects the operator's current
-permissions. When the permission set is unavailable — for example an older server that does not return
-one — the UI MAY render affordances optimistically but MUST still degrade any resulting denial
-gracefully, so an absent permission set can never grant access; only the server can.
+permissions. The refetch SHALL be deduplicated and throttled so that multiple gated components failing
+at once, or repeated denials in quick succession, collapse to a single in-flight request rather than a
+storm of session-endpoint calls. When the permission set is unavailable - for example an older server
+that does not return one - the UI MAY render affordances optimistically but MUST still degrade any
+resulting denial gracefully, so an absent permission set can never grant access; only the server can.
 
 #### Scenario: Deep-link to a gated surface shows a no-access state
 
@@ -62,3 +64,12 @@ gracefully, so an absent permission set can never grant access; only the server 
 - **THEN** the UI renders the no-access state for that action
 - **AND** the UI refetches the session permission set so the corresponding affordance is hidden on
   subsequent renders
+
+#### Scenario: Simultaneous denials collapse to one refetch
+
+- **GIVEN** an operator whose role was revoked mid-session and a page that renders several gated
+  affordances at once
+- **WHEN** multiple of those affordances trigger an authorization denial in quick succession
+- **THEN** the UI issues at most one in-flight refetch of the session permission set rather than one per
+  denial
+- **AND** subsequent renders reflect the refreshed permission set

--- a/openspec/changes/add-capability-based-ui-gating/tasks.md
+++ b/openspec/changes/add-capability-based-ui-gating/tasks.md
@@ -1,12 +1,12 @@
 ## Phase 1: server permission set
 
-- [ ] **1.1** Compute the effective permission set from the active session's role bindings: union of
+- [x] **1.1** Compute the effective permission set from the active session's role bindings: union of
   action grants at the deployment-wide scope, with the `super_admin` `*` wildcard expanded against the
   action registry. Reuse the binding load that session middleware already performs to build the request
   actor; add no new persisted or in-process state (ADR-0010).
-- [ ] **1.2** Add the permission set as an additive field on the `GET /api/session` response body.
+- [x] **1.2** Add the permission set as an additive field on the `GET /api/session` response body.
   Populate it for both SSO and break-glass sessions. Never serialize a wildcard token.
-- [ ] **1.3** Per-context integration test in `server/identity/internal/tests/` covering every seeded
+- [x] **1.3** Per-context integration test in `server/identity/internal/tests/` covering every seeded
   role: an `analyst` session returns the analyst action set and omits `host.kill_process` /
   `application_control.read`; a `senior_analyst` session is a superset that includes them; `admin` and
   `auditor` sessions each return their respective seeded grants; a `super_admin` session returns the
@@ -15,38 +15,38 @@
 
 ## Phase 2: UI capability seam
 
-- [ ] **2.1** Add the new `permissions` field to the `SessionInfo` interface in `ui/src/api.ts` first
+- [x] **2.1** Add the new `permissions` field to the `SessionInfo` interface in `ui/src/api.ts` first
   (so the type is in place before consumers compile), then seed a permission-set provider from the
   existing session bootstrap and expose one check (`can(action)` / `<Can action="…">`). The UI holds no
   role→action mapping; it reads only the server-provided set.
-- [ ] **2.2** Gate navigation entries on the read action for their destination (Application control on
+- [x] **2.2** Gate navigation entries on the read action for their destination (Application control on
   `application_control.read`, etc.).
-- [ ] **2.3** Gate action controls on the action they perform: Kill process (`host.kill_process`),
+- [x] **2.3** Gate action controls on the action they perform: Kill process (`host.kill_process`),
   isolate (`host.isolate`), run script (`host.run_script`), and the alert lifecycle controls on their
   respective actions.
-- [ ] **2.4** UI unit / component tests (vitest, co-located `*.test.tsx` per CLAUDE.md): navigation
+- [x] **2.4** UI unit / component tests (vitest, co-located `*.test.tsx` per CLAUDE.md): navigation
   entry and action control are hidden without the permission and shown with it; the gate reads the set
   rather than a role name.
 
 ## Phase 3: graceful denial
 
-- [ ] **3.1** Replace raw transport-error rendering on a `403` with a human-readable no-access state
+- [x] **3.1** Replace raw transport-error rendering on a `403` with a human-readable no-access state
   for the affected surface or control.
-- [ ] **3.2** On an unanticipated `403`, refetch the session permission set so the stale affordance is
+- [x] **3.2** On an unanticipated `403`, refetch the session permission set so the stale affordance is
   hidden on subsequent renders (self-heal the snapshot-staleness window). Deduplicate and throttle the
   refetch so concurrent or repeated denials collapse to a single in-flight request rather than a refetch
   storm against the session endpoint.
-- [ ] **3.3** Tests: deep-linking to a gated route without permission shows the no-access state, not a
+- [x] **3.3** Tests: deep-linking to a gated route without permission shows the no-access state, not a
   raw `API error: 403`; a `403` after a mid-session role revocation triggers a refetch and hides the
   affordance.
 
 ## Phase 4: documentation + validation gates
 
-- [ ] **4.1** Update `docs/authz.md`: the UI reflects the same action vocabulary as the chokepoint, the
+- [x] **4.1** Update `docs/authz.md`: the UI reflects the same action vocabulary as the chokepoint, the
   permission set is advisory (server authoritative), and gating is not a security control.
-- [ ] **4.2** Document the session-lifetime snapshot semantics (role changes apply on next login or on
+- [x] **4.2** Document the session-lifetime snapshot semantics (role changes apply on next login or on
   refetch) in `docs/authz.md` and the operator runbook.
-- [ ] **4.3** Coverage on new code remains ≥ 80% on the SonarCloud gate; every new `ui/src/**` file
+- [x] **4.3** Coverage on new code remains ≥ 80% on the SonarCloud gate; every new `ui/src/**` file
   carries a `*.test.{ts,tsx}` sibling (CLAUDE.md).
-- [ ] **4.4** Spec-to-test traceability: at least one test references each new or modified SHALL/MUST
+- [x] **4.4** Spec-to-test traceability: at least one test references each new or modified SHALL/MUST
   scenario id (`tools/spectrace`).

--- a/openspec/changes/add-capability-based-ui-gating/tasks.md
+++ b/openspec/changes/add-capability-based-ui-gating/tasks.md
@@ -6,17 +6,19 @@
   actor; add no new persisted or in-process state (ADR-0010).
 - [ ] **1.2** Add the permission set as an additive field on the `GET /api/session` response body.
   Populate it for both SSO and break-glass sessions. Never serialize a wildcard token.
-- [ ] **1.3** Per-context integration test in `server/identity/internal/tests/`: an `analyst` session
-  returns the analyst action set and omits `host.kill_process` / `application_control.read`; a
-  `senior_analyst` session is a superset that includes them; a `super_admin` session returns the
+- [ ] **1.3** Per-context integration test in `server/identity/internal/tests/` covering every seeded
+  role: an `analyst` session returns the analyst action set and omits `host.kill_process` /
+  `application_control.read`; a `senior_analyst` session is a superset that includes them; `admin` and
+  `auditor` sessions each return their respective seeded grants; a `super_admin` session returns the
   concrete action registry (wildcard expanded, no `*`); a logged-out probe still returns 401 with no
   permission set.
 
 ## Phase 2: UI capability seam
 
-- [ ] **2.1** Seed a permission-set provider from the existing session bootstrap and expose one check
-  (`can(action)` / `<Can action="…">`). The UI holds no role→action mapping; it reads only the
-  server-provided set.
+- [ ] **2.1** Add the new `permissions` field to the `SessionInfo` interface in `ui/src/api.ts` first
+  (so the type is in place before consumers compile), then seed a permission-set provider from the
+  existing session bootstrap and expose one check (`can(action)` / `<Can action="…">`). The UI holds no
+  role→action mapping; it reads only the server-provided set.
 - [ ] **2.2** Gate navigation entries on the read action for their destination (Application control on
   `application_control.read`, etc.).
 - [ ] **2.3** Gate action controls on the action they perform: Kill process (`host.kill_process`),
@@ -31,7 +33,9 @@
 - [ ] **3.1** Replace raw transport-error rendering on a `403` with a human-readable no-access state
   for the affected surface or control.
 - [ ] **3.2** On an unanticipated `403`, refetch the session permission set so the stale affordance is
-  hidden on subsequent renders (self-heal the snapshot-staleness window).
+  hidden on subsequent renders (self-heal the snapshot-staleness window). Deduplicate and throttle the
+  refetch so concurrent or repeated denials collapse to a single in-flight request rather than a refetch
+  storm against the session endpoint.
 - [ ] **3.3** Tests: deep-linking to a gated route without permission shows the no-access state, not a
   raw `API error: 403`; a `403` after a mid-session role revocation triggers a refetch and hides the
   affordance.

--- a/openspec/changes/add-capability-based-ui-gating/tasks.md
+++ b/openspec/changes/add-capability-based-ui-gating/tasks.md
@@ -1,0 +1,48 @@
+## Phase 1: server permission set
+
+- [ ] **1.1** Compute the effective permission set from the active session's role bindings: union of
+  action grants at the deployment-wide scope, with the `super_admin` `*` wildcard expanded against the
+  action registry. Reuse the binding load that session middleware already performs to build the request
+  actor; add no new persisted or in-process state (ADR-0010).
+- [ ] **1.2** Add the permission set as an additive field on the `GET /api/session` response body.
+  Populate it for both SSO and break-glass sessions. Never serialize a wildcard token.
+- [ ] **1.3** Per-context integration test in `server/identity/internal/tests/`: an `analyst` session
+  returns the analyst action set and omits `host.kill_process` / `application_control.read`; a
+  `senior_analyst` session is a superset that includes them; a `super_admin` session returns the
+  concrete action registry (wildcard expanded, no `*`); a logged-out probe still returns 401 with no
+  permission set.
+
+## Phase 2: UI capability seam
+
+- [ ] **2.1** Seed a permission-set provider from the existing session bootstrap and expose one check
+  (`can(action)` / `<Can action="…">`). The UI holds no role→action mapping; it reads only the
+  server-provided set.
+- [ ] **2.2** Gate navigation entries on the read action for their destination (Application control on
+  `application_control.read`, etc.).
+- [ ] **2.3** Gate action controls on the action they perform: Kill process (`host.kill_process`),
+  isolate (`host.isolate`), run script (`host.run_script`), and the alert lifecycle controls on their
+  respective actions.
+- [ ] **2.4** UI unit / component tests (vitest, co-located `*.test.tsx` per CLAUDE.md): navigation
+  entry and action control are hidden without the permission and shown with it; the gate reads the set
+  rather than a role name.
+
+## Phase 3: graceful denial
+
+- [ ] **3.1** Replace raw transport-error rendering on a `403` with a human-readable no-access state
+  for the affected surface or control.
+- [ ] **3.2** On an unanticipated `403`, refetch the session permission set so the stale affordance is
+  hidden on subsequent renders (self-heal the snapshot-staleness window).
+- [ ] **3.3** Tests: deep-linking to a gated route without permission shows the no-access state, not a
+  raw `API error: 403`; a `403` after a mid-session role revocation triggers a refetch and hides the
+  affordance.
+
+## Phase 4: documentation + validation gates
+
+- [ ] **4.1** Update `docs/authz.md`: the UI reflects the same action vocabulary as the chokepoint, the
+  permission set is advisory (server authoritative), and gating is not a security control.
+- [ ] **4.2** Document the session-lifetime snapshot semantics (role changes apply on next login or on
+  refetch) in `docs/authz.md` and the operator runbook.
+- [ ] **4.3** Coverage on new code remains ≥ 80% on the SonarCloud gate; every new `ui/src/**` file
+  carries a `*.test.{ts,tsx}` sibling (CLAUDE.md).
+- [ ] **4.4** Spec-to-test traceability: at least one test references each new or modified SHALL/MUST
+  scenario id (`tools/spectrace`).

--- a/server/identity/bootstrap/bootstrap.go
+++ b/server/identity/bootstrap/bootstrap.go
@@ -189,6 +189,7 @@ func New(ctx context.Context, deps Deps) (*Identity, error) {
 			CookieSecure: deps.CookieSecure,
 			Logger:       logger,
 			Audit:        auditStore,
+			Permissions:  authzEngine,
 		}),
 		oidcHandler:       oidcHandler,
 		breakglassHandler: bgHandler,

--- a/server/identity/internal/authz/engine.go
+++ b/server/identity/internal/authz/engine.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io/fs"
 	"log/slog"
+	"sort"
 	"strings"
 
 	"github.com/open-policy-agent/opa/v1/rego"
@@ -54,6 +55,11 @@ type Engine struct {
 	// action is denied with reason `action_not_registered`; the build-time parity check between api.RegisteredActions and
 	// policy/data/actions.json keeps the two in lockstep, this set is the runtime defense in depth.
 	registered map[api.Action]struct{}
+
+	// roleGrants is the role-id -> grant-list map parsed from policy/data/roles.json, the same bundle the Rego store reads. It backs
+	// PermissionsForRoleIDs, which the session probe uses to tell the UI which actions an operator's roles confer. It is presentation
+	// data only; Allow remains the single authorization decision.
+	roleGrants map[string][]string
 }
 
 // Options bundles the optional async-audit dependencies. Zero values are valid: a nil AsyncRead degrades to fully-synchronous audit;
@@ -106,6 +112,11 @@ func New(ctx context.Context, audit api.AuditRecorder, logger *slog.Logger, opts
 		registered[a] = struct{}{}
 	}
 
+	roleGrants, err := parseRoleGrants()
+	if err != nil {
+		return nil, err
+	}
+
 	e := &Engine{
 		query:            query,
 		audit:            audit,
@@ -113,8 +124,42 @@ func New(ctx context.Context, audit api.AuditRecorder, logger *slog.Logger, opts
 		readSamplingRate: opts.ReadSamplingRate,
 		logger:           logger,
 		registered:       registered,
+		roleGrants:       roleGrants,
 	}
 	return e, nil
+}
+
+// PermissionsForRoleIDs returns the union of action grants conferred by the given role ids, with the `*` wildcard (held by
+// super_admin) expanded to the concrete registered action set. The result is deduplicated and sorted for a stable wire shape.
+// Unknown role ids are ignored. Scope is the caller's concern: wave-1 passes only deployment-wide (`global`) bindings, matching the
+// only scope the chokepoint honours.
+//
+// This is presentation data for the session probe: it tells the UI which affordances an operator's roles confer so it can hide the
+// rest. It is NEVER an authorization decision: every privileged action still funnels through Allow, which is the sole security
+// boundary (a stale or wrong permission set can only change what the UI shows, not what the server permits).
+func (e *Engine) PermissionsForRoleIDs(roleIDs []string) []string {
+	seen := make(map[string]struct{})
+	for _, id := range roleIDs {
+		grants, ok := e.roleGrants[id]
+		if !ok {
+			continue
+		}
+		for _, g := range grants {
+			if g == "*" {
+				for _, a := range api.RegisteredActions() {
+					seen[string(a)] = struct{}{}
+				}
+				continue
+			}
+			seen[g] = struct{}{}
+		}
+	}
+	out := make([]string, 0, len(seen))
+	for a := range seen {
+		out = append(out, a)
+	}
+	sort.Strings(out)
+	return out
 }
 
 // Allow evaluates the policy and returns the decision. Implements
@@ -309,6 +354,28 @@ func loadDataBundle() (map[string]any, error) {
 		"actions": stringsToAny(actions.Actions),
 		"roles":   rolesData,
 	}, nil
+}
+
+// parseRoleGrants reads the embedded roles.json and returns the role-id -> grant-list map backing PermissionsForRoleIDs. It parses
+// the same bytes loadDataBundle feeds the OPA store, so the UI's permission set and the chokepoint's grant data come from one source.
+func parseRoleGrants() (map[string][]string, error) {
+	rolesBytes, err := fs.ReadFile(policyFS, "policy/data/roles.json")
+	if err != nil {
+		return nil, fmt.Errorf("authz: read roles.json: %w", err)
+	}
+	var roles struct {
+		Roles map[string]struct {
+			Grants []string `json:"grants"`
+		} `json:"roles"`
+	}
+	if err := json.Unmarshal(rolesBytes, &roles); err != nil {
+		return nil, fmt.Errorf("authz: parse roles.json: %w", err)
+	}
+	out := make(map[string][]string, len(roles.Roles))
+	for id, r := range roles.Roles {
+		out[id] = r.Grants
+	}
+	return out, nil
 }
 
 func stringsToAny(in []string) []any {

--- a/server/identity/internal/authz/engine.go
+++ b/server/identity/internal/authz/engine.go
@@ -138,6 +138,11 @@ func New(ctx context.Context, audit api.AuditRecorder, logger *slog.Logger, opts
 // rest. It is NEVER an authorization decision: every privileged action still funnels through Allow, which is the sole security
 // boundary (a stale or wrong permission set can only change what the UI shows, not what the server permits).
 func (e *Engine) PermissionsForRoleIDs(roleIDs []string) []string {
+	if e == nil {
+		// Defensive: a typed-nil *Engine wrapped in the PermissionResolver interface would otherwise panic on the
+		// e.roleGrants access below. The session handler treats a nil result as an empty permission set.
+		return nil
+	}
 	seen := make(map[string]struct{})
 	for _, id := range roleIDs {
 		grants, ok := e.roleGrants[id]

--- a/server/identity/internal/authz/permissions_test.go
+++ b/server/identity/internal/authz/permissions_test.go
@@ -63,6 +63,7 @@ func TestPermissionsForRoleIDs_PerSeededRole(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			got := e.PermissionsForRoleIDs([]string{tc.roleID})
 
 			assert.True(t, sort.StringsAreSorted(got), "permission set must be returned sorted for a stable wire shape")
@@ -87,6 +88,7 @@ func TestPermissionsForRoleIDs_UnionAndEdges(t *testing.T) {
 	e, _ := newEngine(t)
 
 	t.Run("union of overlapping roles dedups to the superset", func(t *testing.T) {
+		t.Parallel()
 		union := e.PermissionsForRoleIDs([]string{"analyst", "senior_analyst"})
 		seniorOnly := e.PermissionsForRoleIDs([]string{"senior_analyst"})
 		// analyst's grants are a subset of senior_analyst's, so the union equals senior_analyst's set with no duplicates.
@@ -94,14 +96,17 @@ func TestPermissionsForRoleIDs_UnionAndEdges(t *testing.T) {
 	})
 
 	t.Run("unknown role id contributes nothing", func(t *testing.T) {
+		t.Parallel()
 		assert.Empty(t, e.PermissionsForRoleIDs([]string{"does_not_exist"}))
 	})
 
 	t.Run("empty input yields an empty set", func(t *testing.T) {
+		t.Parallel()
 		assert.Empty(t, e.PermissionsForRoleIDs(nil))
 	})
 
 	t.Run("unknown roles are skipped but known roles still resolve", func(t *testing.T) {
+		t.Parallel()
 		got := e.PermissionsForRoleIDs([]string{"ghost", "analyst"})
 		assert.Equal(t, e.PermissionsForRoleIDs([]string{"analyst"}), got)
 	})

--- a/server/identity/internal/authz/permissions_test.go
+++ b/server/identity/internal/authz/permissions_test.go
@@ -1,0 +1,108 @@
+package authz_test
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/fleetdm/edr/server/identity/api"
+)
+
+// TestPermissionsForRoleIDs_PerSeededRole pins the effective action set every seeded role confers, which is what the session probe
+// hands the UI for capability gating. Covers all five built-in roles (the Gemini-expanded task 1.3) plus the wildcard-expansion,
+// union, dedup, and unknown-role edges. The grants are the source of truth in policy/data/roles.json; this is the same data the
+// chokepoint evaluates, so a drift between gating and enforcement fails here.
+func TestPermissionsForRoleIDs_PerSeededRole(t *testing.T) {
+	t.Parallel()
+	e, _ := newEngine(t)
+
+	all := make([]string, 0, len(api.RegisteredActions()))
+	for _, a := range api.RegisteredActions() {
+		all = append(all, string(a))
+	}
+	sort.Strings(all)
+
+	cases := []struct {
+		name        string
+		roleID      string
+		wantContain []string
+		wantOmit    []string
+		wantExact   []string // when set, the result must equal this exactly
+	}{
+		{
+			name:      "analyst is read plus comment only",
+			roleID:    "analyst",
+			wantExact: []string{"alert.comment", "alert.read", "host.read", "process.read"},
+			wantOmit:  []string{"host.kill_process", "application_control.read", "alert.resolve"},
+		},
+		{
+			name:        "senior_analyst is a superset with destructive host actions",
+			roleID:      "senior_analyst",
+			wantContain: []string{"host.kill_process", "host.isolate", "host.run_script", "application_control.read", "alert.resolve"},
+			wantOmit:    []string{"application_control.rule_create", "enrollment.revoke", "user.invite", "audit.read"},
+		},
+		{
+			name:        "admin includes application-control mutation verbs",
+			roleID:      "admin",
+			wantContain: []string{"application_control.read", "application_control.rule_create", "application_control.policy_delete", "enrollment.revoke", "user.invite", "host.kill_process"},
+			wantOmit:    []string{"audit.read"},
+		},
+		{
+			name:        "auditor adds audit.read but no mutations",
+			roleID:      "auditor",
+			wantContain: []string{"audit.read", "host.read", "process.read", "alert.read"},
+			wantOmit:    []string{"host.kill_process", "application_control.read", "alert.comment"},
+		},
+		{
+			name:      "super_admin expands the wildcard to the full registry",
+			roleID:    "super_admin",
+			wantExact: all,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := e.PermissionsForRoleIDs([]string{tc.roleID})
+
+			assert.True(t, sort.StringsAreSorted(got), "permission set must be returned sorted for a stable wire shape")
+			assert.NotContains(t, got, "*", "the wildcard must be expanded, never serialized")
+
+			if tc.wantExact != nil {
+				assert.Equal(t, tc.wantExact, got)
+			}
+			for _, a := range tc.wantContain {
+				assert.Contains(t, got, a)
+			}
+			for _, a := range tc.wantOmit {
+				assert.NotContains(t, got, a)
+			}
+		})
+	}
+}
+
+// TestPermissionsForRoleIDs_UnionAndEdges covers the multi-role union (dedup), the unknown-role skip, and the empty input.
+func TestPermissionsForRoleIDs_UnionAndEdges(t *testing.T) {
+	t.Parallel()
+	e, _ := newEngine(t)
+
+	t.Run("union of overlapping roles dedups to the superset", func(t *testing.T) {
+		union := e.PermissionsForRoleIDs([]string{"analyst", "senior_analyst"})
+		seniorOnly := e.PermissionsForRoleIDs([]string{"senior_analyst"})
+		// analyst's grants are a subset of senior_analyst's, so the union equals senior_analyst's set with no duplicates.
+		assert.Equal(t, seniorOnly, union)
+	})
+
+	t.Run("unknown role id contributes nothing", func(t *testing.T) {
+		assert.Empty(t, e.PermissionsForRoleIDs([]string{"does_not_exist"}))
+	})
+
+	t.Run("empty input yields an empty set", func(t *testing.T) {
+		assert.Empty(t, e.PermissionsForRoleIDs(nil))
+	})
+
+	t.Run("unknown roles are skipped but known roles still resolve", func(t *testing.T) {
+		got := e.PermissionsForRoleIDs([]string{"ghost", "analyst"})
+		assert.Equal(t, e.PermissionsForRoleIDs([]string{"analyst"}), got)
+	})
+}

--- a/server/identity/internal/login/handler.go
+++ b/server/identity/internal/login/handler.go
@@ -25,10 +25,19 @@ import (
 	"github.com/fleetdm/edr/server/identity/api"
 )
 
+// PermissionResolver maps an operator's role ids to the flat set of action identifiers those roles confer (the `*` wildcard expanded
+// to the concrete action set). The session probe attaches the result so the UI can hide affordances the operator's roles do not
+// grant. It is advisory presentation data only; the authorization chokepoint remains the sole security boundary. Satisfied by the
+// authz engine.
+type PermissionResolver interface {
+	PermissionsForRoleIDs(roleIDs []string) []string
+}
+
 // Handler serves the session-check + logout endpoints.
 type Handler struct {
 	svc       api.Service
 	audit     api.AuditRecorder
+	perms     PermissionResolver
 	logger    *slog.Logger
 	cookieSec bool
 }
@@ -43,6 +52,10 @@ type Options struct {
 	// care about the audit trail need not stand one up). When set, the logout path emits one row through this recorder after the action
 	// commits.
 	Audit api.AuditRecorder
+	// Permissions resolves an operator's role ids to their effective action set for the session probe. Optional: when nil the probe
+	// returns an empty permission set (existing tests that don't exercise UI gating need not wire the authz engine). Production wires
+	// identityCtx's authz engine.
+	Permissions PermissionResolver
 }
 
 // New builds a session handler. Panics if svc is nil.
@@ -57,6 +70,7 @@ func New(svc api.Service, opts Options) *Handler {
 	return &Handler{
 		svc:       svc,
 		audit:     opts.Audit,
+		perms:     opts.Permissions,
 		logger:    logger,
 		cookieSec: opts.CookieSecure,
 	}
@@ -83,6 +97,10 @@ type sessionResponse struct {
 	User       userResponse `json:"user"`
 	CSRFToken  string       `json:"csrf_token"`
 	AuthMethod string       `json:"auth_method"`
+	// Permissions is the flat set of action identifiers the operator's roles confer, used by the UI to gate navigation and action
+	// affordances. Always a non-nil array (possibly empty) so the wire shape is stable. Advisory only: the server still enforces every
+	// action at the authorization chokepoint regardless of what this carried.
+	Permissions []string `json:"permissions"`
 }
 
 type errBody struct {
@@ -181,10 +199,36 @@ func (h *Handler) writeSessionJSON(ctx context.Context, w http.ResponseWriter, u
 		authMethod = sess.AuthMethod
 	}
 	writeJSON(ctx, h.logger, w, http.StatusOK, sessionResponse{
-		User:       userResponse{ID: u.ID, Email: u.Email},
-		CSRFToken:  api.EncodeToken(csrfToken),
-		AuthMethod: authMethod,
+		User:        userResponse{ID: u.ID, Email: u.Email},
+		CSRFToken:   api.EncodeToken(csrfToken),
+		AuthMethod:  authMethod,
+		Permissions: h.effectivePermissions(ctx),
 	})
+}
+
+// effectivePermissions returns the action identifiers the operator's roles confer, for the session probe's `permissions` field. It
+// reads the actor the Session middleware pinned on ctx, collects its deployment-wide (`global`) role ids (the only scope wave-1
+// honours), and resolves them through the PermissionResolver. Always returns a non-nil slice so the JSON wire shape is a stable array:
+// an empty set (no resolver wired, no actor, or no global bindings) marshals as `[]`, never `null`.
+func (h *Handler) effectivePermissions(ctx context.Context) []string {
+	if h.perms == nil {
+		return []string{}
+	}
+	actor, ok := api.ActorFromContext(ctx)
+	if !ok {
+		return []string{}
+	}
+	roleIDs := make([]string, 0, len(actor.Roles))
+	for _, b := range actor.Roles {
+		if b.ScopeType == api.RoleBindingScopeGlobal {
+			roleIDs = append(roleIDs, b.RoleID)
+		}
+	}
+	perms := h.perms.PermissionsForRoleIDs(roleIDs)
+	if perms == nil {
+		return []string{}
+	}
+	return perms
 }
 
 func (h *Handler) expireCookie() *http.Cookie {

--- a/server/identity/internal/tests/integration_test.go
+++ b/server/identity/internal/tests/integration_test.go
@@ -12,6 +12,7 @@ package tests
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -25,6 +26,7 @@ import (
 
 	"github.com/fleetdm/edr/server/identity/api"
 	"github.com/fleetdm/edr/server/identity/bootstrap"
+	identityrbac "github.com/fleetdm/edr/server/identity/internal/rbac"
 	identitysessions "github.com/fleetdm/edr/server/identity/internal/sessions"
 	identityusers "github.com/fleetdm/edr/server/identity/internal/users"
 	"github.com/fleetdm/edr/server/testdb/full"
@@ -148,6 +150,93 @@ func TestRegisterRoutes_Authed(t *testing.T) {
 	resp.Body.Close()
 	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode,
 		"GET /api/session via RegisterAuthedRoutes (without Session middleware -> 500 misconfigured)")
+}
+
+// TestSessionProbe_IncludesEffectivePermissions exercises the full GET /api/session path through the real Session middleware (which
+// pins the actor with its live role bindings) and asserts the response carries the operator's effective permission set, expanded from
+// the bound role's grants. This proves the wiring end to end: authz engine -> login handler -> JSON. The exhaustive per-role grant
+// correctness lives in the authz package's PermissionsForRoleIDs unit test; this test pins the wire contract and the role-difference.
+func TestSessionProbe_IncludesEffectivePermissions(t *testing.T) {
+	t.Parallel()
+	id, db := newIdentityWithDB(t)
+	ctx := t.Context()
+
+	// Authed routes behind the real Session middleware, exactly as cmd/main mounts them. GET is cookie-only, so no CSRF wrapper is
+	// needed for the probe.
+	mux := http.NewServeMux()
+	id.RegisterAuthedRoutes(mux)
+	srv := httptest.NewServer(id.SessionMiddleware()(mux))
+	t.Cleanup(srv.Close)
+
+	usersStore := identityusers.New(db)
+	rbacStore := identityrbac.New(db)
+	sessionsStore := identitysessions.New(db, identitysessions.Options{})
+
+	probe := func(t *testing.T, roleID string) []string {
+		t.Helper()
+		u, err := usersStore.Create(ctx, identityusers.CreateRequest{
+			Email: roleID + "@example.com", Password: "long-enough-password-for-test",
+		})
+		require.NoError(t, err)
+		require.NoError(t, rbacStore.BindRole(ctx, rbacStore.DB(), identityrbac.BindRoleRequest{
+			UserID: u.ID, RoleID: roleID, ScopeType: string(api.RoleBindingScopeGlobal), ScopeID: api.RoleBindingScopeWildcard,
+		}))
+		sess, err := sessionsStore.Create(ctx, u.ID, identitysessions.CreateOptions{AuthMethod: "oidc"})
+		require.NoError(t, err)
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL+"/api/session", nil)
+		require.NoError(t, err)
+		req.AddCookie(&http.Cookie{Name: api.SessionCookieName, Value: api.EncodeToken(sess.ID)})
+		resp, err := srv.Client().Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var body struct {
+			User        struct{ Email string } `json:"user"`
+			Permissions []string               `json:"permissions"`
+		}
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+		require.NotNil(t, body.Permissions, "permissions must be a present (non-null) array")
+		return body.Permissions
+	}
+
+	// spec:ui-authentication-session/current-user-lookup/session-probe-while-logged-in
+	t.Run("analyst is gated to read plus comment", func(t *testing.T) {
+		perms := probe(t, "analyst")
+		assert.Contains(t, perms, "host.read")
+		assert.Contains(t, perms, "alert.comment")
+		assert.NotContains(t, perms, "host.kill_process")
+		assert.NotContains(t, perms, "application_control.read")
+	})
+
+	// spec:ui-authentication-session/current-user-lookup/higher-privilege-role-returns-a-superset
+	t.Run("senior_analyst gains destructive and app-control read", func(t *testing.T) {
+		perms := probe(t, "senior_analyst")
+		assert.Contains(t, perms, "host.kill_process")
+		assert.Contains(t, perms, "application_control.read")
+	})
+
+	// spec:ui-authentication-session/current-user-lookup/all-actions-role-is-expanded-rather-than-wildcarded
+	t.Run("super_admin returns the concrete action registry, not a wildcard", func(t *testing.T) {
+		perms := probe(t, "super_admin")
+		// The wildcard must arrive expanded to concrete actions.
+		assert.Contains(t, perms, "host.kill_process")
+		assert.Contains(t, perms, "application_control.policy_delete")
+		assert.Contains(t, perms, "audit.read")
+		assert.NotContains(t, perms, "*")
+		assert.Len(t, perms, len(api.RegisteredActions()))
+	})
+
+	// spec:ui-authentication-session/current-user-lookup/session-probe-while-logged-out
+	t.Run("logged-out probe is 401 with no permission set", func(t *testing.T) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL+"/api/session", nil)
+		require.NoError(t, err)
+		resp, err := srv.Client().Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	})
 }
 
 // TestService_LogoutEmptyToken covers the early-return branch in Logout (sessionToken length zero) so a stale or missing cookie cannot

--- a/tools/spectrace/changes_test.go
+++ b/tools/spectrace/changes_test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeChangeSpec writes a delta spec.md for capability under changesDir/<change>/specs/<capability>/spec.md, creating the
+// directory tree. Mirrors the real openspec/changes/<change>/specs/<cap>/spec.md layout.
+func writeChangeSpec(t *testing.T, changesDir, change, capability, body string) {
+	t.Helper()
+	dir := filepath.Join(changesDir, change, "specs", capability)
+	require.NoError(t, os.MkdirAll(dir, 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "spec.md"), []byte(body), 0o600))
+}
+
+// TestParseChangeScenarioIDs covers the WIP-reference loader: it must collect scenario IDs from in-flight proposals (so a
+// test can reference a not-yet-archived scenario without spectrace flagging a dangling reference), tolerate a MODIFIED
+// requirement that repeats a live heading (duplicates collapse, no error), and degrade to an empty set when there is no
+// changes tree.
+func TestParseChangeScenarioIDs(t *testing.T) {
+	t.Run("collects IDs from a change delta and slugs them canonically", func(t *testing.T) {
+		changes := t.TempDir()
+		writeChangeSpec(t, changes, "add-widget", "web-ui", `## ADDED Requirements
+
+### Requirement: Widget is gated
+The UI SHALL gate the widget.
+
+#### Scenario: Widget hidden without permission
+- **WHEN** the operator lacks the action
+- **THEN** the widget is hidden
+`)
+		ids, err := parseChangeScenarioIDs(changes)
+		require.NoError(t, err)
+		assert.Contains(t, ids, "web-ui/widget-is-gated/widget-hidden-without-permission")
+	})
+
+	t.Run("a MODIFIED requirement repeating a heading collapses without a duplicate error", func(t *testing.T) {
+		changes := t.TempDir()
+		// Two proposals touch the same capability + scenario heading. buildCanonicalSet would reject this for live
+		// specs; the WIP loader must not, because MODIFIED requirements intentionally repeat live headings.
+		body := `## MODIFIED Requirements
+
+### Requirement: Current-user lookup
+The system SHALL return the session.
+
+#### Scenario: Session probe while logged out
+- **THEN** the server returns 401
+`
+		writeChangeSpec(t, changes, "change-a", "ui-authentication-session", body)
+		writeChangeSpec(t, changes, "change-b", "ui-authentication-session", body)
+		ids, err := parseChangeScenarioIDs(changes)
+		require.NoError(t, err)
+		assert.Contains(t, ids, "ui-authentication-session/current-user-lookup/session-probe-while-logged-out")
+		assert.Len(t, ids, 1, "the repeated heading collapses to a single set entry")
+	})
+
+	t.Run("missing changes dir yields an empty set, not an error", func(t *testing.T) {
+		ids, err := parseChangeScenarioIDs(filepath.Join(t.TempDir(), "does-not-exist"))
+		require.NoError(t, err)
+		assert.Empty(t, ids)
+	})
+
+	t.Run("empty changesDir argument yields an empty set", func(t *testing.T) {
+		ids, err := parseChangeScenarioIDs("")
+		require.NoError(t, err)
+		assert.Empty(t, ids)
+	})
+
+	t.Run("a regular file path is tolerated as empty, not an error", func(t *testing.T) {
+		f := filepath.Join(t.TempDir(), "not-a-dir")
+		require.NoError(t, os.WriteFile(f, []byte("x"), 0o600))
+		ids, err := parseChangeScenarioIDs(f)
+		require.NoError(t, err)
+		assert.Empty(t, ids)
+	})
+}

--- a/tools/spectrace/main.go
+++ b/tools/spectrace/main.go
@@ -32,6 +32,11 @@ import (
 const (
 	defaultSpecsDir = "openspec/specs"
 	defaultRootDir  = "."
+	// defaultChangesDir holds in-flight OpenSpec change proposals. Scenarios declared in their delta specs
+	// (openspec/changes/<change>/specs/<capability>/spec.md) are treated as VALID marker targets so a test can
+	// reference a not-yet-archived scenario ID without spectrace flagging a dangling reference. They are not added to
+	// the gated coverage set: a proposal imposes no coverage obligation until it is archived into openspec/specs.
+	defaultChangesDir = "openspec/changes"
 )
 
 func main() {
@@ -62,13 +67,15 @@ func usage() {
 	fmt.Fprint(os.Stderr, `spectrace - openspec spec-to-test traceability linter
 
 Usage:
-  spectrace check    [--specs-dir DIR] [--root DIR] [--strict] [--by-layer] [--new-code] [--base-ref REF]
+  spectrace check    [--specs-dir DIR] [--changes-dir DIR] [--root DIR] [--strict] [--by-layer] [--new-code] [--base-ref REF]
   spectrace list-ids [--specs-dir DIR] [--normative-only]
-  spectrace report   [--specs-dir DIR] [--root DIR] [--format md] [--output FILE] [--normative-only]
+  spectrace report   [--specs-dir DIR] [--changes-dir DIR] [--root DIR] [--format md] [--output FILE] [--normative-only]
 
 Subcommands:
   check     Walk specs and codebase; report uncovered scenarios and invalid references.
             Exit code 0 unless --strict is set or invalid references are present.
+            --changes-dir  openspec/changes tree; scenarios in in-flight proposals are valid
+                           marker targets (not yet gated for coverage). Default openspec/changes.
             --by-layer  Annotate the gap report with per-layer coverage (L0..L6).
             --new-code  Gate only on scenarios added or modified in the current PR (diff against --base-ref).
             --base-ref  Git revision the merge base is computed against (default: origin/main).
@@ -93,6 +100,7 @@ See docs/testing-strategy.md for the marker syntax and rollout plan.
 func runCheck(args []string) int {
 	fs := flag.NewFlagSet("check", flag.ContinueOnError)
 	specsDir := fs.String("specs-dir", defaultSpecsDir, "root of the openspec/specs tree")
+	changesDir := fs.String("changes-dir", defaultChangesDir, "openspec/changes tree; in-flight proposal scenarios are valid marker targets")
 	rootDir := fs.String("root", defaultRootDir, "root of the source tree to scan for markers")
 	strict := fs.Bool("strict", false, "exit non-zero if any SHALL/MUST scenario is uncovered")
 	byLayer := fs.Bool("by-layer", false, "annotate the gap report with per-layer coverage (L0..L6)")
@@ -107,21 +115,21 @@ func runCheck(args []string) int {
 	// because their literal cwd-relative meaning is rarely the intent; explicit values keep cwd-first semantics.
 	setFlags := userSetFlagNames(fs)
 	*specsDir = resolvePathFlag(*specsDir, setFlags["specs-dir"])
+	*changesDir = resolvePathFlag(*changesDir, setFlags["changes-dir"])
 	*rootDir = resolvePathFlag(*rootDir, setFlags["root"])
 
-	scenarios, markers, exitCode := loadScenariosAndMarkers(*specsDir, *rootDir)
+	scenarios, referenceValid, markers, exitCode := loadScenariosAndMarkers(*specsDir, *changesDir, *rootDir)
 	if exitCode != 0 {
 		return exitCode
 	}
-	canonical := make(map[string]struct{}, len(scenarios))
-	for _, s := range scenarios {
-		canonical[s.ID] = struct{}{}
-	}
 
+	// A marker is a valid reference when its ID is in referenceValid (live specs ∪ in-flight proposals); only then does it
+	// count toward `covered`. A live scenario it points at is covered; a WIP-only ID resolves without error but covers no
+	// gated scenario (WIP scenarios are not in `scenarios`, so splitUncovered + --strict ignore them).
 	covered := make(map[string][]Marker, len(markers))
 	var invalid []Marker
 	for _, m := range markers {
-		if _, ok := canonical[m.ID]; ok {
+		if _, ok := referenceValid[m.ID]; ok {
 			covered[m.ID] = append(covered[m.ID], m)
 			continue
 		}

--- a/tools/spectrace/report.go
+++ b/tools/spectrace/report.go
@@ -20,6 +20,7 @@ import (
 func runReport(args []string) int {
 	fs := flag.NewFlagSet("report", flag.ContinueOnError)
 	specsDir := fs.String("specs-dir", defaultSpecsDir, "root of the openspec/specs tree")
+	changesDir := fs.String("changes-dir", defaultChangesDir, "openspec/changes tree; in-flight proposal scenarios are valid marker targets")
 	rootDir := fs.String("root", defaultRootDir, "root of the source tree to scan for markers")
 	format := fs.String("format", "md", "output format (currently only `md` is supported)")
 	output := fs.String("output", "", "write to FILE instead of stdout")
@@ -36,9 +37,10 @@ func runReport(args []string) int {
 	// Promote --specs-dir / --root to repo-root-relative when cwd doesn't have them; matches the runCheck shape.
 	setFlags := userSetFlagNames(fs)
 	*specsDir = resolvePathFlag(*specsDir, setFlags["specs-dir"])
+	*changesDir = resolvePathFlag(*changesDir, setFlags["changes-dir"])
 	*rootDir = resolvePathFlag(*rootDir, setFlags["root"])
 
-	scenarios, markers, exitCode := loadScenariosAndMarkers(*specsDir, *rootDir)
+	scenarios, _, markers, exitCode := loadScenariosAndMarkers(*specsDir, *changesDir, *rootDir)
 	if exitCode != 0 {
 		return exitCode
 	}
@@ -66,23 +68,68 @@ func runReport(args []string) int {
 // (scenarios, markers, exitCode); when exitCode != 0 the error has already been written to stderr and the caller should
 // return it directly. Kept here rather than in main.go because report.go is the first consumer; check predates this and
 // inlines the same three calls. A future refactor could fold them, but the diff would be wider than the deduplication.
-func loadScenariosAndMarkers(specsDir, rootDir string) ([]Scenario, []Marker, int) {
+func loadScenariosAndMarkers(specsDir, changesDir, rootDir string) ([]Scenario, map[string]struct{}, []Marker, int) {
 	scenarios, err := ParseAllSpecs(specsDir)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "spectrace: parse specs:", err)
-		return nil, nil, 2
+		return nil, nil, nil, 2
 	}
 	canonical, dupErr := buildCanonicalSet(scenarios)
 	if dupErr != nil {
 		fmt.Fprintln(os.Stderr, "spectrace:", dupErr)
-		return nil, nil, 2
+		return nil, nil, nil, 2
 	}
-	markers, err := ScanMarkers(rootDir, canonical)
+	// Union the live canonical IDs with the WIP IDs from change proposals to form the reference-valid set: the set a
+	// marker's ID must be in to count as a real reference rather than a dangling one. Live scenarios alone drive coverage
+	// and the --strict gate (see runCheck); WIP IDs only widen what a marker is allowed to point at.
+	wipIDs, err := parseChangeScenarioIDs(changesDir)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "spectrace: parse change specs:", err)
+		return nil, nil, nil, 2
+	}
+	referenceValid := make(map[string]struct{}, len(canonical)+len(wipIDs))
+	for id := range canonical {
+		referenceValid[id] = struct{}{}
+	}
+	for id := range wipIDs {
+		referenceValid[id] = struct{}{}
+	}
+	markers, err := ScanMarkers(rootDir, referenceValid)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "spectrace: scan markers:", err)
-		return nil, nil, 2
+		return nil, nil, nil, 2
 	}
-	return scenarios, markers, 0
+	return scenarios, referenceValid, markers, 0
+}
+
+// parseChangeScenarioIDs returns the set of canonical scenario IDs declared in in-flight OpenSpec change proposals under
+// changesDir (openspec/changes/<change>/specs/<capability>/spec.md). Unlike the live specs these IDs are NOT run through
+// buildCanonicalSet's duplicate detection: a MODIFIED requirement in a proposal intentionally repeats a live scenario
+// heading (and two proposals may touch the same capability), so collisions are expected and collapse harmlessly into the
+// set. A missing or empty changesDir yields an empty set so a repo with no in-flight proposals behaves exactly as before.
+func parseChangeScenarioIDs(changesDir string) (map[string]struct{}, error) {
+	ids := make(map[string]struct{})
+	if changesDir == "" {
+		return ids, nil
+	}
+	info, statErr := os.Stat(changesDir)
+	if statErr != nil {
+		if os.IsNotExist(statErr) {
+			return ids, nil
+		}
+		return nil, statErr
+	}
+	if !info.IsDir() {
+		return ids, nil
+	}
+	scenarios, err := ParseAllSpecs(changesDir)
+	if err != nil {
+		return nil, err
+	}
+	for _, s := range scenarios {
+		ids[s.ID] = struct{}{}
+	}
+	return ids, nil
 }
 
 // openReportWriter returns (writer, cleanup, error). When path is empty the writer is stdout and the cleanup is a no-op.

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -10,12 +10,18 @@ import { Login } from "./components/Login";
 import { BreakGlassSetup } from "./components/BreakGlassSetup";
 import { BreakGlassLogin } from "./components/BreakGlassLogin";
 import { TopNav } from "./components/ui/TopNav";
-import { currentSession, logout, Unauthorized401Error, SessionInfo } from "./api";
+import { currentSession, logout, Unauthorized401Error, SessionInfo, setForbiddenHandler } from "./api";
+import { PermissionsProvider, RequirePermission } from "./permissions";
+import { PermissionAction } from "./permissions-core";
+import { createDedupedRunner } from "./dedupe";
 
 type AuthState =
   | { status: "loading" }
   | { status: "anon" }
-  | { status: "authed"; user: SessionInfo["user"]; authMethod: string };
+  // permissions is the operator's effective action set from the session probe, or
+  // undefined when the server didn't return one (older server). Threaded into the
+  // PermissionsProvider so the capability seam can gate nav + affordances.
+  | { status: "authed"; user: SessionInfo["user"]; authMethod: string; permissions: string[] | undefined };
 
 // Routes are top-level. /ui/login (and the break-glass pages) are
 // public; /ui/* otherwise probes /api/session and gates
@@ -57,6 +63,7 @@ function AuthedApp() {
           status: "authed",
           user: info.user,
           authMethod: info.auth_method ?? "local_password",
+          permissions: info.permissions,
         });
       } catch (err) {
         if (controller.signal.aborted) return;
@@ -77,6 +84,23 @@ function AuthedApp() {
     // route change cost an extra /api/session round-trip per
     // navigation and made the app flicker back to 'loading'
     // mid-route.
+  }, []);
+
+  useEffect(() => {
+    // When the server returns a genuine 403 for an action the UI believed was
+    // permitted (e.g. the operator's role was changed after the session probe),
+    // refresh the permission set so the now-stale affordance is hidden on the next
+    // render. createDedupedRunner collapses a burst of simultaneous denials into a
+    // single /api/session refetch rather than a request storm (the throttle the
+    // capability-gating spec requires). A failed/again-denied refetch is a no-op for
+    // auth state: the per-fetch 401 path handles session loss; a repeat 403 just
+    // means still-denied.
+    const refresh = createDedupedRunner(async () => {
+      const info = await currentSession();
+      setAuth((prev) => (prev.status === "authed" ? { ...prev, permissions: info.permissions } : prev));
+    });
+    setForbiddenHandler(refresh);
+    return () => { setForbiddenHandler(null); };
   }, []);
 
   const handleLogout = useCallback(async () => {
@@ -100,7 +124,7 @@ function AuthedApp() {
   }
 
   return (
-    <>
+    <PermissionsProvider permissions={auth.permissions}>
       <TopNav
         user={auth.user}
         authMethod={auth.authMethod}
@@ -110,13 +134,20 @@ function AuthedApp() {
         <Routes>
           <Route path="/" element={<HostList />} />
           <Route path="/alerts" element={<AlertList />} />
-          <Route path="/app-control/*" element={<ApplicationControlRoutes />} />
+          <Route
+            path="/app-control/*"
+            element={(
+              <RequirePermission action={PermissionAction.AppControlRead} surface="Application control">
+                <ApplicationControlRoutes />
+              </RequirePermission>
+            )}
+          />
           <Route path="/coverage" element={<AttackCoverage />} />
           <Route path="/rules/:ruleId" element={<RuleDetail />} />
           <Route path="/hosts/:hostId" element={<ProcessTreeView />} />
           <Route path="*" element={<Navigate to="/" replace />} />
         </Routes>
       </main>
-    </>
+    </PermissionsProvider>
   );
 }

--- a/ui/src/api.test.ts
+++ b/ui/src/api.test.ts
@@ -14,15 +14,22 @@ interface FakeResponse {
   ok: boolean;
   status: number;
   statusText: string;
+  headers: { get(name: string): string | null };
   clone(): FakeResponse;
   json(): Promise<unknown>;
 }
 
-function stubFetch(body: unknown, status = 200): ReturnType<typeof vi.fn> {
+// stubFetch installs a fake global fetch returning a single response. headers maps response
+// header names (case-insensitive, matching the real Headers.get contract) so tests can drive
+// the X-Edr-Authz-Reason gate on the 403 path.
+function stubFetch(body: unknown, status = 200, headers: Record<string, string> = {}): ReturnType<typeof vi.fn> {
+  const lower: Record<string, string> = {};
+  for (const [k, v] of Object.entries(headers)) lower[k.toLowerCase()] = v;
   const fake: FakeResponse = {
     ok: status >= 200 && status < 300,
     status,
     statusText: "",
+    headers: { get: (name: string): string | null => lower[name.toLowerCase()] ?? null },
     clone(): FakeResponse {
       return fake;
     },
@@ -113,12 +120,22 @@ describe("forbidden handler signalling", () => {
   afterEach(() => { setForbiddenHandler(null); });
 
   // spec:web-ui/authorization-denials-degrade-gracefully/mid-session-revocation-degrades-and-refetches
-  it("fires on a genuine (non-reauth) 403 so the UI can refresh permissions", async () => {
-    stubFetch({ error: "no_matching_rule" }, 403);
+  it("fires on an authz 403 (carrying the chokepoint reason header) so the UI can refresh permissions", async () => {
+    stubFetch({ error: "no_matching_rule" }, 403, { "X-Edr-Authz-Reason": "no_matching_rule" });
     const onForbidden = vi.fn();
     setForbiddenHandler(onForbidden);
     await expect(listAlerts()).rejects.toThrow(/API error: 403/);
     expect(onForbidden).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT fire on a 403 without the authz reason header (e.g. a CSRF failure)", async () => {
+    // CSRF and other non-authz 403s go through WriteCookieAuthFailure and carry no authz header,
+    // so they must not trigger a spurious /api/session permission refetch.
+    stubFetch({ error: "csrf_mismatch" }, 403);
+    const onForbidden = vi.fn();
+    setForbiddenHandler(onForbidden);
+    await expect(listAlerts()).rejects.toThrow(/API error: 403/);
+    expect(onForbidden).not.toHaveBeenCalled();
   });
 
   it("does NOT fire on a reauth-required 403 (that has its own retry flow)", async () => {

--- a/ui/src/api.test.ts
+++ b/ui/src/api.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { listAlerts } from "./api";
+import { listAlerts, setForbiddenHandler, ReauthRequiredError } from "./api";
 
 // listAlerts URL-composition tests. The AlertList component test
 // suite mocks api.listAlerts directly via vi.spyOn, so the real
@@ -106,5 +106,34 @@ describe("listAlerts query-string composition", () => {
     const [target] = fetchMock.mock.calls[0] as [URL];
     const url = target.toString();
     expect(url).not.toContain("source=");
+  });
+});
+
+describe("forbidden handler signalling", () => {
+  afterEach(() => { setForbiddenHandler(null); });
+
+  // spec:web-ui/authorization-denials-degrade-gracefully/mid-session-revocation-degrades-and-refetches
+  it("fires on a genuine (non-reauth) 403 so the UI can refresh permissions", async () => {
+    stubFetch({ error: "no_matching_rule" }, 403);
+    const onForbidden = vi.fn();
+    setForbiddenHandler(onForbidden);
+    await expect(listAlerts()).rejects.toThrow(/API error: 403/);
+    expect(onForbidden).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT fire on a reauth-required 403 (that has its own retry flow)", async () => {
+    stubFetch({ error: "reauth_required", challenge: { auth_method: "oidc", reauth_url: "/api/auth/login" } }, 403);
+    const onForbidden = vi.fn();
+    setForbiddenHandler(onForbidden);
+    await expect(listAlerts()).rejects.toBeInstanceOf(ReauthRequiredError);
+    expect(onForbidden).not.toHaveBeenCalled();
+  });
+
+  it("does NOT fire on a 401 (session expiry has its own path)", async () => {
+    stubFetch(null, 401);
+    const onForbidden = vi.fn();
+    setForbiddenHandler(onForbidden);
+    await expect(listAlerts()).rejects.toBeTruthy();
+    expect(onForbidden).not.toHaveBeenCalled();
   });
 });

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -164,15 +164,21 @@ function assertSafeAPIPath(path: string): void {
   }
 }
 
-// forbiddenHandler is an optional callback invoked when the server returns a genuine
-// (non-reauth) 403 — "your role does not grant this action." The UI registers one so
-// it can refresh a possibly-stale permission set (e.g. the operator's role changed
-// after the session probe). Deduping/throttling is the handler's responsibility (see
-// createDedupedRunner); api.ts just fires the signal. Reauth 403s and 401s do NOT
-// trigger it — those have their own handling.
+// AUTHZ_REASON_HEADER is the response header the authorization chokepoint sets on a policy
+// denial (server/identity/api: AuthzReasonHeader). Its presence distinguishes a genuine
+// authz "your role does not grant this action" 403 from other 403s (CSRF failures, etc.),
+// which the forbidden-handler signal gates on so only authz denials trigger a refetch.
+const AUTHZ_REASON_HEADER = "X-Edr-Authz-Reason";
+
+// forbiddenHandler is an optional callback invoked when the server returns an authorization
+// 403 (one carrying AUTHZ_REASON_HEADER). The UI registers one so it can refresh a
+// possibly-stale permission set (e.g. the operator's role changed after the session probe).
+// Deduping/throttling is the handler's responsibility (see createDedupedRunner); api.ts just
+// fires the signal. Reauth 403s, CSRF 403s, and 401s do NOT trigger it: they have their own
+// handling or are not authz denials.
 let forbiddenHandler: (() => void) | null = null;
 
-// setForbiddenHandler registers (or clears, with null) the genuine-403 callback.
+// setForbiddenHandler registers (or clears, with null) the authz-403 callback.
 export function setForbiddenHandler(handler: (() => void) | null): void {
   forbiddenHandler = handler;
 }
@@ -215,10 +221,14 @@ async function fetchJSON<T>(path: string, init?: RequestInit): Promise<T> {
     // to the !res.ok branch below.
     const reauth = await readReauthChallenge(res);
     if (reauth) throw new ReauthRequiredError(reauth);
-    // A genuine forbidden: the operator's role does not grant this action. Signal the
-    // UI so it can refresh a possibly-stale permission set and hide the affordance on
-    // the next render. The error still propagates below so the caller surfaces it.
-    forbiddenHandler?.();
+    // Signal the UI to refresh a possibly-stale permission set ONLY when this 403 came
+    // from the authorization chokepoint, identified by its reason header. CSRF failures
+    // (csrf_missing / csrf_mismatch) and other non-authz 403s are also 403 but do NOT
+    // carry the header, so they must not trigger a spurious /api/session refetch. The
+    // error still propagates below so the caller surfaces it.
+    if (res.headers.get(AUTHZ_REASON_HEADER)) {
+      forbiddenHandler?.();
+    }
   }
   if (!res.ok) {
     throw new Error(`API error: ${String(res.status)} ${res.statusText}`);

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -83,6 +83,14 @@ export interface SessionInfo {
   // before sending, but the field remains optional for forward-
   // compatibility.
   auth_method?: string;
+  // permissions is the operator's effective action set, computed server-side from
+  // their role bindings (the `*` wildcard expanded to concrete actions). The UI gates
+  // navigation and action affordances on it via the capability seam (see
+  // permissions.tsx). Optional for forward-compatibility: an older server that
+  // predates this field leaves it undefined, which the seam treats as "render
+  // optimistically and rely on the server's 403". Advisory only; the server's
+  // authorization chokepoint remains authoritative.
+  permissions?: string[];
 }
 
 export function getCsrfToken(): string {
@@ -156,6 +164,19 @@ function assertSafeAPIPath(path: string): void {
   }
 }
 
+// forbiddenHandler is an optional callback invoked when the server returns a genuine
+// (non-reauth) 403 — "your role does not grant this action." The UI registers one so
+// it can refresh a possibly-stale permission set (e.g. the operator's role changed
+// after the session probe). Deduping/throttling is the handler's responsibility (see
+// createDedupedRunner); api.ts just fires the signal. Reauth 403s and 401s do NOT
+// trigger it — those have their own handling.
+let forbiddenHandler: (() => void) | null = null;
+
+// setForbiddenHandler registers (or clears, with null) the genuine-403 callback.
+export function setForbiddenHandler(handler: (() => void) | null): void {
+  forbiddenHandler = handler;
+}
+
 async function fetchJSON<T>(path: string, init?: RequestInit): Promise<T> {
   assertSafeAPIPath(path);
   const headers: Record<string, string> = {
@@ -194,6 +215,10 @@ async function fetchJSON<T>(path: string, init?: RequestInit): Promise<T> {
     // to the !res.ok branch below.
     const reauth = await readReauthChallenge(res);
     if (reauth) throw new ReauthRequiredError(reauth);
+    // A genuine forbidden: the operator's role does not grant this action. Signal the
+    // UI so it can refresh a possibly-stale permission set and hide the affordance on
+    // the next render. The error still propagates below so the caller surfaces it.
+    forbiddenHandler?.();
   }
   if (!res.ok) {
     throw new Error(`API error: ${String(res.status)} ${res.statusText}`);

--- a/ui/src/components/AlertList.tsx
+++ b/ui/src/components/AlertList.tsx
@@ -9,6 +9,8 @@ import { Badge, type BadgeVariant } from "./ui/Badge";
 import { Button } from "./ui/Button";
 import { Select } from "./ui/Input";
 import { PageHeader } from "./ui/PageHeader";
+import { Can } from "../permissions";
+import { PermissionAction } from "../permissions-core";
 import "./AlertList.scss";
 
 const SEVERITY_VARIANTS: Record<string, BadgeVariant> = {
@@ -215,31 +217,37 @@ export function AlertList() {
                 <td>
                   <div className="alert-actions">
                     {a.status === "open" && (
-                      <Button
-                        size="small"
-                        variant="inverse"
-                        onClick={() => { handleStatusChange(a.id, "acknowledged"); }}
-                      >
-                        Acknowledge
-                      </Button>
+                      <Can action={PermissionAction.AlertAcknowledge}>
+                        <Button
+                          size="small"
+                          variant="inverse"
+                          onClick={() => { handleStatusChange(a.id, "acknowledged"); }}
+                        >
+                          Acknowledge
+                        </Button>
+                      </Can>
                     )}
                     {a.status !== "resolved" && (
-                      <Button
-                        size="small"
-                        variant="inverse"
-                        onClick={() => { handleStatusChange(a.id, "resolved"); }}
-                      >
-                        Resolve
-                      </Button>
+                      <Can action={PermissionAction.AlertResolve}>
+                        <Button
+                          size="small"
+                          variant="inverse"
+                          onClick={() => { handleStatusChange(a.id, "resolved"); }}
+                        >
+                          Resolve
+                        </Button>
+                      </Can>
                     )}
                     {a.status === "resolved" && (
-                      <Button
-                        size="small"
-                        variant="inverse"
-                        onClick={() => { handleStatusChange(a.id, "open"); }}
-                      >
-                        Reopen
-                      </Button>
+                      <Can action={PermissionAction.AlertReopen}>
+                        <Button
+                          size="small"
+                          variant="inverse"
+                          onClick={() => { handleStatusChange(a.id, "open"); }}
+                        >
+                          Reopen
+                        </Button>
+                      </Can>
                     )}
                   </div>
                 </td>

--- a/ui/src/components/NoAccess.test.tsx
+++ b/ui/src/components/NoAccess.test.tsx
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { NoAccess } from "./NoAccess";
+
+describe("NoAccess", () => {
+  it("renders a generic no-access message with no surface", () => {
+    render(<NoAccess />);
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+    expect(screen.getByText(/don't have access/i)).toBeInTheDocument();
+    expect(screen.getByText(/this page/i)).toBeInTheDocument();
+  });
+
+  it("names the surface when provided", () => {
+    render(<NoAccess surface="Application control" />);
+    expect(screen.getByText(/Application control/)).toBeInTheDocument();
+  });
+
+  it("never leaks a raw transport error", () => {
+    render(<NoAccess surface="Application control" />);
+    expect(screen.queryByText(/API error/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/403/)).not.toBeInTheDocument();
+  });
+});

--- a/ui/src/components/NoAccess.tsx
+++ b/ui/src/components/NoAccess.tsx
@@ -1,0 +1,26 @@
+interface NoAccessProps {
+  // surface is an optional human label for what the operator tried to reach, e.g.
+  // "Application control". When set it is woven into the message.
+  readonly surface?: string;
+}
+
+// NoAccess is the graceful denial state: a clear, human-readable message shown when
+// an operator reaches a surface or action their role does not permit. It replaces the
+// raw `Error: API error: 403` that leaked through before capability gating (ADR-0012).
+//
+// It is intentionally generic and reveals nothing beyond "you lack access" - no role
+// names, no required-permission identifiers - so it is safe to show on a deep-link by
+// an operator who should not even know the surface exists.
+export function NoAccess({ surface }: NoAccessProps) {
+  return (
+    <div className="no-access" role="alert">
+      <h2 className="no-access__title">You don&apos;t have access</h2>
+      <p className="no-access__body">
+        {surface
+          ? `Your role doesn't include access to ${surface}.`
+          : "Your role doesn't include access to this page."}{" "}
+        Contact your administrator if you think this is a mistake.
+      </p>
+    </div>
+  );
+}

--- a/ui/src/components/ProcessDetail.tsx
+++ b/ui/src/components/ProcessDetail.tsx
@@ -20,6 +20,8 @@ import { Card } from "./ui/Card";
 import { Button } from "./ui/Button";
 import { Badge, type BadgeVariant } from "./ui/Badge";
 import { NANOSECONDS_PER_MILLISECOND } from "../constants";
+import { Can } from "../permissions";
+import { PermissionAction } from "../permissions-core";
 import "./ProcessDetail.scss";
 
 // killCommandPollIntervalMs is the cadence we re-fetch the kill command's
@@ -237,26 +239,28 @@ export function ProcessDetail({ hostId, node, onClose }: Props) {
         )}
       </dl>
 
-      <div className="process-detail__kill">
-        <Button
-          variant="alert"
-          size="small"
-          onClick={handleKillProcess}
-          disabled={killDisabled}
-        >
-          Kill process
-        </Button>
-        {killCommand && (
-          <span className={`process-detail__cmd-status process-detail__cmd-status--${killCommand.status}`}>
-            {killCommand.status}
-            {killCommand.status === "failed"
-              && typeof killCommand.result?.error === "string"
-              ? `: ${killCommand.result.error}`
-              : ""}
-            {killCommand.status === "completed" ? " — process killed" : ""}
-          </span>
-        )}
-      </div>
+      <Can action={PermissionAction.HostKillProcess}>
+        <div className="process-detail__kill">
+          <Button
+            variant="alert"
+            size="small"
+            onClick={handleKillProcess}
+            disabled={killDisabled}
+          >
+            Kill process
+          </Button>
+          {killCommand && (
+            <span className={`process-detail__cmd-status process-detail__cmd-status--${killCommand.status}`}>
+              {killCommand.status}
+              {killCommand.status === "failed"
+                && typeof killCommand.result?.error === "string"
+                ? `: ${killCommand.result.error}`
+                : ""}
+              {killCommand.status === "completed" ? " — process killed" : ""}
+            </span>
+          )}
+        </div>
+      </Can>
 
       {loading && <p className="process-detail__loading">Loading network data...</p>}
 

--- a/ui/src/components/ui/TopNav.test.tsx
+++ b/ui/src/components/ui/TopNav.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import type { ReactNode } from "react";
+
+import { TopNav } from "./TopNav";
+import { PermissionsProvider } from "../../permissions";
+import { PermissionAction } from "../../permissions-core";
+
+function renderNav(permissions: string[] | undefined, children: ReactNode = null) {
+  return render(
+    <MemoryRouter>
+      <PermissionsProvider permissions={permissions}>
+        <TopNav user={{ id: 1, email: "op@example.com" }} authMethod="oidc" onLogout={() => undefined} />
+        {children}
+      </PermissionsProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe("TopNav capability gating", () => {
+  // spec:web-ui/navigation-and-action-affordances-are-capability-gated/application-control-entry-hidden-without-read-access
+  it("hides the Application control entry without application_control.read", () => {
+    renderNav([PermissionAction.HostRead, PermissionAction.AlertRead]);
+    expect(screen.queryByRole("link", { name: "Application control" })).not.toBeInTheDocument();
+    // Entries the operator can reach still render.
+    expect(screen.getByRole("link", { name: "Hosts" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Alerts" })).toBeInTheDocument();
+  });
+
+  // spec:web-ui/navigation-and-action-affordances-are-capability-gated/application-control-entry-shown-with-read-access
+  it("shows the Application control entry with application_control.read", () => {
+    renderNav([PermissionAction.HostRead, PermissionAction.AlertRead, PermissionAction.AppControlRead]);
+    expect(screen.getByRole("link", { name: "Application control" })).toBeInTheDocument();
+  });
+
+  it("always shows the ungated Coverage entry", () => {
+    // Even an operator with an empty permission set sees Coverage (no gating action).
+    renderNav([]);
+    expect(screen.getByRole("link", { name: "Coverage" })).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "Hosts" })).not.toBeInTheDocument();
+  });
+
+  it("shows every entry optimistically when the permission set is unavailable", () => {
+    renderNav(undefined);
+    expect(screen.getByRole("link", { name: "Hosts" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Application control" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Coverage" })).toBeInTheDocument();
+  });
+});

--- a/ui/src/components/ui/TopNav.tsx
+++ b/ui/src/components/ui/TopNav.tsx
@@ -1,16 +1,23 @@
 import classnames from "classnames";
 import { Link, useLocation } from "react-router-dom";
 import "./TopNav.scss";
+import { useCan, PermissionAction } from "../../permissions-core";
 
 interface NavLink {
   to: string;
   label: string;
+  // action gates the entry on the operator's effective permission set: the entry is
+  // hidden when the action is absent. Undefined means the destination is not gated by
+  // a dedicated read action (wave-1 Coverage has no `coverage.read`), so it shows for
+  // every authenticated operator. Hiding is presentation only; the server still
+  // enforces every read on the destination surface.
+  action?: string;
 }
 
 const LINKS: NavLink[] = [
-  { to: "/", label: "Hosts" },
-  { to: "/alerts", label: "Alerts" },
-  { to: "/app-control", label: "Application control" },
+  { to: "/", label: "Hosts", action: PermissionAction.HostRead },
+  { to: "/alerts", label: "Alerts", action: PermissionAction.AlertRead },
+  { to: "/app-control", label: "Application control", action: PermissionAction.AppControlRead },
   { to: "/coverage", label: "Coverage" },
 ];
 
@@ -37,6 +44,11 @@ function authMethodLabel(authMethod?: string): string | null {
 
 export function TopNav({ user, authMethod, onLogout }: TopNavProps) {
   const location = useLocation();
+  const can = useCan();
+  // Hide nav entries the operator's role does not confer. An entry with no gating
+  // action (Coverage) always shows. Presentation only: the route guards + server
+  // still enforce access independently.
+  const visibleLinks = LINKS.filter((link) => link.action === undefined || can(link.action));
 
   return (
     <nav className="top-nav">
@@ -48,7 +60,7 @@ export function TopNav({ user, authMethod, onLogout }: TopNavProps) {
           </span>
         </div>
         <ul className="top-nav__links">
-          {LINKS.map((link) => {
+          {visibleLinks.map((link) => {
             const isActive = location.pathname === link.to
               || (link.to !== "/" && location.pathname.startsWith(link.to));
             return (

--- a/ui/src/dedupe.test.ts
+++ b/ui/src/dedupe.test.ts
@@ -11,8 +11,16 @@ function deferred() {
 }
 
 describe("createDedupedRunner", () => {
+  // tick yields a couple of microtasks so the deferred task invocation (the runner schedules task()
+  // via Promise.resolve().then(...)) and its finally have a chance to run before we assert.
+  const tick = async () => { await Promise.resolve(); await Promise.resolve(); };
+
+  // flush waits a macrotask, which drains the entire microtask chain (then -> catch -> finally)
+  // regardless of its length, so inFlight is guaranteed reset before the next run().
+  const flush = () => new Promise<void>((r) => { setTimeout(r, 0); });
+
   // spec:web-ui/authorization-denials-degrade-gracefully/simultaneous-denials-collapse-to-one-refetch
-  it("collapses concurrent invocations to a single in-flight run", () => {
+  it("collapses concurrent invocations to a single in-flight run", async () => {
     const d = deferred();
     const task = vi.fn(() => d.promise);
     const run = createDedupedRunner(task);
@@ -20,7 +28,10 @@ describe("createDedupedRunner", () => {
     run();
     run();
     run();
+    await tick();
 
+    // The dedup guard is set synchronously on the first call, so the 2nd and 3rd calls are dropped
+    // before they queue a task; only one invocation reaches task().
     expect(task).toHaveBeenCalledTimes(1);
   });
 
@@ -31,20 +42,36 @@ describe("createDedupedRunner", () => {
     const run = createDedupedRunner(task);
 
     run();
+    await tick();
     expect(task).toHaveBeenCalledTimes(1);
 
-    // A call mid-flight is dropped.
+    // A call mid-flight is dropped (first.promise is still pending).
     run();
+    await tick();
     expect(task).toHaveBeenCalledTimes(1);
 
     // Settle the first run; the in-flight window closes.
     first.resolve();
-    await Promise.resolve();
-    await Promise.resolve();
+    await tick();
 
     run();
+    await tick();
     expect(task).toHaveBeenCalledTimes(2);
     second.resolve();
+  });
+
+  it("reopens the window when the task throws synchronously", async () => {
+    const task = vi
+      .fn<() => Promise<void>>()
+      .mockImplementationOnce(() => { throw new Error("sync boom"); })
+      .mockResolvedValueOnce(undefined);
+    const run = createDedupedRunner(task);
+
+    run();
+    await flush(); // drains the throw -> catch -> finally chain so inFlight is reset
+    run();
+    await flush();
+    expect(task).toHaveBeenCalledTimes(2);
   });
 
   it("reopens the window even when the task rejects", async () => {
@@ -55,12 +82,9 @@ describe("createDedupedRunner", () => {
     const run = createDedupedRunner(task);
 
     run();
-    // Let the rejected promise settle through the .catch().finally() chain.
-    await Promise.resolve();
-    await Promise.resolve();
-    await Promise.resolve();
-
+    await flush(); // drains the reject -> catch -> finally chain so inFlight is reset
     run();
+    await flush();
     expect(task).toHaveBeenCalledTimes(2);
   });
 });

--- a/ui/src/dedupe.test.ts
+++ b/ui/src/dedupe.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi } from "vitest";
+
+import { createDedupedRunner } from "./dedupe";
+
+// deferred returns a promise plus its resolver so a test can hold a "run" open and
+// observe that concurrent invocations collapse to one.
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((r) => { resolve = r; });
+  return { promise, resolve };
+}
+
+describe("createDedupedRunner", () => {
+  // spec:web-ui/authorization-denials-degrade-gracefully/simultaneous-denials-collapse-to-one-refetch
+  it("collapses concurrent invocations to a single in-flight run", () => {
+    const d = deferred();
+    const task = vi.fn(() => d.promise);
+    const run = createDedupedRunner(task);
+
+    run();
+    run();
+    run();
+
+    expect(task).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows a new run once the previous one settles", async () => {
+    const first = deferred();
+    const second = deferred();
+    const task = vi.fn().mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise);
+    const run = createDedupedRunner(task);
+
+    run();
+    expect(task).toHaveBeenCalledTimes(1);
+
+    // A call mid-flight is dropped.
+    run();
+    expect(task).toHaveBeenCalledTimes(1);
+
+    // Settle the first run; the in-flight window closes.
+    first.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    run();
+    expect(task).toHaveBeenCalledTimes(2);
+    second.resolve();
+  });
+
+  it("reopens the window even when the task rejects", async () => {
+    const task = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("boom"))
+      .mockResolvedValueOnce(undefined);
+    const run = createDedupedRunner(task);
+
+    run();
+    // Let the rejected promise settle through the .catch().finally() chain.
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    run();
+    expect(task).toHaveBeenCalledTimes(2);
+  });
+});

--- a/ui/src/dedupe.ts
+++ b/ui/src/dedupe.ts
@@ -1,0 +1,23 @@
+// createDedupedRunner wraps an async task so that concurrent or rapid-fire
+// invocations collapse to a single in-flight run instead of a storm. While a run is
+// in progress, further calls are dropped; once it settles, the next call starts a
+// fresh run.
+//
+// It backs the permission-set refetch triggered by a server 403 (see App.tsx): when
+// several gated affordances on a page hit a 403 at once, the UI must issue at most one
+// /api/session refetch rather than one per denial (the throttle requirement in the
+// capability-gating spec). Errors from the task are swallowed here so a failed refetch
+// simply ends the in-flight window and lets a later call retry; the caller logs as
+// needed.
+export function createDedupedRunner(task: () => Promise<void>): () => void {
+  let inFlight = false;
+  return () => {
+    if (inFlight) return;
+    inFlight = true;
+    void task()
+      .catch(() => undefined)
+      .finally(() => {
+        inFlight = false;
+      });
+  };
+}

--- a/ui/src/dedupe.ts
+++ b/ui/src/dedupe.ts
@@ -14,7 +14,12 @@ export function createDedupedRunner(task: () => Promise<void>): () => void {
   return () => {
     if (inFlight) return;
     inFlight = true;
-    void task()
+    // Run the task inside Promise.resolve().then(...) so a SYNCHRONOUS throw (a task that
+    // raises before returning its promise) is caught by the same .catch/.finally chain.
+    // Without this, a sync throw would bypass finally and wedge inFlight=true forever,
+    // permanently dropping every later call.
+    void Promise.resolve()
+      .then(() => task())
       .catch(() => undefined)
       .finally(() => {
         inFlight = false;

--- a/ui/src/permissions-core.test.tsx
+++ b/ui/src/permissions-core.test.tsx
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+
+import { PermissionsProvider } from "./permissions";
+import { useCan, PermissionAction } from "./permissions-core";
+
+// wrapper builds a PermissionsProvider around the hook under test with the given
+// permission set (or undefined for "older server / optimistic").
+function wrapper(permissions: string[] | undefined) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <PermissionsProvider permissions={permissions}>{children}</PermissionsProvider>;
+  };
+}
+
+describe("useCan", () => {
+  it("grants only actions in the permission set", () => {
+    const { result } = renderHook(() => useCan(), {
+      wrapper: wrapper([PermissionAction.HostRead, PermissionAction.AlertRead]),
+    });
+    expect(result.current(PermissionAction.HostRead)).toBe(true);
+    expect(result.current(PermissionAction.AlertRead)).toBe(true);
+    expect(result.current(PermissionAction.HostKillProcess)).toBe(false);
+    expect(result.current(PermissionAction.AppControlRead)).toBe(false);
+  });
+
+  it("denies everything when the set is empty", () => {
+    const { result } = renderHook(() => useCan(), { wrapper: wrapper([]) });
+    expect(result.current(PermissionAction.HostRead)).toBe(false);
+    expect(result.current(PermissionAction.HostKillProcess)).toBe(false);
+  });
+
+  it("grants everything optimistically when the set is unavailable (older server)", () => {
+    const { result } = renderHook(() => useCan(), { wrapper: wrapper(undefined) });
+    expect(result.current(PermissionAction.HostKillProcess)).toBe(true);
+    expect(result.current("anything.at.all")).toBe(true);
+  });
+});

--- a/ui/src/permissions-core.ts
+++ b/ui/src/permissions-core.ts
@@ -1,0 +1,47 @@
+import { createContext, useCallback, useContext, useMemo } from "react";
+
+// Capability seam core: the permission context, the useCan hook, and the action
+// identifiers. The React components that consume these (PermissionsProvider, Can,
+// RequirePermission) live in permissions.tsx. The split keeps that .tsx exporting only
+// components so react-refresh fast-refresh stays happy; the non-component exports
+// (hook + constants + context) live here.
+//
+// This is PRESENTATION ONLY. The authorization chokepoint on the server remains the
+// sole security boundary (ADR-0012): a wrong or stale permission set can only change
+// what the UI shows, never what the server allows. The UI holds NO mapping from role
+// names to actions; it reads only the flat, server-computed action set, whose
+// identifiers are the same strings the chokepoint enforces and the audit log records.
+
+// PermissionAction collects the action identifiers the UI gates on, so call sites use
+// a checked constant instead of a bare string literal. It is a subset of the server's
+// full action registry: only actions that gate a visible affordance need an entry.
+export const PermissionAction = {
+  HostRead: "host.read",
+  AlertRead: "alert.read",
+  AlertComment: "alert.comment",
+  AlertAcknowledge: "alert.acknowledge",
+  AlertResolve: "alert.resolve",
+  AlertReopen: "alert.reopen",
+  HostKillProcess: "host.kill_process",
+  AppControlRead: "application_control.read",
+} as const;
+
+export type PermissionActionValue = (typeof PermissionAction)[keyof typeof PermissionAction];
+
+// The context value is the effective action set, or undefined when the server did not
+// return one (an older server predating the permissions field). undefined means
+// "render optimistically": can() returns true for everything and the UI leans on the
+// server's 403 + graceful-denial path. An empty array means "this operator may do
+// nothing" and gates everything off.
+export const PermissionsContext = createContext<readonly string[] | undefined>(undefined);
+
+// useCan returns a stable predicate over the operator's effective permission set. When
+// the set is unknown (undefined) it returns true for every action so an older server
+// degrades to the pre-gating behaviour; the server still enforces.
+export function useCan(): (action: string) => boolean {
+  const perms = useContext(PermissionsContext);
+  // Memoize the lookup set (data, not a closure) so the predicate below stays stable
+  // across renders while perms is unchanged. null means "unknown set" -> optimistic.
+  const set = useMemo(() => (perms === undefined ? null : new Set(perms)), [perms]);
+  return useCallback((action: string) => set === null || set.has(action), [set]);
+}

--- a/ui/src/permissions.test.tsx
+++ b/ui/src/permissions.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+
+import { Can, RequirePermission, PermissionsProvider } from "./permissions";
+import { PermissionAction } from "./permissions-core";
+
+// wrapper builds a PermissionsProvider around a component under test with the given
+// permission set (or undefined for "older server / optimistic").
+function wrapper(permissions: string[] | undefined) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <PermissionsProvider permissions={permissions}>{children}</PermissionsProvider>;
+  };
+}
+
+describe("Can", () => {
+  // spec:web-ui/navigation-and-action-affordances-are-capability-gated/kill-process-control-shown-with-the-action
+  it("renders children when the action is permitted", () => {
+    render(
+      <Can action={PermissionAction.HostKillProcess}>
+        <button type="button">Kill process</button>
+      </Can>,
+      { wrapper: wrapper([PermissionAction.HostKillProcess]) },
+    );
+    expect(screen.getByRole("button", { name: "Kill process" })).toBeInTheDocument();
+  });
+
+  // spec:web-ui/navigation-and-action-affordances-are-capability-gated/kill-process-control-hidden-without-the-action
+  it("hides children (renders fallback) when the action is not permitted", () => {
+    render(
+      <Can action={PermissionAction.HostKillProcess} fallback={<span>nope</span>}>
+        <button type="button">Kill process</button>
+      </Can>,
+      { wrapper: wrapper([PermissionAction.HostRead]) },
+    );
+    expect(screen.queryByRole("button", { name: "Kill process" })).not.toBeInTheDocument();
+    expect(screen.getByText("nope")).toBeInTheDocument();
+  });
+});
+
+describe("RequirePermission", () => {
+  it("renders the guarded surface when permitted", () => {
+    render(
+      <RequirePermission action={PermissionAction.AppControlRead} surface="Application control">
+        <div>secret surface</div>
+      </RequirePermission>,
+      { wrapper: wrapper([PermissionAction.AppControlRead]) },
+    );
+    expect(screen.getByText("secret surface")).toBeInTheDocument();
+    expect(screen.queryByText(/don't have access/i)).not.toBeInTheDocument();
+  });
+
+  // spec:web-ui/authorization-denials-degrade-gracefully/deep-link-to-a-gated-surface-shows-a-no-access-state
+  it("renders a no-access state instead of the surface when not permitted", () => {
+    render(
+      <RequirePermission action={PermissionAction.AppControlRead} surface="Application control">
+        <div>secret surface</div>
+      </RequirePermission>,
+      { wrapper: wrapper([PermissionAction.HostRead]) },
+    );
+    expect(screen.queryByText("secret surface")).not.toBeInTheDocument();
+    expect(screen.getByText(/don't have access/i)).toBeInTheDocument();
+    expect(screen.getByText(/Application control/)).toBeInTheDocument();
+    // The raw transport error must never be what the operator sees.
+    expect(screen.queryByText(/API error: 403/)).not.toBeInTheDocument();
+  });
+});

--- a/ui/src/permissions.tsx
+++ b/ui/src/permissions.tsx
@@ -1,0 +1,52 @@
+import { type ReactNode } from "react";
+
+import { NoAccess } from "./components/NoAccess";
+import { PermissionsContext, useCan } from "./permissions-core";
+
+// React components for the capability seam. The hook (useCan), the action constants
+// (PermissionAction), and the context live in permissions-core.ts; this file exports
+// only components so react-refresh fast-refresh works. See permissions-core.ts and
+// ADR-0012 for the model. Gating here is presentation only; the server's authorization
+// chokepoint remains the sole security boundary.
+
+interface PermissionsProviderProps {
+  readonly permissions: readonly string[] | undefined;
+  readonly children: ReactNode;
+}
+
+export function PermissionsProvider({ permissions, children }: PermissionsProviderProps) {
+  return <PermissionsContext.Provider value={permissions}>{children}</PermissionsContext.Provider>;
+}
+
+interface CanProps {
+  readonly action: string;
+  readonly children: ReactNode;
+  // fallback renders when the action is not permitted. Defaults to nothing (the
+  // affordance simply disappears), which is the right behaviour for buttons + nav.
+  readonly fallback?: ReactNode;
+}
+
+// Can renders its children only when the operator's permission set includes the
+// action. Use for inline affordances (buttons, nav entries). For whole-surface
+// gating prefer RequirePermission, which renders a no-access state on a deep-link.
+export function Can({ action, children, fallback = null }: CanProps) {
+  const can = useCan();
+  return <>{can(action) ? children : fallback}</>;
+}
+
+interface RequirePermissionProps {
+  readonly action: string;
+  // surface is the human label passed to NoAccess when access is denied.
+  readonly surface?: string;
+  readonly children: ReactNode;
+}
+
+// RequirePermission guards a whole route/surface. When the operator's permission set
+// includes the action it renders the children; otherwise it renders the NoAccess
+// state. This is what turns a direct navigation to a gated route (where the nav entry
+// is already hidden) into a friendly no-access page instead of a raw API error.
+export function RequirePermission({ action, surface, children }: RequirePermissionProps) {
+  const can = useCan();
+  if (!can(action)) return <NoAccess surface={surface} />;
+  return <>{children}</>;
+}


### PR DESCRIPTION
<!-- Keep this short. Delete sections that do not apply. -->

## What & why



## Checklist

- [ ] **OpenSpec updated for behavior changes.** If this PR changes observable behavior (a detection rule, the event
      wire schema, persistence semantics, an API/wire shape, or an emitted event), `openspec/specs/**` is updated (and
      an `openspec/changes/` proposal added), with a `spec:<id>` test marker for any new/renamed scenario. Only if this
      PR changes NO observable behavior (a comment / refactor / gofmt / dep bump that happens to touch a scoped path)
      may you assert `no-behavior-change` (label or `[no-behavior-change]` in the title) to clear the OpenSpec-sync gate.
      That is an assertion a reviewer will check, not a way to skip the spec for a real behavior change.
- [ ] Tests added/updated for the change (unit / integration / efficacy / UI as applicable).
- [ ] Agent/extension change touching ESF, XPC, or the event wire format: exercised on a live macOS VM before RC
      (flagged below).

## VM / RC notes (if applicable)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Quick start updated: local UI now served over HTTPS with instructions for exercising local OIDC sign-in.
  * Added ADR, design, spec, tasks and authz docs describing capability-based UI gating and session permission semantics.
* **New Features**
  * UI now receives and uses a session permission set to hide/show navigation and action controls.
  * Friendly "No access" screens shown on denied actions instead of raw errors.
* **Tests**
  * Added unit and integration tests covering permission resolution, gating, and refetch-on-denial behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->