### PR TITLE
Add fleet-edr-demo-seed for the Mac-free docker demo (PR 1)

### DIFF
--- a/server/Dockerfile.demo-seed
+++ b/server/Dockerfile.demo-seed
@@ -1,0 +1,51 @@
+# syntax=docker/dockerfile:1.7
+
+# Build for the fleet-edr-demo-seed one-shot seeder used by docker-compose.demo.yml.
+#
+# Stage 1 (build): Go compiles the seeder. It is pure Go (go-sql-driver/mysql is
+# CGo-free) so the final image lands on distroless/static. The seeder imports
+# test/fakeagent for scenario replay, so the test/ tree is part of the build
+# context (alongside server/ + internal/ + the module graph).
+#
+# Stage 2 (runtime): distroless/static-debian12:nonroot, no shell, no package
+# manager. The container runs once to seed a freshly-booted demo server and exits.
+#
+# Built for linux/amd64 and linux/arm64 via `docker buildx --platform`. Image
+# digests are pinned alongside the human-readable tag for OpenSSF Scorecard's
+# Pinned-Dependencies check; Dependabot keeps them current.
+
+# ---------------------------------------------------------------
+# Stage 1: Go binary
+# ---------------------------------------------------------------
+FROM --platform=$BUILDPLATFORM golang:1.26.4@sha256:68cb6d68bed024785b69195b89af7ac7a444f27791435f98647edff595aa0479 AS build
+ARG TARGETOS
+ARG TARGETARCH
+
+WORKDIR /src
+
+# Explicit copies bound the build context to what the seeder needs: the module
+# graph, the seeder package (under server/), shared helpers, and test/fakeagent.
+COPY go.mod go.sum ./
+COPY server ./server
+COPY internal ./internal
+COPY test ./test
+
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS="${TARGETOS}" GOARCH="${TARGETARCH}" \
+    go build \
+        -trimpath \
+        -ldflags "-s -w" \
+        -o /out/fleet-edr-demo-seed \
+        ./server/cmd/fleet-edr-demo-seed
+
+# ---------------------------------------------------------------
+# Stage 2: runtime
+# ---------------------------------------------------------------
+FROM gcr.io/distroless/static-debian12:nonroot@sha256:d093aa3e30dbadd3efe1310db061a14da60299baff8450a17fe0ccc514a16639
+
+COPY --from=build /out/fleet-edr-demo-seed /usr/local/bin/fleet-edr-demo-seed
+
+USER nonroot:nonroot
+
+ENTRYPOINT ["/usr/local/bin/fleet-edr-demo-seed"]

--- a/server/cmd/fleet-edr-demo-seed/config.go
+++ b/server/cmd/fleet-edr-demo-seed/config.go
@@ -4,15 +4,18 @@ import (
 	"errors"
 	"flag"
 	"strconv"
+	"strings"
 	"time"
 )
 
 // Default timing knobs. The ready window covers MySQL warmup + migrations on first boot; the verify window covers the processor
-// interval plus enroll/ingest round-trips.
+// interval plus enroll/ingest round-trips. defaultHeadroom is the extra budget the overall run context allows beyond
+// ready+verify for the enroll/ingest round-trips themselves.
 const (
 	defaultReadyTimeout  = 90 * time.Second
 	defaultVerifyTimeout = 60 * time.Second
 	defaultPollInterval  = 500 * time.Millisecond
+	defaultHeadroom      = 30 * time.Second
 )
 
 // config is the resolved set of knobs the seeder reads. Every field has an env-var default so the binary runs with zero flags inside
