### PR TITLE
ui(RuleDetail): fix trapped meta-table margin causing tall row + cram…

### DIFF
--- a/test/e2e/tests/qa/reauth-modal-retry.spec.ts
+++ b/test/e2e/tests/qa/reauth-modal-retry.spec.ts
@@ -232,10 +232,15 @@ test.describe.serial("reauth modal retry after stale-session denial", () => {
         await page
           .getByRole("button", { name: /register security key/i })
           .click();
+        // 30s (not the 15s used elsewhere): this navigation is gated on the
+        // full WebAuthn registration ceremony - VA create() + server-side
+        // credential persistence + session mint + redirect - which can exceed
+        // 15s under CI load and flaked here once (the redirect lands a hair
+        // late). Matches the OIDC navigation budgets above.
         await page.waitForURL(
           (url) =>
             !url.pathname.includes("break-glass") && !url.pathname.includes("login"),
-          { timeout: 15_000 },
+          { timeout: 30_000 },
         );
 
         // The admin user lands signed-in with super_admin (per seed)

--- a/ui/src/components/RuleDetail.scss
+++ b/ui/src/components/RuleDetail.scss
@@ -16,11 +16,18 @@
     color: $core-fleet-black;
   }
 
+  // Section headings (Description, Configuration). Global h2 carries no top
+  // margin, so add the section gap here. It sits above the heading rather than
+  // on the preceding meta table, whose bottom margin would otherwise be trapped
+  // inside the bordered .table-wrapper card and read as an empty trailing row.
+  h2 {
+    margin-top: $pad-large;
+  }
+
   // The Severity / ATT&CK / Event-types meta block: small inline table with
   // labels in the left column and values on the right.
   &__meta {
     width: auto;
-    margin-bottom: $pad-large;
 
     th, td {
       padding-top: $pad-small;


### PR DESCRIPTION
…ped Description heading

The Severity/ATT&CK/Event-types meta table is wrapped in a bordered .table-wrapper card. Its margin-bottom: $pad-large was set on the inner <table>, so the border stopped the margin from collapsing out of the card: 24px of empty space rendered INSIDE the card below the last (Event types) row
- reading as an extra empty line - while the card itself had no bottom margin, so <h2>Description</h2> butted right against it.

Move the section gap above the headings (margin-top: $pad-large on .rule-detail h2, since global h2 has margin-top: 0) and drop the trapped margin-bottom on the meta table. Description and Configuration headings now get consistent space above them, and the Event types row is no longer tall.

<!-- Keep this short. Delete sections that do not apply. -->

## What & why



## Checklist

- [ ] **OpenSpec updated for behavior changes.** If this PR changes observable behavior (a detection rule, the event
      wire schema, persistence semantics, an API/wire shape, or an emitted event), `openspec/specs/**` is updated (and
      an `openspec/changes/` proposal added), with a `spec:<id>` test marker for any new/renamed scenario. Only if this
      PR changes NO observable behavior (a comment / refactor / gofmt / dep bump that happens to touch a scoped path)
      may you assert `no-behavior-change` (label or `[no-behavior-change]` in the title) to clear the OpenSpec-sync gate.
      That is an assertion a reviewer will check, not a way to skip the spec for a real behavior change.
- [ ] Tests added/updated for the change (unit / integration / efficacy / UI as applicable).
- [ ] Agent/extension change touching ESF, XPC, or the event wire format: exercised on a live macOS VM before RC
      (flagged below).

## VM / RC notes (if applicable)


