### PR TITLE
Demo eval stack

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -453,9 +453,29 @@ jobs:
           cosign sign \
             "ghcr.io/getvictor/fleet-edr-demo-seed@${IMAGE_DIGEST}"
 
-      # The seeder is internal demo tooling, not a shipped product artifact, so it
-      # carries a cosign signature + SLSA build provenance but not the full SBOM
-      # attestation the server image gets.
+      # Full supply-chain parity with the server image: the seeder is published to the
+      # same public registry, so it gets a cosign-attested SBOM + SLSA provenance too.
+      - name: Generate image SBOM (SPDX)
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          image: ghcr.io/getvictor/fleet-edr-demo-seed@${{ steps.build.outputs.digest }}
+          format: spdx-json
+          artifact-name: fleet-edr-demo-seed-${{ env.RELEASE_TAG }}-sbom.spdx.json
+          output-file: /tmp/fleet-edr-demo-seed-sbom.spdx.json
+          upload-release-assets: false
+
+      - name: Attach image SBOM as cosign attestation
+        if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          COSIGN_YES: 'true'
+          IMAGE_DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          cosign attest \
+            --predicate /tmp/fleet-edr-demo-seed-sbom.spdx.json \
+            --type spdxjson \
+            "ghcr.io/getvictor/fleet-edr-demo-seed@${IMAGE_DIGEST}"
+
       - name: Attest image build provenance
         if: startsWith(github.ref, 'refs/tags/v')
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -395,3 +395,71 @@ jobs:
           subject-name: ghcr.io/getvictor/fleet-edr-server
           subject-digest: ${{ steps.build.outputs.digest }}
           push-to-registry: true
