### PR TITLE
Bump Go to 1.26.4 to patch stdlib advisories GO-2026-5037/5038/5039

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -8,7 +8,7 @@
 # Bumping a version here is the single source of truth; update the CI
 # workflow at the same time (workflows use `go-version-file: go.mod` where
 # possible, which already tracks this file's Go pin via go.mod).
-golang 1.26.3
+golang 1.26.4
 nodejs 22.21.0
 golangci-lint 2.11.3
 lefthook 1.8.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/fleetdm/edr
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/XSAM/otelsql v0.42.0

--- a/tools/comment-wrap-check/lint/go.mod
+++ b/tools/comment-wrap-check/lint/go.mod
@@ -10,7 +10,7 @@
 // and the golangci-lint plugin registrar.
 module github.com/fleetdm/edr/tools/comment-wrap-check/lint
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/golangci/plugin-module-register v0.1.2


### PR DESCRIPTION
osv-scanner fails the PR: the go directive pins 1.26.3, whose stdlib carries GO-2026-5037, GO-2026-5038, and GO-2026-5039 (all fixed in 1.26.4), flagged in both go.mod and tools/comment-wrap-check/lint/go.mod. The govulncheck code-analysis step in the same job also could not load packages because the action's toolchain couldn't satisfy the go directive.

Bump the go directive in both modules and the .tool-versions golang pin to 1.26.4. CI workflows read the version via go-version-file: go.mod, so they follow automatically. Verified locally: both modules build under the auto-resolved 1.26.4 toolchain and govulncheck reports no vulnerabilities in either.

<!-- Keep this short. Delete sections that do not apply. -->

## What & why



## Checklist

- [ ] **OpenSpec updated for behavior changes.** If this PR changes observable behavior (a detection rule, the event
      wire schema, persistence semantics, an API/wire shape, or an emitted event), `openspec/specs/**` is updated (and
      an `openspec/changes/` proposal added), with a `spec:<id>` test marker for any new/renamed scenario. Only if this
      PR changes NO observable behavior (a comment / refactor / gofmt / dep bump that happens to touch a scoped path)
      may you assert `no-behavior-change` (label or `[no-behavior-change]` in the title) to clear the OpenSpec-sync gate.
      That is an assertion a reviewer will check, not a way to skip the spec for a real behavior change.
- [ ] Tests added/updated for the change (unit / integration / efficacy / UI as applicable).
- [ ] Agent/extension change touching ESF, XPC, or the event wire format: exercised on a live macOS VM before RC
      (flagged below).

## VM / RC notes (if applicable)


