### PR TITLE
Activate the extensions on install

### DIFF
--- a/.github/workflows/pkg-dryrun.yml
+++ b/.github/workflows/pkg-dryrun.yml
@@ -165,3 +165,13 @@ jobs:
           echo "=== activation LaunchAgent present in app.pkg ==="
           lsbom /tmp/expanded/app.pkg/Bom | grep -F "Library/LaunchAgents/com.fleetdm.edr.activate.plist" && \
             echo OK
+          # spec:release-packaging/installation-activates-the-system-extensions/install-with-a-user-logged-in-activates-immediately
+          #
+          # The logged-in path lives in the postinstall, which spectrace cannot scan (no .sh
+          # extension), so assert its shape here: the script the pkg actually ships must
+          # bootstrap the activation LaunchAgent into the console user's gui domain.
+          echo "=== postinstall bootstraps the activation LaunchAgent ==="
+          # shellcheck disable=SC2016  # the $-names are literal text to find in the script, not expansions
+          grep -F 'launchctl bootstrap "gui/$CONSOLE_UID" "$ACTIVATE_LA"' \
+            /tmp/expanded/agent.pkg/Scripts/postinstall && \
+            echo OK

--- a/.github/workflows/pkg-dryrun.yml
+++ b/.github/workflows/pkg-dryrun.yml
@@ -157,3 +157,11 @@ jobs:
           test -f /tmp/expanded/agent.pkg/Scripts/preinstall && \
           test -f /tmp/expanded/agent.pkg/Scripts/postinstall && \
             echo OK
+          # spec:release-packaging/installation-activates-the-system-extensions/install-at-the-loginwindow-activates-at-next-login
+          #
+          # The activation LaunchAgent must ship in the app component: its RunAtLoad is the
+          # only thing that activates the extensions on hosts installed at the loginwindow.
+          # lsbom reads the component BOM without unpacking the payload.
+          echo "=== activation LaunchAgent present in app.pkg ==="
+          lsbom /tmp/expanded/app.pkg/Bom | grep -F "Library/LaunchAgents/com.fleetdm.edr.activate.plist" && \
+            echo OK

--- a/docs/fleet-deployment.md
+++ b/docs/fleet-deployment.md
@@ -56,21 +56,21 @@ sudo profiles list | grep fleetdm
 #   com.fleetdm.edr.profile.tcc-fda
 ```
 
-## Step 2: upload the pkg + install script together
+## Step 2: add the pkg with a custom install script
 
-Fleet's software installer bundles a `.pkg` and an optional pre-install script into a single "software package". We use that bundle to ship the pkg AND the enroll-secret write in one deploy step.
+Fleet's software packages carry an `install_script` that replaces the default install command. We use that script to write the enroll-secret config AND run the installer in one step, so the sequencing is guaranteed (unlike generic MDMs where you fight with install-script ordering). Fleet has no separate pre-install script concept; the only pre-install hook is `pre_install_query`, an osquery SQL condition, which we don't need.
 
-Write the install script to a local file:
+Write the install and uninstall scripts to local files:
 
 ```sh
 cat > fleet-edr-install.sh <<'EOF'
 #!/bin/sh
 set -eu
 
-# Fleet's agent expands $FLEET_SECRET_* into the value of the
+# Fleet's agent expands FLEET_SECRET_* into the value of the
 # corresponding custom variable at runtime. Define them at
 # Settings > Integrations > MDM > Variables (or via fleetctl).
-EDR_SERVER_URL="${FLEET_SECRET_EDR_SERVER_URL:-https://edr.example.com}"
+EDR_SERVER_URL="$FLEET_SECRET_EDR_SERVER_URL"
 EDR_ENROLL_SECRET="$FLEET_SECRET_EDR_ENROLL_SECRET"
 
 install -m 0600 /dev/null /etc/fleet-edr.conf
@@ -78,6 +78,17 @@ cat > /etc/fleet-edr.conf <<CONF
 EDR_SERVER_URL=$EDR_SERVER_URL
 EDR_ENROLL_SECRET=$EDR_ENROLL_SECRET
 CONF
