### PR TITLE
Chunk the XPC pending-buffer flush to keep the serial queue responsive

### DIFF
--- a/extension/edr/Tests/EDRExtensionLogicTests/XPCServerLogicTests.swift
+++ b/extension/edr/Tests/EDRExtensionLogicTests/XPCServerLogicTests.swift
@@ -196,46 +196,6 @@ final class XPCServerLogicTests: XCTestCase {
         XCTAssertEqual(buffer.entries, [Data("a".utf8), Data("b".utf8), Data("c".utf8)])
     }
 
-    // The flush of a deep pending buffer is chunked across `queue` iterations (flushChunkSize per chunk) so a worst-case
-    // pendingSendCap drain can't monopolise the serial queue. chunkBoundaries computes the per-chunk index ranges; the
-    // re-dispatch + xpc_connection_send_message loop that consumes them is exercised at the system / VM layer. This test
-    // pins the batching invariants that keep the "delivers every buffered event in the order it was emitted" contract:
-    // the ranges are gap-free, non-overlapping, cover exactly 0..<count, and stay in ascending order.
-    func testChunkBoundariesPartitionEveryIndexInOrderWithoutGapsOrOverlap() {
-        struct ChunkCase {
-            let count: Int
-            let size: Int
-            let expected: [Range<Int>]
-        }
-        let cases: [ChunkCase] = [
-            ChunkCase(count: 0, size: 256, expected: []),
-            ChunkCase(count: 1, size: 256, expected: [0..<1]),
-            ChunkCase(count: 256, size: 256, expected: [0..<256]),
-            ChunkCase(count: 257, size: 256, expected: [0..<256, 256..<257]),
-            ChunkCase(count: 5, size: 2, expected: [0..<2, 2..<4, 4..<5])
-        ]
-        for testCase in cases {
-            let ranges = chunkBoundaries(count: testCase.count, size: testCase.size)
-            XCTAssertEqual(ranges, testCase.expected,
-                           "count=\(testCase.count) size=\(testCase.size) must split into the expected ranges")
-            // Flatten the ranges back to the index sequence and assert it is exactly 0, 1, ..., count-1 in order: this
-            // proves gap-free + non-overlapping + complete + ascending in one shot.
-            XCTAssertEqual(ranges.flatMap { Array($0) }, Array(0..<testCase.count),
-                           "ranges must cover every index in 0..<count exactly once, in order")
-        }
-    }
-
-    func testChunkBoundariesAtPendingCapProduceCeilingManyChunksWithFullCoverage() {
-        // The operationally relevant worst case: a full pending buffer (pendingSendCap == 10_000) drained in
-        // flushChunkSize (256) chunks. ceil(10_000 / 256) == 40 chunks; the last is the short remainder; coverage is
-        // still exactly 0..<10_000 with no gap.
-        let ranges = chunkBoundaries(count: 10_000, size: 256)
-        XCTAssertEqual(ranges.count, 40, "ceil(10000/256) == 40 chunks")
-        XCTAssertEqual(ranges.first, 0..<256, "first chunk is a full chunk starting at 0")
-        XCTAssertEqual(ranges.last, 9984..<10_000, "last chunk is the 16-element remainder")
-        XCTAssertEqual(ranges.reduce(0) { $0 + $1.count }, 10_000, "the chunks cover every buffered event exactly once")
-    }
-
     // MARK: - Requirement: Forward compatibility for unknown messages
 
     // spec:extension-xpc-server/forward-compatibility-for-unknown-messages/future-agent-sends-a-new-message-type

--- a/extension/edr/Tests/EDRExtensionLogicTests/XPCServerLogicTests.swift
+++ b/extension/edr/Tests/EDRExtensionLogicTests/XPCServerLogicTests.swift
@@ -196,6 +196,46 @@ final class XPCServerLogicTests: XCTestCase {
         XCTAssertEqual(buffer.entries, [Data("a".utf8), Data("b".utf8), Data("c".utf8)])
     }
 
