### PR TITLE
Qodo best practices

### DIFF
--- a/.github/rulesets/main.json
+++ b/.github/rulesets/main.json
@@ -12,6 +12,13 @@
     {"type": "deletion"},
     {"type": "non_fast_forward"},
     {
+      "type": "copilot_code_review",
+      "parameters": {
+        "review_on_push": true,
+        "review_draft_pull_requests": false
+      }
+    },
+    {
       "type": "pull_request",
       "parameters": {
         "required_approving_review_count": 0,

--- a/.github/workflows/openspec-sync.yml
+++ b/.github/workflows/openspec-sync.yml
@@ -49,8 +49,10 @@ jobs:
           files=$(gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/files" --jq '.[].filename')
 
           # Behavior-bearing paths: the detection rule catalog (rule logic), the event wire schema, and the detection
-          # DDL (persistence semantics). Test files and fixtures under the catalog are not behavior changes.
-          BEHAVIOR='^server/rules/internal/catalog/.*\.go$|^schema/events\.json$|^server/detection/bootstrap/schema\.go$'
+          # DDL (persistence semantics). The DDL moved from bootstrap/schema.go to goose migrations in PR #115/#309;
+          # this regex must track that location or persistence changes silently bypass the gate.
+          # Test files and fixtures under the catalog are not behavior changes.
+          BEHAVIOR='^server/rules/internal/catalog/.*\.go$|^schema/events\.json$|^server/detection/migrations/.*\.sql$'
           behavior_files=$(echo "$files" | grep -E "$BEHAVIOR" | grep -vE '_test\.go$|/fixtures/' || true)
 
           if [[ -z "$behavior_files" ]]; then

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,12 +1,53 @@
-# Configuration for Qodo code review tool
+# Qodo code review configuration. Reviewed quarterly per
+# docs/maintenance/tasks/ai-review-bot-config-audit.md.
+#
+# Qodo reads this file from the DEFAULT branch, not the PR branch, so changes
+# here take effect on the first PR after the change merges to main.
+#
+# Companion files Qodo also reads from the repo root:
+#   best_practices.md            curated review guidance (suggestions)
+#   pr_compliance_checklist.yaml custom per-PR compliance checks
+# Qodo additionally auto-ingests CLAUDE.md as a compliance source; the
+# compliance_user_guidelines below steer that away from known false positives.
 
 [github_app]
-# Do not auto-run anything when a PR is opened
-pr_commands = []
-# Do not auto-run anything on new commits / pushes
-handle_push_trigger = false
+# Paid plan since 2026-06-12: run the agentic review automatically when a PR
+# opens. Describe is deliberately NOT auto-run; the maintainer owns PR bodies.
+pr_commands = [
+    "/agentic_review",
+]
+# Re-review on every push so findings always match the head SHA. Qodo edits
+# its single review comment in place rather than posting a new one per push,
+# which is also what the ai-review-fixes-edr skill's wait loop expects.
+handle_push_trigger = true
+push_commands = [
+    "/agentic_review",
+]
 
-# Keep the review tool available for manual comment commands
 [review_agent]
 enabled = true
 publish_output = true
+# Inline comments only for action-required findings; lower tiers stay in the
+# summary comment. Ranks: 3 = action_required, 2 = remediation_recommended,
+# 1 = informational.
+inline_comments_severity_threshold = 3
+issues_user_guidelines = """
+This is an EDR (endpoint detection and response) product; security and hot-path performance findings are the priority.
+Prioritize: bypassed or reordered authorization checks, TOCTOU races, blocking calls or network access on Endpoint Security
+callback paths (code-signing evaluation there must pass kSecCSNoNetworkAccess / .noNetworkAccess), unbounded CPU or memory in
+kernel-adjacent handlers, IPC peer-validation gaps (audit_token + code-signing requirement on every XPC channel), trusting
+userspace-claimed fields where a kernel-vouched value exists (use audit_token-derived PIDs, not es_process_t claims), secrets
+or PII in log statements, audit-log tampering (audit_events is append-only), weak crypto, and SQL injection.
+Performance on ingestion paths (ES event handling, event upload pipeline, MySQL writes on the ingest path) is a correctness
+concern: flag per-event allocations, N+1 queries, and lock contention there.
+Do not flag: style or formatting that linters own (golangci-lint, SwiftLint, Prettier, dash-lint); Go 1.26 language and stdlib
+features (integer range expressions, strings.SplitSeq) as compile errors; the word "fleet"/"fleets" in docs/fleet-deployment.md
+(Fleet renamed teams to fleets in v4.82, the doc is correct); long Markdown lines (prose is never hard-wrapped, enforced by
+Prettier proseWrap: never).
+"""
+compliance_user_guidelines = """
+Files under openspec/ use literal tool-parsed section markers: "## ADDED Requirements", "## MODIFIED Requirements",
+"## REMOVED Requirements", "### Requirement: ...", "#### Scenario: ...". These exact strings are part of the OpenSpec file
+format and are exempt from sentence-case heading rules. Markdown prose is intentionally not hard-wrapped; long lines are not
+violations.
+"""

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,7 +83,7 @@ Minimum requirements per PR:
 - **Behavior changes update the spec.** Any observable behavior change (bug fix, feature, detection rule, wire/event
   shape, API, persistence semantics) MUST update `openspec/specs/**` in the same PR, and add an `openspec/changes/`
   proposal for non-trivial deltas. The `OpenSpec sync` CI gate (`.github/workflows/openspec-sync.yml`) enforces this for
-  the highest-signal paths (`server/rules/internal/catalog/`, `schema/events.json`, `server/detection/bootstrap/schema.go`).
+  the highest-signal paths (`server/rules/internal/catalog/`, `schema/events.json`, `server/detection/migrations/`).
   The gate fires on path, so a genuine no-behavior touch of those files (comment / refactor / gofmt / dep bump) asserts
   `no-behavior-change` (label or `[no-behavior-change]` in the title) to clear it. That opt-out is an auditable "this
   changes no behavior" claim a reviewer verifies; it is NEVER a way to skip the spec for a real behavior change.

--- a/best_practices.md
+++ b/best_practices.md
@@ -1,0 +1,29 @@
+# Best practices for Qodo review
+
+Curated review guidance for this repo. Scope: invariants that linters and CI do not already enforce. Style and formatting are owned by golangci-lint, SwiftLint, Prettier, and dash-lint; do not raise them here.
+
+## Security invariants
+
+- Every IPC channel (XPC between extension, agent, and host app) validates the peer before acting: audit_token plus a code-signing requirement pinned to our team ID. A handler that processes a message before peer validation is a finding even if "the message looks harmless".
+- Event payload fields must come from the kernel-vouched source. On macOS that means audit_token-derived PID, UID, and GID, never the userspace-claimed `es_process_t` fields. A diff that reads the claimed field where a vouched one exists is a finding.
+- Endpoint Security callback threads never block on the network or on unbounded work. Any `SecStaticCodeCheckValidity` or code-signing evaluation on the ES path must pass `.noNetworkAccess`. A synchronous DNS lookup, HTTP call, or unbounded loop in an ES handler stalls the syscall for the whole machine.
+- Authorization gates run before the side effect. In server handlers, `HTTPGate` (or the context's authz check) precedes the mutation; a code path that mutates then checks, or that returns early past the gate, is a finding.
+- The `audit_events` table is append-only. Production code must never UPDATE or DELETE rows there, and the dual-emit (DB plus slog) must fire even when the INSERT fails.
+- Secrets and tokens: enroll secrets and host tokens never appear in log statements, error strings, or HTTP responses. At-rest token files are 0600. Event payloads may include file paths, command lines, and URLs; logs may not include PII.
+- Stateless server (ADR-0010): no new in-process map, channel, or queue that holds state a peer replica would need. Durable cross-request state goes in MySQL; per-request state may ride in signed cookies. A per-replica cache is acceptable only with an explicit "safe to lose" comment.
+
+## Performance on hot paths
+
+The hot paths are the ES event handlers in the extension, the agent's event queue and uploader, and the server's ingest endpoint down to the MySQL writes. On these paths:
+
+- Per-event heap allocations matter. Prefer reuse (sync.Pool, preallocated buffers) over per-event allocation when the diff touches a loop that runs per event.
+- Database access is batched. A query inside a per-event loop (N+1) is a finding; the ingest path writes batches in a single transaction.
+- Lock scope is minimal. A mutex held across an I/O call on an ingest or callback path is a finding.
+- Kernel-adjacent handlers bound their CPU and memory. Anything recursive or unbounded (walking process trees, scanning directories) needs an explicit depth or size cap.
+
+## Correctness conventions
+
+- Wire-format changes (new struct fields in the event envelope, batch encoding) ship with a property-based round-trip test (`Marshal` then `Unmarshal` equals identity, via `pgregory.net/rapid`). A new field without one is a gap.
+- Error handling on the agent and server: errors from the queue, uploader, and store are handled or explicitly logged with context; a swallowed error on the ingest path hides data loss.
+- Re-exec chains and process trees: code walking `previous_exec_id` or building process forests must terminate on cycles and missing parents; assume the input can be adversarial.
+- When a symbol is deleted (function, type, command, XPC message kind, config field), every comment referencing it goes in the same diff. Stale references in IPC-adjacent comments are a recurring review defect in this repo.

--- a/packaging/profiles/edr-system-extension.mobileconfig.tmpl
+++ b/packaging/profiles/edr-system-extension.mobileconfig.tmpl
@@ -3,9 +3,9 @@
 <!--
     System Extensions allow-list. Pre-approves the Fleet EDR Endpoint Security
     extension so it activates without the "System Extension Blocked" dialog.
-    Deploy via MDM custom settings. Signed with Developer ID Installer cert at
-    release time (see packaging/profiles/sign.sh); the __TEAM_ID__ token is
-    substituted with the value of APPLE_TEAM_ID.
+    Deploy via MDM custom settings. Ships unsigned on purpose; the MDM signs
+    it at delivery (see packaging/profiles/render.sh). The __TEAM_ID__ token
+    is substituted with the value of APPLE_TEAM_ID.
 
     Identifiers here match the actual bundle IDs shipped by the pkg. If those
     change, update both the host app Info.plist + the AllowedSystemExtensions

--- a/pr_compliance_checklist.yaml
+++ b/pr_compliance_checklist.yaml
@@ -1,0 +1,81 @@
+# Custom Qodo compliance checks, evaluated per PR by the agentic review.
+# Format reference: https://docs.qodo.ai/code-review/qodo-merge/features/custom-compliance
+# These mirror the PR minimum requirements in CLAUDE.md ("UAT and integration
+# test layers") so a gap surfaces in review before a human reads the diff.
+
+pr_compliances:
+  - title: "Behavior changes update the spec"
+    compliance_label: true
+    objective: >-
+      Any observable behavior change (bug fix, feature, detection rule, wire or event shape, API,
+      persistence semantics) must update openspec/specs/** in the same PR. Non-trivial deltas also
+      add an openspec/changes/ proposal.
+    success_criteria: >-
+      The diff changes observable behavior AND updates openspec/specs/**, or the PR carries the
+      no-behavior-change label / "[no-behavior-change]" title marker and the diff genuinely changes
+      no behavior, or the diff changes no observable behavior.
+    failure_criteria: >-
+      The diff changes observable behavior (detection rules under server/rules/internal/catalog/,
+      schema/events.json, server/detection/bootstrap/schema.go, API handlers, event emission) with
+      no openspec/specs/** update and no valid no-behavior-change assertion.
+
+  - title: "New wire-format fields have a round-trip test"
+    compliance_label: true
+    objective: >-
+      Every new wire-format struct or event field ships a property-based round-trip test
+      (Marshal then Unmarshal equals identity) using pgregory.net/rapid.
+    success_criteria: >-
+      New serialized fields in the event envelope, batch encoding, or DB scan/value types come with
+      a rapid-based round-trip test exercising the new field.
+    failure_criteria: >-
+      A new serialized field or wire struct appears with no accompanying property-based round-trip
+      test in the same PR.
+
+  - title: "New detection rules ship an efficacy corpus"
+    compliance_label: true
+    objective: >-
+      Every new detection rule under server/rules/internal/catalog/ ships
+      test/efficacy/corpus/T<MITRE-id>/scenario.yaml plus expected.yaml (and attack.sh when system
+      or VM coverage is needed).
+    success_criteria: >-
+      New catalog rules come with matching corpus scenario and expected files in the same PR.
+    failure_criteria: >-
+      A new rule lands in server/rules/internal/catalog/ with no corresponding
+      test/efficacy/corpus/ addition.
+
+  - title: "No new cross-request in-process state"
+    compliance_label: true
+    objective: >-
+      ADR-0010 stateless server: the server holds no in-process state that survives a request and
+      that a peer replica would need. Durable state goes in MySQL; per-request state may ride in
+      signed cookies.
+    success_criteria: >-
+      No new package-level or long-lived map, channel, or queue holding cross-request state in
+      server code, or any such addition carries an explicit per-replica "safe to lose" comment.
+    failure_criteria: >-
+      The diff adds an in-process map, channel, queue, or cache in server code that stores state
+      across requests without a "safe to lose" justification.
+
+  - title: "Endpoint Security callbacks stay non-blocking"
+    compliance_label: true
+    objective: >-
+      Code on the ES callback path must not block on the network or unbounded work; code-signing
+      evaluation there must pass .noNetworkAccess.
+    success_criteria: >-
+      Diffs touching ES handlers in extension/ keep work bounded and pass .noNetworkAccess to any
+      SecStaticCodeCheckValidity / signing evaluation on that path.
+    failure_criteria: >-
+      The diff introduces network access, synchronous I/O, or signing evaluation without
+      .noNetworkAccess inside an ES callback handler.
+
+  - title: "Live VM verification for agent and extension changes"
+    compliance_label: false
+    objective: >-
+      Agent or extension changes touching ESF, XPC, or the event wire format must be exercised on a
+      live macOS VM before RC, and the PR description must say so.
+    success_criteria: >-
+      PRs touching ESF handlers, XPC plumbing, or the wire format mention VM verification (edr-dev
+      or edr-qa) in the description, or explicitly defer it to the RC gate.
+    failure_criteria: >-
+      An ESF / XPC / wire-format change has no mention of VM verification or an RC-gate deferral in
+      the PR description.

--- a/pr_compliance_checklist.yaml
+++ b/pr_compliance_checklist.yaml
@@ -16,7 +16,7 @@ pr_compliances:
       no behavior, or the diff changes no observable behavior.
     failure_criteria: >-
       The diff changes observable behavior (detection rules under server/rules/internal/catalog/,
-      schema/events.json, server/detection/bootstrap/schema.go, API handlers, event emission) with
+      schema/events.json, server/detection/migrations/, API handlers, event emission) with
       no openspec/specs/** update and no valid no-behavior-change assertion.
 
   - title: "New wire-format fields have a round-trip test"


### PR DESCRIPTION
<!-- Keep this short. Delete sections that do not apply. -->

## What & why



## Checklist

- [ ] **OpenSpec updated for behavior changes.** If this PR changes observable behavior (a detection rule, the event
      wire schema, persistence semantics, an API/wire shape, or an emitted event), `openspec/specs/**` is updated (and
      an `openspec/changes/` proposal added), with a `spec:<id>` test marker for any new/renamed scenario. Only if this
      PR changes NO observable behavior (a comment / refactor / gofmt / dep bump that happens to touch a scoped path)
      may you assert `no-behavior-change` (label or `[no-behavior-change]` in the title) to clear the OpenSpec-sync gate.
      That is an assertion a reviewer will check, not a way to skip the spec for a real behavior change.
- [ ] Tests added/updated for the change (unit / integration / efficacy / UI as applicable).
- [ ] Agent/extension change touching ESF, XPC, or the event wire format: exercised on a live macOS VM before RC
      (flagged below).

## VM / RC notes (if applicable)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced automated code review process with improved agentic review triggers on pull requests and pushes.
  * Updated profile delivery documentation to reflect MDM-based signing approach.

* **Documentation**
  * Added best practices guide covering security, performance, and correctness standards for code contributions.
  * Introduced compliance checklist defining requirements for behavior specifications, testing standards, and system verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->