### PR TITLE
fix(ingest): batch event inserts instead of one round-trip per event

### DIFF
--- a/server/detection/internal/mysql/store.go
+++ b/server/detection/internal/mysql/store.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/go-sql-driver/mysql"
@@ -79,6 +80,12 @@ func (s *Store) InsertEventsAt(ctx context.Context, events []api.Event, ingested
 const (
 	insertMaxAttempts = 5
 	insertBackoffStep = 5 * time.Millisecond
+
+	// eventInsertChunkRows caps rows per multi-row INSERT so we stay well under MySQL's 65535-placeholder limit (6 cols/row) and
+	// the default 4MB max_allowed_packet once JSON payloads are included.
+	eventInsertChunkRows = 500
+	// eventStampChunkRows caps event_ids per SELECT-back IN(...) clause on the duplicate path.
+	eventStampChunkRows = 1000
 )
 
 func (s *Store) insertEventsAt(ctx context.Context, events []api.Event, ingestedAtNs int64) error {
@@ -123,44 +130,105 @@ func (s *Store) insertEventsAtOnce(ctx context.Context, events []api.Event, inge
 	}
 	defer tx.Rollback() //nolint:errcheck // Rollback after commit is a no-op.
 
-	stmt, err := tx.PrepareContext(ctx, `
-		INSERT IGNORE INTO events (event_id, host_id, timestamp_ns, ingested_at_ns, event_type, payload)
-		VALUES (?, ?, ?, ?, ?, ?)
-	`)
-	if err != nil {
-		return fmt.Errorf("prepare: %w", err)
+	// Insert the whole batch with a handful of multi-row INSERT IGNORE statements rather than one statement per event. At fleet
+	// scale a batch carries hundreds of events, and one round-trip per event dominated ingest latency (a ~100-event batch was
+	// ~100 sequential round-trips, seconds of wall time). Chunked to stay under MySQL's placeholder + max_allowed_packet limits.
+	// INSERT IGNORE keeps the statement idempotent, so withDeadlockRetry can re-run it safely.
+	allInserted := true
+	for start := 0; start < len(events); start += eventInsertChunkRows {
+		end := min(start+eventInsertChunkRows, len(events))
+		chunk := events[start:end]
+		placeholders := make([]string, len(chunk))
+		args := make([]any, 0, len(chunk)*6)
+		for i := range chunk {
+			payloadBytes, err := json.Marshal(chunk[i].Payload)
+			if err != nil {
+				return fmt.Errorf("marshal payload for %s: %w", chunk[i].EventID, err)
+			}
+			placeholders[i] = "(?, ?, ?, ?, ?, ?)"
+			args = append(args, chunk[i].EventID, chunk[i].HostID, chunk[i].TimestampNs, ingestedAtNs, chunk[i].EventType, payloadBytes)
+		}
+		res, err := tx.ExecContext(ctx, `INSERT IGNORE INTO events (event_id, host_id, timestamp_ns, ingested_at_ns, event_type, payload) VALUES `+
+			strings.Join(placeholders, ", "), args...)
+		if err != nil {
+			return fmt.Errorf("insert events chunk [%d:%d]: %w", start, end, err)
+		}
+		affected, err := res.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("rows affected: %w", err)
+		}
+		if int(affected) != len(chunk) {
+			allInserted = false // at least one duplicate event_id was IGNOREd in this chunk
+		}
 	}
-	defer stmt.Close()
 
-	// Stamp the caller's slice with the server-chosen ingest time so callers
-	// that hand the same slice straight to the graph builder see the
-	// persisted value.
-	//
-	// Only stamp rows that were actually INSERTed. INSERT IGNORE silently
-	// drops duplicates, and in that case the DB already holds a different
-	// ingested_at_ns from the original insert; mutating the caller's slice
-	// to a value that doesn't match the persisted row would silently break
-	// any correlation the caller tries to do in-memory.
-	for i := range events {
-		payloadBytes, err := json.Marshal(events[i].Payload)
+	// Stamp the caller's slice with the persisted ingested_at_ns (the graph builder reads it). Fast path: when every row was newly
+	// inserted, they all carry this batch's ingestedAtNs, so no extra query is needed. Slow path: a duplicate event_id keeps the
+	// ingested_at_ns from its first insert, so read the real values back. Resolve inside the tx but write to the slice only after a
+	// successful commit, so a rolled-back / retried attempt never leaves the caller's slice half-stamped.
+	var persisted map[string]int64
+	if !allInserted {
+		persisted, err = selectIngestedAt(ctx, tx, events)
 		if err != nil {
-			return fmt.Errorf("marshal payload for %s: %w", events[i].EventID, err)
+			return err
 		}
-		res, err := stmt.ExecContext(ctx, events[i].EventID, events[i].HostID, events[i].TimestampNs,
-			ingestedAtNs, events[i].EventType, payloadBytes)
-		if err != nil {
-			return fmt.Errorf("insert %s: %w", events[i].EventID, err)
-		}
-		rowsAffected, err := res.RowsAffected()
-		if err != nil {
-			return fmt.Errorf("rows affected for %s: %w", events[i].EventID, err)
-		}
-		if rowsAffected > 0 {
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit: %w", err)
+	}
+
+	if allInserted {
+		for i := range events {
 			events[i].IngestedAtNs = ingestedAtNs
 		}
+		return nil
 	}
+	for i := range events {
+		if ts, ok := persisted[events[i].EventID]; ok {
+			events[i].IngestedAtNs = ts
+		}
+	}
+	return nil
+}
 
-	return tx.Commit()
+// selectIngestedAt reads the persisted ingested_at_ns for each event_id, chunked to stay under MySQL's placeholder limit. Used on
+// the duplicate path, where a row that already existed retains the ingested_at_ns from its first insert and so no longer matches
+// this batch's ingestedAtNs.
+func selectIngestedAt(ctx context.Context, tx *sqlx.Tx, events []api.Event) (map[string]int64, error) {
+	persisted := make(map[string]int64, len(events))
+	for start := 0; start < len(events); start += eventStampChunkRows {
+		end := min(start+eventStampChunkRows, len(events))
+		if err := scanIngestedAtChunk(ctx, tx, events[start:end], persisted); err != nil {
+			return nil, err
+		}
+	}
+	return persisted, nil
+}
+
+// scanIngestedAtChunk reads one IN(...) chunk into out. Split from selectIngestedAt so `defer rows.Close()` fires per chunk
+// rather than accumulating until the whole batch is read.
+func scanIngestedAtChunk(ctx context.Context, tx *sqlx.Tx, chunk []api.Event, out map[string]int64) error {
+	placeholders := make([]string, len(chunk))
+	ids := make([]any, len(chunk))
+	for i := range chunk {
+		placeholders[i] = "?"
+		ids[i] = chunk[i].EventID
+	}
+	rows, err := tx.QueryxContext(ctx, `SELECT event_id, ingested_at_ns FROM events WHERE event_id IN (`+
+		strings.Join(placeholders, ", ")+`)`, ids...)
+	if err != nil {
+		return fmt.Errorf("select ingested_at_ns: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var id string
+		var ts int64
+		if err := rows.Scan(&id, &ts); err != nil {
+			return fmt.Errorf("scan ingested_at_ns: %w", err)
+		}
+		out[id] = ts
+	}
+	return rows.Err()
 }
 
 // CountEvents returns the total number of events.

--- a/server/detection/internal/mysql/store.go
+++ b/server/detection/internal/mysql/store.go
@@ -130,42 +130,15 @@ func (s *Store) insertEventsAtOnce(ctx context.Context, events []api.Event, inge
 	}
 	defer tx.Rollback() //nolint:errcheck // Rollback after commit is a no-op.
 
-	// Insert the whole batch with a handful of multi-row INSERT IGNORE statements rather than one statement per event. At fleet
-	// scale a batch carries hundreds of events, and one round-trip per event dominated ingest latency (a ~100-event batch was
-	// ~100 sequential round-trips, seconds of wall time). Chunked to stay under MySQL's placeholder + max_allowed_packet limits.
-	// INSERT IGNORE keeps the statement idempotent, so withDeadlockRetry can re-run it safely.
-	allInserted := true
-	for start := 0; start < len(events); start += eventInsertChunkRows {
-		end := min(start+eventInsertChunkRows, len(events))
-		chunk := events[start:end]
-		placeholders := make([]string, len(chunk))
-		args := make([]any, 0, len(chunk)*6)
-		for i := range chunk {
-			payloadBytes, err := json.Marshal(chunk[i].Payload)
-			if err != nil {
-				return fmt.Errorf("marshal payload for %s: %w", chunk[i].EventID, err)
-			}
-			placeholders[i] = "(?, ?, ?, ?, ?, ?)"
-			args = append(args, chunk[i].EventID, chunk[i].HostID, chunk[i].TimestampNs, ingestedAtNs, chunk[i].EventType, payloadBytes)
-		}
-		res, err := tx.ExecContext(ctx, `INSERT IGNORE INTO events (event_id, host_id, timestamp_ns, ingested_at_ns, event_type, payload) VALUES `+
-			strings.Join(placeholders, ", "), args...)
-		if err != nil {
-			return fmt.Errorf("insert events chunk [%d:%d]: %w", start, end, err)
-		}
-		affected, err := res.RowsAffected()
-		if err != nil {
-			return fmt.Errorf("rows affected: %w", err)
-		}
-		if int(affected) != len(chunk) {
-			allInserted = false // at least one duplicate event_id was IGNOREd in this chunk
-		}
+	allInserted, err := insertEventChunks(ctx, tx, events, ingestedAtNs)
+	if err != nil {
+		return err
 	}
 
-	// Stamp the caller's slice with the persisted ingested_at_ns (the graph builder reads it). Fast path: when every row was newly
-	// inserted, they all carry this batch's ingestedAtNs, so no extra query is needed. Slow path: a duplicate event_id keeps the
-	// ingested_at_ns from its first insert, so read the real values back. Resolve inside the tx but write to the slice only after a
-	// successful commit, so a rolled-back / retried attempt never leaves the caller's slice half-stamped.
+	// Resolve the persisted ingested_at_ns to stamp back onto the caller's slice (the graph builder reads it). Fast path: when
+	// every row was newly inserted they all carry this batch's ingestedAtNs, so no extra query is needed and persisted stays nil.
+	// Slow path: a duplicate event_id keeps the ingested_at_ns from its first insert, so read the real values back. Resolve inside
+	// the tx but write to the slice only after a successful commit, so a rolled-back / retried attempt never half-stamps it.
 	var persisted map[string]int64
 	if !allInserted {
 		persisted, err = selectIngestedAt(ctx, tx, events)
@@ -177,18 +150,69 @@ func (s *Store) insertEventsAtOnce(ctx context.Context, events []api.Event, inge
 		return fmt.Errorf("commit: %w", err)
 	}
 
-	if allInserted {
+	stampIngestedAt(events, ingestedAtNs, persisted)
+	return nil
+}
+
+// insertEventChunks writes the batch as a handful of multi-row INSERT IGNORE statements rather than one statement per event. At
+// fleet scale a batch carries hundreds of events, and one round-trip per event dominated ingest latency (a ~100-event batch was
+// ~100 sequential round-trips, seconds of wall time). Chunked to stay under MySQL's placeholder + max_allowed_packet limits.
+// INSERT IGNORE keeps the statement idempotent, so withDeadlockRetry can re-run it safely. Returns false if any chunk dropped a
+// duplicate event_id (which the caller resolves via selectIngestedAt).
+func insertEventChunks(ctx context.Context, tx *sqlx.Tx, events []api.Event, ingestedAtNs int64) (bool, error) {
+	allInserted := true
+	for start := 0; start < len(events); start += eventInsertChunkRows {
+		end := min(start+eventInsertChunkRows, len(events))
+		chunk := events[start:end]
+		placeholders, args, err := eventInsertArgs(chunk, ingestedAtNs)
+		if err != nil {
+			return false, err
+		}
+		res, err := tx.ExecContext(ctx, `INSERT IGNORE INTO events (event_id, host_id, timestamp_ns, ingested_at_ns, event_type, payload) VALUES `+
+			strings.Join(placeholders, ", "), args...)
+		if err != nil {
+			return false, fmt.Errorf("insert events chunk [%d:%d]: %w", start, end, err)
+		}
+		affected, err := res.RowsAffected()
+		if err != nil {
+			return false, fmt.Errorf("rows affected: %w", err)
+		}
+		if int(affected) != len(chunk) {
+			allInserted = false // at least one duplicate event_id was IGNOREd in this chunk
+		}
+	}
+	return allInserted, nil
+}
+
+// eventInsertArgs builds the placeholder rows and flattened args for one INSERT chunk, marshaling each payload to JSON.
+func eventInsertArgs(chunk []api.Event, ingestedAtNs int64) ([]string, []any, error) {
+	placeholders := make([]string, len(chunk))
+	args := make([]any, 0, len(chunk)*6)
+	for i := range chunk {
+		payloadBytes, err := json.Marshal(chunk[i].Payload)
+		if err != nil {
+			return nil, nil, fmt.Errorf("marshal payload for %s: %w", chunk[i].EventID, err)
+		}
+		placeholders[i] = "(?, ?, ?, ?, ?, ?)"
+		args = append(args, chunk[i].EventID, chunk[i].HostID, chunk[i].TimestampNs, ingestedAtNs, chunk[i].EventType, payloadBytes)
+	}
+	return placeholders, args, nil
+}
+
+// stampIngestedAt writes the persisted ingest time onto the caller's slice. persisted is nil on the fast path (every row newly
+// inserted with this batch's ingestedAtNs); otherwise it maps event_id to the value read back for the duplicate path.
+func stampIngestedAt(events []api.Event, ingestedAtNs int64, persisted map[string]int64) {
+	if persisted == nil {
 		for i := range events {
 			events[i].IngestedAtNs = ingestedAtNs
 		}
-		return nil
+		return
 	}
 	for i := range events {
 		if ts, ok := persisted[events[i].EventID]; ok {
 			events[i].IngestedAtNs = ts
 		}
 	}
-	return nil
 }
 
 // selectIngestedAt reads the persisted ingested_at_ns for each event_id, chunked to stay under MySQL's placeholder limit. Used on

--- a/server/detection/internal/mysql/store_test.go
+++ b/server/detection/internal/mysql/store_test.go
@@ -87,6 +87,51 @@ func TestStore_InsertEventsAtPinsTimestamp(t *testing.T) {
 		"InsertEventsAt must pin the deterministic ingest timestamp")
 }
 
+// TestStore_InsertEventsAt_DuplicateStampsPersistedIngestedAt pins the batched-insert behavior: a duplicate event_id (dropped by
+// INSERT IGNORE) keeps the ingested_at_ns from its FIRST insert, and the caller's slice is stamped with that persisted value, not
+// the current batch's. A genuinely-new row in the same batch still gets the current batch's time.
+func TestStore_InsertEventsAt_DuplicateStampsPersistedIngestedAt(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+
+	first := []api.Event{{EventID: "dup-1", HostID: "h", TimestampNs: 100, EventType: "fork", Payload: json.RawMessage(`{}`)}}
+	require.NoError(t, s.InsertEventsAt(ctx, first, 1000))
+	require.Equal(t, int64(1000), first[0].IngestedAtNs)
+
+	second := []api.Event{
+		{EventID: "dup-1", HostID: "h", TimestampNs: 100, EventType: "fork", Payload: json.RawMessage(`{}`)},
+		{EventID: "dup-2", HostID: "h", TimestampNs: 200, EventType: "fork", Payload: json.RawMessage(`{}`)},
+	}
+	require.NoError(t, s.InsertEventsAt(ctx, second, 2000))
+	assert.Equal(t, int64(1000), second[0].IngestedAtNs, "duplicate keeps its original persisted ingested_at_ns, not the new batch's 2000")
+	assert.Equal(t, int64(2000), second[1].IngestedAtNs, "newly inserted row in the same batch gets the new ingest time")
+
+	count, err := s.CountEvents(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), count, "dup-1 deduped; only dup-2 added")
+}
+
+// TestStore_InsertEventsAt_ChunksLargeBatch inserts more events than eventInsertChunkRows so the multi-row INSERT spans more than
+// one chunk, and asserts every row across the chunk boundary is persisted and stamped.
+func TestStore_InsertEventsAt_ChunksLargeBatch(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+
+	const n = 600 // > eventInsertChunkRows (500): forces two chunks
+	events := make([]api.Event, n)
+	for i := range events {
+		events[i] = api.Event{EventID: "chunk-" + strconv.Itoa(i), HostID: "h", TimestampNs: int64(i + 1), EventType: "fork", Payload: json.RawMessage(`{}`)}
+	}
+	require.NoError(t, s.InsertEventsAt(ctx, events, 7777))
+	for i := range events {
+		require.Equal(t, int64(7777), events[i].IngestedAtNs, "row %d across the chunk boundary must be stamped", i)
+	}
+
+	count, err := s.CountEvents(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(n), count)
+}
+
 func TestStore_InsertEvents_EmptyIsNoOp(t *testing.T) {
 	// The empty-slice fast path returns nil without touching the DB. Important for the retry wrapper: an empty insert must
 	// not waste a deadlock-retry budget on a no-op transaction.


### PR DESCRIPTION
POST /api/events persisted each event with its own INSERT statement inside one transaction (insertEventsAtOnce looped stmt.ExecContext per event). A ~100-event batch was ~100 sequential MySQL round-trips, which a trace showed as 2331ms of 2369ms spent across 101 sql.stmt.exec spans (detection/graph work was ~38ms). It scales O(batch size) in round-trips, so it worsens as the fleet grows.

Replace the per-event loop with chunked multi-row INSERT IGNORE (mirrors the existing pattern in alerts.go), collapsing N round-trips into one per ~500-row chunk. Idempotent, so withDeadlockRetry still re-runs it safely.

Preserve the ingested_at_ns stamping: fast path (no duplicates) stamps the caller's slice in memory with this batch's time; slow path (INSERT IGNORE dropped a duplicate) reads the persisted ingested_at_ns back via one chunked SELECT and stamps each event from the DB, so a duplicate correctly keeps the time from its first insert. Slice is mutated only after a successful commit so a retried attempt never half-stamps.

No observable behavior change: the idempotency contract (dedup by event_id, existing rows unchanged, HTTP 200) is unchanged; this is the server-event-ingestion "Idempotent submission by event_id" requirement, whose scenarios still hold. Tests added for duplicate-stamping and the chunk boundary; full detection suite incl. integration passes.

<!-- Keep this short. Delete sections that do not apply. -->

## What & why



## Checklist

- [ ] **OpenSpec updated for behavior changes.** If this PR changes observable behavior (a detection rule, the event
      wire schema, persistence semantics, an API/wire shape, or an emitted event), `openspec/specs/**` is updated (and
      an `openspec/changes/` proposal added), with a `spec:<id>` test marker for any new/renamed scenario. Only if this
      PR changes NO observable behavior (a comment / refactor / gofmt / dep bump that happens to touch a scoped path)
      may you assert `no-behavior-change` (label or `[no-behavior-change]` in the title) to clear the OpenSpec-sync gate.
      That is an assertion a reviewer will check, not a way to skip the spec for a real behavior change.
- [ ] Tests added/updated for the change (unit / integration / efficacy / UI as applicable).
- [ ] Agent/extension change touching ESF, XPC, or the event wire format: exercised on a live macOS VM before RC
      (flagged below).

## VM / RC notes (if applicable)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized detection event insertion to use batched database operations, reducing database load and improving throughput.

* **Reliability**
  * Enhanced duplicate detection event handling to correctly preserve original ingestion timestamps when duplicate events are encountered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->