+
+  docker-demo-seed:
+    name: Build + push demo-seed image
+    runs-on: ubuntu-latest
+    # Separate job (not a matrix with docker-server) so the proven server-release
+    # path stays byte-identical. This is the one-shot seeder for the Mac-free
+    # docker demo (docker-compose.demo.yml), built + pushed alongside the server
+    # image so the demo can pin both to the same released tag.
+    permissions:
+      contents: read      # checkout source for the build context
+      packages: write     # push multi-arch image to ghcr.io/getvictor/fleet-edr-demo-seed
+      id-token: write     # Sigstore keyless signing of the pushed image
+      attestations: write # actions/attest-build-provenance for the image
+    env:
+      RELEASE_TAG: ${{ github.ref_name }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: .
+          file: server/Dockerfile.demo-seed
+          platforms: linux/amd64,linux/arm64
+          push: ${{ startsWith(github.ref, 'refs/tags/v') }}
+          # `:latest` only advances on stable releases, matching the server image
+          # (pre-release tags contain a `-`).
+          tags: |
+            ghcr.io/getvictor/fleet-edr-demo-seed:${{ env.RELEASE_TAG }}
+            ${{ startsWith(github.ref, 'refs/tags/v') && !contains(env.RELEASE_TAG, '-') && 'ghcr.io/getvictor/fleet-edr-demo-seed:latest' || '' }}
+
+      - name: Install cosign
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          cosign-release: 'v2.5.3'
+
+      - name: Sign image (cosign keyless)
+        if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          COSIGN_YES: 'true'
+          IMAGE_DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          cosign sign \
+            "ghcr.io/getvictor/fleet-edr-demo-seed@${IMAGE_DIGEST}"
+
+      # The seeder is internal demo tooling, not a shipped product artifact, so it
+      # carries a cosign signature + SLSA build provenance but not the full SBOM
+      # attestation the server image gets.
+      - name: Attest image build provenance
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-name: ghcr.io/getvictor/fleet-edr-demo-seed
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ To run from a local source build instead of the pinned release images:
 docker compose -f docker-compose.demo.yml -f docker-compose.demo.build.yml up --build
 ```
 
-### Notes for reviewers
+### Demo notes
 
 - The on-device half (system extension, network extension, agent) needs an Apple-granted Endpoint Security entitlement, an
   MDM, and Apple Silicon, so it cannot run in Docker. The recording linked above (once published) captures it on a real Mac;
@@ -60,7 +60,7 @@ docker compose -f docker-compose.demo.yml -f docker-compose.demo.build.yml up --
   path, and the server's own processor materializes the process graph and fires the alerts.
 - Response actions (kill, isolate) are visible and enqueue, but never complete because no live agent is connected.
 - TLS uses a self-signed `localhost` certificate, so the browser shows a one-time warning. The stack is for evaluation only:
-  empty MySQL password and checked-in dev secrets -- do not expose it.
+  empty MySQL password and checked-in dev secrets. Do not expose it this stack to the public internet.
 - SSO is the documented path. Admin onboarding via break-glass is also available: a redemption URL prints to the server logs
   on first boot (`docker compose -f docker-compose.demo.yml logs server | grep -i break-glass`); redeeming it needs a
   WebAuthn authenticator.

--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ docker compose -f docker-compose.demo.yml -f docker-compose.demo.build.yml up --
 ### Notes for reviewers
 
 - The on-device half (system extension, network extension, agent) needs an Apple-granted Endpoint Security entitlement, an
-  MDM, and Apple Silicon, so it cannot run in Docker. The recording above shows it on a real Mac; this stack exercises the
-  server, UI, and detection pipeline.
+  MDM, and Apple Silicon, so it cannot run in Docker. The recording linked above (once published) captures it on a real Mac;
+  this stack exercises the server, UI, and detection pipeline.
 - The demo data is genuine: the seeder replays a curated attack + noise corpus through the real `POST /api/events` ingest
   path, and the server's own processor materializes the process graph and fires the alerts.
 - Response actions (kill, isolate) are visible and enqueue, but never complete because no live agent is connected.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,48 @@ Fleet EDR is an open-source endpoint detection and response system for macOS fle
 into process and network activity on Apple Silicon Macs, runs behavioral detection rules against a materialized process graph,
 and ships response actions (kill, token rotation, app-control block) without a SaaS dependency.
 
+## Try the demo (no Mac required)
+
+Evaluate Fleet EDR in about five minutes with one command. No Apple Silicon Mac, MDM, or Apple-granted entitlement needed.
+
+<!-- Demo recording: replace this line with the published release-asset link. -->
+Demo recording: _coming soon_ -- extension activation, a correlated detection, and an AUTH_EXEC block, captured on a real Mac.
+
+```sh
+docker compose -f docker-compose.demo.yml up
+```
+
+Then open <https://localhost:8088/ui/>, accept the self-signed certificate warning, and sign in with the bundled SSO account:
+
+- Email: `demo@fleet-edr.local`
+- Password: `demo`
+
+You'll see a process graph, fired ATT&CK detection alerts (keychain dump, sudoers tamper, launchd persistence), and an
+application-control block -- all produced by the real ingestion + detection pipeline from a replayed attack corpus, not
+hand-inserted rows.
+
+To run from a local source build instead of the pinned release images:
+
+```sh
+docker compose -f docker-compose.demo.yml -f docker-compose.demo.build.yml up --build
+```
+
+### Notes for reviewers
+
+- The on-device half (system extension, network extension, agent) needs an Apple-granted Endpoint Security entitlement, an
+  MDM, and Apple Silicon, so it cannot run in Docker. The recording above shows it on a real Mac; this stack exercises the
+  server, UI, and detection pipeline.
+- The demo data is genuine: the seeder replays a curated attack + noise corpus through the real `POST /api/events` ingest
+  path, and the server's own processor materializes the process graph and fires the alerts.
+- Response actions (kill, isolate) are visible and enqueue, but never complete because no live agent is connected.
+- TLS uses a self-signed `localhost` certificate, so the browser shows a one-time warning. The stack is for evaluation only:
+  empty MySQL password and checked-in dev secrets -- do not expose it.
+- SSO is the documented path. Admin onboarding via break-glass is also available: a redemption URL prints to the server logs
+  on first boot (`docker compose -f docker-compose.demo.yml logs server | grep -i break-glass`); redeeming it needs a
+  WebAuthn authenticator.
+- If your browser does not resolve `*.localhost` to `127.0.0.1` (most Chromium and Firefox builds do), add
+  `127.0.0.1 dex.demo.localhost` to your hosts file so the SSO redirect can reach the bundled IdP.
+
 ## Operator docs
 
 Running Fleet EDR (not developing it)? Start with [`docs/`](docs/):

--- a/config/dex/demo-config.yaml
+++ b/config/dex/demo-config.yaml
@@ -1,0 +1,51 @@
+# dex (https://dexidp.io) configuration for the Mac-free docker demo
+# (docker-compose.demo.yml). It backs the one reviewer SSO account so a
+# reviewer can sign in and click around without an MDM, a Mac, or a real IdP.
+#
+# A single static user is pre-provisioned: demo@fleet-edr.local / demo. On
+# first sign-in the EDR JIT-provisions it; docker-compose.demo.yml sets
+# EDR_OIDC_DEFAULT_ROLE=admin so that account lands at the `admin` role and
+# every affordance is visible.
+#
+# DO NOT use this config or these credentials in production. The issuer URL,
+# client secret, and static password are all checked into the repo by design;
+# production OIDC config lives in env vars loaded from a real secrets manager
+# per docs/okta-setup.md.
+#
+# The issuer host `dex.demo.localhost` is deliberate: browsers resolve any
+# *.localhost name to 127.0.0.1 (RFC 6761), so the reviewer's browser reaches
+# dex via its published :5556 port, while the EDR server container resolves the
+# same hostname to the dex service through a docker network alias. One issuer
+# URL that resolves to dex from both sides. See README "Notes for reviewers".
+issuer: http://dex.demo.localhost:5556/dex
+
+storage:
+  type: sqlite3
+  config:
+    file: /var/dex/dex.db
+
+web:
+  http: 0.0.0.0:5556
+
+# Skip the consent screen so the reviewer's sign-in is a single password prompt.
+oauth2:
+  skipApprovalScreen: true
+
+staticClients:
+  - id: edr-demo
+    name: "Fleet EDR demo"
+    secret: edr-demo-client-secret-do-not-use-in-prod
+    redirectURIs:
+      # Must match docker-compose.demo.yml's EDR_OIDC_REDIRECT_URL exactly; dex
+      # refuses any other URL during the authorization-code redirect. This is the
+      # browser-facing EDR server URL, hence localhost (not the in-network name).
+      - "https://localhost:8088/api/auth/callback"
+
+enablePasswordDB: true
+
+staticPasswords:
+  # Password is "demo"; hash generated with `htpasswd -bnBC 10 "" demo | tr -d ':\n'`.
+  - email: "demo@fleet-edr.local"
+    username: "demo"
+    userID: "de300000-0000-4000-8000-000000000001"
+    hash: "$2y$10$EckN0c12ycD1XJti5eWMceLbY9Xz6FDro.jF8cNz7roAmhgefLc52"

--- a/docker-compose.demo.build.yml
+++ b/docker-compose.demo.build.yml
@@ -1,0 +1,23 @@
+# Override layer: build the server + seeder images from the checkout instead of
+# pulling pinned images from ghcr. Use for local source runs and smoke tests
+# (no published tag required):
+#
+#   docker compose -f docker-compose.demo.yml \
+#                  -f docker-compose.demo.build.yml \
+#                  up --build
+#
+# Mirrors docker-compose.prod.build.yml. Keep both demo files checked in
+# together so the override resolves its build context from the repo root.
+services:
+  server:
+    build:
+      context: .
+      dockerfile: server/Dockerfile
+      args:
+        VERSION: ${EDR_VERSION:-demo}
+        COMMIT: ${EDR_COMMIT:-unknown}
+
+  seeder:
+    build:
+      context: .
+      dockerfile: server/Dockerfile.demo-seed

--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -1,0 +1,138 @@
+# Mac-free, one-command demo stack for evaluating Fleet EDR.
+#
+#   docker compose -f docker-compose.demo.yml up
+#   # then open https://localhost:8088/ui/ and sign in: demo@fleet-edr.local / demo
+#
+# It boots the real server + embedded UI against MySQL, generates a self-signed
+# localhost TLS cert, bundles a dex IdP for SSO, and runs a one-shot seeder that
+# replays a curated attack + noise corpus through the real ingest + detection
+# pipeline so the UI shows a process graph, fired ATT&CK alerts, and an
+# application-control block. No Mac, MDM, or Apple entitlement required.
+#
+# Images are pinned to a released tag. To run from a local source build instead
+# (no published tag needed), layer the build override:
+#
+#   docker compose -f docker-compose.demo.yml -f docker-compose.demo.build.yml up --build
+#
+# This stack is for evaluation only: empty MySQL password, self-signed cert,
+# checked-in dev secrets. Do not expose it or use it in production.
+name: fleet-edr-demo
+
+services:
+  mysql:
+    image: mysql:8.4
+    environment:
+      MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+      MYSQL_DATABASE: edr
+    # Ephemeral by design: every `up` starts from a clean, freshly-seeded database.
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+      start_period: 10s
+
+  dex:
+    image: ghcr.io/dexidp/dex:v2.41.1
+    command: ["dex", "serve", "/etc/dex/config.yaml"]
+    volumes:
+      - ./config/dex/demo-config.yaml:/etc/dex/config.yaml:ro
+      - dex-data:/var/dex
+    networks:
+      default:
+        # The server reaches the issuer host (dex.demo.localhost) through this
+        # alias; the browser reaches the same host via *.localhost -> 127.0.0.1
+        # and the published port below. See config/dex/demo-config.yaml.
+        aliases:
+          - dex.demo.localhost
+    ports:
+      - "127.0.0.1:5556:5556"
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:5556/dex/.well-known/openid-configuration"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
+  cert-init:
+    # Generate a self-signed localhost cert into the shared tls volume before the
+    # server boots (the distroless server image has no openssl). SAN covers
+    # `localhost` (the browser-facing URL) and `server` (the in-network hostname
+    # the seeder verifies). Runs once and exits; idempotent across restarts.
+    image: alpine:3.21
+    command:
+      - sh
+      - -c
+      - |
+        set -e
+        if [ -s /tls/dev.crt ] && [ -s /tls/dev.key ]; then
+          echo "cert already present, skipping"
+          exit 0
+        fi
+        apk add --no-cache openssl >/dev/null
+        openssl req -x509 -newkey rsa:2048 -nodes -days 365 \
+          -keyout /tls/dev.key -out /tls/dev.crt \
+          -subj "/CN=localhost" \
+          -addext "subjectAltName=DNS:localhost,DNS:server,IP:127.0.0.1,IP:::1"
+        chmod 0644 /tls/dev.crt /tls/dev.key
+        echo "generated /tls/dev.crt"
+    volumes:
+      - tls:/tls
+
+  server:
+    image: ghcr.io/getvictor/fleet-edr-server:${EDR_VERSION:-v0.1.1-rc.9}
+    restart: unless-stopped
+    depends_on:
+      mysql:
+        condition: service_healthy
+      dex:
+        condition: service_healthy
+      cert-init:
+        condition: service_completed_successfully
+    environment:
+      EDR_DSN: "root@tcp(mysql:3306)/edr?parseTime=true&tls=false"
+      EDR_ENROLL_SECRET: demo-enroll-secret
+      EDR_TLS_CERT_FILE: /tls/dev.crt
+      EDR_TLS_KEY_FILE: /tls/dev.key
+      EDR_LOG_FORMAT: json
+      EDR_SESSION_SIGNING_KEY: demo-only-session-signing-key-do-not-use-in-prod
+      # SSO against the bundled dex. EDR_OIDC_DEFAULT_ROLE lands the single demo
+      # user at `admin` on first sign-in so every affordance is visible.
+      EDR_OIDC_ISSUER: http://dex.demo.localhost:5556/dex
+      EDR_OIDC_CLIENT_ID: edr-demo
+      EDR_OIDC_CLIENT_SECRET: edr-demo-client-secret-do-not-use-in-prod
+      EDR_OIDC_REDIRECT_URL: https://localhost:8088/api/auth/callback
+      EDR_OIDC_ALLOW_JIT_PROVISIONING: "1"
+      EDR_OIDC_DEFAULT_ROLE: admin
+      # Break-glass is available as an alternative login (a redemption URL prints
+      # to the server logs on first boot). See README "Notes for reviewers".
+      EDR_BREAKGLASS_RP_ID: localhost
+      EDR_BREAKGLASS_RP_ORIGINS: https://localhost:8088
+    ports:
+      - "127.0.0.1:8088:8088"
+    volumes:
+      - tls:/tls:ro
+
+  seeder:
+    image: ghcr.io/getvictor/fleet-edr-demo-seed:${EDR_VERSION:-v0.1.1-rc.9}
+    # One-shot: enrolls hosts, replays the corpus, verifies, then exits 0.
+    restart: "no"
+    depends_on:
+      mysql:
+        condition: service_healthy
+      cert-init:
+        condition: service_completed_successfully
+      server:
+        # The server image is distroless (no shell for a container healthcheck),
+        # so the seeder polls /readyz itself rather than gating on health.
+        condition: service_started
+    environment:
+      EDR_DEMO_SERVER_URL: https://server:8088
+      EDR_ENROLL_SECRET: demo-enroll-secret
+      EDR_DSN: "root@tcp(mysql:3306)/edr?parseTime=true&tls=false"
+      EDR_DEMO_CA_CERT: /tls/dev.crt
+    volumes:
+      - tls:/tls:ro
+
+volumes:
+  dex-data:
+  tls:

--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -24,7 +24,9 @@ services:
     environment:
       MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
       MYSQL_DATABASE: edr
-    # Ephemeral by design: every `up` starts from a clean, freshly-seeded database.
+    # No named volume: data lives in an anonymous volume that persists across `up`/`down`
+    # but is discarded by `docker compose ... down -v`. Re-runs are safe regardless: the
+    # seeder is idempotent and skips replay when the demo data is already present.
     healthcheck:
       test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
       interval: 5s

--- a/openspec/specs/server-identity-authentication/spec.md
+++ b/openspec/specs/server-identity-authentication/spec.md
@@ -55,13 +55,12 @@ and redirect the browser to the application's home view.
 The system SHALL provision a user account on first successful Okta login when
 `auth.oidc.allow_jit_provisioning` is enabled and no identity row exists for the
 incoming `(provider, subject)` pair. The newly-created user SHALL be bound to the
-deployment's configured default JIT role at the deployment-wide scope — the seeded
-`analyst` role by default, overridable to another seeded role via `EDR_OIDC_DEFAULT_ROLE`
-— MUST NOT inherit any other role from claims (group → role mapping is out of scope for
+deployment's configured default JIT role at the deployment-wide scope (the seeded
+`analyst` role by default, overridable to another seeded role via `EDR_OIDC_DEFAULT_ROLE`).
+It MUST NOT inherit any other role from claims (group to role mapping is out of scope for
 wave 1), and the provisioning SHALL emit an audit row with action `user.created`. When
-`allow_jit_provisioning` is
-disabled, an unknown subject SHALL be denied with an audit row whose reason is
-`oidc.unknown_subject`.
+`allow_jit_provisioning` is disabled, an unknown subject SHALL be denied with an audit row
+whose reason is `oidc.unknown_subject`.
 
 #### Scenario: First Okta login auto-provisions an analyst
 

--- a/openspec/specs/server-identity-authentication/spec.md
+++ b/openspec/specs/server-identity-authentication/spec.md
@@ -55,9 +55,11 @@ and redirect the browser to the application's home view.
 The system SHALL provision a user account on first successful Okta login when
 `auth.oidc.allow_jit_provisioning` is enabled and no identity row exists for the
 incoming `(provider, subject)` pair. The newly-created user SHALL be bound to the
-seeded `analyst` role at the deployment-wide scope, MUST NOT inherit any other role
-from claims (group → role mapping is out of scope for wave 1), and the provisioning
-SHALL emit an audit row with action `user.created`. When `allow_jit_provisioning` is
+deployment's configured default JIT role at the deployment-wide scope — the seeded
+`analyst` role by default, overridable to another seeded role via `EDR_OIDC_DEFAULT_ROLE`
+— MUST NOT inherit any other role from claims (group → role mapping is out of scope for
+wave 1), and the provisioning SHALL emit an audit row with action `user.created`. When
+`allow_jit_provisioning` is
 disabled, an unknown subject SHALL be denied with an audit row whose reason is
 `oidc.unknown_subject`.
 

--- a/server/cmd/fleet-edr-server/main.go
+++ b/server/cmd/fleet-edr-server/main.go
@@ -230,6 +230,7 @@ func openIdentity(
 			RedirectURL:          cfg.OIDCRedirectURL,
 			Scopes:               cfg.OIDCScopes,
 			AllowJITProvisioning: cfg.OIDCAllowJITProvisioning,
+			DefaultRole:          cfg.OIDCDefaultRole,
 			StateCookieTTL:       cfg.OIDCStateCookieTTL,
 		},
 		Breakglass: identitybootstrap.BreakglassDeps{

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -157,6 +157,10 @@ type Config struct {
 	// binding. true = create on first sign-in (recommended for most deployments); false = require an admin to pre-provision the user.
 	// Default true.
 	OIDCAllowJITProvisioning bool
+	// OIDCDefaultRole is the role a JIT-provisioned OIDC user is bound to. Populated from EDR_OIDC_DEFAULT_ROLE; empty falls through to
+	// the identity context's default (`analyst`). Must name a seeded role. Lets a deployment land SSO users at a higher role without
+	// per-user pre-provisioning (the docker demo uses it to land its single SSO user at `admin`).
+	OIDCDefaultRole string
 	// OIDCStateCookieTTL bounds how long the signed state cookie (carrying state + nonce + PKCE verifier) stays valid. Defaults to 5m;
 	// tune up for slow IdPs / MFA prompts.
 	OIDCStateCookieTTL time.Duration
@@ -426,6 +430,9 @@ func parseOIDCOverrides(c *Config, getenv func(string) string, errs *[]error) {
 	}
 	if v := getenv("EDR_OIDC_ALLOW_JIT_PROVISIONING"); v != "" {
 		c.OIDCAllowJITProvisioning = v == "1"
+	}
+	if v := getenv("EDR_OIDC_DEFAULT_ROLE"); v != "" {
+		c.OIDCDefaultRole = v
 	}
 }
 

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -416,6 +416,12 @@ func loadOIDCConfig(c *Config, getenv func(string) string, errs *[]error) {
 	enforceOIDCGate(c, errs)
 }
 
+// builtinRoleIDs is the set of seeded RBAC role IDs that EDR_OIDC_DEFAULT_ROLE may name. Kept in sync with the canonical list in
+// server/identity/internal/seed/roles.go; config is a platform package and cannot import an identity-context internal package, so
+// the list is duplicated here behind this sync note. Validating against it at boot turns a mistyped role into a clear startup
+// error instead of an opaque foreign-key failure on the first SSO sign-in.
+var builtinRoleIDs = []string{"super_admin", "admin", "senior_analyst", "analyst", "auditor"}
+
 // parseOIDCOverrides reads the optional override env vars (EDR_OIDC_SCOPES, EDR_OIDC_ALLOW_JIT_PROVISIONING) onto c. Pulled out so
 // loadOIDCConfig stays under the cognitive-complexity budget.
 func parseOIDCOverrides(c *Config, getenv func(string) string, errs *[]error) {
@@ -432,7 +438,13 @@ func parseOIDCOverrides(c *Config, getenv func(string) string, errs *[]error) {
 		c.OIDCAllowJITProvisioning = v == "1"
 	}
 	if v := getenv("EDR_OIDC_DEFAULT_ROLE"); v != "" {
-		c.OIDCDefaultRole = v
+		// Normalize away whitespace + case typos; role IDs are canonically lower-case.
+		role := strings.ToLower(strings.TrimSpace(v))
+		if !slices.Contains(builtinRoleIDs, role) {
+			*errs = append(*errs, fmt.Errorf("EDR_OIDC_DEFAULT_ROLE %q is not a known role; allowed values: %s",
+				v, strings.Join(builtinRoleIDs, ", ")))
+		}
+		c.OIDCDefaultRole = role
 	}
 }
 
@@ -446,11 +458,11 @@ func enforceOIDCGate(c *Config, errs *[]error) {
 			"EDR_SESSION_SIGNING_KEY is required when OIDC is enabled; "+
 				"must be at least 32 bytes (use EDR_SESSION_SIGNING_KEY_FILE for docker-secret mounts)"))
 	}
-	partialOIDC := c.OIDCClientID != "" || c.OIDCClientSecret != "" || c.OIDCRedirectURL != ""
+	partialOIDC := c.OIDCClientID != "" || c.OIDCClientSecret != "" || c.OIDCRedirectURL != "" || c.OIDCDefaultRole != ""
 	switch {
 	case c.OIDCIssuer == "" && partialOIDC:
 		*errs = append(*errs, errors.New(
-			"EDR_OIDC_CLIENT_ID/CLIENT_SECRET/REDIRECT_URL set without EDR_OIDC_ISSUER; "+
+			"EDR_OIDC_CLIENT_ID/CLIENT_SECRET/REDIRECT_URL/DEFAULT_ROLE set without EDR_OIDC_ISSUER; "+
 				"set EDR_OIDC_ISSUER to enable OIDC, or unset the partial values to opt out"))
 	case c.OIDCIssuer == "" && !c.AuthAllowNoOIDC:
 		*errs = append(*errs, errors.New(

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -483,6 +483,41 @@ func TestLoad_OIDCConfig(t *testing.T) {
 			},
 		},
 		{
+			name: "EDR_OIDC_DEFAULT_ROLE is normalized (trim + lowercase)",
+			env: withExtra(prodLikeEnv, map[string]string{
+				"EDR_OIDC_ISSUER":         "https://example.okta.com",
+				"EDR_OIDC_CLIENT_ID":      "edr",
+				"EDR_OIDC_CLIENT_SECRET":  "shh",
+				"EDR_OIDC_REDIRECT_URL":   "https://edr.example.com/api/auth/callback",
+				"EDR_OIDC_DEFAULT_ROLE":   "  Senior_Analyst  ",
+				"EDR_SESSION_SIGNING_KEY": "0123456789abcdef0123456789abcdef",
+			}),
+			validate: func(t *testing.T, c *Config) {
+				t.Helper()
+				assert.Equal(t, "senior_analyst", c.OIDCDefaultRole)
+			},
+		},
+		{
+			name: "EDR_OIDC_DEFAULT_ROLE unknown role -> error listing allowed values",
+			env: withExtra(prodLikeEnv, map[string]string{
+				"EDR_OIDC_ISSUER":         "https://example.okta.com",
+				"EDR_OIDC_CLIENT_ID":      "edr",
+				"EDR_OIDC_CLIENT_SECRET":  "shh",
+				"EDR_OIDC_REDIRECT_URL":   "https://edr.example.com/api/auth/callback",
+				"EDR_OIDC_DEFAULT_ROLE":   "wizard",
+				"EDR_SESSION_SIGNING_KEY": "0123456789abcdef0123456789abcdef",
+			}),
+			wantErr: "EDR_OIDC_DEFAULT_ROLE \"wizard\" is not a known role",
+		},
+		{
+			name: "EDR_OIDC_DEFAULT_ROLE without issuer -> partial-OIDC error",
+			env: withExtra(prodLikeEnv, map[string]string{
+				"EDR_OIDC_DEFAULT_ROLE":  "admin",
+				"EDR_AUTH_ALLOW_NO_OIDC": "1",
+			}),
+			wantErr: "set without EDR_OIDC_ISSUER",
+		},
+		{
 			name: "EDR_OIDC_STATE_COOKIE_TTL override",
 			env: withExtra(prodLikeEnv, map[string]string{
 				"EDR_OIDC_ISSUER":           "https://example.okta.com",

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -432,6 +432,7 @@ func TestLoad_OIDCConfig(t *testing.T) {
 				assert.Equal(t, "https://edr.example.com/api/auth/callback", c.OIDCRedirectURL)
 				assert.Equal(t, []string{"openid", "email", "profile"}, c.OIDCScopes)
 				assert.True(t, c.OIDCAllowJITProvisioning)
+				assert.Empty(t, c.OIDCDefaultRole, "default JIT role falls through to the identity-context default")
 				assert.Equal(t, 5*time.Minute, c.OIDCStateCookieTTL)
 				assert.False(t, c.AuthAllowNoOIDC)
 			},
@@ -464,6 +465,21 @@ func TestLoad_OIDCConfig(t *testing.T) {
 			validate: func(t *testing.T, c *Config) {
 				t.Helper()
 				assert.False(t, c.OIDCAllowJITProvisioning)
+			},
+		},
+		{
+			name: "EDR_OIDC_DEFAULT_ROLE override",
+			env: withExtra(prodLikeEnv, map[string]string{
+				"EDR_OIDC_ISSUER":         "https://example.okta.com",
+				"EDR_OIDC_CLIENT_ID":      "edr",
+				"EDR_OIDC_CLIENT_SECRET":  "shh",
+				"EDR_OIDC_REDIRECT_URL":   "https://edr.example.com/api/auth/callback",
+				"EDR_OIDC_DEFAULT_ROLE":   "admin",
+				"EDR_SESSION_SIGNING_KEY": "0123456789abcdef0123456789abcdef",
+			}),
+			validate: func(t *testing.T, c *Config) {
+				t.Helper()
+				assert.Equal(t, "admin", c.OIDCDefaultRole)
 			},
 		},
 		{

--- a/server/identity/bootstrap/bootstrap.go
+++ b/server/identity/bootstrap/bootstrap.go
@@ -85,8 +85,10 @@ type OIDCDeps struct {
 	RedirectURL          string
 	Scopes               []string
 	AllowJITProvisioning bool
-	StateCookieTTL       time.Duration
-	HTTPClient           *http.Client // optional; tests inject a fixture
+	// DefaultRole is the role a JIT-provisioned OIDC user is bound to. Empty falls through to the provisioner default (`analyst`).
+	DefaultRole    string
+	StateCookieTTL time.Duration
+	HTTPClient     *http.Client // optional; tests inject a fixture
 }
 
 const defaultCleanupInterval = 5 * time.Minute
@@ -323,8 +325,9 @@ func buildOIDCHandler(ctx context.Context, in oidcHandlerDeps) (*oidc.Handler, e
 		return nil, fmt.Errorf("identity bootstrap: construct OIDC client: %w", err)
 	}
 	prov := oidc.NewProvisioner(in.deps.DB, in.users, in.identities, in.rbac, in.audit, oidc.ProvisionerOptions{
-		AllowJIT: in.deps.OIDC.AllowJITProvisioning,
-		Logger:   in.logger,
+		AllowJIT:    in.deps.OIDC.AllowJITProvisioning,
+		DefaultRole: in.deps.OIDC.DefaultRole,
+		Logger:      in.logger,
 	})
 	return oidc.NewHandler(oidc.HandlerOptions{
 		Client:      client,

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -78,19 +78,21 @@ sonar.javascript.lcov.reportPaths=ui/coverage/lcov.info,test/e2e/coverage/lcov-e
 sonar.coverage.exclusions=**/cmd/**/main.go,server/detection/testharness/**,schema/**,extension/edr/**,agent/receiver/**,agent/logging/**,server/bootstrap/**,server/httpserver/**,test/**,tools/**,ui/vite.config.ts
 
 # Per-rule suppressions. Sonar's secrets analyser (secrets:S8215) flags the
-# bcrypt password hashes in config/dex/dev-config.yaml as BLOCKER
-# vulnerabilities. Those hashes are intentional dev-fixtures: they pin the
-# four pre-provisioned dex users for `task qa:up` + the Playwright OIDC
-# tests, and the plaintext (qa-password-123) is documented in
-# the local QA notes under ai/qa/ so an operator can reproduce QA locally.
-# The file's own header comment plus its path under config/dex/ make the
-# dev-only intent obvious; the rule still fires because Sonar can't
-# distinguish dev fixtures from production secrets. Suppressing the rule
-# for this exact file keeps the gate honest for prod-bound credentials
-# anywhere else in the tree.
-sonar.issue.ignore.multicriteria=dexDevHashes,migrationDdlLiterals
+# bcrypt password hashes in config/dex/dev-config.yaml + config/dex/demo-config.yaml
+# as BLOCKER vulnerabilities. Those hashes are intentional dev-fixtures: dev-config.yaml
+# pins the four pre-provisioned dex users for `task qa:up` + the Playwright OIDC tests
+# (plaintext qa-password-123, documented in the local QA notes under ai/qa/), and
+# demo-config.yaml pins the single SSO user for the Mac-free docker demo
+# (docker-compose.demo.yml; plaintext "demo", documented in the README + the file
+# header). Each file's header comment plus its path under config/dex/ make the dev-only
+# intent obvious; the rule still fires because Sonar can't distinguish dev fixtures from
+# production secrets. Suppressing the rule for these exact files keeps the gate honest for
+# prod-bound credentials anywhere else in the tree.
+sonar.issue.ignore.multicriteria=dexDevHashes,dexDemoHashes,migrationDdlLiterals
 sonar.issue.ignore.multicriteria.dexDevHashes.ruleKey=secrets:S8215
 sonar.issue.ignore.multicriteria.dexDevHashes.resourceKey=config/dex/dev-config.yaml
+sonar.issue.ignore.multicriteria.dexDemoHashes.ruleKey=secrets:S8215
+sonar.issue.ignore.multicriteria.dexDemoHashes.resourceKey=config/dex/demo-config.yaml
 
 # goose migration files are MySQL DDL, but Sonar analyses them with its PL/SQL
 # analyser, which fires plsql:S1192 ("define a constant instead of duplicating


### PR DESCRIPTION
<!-- Keep this short. Delete sections that do not apply. -->

## What & why



## Checklist

- [ ] **OpenSpec updated for behavior changes.** If this PR changes observable behavior (a detection rule, the event
      wire schema, persistence semantics, an API/wire shape, or an emitted event), `openspec/specs/**` is updated (and
      an `openspec/changes/` proposal added), with a `spec:<id>` test marker for any new/renamed scenario. Only if this
      PR changes NO observable behavior (a comment / refactor / gofmt / dep bump that happens to touch a scoped path)
      may you assert `no-behavior-change` (label or `[no-behavior-change]` in the title) to clear the OpenSpec-sync gate.
      That is an assertion a reviewer will check, not a way to skip the spec for a real behavior change.
- [ ] Tests added/updated for the change (unit / integration / efficacy / UI as applicable).
- [ ] Agent/extension change touching ESF, XPC, or the event wire format: exercised on a live macOS VM before RC
      (flagged below).

## VM / RC notes (if applicable)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Docker Compose-based demo environment for testing without Mac hardware requirements.
  * Included pre-configured SSO demo credentials for authentication testing.

* **Documentation**
  * Updated README with demo setup instructions and expected observability features (process graphs, threat detections, application-control blocks).

* **Chores**
  * Automated container image builds and keyless signing for releases.
  * Added OIDC configuration for demo environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->