### PR TITLE
DNS proxy plan

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -45,6 +45,15 @@ config:
   MD024:
     siblings_only: true
 
+  # Table-column-style (added in markdownlint v0.38, default-on in newer
+  # markdownlint-cli2 releases). The repo writes tables with compact separator
+  # rows (`|---|`) and spaced data cells (`| x |`) consistently across ~30
+  # tables; that mix is cosmetic and renders fine, but MD060 flags it (200+
+  # findings repo-wide on a version bump). Disable it for the same reason we
+  # disable MD033/MD034: it fights the repo's established style without catching
+  # a real defect. Pin a style here later if we ever want enforced uniformity.
+  MD060: false
+
   # Default first-line-h1 stays on so every doc opens with a clear title.
   # MD041: enabled by default.
 

--- a/openspec/changes/2026-06-09-add-dns-correlation-detection/design.md
+++ b/openspec/changes/2026-06-09-add-dns-correlation-detection/design.md
@@ -1,0 +1,67 @@
+# Design: `dns_c2_beacon` correlation rule
+
+## Context
+
+The detection engine evaluates each rule against the current batch of raw events with a `GraphReader` for retrospective graph queries:
+
+```go
+// server/rules/api/types.go
+type Rule interface {
+    ID() string
+    Techniques() []string
+    Doc() Documentation
+    Evaluate(ctx context.Context, events []Event, gr GraphReader) ([]Finding, error)
+}
+```
+
+`GraphReader` today exposes `GetProcessByPID`, `GetChildProcesses`, `GetExecChain` (`server/detection/api/service.go`). The concrete `*mysql.Store` also has `GetNetworkEventsForProcess(hostID, pid, TimeRange) ([]Event, error)` returning a pid's `network_connect` and `dns_query` events (`server/detection/internal/mysql/processes.go:389`), but it is not on the interface, so no rule can reach DNS/network events. Exposing it is the one structural change required.
+
+`osascript_network_exec` is the template for cross-stream correlation: it triggers reverse-direction on the event that lands last (the temp exec), then walks the graph to reassemble the chain. Reverse-direction is race-immune: by the time the trigger event lands in batch N+1, the earlier links are already materialized from batch N.
+
+## The correlation
+
+`dns_c2_beacon` proves the canonical C2 shape across all three streams:
+
+1. A process is `exec`'d (identity + suspicion context).
+2. It resolves a domain — a `dns_query` with `response_addresses`.
+3. It connects to a resolved address — a `network_connect` whose `remote_address` ∈ that query's `response_addresses`.
+
+**Trigger:** on each `network_connect` event in the batch (the last link). For the connecting pid, call `GetNetworkEventsForProcess(pid, window)` and find a `dns_query` whose `response_addresses` contains this connection's `remote_address`. That single join proves "this process resolved this domain, then connected to the address it resolved to" — the exec, DNS, and network events are now all in hand. `GetProcessByPID` supplies the `exec`/process row for identity and the suspicion gate.
+
+**Window:** the `dns_query` and `network_connect` must fall within a bounded window for the same pid (start with 30s, matching the existing `osascript` window; the resolve→connect latency is sub-second in practice, so this is generous).
+
+## The suspicion gate (the open design decision)
+
+A naive "resolved-then-connected" join fires on every browser fetch. The gate keeps false positives near zero. Three options:
+
+- **A — process context**: fire only when the process is suspicious by exec context: exec'd from a temp / world-writable path, or a script interpreter (osascript/python/bash/sh) whose parent is non-interactive. Re-uses signals the catalog already encodes.
+- **B — domain heuristic**: fire only when the resolved `query_name` is suspicious: a small committed watchlist, or a DGA-style signal (high Shannon entropy / long random label). Catches algorithmically-generated C2 domains.
+- **C — both (recommended)**: fire on (suspicious process context **A**) **AND** (resolved-then-connected). The domain heuristic **B** raises severity (`High` → `Critical`) and contributes the `T1568.002` technique when it triggers. Rationale: A alone is precise but misses C2 from a "normal-looking" process; B alone risks FPs on legitimate long subdomains; A∧(join) is precise, and B as a severity booster keeps the DGA signal without making it a hard gate. Benign browser traffic never fires (the browser is not a suspicious-context process).
+
+For the efficacy corpus, the positive scenario uses a temp-path-exec'd binary that resolves a high-entropy domain and connects to the resolved IP (trips A, the join, and B). Negatives: a browser resolving + connecting to a normal domain (no A); a suspicious process that resolves but does not connect to the resolved address (no join).
+
+## Finding shape
+
+```
+Finding{
+  RuleID:     "dns_c2_beacon",
+  Severity:   High,            // Critical when the domain heuristic also trips
+  Title:      "C2 beacon: suspicious process resolved and connected to <domain>",
+  ProcessID:  <connecting process row id>,
+  EventIDs:   [<exec event>, <dns_query event>, <network_connect event>],
+  Techniques: ["T1071.004"]    // + "T1568.002" when the entropy signal contributes
+}
+```
+
+Dedup is by `ProcessID` via the engine's existing subject dedup, so a beaconing process that connects repeatedly produces one alert, not one per connection.
+
+## Why reverse-direction (trigger on network_connect)
+
+The chain completes at the connection. Triggering on the `dns_query` (forward) would require waiting to see whether a connection follows, across batch boundaries; triggering on the `network_connect` means the `dns_query` is already ingested and the join is a single retrospective lookup — race-immune, no state held in the engine (consistent with the stateless-server constraint).
+
+## Scope boundaries
+
+- Classic UDP/TCP/53 DNS only; encrypted DNS (DoH/DoT) bypasses the proxy and is out of scope (roadmap).
+- The suspicion gate is heuristic, not threat-intel; the bar is "demonstrably correlates across three streams," not production reputation. The DGA check is entropy/length, not a trained model.
+- No engine statefulness: the rule holds nothing between batches; all correlation is retrospective graph reads.
+- `GetNetworkEventsForProcess` is added to the interface unchanged in behavior; the rules test kit gains a fake implementation backed by the in-memory scenario store.

--- a/openspec/changes/2026-06-09-add-dns-correlation-detection/design.md
+++ b/openspec/changes/2026-06-09-add-dns-correlation-detection/design.md
@@ -2,7 +2,8 @@
 
 ## Context
 
-The detection engine evaluates each rule against the current batch of raw events with a `GraphReader` for retrospective graph queries:
+The detection engine evaluates each rule against the current batch of raw events with a `GraphReader` for retrospective
+graph queries:
 
 ```go
 // server/rules/api/types.go
@@ -14,54 +15,101 @@ type Rule interface {
 }
 ```
 
