### PR TITLE
Render

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -17,9 +17,13 @@ Operator-facing documentation for Fleet EDR. For developer setup see the repo-ro
 | Recovering when SSO is unavailable, registering a second security key     | [`breakglass.md`](breakglass.md)                     |
 | Reviewing what threats v0.1 covers and where the gaps are                 | [`threat-model.md`](threat-model.md)                 |
 
+## Getting started
+
+The fastest path to an evaluation: deploy the server on Render (one click, TLS and MySQL handled for you), then push the agent to your Macs through Fleet MDM. See [deploy-render.md](deploy-render.md) for the server and [fleet-deployment.md](fleet-deployment.md) for the agents.
+
 ## Shape of a Fleet EDR deployment
 
-- **Server**: container image `ghcr.io/getvictor/fleet-edr-server` running behind your TLS-terminating ingress, backed by MySQL 8.4. Serves the agent ingestion API, the admin web UI, and the OTel metric pipeline.
+- **Server**: container image `ghcr.io/getvictor/fleet-edr-server` running behind your TLS-terminating ingress (or [Render](deploy-render.md), which provides the ingress), backed by MySQL 8.4. Serves the agent ingestion API, the admin web UI, and the OTel metric pipeline.
 - **Agent**: signed + notarized `.pkg` installed on each macOS endpoint. Runs as a LaunchDaemon, receives events from an embedded system extension over XPC, queues them in SQLite, uploads to the server.
 - **MDM profiles**: two unsigned `.mobileconfig` files that pre-approve the system extension and grant Full Disk Access. Delivered by whichever MDM the customer uses; the MDM signs them at delivery time.
 - **Install script**: a one-line Bash snippet your MDM runs before the `.pkg` installer to drop the enroll secret into `/etc/fleet-edr.conf`.

--- a/docs/deploy-render.md
+++ b/docs/deploy-render.md
@@ -25,7 +25,8 @@ No Redis is needed: the server is stateless (ADR-0010) and keeps all durable sta
 
 ## After it is up
 