+
+# $INSTALLER_PATH is set by fleetd to the downloaded pkg's location.
+installer -pkg "$INSTALLER_PATH" -target /
+EOF
+
+cat > fleet-edr-uninstall.sh <<'EOF'
+#!/bin/sh
+set -eu
+if [ -x "/Library/Application Support/com.fleetdm.edr/uninstall.sh" ]; then
+    "/Library/Application Support/com.fleetdm.edr/uninstall.sh"
+fi
 EOF
 ```
 
@@ -87,16 +98,40 @@ Define the two secrets in Fleet so the script can reference them without ever co
 2. Add `EDR_SERVER_URL` with your server's URL.
 3. Add `EDR_ENROLL_SECRET` with the value from `./secrets/enroll_secret` on the server.
 
-Upload the pkg + script bundle:
+**Via fleetctl:** extend the same fleet spec from Step 1 with a `software` section. The CLI path references the pkg by URL (Fleet downloads it server-side); point it at the GitHub Release asset and pin the hash from `SHA256SUMS`:
 
 ```sh
-fleetctl software add \
-    --fleet "EDR pilot" \
-    --path fleet-edr-v0.1.0.pkg \
-    --pre-install-script fleet-edr-install.sh
+fleetctl apply -f - <<'EOF'
+apiVersion: v1
+kind: fleet
+spec:
+  fleet:
+    name: EDR pilot
+    software:
+      packages:
+        - url: https://github.com/getvictor/fleet-edr/releases/download/v0.1.0/fleet-edr-v0.1.0.pkg
+          hash_sha256: <sha256 of the pkg, from SHA256SUMS>
+          install_script:
+            path: ./fleet-edr-install.sh
+          uninstall_script:
+            path: ./fleet-edr-uninstall.sh
+EOF
 ```
 
-Fleet runs the pre-install script first, then `installer -pkg` against the uploaded `.pkg`. The script writes the config file the pkg's postinstall step needs, so the sequencing is guaranteed (unlike generic MDMs where you fight with install-script ordering).
+**Via the Fleet UI** (this path accepts a local pkg file instead of a URL):
+
+1. **Software > Add software > Custom package**, with the "EDR pilot" fleet selected in the scope picker.
+2. **Choose file** and select `fleet-edr-v0.1.0.pkg`.
+3. Expand **Advanced options** and replace the default install script with the contents of `fleet-edr-install.sh`; paste `fleet-edr-uninstall.sh` into the uninstall script field.
+4. **Add software**.
+
+Adding the package only makes it available to the fleet; nothing installs yet. An install triggers per host in one of three ways:
+
+- **Manually**: **Hosts > \<host\> > Software**, find Fleet EDR, **Actions > Install**.
+- **Self-service**: if enabled on the package, end users install it from Fleet Desktop's Self-service tab.
+- **Automatic install**: check **Automatic install** when adding the package in the UI. Fleet creates a policy that installs the EDR on every in-scope host that doesn't have it, which is what you want for a fleet-wide rollout. The checkbox exists only on the add flow (not edit), and the `fleetctl apply` YAML path doesn't expose it; to automate a CLI-managed package, attach it to a policy automation instead.
+
+When an install fires, fleetd downloads the pkg to the host and runs the install script, which writes the config file the pkg's postinstall step needs and then invokes `installer` itself.
 
 Verify on a target Mac after Fleet runs the install:
 
@@ -105,12 +140,15 @@ Verify on a target Mac after Fleet runs the install:
 sudo launchctl print system/com.fleetdm.edr.agent | grep 'state ='
 # Expect: state = running
 
-# Sysext activated silently (thanks to the system-extension profile)
+# Sysext activated silently (the pkg's activation LaunchAgent + the
+# system-extension profile). If this prints nothing and nobody was logged
+# in when the pkg installed, activation fires at the next login.
 systemextensionsctl list | grep fleetdm
 # Expect: * * FDG8Q7N4CC com.fleetdm.edr.securityextension ... [activated enabled]
 
-# Agent enrolled with the server
-sudo tail -n 20 /var/log/fleet-edr-agent.log | grep enrolled
+# Agent enrolled with the server (grep the whole log; enrollment happens
+# once at startup and scrolls out of a tail quickly)
+grep "agent enrolled" /var/log/fleet-edr-agent.log
 ```
 
 ## Step 3: confirm in the EDR admin UI
@@ -119,14 +157,18 @@ Open `https://<your-edr-server>/ui/`. The Macs that finished the Fleet-driven in
 
 ## Upgrade
 
-Push a new pkg version by re-running `fleetctl software add` with the newer file. Fleet replaces the software package in-place; the install script doesn't change.
+**Via fleetctl:** bump the `url` and `hash_sha256` in the Step 2 spec to the new release and re-apply. Fleet replaces the software package in-place; the install script doesn't change.
 
