### PR TITLE
ci: ignore non-applicable esbuild advisory in osv-scanner

### DIFF
--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -32,6 +32,11 @@ jobs:
     with:
       # Recursive scan of every manifest in the repo: go.mod (agent + server),
       # ui/package-lock.json, and .github/workflows pins.
+      #
+      # Advisory suppressions live in an osv-scanner.toml next to the scanned
+      # lockfile (osv-scanner auto-loads it), NOT here. Today: ui/osv-scanner.toml
+      # ignores one Deno-only esbuild advisory. Audit those files when reviewing
+      # what this gate lets through.
       scan-args: |-
         --recursive
         ./

--- a/ui/osv-scanner.toml
+++ b/ui/osv-scanner.toml
@@ -1,0 +1,25 @@
+# OSV-Scanner ignore list for the ui/ npm dependency tree. osv-scanner auto-loads
+# the osv-scanner.toml that sits next to the scanned lockfile (here
+# ui/package-lock.json), so this file must live in ui/, not the repo root, for the
+# CI scan (.github/workflows/osv-scanner.yml, `--recursive ./`) to honor it. Every
+# entry must carry a reason a reviewer can audit; prefer fixing the dependency over
+# ignoring it.
+
+[[IgnoredVulns]]
+id = "GHSA-gv7w-rqvm-qjhr"
+# esbuild <=0.28.0 (we have 0.25.12, transitive via vite -> ui dev/build tooling).
+# Ignored for two independent reasons:
+#   1. Not applicable to this project's runtime. The advisory is a Deno-specific
+#      flaw: esbuild's Deno module downloads its native binary without SHA-256
+#      verification, so an attacker controlling NPM_CONFIG_REGISTRY can inject a
+#      binary. The Node.js install path (what npm + vite use here) performs that
+#      integrity check, and this repo has no Deno toolchain. The vulnerable code
+#      path is never exercised.
+#   2. No compatible fix exists. The fix is only in esbuild 0.28.1, but every
+#      vite release through the latest (8.x) pins esbuild ^0.25 / ^0.27; none
+#      require >=0.28.1. Forcing esbuild 0.28.1 via an npm override breaks the
+#      vite build (incompatible transform target handling, 208 errors).
+# esbuild is a build-time dev dependency: it is not present in the production UI
+# bundle the server embeds. Revisit when a vite release depends on esbuild
+# >=0.28.1, at which point bump vite and drop this entry.
+reason = "Deno-only advisory; this is a Node/npm project so the vulnerable path is unused. esbuild is a build-time dev dep not shipped in the bundle, and no vite release yet pulls the fixed esbuild 0.28.1 (forcing it breaks the build). Revisit when vite supports esbuild >=0.28.1."

--- a/ui/osv-scanner.toml
+++ b/ui/osv-scanner.toml
@@ -22,4 +22,12 @@ id = "GHSA-gv7w-rqvm-qjhr"
 # esbuild is a build-time dev dependency: it is not present in the production UI
 # bundle the server embeds. Revisit when a vite release depends on esbuild
 # >=0.28.1, at which point bump vite and drop this entry.
-reason = "Deno-only advisory; this is a Node/npm project so the vulnerable path is unused. esbuild is a build-time dev dep not shipped in the bundle, and no vite release yet pulls the fixed esbuild 0.28.1 (forcing it breaks the build). Revisit when vite supports esbuild >=0.28.1."
+# TOML multi-line string with trailing-backslash continuations: the newlines are
+# stripped, so osv-scanner still reads one logical line, and the source stays
+# under the repo's 140-char wrap.
+reason = """\
+Deno-only advisory; this is a Node/npm project so the vulnerable path is unused. \
+esbuild is a build-time dev dep not shipped in the bundle, and no vite release yet \
+pulls the fixed esbuild 0.28.1 (forcing it breaks the build). Revisit when vite \
+supports esbuild >=0.28.1.\
+"""


### PR DESCRIPTION
## What & why

`osv-scanner` fails CI on `GHSA-gv7w-rqvm-qjhr` (CVSS 8.1) against `esbuild` 0.25.12, a transitive dev/build-time dependency of `vite` in `ui/`. This adds `ui/osv-scanner.toml` to ignore that one advisory, with a documented reason.

This is a clearing of a **false positive for our runtime**, not a suppression of a real risk:

- The advisory is **Deno-specific**. Per the [primary GitHub advisory](https://github.com/advisories/GHSA-gv7w-rqvm-qjhr): "The Node.js equivalent (`lib/npm/node-install.ts`) includes a robust `binaryIntegrityCheck()` function ... but this protection was never implemented for the Deno distribution." This repo is Node/npm (vite + npm), has no Deno toolchain, so the vulnerable code path is unreachable.
- **No compatible fix exists.** The fix is only in esbuild 0.28.1, but every `vite` release through the latest (8.x) pins esbuild `^0.25`/`^0.27`; none require `>=0.28.1`. Forcing 0.28.1 via an npm override breaks the vite build (208 transform-target errors), so upgrading is not currently possible.
- esbuild is build-time only and is **not in the production UI bundle** the server embeds.

## Notes

- The config lives in `ui/` (not repo root) because osv-scanner auto-loads the `osv-scanner.toml` next to the scanned lockfile; a root file is silently not applied for `--recursive ./` (verified: root → exit 1, `ui/` → exit 0).
- Scoped to a single advisory ID, so it cannot mask any future esbuild vuln. esbuild upgrades naturally once a vite release pulls a fixed version; the entry becomes a harmless no-op then.
- Verified locally: `osv-scanner scan --recursive ./` exits 0 with this file, fails without it.

Unblocks osv-scanner on this branch, `main`, and #361 (on rebase).
