### PR TITLE
Fix network extension delivering no events (missing hello-ack handshake)

### DIFF
--- a/extension/edr/Package.swift
+++ b/extension/edr/Package.swift
@@ -97,7 +97,12 @@ let package = Package(
                 "extension/EventSerializer.swift",
                 "extension/FileHashCache.swift",
                 "extension/SigningInfoFallback.swift",
-                "networkextension/DNSParser.swift"
+                "networkextension/DNSParser.swift",
+                // Pure hello-handshake decision for the network extension's XPCServer. Foundation-only, uniquely named
+                // (NetworkXPCMessageType / networkXPCShouldAck) so it does not collide with the security extension's
+                // XPCMessageType in this single logic module. networkextension/XPCServer.swift itself stays excluded
+                // (it would collide with extension/XPCServer.swift's type names + needs no test beyond this decision).
+                "networkextension/NetworkXPCInbound.swift"
             ]
         ),
         .testTarget(

--- a/extension/edr/Tests/EDRExtensionLogicTests/XPCServerLogicTests.swift
+++ b/extension/edr/Tests/EDRExtensionLogicTests/XPCServerLogicTests.swift
@@ -196,6 +196,20 @@ final class XPCServerLogicTests: XCTestCase {
         XCTAssertEqual(buffer.entries, [Data("a".utf8), Data("b".utf8), Data("c".utf8)])
     }
 
+    // spec:extension-xpc-server/hello-handshake-and-reply/the-agent-sends-a-hello-after-connecting
+    func testNetworkExtensionAcksHelloAndIgnoresEverythingElse() {
+        // Regression for the network-extension event-delivery bug: the NE's XPCServer originally never read inbound
+        // dictionaries, so it never answered the agent's hello and the agent's xpc_bridge_connect timed out every
+        // reconnect cycle — the NE delivered zero network/DNS events. networkXPCShouldAck encodes the fix: ack a hello,
+        // ignore everything else (the NE has no application_control.update inbound, unlike the security extension).
+        XCTAssertTrue(networkXPCShouldAck(type: "hello"), "NE must ack the agent's hello to complete the handshake")
+        XCTAssertEqual(NetworkXPCMessageType.helloAck, "hello-ack", "outbound reply wire-shape must be hello-ack")
+        XCTAssertFalse(networkXPCShouldAck(type: "application_control.update"),
+                       "NE has no inbound control messages; only hello is acked")
+        XCTAssertFalse(networkXPCShouldAck(type: "bogus"), "unknown types are ignored, not acked")
+        XCTAssertFalse(networkXPCShouldAck(type: nil), "a missing type is ignored, not acked")
+    }
+
     // MARK: - Requirement: Forward compatibility for unknown messages
 
     // spec:extension-xpc-server/forward-compatibility-for-unknown-messages/future-agent-sends-a-new-message-type

--- a/extension/edr/Tests/EDRExtensionLogicTests/XPCServerLogicTests.swift
+++ b/extension/edr/Tests/EDRExtensionLogicTests/XPCServerLogicTests.swift
@@ -200,7 +200,7 @@ final class XPCServerLogicTests: XCTestCase {
     func testNetworkExtensionAcksHelloAndIgnoresEverythingElse() {
         // Regression for the network-extension event-delivery bug: the NE's XPCServer originally never read inbound
         // dictionaries, so it never answered the agent's hello and the agent's xpc_bridge_connect timed out every
-        // reconnect cycle — the NE delivered zero network/DNS events. networkXPCShouldAck encodes the fix: ack a hello,
+        // reconnect cycle and the NE delivered zero network/DNS events. networkXPCShouldAck encodes the fix: ack a hello,
         // ignore everything else (the NE has no application_control.update inbound, unlike the security extension).
         XCTAssertTrue(networkXPCShouldAck(type: "hello"), "NE must ack the agent's hello to complete the handshake")
         XCTAssertEqual(NetworkXPCMessageType.helloAck, "hello-ack", "outbound reply wire-shape must be hello-ack")

--- a/extension/edr/networkextension/NetworkXPCInbound.swift
+++ b/extension/edr/networkextension/NetworkXPCInbound.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// XPC message-type strings exchanged between the Go agent and the network extension's XPCServer. The agent sends
 /// `hello` on connect and on every heartbeat ping; the extension MUST reply with `hello-ack` or the agent's
 /// `xpc_bridge_connect` handshake times out after 5s and tears the connection down (agent/xpcbridge/xpc_bridge.c,
@@ -12,7 +10,7 @@ enum NetworkXPCMessageType {
 
 /// networkXPCShouldAck is the pure decision the network extension's XPCServer applies to an inbound message type: reply
 /// with `hello-ack` only to a `hello`. The network extension has no other inbound control messages (unlike the security
-/// extension's `application_control.update`), so every other type — including a missing type — is ignored.
+/// extension's `application_control.update`), so every other type (including a missing type) is ignored.
 ///
 /// Extracted as a free function so the extension-xpc-server hello-handshake contract is unit-testable without standing
 /// up a real Mach listener; the Mach round-trip itself is validated at the system / VM layer per docs/testing-strategy.md.

--- a/extension/edr/networkextension/NetworkXPCInbound.swift
+++ b/extension/edr/networkextension/NetworkXPCInbound.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+/// XPC message-type strings exchanged between the Go agent and the network extension's XPCServer. The agent sends
+/// `hello` on connect and on every heartbeat ping; the extension MUST reply with `hello-ack` or the agent's
+/// `xpc_bridge_connect` handshake times out after 5s and tears the connection down (agent/xpcbridge/xpc_bridge.c,
+/// issue #178). Kept distinct from the security extension's `XPCMessageType` because the two extensions are separate
+/// Xcode targets / Swift modules with no shared framework (see extension/edr/Package.swift).
+enum NetworkXPCMessageType {
+    static let hello = "hello"
+    static let helloAck = "hello-ack"
+}
+
+/// networkXPCShouldAck is the pure decision the network extension's XPCServer applies to an inbound message type: reply
+/// with `hello-ack` only to a `hello`. The network extension has no other inbound control messages (unlike the security
+/// extension's `application_control.update`), so every other type — including a missing type — is ignored.
+///
+/// Extracted as a free function so the extension-xpc-server hello-handshake contract is unit-testable without standing
+/// up a real Mach listener; the Mach round-trip itself is validated at the system / VM layer per docs/testing-strategy.md.
+/// Before this existed the network extension never answered the agent's hello, so its receiver timed out every reconnect
+/// cycle and no network/DNS events were ever delivered.
+func networkXPCShouldAck(type: String?) -> Bool {
+    type == NetworkXPCMessageType.hello
+}

--- a/extension/edr/networkextension/XPCServer.swift
+++ b/extension/edr/networkextension/XPCServer.swift
@@ -78,6 +78,10 @@ final class XPCServer {
                         self?.peers.remove(peer)
                         logger.info("Peer disconnected (total: \(self?.peers.count ?? 0))")
                     }
+                    return
+                }
+                if peerType == XPC_TYPE_DICTIONARY {
+                    self?.handlePeerMessage(peerEvent, peer: peer)
                 }
             }
 
@@ -85,6 +89,23 @@ final class XPCServer {
         } else if type == XPC_TYPE_ERROR {
             logger.error("Listener error")
         }
+    }
+
+    /// handlePeerMessage replies to the agent's "hello" with "hello-ack" to complete the connect handshake. The agent's
+    /// xpc_bridge_connect sends "hello" and tears the connection down if no "hello-ack" arrives within 5s
+    /// (agent/xpcbridge/xpc_bridge.c, issue #178); without this reply the agent's network-extension receiver timed out
+    /// every reconnect cycle and the extension delivered no network/DNS events. The network extension has no inbound
+    /// control messages (unlike the security extension's application_control.update), so any other type is ignored.
+    private func handlePeerMessage(_ event: xpc_object_t, peer: XPCPeer) {
+        let typeStr = xpc_dictionary_get_string(event, "type").map { String(cString: $0) }
+        guard networkXPCShouldAck(type: typeStr) else {
+            // type is peer-supplied; redact in the unified log so a compromised peer cannot inject arbitrary strings.
+            logger.info("unknown XPC message type: \(typeStr ?? "(none)", privacy: .private)")
+            return
+        }
+        let ack = xpc_dictionary_create_empty()
+        xpc_dictionary_set_string(ack, "type", NetworkXPCMessageType.helloAck)
+        xpc_connection_send_message(peer.connection, ack)
     }
 }
 