-`GraphReader` today exposes `GetProcessByPID`, `GetChildProcesses`, `GetExecChain` (`server/detection/api/service.go`). The concrete `*mysql.Store` also has `GetNetworkEventsForProcess(hostID, pid, TimeRange) ([]Event, error)` returning a pid's `network_connect` and `dns_query` events (`server/detection/internal/mysql/processes.go:389`), but it is not on the interface, so no rule can reach DNS/network events. Exposing it is the one structural change required.
+`GraphReader` today exposes `GetProcessByPID`, `GetChildProcesses`, `GetExecChain` (`server/detection/api/service.go`).
+The concrete `*mysql.Store` also has `GetNetworkEventsForProcess(hostID, pid, TimeRange) ([]Event, error)` returning a
+pid's `network_connect` and `dns_query` events (`server/detection/internal/mysql/processes.go:389`), but it is not on
+the interface, so no rule can reach DNS/network events. Exposing it is the one structural change required.
 
-`osascript_network_exec` is the template for cross-stream correlation: it triggers reverse-direction on the event that lands last (the temp exec), then walks the graph to reassemble the chain. Reverse-direction is race-immune: by the time the trigger event lands in batch N+1, the earlier links are already materialized from batch N.
+`osascript_network_exec` is the template for cross-stream correlation: it triggers reverse-direction on the event that
+lands last (the temp exec), then walks the graph to reassemble the chain. Reverse-direction is race-immune: by the time
+the trigger event lands in batch N+1, the earlier links are already materialized from batch N.
 
 ## The correlation
 
 `dns_c2_beacon` proves the canonical C2 shape across all three streams:
 
-1. A process is `exec`'d (identity + suspicion context).
-2. It resolves a domain — a `dns_query` with `response_addresses`.
-3. It connects to a resolved address — a `network_connect` whose `remote_address` ∈ that query's `response_addresses`.
+1. A process is `exec`'d (identity plus suspicion context).
+2. It resolves a domain: a `dns_query` with `response_addresses`.
+3. It connects to a resolved address: a `network_connect` whose `remote_address` is in that query's
+   `response_addresses`.
 
-**Trigger:** on each `network_connect` event in the batch (the last link). For the connecting pid, call `GetNetworkEventsForProcess(pid, window)` and find a `dns_query` whose `response_addresses` contains this connection's `remote_address`. That single join proves "this process resolved this domain, then connected to the address it resolved to" — the exec, DNS, and network events are now all in hand. `GetProcessByPID` supplies the `exec`/process row for identity and the suspicion gate.
+**Trigger:** on each `network_connect` event in the batch (the last link). For the connecting pid, call
+`GetNetworkEventsForProcess(pid, window)` and find a `dns_query` whose `response_addresses` contains this connection's
+`remote_address`. That single join proves "this process resolved this domain, then connected to the address it resolved
+to". `GetProcessByPID` supplies the `exec`/process row for identity and the suspicion gate.
 
-**Window:** the `dns_query` and `network_connect` must fall within a bounded window for the same pid (start with 30s, matching the existing `osascript` window; the resolve→connect latency is sub-second in practice, so this is generous).
+**Address matching:** compare parsed IP values, not raw strings. The rule normalizes both the connection's
+`remote_address` and each `response_addresses` entry via `net.ParseIP` before comparing, so equivalent IPv6 forms (zero
+compression, case) do not cause false negatives.
 
-## The suspicion gate (the open design decision)
+**Selection when several queries match:** if more than one `dns_query` for the process resolves to the connection's
+`remote_address` within the window (for example two domains that both resolve to the same CDN IP), the rule cites the
+most recent matching query (highest `timestamp_ns`); ties break on the lexicographically smallest query name. This keeps
+finding attribution deterministic, which matters for the fixture tests and the demo.
 
-A naive "resolved-then-connected" join fires on every browser fetch. The gate keeps false positives near zero. Three options:
+**Window:** the `dns_query` and `network_connect` must fall within a bounded window for the same pid (start with 30s,
+matching the existing `osascript` window; the resolve-to-connect latency is sub-second in practice, so this is
+generous).
 
-- **A — process context**: fire only when the process is suspicious by exec context: exec'd from a temp / world-writable path, or a script interpreter (osascript/python/bash/sh) whose parent is non-interactive. Re-uses signals the catalog already encodes.
-- **B — domain heuristic**: fire only when the resolved `query_name` is suspicious: a small committed watchlist, or a DGA-style signal (high Shannon entropy / long random label). Catches algorithmically-generated C2 domains.
-- **C — both (recommended)**: fire on (suspicious process context **A**) **AND** (resolved-then-connected). The domain heuristic **B** raises severity (`High` → `Critical`) and contributes the `T1568.002` technique when it triggers. Rationale: A alone is precise but misses C2 from a "normal-looking" process; B alone risks FPs on legitimate long subdomains; A∧(join) is precise, and B as a severity booster keeps the DGA signal without making it a hard gate. Benign browser traffic never fires (the browser is not a suspicious-context process).
+## The suspicion gate (locked: option C, both signals)
 
-For the efficacy corpus, the positive scenario uses a temp-path-exec'd binary that resolves a high-entropy domain and connects to the resolved IP (trips A, the join, and B). Negatives: a browser resolving + connecting to a normal domain (no A); a suspicious process that resolves but does not connect to the resolved address (no join).
+A naive "resolved-then-connected" join fires on every browser fetch. The gate keeps false positives near zero. The
+chosen design uses both signals:
+
+- **Process context** (hard gate): fire only when the process is suspicious by exec context: exec'd from a temp or
+  world-writable path, or a script interpreter (osascript/python/bash/sh) whose parent is non-interactive. Re-uses
+  signals the catalog already encodes.
+- **Domain anomaly** (severity booster): when the resolved `query_name` is anomalous (high Shannon entropy or a long
+  random label, the DGA shape), raise severity from `High` to `Critical` and add the `T1568.002` technique. It is not a
+  hard gate, so a "normal-looking" C2 domain from a suspicious process still fires at `High`.
+
+Rationale: process context alone is precise but misses C2 from a normal-looking domain; domain anomaly alone risks false
+positives on legitimate long subdomains. Process-context-AND-join is precise, and domain anomaly as a booster keeps the
+DGA signal without making it a hard gate. Benign browser traffic never fires (the browser is not a suspicious-context
+process). The exact entropy threshold is tuned empirically during implementation against the efficacy corpus and the
+captured benign demo traffic; the design fixes the shape (entropy/length), not a magic number.
+
+For the efficacy corpus, the positive scenario uses a temp-path-exec'd binary that resolves a high-entropy domain and
+connects to the resolved IP (trips process context, the join, and the anomaly booster). Negatives: a browser resolving
+plus connecting to a normal domain (no process context); a suspicious process that resolves but connects to an address
+it never resolved (no join).
 
 ## Finding shape
 
 ```
 Finding{
   RuleID:     "dns_c2_beacon",
-  Severity:   High,            // Critical when the domain heuristic also trips
+  Severity:   High,            // Critical when the domain anomaly signal also trips
   Title:      "C2 beacon: suspicious process resolved and connected to <domain>",
   ProcessID:  <connecting process row id>,
   EventIDs:   [<exec event>, <dns_query event>, <network_connect event>],
-  Techniques: ["T1071.004"]    // + "T1568.002" when the entropy signal contributes
+  Techniques: ["T1071.004"]    // plus "T1568.002" when the entropy signal contributes
 }
 ```
 
