### PR TITLE
access-log noise fix and OTEL improvements

### DIFF
--- a/config/observability/edr-http-server-dashboard.json
+++ b/config/observability/edr-http-server-dashboard.json
@@ -1,0 +1,184 @@
+{
+  "title": "EDR HTTP server (RED)",
+  "description": "Rate / Errors / Duration for the EDR server's inbound HTTP surface, built on the http.server.request.duration histogram (OpenTelemetry HTTP semantic convention; emitted by the access-log middleware in server/httpserver). This replaces grepping per-request INFO access logs: healthy 2xx/3xx requests no longer log at info, so this dashboard is the volume + latency signal. Import via SigNoz Dashboards -> Import. Queries assume the server exports via OTLP with service.name=fleet-edr-server. The histogram is labeled by http.route (the matched route TEMPLATE, e.g. /api/hosts/{host_id}/tree, never the raw path), http.request.method, and http.response.status_code. SigNoz's import dialog re-numbers panels and may re-pick quantile selectors; the layout block is a starting hint only.",
+  "tags": ["edr", "http", "red"],
+  "layout": [
+    {"i": "1", "x": 0, "y": 0, "w": 6, "h": 4},
+    {"i": "2", "x": 6, "y": 0, "w": 6, "h": 4},
+    {"i": "3", "x": 0, "y": 4, "w": 6, "h": 4},
+    {"i": "4", "x": 6, "y": 4, "w": 6, "h": 4},
+    {"i": "5", "x": 0, "y": 8, "w": 6, "h": 4},
+    {"i": "6", "x": 6, "y": 8, "w": 6, "h": 4}
+  ],
+  "panels": [
+    {
+      "id": "1",
+      "title": "Request rate by route (R)",
+      "description": "Per-second request throughput from the histogram's observation count, grouped by route template. The high-frequency POST /api/events ingest path dominates; a sudden change in its rate is the fleet's heartbeat. Other routes (GET /api/hosts, /api/alerts) show operator + UI traffic.",
+      "panelTypes": "graph",
+      "query": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "queryName": "A",
+              "aggregateAttribute": {"key": "http.server.request.duration", "type": "", "dataType": "float64", "isColumn": true},
+              "aggregateOperator": "rate",
+              "filters": {
+                "op": "AND",
+                "items": [
+                  {"key": {"key": "service.name", "type": "resource"}, "op": "=", "value": "fleet-edr-server"}
+                ]
+              },
+              "groupBy": [{"key": "http.route", "type": "tag"}],
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "2",
+      "title": "Error rate: 5xx by route (E)",
+      "description": "Per-second rate of server-error (5xx) responses, grouped by route. This is the access log's old WARN lines turned into a metric: any sustained non-zero series is a route that is failing. Pair with the 4xx panel to separate server faults from client/auth rejections.",
+      "panelTypes": "graph",
+      "query": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "queryName": "A",
+              "aggregateAttribute": {"key": "http.server.request.duration", "type": "", "dataType": "float64", "isColumn": true},
+              "aggregateOperator": "rate",
+              "filters": {
+                "op": "AND",
+                "items": [
+                  {"key": {"key": "service.name", "type": "resource"}, "op": "=", "value": "fleet-edr-server"},
+                  {"key": {"key": "http.response.status_code", "type": "tag"}, "op": ">=", "value": "500"}
+                ]
+              },
+              "groupBy": [{"key": "http.route", "type": "tag"}],
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "3",
+      "title": "Duration p95 by route (D)",
+      "description": "95th-percentile request latency per route, in seconds, computed from the histogram buckets. The access-log slow-warn threshold is 500ms; a route whose p95 climbs toward that is the regression to chase before it starts emitting WARN lines.",
+      "panelTypes": "graph",
+      "query": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "queryName": "A",
+              "aggregateAttribute": {"key": "http.server.request.duration", "type": "", "dataType": "float64", "isColumn": true},
+              "aggregateOperator": "p95",
+              "filters": {
+                "op": "AND",
+                "items": [
+                  {"key": {"key": "service.name", "type": "resource"}, "op": "=", "value": "fleet-edr-server"}
+                ]
+              },
+              "groupBy": [{"key": "http.route", "type": "tag"}],
+              "stepInterval": 60,
+              "timeAggregation": "p95"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "4",
+      "title": "Duration p99 by route (D)",
+      "description": "99th-percentile request latency per route, in seconds. The tail that p95 hides: a flat p95 with a spiky p99 points at intermittent slow paths (cold caches, lock contention, a slow downstream) rather than a uniform regression.",
+      "panelTypes": "graph",
+      "query": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "queryName": "A",
+              "aggregateAttribute": {"key": "http.server.request.duration", "type": "", "dataType": "float64", "isColumn": true},
+              "aggregateOperator": "p99",
+              "filters": {
+                "op": "AND",
+                "items": [
+                  {"key": {"key": "service.name", "type": "resource"}, "op": "=", "value": "fleet-edr-server"}
+                ]
+              },
+              "groupBy": [{"key": "http.route", "type": "tag"}],
+              "stepInterval": 60,
+              "timeAggregation": "p99"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "5",
+      "title": "Request rate by status code",
+      "description": "Throughput split by exact HTTP status code. The 2xx/3xx/4xx/5xx mix at a glance: a rising 401/403 series is auth pressure (failed sessions, reauth gating), a rising 4xx on the ingest path is malformed agent batches, and any 5xx is a server fault.",
+      "panelTypes": "graph",
+      "query": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "queryName": "A",
+              "aggregateAttribute": {"key": "http.server.request.duration", "type": "", "dataType": "float64", "isColumn": true},
+              "aggregateOperator": "rate",
+              "filters": {
+                "op": "AND",
+                "items": [
+                  {"key": {"key": "service.name", "type": "resource"}, "op": "=", "value": "fleet-edr-server"}
+                ]
+              },
+              "groupBy": [{"key": "http.response.status_code", "type": "tag"}],
+              "stepInterval": 60,
+              "timeAggregation": "rate"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "6",
+      "title": "Top routes by request volume",
+      "description": "Table of total request count by route over the selected window, highest first. Quick capacity view: which endpoints carry the load and where to focus latency work. POST /api/events should top it in any real fleet.",
+      "panelTypes": "table",
+      "query": {
+        "queryType": "builder",
+        "builder": {
+          "queryData": [
+            {
+              "dataSource": "metrics",
+              "queryName": "A",
+              "aggregateAttribute": {"key": "http.server.request.duration", "type": "", "dataType": "float64", "isColumn": true},
+              "aggregateOperator": "count",
+              "filters": {
+                "op": "AND",
+                "items": [
+                  {"key": {"key": "service.name", "type": "resource"}, "op": "=", "value": "fleet-edr-server"}
+                ]
+              },
+              "groupBy": [{"key": "http.route", "type": "tag"}],
+              "stepInterval": 60,
+              "timeAggregation": "count"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/openspec/specs/observability-instrumentation/spec.md
+++ b/openspec/specs/observability-instrumentation/spec.md
@@ -63,6 +63,17 @@ The system SHALL expose a histogram named `edr.db.query.duration` that records t
 - **WHEN** the operator queries the histogram in the backend
 - **THEN** the distinct `op` values match the documented stable set and do not include host ids, table-row values, or other high-cardinality data
 
+### Requirement: HTTP server request duration
+
+The system SHALL expose a histogram named `http.server.request.duration` (the OpenTelemetry HTTP semantic-convention name, in seconds) that records the latency of every inbound HTTP request. Each sample MUST carry `http.request.method`, `http.route`, and `http.response.status_code` attributes, where `http.route` is the matched route TEMPLATE (for example `/api/hosts/{host_id}/tree`) and never the raw path, so high-frequency endpoints do not explode metric cardinality; an unrecognized method MUST collapse to `_OTHER` and a request that matched no route MUST use the route value `unmatched`. Because this metric carries the per-request rate and latency signal, the access log MUST NOT emit an info-level line per successful request: healthy 2xx/3xx requests log at debug, 4xx at info, 5xx or slow requests at warn.
+
+#### Scenario: Inbound requests are timed by route, method, and status
+
+- **GIVEN** the server handles inbound HTTP requests
+- **WHEN** a request completes
+- **THEN** a sample is recorded on `http.server.request.duration` labeled with the request's method, matched route template, and response status code
+- **AND** requests sharing a method, route template, and status code collapse into one time series
+
 ### Requirement: Observable host-fleet gauges
 
 The system SHALL expose two observable gauges, `edr.enrolled.hosts` and `edr.offline.hosts`, evaluated on each collection cycle by the OTel reader. The enrolled gauge MUST report the number of non-revoked enrollments. The offline gauge MUST report the number of hosts whose last-seen timestamp exceeds the configured offline threshold. A failed callback MUST NOT take down the collection cycle for other gauges.

--- a/server/cmd/fleet-edr-server/main.go
+++ b/server/cmd/fleet-edr-server/main.go
@@ -524,7 +524,13 @@ func runIdentity(ctx context.Context, identityCtx *identitybootstrap.Identity, l
 	}
 }
 
-func newHTTPServer(cfg *config.Config, mux *http.ServeMux, logger *slog.Logger, clientIPResolver *httpserver.ClientIPResolver, metricsRec *metrics.Recorder) *http.Server {
+func newHTTPServer(
+	cfg *config.Config,
+	mux *http.ServeMux,
+	logger *slog.Logger,
+	clientIPResolver *httpserver.ClientIPResolver,
+	metricsRec *metrics.Recorder,
+) *http.Server {
 	handler := httpserver.Build(mux, httpserver.Options{
 		Logger:           logger,
 		ServiceName:      serviceName,

--- a/server/cmd/fleet-edr-server/main.go
+++ b/server/cmd/fleet-edr-server/main.go
@@ -156,7 +156,7 @@ func run() error {
 		logger.InfoContext(ctx, "trusting X-Forwarded-For from proxies", "trusted", cfg.TrustedProxies)
 	}
 
-	srv := newHTTPServer(cfg, mux, logger, clientIPResolver)
+	srv := newHTTPServer(cfg, mux, logger, clientIPResolver, metricsRec)
 	if err := configureTLS(ctx, logger, srv, cfg); err != nil {
 		return err
 	}
@@ -524,12 +524,13 @@ func runIdentity(ctx context.Context, identityCtx *identitybootstrap.Identity, l
 	}
 }
 
-func newHTTPServer(cfg *config.Config, mux *http.ServeMux, logger *slog.Logger, clientIPResolver *httpserver.ClientIPResolver) *http.Server {
+func newHTTPServer(cfg *config.Config, mux *http.ServeMux, logger *slog.Logger, clientIPResolver *httpserver.ClientIPResolver, metricsRec *metrics.Recorder) *http.Server {
 	handler := httpserver.Build(mux, httpserver.Options{
 		Logger:           logger,
 		ServiceName:      serviceName,
 		TLSEnabled:       cfg.TLSEnabled(),
 		ClientIPResolver: clientIPResolver,
+		Metrics:          metricsRec,
 	})
 	return &http.Server{
 		Addr:         cfg.ListenAddr,

--- a/server/httpserver/httpserver.go
+++ b/server/httpserver/httpserver.go
@@ -33,10 +33,13 @@ import (
 // latency upgrade from info to warn so SigNoz can alert on regressions without sampling every request.
 const defaultSlowThreshold = 500 * time.Millisecond
 
-// RequestMetrics is the access-log middleware's hook for recording per-request latency on a metric. *metrics.Recorder satisfies
+// accessLogMsg is the slog message for the per-request access log. Shared across the status branches so the literal is defined once.
+const accessLogMsg = "http request"
+
+// HTTPRequestRecorder is the access-log middleware's hook for recording per-request latency on a metric. *metrics.Recorder satisfies
 // it. Kept as a local interface (rather than importing the metrics package) so httpserver stays decoupled and tests can pass a
 // fake. nil disables the recording.
-type RequestMetrics interface {
+type HTTPRequestRecorder interface {
 	// ObserveHTTPRequest records one request's latency. route is the matched route TEMPLATE ("/api/hosts/{host_id}/tree") or
 	// "unmatched"; the implementation owns label cardinality.
 	ObserveHTTPRequest(ctx context.Context, method, route string, statusCode int, d time.Duration)
@@ -48,7 +51,7 @@ type Options struct {
 	Logger *slog.Logger
 	// Metrics, when set, receives one ObserveHTTPRequest call per request from the access-log layer. nil disables it (e.g. the
 	// ingest-only binary or unit tests that don't assert metrics).
-	Metrics RequestMetrics
+	Metrics HTTPRequestRecorder
 	// ServiceName is the operation name passed to otelhttp.NewHandler; used in the span name prefix.
 	ServiceName string
 	// SlowThreshold upgrades access-log lines to warn when the handler took longer than this. Zero uses the default (defaultSlowThreshold
@@ -169,7 +172,7 @@ func routeTemplate(pattern string) string {
 // info-level firehose: healthy 2xx/3xx requests log at debug (off in prod), client errors (4xx) at info, and 5xx or
 // slow (> slowThreshold) requests at warn. The volume + latency signal for every request, including the healthy ones, lives in
 // the http.server.request.duration metric instead, so high-frequency endpoints (POST /api/events) no longer drown the log.
-func accessLog(logger *slog.Logger, slowThreshold time.Duration, recorder RequestMetrics) func(http.Handler) http.Handler {
+func accessLog(logger *slog.Logger, slowThreshold time.Duration, recorder HTTPRequestRecorder) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			start := time.Now()
@@ -179,9 +182,13 @@ func accessLog(logger *slog.Logger, slowThreshold time.Duration, recorder Reques
 			ctx := r.Context()
 
 			// r.Pattern is the route template the ServeMux matched (set on this request before the handler ran); it is bounded by
-			// the route table. Strip the leading "METHOD " (and any host) so the metric label is just the path template. Empty
-			// means no route matched (404 / scanner traffic): record it as "unmatched" rather than the raw path to bound cardinality.
+			// the route table. Strip the leading "METHOD " (and any host) so the label is just the path template. Empty means no
+			// route matched (404 / scanner traffic): use "unmatched" rather than the raw path to bound cardinality. Resolve it here
+			// (not just inside the recorder) so the log attribute and the metric label agree on the same "unmatched" value.
 			route := routeTemplate(r.Pattern)
+			if route == "" {
+				route = "unmatched"
+			}
 			if recorder != nil {
 				recorder.ObserveHTTPRequest(ctx, r.Method, route, rw.status, dur)
 			}
@@ -198,14 +205,14 @@ func accessLog(logger *slog.Logger, slowThreshold time.Duration, recorder Reques
 
 			switch {
 			case rw.status >= http.StatusInternalServerError:
-				logger.WarnContext(ctx, "http request", attrs...)
+				logger.WarnContext(ctx, accessLogMsg, attrs...)
 			case slowThreshold > 0 && dur > slowThreshold:
-				logger.WarnContext(ctx, "http request (slow)", append(attrs, "slow", true)...)
+				logger.WarnContext(ctx, accessLogMsg+" (slow)", append(attrs, "slow", true)...)
 			case rw.status >= http.StatusBadRequest:
-				logger.InfoContext(ctx, "http request", attrs...)
+				logger.InfoContext(ctx, accessLogMsg, attrs...)
 			default:
 				// Healthy 2xx/3xx: debug only. The metric carries the rate + latency; logging every one is the noise this avoids.
-				logger.DebugContext(ctx, "http request", attrs...)
+				logger.DebugContext(ctx, accessLogMsg, attrs...)
 			}
 		})
 	}

--- a/server/httpserver/httpserver.go
+++ b/server/httpserver/httpserver.go
@@ -21,6 +21,7 @@ import (
 	"log/slog"
 	"net/http"
 	"runtime/debug"
+	"strings"
 	"time"
 
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
@@ -32,10 +33,22 @@ import (
 // latency upgrade from info to warn so SigNoz can alert on regressions without sampling every request.
 const defaultSlowThreshold = 500 * time.Millisecond
 
+// RequestMetrics is the access-log middleware's hook for recording per-request latency on a metric. *metrics.Recorder satisfies
+// it. Kept as a local interface (rather than importing the metrics package) so httpserver stays decoupled and tests can pass a
+// fake. nil disables the recording.
+type RequestMetrics interface {
+	// ObserveHTTPRequest records one request's latency. route is the matched route TEMPLATE ("/api/hosts/{host_id}/tree") or
+	// "unmatched"; the implementation owns label cardinality.
+	ObserveHTTPRequest(ctx context.Context, method, route string, statusCode int, d time.Duration)
+}
+
 // Options configures the middleware chain.
 type Options struct {
 	// Logger is required; all middleware logs through it.
 	Logger *slog.Logger
+	// Metrics, when set, receives one ObserveHTTPRequest call per request from the access-log layer. nil disables it (e.g. the
+	// ingest-only binary or unit tests that don't assert metrics).
+	Metrics RequestMetrics
 	// ServiceName is the operation name passed to otelhttp.NewHandler; used in the span name prefix.
 	ServiceName string
 	// SlowThreshold upgrades access-log lines to warn when the handler took longer than this. Zero uses the default (defaultSlowThreshold
@@ -65,7 +78,7 @@ func Build(handler http.Handler, opts Options) http.Handler {
 
 	h := handler
 	h = recoverMiddleware(opts.Logger)(h)
-	h = accessLog(opts.Logger, opts.SlowThreshold)(h)
+	h = accessLog(opts.Logger, opts.SlowThreshold, opts.Metrics)(h)
 	if opts.TLSEnabled {
 		h = hstsHeader()(h)
 	}
@@ -143,32 +156,56 @@ func recoverMiddleware(logger *slog.Logger) func(http.Handler) http.Handler {
 	}
 }
 
-// accessLog emits one log line per request. Status 5xx or duration > slowThreshold upgrade to warn.
-func accessLog(logger *slog.Logger, slowThreshold time.Duration) func(http.Handler) http.Handler {
+// routeTemplate extracts the path template from a ServeMux pattern: "POST /api/events" -> "/api/events", "/healthz" -> "/healthz".
+// The path begins at the first '/', after any optional "METHOD " and host. Returns "" for an empty pattern (no route matched).
+func routeTemplate(pattern string) string {
+	if i := strings.IndexByte(pattern, '/'); i >= 0 {
+		return pattern[i:]
+	}
+	return ""
+}
+
+// accessLog records each request's latency on the metrics hook and logs the noteworthy ones. The per-request line is NOT an
+// info-level firehose: healthy 2xx/3xx requests log at debug (off in prod), client errors (4xx) at info, and 5xx or
+// slow (> slowThreshold) requests at warn. The volume + latency signal for every request, including the healthy ones, lives in
+// the http.server.request.duration metric instead, so high-frequency endpoints (POST /api/events) no longer drown the log.
+func accessLog(logger *slog.Logger, slowThreshold time.Duration, recorder RequestMetrics) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			start := time.Now()
 			rw := &statusCapture{ResponseWriter: w, status: http.StatusOK}
 			next.ServeHTTP(rw, r)
 			dur := time.Since(start)
+			ctx := r.Context()
+
+			// r.Pattern is the route template the ServeMux matched (set on this request before the handler ran); it is bounded by
+			// the route table. Strip the leading "METHOD " (and any host) so the metric label is just the path template. Empty
+			// means no route matched (404 / scanner traffic): record it as "unmatched" rather than the raw path to bound cardinality.
+			route := routeTemplate(r.Pattern)
+			if recorder != nil {
+				recorder.ObserveHTTPRequest(ctx, r.Method, route, rw.status, dur)
+			}
 
 			attrs := []any{
 				"method", r.Method,
 				"path", r.URL.Path,
+				"route", route,
 				"status", rw.status,
 				"bytes", rw.bytes,
 				"duration_ms", dur.Milliseconds(),
 				"remote_addr", ClientIP(r),
 			}
 
-			ctx := r.Context()
 			switch {
 			case rw.status >= http.StatusInternalServerError:
 				logger.WarnContext(ctx, "http request", attrs...)
 			case slowThreshold > 0 && dur > slowThreshold:
 				logger.WarnContext(ctx, "http request (slow)", append(attrs, "slow", true)...)
-			default:
+			case rw.status >= http.StatusBadRequest:
 				logger.InfoContext(ctx, "http request", attrs...)
+			default:
+				// Healthy 2xx/3xx: debug only. The metric carries the rate + latency; logging every one is the noise this avoids.
+				logger.DebugContext(ctx, "http request", attrs...)
 			}
 		})
 	}

--- a/server/httpserver/httpserver_test.go
+++ b/server/httpserver/httpserver_test.go
@@ -242,3 +242,30 @@ func splitLines(t *testing.T, b []byte) [][]byte {
 	lines := bytes.Split(bytes.TrimRight(b, "\n"), []byte("\n"))
 	return lines
 }
+
+// TestBuild_AccessLog_UnmatchedRouteLabel pins the Gemini + Copilot fix: a request matching no route logs and records the route
+// as "unmatched" (not ""), so the access-log attribute and the metric label agree.
+func TestBuild_AccessLog_UnmatchedRouteLabel(t *testing.T) {
+	installTracer(t)
+	var logs bytes.Buffer
+	logger := newLogger(&logs)
+	rec := &fakeRequestMetrics{}
+	h := Build(http.NewServeMux(), Options{Logger: logger, Metrics: rec}) // empty mux: every request is an unmatched 404
+
+	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+"/no/such/path", nil)
+	require.NoError(t, err)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	lines := splitLines(t, logs.Bytes())
+	require.Len(t, lines, 1)
+	var line map[string]any
+	require.NoError(t, json.Unmarshal(lines[0], &line))
+	assert.Equal(t, "unmatched", line["route"])
+	require.Len(t, rec.calls, 1)
+	assert.Equal(t, "unmatched", rec.calls[0].route)
+}

--- a/server/httpserver/httpserver_test.go
+++ b/server/httpserver/httpserver_test.go
@@ -113,6 +113,9 @@ func TestBuild_AccessLogLevels(t *testing.T) {
 	mux.HandleFunc("GET /ok", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
+	mux.HandleFunc("GET /bad", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+	})
 	mux.HandleFunc("GET /slow", func(w http.ResponseWriter, _ *http.Request) {
 		time.Sleep(30 * time.Millisecond)
 		w.WriteHeader(http.StatusOK)
@@ -120,12 +123,13 @@ func TestBuild_AccessLogLevels(t *testing.T) {
 	mux.HandleFunc("GET /boom", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 	})
-	h := Build(mux, Options{Logger: logger, SlowThreshold: 10 * time.Millisecond})
+	rec := &fakeRequestMetrics{}
+	h := Build(mux, Options{Logger: logger, SlowThreshold: 10 * time.Millisecond, Metrics: rec})
 
 	srv := httptest.NewServer(h)
 	t.Cleanup(srv.Close)
 
-	for _, path := range []string{"/ok", "/slow", "/boom"} {
+	for _, path := range []string{"/ok", "/bad", "/slow", "/boom"} {
 		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+path, nil)
 		require.NoError(t, err)
 		resp, err := http.DefaultClient.Do(req)
@@ -134,7 +138,7 @@ func TestBuild_AccessLogLevels(t *testing.T) {
 	}
 
 	lines := splitLines(t, logs.Bytes())
-	require.Len(t, lines, 3)
+	require.Len(t, lines, 4)
 
 	byPath := map[string]map[string]any{}
 	for _, ln := range lines {
@@ -143,10 +147,39 @@ func TestBuild_AccessLogLevels(t *testing.T) {
 		byPath[rec["path"].(string)] = rec
 	}
 
-	assert.Equal(t, "INFO", byPath["/ok"]["level"])
+	// Healthy 2xx drops to debug (the noise fix); client errors stay at info; slow + 5xx stay at warn.
+	assert.Equal(t, "DEBUG", byPath["/ok"]["level"])
+	assert.Equal(t, "INFO", byPath["/bad"]["level"])
 	assert.Equal(t, "WARN", byPath["/slow"]["level"])
 	assert.Equal(t, true, byPath["/slow"]["slow"])
 	assert.Equal(t, "WARN", byPath["/boom"]["level"])
+	// The route template (not the raw path) is stamped on the line and is what the metric is labeled by.
+	assert.Equal(t, "/ok", byPath["/ok"]["route"])
+
+	// Every request, including the healthy 2xx that no longer logs at info, is recorded on the metric.
+	require.Len(t, rec.calls, 4)
+	got := map[string]metricCall{}
+	for _, c := range rec.calls {
+		got[c.route] = c
+	}
+	assert.Equal(t, http.MethodGet, got["/ok"].method)
+	assert.Equal(t, http.StatusOK, got["/ok"].status)
+	assert.Equal(t, http.StatusBadRequest, got["/bad"].status)
+	assert.Equal(t, http.StatusInternalServerError, got["/boom"].status)
+}
+
+type metricCall struct {
+	method, route string
+	status        int
+	dur           time.Duration
+}
+
+// fakeRequestMetrics captures ObserveHTTPRequest calls so the access-log test can assert the metric is recorded for every
+// request (including the healthy ones that no longer log) with the route template, not the raw path.
+type fakeRequestMetrics struct{ calls []metricCall }
+
+func (f *fakeRequestMetrics) ObserveHTTPRequest(_ context.Context, method, route string, status int, d time.Duration) {
+	f.calls = append(f.calls, metricCall{method: method, route: route, status: status, dur: d})
 }
 
 func TestBuild_RecoversPanic(t *testing.T) {

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -12,6 +12,7 @@ package metrics
 import (
 	"context"
 	"log/slog"
+	"net/http"
 	"time"
 
 	"go.opentelemetry.io/otel"
@@ -32,6 +33,18 @@ const (
 // indexed batch reads, hundreds of milliseconds on the worst-case unindexed retention scans.
 var dbQueryHistogramBuckets = []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5}
 
+// httpDurationBuckets is the OTel HTTP semantic-convention default bucket set for http.server.request.duration, in seconds.
+// Using the conventional boundaries keeps p50/p95/p99 readings comparable with any other OTel-instrumented service and with
+// SigNoz's built-in expectations for this metric.
+var httpDurationBuckets = []float64{0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10}
+
+// knownHTTPMethods bounds the http.request.method label. An unrecognized method (a scanner sending garbage verbs) collapses to
+// "_OTHER" per the OTel HTTP semantic conventions, so a flood of junk methods cannot inflate the metric's cardinality.
+var knownHTTPMethods = map[string]bool{
+	http.MethodGet: true, http.MethodHead: true, http.MethodPost: true, http.MethodPut: true, http.MethodPatch: true,
+	http.MethodDelete: true, http.MethodConnect: true, http.MethodOptions: true, http.MethodTrace: true,
+}
+
 // GaugeSource is the read-only contract used by the observable gauges. The OTel reader invokes the callbacks on its collection
 // cadence; the callback issues a live DB query each time. Interface not concrete struct so tests can swap in fakes without pulling in
 // a MySQL dependency.
@@ -49,6 +62,7 @@ type Recorder struct {
 	retentionRowsDeleted metric.Int64Counter
 	processesReconciled  metric.Int64Counter
 	queueDropped         metric.Int64Counter
+	httpRequestDuration  metric.Float64Histogram
 	// observable gauges retained only so the GC can't collect them; the callbacks run
 	// against the global meter provider.
 	enrolledGauge metric.Int64ObservableGauge
@@ -112,6 +126,15 @@ func New(gauges GaugeSource, opts Options) *Recorder {
 		"edr.agent.queue.dropped",
 		metric.WithDescription("Events dropped by agent queue cap. Attribute `lossy=true` means data loss; `lossy=false` means already-delivered rows trimmed for space."),
 		metric.WithUnit("{event}"),
+	)
+	// Deliberately the OTel HTTP semantic-convention name (not the edr.* prefix the metrics above use): tooling, including SigNoz,
+	// recognizes http.server.request.duration and its standard attributes. The histogram's count gives request rate, a status-code
+	// filter gives the error rate, and the buckets give latency quantiles, so this one instrument covers the full RED picture.
+	r.httpRequestDuration, _ = meter.Float64Histogram(
+		"http.server.request.duration",
+		metric.WithDescription("Duration of inbound HTTP requests, by route + method + status. The per-request access log only fires for 4xx/5xx/slow; this metric is the volume + latency signal."),
+		metric.WithUnit("s"),
+		metric.WithExplicitBucketBoundaries(httpDurationBuckets...),
 	)
 
 	if gauges != nil {
@@ -203,6 +226,27 @@ func (r *Recorder) ObserveDBQuery(ctx context.Context, op string, d time.Duratio
 		return
 	}
 	r.dbQueryDuration.Record(ctx, d.Seconds(), metric.WithAttributes(attribute.String("op", op)))
+}
+
+// ObserveHTTPRequest records one inbound HTTP request's latency on the http.server.request.duration histogram. `route` must be
+// the matched route TEMPLATE (e.g. "/api/hosts/{host_id}/tree"), never the raw path: a raw path carrying ids would make every
+// host its own time series. The caller passes "unmatched" for requests that hit no route. `method` is normalized against the
+// known-verb set so a garbage method collapses to "_OTHER". Status code is bounded by construction.
+func (r *Recorder) ObserveHTTPRequest(ctx context.Context, method, route string, statusCode int, d time.Duration) {
+	if r == nil || r.httpRequestDuration == nil {
+		return
+	}
+	if !knownHTTPMethods[method] {
+		method = "_OTHER"
+	}
+	if route == "" {
+		route = "unmatched"
+	}
+	r.httpRequestDuration.Record(ctx, d.Seconds(), metric.WithAttributes(
+		attribute.String("http.request.method", method),
+		attribute.String("http.route", route),
+		attribute.Int("http.response.status_code", statusCode),
+	))
 }
 
 // RetentionRowsDeleted satisfies retention.MetricsRecorder.

--- a/server/metrics/metrics_test.go
+++ b/server/metrics/metrics_test.go
@@ -381,3 +381,29 @@ func appendObserveDBQueryViolations(bads []observeDBQueryViolation, file *ast.Fi
 	})
 	return bads
 }
+
+// spec:observability-instrumentation/http-server-request-duration/inbound-requests-are-timed-by-route-method-and-status
+//
+// ObserveHTTPRequest records on the OTel-semantic-convention http.server.request.duration histogram. The test pins: (a) two
+// requests sharing method+route+status collapse into one series with count 2, (b) a distinct status is its own series, and
+// (c) the cardinality guards fire: an unknown method collapses to "_OTHER" and an empty route to "unmatched".
+func TestObserveHTTPRequest(t *testing.T) {
+	r, collect := newTestRecorder(t, nil, Options{})
+	ctx := context.Background()
+	r.ObserveHTTPRequest(ctx, "POST", "/api/events", 200, 50*time.Millisecond)
+	r.ObserveHTTPRequest(ctx, "POST", "/api/events", 200, 70*time.Millisecond)
+	r.ObserveHTTPRequest(ctx, "GET", "/api/hosts/{host_id}/tree", 500, 5*time.Millisecond)
+	r.ObserveHTTPRequest(ctx, "BREW", "", 418, time.Millisecond)
+
+	rm := collect()
+	const name = "http.server.request.duration"
+	assert.Equal(t, uint64(2), findHistogramCount(t, rm, name, map[string]any{
+		"http.request.method": "POST", "http.route": "/api/events", "http.response.status_code": int64(200),
+	}), "two POST /api/events 200s share one series")
+	assert.Equal(t, uint64(1), findHistogramCount(t, rm, name, map[string]any{
+		"http.request.method": "GET", "http.route": "/api/hosts/{host_id}/tree", "http.response.status_code": int64(500),
+	}))
+	assert.Equal(t, uint64(1), findHistogramCount(t, rm, name, map[string]any{
+		"http.request.method": "_OTHER", "http.route": "unmatched", "http.response.status_code": int64(418),
+	}), "unknown method -> _OTHER and empty route -> unmatched (cardinality guard)")
+}


### PR DESCRIPTION
<!-- Keep this short. Delete sections that do not apply. -->

## What & why



## Checklist

- [ ] **OpenSpec updated for behavior changes.** If this PR changes observable behavior (a detection rule, the event
      wire schema, persistence semantics, an API/wire shape, or an emitted event), `openspec/specs/**` is updated (and
      an `openspec/changes/` proposal added), with a `spec:<id>` test marker for any new/renamed scenario. Only if this
      PR changes NO observable behavior (a comment / refactor / gofmt / dep bump that happens to touch a scoped path)
      may you assert `no-behavior-change` (label or `[no-behavior-change]` in the title) to clear the OpenSpec-sync gate.
      That is an assertion a reviewer will check, not a way to skip the spec for a real behavior change.
- [ ] Tests added/updated for the change (unit / integration / efficacy / UI as applicable).
- [ ] Agent/extension change touching ESF, XPC, or the event wire format: exercised on a live macOS VM before RC
      (flagged below).

## VM / RC notes (if applicable)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * HTTP inbound request metrics now tracked, including duration, request rate, and error rates for improved server observability
  * Added SigNoz dashboard with 6 panels displaying request rate by route, error rates, latency percentiles, and top routes

* **Documentation**
  * Published observability specification defining HTTP server request metrics requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->