### PR TITLE
Changed MySQL ports

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,12 +104,12 @@ ADR-0004 carved `server/` into five bounded contexts: `identity`, `endpoint`,
 
 ## Dev environment
 
-- Local MySQL: `task db:up` brings up `127.0.0.1:3316` (dev) and `:3317` (test).
+- Local MySQL: `task db:up` brings up `127.0.0.1:33306` (dev) and `:33307` (test).
   Empty password (`MYSQL_ALLOW_EMPTY_PASSWORD=yes` in `docker-compose.yml`).
 - Dev server: `task dev:server` listens on `127.0.0.1:8088` against
-  `127.0.0.1:3316/edr`. Real-tool QA must use this; never fall back to curl
+  `127.0.0.1:33306/edr`. Real-tool QA must use this; never fall back to curl
   or unit tests when the user asks for a Chrome / VM / dev-server check.
-- Test DSN: `EDR_TEST_DSN=root@tcp(127.0.0.1:3317)/edr_test?parseTime=true`.
+- Test DSN: `EDR_TEST_DSN=root@tcp(127.0.0.1:33307)/edr_test?parseTime=true`.
 
 ## Coverage gates
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ If a linter disagrees with a specific change, prefer fixing the code over disabl
 ## Tests
 
 Run `task test` before pushing. Targeted runs: `task test:go`, `task test:ui`. Use subtests (`t.Run`) and table-driven cases