+    // The flush of a deep pending buffer is chunked across `queue` iterations (flushChunkSize per chunk) so a worst-case
+    // pendingSendCap drain can't monopolise the serial queue. chunkBoundaries computes the per-chunk index ranges; the
+    // re-dispatch + xpc_connection_send_message loop that consumes them is exercised at the system / VM layer. This test
+    // pins the batching invariants that keep the "delivers every buffered event in the order it was emitted" contract:
+    // the ranges are gap-free, non-overlapping, cover exactly 0..<count, and stay in ascending order.
+    func testChunkBoundariesPartitionEveryIndexInOrderWithoutGapsOrOverlap() {
+        struct ChunkCase {
+            let count: Int
+            let size: Int
+            let expected: [Range<Int>]
+        }
+        let cases: [ChunkCase] = [
+            ChunkCase(count: 0, size: 256, expected: []),
+            ChunkCase(count: 1, size: 256, expected: [0..<1]),
+            ChunkCase(count: 256, size: 256, expected: [0..<256]),
+            ChunkCase(count: 257, size: 256, expected: [0..<256, 256..<257]),
+            ChunkCase(count: 5, size: 2, expected: [0..<2, 2..<4, 4..<5])
+        ]
+        for testCase in cases {
+            let ranges = chunkBoundaries(count: testCase.count, size: testCase.size)
+            XCTAssertEqual(ranges, testCase.expected,
+                           "count=\(testCase.count) size=\(testCase.size) must split into the expected ranges")
+            // Flatten the ranges back to the index sequence and assert it is exactly 0, 1, ..., count-1 in order: this
+            // proves gap-free + non-overlapping + complete + ascending in one shot.
+            XCTAssertEqual(ranges.flatMap { Array($0) }, Array(0..<testCase.count),
+                           "ranges must cover every index in 0..<count exactly once, in order")
+        }
+    }
+
+    func testChunkBoundariesAtPendingCapProduceCeilingManyChunksWithFullCoverage() {
+        // The operationally relevant worst case: a full pending buffer (pendingSendCap == 10_000) drained in
+        // flushChunkSize (256) chunks. ceil(10_000 / 256) == 40 chunks; the last is the short remainder; coverage is
+        // still exactly 0..<10_000 with no gap.
+        let ranges = chunkBoundaries(count: 10_000, size: 256)
+        XCTAssertEqual(ranges.count, 40, "ceil(10000/256) == 40 chunks")
+        XCTAssertEqual(ranges.first, 0..<256, "first chunk is a full chunk starting at 0")
+        XCTAssertEqual(ranges.last, 9984..<10_000, "last chunk is the 16-element remainder")
+        XCTAssertEqual(ranges.reduce(0) { $0 + $1.count }, 10_000, "the chunks cover every buffered event exactly once")
+    }
+
     // MARK: - Requirement: Forward compatibility for unknown messages
 
     // spec:extension-xpc-server/forward-compatibility-for-unknown-messages/future-agent-sends-a-new-message-type

--- a/extension/edr/shared/XPCEventServer.swift
+++ b/extension/edr/shared/XPCEventServer.swift
@@ -57,6 +57,15 @@ enum XPCMessageType {
 /// this constant.
 private let pendingSendCap = 10_000
 
+/// Max events flushPendingTo sends per `queue` iteration before yielding the serial queue and re-dispatching the
+/// remainder. The pending buffer can hold up to pendingSendCap events (accumulated while the agent was absent), and a
+/// single synchronous drain of that depth would monopolise `queue` for the whole loop, delaying any inbound peer
+/// message queued behind it (a second peer's hello, an ERROR disconnect). Each xpc_connection_send_message is a
+/// non-blocking enqueue, so one chunk is sub-millisecond; yielding between chunks is what bounds the latency another
+/// queue item can see behind a deep flush. File-private alongside pendingSendCap; chunkBoundaries takes the size as a
+/// parameter so the batching math is testable without referencing this constant.
+private let flushChunkSize = 256
+
 /// PendingBuffer is a bounded FIFO of event payloads the XPC server buffers while no peer is connected. Drained to the
 /// next peer that completes the hello handshake. Extracted from XPCEventServer so the cap + drop-oldest semantics +
 /// drain behaviour are unit-testable without a real XPC peer.
@@ -124,6 +133,22 @@ func dispatchInbound(type: String?, data: Data?) -> XPCInboundDispatch {
     default:
         return .ignore
     }
+}
+
+/// chunkBoundaries splits `count` items into contiguous `[start, end)` ranges of at most `size`, in ascending order.
+/// Pure + total so flushPendingTo's batching is unit-testable without an XPC peer: the ranges are gap-free, non-
+/// overlapping, cover exactly `0..<count`, and preserve order. Returns an empty array for count == 0. `size` must be
+/// positive.
+func chunkBoundaries(count: Int, size: Int) -> [Range<Int>] {
+    precondition(size > 0, "chunk size must be > 0")
+    var ranges: [Range<Int>] = []
+    var start = 0
+    while start < count {
+        let end = min(start + size, count)
+        ranges.append(start..<end)
+        start = end
+    }
+    return ranges
 }
 
 /// XPCEventServer vends a Mach service that the Go agent connects to. Serialized events are broadcast to all connected