@@ -21,7 +24,7 @@ type config struct {
 	serverURL    string
 	enrollSecret string
 	dsn          string
-	insecure     bool
+	caCertPath   string
 	force        bool
 
 	// demoOIDCSubject is the dex-issued OIDC subject for the SSO demo user. Empty (the default) disables the demo-user seed entirely,
@@ -46,8 +49,8 @@ func resolveConfig(getenv func(string) string, args []string) (config, error) {
 		"enrollment secret the server was started with")
 	fs.StringVar(&c.dsn, "dsn", envOr(getenv, "EDR_DSN", ""),
 		"MySQL DSN used to verify materialised demo data and seed the SSO demo user")
-	fs.BoolVar(&c.insecure, "insecure", envBool(getenv, "EDR_DEMO_INSECURE", true),
-		"skip TLS verification (the demo stack serves a self-signed localhost cert)")
+	fs.StringVar(&c.caCertPath, "ca-cert", envOr(getenv, "EDR_DEMO_CA_CERT", ""),
+		"PEM CA/cert file to trust for the server's TLS (the demo stack's self-signed localhost cert); empty uses system roots")
 	fs.BoolVar(&c.force, "force", envBool(getenv, "EDR_DEMO_FORCE", false),
 		"replay scenarios even if demo data is already present")
 	fs.StringVar(&c.demoEmail, "demo-email", envOr(getenv, "EDR_DEMO_EMAIL", "demo@fleet-edr.local"),
@@ -65,6 +68,8 @@ func resolveConfig(getenv func(string) string, args []string) (config, error) {
 	if err := fs.Parse(args); err != nil {
 		return config{}, err
 	}
+	// Trim a trailing slash so path concatenation (serverURL + "/api/enroll") never produces a double slash.
+	c.serverURL = strings.TrimSuffix(c.serverURL, "/")
 	if c.dsn == "" {
 		return config{}, errors.New("a MySQL DSN is required: set EDR_DSN or pass --dsn")
 	}

--- a/server/cmd/fleet-edr-demo-seed/config.go
+++ b/server/cmd/fleet-edr-demo-seed/config.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"strconv"
+	"time"
+)
+
+// Default timing knobs. The ready window covers MySQL warmup + migrations on first boot; the verify window covers the processor
+// interval plus enroll/ingest round-trips.
+const (
+	defaultReadyTimeout  = 90 * time.Second
+	defaultVerifyTimeout = 60 * time.Second
+	defaultPollInterval  = 500 * time.Millisecond
+)
+
+// config is the resolved set of knobs the seeder reads. Every field has an env-var default so the binary runs with zero flags inside
+// the demo compose stack, while flags stay available for local runs against `task dev:server`.
+type config struct {
+	serverURL    string
+	enrollSecret string
+	dsn          string
+	insecure     bool
+	force        bool
+
+	// demoOIDCSubject is the dex-issued OIDC subject for the SSO demo user. Empty (the default) disables the demo-user seed entirely,
+	// which is what a PR-1 run against `task dev:server` (break-glass only, no dex) wants. PR 2 wires the captured subject.
+	demoEmail       string
+	demoOIDCSubject string
+	demoRole        string
+
+	readyTimeout  time.Duration
+	verifyTimeout time.Duration
+	pollInterval  time.Duration
+}
+
+// resolveConfig builds the config from env-var defaults overridden by command-line flags. getenv is injected so tests exercise the
+// env-default path without mutating the process environment.
+func resolveConfig(getenv func(string) string, args []string) (config, error) {
+	fs := flag.NewFlagSet("fleet-edr-demo-seed", flag.ContinueOnError)
+	var c config
+	fs.StringVar(&c.serverURL, "server-url", envOr(getenv, "EDR_DEMO_SERVER_URL", "https://localhost:8088"),
+		"base URL of the EDR server")
+	fs.StringVar(&c.enrollSecret, "enroll-secret", envOr(getenv, "EDR_ENROLL_SECRET", "demo-enroll-secret"),
+		"enrollment secret the server was started with")
+	fs.StringVar(&c.dsn, "dsn", envOr(getenv, "EDR_DSN", ""),
+		"MySQL DSN used to verify materialised demo data and seed the SSO demo user")
+	fs.BoolVar(&c.insecure, "insecure", envBool(getenv, "EDR_DEMO_INSECURE", true),
+		"skip TLS verification (the demo stack serves a self-signed localhost cert)")
+	fs.BoolVar(&c.force, "force", envBool(getenv, "EDR_DEMO_FORCE", false),
+		"replay scenarios even if demo data is already present")
+	fs.StringVar(&c.demoEmail, "demo-email", envOr(getenv, "EDR_DEMO_EMAIL", "demo@fleet-edr.local"),
+		"email of the SSO demo user")
+	fs.StringVar(&c.demoOIDCSubject, "demo-oidc-subject", envOr(getenv, "EDR_DEMO_OIDC_SUBJECT", ""),
+		"dex-issued OIDC subject for the demo user; empty disables the demo-user seed")
+	fs.StringVar(&c.demoRole, "demo-role", envOr(getenv, "EDR_DEMO_ROLE", "senior_analyst"),
+		"role bound to the SSO demo user (must be a seeded role id)")
+	fs.DurationVar(&c.readyTimeout, "ready-timeout", envDuration(getenv, "EDR_DEMO_READY_TIMEOUT", defaultReadyTimeout),
+		"how long to wait for the server's /readyz to report ok")
+	fs.DurationVar(&c.verifyTimeout, "verify-timeout", envDuration(getenv, "EDR_DEMO_VERIFY_TIMEOUT", defaultVerifyTimeout),
+		"how long to wait for the processor to materialise demo data")
+	fs.DurationVar(&c.pollInterval, "poll-interval", envDuration(getenv, "EDR_DEMO_POLL_INTERVAL", defaultPollInterval),
+		"poll cadence for readiness and verification")
+	if err := fs.Parse(args); err != nil {
+		return config{}, err
+	}
+	if c.dsn == "" {
+		return config{}, errors.New("a MySQL DSN is required: set EDR_DSN or pass --dsn")
+	}
+	return c, nil
+}
+
+// envOr returns the env var's value if set and non-empty, else fallback.
+func envOr(getenv func(string) string, key, fallback string) string {
+	if v := getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}
+
+// envBool parses a boolean env var, falling back on unset or unparseable input.
+func envBool(getenv func(string) string, key string, fallback bool) bool {
+	v := getenv(key)
+	if v == "" {
+		return fallback
+	}
+	parsed, err := strconv.ParseBool(v)
+	if err != nil {
+		return fallback
+	}
+	return parsed
+}
+
+// envDuration parses a Go duration env var, falling back on unset or unparseable input.
+func envDuration(getenv func(string) string, key string, fallback time.Duration) time.Duration {
+	v := getenv(key)
+	if v == "" {
+		return fallback
+	}
+	parsed, err := time.ParseDuration(v)
+	if err != nil {
+		return fallback
+	}
+	return parsed
+}

--- a/server/cmd/fleet-edr-demo-seed/corpus/app-control-blocked-app.yaml
+++ b/server/cmd/fleet-edr-demo-seed/corpus/app-control-blocked-app.yaml
@@ -1,0 +1,28 @@
+# Demo-only scenario backing the application-control block record.
+#
+# fakeagent does not emit application_control_block events (those are
+# produced reactively by the extension's AUTH_EXEC walker, not by attack
+# corpus), so the seeder posts that event itself. This scenario just
+# materialises the process the block refers to: a fork + exec of a binary an
+# admin policy would deny, with NO exit so the process stays live and the
+# ApplicationControlBlock rule's GetProcessByPID lookup resolves. The seeder
+# reads the exec event's pid + path to build the matching block event.
+name: "app-control: exec of a policy-blocked binary"
+host:
+  id: DE300AC1-0000-0000-0000-000000000001
+  hostname: demo-finance-laptop.local
+  os: macOS 26.0
+timeline:
+  - at: 0ms
+    type: fork
+    child_pid: 6123
+    parent_pid: 1
+  - at: 10ms
+    type: exec
+    pid: 6123
+    ppid: 1
+    path: /Applications/CoinMiner.app/Contents/MacOS/CoinMiner
+    args: ["CoinMiner", "--stratum", "pool.example.net:3333"]
+    cwd: /Applications/CoinMiner.app
+    uid: 501
+    gid: 20

--- a/server/cmd/fleet-edr-demo-seed/corpus/keychain-dump.yaml
+++ b/server/cmd/fleet-edr-demo-seed/corpus/keychain-dump.yaml
@@ -1,0 +1,26 @@
+# Demo corpus copy of test/efficacy/corpus/T1555.001-keychain-dump.
+# T1555.001 Credentials from Password Stores: Keychain.
+#
+# A process spawns /usr/bin/security with the dump-keychain subcommand. The
+# credential_keychain_dump rule matches path == /usr/bin/security and
+# args[1] == dump-keychain and fires a high-severity alert.
+name: "T1555.001 credential dump via /usr/bin/security dump-keychain"
+mitre: T1555.001
+host:
+  id: DE300555-0001-0000-0000-000000000001
+  hostname: demo-analyst-laptop.local
+  os: macOS 26.0
+timeline:
+  - at: 0ms
+    type: fork
+    child_pid: 4555
+    parent_pid: 1
+  - at: 10ms
+    type: exec
+    pid: 4555
+    ppid: 1
+    path: /usr/bin/security
+    args: ["security", "dump-keychain"]
+    cwd: /
+    uid: 501
+    gid: 20

--- a/server/cmd/fleet-edr-demo-seed/corpus/launchagent-persistence.yaml
+++ b/server/cmd/fleet-edr-demo-seed/corpus/launchagent-persistence.yaml
@@ -1,0 +1,26 @@
+# Demo corpus copy of test/efficacy/corpus/T1543.001-launchagent-persistence.
+# T1543.001 Create or Modify System Process: Launch Agent.
+#
+# A process invokes /bin/launchctl load against a plist path. The
+# persistence_launchagent rule matches path == /bin/launchctl plus the
+# `load` subcommand argument and fires a high-severity alert.
+name: "T1543.001 persistence via launchctl load <plist>"
+mitre: T1543.001
+host:
+  id: DE300543-0001-0000-0000-000000000001
+  hostname: demo-analyst-laptop.local
+  os: macOS 26.0
+timeline:
+  - at: 0ms
+    type: fork
+    child_pid: 4543
+    parent_pid: 1
+  - at: 10ms
+    type: exec
+    pid: 4543
+    ppid: 1
+    path: /bin/launchctl
+    args: ["launchctl", "load", "/Users/demo/Library/LaunchAgents/com.acme.persist.plist"]
+    cwd: /Users/demo
+    uid: 501
+    gid: 20

--- a/server/cmd/fleet-edr-demo-seed/corpus/noise-developer-workstation.yaml
+++ b/server/cmd/fleet-edr-demo-seed/corpus/noise-developer-workstation.yaml
@@ -1,0 +1,70 @@
+# Demo corpus copy of test/efficacy/noise/developer-workstation.yaml.
+# Ambient noise: a developer's workstation morning. Boot a terminal, list
+# files, run a Go build. None of these touch the catalog rules' triggering
+# shapes, so the host stays alert-free -- it shows up in the demo UI with a
+# rich process tree and zero alerts, demonstrating low false-positive noise.
+name: "noise: developer workstation -- terminal + ls + go build"
+host:
+  id: DE3000B1-0000-0000-0000-000000000001
+  hostname: demo-developer-workstation.local
+  os: macOS 26.0
+timeline:
+  # Terminal launches.
+  - at: 0ms
+    type: fork
+    child_pid: 8001
+    parent_pid: 1
+  - at: 10ms
+    type: exec
+    pid: 8001
+    ppid: 1
+    path: /System/Applications/Utilities/Terminal.app/Contents/MacOS/Terminal
+    args: ["Terminal"]
+    cwd: /Users/dev
+    uid: 501
+    gid: 20
+
+  # Login shell (zsh) under Terminal.
+  - at: 100ms
+    type: fork
+    child_pid: 8002
+    parent_pid: 8001
+  - at: 110ms
+    type: exec
+    pid: 8002
+    ppid: 8001
+    path: /bin/zsh
+    args: ["-zsh"]
+    cwd: /Users/dev
+    uid: 501
+    gid: 20
+
+  # Developer runs `ls -la`.
+  - at: 200ms
+    type: fork
+    child_pid: 8003
+    parent_pid: 8002
+  - at: 210ms
+    type: exec
+    pid: 8003
+    ppid: 8002
+    path: /bin/ls
+    args: ["ls", "-la"]
+    cwd: /Users/dev/projects/myapp
+    uid: 501
+    gid: 20
+
+  # Developer runs `go build ./...`.
+  - at: 300ms
+    type: fork
+    child_pid: 8004
+    parent_pid: 8002
+  - at: 310ms
+    type: exec
+    pid: 8004
+    ppid: 8002
+    path: /usr/local/go/bin/go
+    args: ["go", "build", "./..."]
+    cwd: /Users/dev/projects/myapp
+    uid: 501
+    gid: 20

--- a/server/cmd/fleet-edr-demo-seed/corpus/sudoers-tamper.yaml
+++ b/server/cmd/fleet-edr-demo-seed/corpus/sudoers-tamper.yaml
@@ -1,0 +1,31 @@
+# Demo corpus copy of test/efficacy/corpus/T1548.003-sudoers-tamper.
+# T1548.003 Abuse Elevation Control Mechanism: Sudo and Sudo Caching.
+#
+# A process overwrites /etc/sudoers via `cp /tmp/evil /etc/sudoers`. The
+# sudoers_tamper rule triggers on an `open` event for the sudoers path with
+# write-mode flags. Flags 1537 = O_WRONLY | O_CREAT | O_TRUNC.
+name: "T1548.003 sudoers tamper via cp /tmp/evil /etc/sudoers"
+mitre: T1548.003
+host:
+  id: DE300548-0003-0000-0000-000000000003
+  hostname: demo-build-server.local
+  os: macOS 26.0
+timeline:
+  - at: 0ms
+    type: fork
+    child_pid: 4548
+    parent_pid: 1
+  - at: 10ms
+    type: exec
+    pid: 4548
+    ppid: 1
+    path: /bin/cp
+    args: ["cp", "/tmp/evil", "/etc/sudoers"]
+    cwd: /tmp
+    uid: 0
+    gid: 0
+  - at: 20ms
+    type: open
+    pid: 4548
+    path: /etc/sudoers
+    flags: 1537

--- a/server/cmd/fleet-edr-demo-seed/db_test.go
+++ b/server/cmd/fleet-edr-demo-seed/db_test.go
@@ -72,7 +72,7 @@ func TestSeedDemoUser(t *testing.T) {
 func TestCountsAndAlreadySeeded(t *testing.T) {
 	db := full.Open(t)
 	ctx := t.Context()
-	s := newSeeder(config{}, db, discardLogger())
+	s := newSeeder(config{}, db, testHTTPClient(), discardLogger())
 
 	c, err := s.counts(ctx)
 	require.NoError(t, err)
@@ -101,7 +101,7 @@ func TestCountsAndAlreadySeeded(t *testing.T) {
 func TestWaitForProcess(t *testing.T) {
 	db := full.Open(t)
 	ctx := t.Context()
-	s := newSeeder(config{pollInterval: time.Millisecond, verifyTimeout: time.Second}, db, discardLogger())
+	s := newSeeder(config{pollInterval: time.Millisecond, verifyTimeout: time.Second}, db, testHTTPClient(), discardLogger())
 
 	insertProcess(t, db, "HOST-B", 200)
 	require.NoError(t, s.waitForProcess(ctx, "HOST-B", 200))
@@ -168,7 +168,7 @@ func TestRunSeedsEndToEnd(t *testing.T) {
 	ts := demoServer(t, &enrollCalls)
 	defer ts.Close()
 
-	s := newSeeder(runTestConfig(ts.URL), db, discardLogger())
+	s := newSeeder(runTestConfig(ts.URL), db, testHTTPClient(), discardLogger())
 	require.NoError(t, s.run(ctx))
 
 	assert.Equal(t, len(corpusManifest), int(enrollCalls.Load()), "every scenario host was enrolled")
@@ -189,7 +189,7 @@ func TestRunSkipsWhenAlreadySeeded(t *testing.T) {
 	ts := demoServer(t, &enrollCalls)
 	defer ts.Close()
 
-	s := newSeeder(runTestConfig(ts.URL), db, discardLogger())
+	s := newSeeder(runTestConfig(ts.URL), db, testHTTPClient(), discardLogger())
 	require.NoError(t, s.run(ctx))
 
 	assert.Equal(t, 0, int(enrollCalls.Load()), "replay skipped when demo data already present")

--- a/server/cmd/fleet-edr-demo-seed/db_test.go
+++ b/server/cmd/fleet-edr-demo-seed/db_test.go
@@ -1,0 +1,202 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fleetdm/edr/server/testdb/full"
+)
+
+// insertRole ensures a role row exists so role_bindings' FK is satisfied. INSERT IGNORE because the identity testkit already seeds
+// the built-in roles (as the real server does at boot); this just makes the dependency explicit and robust to either state.
+func insertRole(t *testing.T, db *sqlx.DB, id string) {
+	t.Helper()
+	_, err := db.ExecContext(t.Context(),
+		`INSERT IGNORE INTO roles (id, display_name, is_builtin) VALUES (?, ?, 1)`, id, id)
+	require.NoError(t, err)
+}
+
+func insertProcess(t *testing.T, db *sqlx.DB, hostID string, pid int) {
+	t.Helper()
+	_, err := db.ExecContext(t.Context(),
+		`INSERT INTO processes (host_id, pid, ppid, path, fork_time_ns) VALUES (?, ?, 1, '/bin/x', 1)`, hostID, pid)
+	require.NoError(t, err)
+}
+
+func insertAlert(t *testing.T, db *sqlx.DB, hostID, ruleID, source, severity string) {
+	t.Helper()
+	_, err := db.ExecContext(t.Context(),
+		`INSERT INTO alerts (host_id, rule_id, source, severity, title, description) VALUES (?, ?, ?, ?, ?, '')`,
+		hostID, ruleID, source, severity, ruleID)
+	require.NoError(t, err)
+}
+
+func TestSeedDemoUser(t *testing.T) {
+	db := full.Open(t)
+	ctx := t.Context()
+	insertRole(t, db, "senior_analyst")
+
+	const email, subject = "demo@fleet-edr.local", "ChdkZW1vCgVsb2NhbA"
+	require.NoError(t, seedDemoUser(ctx, db, email, subject, "senior_analyst"))
+
+	var userID int64
+	require.NoError(t, db.QueryRowContext(ctx, `SELECT id FROM users WHERE email = ?`, email).Scan(&userID))
+
+	var identityCount, bindingCount int
+	require.NoError(t, db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM identities WHERE provider = 'oidc' AND subject = ? AND user_id = ?`, subject, userID).Scan(&identityCount))
+	assert.Equal(t, 1, identityCount)
+	require.NoError(t, db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM role_bindings WHERE user_id = ? AND role_id = 'senior_analyst'`, userID).Scan(&bindingCount))
+	assert.Equal(t, 1, bindingCount)
+
+	// Idempotent: a second run must not duplicate any row.
+	require.NoError(t, seedDemoUser(ctx, db, email, subject, "senior_analyst"))
+	var users, identities, bindings int
+	require.NoError(t, db.QueryRowContext(ctx, `SELECT COUNT(*) FROM users WHERE email = ?`, email).Scan(&users))
+	require.NoError(t, db.QueryRowContext(ctx, `SELECT COUNT(*) FROM identities WHERE subject = ?`, subject).Scan(&identities))
+	require.NoError(t, db.QueryRowContext(ctx, `SELECT COUNT(*) FROM role_bindings WHERE user_id = ?`, userID).Scan(&bindings))
+	assert.Equal(t, 1, users)
+	assert.Equal(t, 1, identities)
+	assert.Equal(t, 1, bindings)
+}
+
+func TestCountsAndAlreadySeeded(t *testing.T) {
+	db := full.Open(t)
+	ctx := t.Context()
+	s := newSeeder(config{}, db, discardLogger())
+
+	c, err := s.counts(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, demoCounts{}, c)
+
+	seeded, err := s.alreadySeeded(ctx)
+	require.NoError(t, err)
+	assert.False(t, seeded)
+
+	insertProcess(t, db, "HOST-A", 100)
+	insertAlert(t, db, "HOST-A", "sudoers_tamper", "detection", "high")
+	insertAlert(t, db, "HOST-A", "demo_blocklist_binary", "application_control", "high")
+	insertAlert(t, db, "HOST-A", keychainRuleID, "detection", "high")
+
+	c, err = s.counts(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, c.processes)
+	assert.Equal(t, 2, c.detectionAlerts)
+	assert.Equal(t, 1, c.appControlAlerts)
+
+	seeded, err = s.alreadySeeded(ctx)
+	require.NoError(t, err)
+	assert.True(t, seeded)
+}
+
+func TestWaitForProcess(t *testing.T) {
+	db := full.Open(t)
+	ctx := t.Context()
+	s := newSeeder(config{pollInterval: time.Millisecond, verifyTimeout: time.Second}, db, discardLogger())
+
+	insertProcess(t, db, "HOST-B", 200)
+	require.NoError(t, s.waitForProcess(ctx, "HOST-B", 200))
+
+	s.cfg.verifyTimeout = 20 * time.Millisecond
+	err := s.waitForProcess(ctx, "HOST-B", 999)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not met within")
+}
+
+// demoServer stands in for the EDR ingest API: readiness, enroll (echoing the requested host id), and events.
+func demoServer(t *testing.T, enrollCalls *atomic.Int32) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/readyz", func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+	mux.HandleFunc("/api/enroll", func(w http.ResponseWriter, r *http.Request) {
+		enrollCalls.Add(1)
+		var req map[string]string
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		_ = json.NewEncoder(w).Encode(map[string]any{"host_id": req["hardware_uuid"], "host_token": "tok"})
+	})
+	mux.HandleFunc("/api/events", func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+	return httptest.NewServer(mux)
+}
+
+func runTestConfig(serverURL string) config {
+	return config{
+		serverURL:       serverURL,
+		enrollSecret:    "test-secret",
+		pollInterval:    time.Millisecond,
+		readyTimeout:    2 * time.Second,
+		verifyTimeout:   2 * time.Second,
+		demoEmail:       "demo@fleet-edr.local",
+		demoOIDCSubject: "ChdkZW1v",
+		demoRole:        "senior_analyst",
+	}
+}
+
+func TestRunSeedsEndToEnd(t *testing.T) {
+	db := full.Open(t)
+	ctx := t.Context()
+	insertRole(t, db, "senior_analyst")
+
+	// Find the app-control host/pid so we can pre-materialise the process its block event targets (the test server does not run
+	// the real processor, so waitForProcess + verify need their rows seeded directly).
+	scs, err := loadScenarios()
+	require.NoError(t, err)
+	var acHost string
+	var acPID int
+	for _, sc := range scs {
+		if sc.Kind == kindAppControl {
+			acHost = sc.Scenario.Host.ID
+			acPID, _, _ = firstExec(sc.Scenario)
+		}
+	}
+	require.NotEmpty(t, acHost)
+	insertProcess(t, db, acHost, acPID)
+	// A detection + an app-control alert so verify's predicate is satisfied. No keychain alert, so alreadySeeded stays false and
+	// the full replay path runs.
+	insertAlert(t, db, "HOST-SEED", "sudoers_tamper", "detection", "high")
+	insertAlert(t, db, acHost, "demo_blocklist_binary", "application_control", "high")
+
+	var enrollCalls atomic.Int32
+	ts := demoServer(t, &enrollCalls)
+	defer ts.Close()
+
+	s := newSeeder(runTestConfig(ts.URL), db, discardLogger())
+	require.NoError(t, s.run(ctx))
+
+	assert.Equal(t, len(corpusManifest), int(enrollCalls.Load()), "every scenario host was enrolled")
+
+	var userCount int
+	require.NoError(t, db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM users WHERE email = 'demo@fleet-edr.local'`).Scan(&userCount))
+	assert.Equal(t, 1, userCount, "SSO demo user provisioned")
+}
+
+func TestRunSkipsWhenAlreadySeeded(t *testing.T) {
+	db := full.Open(t)
+	ctx := t.Context()
+	insertRole(t, db, "senior_analyst")
+	insertAlert(t, db, "HOST-OLD", keychainRuleID, "detection", "high")
+
+	var enrollCalls atomic.Int32
+	ts := demoServer(t, &enrollCalls)
+	defer ts.Close()
+
+	s := newSeeder(runTestConfig(ts.URL), db, discardLogger())
+	require.NoError(t, s.run(ctx))
+
+	assert.Equal(t, 0, int(enrollCalls.Load()), "replay skipped when demo data already present")
+
+	// The demo-user seed still runs on the already-seeded path.
+	var userCount int
+	require.NoError(t, db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM users WHERE email = 'demo@fleet-edr.local'`).Scan(&userCount))
+	assert.Equal(t, 1, userCount)
+}

--- a/server/cmd/fleet-edr-demo-seed/main.go
+++ b/server/cmd/fleet-edr-demo-seed/main.go
@@ -40,6 +40,11 @@ func realMain(logger *slog.Logger, getenv func(string) string, args []string) er
 		return err
 	}
 
+	client, err := newHTTPClient(cfg.caCertPath)
+	if err != nil {
+		return fmt.Errorf("build http client: %w", err)
+	}
+
 	db, err := sql.Open("mysql", cfg.dsn)
 	if err != nil {
 		return fmt.Errorf("open mysql: %w", err)
@@ -47,12 +52,30 @@ func realMain(logger *slog.Logger, getenv func(string) string, args []string) er
 	defer db.Close()
 
 	// Budget the overall run at the readiness + verification windows plus headroom for enroll/ingest round-trips.
-	ctx, cancel := context.WithTimeout(context.Background(), cfg.readyTimeout+cfg.verifyTimeout+30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), cfg.readyTimeout+cfg.verifyTimeout+defaultHeadroom)
 	defer cancel()
 
-	if err := db.PingContext(ctx); err != nil {
-		return fmt.Errorf("ping mysql: %w", err)
+	if err := pingUntilReady(ctx, db, cfg.readyTimeout, cfg.pollInterval); err != nil {
+		return err
 	}
 
-	return newSeeder(cfg, db, logger).run(ctx)
+	return newSeeder(cfg, db, client, logger).run(ctx)
+}
+
+// pingUntilReady retries the DB ping until it succeeds or the ready window elapses. In docker-compose first boot, MySQL may still be
+// warming up or running migrations when the seeder starts, so a single ping would crash the container spuriously.
+func pingUntilReady(ctx context.Context, db *sql.DB, timeout, interval time.Duration) error {
+	pingCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	for {
+		err := db.PingContext(pingCtx)
+		if err == nil {
+			return nil
+		}
+		select {
+		case <-pingCtx.Done():
+			return fmt.Errorf("ping mysql: %w", err)
+		case <-time.After(interval):
+		}
+	}
 }

--- a/server/cmd/fleet-edr-demo-seed/main.go
+++ b/server/cmd/fleet-edr-demo-seed/main.go
@@ -1,0 +1,58 @@
+// Command fleet-edr-demo-seed preloads a running EDR server with demo data so the repo is evaluable in minutes without a Mac fleet.
+//
+// It enrols synthetic hosts, replays a curated attack + noise corpus through the real ingest API so the server's own processor builds
+// the process graph and fires detection alerts, fabricates one application-control block, verifies the data materialised, and
+// optionally provisions the SSO demo user at a full-capability role. It writes nothing the running server could not have produced,
+// except the demo-user rows (an operator action), so the demo stays faithful to the real pipeline.
+//
+// It is meant to run as a one-shot container in docker-compose.demo.yml, but runs equally well by hand against `task dev:server`:
+//
+//	go run ./server/cmd/fleet-edr-demo-seed \
+//	  --server-url https://localhost:8088 --enroll-secret dev-enroll-secret \
+//	  --dsn 'root:@tcp(127.0.0.1:33306)/edr?parseTime=true'
+package main
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log/slog"
+	"os"
+	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+)
+
+func main() {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	// Wiring boundary: env + args are read here and passed into realMain as values (issue #172).
+	if err := realMain(logger, os.Getenv, os.Args[1:]); err != nil { //nolint:forbidigo // wiring boundary, lifted into resolveConfig
+		logger.ErrorContext(context.Background(), "demo seed failed", "err", err)
+		os.Exit(1)
+	}
+}
+
+// realMain resolves config, opens the database, and runs the seeder. getenv + args are injected so it is testable without mutating
+// process state. Split out from main so the exit-code path stays a one-liner.
+func realMain(logger *slog.Logger, getenv func(string) string, args []string) error {
+	cfg, err := resolveConfig(getenv, args)
+	if err != nil {
+		return err
+	}
+
+	db, err := sql.Open("mysql", cfg.dsn)
+	if err != nil {
+		return fmt.Errorf("open mysql: %w", err)
+	}
+	defer db.Close()
+
+	// Budget the overall run at the readiness + verification windows plus headroom for enroll/ingest round-trips.
+	ctx, cancel := context.WithTimeout(context.Background(), cfg.readyTimeout+cfg.verifyTimeout+30*time.Second)
+	defer cancel()
+
+	if err := db.PingContext(ctx); err != nil {
+		return fmt.Errorf("ping mysql: %w", err)
+	}
+
+	return newSeeder(cfg, db, logger).run(ctx)
+}

--- a/server/cmd/fleet-edr-demo-seed/main_test.go
+++ b/server/cmd/fleet-edr-demo-seed/main_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// badDB returns a handle whose connections always fail fast, to exercise DB error branches without a live server.
+func badDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("mysql", "root:nope@tcp(127.0.0.1:1)/x?timeout=300ms")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func TestRealMainMissingDSN(t *testing.T) {
+	err := realMain(discardLogger(), func(string) string { return "" }, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "DSN is required")
+}
+
+func TestRealMainPingFails(t *testing.T) {
+	getenv := func(k string) string {
+		if k == "EDR_DSN" {
+			return "root:nope@tcp(127.0.0.1:1)/x?timeout=300ms"
+		}
+		return ""
+	}
+	err := realMain(discardLogger(), getenv, []string{"--ready-timeout=200ms", "--verify-timeout=200ms"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ping mysql")
+}
+
+func TestSeedUserIfConfiguredNoSubject(t *testing.T) {
+	s := newSeeder(config{demoOIDCSubject: ""}, nil, discardLogger())
+	require.NoError(t, s.seedUserIfConfigured(context.Background()))
+}
+
+func TestDBErrorsPropagate(t *testing.T) {
+	s := newSeeder(config{pollInterval: time.Millisecond, verifyTimeout: 30 * time.Millisecond}, badDB(t), discardLogger())
+	ctx := context.Background()
+
+	_, err := s.counts(ctx)
+	require.Error(t, err)
+
+	_, err = s.alreadySeeded(ctx)
+	require.Error(t, err)
+
+	err = s.verify(ctx)
+	require.Error(t, err)
+
+	err = s.waitForProcess(ctx, "HOST", 1)
+	require.Error(t, err)
+}
+
+func TestSeedDemoUserError(t *testing.T) {
+	err := seedDemoUser(context.Background(), badDB(t), "demo@fleet-edr.local", "subject", "senior_analyst")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "seed demo user row")
+}
+
+func TestNewHTTPClientInsecure(t *testing.T) {
+	tr, ok := newHTTPClient(true).Transport.(*http.Transport)
+	require.True(t, ok)
+	require.NotNil(t, tr.TLSClientConfig)
+	assert.True(t, tr.TLSClientConfig.InsecureSkipVerify)
+
+	tr, ok = newHTTPClient(false).Transport.(*http.Transport)
+	require.True(t, ok)
+	assert.Nil(t, tr.TLSClientConfig)
+}

--- a/server/cmd/fleet-edr-demo-seed/main_test.go
+++ b/server/cmd/fleet-edr-demo-seed/main_test.go
@@ -2,8 +2,17 @@ package main
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"database/sql"
+	"encoding/pem"
+	"math/big"
 	"net/http"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -39,12 +48,12 @@ func TestRealMainPingFails(t *testing.T) {
 }
 
 func TestSeedUserIfConfiguredNoSubject(t *testing.T) {
-	s := newSeeder(config{demoOIDCSubject: ""}, nil, discardLogger())
+	s := newSeeder(config{demoOIDCSubject: ""}, nil, testHTTPClient(), discardLogger())
 	require.NoError(t, s.seedUserIfConfigured(context.Background()))
 }
 
 func TestDBErrorsPropagate(t *testing.T) {
-	s := newSeeder(config{pollInterval: time.Millisecond, verifyTimeout: 30 * time.Millisecond}, badDB(t), discardLogger())
+	s := newSeeder(config{pollInterval: time.Millisecond, verifyTimeout: 30 * time.Millisecond}, badDB(t), testHTTPClient(), discardLogger())
 	ctx := context.Background()
 
 	_, err := s.counts(ctx)
@@ -66,13 +75,58 @@ func TestSeedDemoUserError(t *testing.T) {
 	assert.Contains(t, err.Error(), "seed demo user row")
 }
 
-func TestNewHTTPClientInsecure(t *testing.T) {
-	tr, ok := newHTTPClient(true).Transport.(*http.Transport)
-	require.True(t, ok)
-	require.NotNil(t, tr.TLSClientConfig)
-	assert.True(t, tr.TLSClientConfig.InsecureSkipVerify)
+func TestNewHTTPClient(t *testing.T) {
+	t.Run("no ca cert keeps default verification", func(t *testing.T) {
+		c, err := newHTTPClient("")
+		require.NoError(t, err)
+		tr, ok := c.Transport.(*http.Transport)
+		require.True(t, ok)
+		// Clone() of DefaultTransport may carry a TLSClientConfig (h2 NextProtos etc.); what matters is that verification is
+		// intact: no custom roots and not insecure.
+		if tr.TLSClientConfig != nil {
+			assert.Nil(t, tr.TLSClientConfig.RootCAs)
+			assert.False(t, tr.TLSClientConfig.InsecureSkipVerify)
+		}
+	})
 
-	tr, ok = newHTTPClient(false).Transport.(*http.Transport)
-	require.True(t, ok)
-	assert.Nil(t, tr.TLSClientConfig)
+	t.Run("valid ca cert sets a RootCAs pool", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "ca.pem")
+		require.NoError(t, os.WriteFile(path, selfSignedCertPEM(t), 0o600))
+		c, err := newHTTPClient(path)
+		require.NoError(t, err)
+		tr, ok := c.Transport.(*http.Transport)
+		require.True(t, ok)
+		require.NotNil(t, tr.TLSClientConfig)
+		assert.NotNil(t, tr.TLSClientConfig.RootCAs)
+	})
+
+	t.Run("missing ca file errors", func(t *testing.T) {
+		_, err := newHTTPClient(filepath.Join(t.TempDir(), "nope.pem"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "read ca cert")
+	})
+
+	t.Run("invalid pem errors", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "bad.pem")
+		require.NoError(t, os.WriteFile(path, []byte("not a pem"), 0o600))
+		_, err := newHTTPClient(path)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no PEM certificates")
+	})
+}
+
+// selfSignedCertPEM mints a throwaway self-signed certificate so the CA-cert path of newHTTPClient can be exercised.
+func selfSignedCertPEM(t *testing.T) []byte {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "localhost"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
 }

--- a/server/cmd/fleet-edr-demo-seed/scenarios.go
+++ b/server/cmd/fleet-edr-demo-seed/scenarios.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"embed"
+	"fmt"
+	"io/fs"
+
+	"sigs.k8s.io/yaml"
+
+	"github.com/fleetdm/edr/test/fakeagent"
+)
+
+// corpusFS holds the curated scenario set replayed into the demo database. The files are local copies of test/efficacy/corpus +
+// test/efficacy/noise (go:embed cannot reach those from another module subtree) plus app-control-blocked-app.yaml, which is
+// demo-only because fakeagent does not emit application_control_block events.
+//
+//go:embed corpus/*.yaml
+var corpusFS embed.FS
+
+// scenarioKind classifies what the seeder does with each scenario after replaying its events.
+type scenarioKind string
+
+const (
+	// kindAttack scenarios are expected to trip a catalog rule (ExpectRule names it).
+	kindAttack scenarioKind = "attack"
+	// kindNoise scenarios are benign: they enrich the process graph and must NOT produce alerts.
+	kindNoise scenarioKind = "noise"
+	// kindAppControl scenarios materialise the process that a follow-up application_control_block event refers to.
+	kindAppControl scenarioKind = "app_control"
+)
+
+// demoScenario pairs a curated corpus file with its kind, the catalog rule an attack scenario should fire, and the parsed scenario.
+type demoScenario struct {
+	File       string
+	Kind       scenarioKind
+	ExpectRule string
+	Scenario   *fakeagent.Scenario
+}
+
+// corpusManifest is the ordered, curated demo set. Order is the replay order; it is also the order hosts appear in the demo UI.
+var corpusManifest = []demoScenario{
+	{File: "keychain-dump.yaml", Kind: kindAttack, ExpectRule: "credential_keychain_dump"},
+	{File: "sudoers-tamper.yaml", Kind: kindAttack, ExpectRule: "sudoers_tamper"},
+	{File: "launchagent-persistence.yaml", Kind: kindAttack, ExpectRule: "persistence_launchagent"},
+	{File: "noise-developer-workstation.yaml", Kind: kindNoise},
+	{File: "app-control-blocked-app.yaml", Kind: kindAppControl},
+}
+
+// loadScenarios reads, parses, and validates every embedded scenario named in corpusManifest. A parse or validation failure is a
+// build-time bug (the files are checked in), so it returns an error rather than skipping.
+func loadScenarios() ([]demoScenario, error) {
+	out := make([]demoScenario, 0, len(corpusManifest))
+	for _, entry := range corpusManifest {
+		raw, err := fs.ReadFile(corpusFS, "corpus/"+entry.File)
+		if err != nil {
+			return nil, fmt.Errorf("read embedded corpus %s: %w", entry.File, err)
+		}
+		var sc fakeagent.Scenario
+		if err := yaml.Unmarshal(raw, &sc); err != nil {
+			return nil, fmt.Errorf("parse corpus %s: %w", entry.File, err)
+		}
+		if err := sc.Validate(); err != nil {
+			return nil, fmt.Errorf("validate corpus %s: %w", entry.File, err)
+		}
+		entry.Scenario = &sc
+		out = append(out, entry)
+	}
+	return out, nil
+}
+
+// firstExec returns the pid and path of the first exec event in the scenario. The app-control flow uses it to target the
+// follow-up block event at the process the scenario just materialised.
+func firstExec(sc *fakeagent.Scenario) (pid int, execPath string, ok bool) {
+	for _, ev := range sc.Timeline {
+		if ev.Type == "exec" {
+			return ev.PID, ev.Path, true
+		}
+	}
+	return 0, "", false
+}