-Dedup is by `ProcessID` via the engine's existing subject dedup, so a beaconing process that connects repeatedly produces one alert, not one per connection.
+Dedup is by `ProcessID` via the engine's existing subject dedup, so a beaconing process that connects repeatedly
+produces one alert, not one per connection.
 
 ## Why reverse-direction (trigger on network_connect)
 
-The chain completes at the connection. Triggering on the `dns_query` (forward) would require waiting to see whether a connection follows, across batch boundaries; triggering on the `network_connect` means the `dns_query` is already ingested and the join is a single retrospective lookup — race-immune, no state held in the engine (consistent with the stateless-server constraint).
+The chain completes at the connection. Triggering on the `dns_query` (forward) would require waiting to see whether a
+connection follows, across batch boundaries; triggering on the `network_connect` means the `dns_query` is already
+ingested and the join is a single retrospective lookup: race-immune, no state held in the engine (consistent with the
+stateless-server constraint).
 
 ## Scope boundaries
 
 - Classic UDP/TCP/53 DNS only; encrypted DNS (DoH/DoT) bypasses the proxy and is out of scope (roadmap).
-- The suspicion gate is heuristic, not threat-intel; the bar is "demonstrably correlates across three streams," not production reputation. The DGA check is entropy/length, not a trained model.
+- The suspicion gate is heuristic, not threat-intel; the bar is "demonstrably correlates across three streams", not
+  production reputation. The DGA check is entropy/length, not a trained model.
 - No engine statefulness: the rule holds nothing between batches; all correlation is retrospective graph reads.
-- `GetNetworkEventsForProcess` is added to the interface unchanged in behavior; the rules test kit gains a fake implementation backed by the in-memory scenario store.
+- `GetNetworkEventsForProcess` is added to the interface unchanged in behavior; the rules test kit gains a fake
+  implementation backed by the in-memory scenario store.
+
+## Activate-flow implementation note
+
+`activate` must enable the content filter and then the DNS proxy. The current `enableContentFilter()` and
+`enableDNSProxy()` in `extension/edr/edr/main.swift` each call `exit(EXIT_SUCCESS)` / `exit(EXIT_FAILURE)` inside their
+own completion handlers, so they cannot simply be called in sequence (the first would exit the process). The
+implementation refactors them to chain via a completion callback (enable the filter, then on success enable the DNS
+proxy, then exit) rather than exiting from each handler.

