### PR TITLE
Fix NE event delivery: revert NE XPC service to the app-group Mach name

### DIFF
--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -17,9 +17,13 @@ import (
 
 const (
 	defaultXPCService = "FDG8Q7N4CC.com.fleetdm.edr.securityextension.xpc"
-	// Team-prefixed (globally resolvable) Mach service. An app-group-scoped name (group.*) is only reachable by
-	// processes holding that app-group entitlement, which the agent does not, so the agent could never connect.
-	defaultNetXPCService = "FDG8Q7N4CC.com.fleetdm.edr.networkextension.xpc"
+	// The network extension's only launchd-registered Mach service is its NEMachServiceName, which Apple requires to be
+	// app-group-scoped. A team-prefixed name is NOT registered for a NetworkExtension sysext (unlike the security
+	// extension, which gets its team-prefixed name registered via NSEndpointSecurityMachServiceName), so dialing one
+	// fails at the Mach bootstrap lookup with "xpc_bridge_connect failed". The agent reaches the app-group name fine
+	// (verified on edr-qa: "receiver connected" to group.com.fleetdm.edr.networkextension across many sessions). #300
+	// switched this to a team-prefixed name on a false premise and silently broke NE event delivery.
+	defaultNetXPCService = "group.com.fleetdm.edr.networkextension"
 	defaultQueueDBPath   = "/var/db/fleet-edr/events.db"
 
 	// defaultPruneAge is the default for EDR_PRUNE_AGE: drop uploaded events

--- a/extension/edr/networkextension/Info.plist
+++ b/extension/edr/networkextension/Info.plist
@@ -4,13 +4,11 @@
 <dict>
 	<key>MachServices</key>
 	<dict>
-		<!-- App-group-scoped service the NetworkExtension framework requires (matches NEMachServiceName below). -->
+		<!-- App-group-scoped service the NetworkExtension framework requires (matches NEMachServiceName below). This is
+		     the only Mach service launchd registers for the NE sysext, and the one the agent connects to for the event
+		     channel. A team-prefixed entry here is NOT honored for a NetworkExtension sysext (only ES gets a team-prefixed
+		     registration, via NSEndpointSecurityMachServiceName), so listing one is dead config that broke NE delivery in #300. -->
 		<key>group.com.fleetdm.edr.networkextension</key>
-		<true/>
-		<!-- Team-prefixed, globally resolvable Mach service the Go agent connects to for the event channel. The
-		     app-group name above is only reachable by processes holding the app-group entitlement, which the agent
-		     does not; the team-prefixed name is reachable by any peer that satisfies the listener's code-signing pin. -->
-		<key>FDG8Q7N4CC.com.fleetdm.edr.networkextension.xpc</key>
 		<true/>
 	</dict>
 	<key>NEProviderClasses</key>

--- a/extension/edr/networkextension/XPCServer.swift
+++ b/extension/edr/networkextension/XPCServer.swift
@@ -2,16 +2,18 @@ import Foundation
 import os.log
 
 /// The network extension's XPC server: a shared XPCEventServer (see shared/XPCEventServer.swift) bound to the network
-/// extension's team-prefixed Mach service. It has no inbound control messages (unlike the security extension's
+/// extension's app-group Mach service. It has no inbound control messages (unlike the security extension's
 /// application_control.update), so onApplicationControl is nil. NetworkFilter + DNSProxyProvider broadcast events via
 /// XPCServer.shared.send; main.swift starts the listener via XPCServer.shared.start.
 ///
-/// Team-prefixed Mach service (globally resolvable), NOT the app-group-scoped name: the Go agent does not hold the
-/// app-group entitlement, so a group.* name is unreachable from it. The app-group name stays as NEMachServiceName in
-/// Info.plist for the NetworkExtension framework, which Apple requires to be app-group-scoped.
+/// The service name MUST be the app-group NEMachServiceName: that is the only Mach service launchd registers for a
+/// NetworkExtension sysext. A team-prefixed name (the kind the security extension vends via NSEndpointSecurityMachServiceName)
+/// is never bound for an NE, so a listener on it gets no bootstrap registration and the agent's connect fails with
+/// "xpc_bridge_connect failed". The agent reaches this app-group name fine (verified on edr-qa); #300 switched this to a
+/// team-prefixed name on a false premise and silently broke NE event delivery.
 enum XPCServer {
     static let shared = XPCEventServer(
-        serviceName: "FDG8Q7N4CC.com.fleetdm.edr.networkextension.xpc",
+        serviceName: "group.com.fleetdm.edr.networkextension",
         logger: Logger(subsystem: "com.fleetdm.edr.networkextension", category: "XPCServer")
     )
 }


### PR DESCRIPTION
The network extension has delivered zero events since #300 (2026-05-29). #300 switched the NE's XPC Mach service from the app-group NEMachServiceName (group.com.fleetdm.edr.networkextension) to a team-prefixed name (FDG8Q7N4CC.com.fleetdm.edr.networkextension.xpc) on the premise that the Go agent cannot reach a group.* name without the app-group entitlement.

That premise is false. launchd registers only ONE Mach service for a NetworkExtension sysext: its NEMachServiceName, which Apple requires to be app-group-scoped. A team-prefixed name is never bound for an NE (unlike the security extension, which gets its team-prefixed name registered via NSEndpointSecurityMachServiceName), so the extension's listener on it gets no bootstrap registration and the agent's connect fails at the Mach lookup with "xpc_bridge_connect failed". The MachServices Info.plist dict entry #300 added for the team-prefixed name is dead config; launchd does not honor it for a sysext.

Verified on edr-qa (rc.10): the agent logged "receiver connected" to group.com.fleetdm.edr.networkextension across many sessions through 2026-05-13 (pre-#300), and "xpc_bridge_connect failed" for the team-prefixed name after. The NE filter starts and its listener comes up; only the service name was wrong. This also matches docs/architecture.md and docs/lessons-and-gotchas.md, which always documented NEMachServiceName as the NE XPC endpoint — #300 diverged the code from the docs.

Revert defaultNetXPCService (agent) and the NE XPCServer service name to the app-group name, drop the dead team-prefixed MachServices entry, and correct the comments. Keeps the #331 hello-ack handshake, which is the layer above a working connection. Re-verify on the QA VM after the next RC.

<!-- Keep this short. Delete sections that do not apply. -->

## What & why



## Checklist

- [ ] **OpenSpec updated for behavior changes.** If this PR changes observable behavior (a detection rule, the event
      wire schema, persistence semantics, an API/wire shape, or an emitted event), `openspec/specs/**` is updated (and
      an `openspec/changes/` proposal added), with a `spec:<id>` test marker for any new/renamed scenario. Only if this
      PR changes NO observable behavior (a comment / refactor / gofmt / dep bump that happens to touch a scoped path)
      may you assert `no-behavior-change` (label or `[no-behavior-change]` in the title) to clear the OpenSpec-sync gate.
      That is an assertion a reviewer will check, not a way to skip the spec for a real behavior change.
- [ ] Tests added/updated for the change (unit / integration / efficacy / UI as applicable).
- [ ] Agent/extension change touching ESF, XPC, or the event wire format: exercised on a live macOS VM before RC
      (flagged below).

## VM / RC notes (if applicable)


