### PR TITLE
Pin to MySQL 8.4.9

### DIFF
--- a/.github/workflows/efficacy.yml
+++ b/.github/workflows/efficacy.yml
@@ -57,7 +57,7 @@ jobs:
     # real MySQL via testdb/full.Open.
     services:
       mysql:
-        image: mysql:8.4@sha256:c36050afdca850f23cef85703f84c7531a5ae155a11b5ee1c60acb09937c4084
+        image: mysql:8.4.9@sha256:c36050afdca850f23cef85703f84c7531a5ae155a11b5ee1c60acb09937c4084
         env:
           MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
           MYSQL_DATABASE: edr_test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -174,7 +174,7 @@ jobs:
     # matches the local docker-compose dev/test posture (see CLAUDE.md).
     services:
       mysql:
-        image: mysql:8.4@sha256:c36050afdca850f23cef85703f84c7531a5ae155a11b5ee1c60acb09937c4084
+        image: mysql:8.4.9@sha256:c36050afdca850f23cef85703f84c7531a5ae155a11b5ee1c60acb09937c4084
         env:
           MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
           MYSQL_DATABASE: edr_test

--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -20,7 +20,7 @@ name: fleet-edr-demo
 
 services:
   mysql:
-    image: mysql:8.4.9
+    image: mysql:8.4.9@sha256:c36050afdca850f23cef85703f84c7531a5ae155a11b5ee1c60acb09937c4084
     environment:
       MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
       MYSQL_DATABASE: edr

--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -20,7 +20,7 @@ name: fleet-edr-demo
 
 services:
   mysql:
-    image: mysql:8.4
+    image: mysql:8.4.9
     environment:
       MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
       MYSQL_DATABASE: edr

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -11,7 +11,7 @@
 
 services:
   mysql:
-    image: mysql:8.4.9
+    image: mysql:8.4.9@sha256:c36050afdca850f23cef85703f84c7531a5ae155a11b5ee1c60acb09937c4084
     restart: unless-stopped
     environment:
       # MySQL 8.4 reads these _FILE variants natively. Avoids root password in

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -11,7 +11,7 @@
 
 services:
   mysql:
-    image: mysql:8.4
+    image: mysql:8.4.9
     restart: unless-stopped
     environment:
       # MySQL 8.4 reads these _FILE variants natively. Avoids root password in

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@
 # Server and ingest CLI defaults match these ports.
 services:
   mysql:
-    image: mysql:8.4
+    image: mysql:8.4.9
     container_name: fleet-edr-mysql
     environment:
       MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
@@ -28,7 +28,7 @@ services:
       retries: 10
 
   mysql_test:
-    image: mysql:8.4
+    image: mysql:8.4.9
     container_name: fleet-edr-mysql_test
     environment:
       MYSQL_ALLOW_EMPTY_PASSWORD: "yes"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@
 # Server and ingest CLI defaults match these ports.
 services:
   mysql:
-    image: mysql:8.4.9
+    image: mysql:8.4.9@sha256:c36050afdca850f23cef85703f84c7531a5ae155a11b5ee1c60acb09937c4084
     container_name: fleet-edr-mysql
     environment:
       MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
@@ -28,7 +28,7 @@ services:
       retries: 10
 
   mysql_test:
-    image: mysql:8.4.9
+    image: mysql:8.4.9@sha256:c36050afdca850f23cef85703f84c7531a5ae155a11b5ee1c60acb09937c4084
     container_name: fleet-edr-mysql_test
     environment:
       MYSQL_ALLOW_EMPTY_PASSWORD: "yes"

--- a/packaging/docker-compose-multi-replica.yml
+++ b/packaging/docker-compose-multi-replica.yml
@@ -61,7 +61,7 @@ x-server: &server
 
 services:
   mysql:
-    image: mysql:8.4
+    image: mysql:8.4.9
     restart: unless-stopped
     environment:
       MYSQL_ROOT_PASSWORD_FILE: /run/secrets/mysql_root

--- a/packaging/docker-compose-multi-replica.yml
+++ b/packaging/docker-compose-multi-replica.yml
@@ -61,7 +61,7 @@ x-server: &server
 
 services:
   mysql:
-    image: mysql:8.4.9
+    image: mysql:8.4.9@sha256:c36050afdca850f23cef85703f84c7531a5ae155a11b5ee1c60acb09937c4084
     restart: unless-stopped
     environment:
       MYSQL_ROOT_PASSWORD_FILE: /run/secrets/mysql_root

--- a/render.yaml
+++ b/render.yaml
@@ -81,7 +81,7 @@ services:
     runtime: image
     plan: standard
     image:
-      url: 'docker.io/library/mysql:8.4.9'
+      url: 'docker.io/library/mysql:8.4.9@sha256:c36050afdca850f23cef85703f84c7531a5ae155a11b5ee1c60acb09937c4084'
     disk:
       name: mysql
       mountPath: /var/lib/mysql

--- a/render.yaml
+++ b/render.yaml
@@ -75,9 +75,13 @@ services:
 
   - name: fleet-edr-mysql
     type: pserv
-    runtime: docker
+    # Run the official MySQL image directly so the bundled DB matches the
+    # 8.4.9 we build, test, and ship against everywhere else (docker-compose*.yml,
+    # packaging/, CI). The old render-examples/mysql repo pinned 8.0.24.
+    runtime: image
     plan: standard
-    repo: https://github.com/render-examples/mysql
+    image:
+      url: 'docker.io/library/mysql:8.4.9'
     disk:
       name: mysql
       mountPath: /var/lib/mysql


### PR DESCRIPTION
<!-- Keep this short. Delete sections that do not apply. -->

## What & why



## Checklist

- [ ] **OpenSpec updated for behavior changes.** If this PR changes observable behavior (a detection rule, the event
      wire schema, persistence semantics, an API/wire shape, or an emitted event), `openspec/specs/**` is updated (and
      an `openspec/changes/` proposal added), with a `spec:<id>` test marker for any new/renamed scenario. Only if this
      PR changes NO observable behavior (a comment / refactor / gofmt / dep bump that happens to touch a scoped path)
      may you assert `no-behavior-change` (label or `[no-behavior-change]` in the title) to clear the OpenSpec-sync gate.
      That is an assertion a reviewer will check, not a way to skip the spec for a real behavior change.
- [ ] Tests added/updated for the change (unit / integration / efficacy / UI as applicable).
- [ ] Agent/extension change touching ESF, XPC, or the event wire format: exercised on a live macOS VM before RC
      (flagged below).

## VM / RC notes (if applicable)