--- a/openspec/changes/2026-06-09-add-dns-correlation-detection/proposal.md
+++ b/openspec/changes/2026-06-09-add-dns-correlation-detection/proposal.md
@@ -1,0 +1,24 @@
+# DNS-correlated C2 beacon detection
+
+## Why
+
+The EDR's differentiation is three-layer composition + correlation: it joins process (`exec`), network (`network_connect`), and DNS (`dns_query`) telemetry that no single open-source tool joins today. Two of the three streams already drive detection rules; DNS does not. Until a rule actually *correlates* a DNS query with the exec that issued it and the network connection that followed, the three-stream claim is unproven in the product — the detection catalog reads as "process + network," which is what commodity agents already ship.
+
+The on-device DNS capture is built and verified: `DNSProxyProvider` emits `dns_query` events (query name, type, resolved addresses, originating pid/path) through the network extension, the server ingests and associates them to processes, and a spike on a SIP-on host confirmed the proxy enables cleanly and all three streams flow and coexist. What is missing is the detection layer: a rule that joins the three streams into a single, auditable finding.
+
+This change adds `dns_c2_beacon`, a correlation rule that fires when a suspicious process resolves a domain and then connects to the resolved address — citing the `exec`, `dns_query`, and `network_connect` events together. It makes the three-stream correlation a spec'd, tested behavior a reviewer can confirm by reading the repo.
+
+## What Changes
+
+- Expose the existing network/DNS per-process query primitive on the detection rules-engine interface. `(*mysql.Store).GetNetworkEventsForProcess(hostID, pid, TimeRange)` already returns a process's `network_connect` and `dns_query` events; add it to the `GraphReader` interface (and the rules test kit's fake) so rules can reach DNS + network events for correlation. No storage or query change.
+- Add the `dns_c2_beacon` detection rule under `server/rules/internal/catalog/`, registered in the catalog so it evaluates against every batch. It triggers reverse-direction on a `network_connect` event, joins to the connecting process's `dns_query` events (matching a resolved address to the connection's remote address), gates on a suspicion signal to keep false positives near zero on benign browser traffic, and emits one `High` finding citing the `exec`, `dns_query`, and `network_connect` events. MITRE: `T1071.004` (Application Layer Protocol: DNS), and `T1568.002` (Domain Generation Algorithms) when the domain-entropy signal contributes.
+- Ship the rule's tests + traceability: per-package unit + fixture tests (positive and negative), an efficacy corpus at `test/efficacy/corpus/T1071.004-dns-c2-beacon/` (`scenario.yaml` + `expected.yaml`), and a spectrace `// spec:` marker on the rule test referencing the new scenario.
+- Enable the DNS proxy by default in the host app's `activate` flow, so a freshly activated host emits all three streams (exec + network + DNS) without a separate opt-in step. `activate` enables the content filter and the DNS proxy on success; `enable-dns-proxy` / `disable-dns-proxy` remain for independent toggling. This makes DNS the third stream the product leads with, not an opt-in extra. Because the proxy now sits in every activated host's DNS path, fail-open hardening (a proxy fault must not break host DNS) becomes a near-term follow-up.
+- README: document DNS as the third telemetry stream and the newest component, with encrypted-DNS and failure-mode handling noted as roadmap.
+
+### Not in this change (deferred)
+
+- A DNS-proxy `.mobileconfig` for unattended/MDM pre-approval — the spike showed the proxy enables without it on an approved host. No `release-packaging` change here.
+- Fail-open proxy hardening (timeouts so a proxy fault can't break host DNS) — its own follow-up, now higher priority because `activate` enables the proxy by default.
+- Encrypted DNS (DoH/DoT) visibility, a domain-reputation feed, a full DGA model, and NXDOMAIN / beacon-cadence signals — their own later changes.
+- The `endpoint-event-collection` DNS-capture contract is unchanged; the observed `dns_query` payload already matches the existing spec, so this change references it without modifying it.

--- a/openspec/changes/2026-06-09-add-dns-correlation-detection/proposal.md
+++ b/openspec/changes/2026-06-09-add-dns-correlation-detection/proposal.md
@@ -2,23 +2,51 @@
 
 ## Why
 
-The EDR's differentiation is three-layer composition + correlation: it joins process (`exec`), network (`network_connect`), and DNS (`dns_query`) telemetry that no single open-source tool joins today. Two of the three streams already drive detection rules; DNS does not. Until a rule actually *correlates* a DNS query with the exec that issued it and the network connection that followed, the three-stream claim is unproven in the product — the detection catalog reads as "process + network," which is what commodity agents already ship.
+The EDR's differentiation is three-layer composition plus correlation: it joins process (`exec`), network
+(`network_connect`), and DNS (`dns_query`) telemetry that no single open-source tool joins today. Two of the three
+streams already drive detection rules; DNS does not. Until a rule actually correlates a DNS query with the exec that
+issued it and the network connection that followed, the three-stream claim is unproven in the product: the detection
+catalog reads as "process plus network," which is what commodity agents already ship.
 
-The on-device DNS capture is built and verified: `DNSProxyProvider` emits `dns_query` events (query name, type, resolved addresses, originating pid/path) through the network extension, the server ingests and associates them to processes, and a spike on a SIP-on host confirmed the proxy enables cleanly and all three streams flow and coexist. What is missing is the detection layer: a rule that joins the three streams into a single, auditable finding.
+The on-device DNS capture is built and verified: `DNSProxyProvider` emits `dns_query` events (query name, type, resolved
+addresses, originating pid/path) through the network extension, the server ingests and associates them to processes, and
+a spike on a SIP-on host confirmed the proxy enables cleanly and all three streams flow and coexist. What is missing is
+the detection layer: a rule that joins the three streams into a single, auditable finding.
 
-This change adds `dns_c2_beacon`, a correlation rule that fires when a suspicious process resolves a domain and then connects to the resolved address — citing the `exec`, `dns_query`, and `network_connect` events together. It makes the three-stream correlation a spec'd, tested behavior a reviewer can confirm by reading the repo.
+This change adds `dns_c2_beacon`, a correlation rule that fires when a suspicious process resolves a domain and then
+connects to the resolved address, citing the `exec`, `dns_query`, and `network_connect` events together. It makes the
+three-stream correlation a spec'd, tested behavior a reviewer can confirm by reading the repo.
 
 ## What Changes
 
-- Expose the existing network/DNS per-process query primitive on the detection rules-engine interface. `(*mysql.Store).GetNetworkEventsForProcess(hostID, pid, TimeRange)` already returns a process's `network_connect` and `dns_query` events; add it to the `GraphReader` interface (and the rules test kit's fake) so rules can reach DNS + network events for correlation. No storage or query change.
-- Add the `dns_c2_beacon` detection rule under `server/rules/internal/catalog/`, registered in the catalog so it evaluates against every batch. It triggers reverse-direction on a `network_connect` event, joins to the connecting process's `dns_query` events (matching a resolved address to the connection's remote address), gates on a suspicion signal to keep false positives near zero on benign browser traffic, and emits one `High` finding citing the `exec`, `dns_query`, and `network_connect` events. MITRE: `T1071.004` (Application Layer Protocol: DNS), and `T1568.002` (Domain Generation Algorithms) when the domain-entropy signal contributes.
-- Ship the rule's tests + traceability: per-package unit + fixture tests (positive and negative), an efficacy corpus at `test/efficacy/corpus/T1071.004-dns-c2-beacon/` (`scenario.yaml` + `expected.yaml`), and a spectrace `// spec:` marker on the rule test referencing the new scenario.
-- Enable the DNS proxy by default in the host app's `activate` flow, so a freshly activated host emits all three streams (exec + network + DNS) without a separate opt-in step. `activate` enables the content filter and the DNS proxy on success; `enable-dns-proxy` / `disable-dns-proxy` remain for independent toggling. This makes DNS the third stream the product leads with, not an opt-in extra. Because the proxy now sits in every activated host's DNS path, fail-open hardening (a proxy fault must not break host DNS) becomes a near-term follow-up.
-- README: document DNS as the third telemetry stream and the newest component, with encrypted-DNS and failure-mode handling noted as roadmap.
+- Expose the existing network/DNS per-process query primitive on the detection rules-engine interface.
+  `(*mysql.Store).GetNetworkEventsForProcess(hostID, pid, TimeRange)` already returns a process's `network_connect` and
+  `dns_query` events; add it to the `GraphReader` interface (and the rules test kit's fake) so rules can reach DNS plus
+  network events for correlation. No storage or query change.
+- Add the `dns_c2_beacon` detection rule under `server/rules/internal/catalog/`, registered in the catalog so it
+  evaluates against every batch. It triggers reverse-direction on a `network_connect` event, joins to the connecting
+  process's `dns_query` events (matching a resolved address to the connection's remote address, on normalized IP
+  values), gates on a suspicion signal to keep false positives near zero on benign browser traffic, and emits one
+  `High` finding citing the `exec`, `dns_query`, and `network_connect` events. MITRE: `T1071.004` (Application Layer
+  Protocol: DNS), and `T1568.002` (Domain Generation Algorithms) when the domain-entropy signal contributes.
+- Enable the DNS proxy by default in the host app's `activate` flow, so a freshly activated host emits all three streams
+  (exec, network, DNS) without a separate opt-in step. `activate` enables the content filter and the DNS proxy on
+  success; `enable-dns-proxy` / `disable-dns-proxy` remain for independent toggling. This makes DNS the third stream the
+  product leads with, not an opt-in extra. Because the proxy now sits in every activated host's DNS path, fail-open
+  hardening (a proxy fault must not break host DNS) becomes a near-term follow-up.
+- Ship the rule's tests plus traceability: per-package unit and fixture tests (positive and negative), an efficacy
+  corpus at `test/efficacy/corpus/T1071.004-dns-c2-beacon/` (`scenario.yaml` plus `expected.yaml`), and a spectrace
+  `// spec:` marker on the rule test referencing the new scenario.
+- README: document DNS as the third telemetry stream and the newest component, with encrypted-DNS and failure-mode
+  handling noted as roadmap.
 
 ### Not in this change (deferred)
 