-in Go. Integration tests hit a real MySQL on port 3317; do not mock the database in store-layer tests.
+in Go. Integration tests hit a real MySQL on port 33307; do not mock the database in store-layer tests.
 
 Coverage is measured by SonarCloud; the new-code coverage gate is 80%. PRs that add code without adding tests will fail the
 gate.

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ task --list
 ## Quick start
 
 ```bash
-# Start MySQL (local dev + test on ports 3316/3317)
+# Start MySQL (local dev + test on ports 33306/33307)
 task db:up
 
 # Build the UI (embedded in the server binary via server/ui/dist/)

--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@
 
 <!-- Build & quality -->
 ![Go version](https://img.shields.io/github/go-mod/go-version/getvictor/fleet-edr?filename=go.mod&style=flat-square)
-[![Tests](https://img.shields.io/github/actions/workflow/status/getvictor/fleet-edr/test.yml?branch=main&label=tests&style=flat-square)](https://github.com/getvictor/fleet-edr/actions/workflows/test.yml)
+[![Tests](https://github.com/getvictor/fleet-edr/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/getvictor/fleet-edr/actions/workflows/test.yml)
 [![Quality Gate](https://sonarcloud.io/api/project_badges/measure?project=getvictor_fleet-edr&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=getvictor_fleet-edr)
 [![Coverage](https://img.shields.io/codecov/c/github/getvictor/fleet-edr?style=flat-square&logo=codecov)](https://codecov.io/gh/getvictor/fleet-edr)
 
 <!-- Security scanners -->
-[![CodeQL](https://img.shields.io/github/actions/workflow/status/getvictor/fleet-edr/codeql.yml?branch=main&label=CodeQL&style=flat-square)](https://github.com/getvictor/fleet-edr/actions/workflows/codeql.yml)
-[![govulncheck](https://img.shields.io/github/actions/workflow/status/getvictor/fleet-edr/go-vulncheck.yml?branch=main&label=govulncheck&style=flat-square)](https://github.com/getvictor/fleet-edr/actions/workflows/go-vulncheck.yml)
-[![OSV-Scanner](https://img.shields.io/github/actions/workflow/status/getvictor/fleet-edr/osv-scanner.yml?branch=main&label=OSV-Scanner&style=flat-square)](https://github.com/getvictor/fleet-edr/actions/workflows/osv-scanner.yml)
+[![CodeQL](https://github.com/getvictor/fleet-edr/actions/workflows/codeql.yml/badge.svg?branch=main)](https://github.com/getvictor/fleet-edr/actions/workflows/codeql.yml)
+[![govulncheck](https://github.com/getvictor/fleet-edr/actions/workflows/go-vulncheck.yml/badge.svg?branch=main)](https://github.com/getvictor/fleet-edr/actions/workflows/go-vulncheck.yml)
+[![OSV-Scanner](https://github.com/getvictor/fleet-edr/actions/workflows/osv-scanner.yml/badge.svg?branch=main)](https://github.com/getvictor/fleet-edr/actions/workflows/osv-scanner.yml)
 
 <!-- Supply chain -->
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12994/badge)](https://www.bestpractices.dev/projects/12994)

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -147,11 +147,11 @@ tasks:
     desc: |
       Run Go tests with race detector (server + agent + internal). Uses
       $EDR_TEST_DSN from the environment if set; otherwise defaults to the
-      docker-compose mysql_test service on port 3317 (see db:up). Pointing at
-      the dev DB on 3316 by accident is a common foot-gun because dev tests
+      docker-compose mysql_test service on port 33307 (see db:up). Pointing at
+      the dev DB on 33306 by accident is a common foot-gun because dev tests
       truncate tables. CI sets its own DSN.
     env:
-      EDR_TEST_DSN: '{{.EDR_TEST_DSN | default "root@tcp(127.0.0.1:3317)/edr_test?parseTime=true"}}'
+      EDR_TEST_DSN: '{{.EDR_TEST_DSN | default "root@tcp(127.0.0.1:33307)/edr_test?parseTime=true"}}'
     cmds:
       - go test -race -count=1 -timeout=10m ./server/... ./agent/... ./internal/...
 
@@ -203,13 +203,13 @@ tasks:
   test:go:server:
     desc: |
       Run Go tests with race detector for the server + shared code. Requires
-      $EDR_TEST_DSN set or the docker-compose mysql_test on port 3317.
+      $EDR_TEST_DSN set or the docker-compose mysql_test on port 33307.
 
       Runs WITHOUT the integration build tag so the layer-2 + layer-3 tests
       (`server/<X>/internal/tests/`, `test/integration/`) are excluded; for
       those use test:go:server:integration.
     env:
-      EDR_TEST_DSN: '{{.EDR_TEST_DSN | default "root@tcp(127.0.0.1:3317)/edr_test?parseTime=true"}}'
+      EDR_TEST_DSN: '{{.EDR_TEST_DSN | default "root@tcp(127.0.0.1:33307)/edr_test?parseTime=true"}}'
     cmds:
       - go test -race -count=1 -timeout=10m ./server/... ./internal/...
 
@@ -219,7 +219,7 @@ tasks:
       under server/<X>/internal/tests/ + layer-3 cross-context tests under
       test/integration/). Requires a real MySQL via $EDR_TEST_DSN.
     env:
-      EDR_TEST_DSN: '{{.EDR_TEST_DSN | default "root@tcp(127.0.0.1:3317)/edr_test?parseTime=true"}}'
+      EDR_TEST_DSN: '{{.EDR_TEST_DSN | default "root@tcp(127.0.0.1:33307)/edr_test?parseTime=true"}}'
     cmds:
       - go test -race -count=1 -timeout=10m -tags=integration ./server/... ./internal/... ./test/integration/...
 
@@ -243,7 +243,7 @@ tasks:
       the same tests are picked up automatically by test:go:server:integration
       under the recursive ./test/integration/... glob on the ubuntu runner.
     env:
-      EDR_TEST_DSN: '{{.EDR_TEST_DSN | default "root@tcp(127.0.0.1:3317)/edr_test?parseTime=true"}}'
+      EDR_TEST_DSN: '{{.EDR_TEST_DSN | default "root@tcp(127.0.0.1:33307)/edr_test?parseTime=true"}}'
       CGO_ENABLED: 0
     cmds:
       - go test -count=1 -timeout=5m -tags=integration ./test/integration/agentserver/...
@@ -264,7 +264,7 @@ tasks:
       Nightly CI runs this via .github/workflows/efficacy.yml; this task is
       for local iteration.
     env:
-      EDR_TEST_DSN: '{{.EDR_TEST_DSN | default "root@tcp(127.0.0.1:3317)/edr_test?parseTime=true"}}'
+      EDR_TEST_DSN: '{{.EDR_TEST_DSN | default "root@tcp(127.0.0.1:33307)/edr_test?parseTime=true"}}'
       CGO_ENABLED: 0
     cmds:
       - go test -count=1 -timeout=5m -tags=integration ./test/efficacy/...
@@ -332,7 +332,7 @@ tasks:
       cross-package coverage attribution; without that, the bootstrap.go and
       service.go files (which the integration tests exercise) would report 0%.
     env:
-      EDR_TEST_DSN: '{{.EDR_TEST_DSN | default "root@tcp(127.0.0.1:3317)/edr_test?parseTime=true"}}'
+      EDR_TEST_DSN: '{{.EDR_TEST_DSN | default "root@tcp(127.0.0.1:33307)/edr_test?parseTime=true"}}'
     cmds:
       # -coverpkg=./server/...,./internal/... attributes coverage from one
       # package's tests back to symbols in any other package they exercise.
@@ -622,7 +622,7 @@ tasks:
       serve the embedded copy.
     deps: [dev:certs]
     env:
-      EDR_DSN: "root:@tcp(127.0.0.1:3316)/edr?parseTime=true"
+      EDR_DSN: "root:@tcp(127.0.0.1:33306)/edr?parseTime=true"
       EDR_ENROLL_SECRET: dev-enroll-secret
       EDR_TLS_CERT_FILE: tmp/dev.crt
       EDR_TLS_KEY_FILE: tmp/dev.key
@@ -711,12 +711,12 @@ tasks:
       DESTRUCTIVE: drop the dev database and recreate empty. Requires explicit
       confirmation (Taskfile's prompt:). Use only when the schema is out of
       sync with current migrations; routine dev never needs this.
-      Credentials match the dev:server DSN (root, empty password, port 3316);
+      Credentials match the dev:server DSN (root, empty password, port 33306);
       see the dev:server desc for why the password is empty (matches docker-compose
       MYSQL_ALLOW_EMPTY_PASSWORD=yes; a `-ptoor` invocation produces access-denied).
     prompt: About to DROP DATABASE edr. Continue?
     cmds:
-      - mysql -uroot -h127.0.0.1 -P3316 -e "DROP DATABASE IF EXISTS edr; CREATE DATABASE edr CHARACTER SET utf8mb4;"
+      - mysql -uroot -h127.0.0.1 -P33306 -e "DROP DATABASE IF EXISTS edr; CREATE DATABASE edr CHARACTER SET utf8mb4;"
 
   db:backup:
     desc: |
@@ -733,7 +733,7 @@ tasks:
       - mkdir -p tmp
       - |
         OUT="tmp/edr-dev-$(date +%Y%m%d-%H%M%S).sql.gz"
-        mysqldump -uroot -h127.0.0.1 -P3316 \
+        mysqldump -uroot -h127.0.0.1 -P33306 \
           --single-transaction --routines --triggers \
           edr | gzip > "$OUT"
         echo "wrote $OUT ($(du -h "$OUT" | cut -f1))"
@@ -759,7 +759,7 @@ tasks:
       - sh: 'test -f "{{.BACKUP_FILE}}"'
         msg: 'BACKUP_FILE not found: {{.BACKUP_FILE}}'
     cmds:
-      - mysql -uroot -h127.0.0.1 -P3316 -e "DROP DATABASE IF EXISTS edr; CREATE DATABASE edr CHARACTER SET utf8mb4;"
+      - mysql -uroot -h127.0.0.1 -P33306 -e "DROP DATABASE IF EXISTS edr; CREATE DATABASE edr CHARACTER SET utf8mb4;"
       - |
         # gzip -dcf works on both macOS and Linux: -d decompresses,
         # -c streams to stdout, -f passes plaintext through
@@ -767,8 +767,8 @@ tasks:
         # so the task runs the same on Debian/Ubuntu (where /bin/sh
         # is dash and doesn't grok [[ ]]) as it does on macOS bash.
         case "{{.BACKUP_FILE}}" in
-          *.gz) gzip -dcf "{{.BACKUP_FILE}}" | mysql -uroot -h127.0.0.1 -P3316 edr ;;
-          *)    mysql -uroot -h127.0.0.1 -P3316 edr < "{{.BACKUP_FILE}}" ;;
+          *.gz) gzip -dcf "{{.BACKUP_FILE}}" | mysql -uroot -h127.0.0.1 -P33306 edr ;;
+          *)    mysql -uroot -h127.0.0.1 -P33306 edr < "{{.BACKUP_FILE}}" ;;
         esac
         echo "restored edr from {{.BACKUP_FILE}}"
 
@@ -821,7 +821,7 @@ tasks:
       config/dex/dev-config.yaml's redirectURIs list mirrors that.
     deps: [dev:certs]
     env:
-      EDR_DSN: "root:@tcp(127.0.0.1:3316)/edr?parseTime=true"
+      EDR_DSN: "root:@tcp(127.0.0.1:33306)/edr?parseTime=true"
       EDR_ENROLL_SECRET: dev-enroll-secret
       EDR_TLS_CERT_FILE: tmp/dev.crt
       EDR_TLS_KEY_FILE: tmp/dev.key

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-# Local dev MySQL. Ports 3316/3317 avoid conflicts with other local MySQL instances.
+# Local dev MySQL. Ports 33306/33307 avoid conflicts with other local MySQL instances.
 # Server and ingest CLI defaults match these ports.
 services:
   mysql:
@@ -10,7 +10,7 @@ services:
     # Cap binlog retention at 1 day. Default is 30 days
     command: ["--binlog-expire-logs-seconds=86400"]
     ports:
-      - "127.0.0.1:3316:3306"
+      - "127.0.0.1:33306:3306"
     volumes:
       - edr-mysql-data:/var/lib/mysql
     healthcheck:
@@ -30,7 +30,7 @@ services:
     # same via `SET GLOBAL` since the GHA service container has no volume mount.
     command: ["--max-connections=500"]
     ports:
-      - "127.0.0.1:3317:3306"
+      - "127.0.0.1:33307:3306"
     healthcheck:
       test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
       interval: 5s

--- a/docs/adr/0005-mysql-only-data-plane.md
+++ b/docs/adr/0005-mysql-only-data-plane.md
@@ -62,7 +62,7 @@ Three demands push back on MySQL-only:
 The data plane runs on MySQL 8.4 only. There is no abstraction layer over
 the SQL dialect: stores use raw MySQL features (`FOR UPDATE SKIP LOCKED`,
 duplicate-error swallowing, `parseTime=true`, the docker-compose
-`mysql_test` service on port 3317 for integration tests). The reference
+`mysql_test` service on port 33307 for integration tests). The reference
 deployment is the `mysql:8.4` image from the official Docker library, run
 either as a sidecar container or as a managed service (RDS, CloudSQL,
 Aurora MySQL-compatible) keyed off `EDR_DSN`.
@@ -83,7 +83,7 @@ the EDR's primary store stays MySQL.
   `FOR UPDATE SKIP LOCKED` claim pattern, and the `parseTime=true`
   invariant are all MySQL-specific and only have to be right in one place.
 - Test infrastructure is single-shape: `testdb/full.Open` against a real
-  MySQL on `127.0.0.1:3317` is the integration-test seam, with parallel
+  MySQL on `127.0.0.1:33307` is the integration-test seam, with parallel
   schema isolation. No matrix builds across RDBMSes.
 - Operators get a predictable upgrade path within MySQL 8.x; the team
   audits one stream of CVEs and one set of breaking-change notes.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -294,14 +294,14 @@ XPC peer validation to work at the kernel level.
 # Start MySQL
 docker compose up mysql -d
 
-# Build and run the server (port 3316 for MySQL)
+# Build and run the server (port 33306 for MySQL)
 cd ui && npm run build && cd ..
-go run ./server/cmd/fleet-edr-server/ -dsn "root@tcp(127.0.0.1:3316)/edr?parseTime=true"
+go run ./server/cmd/fleet-edr-server/ -dsn "root@tcp(127.0.0.1:33306)/edr?parseTime=true"
 
 # Open http://localhost:8088/ui/
 
 # Run tests
-EDR_TEST_DSN="root@tcp(127.0.0.1:3316)/edr_test?parseTime=true" go test ./server/...
+EDR_TEST_DSN="root@tcp(127.0.0.1:33306)/edr_test?parseTime=true" go test ./server/...
 go test ./agent/... ./internal/...
 ```
 