-```sh
-fleetctl software add \
-    --fleet "EDR pilot" \
-    --path fleet-edr-v0.1.1.pkg \
-    --pre-install-script fleet-edr-install.sh
+```yaml
+- url: https://github.com/getvictor/fleet-edr/releases/download/v0.1.1/fleet-edr-v0.1.1.pkg
+  hash_sha256: <sha256 of the new pkg>
+  install_script:
+    path: ./fleet-edr-install.sh
+  uninstall_script:
+    path: ./fleet-edr-uninstall.sh
 ```
+
+**Via the Fleet UI:** **Software**, select the Fleet EDR package (with the "EDR pilot" fleet in scope), then **Actions > Edit**, choose the newer pkg file, and save. The scripts carry over unless you change them.
 
 On each Mac the EDR pkg's preinstall stops the old daemon and the postinstall starts the new one. The host token at `/var/db/fleet-edr/enrolled.plist` survives the upgrade so agents don't re-enroll.
 
@@ -134,23 +176,7 @@ If the new release changes one of the two `.mobileconfig` profiles, push the new
 
 ## Uninstall
 
-Fleet's software UI supports uninstall scripts on a software package. Add one:
-
-```sh
-cat > fleet-edr-uninstall.sh <<'EOF'
-#!/bin/sh
-set -eu
-if [ -x "/Library/Application Support/com.fleetdm.edr/uninstall.sh" ]; then
-    "/Library/Application Support/com.fleetdm.edr/uninstall.sh"
-fi
-EOF
-
-fleetctl software add \
-    --fleet "EDR pilot" \
-    --path fleet-edr-v0.1.1.pkg \
-    --pre-install-script fleet-edr-install.sh \
-    --uninstall-script fleet-edr-uninstall.sh
-```
+The uninstall script attached in Step 2 wraps the pkg's bundled `uninstall.sh`, which removes the daemon, host app, and system extension. Trigger it per host in the Fleet UI: **Hosts > \<host\> > Software**, find Fleet EDR, then **Actions > Uninstall**. There is no fleetctl command for a per-host uninstall; script results land under **Hosts > \<host\> > Activity**.
 
 To remove the profiles as well, edit the fleet's YAML and drop the two `custom_settings` entries. Fleet removes the profiles from each Mac on the next check-in; macOS tears down the TCC grants and sysext allow-list within minutes.
 
@@ -161,7 +187,8 @@ The secret is stored as a Fleet custom variable (`FLEET_SECRET_EDR_ENROLL_SECRET
 1. Generate a new value on the EDR server and write it to `./secrets/enroll_secret` (see [install-server.md](install-server.md#rotate-secrets)).
 2. Restart the server so the new secret takes effect: `docker compose restart server`.
 3. In Fleet: **Settings > Integrations > MDM > Custom variables**, update `EDR_ENROLL_SECRET` to the new value.
-4. Re-run `fleetctl software add` so Fleet re-pushes the install script with the new variable value.
+
+There is nothing to re-upload: `$FLEET_SECRET_*` variables expand when the install script runs on a host, so the next install picks up the rotated value automatically.
 
 Existing hosts keep working because they authenticate with their per-host token, not the enroll secret. The rotated secret only matters the next time a brand-new Mac enrolls.
 
@@ -178,7 +205,7 @@ done
 
 **Profile stuck at "pending" in Fleet.** The Mac isn't UAMDM-enrolled. Open **Hosts > <host> > MDM** in Fleet; if it says "Enrolled (manual)" without UAMDM, re-enroll via ADE or walk the user through the manual UAMDM prompt in System Settings. Restricted payloads will not install otherwise.
 
-**Software package says "installed" but the pkg never ran.** Fleet considers a package "installed" once the pre-install script succeeds and the installer command starts. If the pkg itself fails, check **Hosts > <host> > Scripts** for the installer stdout/stderr.
+**Software install reports "failed" or the pkg never ran.** The install script owns both the config write and the `installer -pkg` call, so its exit status is the install result. Check **Hosts > \<host\> > Activity** and open the install details for the script's stdout/stderr; a non-zero exit from `installer` (or an unset `$FLEET_SECRET_*` variable tripping `set -eu`) shows up there.
 
 **Agent enrolls but events don't appear in the EDR UI.** The TCC FDA profile didn't reach the Mac. Check `sudo profiles list | grep tcc-fda` on the host; if missing, re-scope the profile to the fleet. After it lands, kick the daemon: `sudo launchctl kickstart -k system/com.fleetdm.edr.agent`.
 

--- a/docs/install-agent-manual.md
+++ b/docs/install-agent-manual.md
@@ -127,7 +127,7 @@ The postinstall script loads the LaunchDaemon. The agent starts immediately, rea
 
 ## Step 5: approve the system extension
 
-The installer only stages the sysext; activating it requires a human click on a Mac that isn't MDM-managed. macOS shows a "System Extension Blocked" notification the first time the host app tries to activate it.
+The pkg's activation LaunchAgent (`com.fleetdm.edr.activate`) runs the host app's `activate` right after install (and again at every login), but on a Mac that isn't MDM-managed the activation still requires a human click. macOS shows a "System Extension Blocked" notification when the host app tries to activate it.
 
 1. Open **System Settings > Privacy & Security**.
 2. Scroll to "Security". You'll see _"System extension blocked. Click to allow"_ or a similar message.

--- a/docs/mdm-deployment.md
+++ b/docs/mdm-deployment.md
@@ -56,7 +56,7 @@ shasum -a 256 -c SHA256SUMS --ignore-missing
 
 Upload `edr-system-extension.mobileconfig` to your MDM as a custom configuration profile and scope it to the Macs that will run the agent.
 
-What the profile does: pre-approves the bundle ID `com.fleetdm.edr.securityextension` under team ID `FDG8Q7N4CC` in the `com.apple.system-extension-policy` payload. When the pkg installer runs the host app's sysext-activation request, macOS finds the pre-approval, skips the user prompt, and activates the sysext immediately.
+What the profile does: pre-approves the bundle ID `com.fleetdm.edr.securityextension` under team ID `FDG8Q7N4CC` in the `com.apple.system-extension-policy` payload. When the pkg's activation LaunchAgent runs the host app's sysext-activation request, macOS finds the pre-approval, skips the user prompt, and activates the sysext immediately.
 
 Verify on a target Mac:
 
@@ -117,9 +117,9 @@ The pkg's install flow:
 
 1. `installationCheck()` validates the Mac is Apple Silicon + macOS 13+.
 2. Preinstall script stops any existing `com.fleetdm.edr.agent` LaunchDaemon and deactivates any prior sysext (idempotent; no-op on fresh installs).
-3. Payload lands under `/usr/local/bin`, `/Applications`, `/Library/LaunchDaemons`, `/Library/Application Support/com.fleetdm.edr`.
+3. Payload lands under `/usr/local/bin`, `/Applications`, `/Library/LaunchDaemons`, `/Library/LaunchAgents`, `/Library/Application Support/com.fleetdm.edr`.
 4. Postinstall script loads the LaunchDaemon (`launchctl bootstrap system ...`) and kickstarts it. The agent reads `/etc/fleet-edr.conf`, enrolls, starts polling.
-5. On first agent-to-sysext XPC call, the host app triggers sysext activation. Thanks to Step 1's profile, this is silent.
+5. Postinstall also starts the activation LaunchAgent (`com.fleetdm.edr.activate`) in the console user's GUI session, which runs the host app's `activate` and brings up the system extensions. Thanks to Step 1's profile this is silent. If nobody is logged in at install time (loginwindow, ADE), activation happens at the next login instead: the LaunchAgent runs at every login, which also re-activates the new bundle after upgrades. Until activation, the agent runs and enrolls but logs `receiver connect` warnings; that's the expected pre-activation state, not a failure.
 
 Verify on a target Mac:
 

--- a/openspec/changes/activate-extensions-on-install/proposal.md
+++ b/openspec/changes/activate-extensions-on-install/proposal.md
@@ -1,0 +1,18 @@
+# Activate extensions on install
+
+## Why
+
+The MDM deployment path never activates the system extensions. The pkg postinstall only bootstraps the agent LaunchDaemon; the agent has no activation code; the host app's `edr activate` (the only activation entry point) is never invoked by anything. On a fresh MDM-managed host the profiles land, the pkg installs, the agent enrolls, and then the agent loops `receiver connect` warnings forever because the extensions whose XPC services it needs were never activated. Observed on a fresh edr-qa copy on 2026-06-12; earlier QA setups had activation run manually, masking the gap. `docs/mdm-deployment.md` and the postinstall comment both claim an activation step that does not exist.
+
+## What changes
+
+- The pkg ships a LaunchAgent (`/Library/LaunchAgents/com.fleetdm.edr.activate.plist`, staged in the app component) that runs the host app's `activate` subcommand at every login (`RunAtLoad`, no `KeepAlive`). Activation requests must originate from the host app in a user session, so a LaunchAgent is the only Apple-sanctioned vehicle; running at every login is idempotent because re-activation replaces the extensions with the current bundle (already specified in `host-app-extension-manager`).
+- The postinstall bootstraps that LaunchAgent into the console user's GUI domain when a user is logged in at install time, so activation happens within seconds instead of waiting for the next login. Activation problems never fail the install.
+- The preinstall boots the LaunchAgent out before an upgrade replaces the app bundle; `uninstall.sh` boots it out and removes the plist.
+- The pkg dry-run CI job asserts the LaunchAgent is present in the app component's BOM.
+- Docs corrected: `mdm-deployment.md`'s claim that "the pkg installer runs the host app's sysext-activation request" becomes true and the install-flow step list gains the activation step; `install-agent-manual.md` notes the login-time auto-attempt.
+
+### Not in this change
+
+- Backoff for unmanaged Macs where the user declines the approval prompt (the LaunchAgent re-prompts at each login; acceptable for an EDR's required permissions).
+- Headless hosts with no GUI session: Apple provides no path to activate a system extension without a user session; known limitation.

--- a/openspec/changes/activate-extensions-on-install/specs/release-packaging/spec.md
+++ b/openspec/changes/activate-extensions-on-install/specs/release-packaging/spec.md
@@ -1,0 +1,26 @@
+# Release packaging: activate extensions on install delta
+
+## ADDED Requirements
+
+### Requirement: Installation activates the system extensions
+
+The released package SHALL ship a LaunchAgent at `/Library/LaunchAgents/com.fleetdm.edr.activate.plist` that runs the host app's `activate` subcommand in the logged-in user's GUI session, and the install scripts SHALL start it so that on an MDM-managed host (system-extension profile present) the extensions reach `activated enabled` without any operator interaction: immediately when a user is logged in at install time, otherwise at the next login. Activation requests must originate from the host app in a user session (Apple's model), so the package MUST NOT rely on the root postinstall or the agent daemon to submit them, and activation failures MUST NOT fail the install. Uninstall MUST remove the LaunchAgent.
+
+#### Scenario: Install with a user logged in activates immediately
+
+- **GIVEN** an MDM-managed host with the system-extension profile installed and a user logged in at the console
+- **WHEN** the pkg installs
+- **THEN** the postinstall bootstraps the activation LaunchAgent into the console user's GUI domain
+- **AND** both extensions reach `activated enabled` without any user interaction
+
+#### Scenario: Install at the loginwindow activates at next login
+
+- **GIVEN** an MDM-managed host with the system-extension profile installed and no user logged in
+- **WHEN** the pkg installs and a user later logs in
+- **THEN** the LaunchAgent runs the host app's `activate` at login and both extensions reach `activated enabled` without any user interaction
+
+#### Scenario: Uninstall removes the activation LaunchAgent
+
+- **GIVEN** a host where the released package is installed
+- **WHEN** the operator runs the uninstall script
+- **THEN** the activation LaunchAgent is booted out of the GUI domain and its plist is removed

--- a/openspec/changes/activate-extensions-on-install/tasks.md
+++ b/openspec/changes/activate-extensions-on-install/tasks.md
@@ -1,0 +1,25 @@
+# Activate extensions on install: tasks
+
+## 1. Packaging
+
+- [x] New LaunchAgent `packaging/pkg/com.fleetdm.edr.activate.plist` (RunAtLoad, runs `Fleet EDR.app/Contents/MacOS/edr activate`).
+- [x] `build.sh`: stage the plist into `app-root/Library/LaunchAgents/` on both the dry-run and release branches.
+- [x] `postinstall`: bootstrap the LaunchAgent into `gui/<console-uid>` when a user is on console; fix the false "LaunchDaemon activates the sysext" comment; never fail the install.
+- [x] `preinstall`: bootout the LaunchAgent on upgrade before the app bundle is replaced.
+- [x] `uninstall.sh`: bootout the LaunchAgent and remove the plist.
+
+## 2. CI + spec
+
+- [x] `pkg-dryrun.yml`: lsbom check that app.pkg contains `Library/LaunchAgents/com.fleetdm.edr.activate.plist`.
+- [x] `release-packaging` spec: ADDED requirement "Installation activates the system extensions" with scenarios for install-while-logged-in, install-at-loginwindow, and uninstall cleanup; markers in postinstall, pkg-dryrun.yml, and uninstall.sh.
+
+## 3. Docs
+
+- [x] `docs/mdm-deployment.md`: correct the activation claim and add the activation step to the install-flow list.
+- [x] `docs/fleet-deployment.md`: verify section notes activation fires at install time (or next login when installed at the loginwindow).
+- [x] `docs/install-agent-manual.md`: note the LaunchAgent retries activation at each login on unmanaged Macs.
+
+## 4. Verification
+
+- [x] `plutil -lint` the LaunchAgent; shellcheck postinstall/preinstall/uninstall.sh; actionlint; `openspec validate`; spectrace.
+- [x] edr-qa VM: emulate the postinstall path (copy plist, `launchctl bootstrap gui/501`) and confirm both extensions reach `activated enabled` silently and the agent's `receiver connect` warnings stop.

--- a/openspec/specs/release-packaging/spec.md
+++ b/openspec/specs/release-packaging/spec.md
@@ -95,6 +95,29 @@ The release pipeline SHALL produce two `.mobileconfig` profiles that operators u
 - **THEN** the build produces `edr-system-extension.mobileconfig` and `edr-tcc-fda.mobileconfig` with the team id substituted
 - **AND** each profile is plain XML with no CMS signature, accepted verbatim by an MDM that signs at delivery time
 
+### Requirement: Installation activates the system extensions
+
+The released package SHALL ship a LaunchAgent at `/Library/LaunchAgents/com.fleetdm.edr.activate.plist` that runs the host app's `activate` subcommand in the logged-in user's GUI session, and the install scripts SHALL start it so that on an MDM-managed host (system-extension profile present) the extensions reach `activated enabled` without any operator interaction: immediately when a user is logged in at install time, otherwise at the next login. Activation requests must originate from the host app in a user session (Apple's model), so the package MUST NOT rely on the root postinstall or the agent daemon to submit them, and activation failures MUST NOT fail the install. Uninstall MUST remove the LaunchAgent.
+
+#### Scenario: Install with a user logged in activates immediately
+
+- **GIVEN** an MDM-managed host with the system-extension profile installed and a user logged in at the console
+- **WHEN** the pkg installs
+- **THEN** the postinstall bootstraps the activation LaunchAgent into the console user's GUI domain
+- **AND** both extensions reach `activated enabled` without any user interaction
+
+#### Scenario: Install at the loginwindow activates at next login
+
+- **GIVEN** an MDM-managed host with the system-extension profile installed and no user logged in
+- **WHEN** the pkg installs and a user later logs in
+- **THEN** the LaunchAgent runs the host app's `activate` at login and both extensions reach `activated enabled` without any user interaction
+
+#### Scenario: Uninstall removes the activation LaunchAgent
+
+- **GIVEN** a host where the released package is installed
+- **WHEN** the operator runs the uninstall script
+- **THEN** the activation LaunchAgent is booted out of the GUI domain and its plist is removed
+
 ### Requirement: Uninstall path is deliverable
 
 The released package SHALL include an uninstall script that an operator (or the customer's MDM) can invoke to remove the agent, the host app, and the system extension cleanly from a host without requiring the original package. The uninstall path is part of the product contract; an installer that cannot be cleanly uninstalled is not shippable.

--- a/packaging/pkg/build.sh
+++ b/packaging/pkg/build.sh
@@ -256,6 +256,20 @@ else
         "$STAGE/app-root/Applications/Fleet EDR.app"
 fi
 
+# spec:release-packaging/installation-activates-the-system-extensions/install-with-a-user-logged-in-activates-immediately
+#
+# Activation LaunchAgent rides in the app component because it launches the
+# app: OSSystemExtensionRequest must come from the host app in a user session,
+# so login-time (RunAtLoad) plus the postinstall's gui-domain bootstrap are
+# what turn "pkg installed" into "extensions activated" without an operator.
+# The gui-domain bootstrap lives in packaging/pkg/scripts/postinstall, which
+# spectrace cannot scan (no .sh extension); this staging block plus that
+# script are the scenario's enforcement surface.
+mkdir -p "$STAGE/app-root/Library/LaunchAgents"
+cp "$ROOT/packaging/pkg/com.fleetdm.edr.activate.plist" \
+    "$STAGE/app-root/Library/LaunchAgents/com.fleetdm.edr.activate.plist"
+chmod 0644 "$STAGE/app-root/Library/LaunchAgents/com.fleetdm.edr.activate.plist"
+
 echo "==> packaging app component pkg"
 sign_pkg pkgbuild \
     --identifier com.fleetdm.edr.app \

--- a/packaging/pkg/com.fleetdm.edr.activate.plist
+++ b/packaging/pkg/com.fleetdm.edr.activate.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+    LaunchAgent that activates the Fleet EDR system extensions. OSSystemExtensionRequest
+    must be submitted by the host app running in a user (Aqua) session: a root daemon or
+    the pkg postinstall cannot do it. RunAtLoad makes activation happen at every login;
+    re-activation when already active replaces the extensions with the current bundle and
+    exits, so this is idempotent and doubles as re-activation after an app upgrade. The
+    postinstall additionally bootstraps this agent into the console user's GUI domain at
+    install time so a logged-in host activates immediately rather than at next login.
+    No KeepAlive: the activate subcommand exits when done.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.fleetdm.edr.activate</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/Applications/Fleet EDR.app/Contents/MacOS/edr</string>
+        <string>activate</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+</dict>
+</plist>

--- a/packaging/pkg/com.fleetdm.edr.activate.plist
+++ b/packaging/pkg/com.fleetdm.edr.activate.plist
@@ -8,7 +8,9 @@
     exits, so this is idempotent and doubles as re-activation after an app upgrade. The
     postinstall additionally bootstraps this agent into the console user's GUI domain at
     install time so a logged-in host activates immediately rather than at next login.
-    No KeepAlive: the activate subcommand exits when done.
+    No KeepAlive: the activate subcommand exits when done. On an unmanaged Mac the
+    process intentionally stays alive while approval is pending (the live request is
+    what System Settings' Allow button completes); it exits once approved or denied.
 -->
 <plist version="1.0">
 <dict>

--- a/packaging/pkg/scripts/postinstall
+++ b/packaging/pkg/scripts/postinstall
@@ -62,10 +62,16 @@ ACTIVATE_LA=/Library/LaunchAgents/com.fleetdm.edr.activate.plist
 CONSOLE_UID=$(/usr/bin/stat -f %u /dev/console 2>/dev/null || echo 0)
 if [ -f "$ACTIVATE_LA" ] && [ "$CONSOLE_UID" -gt 0 ]; then
     # bootstrap returns 37 ("already loaded") on reinstalls; kickstart re-runs
-    # the agent in that case so an upgrade re-activates the new bundle.
-    /bin/launchctl bootstrap "gui/$CONSOLE_UID" "$ACTIVATE_LA" 2>/dev/null \
-        || /bin/launchctl kickstart -k "gui/$CONSOLE_UID/com.fleetdm.edr.activate" 2>/dev/null \
-        || true
+    # the activation LaunchAgent in that case so an upgrade re-activates the
+    # new bundle. If BOTH fail, say so on stderr (which installer captures
+    # into /var/log/install.log) so the failure is diagnosable, but still
+    # exit 0: the LaunchAgent's RunAtLoad retries at the next login.
+    if ! /bin/launchctl bootstrap "gui/$CONSOLE_UID" "$ACTIVATE_LA" 2>/dev/null; then
+        if ! /bin/launchctl kickstart -k "gui/$CONSOLE_UID/com.fleetdm.edr.activate" 2>/dev/null; then
+            echo "postinstall: could not start com.fleetdm.edr.activate in gui/$CONSOLE_UID;" \
+                "extension activation deferred to next login" >&2
+        fi
+    fi
 fi
 
 exit 0

--- a/packaging/pkg/scripts/postinstall
+++ b/packaging/pkg/scripts/postinstall
@@ -1,9 +1,12 @@
 #!/bin/sh
 # Post-install script for Fleet EDR.
 #
-# Runs after pkg payload is laid down. Loads the LaunchDaemon (which activates
-# the sysext via the host app's XPC request on first run) and ensures var/db +
-# var/log directories exist.
+# Runs after pkg payload is laid down. Loads the agent LaunchDaemon, ensures
+# var/db + var/log directories exist, and starts the activation LaunchAgent in
+# the console user's GUI session so the system extensions activate immediately
+# on hosts where someone is logged in. (The agent daemon does NOT activate
+# extensions; only the host app running in a user session can submit the
+# OSSystemExtensionRequest.)
 #
 # Fleet's install-script contract writes /etc/fleet-edr.conf BEFORE invoking
 # `installer`, so by the time we run, the agent has its enroll secret + server
@@ -47,5 +50,22 @@ if [ "$rc" -ne 0 ] && [ "$rc" -ne 37 ]; then
     exit "$rc"
 fi
 /bin/launchctl kickstart -k "system/${LABEL}"
+
+# spec:release-packaging/installation-activates-the-system-extensions/install-with-a-user-logged-in-activates-immediately
+#
+# Start the activation LaunchAgent in the console user's GUI session so the
+# extensions activate now instead of at the next login. Installs that happen
+# at the loginwindow skip this (no console user); the LaunchAgent's RunAtLoad
+# covers them on the next login. Nothing here may fail the install: a Mac
+# where activation needs the user's click still installed correctly.
+ACTIVATE_LA=/Library/LaunchAgents/com.fleetdm.edr.activate.plist
+CONSOLE_UID=$(/usr/bin/stat -f %u /dev/console 2>/dev/null || echo 0)
+if [ -f "$ACTIVATE_LA" ] && [ "$CONSOLE_UID" -gt 0 ]; then
+    # bootstrap returns 37 ("already loaded") on reinstalls; kickstart re-runs
+    # the agent in that case so an upgrade re-activates the new bundle.
+    /bin/launchctl bootstrap "gui/$CONSOLE_UID" "$ACTIVATE_LA" 2>/dev/null \
+        || /bin/launchctl kickstart -k "gui/$CONSOLE_UID/com.fleetdm.edr.activate" 2>/dev/null \
+        || true
+fi
 
 exit 0

--- a/packaging/pkg/scripts/preinstall
+++ b/packaging/pkg/scripts/preinstall
@@ -21,6 +21,15 @@ if [ -f "$PLIST" ]; then
     /bin/launchctl bootout system "$PLIST" 2>/dev/null || true
 fi
 
+# Boot the activation LaunchAgent out of the console user's GUI session so an
+# upgrade doesn't replace the app bundle under a running activate. No-op on
+# fresh installs and at the loginwindow.
+ACTIVATE_LA=/Library/LaunchAgents/com.fleetdm.edr.activate.plist
+CONSOLE_UID=$(/usr/bin/stat -f %u /dev/console 2>/dev/null || echo 0)
+if [ -f "$ACTIVATE_LA" ] && [ "$CONSOLE_UID" -gt 0 ]; then
+    /bin/launchctl bootout "gui/$CONSOLE_UID" "$ACTIVATE_LA" 2>/dev/null || true
+fi
+
 # Deactivate the running system extension so the bundle can be replaced.
 # Derive the team ID from the installed host app's codesign output so this
 # script tracks whatever team ID the previous install was signed under,

--- a/packaging/pkg/uninstall.sh
+++ b/packaging/pkg/uninstall.sh
@@ -38,6 +38,17 @@ if [ -f "$PLIST" ]; then
     rm -f "$PLIST"
 fi
 
+# spec:release-packaging/installation-activates-the-system-extensions/uninstall-removes-the-activation-launchagent
+echo "==> removing activation LaunchAgent"
+ACTIVATE_LA=/Library/LaunchAgents/com.fleetdm.edr.activate.plist
+if [ -f "$ACTIVATE_LA" ]; then
+    CONSOLE_UID=$(/usr/bin/stat -f %u /dev/console 2>/dev/null || echo 0)
+    if [ "$CONSOLE_UID" -gt 0 ]; then
+        /bin/launchctl bootout "gui/$CONSOLE_UID" "$ACTIVATE_LA" 2>/dev/null || true
+    fi
+    rm -f "$ACTIVATE_LA"
+fi
+
 echo "==> deactivating system extension"
 # Derive the team ID from the installed host app rather than hardcoding; an
 # operator who re-signed with a different team ID (fork, team migration)


### PR DESCRIPTION
<!-- Keep this short. Delete sections that do not apply. -->

## What & why



## Checklist

- [ ] **OpenSpec updated for behavior changes.** If this PR changes observable behavior (a detection rule, the event
      wire schema, persistence semantics, an API/wire shape, or an emitted event), `openspec/specs/**` is updated (and
      an `openspec/changes/` proposal added), with a `spec:<id>` test marker for any new/renamed scenario. Only if this
      PR changes NO observable behavior (a comment / refactor / gofmt / dep bump that happens to touch a scoped path)
      may you assert `no-behavior-change` (label or `[no-behavior-change]` in the title) to clear the OpenSpec-sync gate.
      That is an assertion a reviewer will check, not a way to skip the spec for a real behavior change.
- [ ] Tests added/updated for the change (unit / integration / efficacy / UI as applicable).
- [ ] Agent/extension change touching ESF, XPC, or the event wire format: exercised on a live macOS VM before RC
      (flagged below).

## VM / RC notes (if applicable)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * System extensions now activate automatically during installation when a user is logged in, or at next login otherwise, without requiring manual intervention.

* **Documentation**
  * Updated deployment guides to document automatic extension activation during package installation and at login.
  * Clarified activation behavior differences on MDM-managed versus non-MDM Macs.
  * Expanded post-install verification and troubleshooting guidance for installation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->