-- A DNS-proxy `.mobileconfig` for unattended/MDM pre-approval — the spike showed the proxy enables without it on an approved host. No `release-packaging` change here.
-- Fail-open proxy hardening (timeouts so a proxy fault can't break host DNS) — its own follow-up, now higher priority because `activate` enables the proxy by default.
-- Encrypted DNS (DoH/DoT) visibility, a domain-reputation feed, a full DGA model, and NXDOMAIN / beacon-cadence signals — their own later changes.
-- The `endpoint-event-collection` DNS-capture contract is unchanged; the observed `dns_query` payload already matches the existing spec, so this change references it without modifying it.
+- A DNS-proxy `.mobileconfig` for unattended/MDM pre-approval: the spike showed the proxy enables without it on an
+  approved host. No `release-packaging` change here.
+- Fail-open proxy hardening (timeouts so a proxy fault can't break host DNS): its own follow-up, now higher priority
+  because `activate` enables the proxy by default.
+- Encrypted DNS (DoH/DoT) visibility, a domain-reputation feed, a full DGA model, and NXDOMAIN / beacon-cadence signals:
+  their own later changes.
+- The `endpoint-event-collection` DNS-capture contract is unchanged; the observed `dns_query` payload already matches
+  the existing spec, so this change references it without modifying it.

--- a/openspec/changes/2026-06-09-add-dns-correlation-detection/specs/host-app-extension-manager/spec.md
+++ b/openspec/changes/2026-06-09-add-dns-correlation-detection/specs/host-app-extension-manager/spec.md
@@ -1,4 +1,4 @@
-# Host-app extension manager — DNS proxy on by default delta
+# Host-app extension manager: DNS proxy on by default delta
 
 ## MODIFIED Requirements
 
@@ -6,10 +6,10 @@
 
 The host app SHALL provide an `activate` subcommand that submits an activation request for both the system extension
 (Endpoint Security) and the network extension, and on success enables both the network content filter AND the DNS proxy.
-Enabling the DNS proxy as part of `activate` makes the third telemetry stream (DNS) on by default, so a freshly activated
-host emits correlated exec, network, and DNS events without a separate opt-in step. The DNS proxy remains independently
-toggleable afterward via `disable-dns-proxy` / `enable-dns-proxy`. The user MAY be required to approve the extensions in
-System Settings; the subcommand MUST report when approval is pending.
+Enabling the DNS proxy as part of `activate` makes the third telemetry stream (DNS) on by default, so a freshly
+activated host emits correlated exec, network, and DNS events without a separate opt-in step. The DNS proxy remains
+independently toggleable afterward via `disable-dns-proxy` / `enable-dns-proxy`. The user MAY be required to approve the
+extensions in System Settings; the subcommand MUST report when approval is pending.
 
 #### Scenario: First-time activation on an unconfigured machine
 

--- a/openspec/changes/2026-06-09-add-dns-correlation-detection/specs/host-app-extension-manager/spec.md
+++ b/openspec/changes/2026-06-09-add-dns-correlation-detection/specs/host-app-extension-manager/spec.md
@@ -1,0 +1,28 @@
+# Host-app extension manager — DNS proxy on by default delta
+
+## MODIFIED Requirements
+
+### Requirement: Activate subcommand registers both extensions and enables the filter
+
+The host app SHALL provide an `activate` subcommand that submits an activation request for both the system extension
+(Endpoint Security) and the network extension, and on success enables both the network content filter AND the DNS proxy.
+Enabling the DNS proxy as part of `activate` makes the third telemetry stream (DNS) on by default, so a freshly activated
+host emits correlated exec, network, and DNS events without a separate opt-in step. The DNS proxy remains independently
+toggleable afterward via `disable-dns-proxy` / `enable-dns-proxy`. The user MAY be required to approve the extensions in
+System Settings; the subcommand MUST report when approval is pending.
+
+#### Scenario: First-time activation on an unconfigured machine
+
+- **GIVEN** neither extension is installed and the user has not previously approved EDR system extensions
+- **WHEN** an operator runs `edr activate`
+- **THEN** the host app submits activation requests for both extensions
+- **AND** the host app reports that user approval is pending
+- **AND** once the user approves, the host app enables the content filter and the DNS proxy and exits successfully
+
+#### Scenario: Re-activation when extensions are already approved
+
+- **GIVEN** both extensions were previously activated and are still approved
+- **WHEN** an operator runs `edr activate`
+- **THEN** the host app replaces the running extensions with the current bundle on disk
+- **AND** the host app enables the content filter and the DNS proxy
+- **AND** the host app exits successfully

--- a/openspec/changes/2026-06-09-add-dns-correlation-detection/specs/server-detection-rules-engine/spec.md
+++ b/openspec/changes/2026-06-09-add-dns-correlation-detection/specs/server-detection-rules-engine/spec.md
@@ -1,15 +1,33 @@
-# Server detection rules engine — DNS correlation delta
+# Server detection rules engine: DNS correlation delta
 
 ## ADDED Requirements
 
 ### Requirement: DNS-correlated C2 beacon detection
 
-The system SHALL register a `dns_c2_beacon` rule that fires when a suspicious process resolves a domain and then connects to the resolved address, correlating all three telemetry streams. The rule MUST require, for a single originating process: a `dns_query` event carrying one or more `response_addresses`, and a subsequent `network_connect` event whose `remote_address` is one of those `response_addresses`, both within a bounded time window for that process. The rule MUST gate on a suspicion signal derived from the originating process's exec context (for example an exec from a temporary or world-writable path, or a script interpreter with a non-interactive parent) so that ordinary browser traffic that resolves and connects to a domain does NOT fire. When the resolved domain also matches a domain-anomaly signal (a high-entropy or algorithmically-generated name), the rule MAY raise the finding severity and MUST add the `T1568.002` technique. A firing alert SHALL cite the `exec`, `dns_query`, and `network_connect` events that compose the chain, and SHALL be attributed to the originating process so the engine's per-process dedup collapses repeated beacons into a single alert. The rule MUST hold no state between batches; the correlation is performed by retrospective graph reads.
+The system SHALL register a `dns_c2_beacon` rule that fires when a suspicious process resolves a domain and then
+connects to the resolved address, correlating all three telemetry streams. The rule MUST require, for a single
+originating process: a `dns_query` event carrying one or more `response_addresses`, and a subsequent `network_connect`
+event whose `remote_address` is one of those `response_addresses`, both within a bounded time window for that process.
+Address matching MUST be performed on parsed/normalized IP values (not raw strings) so that equivalent IPv6 forms
+compare equal. When several `dns_query` events for the process match the connection's `remote_address`, the rule MUST
+select the most recent matching query (deterministic tie-break by query name) for finding attribution.
+
+The rule MUST gate on a suspicion signal derived from the originating process's exec context (for example an exec from a
+temporary or world-writable path, or a script interpreter with a non-interactive parent) so that ordinary browser
+traffic that resolves and connects to a domain does NOT fire. When the resolved domain also matches a domain-anomaly
+signal (a high-entropy or algorithmically-generated name), the rule MAY raise the finding severity and MUST add the
+`T1568.002` technique.
+
+A firing alert SHALL cite the `exec`, `dns_query`, and `network_connect` events that compose the chain, and SHALL be
+attributed to the originating process so the engine's per-process dedup collapses repeated beacons into a single alert.
+The rule MUST hold no state between batches; the correlation is performed by retrospective graph reads.
 
 #### Scenario: A suspicious process resolves a domain and connects to the resolved address
 
-- **GIVEN** a process exec'd from a temporary path that issued a `dns_query` for a high-entropy domain whose `response_addresses` include `203.0.113.10`
-- **WHEN** a `network_connect` event for the same process to `remote_address` `203.0.113.10` is evaluated, within the correlation window
+- **GIVEN** a process exec'd from a temporary path that issued a `dns_query` for a high-entropy domain whose
+  `response_addresses` include `203.0.113.10`
+- **WHEN** a `network_connect` event for the same process to `remote_address` `203.0.113.10` is evaluated, within the
+  correlation window
 - **THEN** the engine produces one `dns_c2_beacon` finding
 - **AND** the finding cites the originating `exec`, the `dns_query`, and the `network_connect` event identifiers
 - **AND** the finding is attributed to the originating process
@@ -17,14 +35,17 @@ The system SHALL register a `dns_c2_beacon` rule that fires when a suspicious pr
 
 #### Scenario: A browser resolving and connecting to an ordinary domain does not fire
 
-- **GIVEN** a browser process that issued a `dns_query` for an ordinary domain and connected to one of its `response_addresses`
+- **GIVEN** a browser process that issued a `dns_query` for an ordinary domain and connected to one of its
+  `response_addresses`
 - **WHEN** the `network_connect` event is evaluated
-- **THEN** the engine produces no `dns_c2_beacon` finding, because the originating process does not satisfy the suspicious-exec-context gate
+- **THEN** the engine produces no `dns_c2_beacon` finding, because the originating process does not satisfy the
+  suspicious-exec-context gate
 
 #### Scenario: A suspicious process that connects to an address it never resolved does not fire
 
 - **GIVEN** a process exec'd from a temporary path that issued a `dns_query` resolving to `203.0.113.10`
-- **WHEN** the same process emits a `network_connect` to `198.51.100.7`, an address that appears in none of its `dns_query` `response_addresses`
+- **WHEN** the same process emits a `network_connect` to `198.51.100.7`, an address that appears in none of its
+  `dns_query` `response_addresses`
 - **THEN** the engine produces no `dns_c2_beacon` finding, because the resolve-then-connect join is not satisfied
 
 ## MODIFIED Requirements

--- a/openspec/changes/2026-06-09-add-dns-correlation-detection/specs/server-detection-rules-engine/spec.md
+++ b/openspec/changes/2026-06-09-add-dns-correlation-detection/specs/server-detection-rules-engine/spec.md
@@ -1,0 +1,44 @@
+# Server detection rules engine — DNS correlation delta
+
+## ADDED Requirements
+
+### Requirement: DNS-correlated C2 beacon detection
+
+The system SHALL register a `dns_c2_beacon` rule that fires when a suspicious process resolves a domain and then connects to the resolved address, correlating all three telemetry streams. The rule MUST require, for a single originating process: a `dns_query` event carrying one or more `response_addresses`, and a subsequent `network_connect` event whose `remote_address` is one of those `response_addresses`, both within a bounded time window for that process. The rule MUST gate on a suspicion signal derived from the originating process's exec context (for example an exec from a temporary or world-writable path, or a script interpreter with a non-interactive parent) so that ordinary browser traffic that resolves and connects to a domain does NOT fire. When the resolved domain also matches a domain-anomaly signal (a high-entropy or algorithmically-generated name), the rule MAY raise the finding severity and MUST add the `T1568.002` technique. A firing alert SHALL cite the `exec`, `dns_query`, and `network_connect` events that compose the chain, and SHALL be attributed to the originating process so the engine's per-process dedup collapses repeated beacons into a single alert. The rule MUST hold no state between batches; the correlation is performed by retrospective graph reads.
+
+#### Scenario: A suspicious process resolves a domain and connects to the resolved address
+
+- **GIVEN** a process exec'd from a temporary path that issued a `dns_query` for a high-entropy domain whose `response_addresses` include `203.0.113.10`
+- **WHEN** a `network_connect` event for the same process to `remote_address` `203.0.113.10` is evaluated, within the correlation window
+- **THEN** the engine produces one `dns_c2_beacon` finding
+- **AND** the finding cites the originating `exec`, the `dns_query`, and the `network_connect` event identifiers
+- **AND** the finding is attributed to the originating process
+- **AND** the finding carries the `T1071.004` technique, plus `T1568.002` because the domain tripped the anomaly signal
+
+#### Scenario: A browser resolving and connecting to an ordinary domain does not fire
+
+- **GIVEN** a browser process that issued a `dns_query` for an ordinary domain and connected to one of its `response_addresses`
+- **WHEN** the `network_connect` event is evaluated
+- **THEN** the engine produces no `dns_c2_beacon` finding, because the originating process does not satisfy the suspicious-exec-context gate
+
+#### Scenario: A suspicious process that connects to an address it never resolved does not fire
+
+- **GIVEN** a process exec'd from a temporary path that issued a `dns_query` resolving to `203.0.113.10`
+- **WHEN** the same process emits a `network_connect` to `198.51.100.7`, an address that appears in none of its `dns_query` `response_addresses`
+- **THEN** the engine produces no `dns_c2_beacon` finding, because the resolve-then-connect join is not satisfied
+
+## MODIFIED Requirements
+
+### Requirement: Registered rule catalog
+
+The system SHALL register the following named rules at startup so each becomes evaluable against every batch:
+`suspicious_exec`, `shell_from_office`, `osascript_network_exec`, `persistence_launchagent`, `dyld_insert`,
+`credential_keychain_dump`, `privilege_launchd_plist_write`, `sudoers_tamper`, and `dns_c2_beacon`.
+
+#### Scenario: The engine reports its rule catalog
+
+- **GIVEN** a running detection engine in its default configuration
+- **WHEN** an operator inspects the catalog of registered rules
+- **THEN** the catalog includes `suspicious_exec`, `shell_from_office`, `osascript_network_exec`,
+  `persistence_launchagent`, `dyld_insert`, `credential_keychain_dump`, `privilege_launchd_plist_write`,
+  `sudoers_tamper`, and `dns_c2_beacon`

--- a/openspec/changes/2026-06-09-add-dns-correlation-detection/tasks.md
+++ b/openspec/changes/2026-06-09-add-dns-correlation-detection/tasks.md
@@ -1,0 +1,51 @@
+# DNS-correlated C2 beacon detection — tasks
+
+## 0. Spike (done, 2026-06-09)
+
+- [x] Enable the DNS proxy on edr-qa via `edr enable-dns-proxy`; confirm no approval prompt is required on an already-approved host.
+- [x] Confirm `dns_query` events flow end-to-end with the full payload (query_name/type/response_addresses/pid/path/uid) and the query→response follow-on pair.
+- [x] Confirm the content filter and DNS proxy coexist (network_connect + dns_query + exec all flow in one session).
+
+## 1. Engine interface
+
+- [ ] Add `GetNetworkEventsForProcess(ctx, hostID string, pid int, tr TimeRange) ([]Event, error)` to the `GraphReader` interface (`server/detection/api/service.go`). The concrete `*mysql.Store` already implements it; this is interface plumbing.
+- [ ] Add the method to the rules test kit's `GraphReader` fake / scenario store so catalog tests can exercise correlation without MySQL specifics.
+- [ ] Unit-test the test-kit fake returns a process's `dns_query` + `network_connect` events within the time range, ordered by timestamp.
+
+## 2. The rule
+
+- [ ] `server/rules/internal/catalog/dns_c2_beacon.go`: `ID()`, `Techniques()` (`T1071.004`, conditionally `T1568.002`), `Doc()`, `Evaluate()`.
+- [ ] Trigger reverse-direction on `network_connect`; join to a `dns_query` whose `response_addresses` contains the connection's `remote_address` for the same pid within the window.
+- [ ] Suspicion gate per design.md (option C: suspicious process context AND the join; domain-entropy signal boosts severity + adds `T1568.002`).
+- [ ] Emit one `High`/`Critical` finding citing the `exec`, `dns_query`, and `network_connect` event IDs; dedup by `ProcessID`.
+- [ ] Register `dns_c2_beacon` in the catalog registry.
+
+## 3. Tests + traceability
+
+- [ ] Per-package table-driven unit test + `fixtures/dns_c2_beacon/` (positive: temp-exec → resolve high-entropy domain → connect to resolved IP; negatives: browser resolve+connect to a normal domain; suspicious process that resolves but connects elsewhere).
+- [ ] Efficacy corpus `test/efficacy/corpus/T1071.004-dns-c2-beacon/` (`scenario.yaml` + `expected.yaml`). `attack.sh` deferred unless VM coverage is wanted.
+- [ ] Add the spectrace `// spec:` marker on the rule test referencing the new `server-detection-rules-engine` scenario ID.
+- [ ] `go test ./server/...`; `cd tools/spectrace && go run . check`; `openspec validate 2026-06-09-add-dns-correlation-detection --strict`.
+
+## 4. DNS proxy on by default
+
+- [ ] `edr/main.swift`: the `activate` flow enables the DNS proxy after the content filter (reuse `enableDNSProxy()`), so a freshly activated host has all three streams on. `enable-dns-proxy` / `disable-dns-proxy` remain for independent toggling.
+- [ ] Update / add host-app extension-manager logic tests so `activate` asserts both the filter and the DNS proxy are enabled on success.
+- [ ] Verify on edr-qa: a clean `edr activate` leaves the content filter AND the DNS proxy enabled.
+
+## 5. Spec
+
+- [ ] `server-detection-rules-engine` delta: MODIFY "Registered rule catalog" to include `dns_c2_beacon`; ADD "Requirement: DNS-correlated C2 beacon detection" with the positive + two negative scenarios.
+- [ ] `host-app-extension-manager` delta: MODIFY the `activate` requirement so it enables the DNS proxy in addition to the content filter.
+
+## 6. Docs + demo
+
+- [ ] README: add DNS as the third telemetry stream, note it's the newest component (encrypted-DNS + failure modes are roadmap).
+- [ ] Demo: recapture the demo dataset on edr-qa with DNS live; weave a `dns_c2_beacon` detection into one host's story as a 4th in-context attack (ties into the demo-data plan at `ai/demo/rich-demo-data-plan.md`).
+
+## Deferred (separate changes)
+
+- [ ] Default-on DNS activation in `activate` (after fail-open hardening).
+- [ ] DNS-proxy `.mobileconfig` for unattended/MDM pre-approval.
+- [ ] Fail-open proxy hardening (timeouts so a proxy fault can't break host DNS).
+- [ ] Encrypted DNS (DoH/DoT), domain reputation, trained DGA model, NXDOMAIN/beacon-cadence signals.

--- a/openspec/changes/2026-06-09-add-dns-correlation-detection/tasks.md
+++ b/openspec/changes/2026-06-09-add-dns-correlation-detection/tasks.md
@@ -1,51 +1,76 @@
-# DNS-correlated C2 beacon detection — tasks
+# DNS-correlated C2 beacon detection: tasks
 
 ## 0. Spike (done, 2026-06-09)
 
-- [x] Enable the DNS proxy on edr-qa via `edr enable-dns-proxy`; confirm no approval prompt is required on an already-approved host.
-- [x] Confirm `dns_query` events flow end-to-end with the full payload (query_name/type/response_addresses/pid/path/uid) and the query→response follow-on pair.
-- [x] Confirm the content filter and DNS proxy coexist (network_connect + dns_query + exec all flow in one session).
+- [x] Enable the DNS proxy on edr-qa via `edr enable-dns-proxy`; confirm no approval prompt is required on an
+  already-approved host.
+- [x] Confirm `dns_query` events flow end-to-end with the full payload (query_name/type/response_addresses/pid/path/uid)
+  and the query-to-response follow-on pair.
+- [x] Confirm the content filter and DNS proxy coexist (network_connect plus dns_query plus exec all flow in one
+  session).
 
 ## 1. Engine interface
 
-- [ ] Add `GetNetworkEventsForProcess(ctx, hostID string, pid int, tr TimeRange) ([]Event, error)` to the `GraphReader` interface (`server/detection/api/service.go`). The concrete `*mysql.Store` already implements it; this is interface plumbing.
-- [ ] Add the method to the rules test kit's `GraphReader` fake / scenario store so catalog tests can exercise correlation without MySQL specifics.
-- [ ] Unit-test the test-kit fake returns a process's `dns_query` + `network_connect` events within the time range, ordered by timestamp.
+- [ ] Add `GetNetworkEventsForProcess(ctx, hostID string, pid int, tr TimeRange) ([]Event, error)` to the `GraphReader`
+  interface (`server/detection/api/service.go`). The concrete `*mysql.Store` already implements it; this is interface
+  plumbing.
+- [ ] Add the method to the rules test kit's `GraphReader` fake / scenario store so catalog tests can exercise
+  correlation without MySQL specifics.
+- [ ] Unit-test the test-kit fake returns a process's `dns_query` plus `network_connect` events within the time range,
+  ordered by timestamp.
 
 ## 2. The rule
 
-- [ ] `server/rules/internal/catalog/dns_c2_beacon.go`: `ID()`, `Techniques()` (`T1071.004`, conditionally `T1568.002`), `Doc()`, `Evaluate()`.
-- [ ] Trigger reverse-direction on `network_connect`; join to a `dns_query` whose `response_addresses` contains the connection's `remote_address` for the same pid within the window.
-- [ ] Suspicion gate per design.md (option C: suspicious process context AND the join; domain-entropy signal boosts severity + adds `T1568.002`).
-- [ ] Emit one `High`/`Critical` finding citing the `exec`, `dns_query`, and `network_connect` event IDs; dedup by `ProcessID`.
+- [ ] `server/rules/internal/catalog/dns_c2_beacon.go`: `ID()`, `Techniques()` (`T1071.004`, conditionally
+  `T1568.002`), `Doc()`, `Evaluate()`.
+- [ ] Trigger reverse-direction on `network_connect`; join to a `dns_query` whose `response_addresses` contains the
+  connection's `remote_address` for the same pid within the window. Match on normalized IPs (`net.ParseIP`); when
+  several queries match, cite the most recent (tie-break lexicographic on query name).
+- [ ] Suspicion gate per design.md (option C: suspicious process context AND the join; domain-entropy signal boosts
+  severity plus adds `T1568.002`).
+- [ ] Emit one `High`/`Critical` finding citing the `exec`, `dns_query`, and `network_connect` event IDs; dedup by
+  `ProcessID`.
 - [ ] Register `dns_c2_beacon` in the catalog registry.
 
-## 3. Tests + traceability
+## 3. Tests plus traceability
 
-- [ ] Per-package table-driven unit test + `fixtures/dns_c2_beacon/` (positive: temp-exec → resolve high-entropy domain → connect to resolved IP; negatives: browser resolve+connect to a normal domain; suspicious process that resolves but connects elsewhere).
-- [ ] Efficacy corpus `test/efficacy/corpus/T1071.004-dns-c2-beacon/` (`scenario.yaml` + `expected.yaml`). `attack.sh` deferred unless VM coverage is wanted.
-- [ ] Add the spectrace `// spec:` marker on the rule test referencing the new `server-detection-rules-engine` scenario ID.
-- [ ] `go test ./server/...`; `cd tools/spectrace && go run . check`; `openspec validate 2026-06-09-add-dns-correlation-detection --strict`.
+- [ ] Per-package table-driven unit test plus `fixtures/dns_c2_beacon/` (positive: temp-exec, resolve high-entropy
+  domain, connect to resolved IP; negatives: browser resolve+connect to a normal domain; suspicious process that
+  resolves but connects elsewhere).
+- [ ] Efficacy corpus `test/efficacy/corpus/T1071.004-dns-c2-beacon/` (`scenario.yaml` plus `expected.yaml`).
+  `attack.sh` deferred unless VM coverage is wanted.
+- [ ] Add the spectrace `// spec:` marker on the rule test referencing the new `server-detection-rules-engine`
+  scenario ID.
+- [ ] `go test ./server/...`; `cd tools/spectrace && go run . check`; `openspec validate
+  2026-06-09-add-dns-correlation-detection --strict`.
 
 ## 4. DNS proxy on by default
 
-- [ ] `edr/main.swift`: the `activate` flow enables the DNS proxy after the content filter (reuse `enableDNSProxy()`), so a freshly activated host has all three streams on. `enable-dns-proxy` / `disable-dns-proxy` remain for independent toggling.
-- [ ] Update / add host-app extension-manager logic tests so `activate` asserts both the filter and the DNS proxy are enabled on success.
+- [ ] `edr/main.swift`: the `activate` flow enables the DNS proxy after the content filter. Note: `enableContentFilter()`
+  and `enableDNSProxy()` currently each call `exit()` in their completion handlers, so they must be refactored to chain
+  via a completion callback (enable filter, then on success enable DNS proxy, then exit) rather than exiting from each
+  handler. `enable-dns-proxy` / `disable-dns-proxy` remain for independent toggling.
+- [ ] Update / add host-app extension-manager logic tests so `activate` asserts both the filter and the DNS proxy are
+  enabled on success.
 - [ ] Verify on edr-qa: a clean `edr activate` leaves the content filter AND the DNS proxy enabled.
 
 ## 5. Spec
 
-- [ ] `server-detection-rules-engine` delta: MODIFY "Registered rule catalog" to include `dns_c2_beacon`; ADD "Requirement: DNS-correlated C2 beacon detection" with the positive + two negative scenarios.
-- [ ] `host-app-extension-manager` delta: MODIFY the `activate` requirement so it enables the DNS proxy in addition to the content filter.
+- [ ] `server-detection-rules-engine` delta: MODIFY "Registered rule catalog" to include `dns_c2_beacon`; ADD
+  "Requirement: DNS-correlated C2 beacon detection" with the positive plus two negative scenarios.
+- [ ] `host-app-extension-manager` delta: MODIFY the `activate` requirement so it enables the DNS proxy in addition to
+  the content filter.
 
-## 6. Docs + demo
+## 6. Docs plus demo
 
-- [ ] README: add DNS as the third telemetry stream, note it's the newest component (encrypted-DNS + failure modes are roadmap).
-- [ ] Demo: recapture the demo dataset on edr-qa with DNS live; weave a `dns_c2_beacon` detection into one host's story as a 4th in-context attack (ties into the demo-data plan at `ai/demo/rich-demo-data-plan.md`).
+- [ ] README: add DNS as the third telemetry stream, note it's the newest component (encrypted-DNS plus failure modes
+  are roadmap).
+- [ ] Demo: recapture the demo dataset on edr-qa with DNS live; weave a `dns_c2_beacon` detection into one host's story
+  as a 4th in-context attack (ties into the demo-data plan at `ai/demo/rich-demo-data-plan.md`).
 
 ## Deferred (separate changes)
 
-- [ ] Default-on DNS activation in `activate` (after fail-open hardening).
 - [ ] DNS-proxy `.mobileconfig` for unattended/MDM pre-approval.
-- [ ] Fail-open proxy hardening (timeouts so a proxy fault can't break host DNS).
+- [ ] Fail-open proxy hardening (timeouts so a proxy fault can't break host DNS); higher priority now that `activate`
+  enables the proxy by default.
 - [ ] Encrypted DNS (DoH/DoT), domain reputation, trained DGA model, NXDOMAIN/beacon-cadence signals.


### PR DESCRIPTION
<!-- Keep this short. Delete sections that do not apply. -->

## What & why



## Checklist

- [ ] **OpenSpec updated for behavior changes.** If this PR changes observable behavior (a detection rule, the event
      wire schema, persistence semantics, an API/wire shape, or an emitted event), `openspec/specs/**` is updated (and
      an `openspec/changes/` proposal added), with a `spec:<id>` test marker for any new/renamed scenario. Only if this
      PR changes NO observable behavior (a comment / refactor / gofmt / dep bump that happens to touch a scoped path)
      may you assert `no-behavior-change` (label or `[no-behavior-change]` in the title) to clear the OpenSpec-sync gate.
      That is an assertion a reviewer will check, not a way to skip the spec for a real behavior change.
- [ ] Tests added/updated for the change (unit / integration / efficacy / UI as applicable).
- [ ] Agent/extension change touching ESF, XPC, or the event wire format: exercised on a live macOS VM before RC
      (flagged below).

## VM / RC notes (if applicable)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced new DNS C2 beacon detection rule that correlates suspicious process execution with DNS query responses and subsequent network connections using time-bounded analysis.

* **Chores**
  * DNS proxy is now enabled by default when activating the EDR tool, while remaining independently toggleable through disable/enable commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->