--- a/scripts/test-e2e-coverage.sh
+++ b/scripts/test-e2e-coverage.sh
@@ -52,7 +52,7 @@ COV_OUT="$REPO_ROOT/coverage-server-e2e.out"
 # The covered binary refuses to boot without EDR_TLS_CERT_FILE + EDR_TLS_KEY_FILE.
 task dev:certs > /dev/null
 COMMON_ENV=(
-  EDR_DSN="root:@tcp(127.0.0.1:3316)/edr?parseTime=true"
+  EDR_DSN="root:@tcp(127.0.0.1:33306)/edr?parseTime=true"
   EDR_ENROLL_SECRET=dev-enroll-secret
   EDR_TLS_CERT_FILE="$REPO_ROOT/tmp/dev.crt"
   EDR_TLS_KEY_FILE="$REPO_ROOT/tmp/dev.key"

--- a/server/bootstrap/db.go
+++ b/server/bootstrap/db.go
@@ -16,7 +16,7 @@ import (
 // calls this once and shares the returned handle across every
 // bounded context's bootstrap so all contexts share one connection
 // budget. The dsn should be in go-sql-driver/mysql format, e.g.
-// "user:pass@tcp(127.0.0.1:3316)/edr?parseTime=true". parseTime=true
+// "user:pass@tcp(127.0.0.1:33306)/edr?parseTime=true". parseTime=true
 // is appended automatically when missing.
 //
 // The connection pool lives in the platform bootstrap package because

--- a/server/testdb/open.go
+++ b/server/testdb/open.go
@@ -83,7 +83,7 @@ func getAdminPool(baseDSN string) (*sqlx.DB, error) {
 // is the canonical fixture for cross-context integration tests.
 //
 // Requires EDR_TEST_DSN to be set (e.g.
-// "root:@tcp(127.0.0.1:3316)/edr_test?parseTime=true"). The database
+// "root:@tcp(127.0.0.1:33306)/edr_test?parseTime=true"). The database
 // name in the DSN is used only to connect initially; the test runs
 // against its own temporary database.
 //

--- a/test/e2e/fixtures/db.ts
+++ b/test/e2e/fixtures/db.ts
@@ -2,11 +2,11 @@ import * as crypto from "node:crypto";
 import mysql, { Connection } from "mysql2/promise";
 
 // Dev DB matches Taskfile's dev:server* env block: root user, empty
-// password, port 3316. Keep this constant in sync with
+// password, port 33306. Keep this constant in sync with
 // Taskfile.yml's EDR_DSN.
 const DEV_DSN = {
   host: "127.0.0.1",
-  port: 3316,
+  port: 33306,
   user: "root",
   password: "",
   database: "edr",


### PR DESCRIPTION
<!-- Keep this short. Delete sections that do not apply. -->

## What & why



## Checklist

- [ ] **OpenSpec updated for behavior changes.** If this PR changes observable behavior (a detection rule, the event
      wire schema, persistence semantics, an API/wire shape, or an emitted event), `openspec/specs/**` is updated (and
      an `openspec/changes/` proposal added), with a `spec:<id>` test marker for any new/renamed scenario. Only if this
      PR changes NO observable behavior (a comment / refactor / gofmt / dep bump that happens to touch a scoped path)
      may you assert `no-behavior-change` (label or `[no-behavior-change]` in the title) to clear the OpenSpec-sync gate.
      That is an assertion a reviewer will check, not a way to skip the spec for a real behavior change.
- [ ] Tests added/updated for the change (unit / integration / efficacy / UI as applicable).
- [ ] Agent/extension change touching ESF, XPC, or the event wire format: exercised on a live macOS VM before RC
      (flagged below).

## VM / RC notes (if applicable)