### PR DESCRIPTION
The network extension's XPCServer never delivered network_connect/dns_query events to the agent: the agent's receiver logged "xpc_bridge_connect failed for ...networkextension.xpc" every reconnect cycle, while the security extension worked fine through the same agent.

Root cause: the agent's xpc_bridge_connect (agent/xpcbridge/xpc_bridge.c, issue #178) sends a {"type":"hello"} and cancels the connection + returns failure if no {"type":"hello-ack"} arrives within 5s. The security extension's XPCServer answers hello with hello-ack; the network extension's XPCServer only handled XPC_TYPE_ERROR on its peer connection and never read inbound dictionaries, so it never saw the agent's hello and never acked. The agent's network-extension receiver therefore timed out forever and no flow/DNS events were consumed. The NE server had drifted from the ES server when the hello-ack handshake (issue #178) was added only to ES.

Fix: the NE XPCServer now dispatches inbound XPC_TYPE_DICTIONARY messages and replies to hello with hello-ack (networkXPCShouldAck), matching the security extension and satisfying the existing extension-xpc-server "Hello handshake and reply" spec requirement (which applies to both extensions). The decision is extracted into a Foundation-only NetworkXPCInbound.swift so it is unit-testable via the SwiftPM logic facade (auto-compiled into the networkextension Xcode target via its synchronized file group) and pinned by a regression test.

Verified: swift build + swift test (16 logic tests, incl. the new NE handshake regression), swiftlint, spectrace 380/380. End-to-end (events actually flow on a VM with the rebuilt extension) still to confirm.

Follow-up: the ES and NE XPCServers are near-duplicate; extracting a shared XPC server would prevent this kind of drift. Tracked separately.

<!-- Keep this short. Delete sections that do not apply. -->

## What & why



## Checklist

- [ ] **OpenSpec updated for behavior changes.** If this PR changes observable behavior (a detection rule, the event
      wire schema, persistence semantics, an API/wire shape, or an emitted event), `openspec/specs/**` is updated (and
      an `openspec/changes/` proposal added), with a `spec:<id>` test marker for any new/renamed scenario. Only if this
      PR changes NO observable behavior (a comment / refactor / gofmt / dep bump that happens to touch a scoped path)
      may you assert `no-behavior-change` (label or `[no-behavior-change]` in the title) to clear the OpenSpec-sync gate.
      That is an assertion a reviewer will check, not a way to skip the spec for a real behavior change.
- [ ] Tests added/updated for the change (unit / integration / efficacy / UI as applicable).
- [ ] Agent/extension change touching ESF, XPC, or the event wire format: exercised on a live macOS VM before RC
      (flagged below).

## VM / RC notes (if applicable)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced network extension initialization with improved handshake protocol and error handling for peer communication.

* **Tests**
  * Added test coverage for network extension message validation and handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->