--- a/server/cmd/fleet-edr-demo-seed/seed.go
+++ b/server/cmd/fleet-edr-demo-seed/seed.go
@@ -5,12 +5,14 @@ import (
 	"context"
 	"crypto/rand"
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/fleetdm/edr/test/fakeagent"
@@ -30,8 +32,14 @@ const (
 	keychainRuleID = "credential_keychain_dump"
 )
 
-// httpClientTimeout bounds every enroll, ingest, and readiness request.
-const httpClientTimeout = 30 * time.Second
+const (
+	// httpClientTimeout bounds every enroll, ingest, and readiness request.
+	httpClientTimeout = 30 * time.Second
+	// errorBodyLimit caps how much of a failed response body is read into an error message.
+	errorBodyLimit = 1024
+	// maxResponseBytes caps a decoded success response so a malformed or oversized body cannot exhaust memory.
+	maxResponseBytes = 1 << 20
+)
 
 // seeder drives the demo seed end to end: wait for readiness, replay the curated corpus, fabricate the app-control block, verify the
 // processor materialised everything, and optionally provision the SSO demo user.
@@ -42,19 +50,29 @@ type seeder struct {
 	logger *slog.Logger
 }
 
-// newSeeder wires a seeder with an HTTP client honouring cfg.insecure.
-func newSeeder(cfg config, db dbExecQuerier, logger *slog.Logger) *seeder {
-	return &seeder{cfg: cfg, db: db, client: newHTTPClient(cfg.insecure), logger: logger}
+// newSeeder wires a seeder with a pre-built HTTP client (built in main so config errors surface at the wiring boundary).
+func newSeeder(cfg config, db dbExecQuerier, client *http.Client, logger *slog.Logger) *seeder {
+	return &seeder{cfg: cfg, db: db, client: client, logger: logger}
 }
 
-// newHTTPClient builds the client used for enroll, ingest, and readiness probes. With insecure set it skips TLS verification so the
-// demo stack's self-signed localhost cert is accepted without priming a trust store.
-func newHTTPClient(insecure bool) *http.Client {
-	tr := &http.Transport{}
-	if insecure {
-		tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} //nolint:gosec // demo stack serves a self-signed localhost cert
+// newHTTPClient builds the client used for enroll, ingest, and readiness probes. It clones http.DefaultTransport to keep the stock
+// connection-pool + timeout tuning. When caCertPath is set, the server's TLS is verified against that PEM (the demo stack's
+// self-signed localhost cert) rather than disabling verification; an empty path uses the system trust store.
+func newHTTPClient(caCertPath string) (*http.Client, error) {
+	tr := http.DefaultTransport.(*http.Transport).Clone()
+	if caCertPath != "" {
+		//nolint:gosec // G304: caCertPath is operator-supplied wiring config (a trusted CA path), not untrusted input
+		pemBytes, err := os.ReadFile(caCertPath)
+		if err != nil {
+			return nil, fmt.Errorf("read ca cert %s: %w", caCertPath, err)
+		}
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM(pemBytes) {
+			return nil, fmt.Errorf("ca cert %s: no PEM certificates found", caCertPath)
+		}
+		tr.TLSClientConfig = &tls.Config{RootCAs: pool, MinVersion: tls.VersionTLS12}
 	}
-	return &http.Client{Timeout: httpClientTimeout, Transport: tr}
+	return &http.Client{Timeout: httpClientTimeout, Transport: tr}, nil
 }
 
 // run executes the full seed. It is safe to re-run: replay is skipped when demo data is already present unless cfg.force is set.
@@ -193,13 +211,15 @@ func (s *seeder) enroll(ctx context.Context, hostID, hostname string) (string, e
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("POST /api/enroll for %s: HTTP %d", hostID, resp.StatusCode)
+		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, errorBodyLimit))
+		return "", fmt.Errorf("POST /api/enroll for %s: HTTP %d (%s)", hostID, resp.StatusCode, bytes.TrimSpace(snippet))
 	}
 	var er struct {
 		HostID    string `json:"host_id"`
 		HostToken string `json:"host_token"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&er); err != nil {
+	// Bound the decoded body so an unexpectedly large response cannot exhaust memory.
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxResponseBytes)).Decode(&er); err != nil {
 		return "", fmt.Errorf("decode enroll response: %w", err)
 	}
 	if er.HostToken == "" {
@@ -226,10 +246,11 @@ func (s *seeder) postEnvelopes(ctx context.Context, token string, envs []fakeage
 		return fmt.Errorf("POST /api/events: %w", err)
 	}
 	defer resp.Body.Close()
-	_, _ = io.Copy(io.Discard, resp.Body)
 	if resp.StatusCode/100 != 2 {
-		return fmt.Errorf("POST /api/events: HTTP %d", resp.StatusCode)
+		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, errorBodyLimit))
+		return fmt.Errorf("POST /api/events: HTTP %d (%s)", resp.StatusCode, bytes.TrimSpace(snippet))
 	}
+	_, _ = io.Copy(io.Discard, resp.Body)
 	return nil
 }
 
@@ -249,7 +270,11 @@ func (s *seeder) waitReady(ctx context.Context) error {
 		}
 		defer resp.Body.Close()
 		_, _ = io.Copy(io.Discard, resp.Body)
-		return resp.StatusCode == http.StatusOK, nil
+		if resp.StatusCode != http.StatusOK {
+			lastErr = fmt.Errorf("readyz HTTP %d", resp.StatusCode)
+			return false, nil // server up but not ready (e.g. 503 during migrations); keep polling
+		}
+		return true, nil
 	})
 	if err != nil && lastErr != nil {
 		return fmt.Errorf("%w (last probe error: %w)", err, lastErr)
@@ -294,15 +319,22 @@ func (s *seeder) waitForProcess(ctx context.Context, hostID string, pid int) err
 // verify polls until the processor has materialised a process graph, at least one detection alert, and at least one app-control
 // alert, or verifyTimeout elapses.
 func (s *seeder) verify(ctx context.Context) error {
-	return s.poll(ctx, s.cfg.verifyTimeout, func() (bool, error) {
+	var last demoCounts
+	err := s.poll(ctx, s.cfg.verifyTimeout, func() (bool, error) {
 		c, err := s.counts(ctx)
 		if err != nil {
 			return false, err
 		}
+		last = c
 		s.logger.DebugContext(ctx, "verify counts",
 			"processes", c.processes, "detection_alerts", c.detectionAlerts, "app_control_alerts", c.appControlAlerts)
 		return c.processes > 0 && c.detectionAlerts > 0 && c.appControlAlerts > 0, nil
 	})
+	if err != nil {
+		return fmt.Errorf("%w (processes=%d detection_alerts=%d app_control_alerts=%d)",
+			err, last.processes, last.detectionAlerts, last.appControlAlerts)
+	}
+	return nil
 }
 
 // demoCounts is the materialised-data tally verify checks.

--- a/server/cmd/fleet-edr-demo-seed/seed.go
+++ b/server/cmd/fleet-edr-demo-seed/seed.go
@@ -1,0 +1,371 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/tls"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/fleetdm/edr/test/fakeagent"
+)
+
+// Constants for the synthetic application-control block. The block decision is normally made on-device by the extension's AUTH_EXEC
+// walker; the demo fabricates one so the unified alerts view shows an application_control source alongside detection alerts.
+const (
+	appControlEventType = "application_control_block"
+	appControlRuleID    = "demo_blocklist_binary"
+	appControlRuleType  = "BINARY"
+	appControlSeverity  = "high"
+	appControlMessage   = "Blocked by Acme Corp application-control policy."
+
+	// keychainRuleID is the marker the already-seeded check looks for: if a credential_keychain_dump alert exists, the demo data
+	// is present and replay is skipped (unless --force).
+	keychainRuleID = "credential_keychain_dump"
+)
+
+// httpClientTimeout bounds every enroll, ingest, and readiness request.
+const httpClientTimeout = 30 * time.Second
+
+// seeder drives the demo seed end to end: wait for readiness, replay the curated corpus, fabricate the app-control block, verify the
+// processor materialised everything, and optionally provision the SSO demo user.
+type seeder struct {
+	cfg    config
+	db     dbExecQuerier
+	client *http.Client
+	logger *slog.Logger
+}
+
+// newSeeder wires a seeder with an HTTP client honouring cfg.insecure.
+func newSeeder(cfg config, db dbExecQuerier, logger *slog.Logger) *seeder {
+	return &seeder{cfg: cfg, db: db, client: newHTTPClient(cfg.insecure), logger: logger}
+}
+
+// newHTTPClient builds the client used for enroll, ingest, and readiness probes. With insecure set it skips TLS verification so the
+// demo stack's self-signed localhost cert is accepted without priming a trust store.
+func newHTTPClient(insecure bool) *http.Client {
+	tr := &http.Transport{}
+	if insecure {
+		tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} //nolint:gosec // demo stack serves a self-signed localhost cert
+	}
+	return &http.Client{Timeout: httpClientTimeout, Transport: tr}
+}
+
+// run executes the full seed. It is safe to re-run: replay is skipped when demo data is already present unless cfg.force is set.
+func (s *seeder) run(ctx context.Context) error {
+	if err := s.waitReady(ctx); err != nil {
+		return fmt.Errorf("server did not become ready: %w", err)
+	}
+
+	scenarios, err := loadScenarios()
+	if err != nil {
+		return err
+	}
+
+	if !s.cfg.force {
+		seeded, err := s.alreadySeeded(ctx)
+		if err != nil {
+			return fmt.Errorf("check already-seeded: %w", err)
+		}
+		if seeded {
+			s.logger.InfoContext(ctx, "demo data already present, skipping replay (pass --force to re-seed)")
+			return s.seedUserIfConfigured(ctx)
+		}
+	}
+
+	for _, sc := range scenarios {
+		if err := s.replay(ctx, sc); err != nil {
+			return fmt.Errorf("replay %s: %w", sc.File, err)
+		}
+	}
+
+	if err := s.verify(ctx); err != nil {
+		return fmt.Errorf("verify demo data: %w", err)
+	}
+	if err := s.seedUserIfConfigured(ctx); err != nil {
+		return err
+	}
+
+	s.logger.InfoContext(ctx, "demo seed complete")
+	return nil
+}
+
+// replay enrols the scenario's host, posts its events directly to the ingest API, and for app-control scenarios fabricates the
+// follow-up block event.
+func (s *seeder) replay(ctx context.Context, sc demoScenario) error {
+	hostID := sc.Scenario.Host.ID
+	token, err := s.enroll(ctx, hostID, sc.Scenario.Host.Hostname)
+	if err != nil {
+		return err
+	}
+
+	base := time.Now()
+	if err := sc.Scenario.PostDirect(ctx, s.cfg.serverURL, token,
+		fakeagent.WithHTTPClient(s.client), fakeagent.WithStartTime(base)); err != nil {
+		return err
+	}
+	s.logger.InfoContext(ctx, "replayed scenario",
+		"file", sc.File, "host_id", hostID, "kind", string(sc.Kind), "events", len(sc.Scenario.Timeline))
+
+	if sc.Kind == kindAppControl {
+		return s.postAppControlBlock(ctx, sc, token, base)
+	}
+	return nil
+}
+
+// postAppControlBlock fabricates and posts the application_control_block event for an app-control scenario. The block rule resolves
+// the event's pid against the materialised graph, so it first waits for the scenario's exec to land; otherwise the rule would skip
+// the event permanently (the processor evaluates each event once).
+func (s *seeder) postAppControlBlock(ctx context.Context, sc demoScenario, token string, base time.Time) error {
+	pid, execPath, ok := firstExec(sc.Scenario)
+	if !ok {
+		return fmt.Errorf("app-control scenario %s has no exec event", sc.File)
+	}
+	hostID := sc.Scenario.Host.ID
+
+	if err := s.waitForProcess(ctx, hostID, pid); err != nil {
+		return fmt.Errorf("app-control process pid %d never materialised: %w", pid, err)
+	}
+
+	// Stamp the block one second past the scenario start so it sits after the fork/exec; the scenario emits no exit, so the live
+	// process resolves at this timestamp.
+	blockTS := base.Add(time.Second).UnixNano()
+	env := buildBlockEnvelope(hostID, pid, execPath, blockTS)
+	if err := s.postEnvelopes(ctx, token, []fakeagent.Envelope{env}); err != nil {
+		return fmt.Errorf("post application_control_block event: %w", err)
+	}
+	s.logger.InfoContext(ctx, "posted application-control block", "host_id", hostID, "pid", pid, "path", execPath)
+	return nil
+}
+
+// buildBlockEnvelope constructs the application_control_block wire envelope the ApplicationControlBlock rule consumes. Payload shape
+// mirrors server/rules/internal/catalog/application_control_block.go's applicationControlBlockPayload.
+func buildBlockEnvelope(hostID string, pid int, execPath string, tsNs int64) fakeagent.Envelope {
+	payload := map[string]any{
+		"pid":            pid,
+		"path":           execPath,
+		"rule_id":        appControlRuleID,
+		"rule_type":      appControlRuleType,
+		"identifier":     execPath,
+		"severity":       appControlSeverity,
+		"custom_msg":     appControlMessage,
+		"policy_id":      1,
+		"policy_version": 1,
+	}
+	// map[string]any of scalars + strings always marshals; the error is unreachable.
+	raw, _ := json.Marshal(payload)
+	return fakeagent.Envelope{
+		EventID:     randomEventID(),
+		HostID:      hostID,
+		TimestampNs: tsNs,
+		EventType:   appControlEventType,
+		Payload:     raw,
+	}
+}
+
+// enroll posts to /api/enroll and returns the issued host token. Mirrors the agent's enroll contract (server/endpoint/api).
+func (s *seeder) enroll(ctx context.Context, hostID, hostname string) (string, error) {
+	body, err := json.Marshal(map[string]string{
+		"enroll_secret": s.cfg.enrollSecret,
+		"hardware_uuid": hostID,
+		"hostname":      hostname,
+		"agent_version": "demo-seed",
+		"os_version":    "macOS 26.0",
+	})
+	if err != nil {
+		return "", err
+	}
+	//nolint:gosec // G704: serverURL is operator-supplied demo/wiring config, not attacker-controlled input
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.cfg.serverURL+"/api/enroll", bytes.NewReader(body))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := s.client.Do(req) //nolint:gosec // G704: request targets the operator-configured server URL
+	if err != nil {
+		return "", fmt.Errorf("POST /api/enroll: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("POST /api/enroll for %s: HTTP %d", hostID, resp.StatusCode)
+	}
+	var er struct {
+		HostID    string `json:"host_id"`
+		HostToken string `json:"host_token"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&er); err != nil {
+		return "", fmt.Errorf("decode enroll response: %w", err)
+	}
+	if er.HostToken == "" {
+		return "", fmt.Errorf("enroll response for %s missing host_token", hostID)
+	}
+	return er.HostToken, nil
+}
+
+// postEnvelopes posts a batch of envelopes to /api/events with the host bearer token.
+func (s *seeder) postEnvelopes(ctx context.Context, token string, envs []fakeagent.Envelope) error {
+	body, err := json.Marshal(envs)
+	if err != nil {
+		return err
+	}
+	//nolint:gosec // G704: serverURL is operator-supplied demo/wiring config, not attacker-controlled input
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.cfg.serverURL+"/api/events", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := s.client.Do(req) //nolint:gosec // G704: request targets the operator-configured server URL
+	if err != nil {
+		return fmt.Errorf("POST /api/events: %w", err)
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
+	if resp.StatusCode/100 != 2 {
+		return fmt.Errorf("POST /api/events: HTTP %d", resp.StatusCode)
+	}
+	return nil
+}
+
+// waitReady polls GET /readyz until it returns 200 or readyTimeout elapses.
+func (s *seeder) waitReady(ctx context.Context) error {
+	var lastErr error
+	err := s.poll(ctx, s.cfg.readyTimeout, func() (bool, error) {
+		//nolint:gosec // G704: serverURL is operator-supplied demo/wiring config, not attacker-controlled input
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, s.cfg.serverURL+"/readyz", nil)
+		if err != nil {
+			return false, err
+		}
+		resp, err := s.client.Do(req) //nolint:gosec // G704: request targets the operator-configured server URL
+		if err != nil {
+			lastErr = err
+			return false, nil // server not up yet; keep polling
+		}
+		defer resp.Body.Close()
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return resp.StatusCode == http.StatusOK, nil
+	})
+	if err != nil && lastErr != nil {
+		return fmt.Errorf("%w (last probe error: %w)", err, lastErr)
+	}
+	return err
+}
+
+// seedUserIfConfigured provisions the SSO demo user when a subject is configured; otherwise it is a logged no-op.
+func (s *seeder) seedUserIfConfigured(ctx context.Context) error {
+	if s.cfg.demoOIDCSubject == "" {
+		s.logger.InfoContext(ctx, "no demo OIDC subject configured, skipping SSO demo-user seed")
+		return nil
+	}
+	if err := seedDemoUser(ctx, s.db, s.cfg.demoEmail, s.cfg.demoOIDCSubject, s.cfg.demoRole); err != nil {
+		return fmt.Errorf("seed demo user: %w", err)
+	}
+	s.logger.InfoContext(ctx, "seeded SSO demo user", "email", s.cfg.demoEmail, "role", s.cfg.demoRole)
+	return nil
+}
+
+// alreadySeeded reports whether the headline detection alert already exists, used to make the seeder idempotent across restarts.
+func (s *seeder) alreadySeeded(ctx context.Context) (bool, error) {
+	var n int
+	if err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM alerts WHERE rule_id = ?`, keychainRuleID).Scan(&n); err != nil {
+		return false, err
+	}
+	return n > 0, nil
+}
+
+// waitForProcess polls until at least one process row exists for the host/pid, or verifyTimeout elapses.
+func (s *seeder) waitForProcess(ctx context.Context, hostID string, pid int) error {
+	return s.poll(ctx, s.cfg.verifyTimeout, func() (bool, error) {
+		var n int
+		err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM processes WHERE host_id = ? AND pid = ?`, hostID, pid).Scan(&n)
+		if err != nil {
+			return false, err
+		}
+		return n > 0, nil
+	})
+}
+
+// verify polls until the processor has materialised a process graph, at least one detection alert, and at least one app-control
+// alert, or verifyTimeout elapses.
+func (s *seeder) verify(ctx context.Context) error {
+	return s.poll(ctx, s.cfg.verifyTimeout, func() (bool, error) {
+		c, err := s.counts(ctx)
+		if err != nil {
+			return false, err
+		}
+		s.logger.DebugContext(ctx, "verify counts",
+			"processes", c.processes, "detection_alerts", c.detectionAlerts, "app_control_alerts", c.appControlAlerts)
+		return c.processes > 0 && c.detectionAlerts > 0 && c.appControlAlerts > 0, nil
+	})
+}
+
+// demoCounts is the materialised-data tally verify checks.
+type demoCounts struct {
+	processes        int
+	detectionAlerts  int
+	appControlAlerts int
+}
+
+// counts reads the current process + alert tallies from the database.
+func (s *seeder) counts(ctx context.Context) (demoCounts, error) {
+	var c demoCounts
+	if err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM processes`).Scan(&c.processes); err != nil {
+		return c, fmt.Errorf("count processes: %w", err)
+	}
+	if err := s.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM alerts WHERE source = 'detection'`).Scan(&c.detectionAlerts); err != nil {
+		return c, fmt.Errorf("count detection alerts: %w", err)
+	}
+	if err := s.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM alerts WHERE source = 'application_control'`).Scan(&c.appControlAlerts); err != nil {
+		return c, fmt.Errorf("count app-control alerts: %w", err)
+	}
+	return c, nil
+}
+
+// poll runs cond on cfg.pollInterval until it returns true, cond errors, the context is cancelled, or timeout elapses.
+func (s *seeder) poll(ctx context.Context, timeout time.Duration, cond func() (bool, error)) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		ok, err := cond()
+		if err != nil {
+			return err
+		}
+		if ok {
+			return nil
+		}
+		if !time.Now().Before(deadline) {
+			return fmt.Errorf("condition not met within %s", timeout)
+		}
+		if err := sleep(ctx, s.cfg.pollInterval); err != nil {
+			return err
+		}
+	}
+}
+
+// sleep is a context-aware sleep.
+func sleep(ctx context.Context, d time.Duration) error {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-t.C:
+		return nil
+	}
+}
+
+// randomEventID returns a 32-char lower-hex random id for the fabricated block event.
+func randomEventID() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		panic("demo-seed: crypto/rand.Read: " + err.Error())
+	}
+	return hex.EncodeToString(b[:])
+}

--- a/server/cmd/fleet-edr-demo-seed/seed_test.go
+++ b/server/cmd/fleet-edr-demo-seed/seed_test.go
@@ -1,0 +1,251 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fleetdm/edr/test/fakeagent"
+)
+
+func discardLogger() *slog.Logger { return slog.New(slog.NewTextHandler(io.Discard, nil)) }
+
+// httpSeeder builds a seeder pointed at a test server, with short timeouts so polling paths run fast.
+func httpSeeder(serverURL string) *seeder {
+	cfg := config{
+		serverURL:    serverURL,
+		enrollSecret: "test-secret",
+		pollInterval: time.Millisecond,
+		readyTimeout: time.Second,
+	}
+	return newSeeder(cfg, nil, discardLogger())
+}
+
+func TestResolveConfig(t *testing.T) {
+	t.Run("defaults with dsn from env", func(t *testing.T) {
+		env := map[string]string{"EDR_DSN": "root@tcp(localhost:3306)/edr"}
+		c, err := resolveConfig(func(k string) string { return env[k] }, nil)
+		require.NoError(t, err)
+		assert.Equal(t, "https://localhost:8088", c.serverURL)
+		assert.Equal(t, "demo-enroll-secret", c.enrollSecret)
+		assert.Equal(t, "demo@fleet-edr.local", c.demoEmail)
+		assert.Equal(t, "senior_analyst", c.demoRole)
+		assert.Empty(t, c.demoOIDCSubject)
+		assert.True(t, c.insecure)
+		assert.False(t, c.force)
+		assert.Equal(t, 90*time.Second, c.readyTimeout)
+	})
+
+	t.Run("flags override env defaults", func(t *testing.T) {
+		env := map[string]string{"EDR_DSN": "from-env"}
+		args := []string{
+			"--server-url=https://demo.example:9000",
+			"--dsn=from-flag",
+			"--force",
+			"--insecure=false",
+			"--demo-oidc-subject=ChdkZW1v",
+			"--demo-role=admin",
+			"--poll-interval=250ms",
+		}
+		c, err := resolveConfig(func(k string) string { return env[k] }, args)
+		require.NoError(t, err)
+		assert.Equal(t, "https://demo.example:9000", c.serverURL)
+		assert.Equal(t, "from-flag", c.dsn)
+		assert.True(t, c.force)
+		assert.False(t, c.insecure)
+		assert.Equal(t, "ChdkZW1v", c.demoOIDCSubject)
+		assert.Equal(t, "admin", c.demoRole)
+		assert.Equal(t, 250*time.Millisecond, c.pollInterval)
+	})
+
+	t.Run("missing dsn is an error", func(t *testing.T) {
+		_, err := resolveConfig(func(string) string { return "" }, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "DSN is required")
+	})
+}
+
+func TestEnvHelpers(t *testing.T) {
+	get := func(m map[string]string) func(string) string {
+		return func(k string) string { return m[k] }
+	}
+	assert.Equal(t, "v", envOr(get(map[string]string{"K": "v"}), "K", "fallback"))
+	assert.Equal(t, "fallback", envOr(get(nil), "K", "fallback"))
+
+	assert.True(t, envBool(get(map[string]string{"K": "true"}), "K", false))
+	assert.False(t, envBool(get(map[string]string{"K": "0"}), "K", true))
+	assert.True(t, envBool(get(map[string]string{"K": "garbage"}), "K", true), "unparseable falls back")
+	assert.True(t, envBool(get(nil), "K", true), "unset falls back")
+
+	assert.Equal(t, 5*time.Second, envDuration(get(map[string]string{"K": "5s"}), "K", time.Minute))
+	assert.Equal(t, time.Minute, envDuration(get(map[string]string{"K": "nope"}), "K", time.Minute))
+	assert.Equal(t, time.Minute, envDuration(get(nil), "K", time.Minute))
+}
+
+func TestLoadScenarios(t *testing.T) {
+	scenarios, err := loadScenarios()
+	require.NoError(t, err)
+	require.Len(t, scenarios, len(corpusManifest))
+
+	byFile := map[string]demoScenario{}
+	hostIDs := map[string]bool{}
+	for _, sc := range scenarios {
+		require.NotNil(t, sc.Scenario, "scenario %s parsed", sc.File)
+		require.NotEmpty(t, sc.Scenario.Host.ID)
+		assert.False(t, hostIDs[sc.Scenario.Host.ID], "host id %s is unique across the corpus", sc.Scenario.Host.ID)
+		hostIDs[sc.Scenario.Host.ID] = true
+		byFile[sc.File] = sc
+	}
+
+	// Attack scenarios must name the catalog rule they trip.
+	for _, f := range []string{"keychain-dump.yaml", "sudoers-tamper.yaml", "launchagent-persistence.yaml"} {
+		sc, ok := byFile[f]
+		require.True(t, ok, "manifest includes %s", f)
+		assert.Equal(t, kindAttack, sc.Kind)
+		assert.NotEmpty(t, sc.ExpectRule)
+	}
+
+	// The app-control scenario must carry an exec the block event can target.
+	ac, ok := byFile["app-control-blocked-app.yaml"]
+	require.True(t, ok)
+	assert.Equal(t, kindAppControl, ac.Kind)
+	_, _, hasExec := firstExec(ac.Scenario)
+	assert.True(t, hasExec, "app-control scenario has an exec event")
+}
+
+func TestFirstExec(t *testing.T) {
+	withExec := &fakeagent.Scenario{Timeline: []fakeagent.Event{
+		{Type: "fork", ChildPID: 10, ParentPID: 1},
+		{Type: "exec", PID: 10, Path: "/bin/zsh"},
+	}}
+	pid, p, ok := firstExec(withExec)
+	require.True(t, ok)
+	assert.Equal(t, 10, pid)
+	assert.Equal(t, "/bin/zsh", p)
+
+	forkOnly := &fakeagent.Scenario{Timeline: []fakeagent.Event{{Type: "fork", ChildPID: 5, ParentPID: 1}}}
+	_, _, ok = firstExec(forkOnly)
+	assert.False(t, ok)
+}
+
+func TestBuildBlockEnvelope(t *testing.T) {
+	env := buildBlockEnvelope("HOST-1", 6123, "/Applications/CoinMiner.app/Contents/MacOS/CoinMiner", 1700000000000000000)
+	assert.Equal(t, "HOST-1", env.HostID)
+	assert.Equal(t, appControlEventType, env.EventType)
+	assert.Equal(t, int64(1700000000000000000), env.TimestampNs)
+	assert.Len(t, env.EventID, 32)
+
+	var p map[string]any
+	require.NoError(t, json.Unmarshal(env.Payload, &p))
+	assert.EqualValues(t, 6123, p["pid"])
+	assert.Equal(t, "/Applications/CoinMiner.app/Contents/MacOS/CoinMiner", p["path"])
+	assert.Equal(t, "/Applications/CoinMiner.app/Contents/MacOS/CoinMiner", p["identifier"])
+	assert.Equal(t, appControlRuleID, p["rule_id"])
+	assert.Equal(t, appControlRuleType, p["rule_type"])
+	assert.Equal(t, appControlSeverity, p["severity"])
+	assert.Equal(t, appControlMessage, p["custom_msg"])
+	assert.EqualValues(t, 1, p["policy_id"])
+	assert.EqualValues(t, 1, p["policy_version"])
+}
+
+func TestEnroll(t *testing.T) {
+	t.Run("returns the issued token and echoes host id", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/api/enroll", r.URL.Path)
+			assert.Equal(t, http.MethodPost, r.Method)
+			var req map[string]string
+			assert.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+			assert.Equal(t, "test-secret", req["enroll_secret"])
+			_ = json.NewEncoder(w).Encode(map[string]any{"host_id": req["hardware_uuid"], "host_token": "tok-" + req["hardware_uuid"]})
+		}))
+		defer ts.Close()
+
+		token, err := httpSeeder(ts.URL).enroll(context.Background(), "HOST-9", "host9.local")
+		require.NoError(t, err)
+		assert.Equal(t, "tok-HOST-9", token)
+	})
+
+	t.Run("non-200 is an error", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusForbidden)
+		}))
+		defer ts.Close()
+		_, err := httpSeeder(ts.URL).enroll(context.Background(), "HOST-9", "h")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "HTTP 403")
+	})
+
+	t.Run("missing token is an error", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode(map[string]any{"host_id": "HOST-9", "host_token": ""})
+		}))
+		defer ts.Close()
+		_, err := httpSeeder(ts.URL).enroll(context.Background(), "HOST-9", "h")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "missing host_token")
+	})
+}
+
+func TestPostEnvelopes(t *testing.T) {
+	t.Run("2xx succeeds and sends bearer token", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/api/events", r.URL.Path)
+			assert.Equal(t, "Bearer tok", r.Header.Get("Authorization"))
+			var envs []fakeagent.Envelope
+			assert.NoError(t, json.NewDecoder(r.Body).Decode(&envs))
+			assert.Len(t, envs, 1)
+			_, _ = w.Write([]byte(`{"accepted":1}`))
+		}))
+		defer ts.Close()
+		err := httpSeeder(ts.URL).postEnvelopes(context.Background(), "tok",
+			[]fakeagent.Envelope{buildBlockEnvelope("H", 1, "/x", 1)})
+		require.NoError(t, err)
+	})
+
+	t.Run("non-2xx is an error", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer ts.Close()
+		err := httpSeeder(ts.URL).postEnvelopes(context.Background(), "tok", nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "HTTP 500")
+	})
+}
+
+func TestWaitReady(t *testing.T) {
+	t.Run("becomes ready after initial 503s", func(t *testing.T) {
+		var calls atomic.Int32
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			if calls.Add(1) < 3 {
+				w.WriteHeader(http.StatusServiceUnavailable)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer ts.Close()
+		require.NoError(t, httpSeeder(ts.URL).waitReady(context.Background()))
+		assert.GreaterOrEqual(t, calls.Load(), int32(3))
+	})
+
+	t.Run("times out while never ready", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusServiceUnavailable)
+		}))
+		defer ts.Close()
+		s := httpSeeder(ts.URL)
+		s.cfg.readyTimeout = 20 * time.Millisecond
+		err := s.waitReady(context.Background())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not met within")
+	})
+}

--- a/server/cmd/fleet-edr-demo-seed/seed_test.go
+++ b/server/cmd/fleet-edr-demo-seed/seed_test.go
@@ -19,6 +19,9 @@ import (
 
 func discardLogger() *slog.Logger { return slog.New(slog.NewTextHandler(io.Discard, nil)) }
 
+// testHTTPClient builds the default (system-roots) client tests use when they don't exercise CA-cert handling.
+func testHTTPClient() *http.Client { c, _ := newHTTPClient(""); return c }
+
 // httpSeeder builds a seeder pointed at a test server, with short timeouts so polling paths run fast.
 func httpSeeder(serverURL string) *seeder {
 	cfg := config{
@@ -27,7 +30,8 @@ func httpSeeder(serverURL string) *seeder {
 		pollInterval: time.Millisecond,
 		readyTimeout: time.Second,
 	}
-	return newSeeder(cfg, nil, discardLogger())
+	client, _ := newHTTPClient("")
+	return newSeeder(cfg, nil, client, discardLogger())
 }
 
 func TestResolveConfig(t *testing.T) {
@@ -40,7 +44,7 @@ func TestResolveConfig(t *testing.T) {
 		assert.Equal(t, "demo@fleet-edr.local", c.demoEmail)
 		assert.Equal(t, "senior_analyst", c.demoRole)
 		assert.Empty(t, c.demoOIDCSubject)
-		assert.True(t, c.insecure)
+		assert.Empty(t, c.caCertPath)
 		assert.False(t, c.force)
 		assert.Equal(t, 90*time.Second, c.readyTimeout)
 	})
@@ -51,7 +55,7 @@ func TestResolveConfig(t *testing.T) {
 			"--server-url=https://demo.example:9000",
 			"--dsn=from-flag",
 			"--force",
-			"--insecure=false",
+			"--ca-cert=/etc/tls/dev.crt",
 			"--demo-oidc-subject=ChdkZW1v",
 			"--demo-role=admin",
 			"--poll-interval=250ms",
@@ -61,10 +65,17 @@ func TestResolveConfig(t *testing.T) {
 		assert.Equal(t, "https://demo.example:9000", c.serverURL)
 		assert.Equal(t, "from-flag", c.dsn)
 		assert.True(t, c.force)
-		assert.False(t, c.insecure)
+		assert.Equal(t, "/etc/tls/dev.crt", c.caCertPath)
 		assert.Equal(t, "ChdkZW1v", c.demoOIDCSubject)
 		assert.Equal(t, "admin", c.demoRole)
 		assert.Equal(t, 250*time.Millisecond, c.pollInterval)
+	})
+
+	t.Run("trims trailing slash from server-url", func(t *testing.T) {
+		env := map[string]string{"EDR_DSN": "d", "EDR_DEMO_SERVER_URL": "https://localhost:8088/"}
+		c, err := resolveConfig(func(k string) string { return env[k] }, nil)
+		require.NoError(t, err)
+		assert.Equal(t, "https://localhost:8088", c.serverURL)
 	})
 
 	t.Run("missing dsn is an error", func(t *testing.T) {

--- a/server/cmd/fleet-edr-demo-seed/user.go
+++ b/server/cmd/fleet-edr-demo-seed/user.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+)
+
+// dbExecQuerier is the subset of database/sql the seeder's DB-facing helpers use. Both *sql.DB (production) and *sqlx.DB (the
+// testdb/full handle the tests open) satisfy it, so the same code is exercised against a real schema in tests.
+type dbExecQuerier interface {
+	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
+	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
+}
+
+// seedDemoUser idempotently provisions the SSO demo user so first login lands at a full-capability role instead of the OIDC JIT
+// default (analyst, hardcoded in server/identity/internal/oidc/jit.go). It inserts the users row, an oidc identity bound to the
+// dex-issued subject, and a global role binding. On login ProvisionOrFind matches the existing (provider, subject) identity and
+// reuses it rather than JIT-provisioning, so the higher role sticks.
+//
+// roleID must already exist in the roles table: the server seeds the five built-in roles at boot, which happens before this seeder
+// runs against it. Every statement is idempotent on its unique key so a container restart re-runs the seeder harmlessly.
+func seedDemoUser(ctx context.Context, db dbExecQuerier, email, subject, roleID string) error {
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO users (email, display_name, status)
+		VALUES (?, 'Demo User', 'active')
+		ON DUPLICATE KEY UPDATE display_name = VALUES(display_name)`, email); err != nil {
+		return fmt.Errorf("seed demo user row: %w", err)
+	}
+
+	var userID int64
+	if err := db.QueryRowContext(ctx, `SELECT id FROM users WHERE email = ?`, email).Scan(&userID); err != nil {
+		return fmt.Errorf("look up demo user id: %w", err)
+	}
+
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO identities (user_id, provider, subject)
+		VALUES (?, 'oidc', ?)
+		ON DUPLICATE KEY UPDATE user_id = VALUES(user_id)`, userID, subject); err != nil {
+		return fmt.Errorf("seed demo identity: %w", err)
+	}
+
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO role_bindings (user_id, role_id, scope_type, scope_id)
+		VALUES (?, ?, 'global', '*')
+		ON DUPLICATE KEY UPDATE role_id = VALUES(role_id)`, userID, roleID); err != nil {
+		return fmt.Errorf("seed demo role binding: %w", err)
+	}
+	return nil
+}