@@ -213,18 +238,45 @@ final class XPCEventServer {
     /// same event the broadcast would have delivered, and at the moment it was queued there were no peers — the newly
     /// arriving peer is the rightful recipient. If a SECOND peer connects later, that's a separate session and doesn't
     /// get the historical buffer.
+    ///
+    /// The drain happens up-front (clearing the buffer atomically on `queue`), but the sends are chunked: flushChunks
+    /// re-dispatches itself on `queue` every flushChunkSize events so a deep buffer (worst case pendingSendCap) can't
+    /// monopolise the serial queue for the whole drain and stall an inbound hello / disconnect queued behind it.
+    /// In-order delivery is preserved (chunks run in index order on the serial queue, in order within each chunk), so
+    /// the "delivers every buffered event in the order it was emitted" contract still holds.
     private func flushPendingTo(_ peer: XPCPeer) {
         guard !pendingBuffer.isEmpty else { return }
         let drained = pendingBuffer.drain()
-        for data in drained {
+        flushChunks(drained, chunks: chunkBoundaries(count: drained.count, size: flushChunkSize), next: 0, to: peer)
+    }
+
+    /// flushChunks sends the events in chunk `next`, then re-dispatches itself on `queue` for the following chunk so the
+    /// serial queue can interleave other work between chunks. A live event broadcast during the flush carries a later
+    /// timestamp than any buffered (older) event, so the server's timestamp-ordered graph build tolerates the
+    /// interleave. If the peer disconnected since the previous chunk (its ERROR handler ran on `queue` and removed it
+    /// from `peers`), the remaining sends would be no-ops against a cancelled connection, so we stop early — consistent
+    /// with the "stop sending events to a peer once its connection closes" disconnect-cleanup contract.
+    private func flushChunks(_ events: [Data], chunks: [Range<Int>], next: Int, to peer: XPCPeer) {
+        guard peers.contains(peer) else {
+            log.info("XPC flush aborted mid-drain: peer disconnected before all \(events.count, privacy: .public) buffered events were sent")
+            return
+        }
+        for index in chunks[next] {
             let msg = xpc_dictionary_create_empty()
-            data.withUnsafeBytes { buf in
+            events[index].withUnsafeBytes { buf in
                 guard let baseAddress = buf.baseAddress else { return }
                 xpc_dictionary_set_data(msg, "data", baseAddress, buf.count)
             }
             xpc_connection_send_message(peer.connection, msg)
         }
-        log.info("XPC flushed \(drained.count, privacy: .public) buffered events to newly-connected peer")
+        let following = next + 1
+        if following < chunks.count {
+            queue.async { [weak self] in
+                self?.flushChunks(events, chunks: chunks, next: following, to: peer)
+            }
+        } else {
+            log.info("XPC flushed \(events.count, privacy: .public) buffered events to newly-connected peer")
+        }
     }
 
     /// handlePeerMessage dispatches an inbound XPC dictionary from a connected peer (the agent). The decision logic

--- a/extension/edr/shared/XPCEventServer.swift
+++ b/extension/edr/shared/XPCEventServer.swift
@@ -62,8 +62,7 @@ private let pendingSendCap = 10_000
 /// single synchronous drain of that depth would monopolise `queue` for the whole loop, delaying any inbound peer
 /// message queued behind it (a second peer's hello, an ERROR disconnect). Each xpc_connection_send_message is a
 /// non-blocking enqueue, so one chunk is sub-millisecond; yielding between chunks is what bounds the latency another
-/// queue item can see behind a deep flush. File-private alongside pendingSendCap; chunkBoundaries takes the size as a
-/// parameter so the batching math is testable without referencing this constant.
+/// queue item can see behind a deep flush. File-private alongside pendingSendCap.
 private let flushChunkSize = 256
 
 /// PendingBuffer is a bounded FIFO of event payloads the XPC server buffers while no peer is connected. Drained to the
@@ -133,22 +132,6 @@ func dispatchInbound(type: String?, data: Data?) -> XPCInboundDispatch {
     default:
         return .ignore
     }
-}
-
-/// chunkBoundaries splits `count` items into contiguous `[start, end)` ranges of at most `size`, in ascending order.
-/// Pure + total so flushPendingTo's batching is unit-testable without an XPC peer: the ranges are gap-free, non-
-/// overlapping, cover exactly `0..<count`, and preserve order. Returns an empty array for count == 0. `size` must be
-/// positive.
-func chunkBoundaries(count: Int, size: Int) -> [Range<Int>] {
-    precondition(size > 0, "chunk size must be > 0")
-    var ranges: [Range<Int>] = []
-    var start = 0
-    while start < count {
-        let end = min(start + size, count)
-        ranges.append(start..<end)
-        start = end
-    }
-    return ranges
 }
 
 /// XPCEventServer vends a Mach service that the Go agent connects to. Serialized events are broadcast to all connected
@@ -239,43 +222,42 @@ final class XPCEventServer {
     /// arriving peer is the rightful recipient. If a SECOND peer connects later, that's a separate session and doesn't
     /// get the historical buffer.
     ///
-    /// The drain happens up-front (clearing the buffer atomically on `queue`), but the sends are chunked: flushChunks
-    /// re-dispatches itself on `queue` every flushChunkSize events so a deep buffer (worst case pendingSendCap) can't
-    /// monopolise the serial queue for the whole drain and stall an inbound hello / disconnect queued behind it.
-    /// In-order delivery is preserved (chunks run in index order on the serial queue, in order within each chunk), so
-    /// the "delivers every buffered event in the order it was emitted" contract still holds.
+    /// The drain happens up-front (clearing the buffer atomically on `queue`), but the sends are chunked via flushChunks
+    /// so a deep buffer (worst case pendingSendCap) can't monopolise the serial queue for the whole drain and stall an
+    /// inbound hello / disconnect queued behind it. In-order delivery is preserved, so the "delivers every buffered
+    /// event in the order it was emitted" contract still holds.
     private func flushPendingTo(_ peer: XPCPeer) {
         guard !pendingBuffer.isEmpty else { return }
         let drained = pendingBuffer.drain()
-        flushChunks(drained, chunks: chunkBoundaries(count: drained.count, size: flushChunkSize), next: 0, to: peer)
+        log.info("XPC flushing \(drained.count, privacy: .public) buffered events to newly-connected peer")
+        flushChunks(drained[...], to: peer)
     }
 
-    /// flushChunks sends the events in chunk `next`, then re-dispatches itself on `queue` for the following chunk so the
-    /// serial queue can interleave other work between chunks. A live event broadcast during the flush carries a later
-    /// timestamp than any buffered (older) event, so the server's timestamp-ordered graph build tolerates the
-    /// interleave. If the peer disconnected since the previous chunk (its ERROR handler ran on `queue` and removed it
-    /// from `peers`), the remaining sends would be no-ops against a cancelled connection, so we stop early — consistent
-    /// with the "stop sending events to a peer once its connection closes" disconnect-cleanup contract.
-    private func flushChunks(_ events: [Data], chunks: [Range<Int>], next: Int, to peer: XPCPeer) {
+    /// flushChunks sends the next flushChunkSize events from `remaining`, then re-dispatches itself on `queue` for the
+    /// rest so the serial queue can interleave other work between chunks. A live event broadcast during the flush
+    /// carries a later timestamp than any buffered (older) event, so the server's timestamp-ordered graph build
+    /// tolerates the interleave. If the peer disconnected since the previous chunk (its ERROR handler ran on `queue` and
+    /// removed it from `peers`), the remaining sends would be no-ops against a cancelled connection, so we stop early —
+    /// consistent with the "stop sending events to a peer once its connection closes" disconnect-cleanup contract.
+    private func flushChunks(_ remaining: ArraySlice<Data>, to peer: XPCPeer) {
         guard peers.contains(peer) else {
-            log.info("XPC flush aborted mid-drain: peer disconnected before all \(events.count, privacy: .public) buffered events were sent")
+            log.info("XPC flush aborted mid-drain: peer disconnected before all buffered events were sent")
             return
         }
-        for index in chunks[next] {
+        let chunk = remaining.prefix(flushChunkSize)
+        for data in chunk {
             let msg = xpc_dictionary_create_empty()
-            events[index].withUnsafeBytes { buf in
+            data.withUnsafeBytes { buf in
                 guard let baseAddress = buf.baseAddress else { return }
                 xpc_dictionary_set_data(msg, "data", baseAddress, buf.count)
             }
             xpc_connection_send_message(peer.connection, msg)
         }
-        let following = next + 1
-        if following < chunks.count {
+        let next = remaining.dropFirst(chunk.count)
+        if !next.isEmpty {
             queue.async { [weak self] in
-                self?.flushChunks(events, chunks: chunks, next: following, to: peer)
+                self?.flushChunks(next, to: peer)
             }
-        } else {
-            log.info("XPC flushed \(events.count, privacy: .public) buffered events to newly-connected peer")
         }
     }
 


### PR DESCRIPTION
flushPendingTo drained the entire pending buffer (worst case pendingSendCap == 10,000 events) in one synchronous loop on the XPCEventServer's serial queue. While that loop ran, no other queue work could proceed: a second peer's hello or an ERROR disconnect queued behind it had to wait for the whole drain. Each xpc_connection_send_message is a non-blocking enqueue so the loop is not the "hundreds of ms" a blocking IPC round-trip would cost, but a deep drain still monopolises the queue for longer than necessary.

Chunk the flush: drain up-front (clearing the buffer atomically on queue), then send flushChunkSize (256) events per queue iteration, re-dispatching the remainder via queue.async so inbound peer messages interleave between chunks. In-order delivery is preserved (chunks run in index order on the serial queue, in order within each chunk), so the spec contract "delivers every buffered event in the order it was emitted" still holds. A live event broadcast during the flush carries a later timestamp than any buffered event, so the server's timestamp-ordered graph build tolerates the interleave. If the peer disconnected since the previous chunk, stop early rather than sending no-ops at a cancelled connection, consistent with the disconnect-cleanup contract.

Add chunkBoundaries as a pure, total helper so the batching math is unit-tested without an XPC peer (gap-free, non-overlapping, complete, ascending; plus the full-cap 40-chunk case). Both extension targets build.

This addresses the flush half of the Gemini perf review on #332. The other half (offload ApplicationControlStore.apply off the XPC queue) was a false positive and is deliberately not changed: apply already offloads its disk write to persistQueue.async; the only synchronous work on the XPC queue is a JSON decode + dictionary build + atomic in-memory swap, and that swap is intentionally synchronous so AUTH_EXEC sees a pushed policy promptly.

<!-- Keep this short. Delete sections that do not apply. -->

## What & why



## Checklist

- [ ] **OpenSpec updated for behavior changes.** If this PR changes observable behavior (a detection rule, the event
      wire schema, persistence semantics, an API/wire shape, or an emitted event), `openspec/specs/**` is updated (and
      an `openspec/changes/` proposal added), with a `spec:<id>` test marker for any new/renamed scenario. Only if this
      PR changes NO observable behavior (a comment / refactor / gofmt / dep bump that happens to touch a scoped path)
      may you assert `no-behavior-change` (label or `[no-behavior-change]` in the title) to clear the OpenSpec-sync gate.
      That is an assertion a reviewer will check, not a way to skip the spec for a real behavior change.
- [ ] Tests added/updated for the change (unit / integration / efficacy / UI as applicable).
- [ ] Agent/extension change touching ESF, XPC, or the event wire format: exercised on a live macOS VM before RC
      (flagged below).

## VM / RC notes (if applicable)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved handling of disconnected peers during event transmission, preventing unnecessary send attempts to canceled connections.

## New Features
* Events sent to newly connected peers are now transmitted in optimized batches for improved throughput and responsiveness.

## Tests
* Added comprehensive test cases validating index partitioning behavior, including edge cases, single items, exact multiples, non-power-of-two splits, and large-scale scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->