-- **Grab the break-glass admin password.** On first boot the server prints a one-time admin password to its logs. In the Render dashboard open the `fleet-edr-server` service logs and search for the break-glass banner. Use it to sign in at `/ui/`, then configure OIDC (set `EDR_OIDC_ISSUER` and remove `EDR_AUTH_ALLOW_NO_OIDC`) for ongoing access.
+- **Enable break-glass sign-in for your Render URL.** Break-glass uses WebAuthn, which binds credentials to a specific host, so on a non-localhost deployment you must tell the server its public host. Once Render assigns the URL, set two env vars on the `fleet-edr-server` service and let it redeploy: `EDR_BREAKGLASS_RP_ID=<your-service>.onrender.com` and `EDR_BREAKGLASS_RP_ORIGINS=https://<your-service>.onrender.com`. Without them the break-glass ceremony fails. (Skip this if you configure OIDC instead, below.)
+- **Redeem the break-glass admin.** On first boot the server prints a one-time break-glass redemption URL (not a password) to its logs. In the Render dashboard open the `fleet-edr-server` service logs and search for the break-glass banner, open the URL, and register a passkey to become admin. Then configure OIDC (set `EDR_OIDC_ISSUER` and remove `EDR_AUTH_ALLOW_NO_OIDC`) for ongoing access.
 - **Grab the enroll secret.** In the `fleet-edr-server` service, **Environment** tab, copy the generated `EDR_ENROLL_SECRET`. Your MDM install script needs it (it is the `EDR_ENROLL_SECRET` in [fleet-deployment.md](fleet-deployment.md)'s install script).
 - **Note your server URL.** `https://<your-service>.onrender.com` is the `EDR_SERVER_URL` agents enroll against. Set it as the `FLEET_SECRET_EDR_SERVER_URL` (or equivalent) in your MDM.
 

--- a/docs/deploy-render.md
+++ b/docs/deploy-render.md
@@ -1,0 +1,40 @@
+# Deploy the EDR server on Render
+
+This is the fastest way to stand up a Fleet EDR server for an evaluation or pilot: Render hosts the server and a bundled MySQL, and terminates TLS at its edge so there are no certificates to manage. Once the server is up, deploy the agent to your Macs through your MDM (see [fleet-deployment.md](fleet-deployment.md) for the Fleet recipe, or [mdm-deployment.md](mdm-deployment.md) for the vendor-neutral contract).
+
+For a self-hosted server with your own TLS certificates instead, see the production docker-compose stack (`docker-compose.prod.yml`).
+
+## What the blueprint creates
+
+The [`render.yaml`](../render.yaml) blueprint provisions two services:
+
+- **`fleet-edr-server`** (web): the `ghcr.io/getvictor/fleet-edr-server` image behind Render's TLS-terminating edge. It listens plaintext HTTP inside Render's network (`EDR_TLS_TERMINATED_BY_PROXY=1`) while agents reach it over Render's publicly-trusted `https://…onrender.com` URL, so the data plane is encrypted end to edge with zero certificate management. Schema migrations apply automatically on boot.
+- **`fleet-edr-mysql`** (private service): a MySQL instance with a 10 GB disk, reachable only from the server. Good for pilots; swap to a managed database later by setting `EDR_DSN` on the server and removing this service.
+
+No Redis is needed: the server is stateless (ADR-0010) and keeps all durable state in MySQL.
+
+## Deploy
+
+1. Click the button (or in the Render dashboard: **New > Blueprint**, point it at this repo):
+
+   [![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/getvictor/fleet-edr)
+
+2. Render reads `render.yaml`, creates both services, generates the MySQL password and the agent enroll secret, and wires them together. First boot runs the migrations and seeds a break-glass admin.
+
+3. When the server is live, open its Render URL. The admin UI is at `https://<your-service>.onrender.com/ui/`.
+
+## After it is up
+
+- **Grab the break-glass admin password.** On first boot the server prints a one-time admin password to its logs. In the Render dashboard open the `fleet-edr-server` service logs and search for the break-glass banner. Use it to sign in at `/ui/`, then configure OIDC (set `EDR_OIDC_ISSUER` and remove `EDR_AUTH_ALLOW_NO_OIDC`) for ongoing access.
+- **Grab the enroll secret.** In the `fleet-edr-server` service, **Environment** tab, copy the generated `EDR_ENROLL_SECRET`. Your MDM install script needs it (it is the `EDR_ENROLL_SECRET` in [fleet-deployment.md](fleet-deployment.md)'s install script).
+- **Note your server URL.** `https://<your-service>.onrender.com` is the `EDR_SERVER_URL` agents enroll against. Set it as the `FLEET_SECRET_EDR_SERVER_URL` (or equivalent) in your MDM.
+
+## Deploy the agents
+
+With the server URL and enroll secret in hand, follow [fleet-deployment.md](fleet-deployment.md) to push the agent `.pkg`, the two `.mobileconfig` profiles, and the install script through Fleet (or your MDM of choice). The agents enroll directly to the Render URL; Fleet never sees the EDR data plane.
+
+## Notes and limits
+
+- **Custom domain:** add one in Render's dashboard; the agents then enroll against your domain instead of the `onrender.com` URL. Render manages the certificate either way.
+- **The bundled MySQL is pilot-grade.** It persists on a Render disk but has no managed backups. For production, point `EDR_DSN` at a managed MySQL and drop the bundled service.
+- **Do not set `EDR_TLS_CERT_FILE`/`EDR_TLS_KEY_FILE` alongside `EDR_TLS_TERMINATED_BY_PROXY=1`.** The server rejects that combination: terminate TLS at the proxy (the Render default here) or at the server (self-hosted), never both.

--- a/docs/install-server.md
+++ b/docs/install-server.md
@@ -116,7 +116,7 @@ EDR_TLS_CERT_FILE=/tls/fullchain.pem
 EDR_TLS_KEY_FILE=/tls/privkey.pem
 ```
 
-**Option B: terminate TLS upstream (nginx, Caddy, an ALB, Cloudflare Tunnel).** The proxy is the external HTTPS endpoint; the proxy-to-EDR hop also runs over TLS: issue #140 removed the plaintext-HTTP opt-out, so the EDR server binary cannot serve HTTP under any configuration. Issue the proxy-to-backend cert from your internal CA (or reuse the public cert) and mount it under `./tls/`; the env-var shape is identical to Option A.
+**Option B: terminate TLS upstream (nginx, Caddy, an ALB, Cloudflare Tunnel).** The proxy is the external HTTPS endpoint. By default the proxy-to-EDR hop also runs over TLS (issue #140 makes the server terminate TLS itself): issue the proxy-to-backend cert from your internal CA or reuse the public cert, mount it under `./tls/`, and the env-var shape is identical to Option A. If your platform cannot present a backend certificate (most PaaS edges, including Render, proxy plaintext to the service), set `EDR_TLS_TERMINATED_BY_PROXY=1` instead and omit the cert files: the server then listens plaintext HTTP on the assumption that the proxy terminates TLS in front of it. The flag and cert files are mutually exclusive. For the Render one-click path see [deploy-render.md](deploy-render.md).
 
 ### 5. Pin a version in .env
 
@@ -209,7 +209,7 @@ Non-exhaustive; see `server/config/config.go` for every knob. Anything unset use
 | `EDR_DSN` / `EDR_DSN_FILE` | yes | none | MySQL DSN, `user:pass@tcp(host:port)/db?parseTime=true` |
 | `EDR_ENROLL_SECRET` / `EDR_ENROLL_SECRET_FILE` | yes | none | Shared secret agents present at enrollment |
 | `EDR_LISTEN_ADDR` | no | `:8088` | TCP address the HTTPS server binds |
-| `EDR_TLS_CERT_FILE` | **yes** | none | PEM cert. Unconditionally required; the server has no plaintext-HTTP mode (issue #140) |
+| `EDR_TLS_CERT_FILE` | **yes** | none | PEM cert. Required unless `EDR_TLS_TERMINATED_BY_PROXY=1`; the server has no _unguarded_ plaintext-HTTP mode (issue #140) |
 | `EDR_TLS_KEY_FILE` | **yes** | none | PEM key (pair with cert) |
 | `EDR_TLS_ALLOW_TLS12` | no | 0 | Allow TLS 1.2 (default is 1.3-only) |
 | `EDR_SHUTDOWN_DRAIN` | no | 30s | On SIGTERM the server reports `/readyz` 503 and keeps serving for this long before closing the listener, so a load balancer drains the replica from rotation first. 0 disables the wait (immediate shutdown) |
@@ -338,7 +338,7 @@ docker compose -f docker-compose.prod.yml restart server
 
 **Server keeps exiting with "EDR_DSN is required"**: the `edr_dsn` secret file is missing or unreadable. Re-run the secrets step in Setup.
 
-**Server exits with "EDR_TLS_CERT_FILE and EDR_TLS_KEY_FILE are both required"**: either cert path is unset or unreadable. The server has no plaintext-HTTP mode (issue #140); mount fullchain.pem + privkey.pem under `./tls/` and re-export the `EDR_TLS_CERT_FILE` / `EDR_TLS_KEY_FILE` env vars before retrying.
+**Server exits with "EDR_TLS_CERT_FILE and EDR_TLS_KEY_FILE are both required"**: either cert path is unset or unreadable. The server has no unguarded plaintext-HTTP mode (issue #140); mount fullchain.pem + privkey.pem under `./tls/` and re-export the `EDR_TLS_CERT_FILE` / `EDR_TLS_KEY_FILE` env vars before retrying. (Behind a TLS-terminating proxy that cannot present a backend cert, set `EDR_TLS_TERMINATED_BY_PROXY=1` and omit the cert files instead.)
 
 **Agents see "enrollment failed: unauthorized"**: the `enroll_secret` on the server and the `EDR_ENROLL_SECRET` the agent reads from `/etc/fleet-edr.conf` are different. Confirm the MDM install-script writes the exact value from `secrets/enroll_secret`.
 

--- a/openspec/changes/render-deployment-blueprint/proposal.md
+++ b/openspec/changes/render-deployment-blueprint/proposal.md
@@ -1,0 +1,19 @@
+# Render deployment blueprint
+
+## Why
+
+The getting-started story for the EDR is "stand up a server, then deploy agents via MDM." The agent/MDM side is documented (fleet-deployment.md), but standing up the server still means running the prod docker-compose with bring-your-own TLS certs, which is too much friction for an evaluation. A one-click "Deploy to Render" blueprint (server + bundled MySQL behind Render's TLS edge) makes the server side as easy as the agent side, mirroring how Fleet ships a `render.yaml`.
+
+The blocker was TLS: the server makes TLS mandatory (#140 removed the plaintext-HTTP mode), but Render terminates TLS at its edge and proxies plaintext HTTP to the service. Fleet solves the identical problem with `FLEET_SERVER_TLS=false` and documents TLS-terminated-by-proxy as a first-class, recommended pattern (ALB SSL offload); it is the industry-standard PaaS/load-balancer posture.
+
+## What changes
+
+- **Gated proxy-TLS mode.** A new `EDR_TLS_TERMINATED_BY_PROXY=1` opt-in lets the server listen plaintext HTTP when an operator asserts a TLS-terminating proxy is in front. Mandatory-TLS stays the default; setting the flag together with cert files is rejected as ambiguous. In proxy mode the server logs a startup warning that it serves plaintext and must not be exposed directly. Agents connect to the proxy's publicly-trusted cert, so the data plane is encrypted end-to-edge with no cert management.
+- **DSN from discrete parts.** When `EDR_DSN` is unset, the server composes it from `EDR_MYSQL_ADDRESS` / `EDR_MYSQL_USERNAME` / `EDR_MYSQL_PASSWORD` / `EDR_MYSQL_DATABASE`. Render (like Fleet's blueprint) wires a bundled DB's host:port and generated password into discrete env vars via `fromService` and cannot interpolate them into one DSN string; an explicit `EDR_DSN` still wins.
+- **`render.yaml` blueprint.** Web service (`ghcr.io/getvictor/fleet-edr-server:latest`, `healthCheckPath: /readyz`, proxy-TLS on, enroll secret generated, DSN parts wired from the MySQL pserv) plus a bundled MySQL private service with a 10GB disk. No Redis (stateless, ADR-0010); no preDeployCommand (migrations self-apply on boot under the advisory lock).
+- **`docs/deploy-render.md`.** Deploy-to-Render walkthrough that hands off to fleet-deployment.md for agents, completing the "Render + Fleet MDM" getting-started path.
+
+### Not in this change
+
+- Production durability/backup guidance for the bundled MySQL beyond the mounted disk (the doc notes swapping to a managed DB via `EDR_DSN`).
+- Other PaaS targets (Fly, Cloud Run); the proxy-TLS flag and DSN-parts make them straightforward later.

--- a/openspec/changes/render-deployment-blueprint/specs/server-availability/spec.md
+++ b/openspec/changes/render-deployment-blueprint/specs/server-availability/spec.md
@@ -1,0 +1,25 @@
+# Server availability: TLS termination by a front proxy delta
+
+## ADDED Requirements
+
+### Requirement: TLS may be terminated by a front proxy
+
+The server SHALL terminate TLS itself by default and refuse to boot without a certificate and key (issue #140 removed the unguarded plaintext-HTTP mode). It SHALL additionally support running behind a TLS-terminating proxy (a PaaS edge, ALB, or reverse proxy) via an explicit opt-in: when the operator sets that opt-in, the server SHALL listen plaintext HTTP and SHALL NOT require certificate files, on the assertion that the proxy terminates TLS in front of it. The opt-in and server-terminated TLS SHALL be mutually exclusive so the operator cannot ambiguously configure both. When running in proxy-terminated mode the server SHALL emit a startup warning that it is serving plaintext and must not be exposed directly.
+
+#### Scenario: Proxy-termination opt-in allows plaintext HTTP
+
+- **GIVEN** an operator who sets the proxy-termination opt-in and supplies no certificate files
+- **WHEN** the server loads its configuration
+- **THEN** configuration succeeds and the server listens plaintext HTTP rather than refusing to boot
+
+#### Scenario: Proxy flag and cert files are mutually exclusive
+
+- **GIVEN** an operator who sets the proxy-termination opt-in AND supplies certificate files
+- **WHEN** the server loads its configuration
+- **THEN** configuration fails with an error that the two are mutually exclusive
+
+#### Scenario: Mandatory TLS remains the default
+
+- **GIVEN** an operator who sets neither the proxy-termination opt-in nor certificate files
+- **WHEN** the server loads its configuration
+- **THEN** configuration fails because a certificate and key are required

--- a/openspec/changes/render-deployment-blueprint/tasks.md
+++ b/openspec/changes/render-deployment-blueprint/tasks.md
@@ -1,0 +1,25 @@
+# Render deployment blueprint: tasks
+
+## 1. Server config
+
+- [x] `config.go`: add `TLSTerminatedByProxy`, parse `EDR_TLS_TERMINATED_BY_PROXY`; gate loadTLSConfig (skip cert requirement when set, reject flag + cert files together).
+- [x] `config.go`: compose `EDR_DSN` from `EDR_MYSQL_*` parts when `EDR_DSN` is unset; explicit DSN wins.
+- [x] `main.go` configureTLS: skip TLS wiring + warn in proxy mode (leaves `srv.TLSConfig` nil).
+- [x] `serve.go` RunAndShutdown: serve plaintext HTTP when `srv.TLSConfig` is nil, else TLS.
+- [x] Config tests: proxy-mode boot, proxy+cert mutual exclusion, DSN compose, explicit-DSN-wins, partial-parts error.
+
+## 2. Blueprint + docs
+
+- [x] `render.yaml`: web service + bundled MySQL pserv, proxy-TLS, DSN parts via `fromService`, `/readyz` health check.
+- [ ] `docs/deploy-render.md`: deploy walkthrough + hand-off to fleet-deployment.md.
+- [ ] `docs/README.md`: link the Render path from the getting-started shape.
+
+## 3. Spec
+
+- [x] `server-availability` spec: ADDED requirement "TLS may be terminated by a front proxy" with three scenarios; markers in config tests.
+
+## 4. Verification
+
+- [ ] `go test ./server/config/...` green; `go build ./server/...`.
+- [ ] Local smoke: run the image with `EDR_TLS_TERMINATED_BY_PROXY=1` + a MySQL, `curl http://localhost:PORT/readyz` returns 200.
+- [ ] `openspec validate render-deployment-blueprint`, spectrace, gofmt, golangci-lint, markdown + dash lints, render.yaml parses.

--- a/openspec/specs/server-availability/spec.md
+++ b/openspec/specs/server-availability/spec.md
@@ -38,6 +38,28 @@ The server SHALL NOT retain in-process state that outlives a single request and 
 - **WHEN** a later request that depends on that state is routed to a different replica
 - **THEN** the second replica serves it correctly from the shared store, with no reliance on any request-surviving in-process state from the first replica
 
+### Requirement: TLS may be terminated by a front proxy
+
+The server SHALL terminate TLS itself by default and refuse to boot without a certificate and key (issue #140 removed the unguarded plaintext-HTTP mode). It SHALL additionally support running behind a TLS-terminating proxy (a PaaS edge, ALB, or reverse proxy) via an explicit opt-in: when the operator sets that opt-in, the server SHALL listen plaintext HTTP and SHALL NOT require certificate files, on the assertion that the proxy terminates TLS in front of it. The opt-in and server-terminated TLS SHALL be mutually exclusive so the operator cannot ambiguously configure both. When running in proxy-terminated mode the server SHALL emit a startup warning that it is serving plaintext and must not be exposed directly.
+
+#### Scenario: Proxy-termination opt-in allows plaintext HTTP
+
+- **GIVEN** an operator who sets the proxy-termination opt-in and supplies no certificate files
+- **WHEN** the server loads its configuration
+- **THEN** configuration succeeds and the server listens plaintext HTTP rather than refusing to boot
+
+#### Scenario: Proxy flag and cert files are mutually exclusive
+
+- **GIVEN** an operator who sets the proxy-termination opt-in AND supplies certificate files
+- **WHEN** the server loads its configuration
+- **THEN** configuration fails with an error that the two are mutually exclusive
+
+#### Scenario: Mandatory TLS remains the default
+
+- **GIVEN** an operator who sets neither the proxy-termination opt-in nor certificate files
+- **WHEN** the server loads its configuration
+- **THEN** configuration fails because a certificate and key are required
+
 ### Requirement: SIGTERM produces a load-balancer-drainable graceful shutdown
 
 On SIGTERM the server SHALL begin draining before it closes its listener: it SHALL report not-ready on its readiness probe so a load balancer removes the replica from rotation, SHALL keep serving in-flight and newly-accepted requests for a bounded drain window, and SHALL then stop accepting new connections and wait for in-flight requests to finish up to a bounded shutdown deadline. The process SHALL exit within the drain window plus the shutdown deadline. The drain window is operator-configurable and MAY be zero to disable the wait.

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,85 @@
+# Render blueprint for the Fleet EDR server. One-click getting-started deploy:
+# the server behind Render's TLS-terminating edge plus a bundled MySQL.
+# Deploy agents to your Macs separately via an MDM (see docs/fleet-deployment.md).
+#
+# Render terminates TLS at its edge and proxies plaintext HTTP to the service on
+# $PORT, so the server runs with EDR_TLS_TERMINATED_BY_PROXY=1 (its gated
+# exception to mandatory-TLS, issue #140). Agents connect to Render's
+# publicly-trusted https URL, so the data plane is encrypted end-to-edge with no
+# certificate management. The server self-applies schema migrations on boot
+# under a MySQL advisory lock, so there is no preDeployCommand. No Redis: the
+# server is stateless (ADR-0010) and keeps all durable state in MySQL.
+services:
+  - name: fleet-edr-server
+    type: web
+    runtime: image
+    plan: standard
+    image:
+      url: 'ghcr.io/getvictor/fleet-edr-server:latest'
+    healthCheckPath: /readyz
+    envVars:
+      # Render injects PORT; bind all interfaces so the edge proxy can reach us.
+      - key: EDR_LISTEN_ADDR
+        value: '0.0.0.0:10000'
+      - key: PORT
+        value: 10000
+      # The gated plaintext-HTTP opt-in. Safe here precisely because Render's
+      # edge terminates TLS in front of this service.
+      - key: EDR_TLS_TERMINATED_BY_PROXY
+        value: '1'
+      # Render's proxy fronts every request; trust its forwarded client IP so
+      # per-IP enroll rate limiting buckets by the real agent, not the proxy.
+      - key: EDR_TRUSTED_PROXIES
+        value: '10.0.0.0/8'
+      - key: EDR_LOG_FORMAT
+        value: json
+      # Generated once by Render and shown in the dashboard. Copy it into your
+      # MDM install script as the agent enroll secret (docs/fleet-deployment.md).
+      - key: EDR_ENROLL_SECRET
+        generateValue: true
+      # The server composes EDR_DSN from these parts (Render can't interpolate
+      # one env var into another, so we wire the host:port + generated password
+      # discretely, the same shape Fleet's blueprint uses).
+      - key: EDR_MYSQL_ADDRESS
+        fromService:
+          name: fleet-edr-mysql
+          type: pserv
+          property: hostport
+      - key: EDR_MYSQL_DATABASE
+        fromService:
+          name: fleet-edr-mysql
+          type: pserv
+          envVarKey: MYSQL_DATABASE
+      - key: EDR_MYSQL_USERNAME
+        fromService:
+          name: fleet-edr-mysql
+          type: pserv
+          envVarKey: MYSQL_USER
+      - key: EDR_MYSQL_PASSWORD
+        fromService:
+          name: fleet-edr-mysql
+          type: pserv
+          envVarKey: MYSQL_PASSWORD
+      # Break-glass admin bootstrap: the server prints a one-time admin password
+      # to the logs on first boot. OIDC can be configured post-deploy.
+      - key: EDR_AUTH_ALLOW_NO_OIDC
+        value: '1'
+
+  - name: fleet-edr-mysql
+    type: pserv
+    runtime: docker
+    plan: standard
+    repo: https://github.com/render-examples/mysql
+    disk:
+      name: mysql
+      mountPath: /var/lib/mysql
+      sizeGB: 10
+    envVars:
+      - key: MYSQL_DATABASE
+        value: edr
+      - key: MYSQL_USER
+        value: edr
+      - key: MYSQL_PASSWORD
+        generateValue: true
+      - key: MYSQL_ROOT_PASSWORD
+        generateValue: true

--- a/render.yaml
+++ b/render.yaml
@@ -37,6 +37,11 @@ services:
       # MDM install script as the agent enroll secret (docs/fleet-deployment.md).
       - key: EDR_ENROLL_SECRET
         generateValue: true
+      # Identity bootstrap requires a session signing key whenever break-glass is
+      # configured (which it is here, via EDR_AUTH_ALLOW_NO_OIDC). Without it the
+      # server exits on first boot. Render generates and persists it.
+      - key: EDR_SESSION_SIGNING_KEY
+        generateValue: true
       # The server composes EDR_DSN from these parts (Render can't interpolate
       # one env var into another, so we wire the host:port + generated password
       # discretely, the same shape Fleet's blueprint uses).
@@ -60,8 +65,11 @@ services:
           name: fleet-edr-mysql
           type: pserv
           envVarKey: MYSQL_PASSWORD
-      # Break-glass admin bootstrap: the server prints a one-time admin password
-      # to the logs on first boot. OIDC can be configured post-deploy.
+      # Break-glass admin bootstrap: the server prints a one-time break-glass
+      # redemption URL to the logs on first boot. To complete break-glass sign-in
+      # on the assigned Render URL, set EDR_BREAKGLASS_RP_ID to the host and
+      # EDR_BREAKGLASS_RP_ORIGINS to https://<host> post-deploy (see
+      # docs/deploy-render.md), or configure OIDC instead.
       - key: EDR_AUTH_ALLOW_NO_OIDC
         value: '1'
 

--- a/server/cmd/fleet-edr-ingest/main.go
+++ b/server/cmd/fleet-edr-ingest/main.go
@@ -126,7 +126,13 @@ func run() error {
 		WriteTimeout: httpWriteTimeout,
 		IdleTimeout:  httpIdleTimeout,
 	}
-	if err := httpserver.ConfigureTLS(ctx, srv, httpserver.TLSOptions{
+	// Honor EDR_TLS_TERMINATED_BY_PROXY here too: config validation allows missing cert files in that mode, so calling
+	// ConfigureTLS with empty paths would fail to load a keypair and brick ingest boot behind a proxy. Leaving TLSConfig nil
+	// makes RunAndShutdown serve plaintext, matching the main server.
+	if cfg.TLSTerminatedByProxy {
+		logger.WarnContext(ctx, "ingest serving plaintext HTTP: EDR_TLS_TERMINATED_BY_PROXY=1 is set; only safe behind a "+
+			"TLS-terminating proxy", "listen_addr", cfg.ListenAddr)
+	} else if err := httpserver.ConfigureTLS(ctx, srv, httpserver.TLSOptions{
 		CertFile:   cfg.TLSCertFile,
 		KeyFile:    cfg.TLSKeyFile,
 		AllowTLS12: cfg.AllowTLS12,

--- a/server/cmd/fleet-edr-server/main.go
+++ b/server/cmd/fleet-edr-server/main.go
@@ -504,6 +504,15 @@ func redemptionURL(cfg *config.Config, plaintext string) string {
 }
 
 func configureTLS(ctx context.Context, logger *slog.Logger, srv *http.Server, cfg *config.Config) error {
+	if cfg.TLSTerminatedByProxy {
+		// Leave srv.TLSConfig nil so RunAndShutdown serves plaintext HTTP. Config validation already guaranteed no cert files are
+		// set in this mode. Warn loudly so an operator who set the flag by accident (no proxy actually in front) sees that the
+		// data plane is plaintext on the bind address.
+		logger.WarnContext(ctx, "serving plaintext HTTP: EDR_TLS_TERMINATED_BY_PROXY=1 is set; this is only safe behind a "+
+			"TLS-terminating proxy (PaaS edge, ALB, nginx). Do not expose this bind address directly to agents or the internet.",
+			"listen_addr", cfg.ListenAddr)
+		return nil
+	}
 	return httpserver.ConfigureTLS(ctx, srv, httpserver.TLSOptions{
 		CertFile:   cfg.TLSCertFile,
 		KeyFile:    cfg.TLSKeyFile,

--- a/server/cmd/fleet-edr-server/main.go
+++ b/server/cmd/fleet-edr-server/main.go
@@ -219,7 +219,7 @@ func openIdentity(
 	identityCtx, err := identitybootstrap.New(ctx, identitybootstrap.Deps{
 		DB:                 db,
 		Logger:             logger,
-		CookieSecure:       cfg.TLSEnabled(),
+		CookieSecure:       cfg.ExternalTLS(),
 		AuditReadSampling:  cfg.AuditReadSampling,
 		AuditAsyncQueueCap: cfg.AuditAsyncQueueCap,
 		SessionSigningKey:  cfg.SessionSigningKey,
@@ -541,9 +541,11 @@ func newHTTPServer(
 	metricsRec *metrics.Recorder,
 ) *http.Server {
 	handler := httpserver.Build(mux, httpserver.Options{
-		Logger:           logger,
-		ServiceName:      serviceName,
-		TLSEnabled:       cfg.TLSEnabled(),
+		Logger:      logger,
+		ServiceName: serviceName,
+		// HSTS keys on the client-facing scheme: emit it when a front proxy terminates TLS too, since the browser reaches us
+		// over HTTPS. Safe under the accidental-flag case because browsers ignore HSTS received over a direct plain-HTTP hit.
+		TLSEnabled:       cfg.ExternalTLS(),
 		ClientIPResolver: clientIPResolver,
 		Metrics:          metricsRec,
 	})

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -59,6 +59,12 @@ type Config struct {
 	TLSCertFile  string
 	TLSKeyFile   string
 	AllowTLS12   bool
+	// TLSTerminatedByProxy lets the server listen plaintext HTTP when a TLS-terminating proxy (a PaaS edge like Render, or an
+	// ALB / nginx / Cloudflare) sits in front. It is the gated exception to the mandatory-TLS default (issue #140): the default
+	// still refuses to boot without certs, but an operator who sets EDR_TLS_TERMINATED_BY_PROXY=1 asserts that something in front
+	// terminates TLS, so the data plane is still encrypted end-to-edge. Setting it together with cert files is rejected as
+	// ambiguous. This is the same posture Fleet ships (FLEET_SERVER_TLS=false behind Render/ALB).
+	TLSTerminatedByProxy bool
 	// ShutdownDrain is how long RunAndShutdown keeps serving after SIGTERM (with /readyz reporting 503) before closing the
 	// listener, so a load balancer drains this replica first. Default 30s; 0 disables the drain wait. From EDR_SHUTDOWN_DRAIN.
 	ShutdownDrain    time.Duration
@@ -222,6 +228,19 @@ type Config struct {
 	ReauthWindow time.Duration
 }
 
+// composeDSN builds a go-sql-driver DSN from discrete EDR_MYSQL_* parts, or returns "" if any required part is missing. The parts
+// mirror the values a PaaS blueprint can wire from a managed/bundled MySQL service (host:port + generated user/password/db).
+func composeDSN(getenv func(string) string) string {
+	addr := getenv("EDR_MYSQL_ADDRESS")
+	user := getenv("EDR_MYSQL_USERNAME")
+	pass := getenv("EDR_MYSQL_PASSWORD")
+	db := getenv("EDR_MYSQL_DATABASE")
+	if addr == "" || user == "" || pass == "" || db == "" {
+		return ""
+	}
+	return fmt.Sprintf("%s:%s@tcp(%s)/%s?parseTime=true", user, pass, addr, db)
+}
+
 // TLSEnabled reports whether TLS cert and key are both set.
 func (c Config) TLSEnabled() bool {
 	return c.TLSCertFile != "" && c.TLSKeyFile != ""
@@ -293,13 +312,25 @@ func loadFrom(getenv func(string) string) (*Config, error) {
 // loadCoreEnv reads required strings + scalar feature flags. The TLS certificate paths land here too because they're optionalStr;
 // their cross-field validation runs in loadTLSConfig once both sides are known.
 func loadCoreEnv(c *Config, getenv func(string) string, errs *[]error) {
-	requireStr(&c.DSN, "EDR_DSN", getenv, errs, true)
+	// EDR_DSN is the canonical single-string DSN. When it is empty, compose one from discrete parts
+	// (EDR_MYSQL_ADDRESS/USERNAME/PASSWORD/DATABASE). PaaS blueprints (Render's fromService, and the same shape on Fly / ECS) hand
+	// the DB host:port and a generated password to separate env vars and cannot interpolate them into one DSN string, so the
+	// compose-from-parts path is what makes a one-click blueprint work. An explicit EDR_DSN always wins.
+	optionalStr(&c.DSN, "EDR_DSN", getenv)
+	if c.DSN == "" {
+		c.DSN = composeDSN(getenv)
+	}
+	if c.DSN == "" {
+		*errs = append(*errs, errors.New(
+			"EDR_DSN is required (or supply EDR_MYSQL_ADDRESS + EDR_MYSQL_USERNAME + EDR_MYSQL_PASSWORD + EDR_MYSQL_DATABASE)"))
+	}
 	optionalStr(&c.ListenAddr, "EDR_LISTEN_ADDR", getenv)
 	requireStr(&c.EnrollSecret, "EDR_ENROLL_SECRET", getenv, errs, true)
 	optionalStr(&c.TLSCertFile, "EDR_TLS_CERT_FILE", getenv)
 	optionalStr(&c.TLSKeyFile, "EDR_TLS_KEY_FILE", getenv)
 
 	c.AllowTLS12 = getenv("EDR_TLS_ALLOW_TLS12") == "1"
+	c.TLSTerminatedByProxy = getenv("EDR_TLS_TERMINATED_BY_PROXY") == "1"
 	// NonNegative (not Positive): 0 is the documented "disable the drain wait" sentinel. RunAndShutdown skips the drain phase and
 	// shuts down immediately. Integration + single-process tests set EDR_SHUTDOWN_DRAIN=0 so they don't sleep the drain window.
 	envparse.NonNegativeDuration(getenv, "EDR_SHUTDOWN_DRAIN", &c.ShutdownDrain, errs)
@@ -314,9 +345,21 @@ func loadCoreEnv(c *Config, getenv func(string) string, errs *[]error) {
 // loadTLSConfig validates the TLS configuration's cross-field
 // invariants now that loadCoreEnv has populated the cert paths.
 func loadTLSConfig(c *Config, errs *[]error) {
+	if c.TLSTerminatedByProxy {
+		// Gated exception to #140: a TLS-terminating proxy is in front, so the server listens plaintext HTTP. Reject cert files
+		// alongside it: the operator either terminates TLS here (cert files, no flag) or at the proxy (flag, no cert files), never
+		// a confused half-and-half where the cert files silently win or are silently ignored.
+		if c.TLSCertFile != "" || c.TLSKeyFile != "" {
+			*errs = append(*errs, errors.New(
+				"EDR_TLS_TERMINATED_BY_PROXY=1 is mutually exclusive with EDR_TLS_CERT_FILE/EDR_TLS_KEY_FILE: "+
+					"terminate TLS at the proxy (flag only) or at the server (cert files only), not both"))
+		}
+		return
+	}
 	if c.TLSCertFile == "" || c.TLSKeyFile == "" {
 		*errs = append(*errs, errors.New(
-			"EDR_TLS_CERT_FILE and EDR_TLS_KEY_FILE are both required: the server has no plaintext-HTTP mode (issue #140)"))
+			"EDR_TLS_CERT_FILE and EDR_TLS_KEY_FILE are both required unless EDR_TLS_TERMINATED_BY_PROXY=1: "+
+				"the server has no unguarded plaintext-HTTP mode (issue #140)"))
 		return
 	}
 	// Fail fast on unreadable / mismatched cert material so boot exits before bootstrap.New mutates the DB (admin seeding prints

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -14,6 +14,8 @@ import (
 	"strings"
 	"time"
 
+	mysqldriver "github.com/go-sql-driver/mysql"
+
 	"github.com/fleetdm/edr/internal/envparse"
 )
 
@@ -229,7 +231,10 @@ type Config struct {
 }
 
 // composeDSN builds a go-sql-driver DSN from discrete EDR_MYSQL_* parts, or returns "" if any required part is missing. The parts
-// mirror the values a PaaS blueprint can wire from a managed/bundled MySQL service (host:port + generated user/password/db).
+// mirror the values a PaaS blueprint can wire from a managed/bundled MySQL service (host:port + generated user/password/db). It
+// goes through go-sql-driver's Config.FormatDSN rather than fmt.Sprintf so a generated password containing DSN metacharacters
+// (`@`, `:`, `/`, `?`) is escaped instead of corrupting the DSN. PaaS blueprints generate such passwords routinely, so naive
+// string interpolation would intermittently brick boot (the same round-trip rationale as testdb's replaceDBName).
 func composeDSN(getenv func(string) string) string {
 	addr := getenv("EDR_MYSQL_ADDRESS")
 	user := getenv("EDR_MYSQL_USERNAME")
@@ -238,12 +243,26 @@ func composeDSN(getenv func(string) string) string {
 	if addr == "" || user == "" || pass == "" || db == "" {
 		return ""
 	}
-	return fmt.Sprintf("%s:%s@tcp(%s)/%s?parseTime=true", user, pass, addr, db)
+	dc := mysqldriver.NewConfig()
+	dc.User = user
+	dc.Passwd = pass
+	dc.Net = "tcp"
+	dc.Addr = addr
+	dc.DBName = db
+	dc.ParseTime = true
+	return dc.FormatDSN()
 }
 
-// TLSEnabled reports whether TLS cert and key are both set.
+// TLSEnabled reports whether the server terminates TLS itself (cert and key both set).
 func (c Config) TLSEnabled() bool {
 	return c.TLSCertFile != "" && c.TLSKeyFile != ""
+}
+
+// ExternalTLS reports whether the client-facing connection is HTTPS: either the server terminates TLS itself, or a front proxy
+// does (EDR_TLS_TERMINATED_BY_PROXY). Browser-facing security wiring (Secure cookies, HSTS) keys on this rather than TLSEnabled
+// so a behind-proxy deployment still marks cookies Secure and emits HSTS, since the browser only ever reaches us over HTTPS.
+func (c Config) ExternalTLS() bool {
+	return c.TLSEnabled() || c.TLSTerminatedByProxy
 }
 
 // Defaults returns a Config populated with default values. Callers should overlay env vars on top.

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	mysqldriver "github.com/go-sql-driver/mysql"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -174,6 +175,43 @@ func TestLoad(t *testing.T) {
 			validate: func(t *testing.T, c *Config) {
 				t.Helper()
 				assert.Equal(t, "edr:secret@tcp(db.internal:3306)/edr?parseTime=true", c.DSN)
+			},
+		},
+		{
+			name: "composed DSN escapes special chars in generated password",
+			env: map[string]string{
+				"EDR_MYSQL_ADDRESS":      "db.internal:3306",
+				"EDR_MYSQL_USERNAME":     "edr",
+				"EDR_MYSQL_PASSWORD":     "p@ss:w/rd?x",
+				"EDR_MYSQL_DATABASE":     "edr",
+				"EDR_ENROLL_SECRET":      "s",
+				"EDR_TLS_CERT_FILE":      certFile,
+				"EDR_TLS_KEY_FILE":       keyFile,
+				"EDR_AUTH_ALLOW_NO_OIDC": "1",
+			},
+			validate: func(t *testing.T, c *Config) {
+				t.Helper()
+				// Round-trips through go-sql-driver: parsing the composed DSN must recover the exact password, which naive
+				// fmt.Sprintf interpolation would corrupt on the '@' / ':' / '/' / '?' characters.
+				parsed, err := mysqldriver.ParseDSN(c.DSN)
+				require.NoError(t, err)
+				assert.Equal(t, "p@ss:w/rd?x", parsed.Passwd)
+				assert.Equal(t, "db.internal:3306", parsed.Addr)
+				assert.True(t, parsed.ParseTime)
+			},
+		},
+		{
+			name: "ExternalTLS true under proxy termination",
+			env: map[string]string{
+				"EDR_DSN":                     "x",
+				"EDR_ENROLL_SECRET":           "s",
+				"EDR_AUTH_ALLOW_NO_OIDC":      "1",
+				"EDR_TLS_TERMINATED_BY_PROXY": "1",
+			},
+			validate: func(t *testing.T, c *Config) {
+				t.Helper()
+				assert.False(t, c.TLSEnabled(), "server does not terminate TLS in proxy mode")
+				assert.True(t, c.ExternalTLS(), "external connection is HTTPS via the proxy, so cookies/HSTS stay secure")
 			},
 		},
 		{

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -179,6 +179,7 @@ func TestLoad(t *testing.T) {
 		},
 		{
 			name: "composed DSN escapes special chars in generated password",
+			// #nosec G101 -- test fixture: not a real credential.
 			env: map[string]string{
 				"EDR_MYSQL_ADDRESS":      "db.internal:3306",
 				"EDR_MYSQL_USERNAME":     "edr",

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -106,6 +106,7 @@ func TestLoad(t *testing.T) {
 			wantErr: "EDR_ENROLL_SECRET",
 		},
 		{
+			// spec:server-availability/tls-may-be-terminated-by-a-front-proxy/mandatory-tls-remains-the-default
 			name: "TLS cert + key unconditionally required (no opt-out)",
 			env: map[string]string{
 				"EDR_DSN":           "x",
@@ -130,6 +131,79 @@ func TestLoad(t *testing.T) {
 				"EDR_TLS_CERT_FILE": "/tmp/edr.crt",
 			},
 			wantErr: "EDR_TLS_CERT_FILE and EDR_TLS_KEY_FILE are both required",
+		},
+		{
+			// spec:server-availability/tls-may-be-terminated-by-a-front-proxy/proxy-termination-opt-in-allows-plaintext-http
+			name: "EDR_TLS_TERMINATED_BY_PROXY allows boot without certs",
+			env: map[string]string{
+				"EDR_DSN":                     "x",
+				"EDR_ENROLL_SECRET":           "s",
+				"EDR_AUTH_ALLOW_NO_OIDC":      "1",
+				"EDR_TLS_TERMINATED_BY_PROXY": "1",
+			},
+			validate: func(t *testing.T, c *Config) {
+				t.Helper()
+				assert.True(t, c.TLSTerminatedByProxy)
+				assert.False(t, c.TLSEnabled(), "proxy-terminated mode does not terminate TLS at the server")
+			},
+		},
+		{
+			// spec:server-availability/tls-may-be-terminated-by-a-front-proxy/proxy-flag-and-cert-files-are-mutually-exclusive
+			name: "EDR_TLS_TERMINATED_BY_PROXY with cert files is rejected",
+			env: map[string]string{
+				"EDR_DSN":                     "x",
+				"EDR_ENROLL_SECRET":           "s",
+				"EDR_TLS_TERMINATED_BY_PROXY": "1",
+				"EDR_TLS_CERT_FILE":           certFile,
+				"EDR_TLS_KEY_FILE":            keyFile,
+			},
+			wantErr: "mutually exclusive",
+		},
+		{
+			name: "EDR_DSN composed from EDR_MYSQL_* parts when DSN unset",
+			env: map[string]string{
+				"EDR_MYSQL_ADDRESS":      "db.internal:3306",
+				"EDR_MYSQL_USERNAME":     "edr",
+				"EDR_MYSQL_PASSWORD":     "secret",
+				"EDR_MYSQL_DATABASE":     "edr",
+				"EDR_ENROLL_SECRET":      "s",
+				"EDR_TLS_CERT_FILE":      certFile,
+				"EDR_TLS_KEY_FILE":       keyFile,
+				"EDR_AUTH_ALLOW_NO_OIDC": "1",
+			},
+			validate: func(t *testing.T, c *Config) {
+				t.Helper()
+				assert.Equal(t, "edr:secret@tcp(db.internal:3306)/edr?parseTime=true", c.DSN)
+			},
+		},
+		{
+			name: "explicit EDR_DSN wins over parts",
+			env: map[string]string{
+				"EDR_DSN":                "root@tcp(127.0.0.1:3306)/edr?parseTime=true",
+				"EDR_MYSQL_ADDRESS":      "db.internal:3306",
+				"EDR_MYSQL_USERNAME":     "edr",
+				"EDR_MYSQL_PASSWORD":     "secret",
+				"EDR_MYSQL_DATABASE":     "edr",
+				"EDR_ENROLL_SECRET":      "s",
+				"EDR_TLS_CERT_FILE":      certFile,
+				"EDR_TLS_KEY_FILE":       keyFile,
+				"EDR_AUTH_ALLOW_NO_OIDC": "1",
+			},
+			validate: func(t *testing.T, c *Config) {
+				t.Helper()
+				assert.Equal(t, "root@tcp(127.0.0.1:3306)/edr?parseTime=true", c.DSN)
+			},
+		},
+		{
+			name: "partial EDR_MYSQL_* parts still error (no DSN)",
+			env: map[string]string{
+				"EDR_MYSQL_ADDRESS":  "db.internal:3306",
+				"EDR_MYSQL_USERNAME": "edr",
+				"EDR_ENROLL_SECRET":  "s",
+				"EDR_TLS_CERT_FILE":  certFile,
+				"EDR_TLS_KEY_FILE":   keyFile,
+			},
+			wantErr: "EDR_DSN is required",
 		},
 		{
 			name: "missing every required var reports each",

--- a/server/httpserver/serve.go
+++ b/server/httpserver/serve.go
@@ -27,9 +27,10 @@ func (d *DrainState) BeginDrain() { d.draining.Store(true) }
 // IsDraining reports whether graceful-shutdown draining has begun.
 func (d *DrainState) IsDraining() bool { return d.draining.Load() }
 
-// RunAndShutdown starts srv on TLS in a background goroutine, blocks until ctx is cancelled or the server returns a fatal error,
-// then performs a graceful shutdown. ConfigureTLS must have populated srv.TLSConfig beforehand so the empty-string cert/key
-// arguments are correct. The plaintext-HTTP path was removed in issue #140; production binaries can only serve TLS.
+// RunAndShutdown starts srv in a background goroutine, blocks until ctx is cancelled or the server returns a fatal error, then
+// performs a graceful shutdown. It serves TLS when srv.TLSConfig is populated (ConfigureTLS ran, the default), and plaintext HTTP
+// when it is nil. The server terminates TLS itself by default (issue #140); the nil-TLSConfig plaintext path is reached only when
+// the operator opts into EDR_TLS_TERMINATED_BY_PROXY, i.e. a TLS-terminating proxy is in front (callers skip ConfigureTLS then).
 //
 // Returns the server-side error on abnormal exit, or nil on a ctx-driven graceful shutdown (which also logs "shutdown complete"
 // on the way out).

--- a/server/httpserver/serve.go
+++ b/server/httpserver/serve.go
@@ -42,8 +42,16 @@ func (d *DrainState) IsDraining() bool { return d.draining.Load() }
 func RunAndShutdown(ctx context.Context, srv *http.Server, logger *slog.Logger, drain *DrainState, drainDelay time.Duration) error {
 	serverErr := make(chan error, 1)
 	go func() {
-		// ConfigureTLS owns the cert source via GetCertificate; pass empty strings.
-		serveErr := srv.ListenAndServeTLS("", "")
+		// srv.TLSConfig is populated by ConfigureTLS when the server terminates TLS itself. When it's nil the operator opted into
+		// EDR_TLS_TERMINATED_BY_PROXY (a TLS-terminating proxy is in front), so we serve plaintext HTTP. Branching on TLSConfig
+		// keeps the proxy-mode plumbing out of this function's signature and its two callers.
+		var serveErr error
+		if srv.TLSConfig != nil {
+			// ConfigureTLS owns the cert source via GetCertificate; pass empty strings.
+			serveErr = srv.ListenAndServeTLS("", "")
+		} else {
+			serveErr = srv.ListenAndServe()
+		}
 		if serveErr != nil && !errors.Is(serveErr, http.ErrServerClosed) {
 			serverErr <- serveErr
 		}


### PR DESCRIPTION
<!-- Keep this short. Delete sections that do not apply. -->

## What & why



## Checklist

- [ ] **OpenSpec updated for behavior changes.** If this PR changes observable behavior (a detection rule, the event
      wire schema, persistence semantics, an API/wire shape, or an emitted event), `openspec/specs/**` is updated (and
      an `openspec/changes/` proposal added), with a `spec:<id>` test marker for any new/renamed scenario. Only if this
      PR changes NO observable behavior (a comment / refactor / gofmt / dep bump that happens to touch a scoped path)
      may you assert `no-behavior-change` (label or `[no-behavior-change]` in the title) to clear the OpenSpec-sync gate.
      That is an assertion a reviewer will check, not a way to skip the spec for a real behavior change.
- [ ] Tests added/updated for the change (unit / integration / efficacy / UI as applicable).
- [ ] Agent/extension change touching ESF, XPC, or the event wire format: exercised on a live macOS VM before RC
      (flagged below).

## VM / RC notes (if applicable)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Render deployment with one-click "Deploy to Render" blueprint
  * Added support for TLS termination by proxy for deployments behind TLS-terminating infrastructure
  * Added flexible MySQL configuration via separate environment variables

* **Documentation**
  * Added Render deployment guide
  * Updated README with "Getting started" section

<!-- end of auto-generated comment: release notes by coderabbit.ai -->