--- a/server/cmd/fleet-edr-demo-seed/user.go
+++ b/server/cmd/fleet-edr-demo-seed/user.go
@@ -33,11 +33,22 @@ func seedDemoUser(ctx context.Context, db dbExecQuerier, email, subject, roleID 
 		return fmt.Errorf("look up demo user id: %w", err)
 	}
 
+	// Insert the identity, leaving any pre-existing (provider, subject) mapping untouched (ON DUPLICATE ... user_id = user_id is a
+	// no-op). Then confirm the mapping points at the demo user: refuse to silently re-bind a subject already owned by another user
+	// rather than hijacking it.
 	if _, err := db.ExecContext(ctx, `
 		INSERT INTO identities (user_id, provider, subject)
 		VALUES (?, 'oidc', ?)
-		ON DUPLICATE KEY UPDATE user_id = VALUES(user_id)`, userID, subject); err != nil {
+		ON DUPLICATE KEY UPDATE user_id = user_id`, userID, subject); err != nil {
 		return fmt.Errorf("seed demo identity: %w", err)
+	}
+	var boundUserID int64
+	if err := db.QueryRowContext(ctx,
+		`SELECT user_id FROM identities WHERE provider = 'oidc' AND subject = ?`, subject).Scan(&boundUserID); err != nil {
+		return fmt.Errorf("verify demo identity binding: %w", err)
+	}
+	if boundUserID != userID {
+		return fmt.Errorf("oidc subject %q is already bound to user %d, not demo user %d; refusing to re-bind", subject, boundUserID, userID)
 	}
 
 	if _, err := db.ExecContext(ctx, `


### PR DESCRIPTION
First PR of the tag-pinned docker demo (ai/demo/docker-eval-demo-plan.md): a one-shot seeder that preloads a running server with demo data through the real ingest + detection pipeline, so the repo is evaluable without a Mac fleet.

What it does:
- Enrolls synthetic hosts and replays a curated corpus (keychain dump T1555.001, sudoers tamper T1548.003, launchagent persistence T1543.001, a benign developer-workstation noise host) via fakeagent PostDirect, so the server's own processor materializes the process graph and the detection engine fires the alerts.
- Fabricates one application_control_block event (fakeagent does not emit those) after waiting for its target process to materialize, so the ApplicationControlBlock rule's GetProcessByPID lookup resolves and the unified alerts view shows an application_control source.
- Verifies the materialized data via SQL, and idempotently provisions the SSO demo user at a full-capability role (senior_analyst) so first login skips the OIDC JIT analyst default. The demo-user seed is gated on --demo-oidc-subject and disabled by default (PR 2 wires the captured dex subject); a PR-1 run against `task dev:server` skips it.

Independently runnable against `task dev:server`; smoke-tested end to end against a live server (3 detection alerts + 1 app-control alert, 0 noise-host false positives, 8-node graph). Tests cover scenarios, config, HTTP, and the DB paths via testdb/full; package coverage 82%. server/Dockerfile.demo-seed builds the one-shot image for the compose stack (wired in PR 2).

<!-- Keep this short. Delete sections that do not apply. -->

## What & why



## Checklist

- [ ] **OpenSpec updated for behavior changes.** If this PR changes observable behavior (a detection rule, the event
      wire schema, persistence semantics, an API/wire shape, or an emitted event), `openspec/specs/**` is updated (and
      an `openspec/changes/` proposal added), with a `spec:<id>` test marker for any new/renamed scenario. Only if this
      PR changes NO observable behavior (a comment / refactor / gofmt / dep bump that happens to touch a scoped path)
      may you assert `no-behavior-change` (label or `[no-behavior-change]` in the title) to clear the OpenSpec-sync gate.
      That is an assertion a reviewer will check, not a way to skip the spec for a real behavior change.
- [ ] Tests added/updated for the change (unit / integration / efficacy / UI as applicable).
- [ ] Agent/extension change touching ESF, XPC, or the event wire format: exercised on a live macOS VM before RC
      (flagged below).

## VM / RC notes (if applicable)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a demo data seeder utility that automatically populates the EDR server with test hosts, event timelines, and realistic threat scenarios—including attack patterns, application control blocks, and normal workstation activity—for testing and demonstration purposes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->