### PR TITLE
detection: prune the processes table on the retention window (#360)

### DIFF
--- a/openspec/changes/add-processes-retention/proposal.md
+++ b/openspec/changes/add-processes-retention/proposal.md
@@ -1,0 +1,19 @@
+# Processes retention window
+
+## Why
+
+The retention runner only deletes from `events` (`EDR_RETENTION_DAYS`, default 30, hourly). The `processes` table has no retention or pruning whatsoever, so rows accumulate indefinitely (issue #360). The only process-side background job, the freshness-TTL reconciler, synthesizes a missing exit time for missed-exit rows; it never deletes. On 2026-06-13 a single dev host had accumulated 275K process rows across test sessions, and `GET /api/hosts/{host_id}/tree` tripped its 500ms slow-request warning at 1.1s because the "alive at any point in the window" predicate scanned ~158K index entries. On a long-lived pilot host the same unbounded growth would surface in production, and restore-from-backup makes it worse.
+
+## What changes
+
+- **Retention runner prunes completed processes.** The existing `RetentionRunner` gains a second batched DELETE, on the same cadence and `EDR_RETENTION_DAYS` cutoff as the event delete. No new config surface: pruning is on whenever event retention is on.
+- **Keyed on exit time, not fork time.** A record is prunable only once it has a recorded exit time older than the cutoff. A still-running record (no exit time, which includes the live snapshot working set) is therefore never deleted, and a long-running process that only recently exited is retained for the full window measured from its exit. This is strictly safer than a fork-time predicate (it can never delete a row that is part of a live process tree) and the issue's "preserve the live snapshot working set" guard holds by construction.
+- **Two-job composition.** Stale records whose exit event went missing are force-closed by the freshness-TTL reconciler (#6, default-on at 6h), which sets a synthesized exit time; they then become prunable here once that exit ages past the window. TTL marks dead, retention deletes old-dead.
+- **Alert FK guard.** `alerts.process_id` is `ON DELETE RESTRICT`, so the prune skips any process referenced by an alert (`NOT EXISTS`, index-backed by InnoDB's implicit FK index) and alert detail views keep resolving their originating process.
+- **Supporting index.** `idx_processes_exit_time (exit_time_ns)` turns the ordered range delete into a bounded range scan, mirroring `idx_events_timestamp` for the event delete.
+- **Observability.** A dedicated counter `edr.retention.processes.rows_deleted` (separate from the event-row counter) plus span attributes.
+
+### Not in this change
+
+- Bounding the `/tree` query's "alive-before-window" lookback (the secondary optimization called out in #360). The new index and the bounded table make it smaller; it can land separately.
+- Any new env var or per-host override; the prune reuses `EDR_RETENTION_DAYS`.

--- a/openspec/changes/add-processes-retention/specs/server-process-graph-builder/spec.md
+++ b/openspec/changes/add-processes-retention/specs/server-process-graph-builder/spec.md
@@ -1,0 +1,27 @@
+# Server process graph builder: processes retention delta
+
+## ADDED Requirements
+
+### Requirement: Completed process records are pruned after the retention window
+
+The system SHALL delete process records whose recorded exit time is older than the configured retention window, on the same cadence and cutoff as event retention, so the processes table does not grow without bound on long-lived hosts. The prune MUST key on the exit time, never on the fork time, so a still-running record (no exit time, which includes the live snapshot working set) is never deleted and a long-running process that only recently exited is retained for the full window measured from its exit. The prune MUST skip any process record still referenced by an alert so alert detail views continue to resolve their originating process. Records whose exit event went missing are first force-closed by the freshness-TTL reconciler and become eligible for this prune once their synthesized exit time ages past the window.
+
+#### Scenario: A completed record older than the window is pruned
+
+- **GIVEN** a process record with an exit timestamp older than the retention window
+- **AND** no alert references the record
+- **WHEN** a retention pass runs
+- **THEN** the record is deleted
+
+#### Scenario: A live record is never pruned
+
+- **GIVEN** a process record with no exit timestamp, whose fork timestamp is older than the retention window
+- **WHEN** a retention pass runs
+- **THEN** the record is NOT deleted
+
+#### Scenario: A completed record referenced by an alert is retained
+
+- **GIVEN** a process record with an exit timestamp older than the retention window
+- **AND** an alert references the record
+- **WHEN** a retention pass runs
+- **THEN** the record is NOT deleted

--- a/openspec/changes/add-processes-retention/tasks.md
+++ b/openspec/changes/add-processes-retention/tasks.md
@@ -1,0 +1,30 @@
+# Processes retention window: tasks
+
+## 1. Runner
+
+- [x] `retention.go`: add a batched processes DELETE to `Run` keyed on `exit_time_ns < cutoff`, completed rows only, with the `NOT EXISTS` alerts FK guard; factor a `pruneBatched` helper shared with the event delete.
+- [x] `retention.go`: update the `RetentionRunner` doc comment to describe both row families and the exit-time-not-fork-time rationale.
+
+## 2. Schema
+
+- [x] Migration `00002_processes_retention_index.sql`: `idx_processes_exit_time (exit_time_ns)` (goose up/down).
+
+## 3. Observability
+
+- [x] `detection/api` `MetricsRecorder`: add `ProcessRetentionRowsDeleted`.
+- [x] `metrics.go`: `edr.retention.processes.rows_deleted` counter + method.
+- [x] `retention.go`: emit the new metric + `edr.retention.processes.rows_deleted` span attribute.
+
+## 4. Spec
+
+- [x] `server-process-graph-builder` spec: ADDED requirement "Completed process records are pruned after the retention window" with three scenarios.
+
+## 5. Tests
+
+- [x] Integration test (`TestRetention_PrunesCompletedProcesses`, real MySQL): old-completed pruned; recent-completed, live-snapshot, live-non-snapshot, and alert-referenced all retained; metric counts one. Scenario markers on the test.
+
+## 6. Verification
+
+- [ ] `go build ./server/...`; `go test -tags integration ./server/detection/internal/tests/...` green.
+- [ ] `go test ./server/metrics/...` green.
+- [ ] gofmt, golangci-lint, spectrace, markdown + dash lints, `openspec validate add-processes-retention`.

--- a/openspec/specs/server-process-graph-builder/spec.md
+++ b/openspec/specs/server-process-graph-builder/spec.md
@@ -155,6 +155,30 @@ The system SHALL periodically force-close process records whose freshness window
 - **THEN** the record is force-closed with the TTL-reconciliation exit reason
 - **AND** the synthesized exit timestamp lands at the fork timestamp plus the TTL window
 
+### Requirement: Completed process records are pruned after the retention window
+
+The system SHALL delete process records whose recorded exit time is older than the configured retention window, on the same cadence and cutoff as event retention, so the processes table does not grow without bound on long-lived hosts. The prune MUST key on the exit time, never on the fork time, so a still-running record (no exit time, which includes the live snapshot working set) is never deleted and a long-running process that only recently exited is retained for the full window measured from its exit. The prune MUST skip any process record still referenced by an alert so alert detail views continue to resolve their originating process. Records whose exit event went missing are first force-closed by the freshness-TTL reconciler and become eligible for this prune once their synthesized exit time ages past the window.
+
+#### Scenario: A completed record older than the window is pruned
+
+- **GIVEN** a process record with an exit timestamp older than the retention window
+- **AND** no alert references the record
+- **WHEN** a retention pass runs
+- **THEN** the record is deleted
+
+#### Scenario: A live record is never pruned
+
+- **GIVEN** a process record with no exit timestamp, whose fork timestamp is older than the retention window
+- **WHEN** a retention pass runs
+- **THEN** the record is NOT deleted
+
+#### Scenario: A completed record referenced by an alert is retained
+
+- **GIVEN** a process record with an exit timestamp older than the retention window
+- **AND** an alert references the record
+- **WHEN** a retention pass runs
+- **THEN** the record is NOT deleted
+
 ### Requirement: Exit-before-snapshot-exec race buffer
 
 The system SHALL handle the race in which a kernel-observed `exit` event for a PID is processed BEFORE the snapshot `exec` event for the same PID is processed. Because the snapshot exec arrives last but describes an earlier moment, the exit's update would otherwise find no row and the later snapshot exec would synthesize a phantom alive row that survives until TTL. The builder MUST buffer such unmatched exits briefly and consume them when the companion snapshot exec arrives, producing a single record that is born already-exited.

--- a/server/detection/api/service.go
+++ b/server/detection/api/service.go
@@ -79,6 +79,9 @@ type MetricsRecorder interface {
 	// stale-process janitor on every reconciliation pass.
 	ProcessesTTLReconciled(ctx context.Context, n int64)
 	// RetentionRowsDeleted is called by the pipeline's retention
-	// runner on every retention pass.
+	// runner on every retention pass, reporting event rows deleted.
 	RetentionRowsDeleted(ctx context.Context, n int64)
+	// ProcessRetentionRowsDeleted is called by the pipeline's retention runner on every pass with the count of completed process rows
+	// pruned past the retention window (counted separately from event rows).
+	ProcessRetentionRowsDeleted(ctx context.Context, n int64)
 }

--- a/server/detection/internal/pipeline/retention.go
+++ b/server/detection/internal/pipeline/retention.go
@@ -127,7 +127,10 @@ func (r *RetentionRunner) Run(ctx context.Context) (int64, error) {
 		attribute.Int64("edr.retention.cutoff_ns", cutoff),
 	)
 
-	events, err := r.pruneBatched(ctx, `
+	// Emit each delete's count as soon as that delete returns, before checking its error. pruneBatched reports rows actually deleted even
+	// on a mid-batch failure, and a failure in the second (processes) delete must not suppress the telemetry for the first (events) one,
+	// else a partial-failure run reports zero events pruned when rows were in fact removed.
+	events, eventsErr := r.pruneBatched(ctx, `
 		DELETE FROM events
 		WHERE timestamp_ns < ?
 		  AND NOT EXISTS (
@@ -136,14 +139,18 @@ func (r *RetentionRunner) Run(ctx context.Context) (int64, error) {
 		ORDER BY timestamp_ns
 		LIMIT ?
 	`, cutoff)
-	if err != nil {
-		return events, fmt.Errorf("retention delete events batch: %w", err)
+	span.SetAttributes(attribute.Int64("edr.retention.rows_deleted", events))
+	if r.metrics != nil {
+		r.metrics.RetentionRowsDeleted(ctx, events)
+	}
+	if eventsErr != nil {
+		return events, fmt.Errorf("retention delete events batch: %w", eventsErr)
 	}
 
 	// Completed processes only (exit_time_ns IS NOT NULL): see the type doc for why NULL-exit rows are intentionally left to the
 	// freshness-TTL reconciler. The alerts.process_id FK is ON DELETE RESTRICT, so an alert-referenced row must be skipped or the
 	// batch DELETE errors; the NOT EXISTS guard does that and is index-backed by InnoDB's implicit FK index on alerts.process_id.
-	processes, err := r.pruneBatched(ctx, `
+	processes, procErr := r.pruneBatched(ctx, `
 		DELETE FROM processes
 		WHERE exit_time_ns IS NOT NULL
 		  AND exit_time_ns < ?
@@ -153,18 +160,14 @@ func (r *RetentionRunner) Run(ctx context.Context) (int64, error) {
 		ORDER BY exit_time_ns
 		LIMIT ?
 	`, cutoff)
-	if err != nil {
-		return events + processes, fmt.Errorf("retention delete processes batch: %w", err)
-	}
-
-	span.SetAttributes(
-		attribute.Int64("edr.retention.rows_deleted", events),
-		attribute.Int64("edr.retention.processes.rows_deleted", processes),
-	)
+	span.SetAttributes(attribute.Int64("edr.retention.processes.rows_deleted", processes))
 	if r.metrics != nil {
-		r.metrics.RetentionRowsDeleted(ctx, events)
 		r.metrics.ProcessRetentionRowsDeleted(ctx, processes)
 	}
+	if procErr != nil {
+		return events + processes, fmt.Errorf("retention delete processes batch: %w", procErr)
+	}
+
 	r.logger.InfoContext(ctx, "retention run",
 		attrRetentionDays, r.retentionDays,
 		"edr.retention.cutoff_ns", cutoff,

--- a/server/detection/internal/pipeline/retention.go
+++ b/server/detection/internal/pipeline/retention.go
@@ -37,8 +37,16 @@ type RetentionOptions struct {
 
 const attrRetentionDays = "edr.retention.days"
 
-// RetentionRunner executes retention passes on a cadence. Deletes rows from `events` older than RetentionDays, preserving any event
-// referenced by an alert_events row so alert detail views still render. Per-batch DELETE bounds InnoDB row-lock footprint.
+// RetentionRunner executes retention passes on a cadence. Each pass deletes two row families older than RetentionDays, each preserving
+// rows still referenced by an alert so alert detail views keep rendering:
+//   - `events` older than the cutoff (by timestamp_ns), skipping any event referenced by an alert_events row.
+//   - completed `processes` whose exit_time_ns is older than the cutoff, skipping any process referenced by an alerts.process_id row.
+//
+// The process prune keys on exit_time_ns, never fork_time_ns: a still-running record (exit_time_ns IS NULL, which includes the live
+// snapshot working set) is therefore never deleted, and a long-running process that only recently exited is retained for the full
+// window measured from its exit. Stale records whose exit event went missing are first force-closed by the freshness-TTL reconciler
+// (ProcessTTLRunner, issue #6) and become prunable here once their synthesized exit ages past the window; that two-job split is why this
+// prune can safely ignore NULL-exit rows. Per-batch DELETE bounds InnoDB row-lock footprint.
 type RetentionRunner struct {
 	db            retentionDeleter
 	retentionDays int
@@ -107,7 +115,7 @@ func (r *RetentionRunner) Loop(ctx context.Context) {
 	}
 }
 
-// Run executes one retention pass and returns total rows deleted.
+// Run executes one retention pass and returns total rows deleted across events + processes.
 func (r *RetentionRunner) Run(ctx context.Context) (int64, error) {
 	if r.retentionDays == 0 {
 		return 0, nil
@@ -119,19 +127,63 @@ func (r *RetentionRunner) Run(ctx context.Context) (int64, error) {
 		attribute.Int64("edr.retention.cutoff_ns", cutoff),
 	)
 
+	events, err := r.pruneBatched(ctx, `
+		DELETE FROM events
+		WHERE timestamp_ns < ?
+		  AND NOT EXISTS (
+		      SELECT 1 FROM alert_events ae WHERE ae.event_id = events.event_id
+		  )
+		ORDER BY timestamp_ns
+		LIMIT ?
+	`, cutoff)
+	if err != nil {
+		return events, fmt.Errorf("retention delete events batch: %w", err)
+	}
+
+	// Completed processes only (exit_time_ns IS NOT NULL): see the type doc for why NULL-exit rows are intentionally left to the
+	// freshness-TTL reconciler. The alerts.process_id FK is ON DELETE RESTRICT, so an alert-referenced row must be skipped or the
+	// batch DELETE errors; the NOT EXISTS guard does that and is index-backed by InnoDB's implicit FK index on alerts.process_id.
+	processes, err := r.pruneBatched(ctx, `
+		DELETE FROM processes
+		WHERE exit_time_ns IS NOT NULL
+		  AND exit_time_ns < ?
+		  AND NOT EXISTS (
+		      SELECT 1 FROM alerts a WHERE a.process_id = processes.id
+		  )
+		ORDER BY exit_time_ns
+		LIMIT ?
+	`, cutoff)
+	if err != nil {
+		return events + processes, fmt.Errorf("retention delete processes batch: %w", err)
+	}
+
+	span.SetAttributes(
+		attribute.Int64("edr.retention.rows_deleted", events),
+		attribute.Int64("edr.retention.processes.rows_deleted", processes),
+	)
+	if r.metrics != nil {
+		r.metrics.RetentionRowsDeleted(ctx, events)
+		r.metrics.ProcessRetentionRowsDeleted(ctx, processes)
+	}
+	r.logger.InfoContext(ctx, "retention run",
+		attrRetentionDays, r.retentionDays,
+		"edr.retention.cutoff_ns", cutoff,
+		"edr.retention.rows_deleted", events,
+		"edr.retention.processes.rows_deleted", processes,
+	)
+	return events + processes, nil
+}
+
+// pruneBatched runs a batched DELETE until a batch removes fewer than batchSize rows, returning the total deleted. query MUST end in a
+// `LIMIT ?` bind; pruneBatched appends batchSize as that final arg (constant across batches, so the args slice is built once). Per-batch
+// LIMIT bounds the InnoDB row-lock and undo-log footprint of a single statement on a large backlog.
+func (r *RetentionRunner) pruneBatched(ctx context.Context, query string, args ...any) (int64, error) {
+	args = append(args, r.batchSize)
 	var total int64
 	for {
-		res, err := r.db.ExecContext(ctx, `
-			DELETE FROM events
-			WHERE timestamp_ns < ?
-			  AND NOT EXISTS (
-			      SELECT 1 FROM alert_events ae WHERE ae.event_id = events.event_id
-			  )
-			ORDER BY timestamp_ns
-			LIMIT ?
-		`, cutoff, r.batchSize)
+		res, err := r.db.ExecContext(ctx, query, args...)
 		if err != nil {
-			return total, fmt.Errorf("retention delete batch: %w", err)
+			return total, err
 		}
 		n, err := res.RowsAffected()
 		if err != nil {
@@ -139,18 +191,7 @@ func (r *RetentionRunner) Run(ctx context.Context) (int64, error) {
 		}
 		total += n
 		if n < int64(r.batchSize) {
-			break
+			return total, nil
 		}
 	}
-
-	span.SetAttributes(attribute.Int64("edr.retention.rows_deleted", total))
-	if r.metrics != nil {
-		r.metrics.RetentionRowsDeleted(ctx, total)
-	}
-	r.logger.InfoContext(ctx, "retention run",
-		attrRetentionDays, r.retentionDays,
-		"edr.retention.cutoff_ns", cutoff,
-		"edr.retention.rows_deleted", total,
-	)
-	return total, nil
 }

--- a/server/detection/internal/tests/integration_test.go
+++ b/server/detection/internal/tests/integration_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/fleetdm/edr/server/detection/api"
 	"github.com/fleetdm/edr/server/detection/bootstrap"
 	"github.com/fleetdm/edr/server/detection/internal/intake"
+	"github.com/fleetdm/edr/server/detection/internal/pipeline"
 	endpointapi "github.com/fleetdm/edr/server/endpoint/api"
 	identityapi "github.com/fleetdm/edr/server/identity/api"
 	rulesapi "github.com/fleetdm/edr/server/rules/api"
@@ -237,6 +238,7 @@ type recordingMetrics struct {
 	alertsCreated       int
 	processesReconciled int64
 	rowsDeleted         int64
+	processRowsDeleted  int64
 }
 
 func (m *recordingMetrics) EventsIngested(_ context.Context, _ string, n int) {
@@ -258,6 +260,11 @@ func (m *recordingMetrics) RetentionRowsDeleted(_ context.Context, n int64) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.rowsDeleted += n
+}
+func (m *recordingMetrics) ProcessRetentionRowsDeleted(_ context.Context, n int64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.processRowsDeleted += n
 }
 
 func (m *recordingMetrics) snapshot() (events, alerts int, reconciled, deleted int64) {
@@ -1372,6 +1379,77 @@ func TestBootstrap_FullModeRunsAllGoroutines(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("Run did not return after ctx cancel")
 	}
+}
+
+// spec:server-process-graph-builder/completed-process-records-are-pruned-after-the-retention-window/a-completed-record-older-than-the-window-is-pruned
+// spec:server-process-graph-builder/completed-process-records-are-pruned-after-the-retention-window/a-live-record-is-never-pruned
+// spec:server-process-graph-builder/completed-process-records-are-pruned-after-the-retention-window/a-completed-record-referenced-by-an-alert-is-retained
+//
+// Exercises the processes prune added to the retention runner (issue #360) end to end against real MySQL: only a completed,
+// alert-free, past-cutoff row is deleted; live rows (NULL exit, snapshot or not) and an alert-referenced completed row survive.
+func TestRetention_PrunesCompletedProcesses(t *testing.T) {
+	t.Parallel()
+	db := full.Open(t)
+	ctx := t.Context()
+
+	const dayNs = int64(24 * time.Hour)
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	nowNs := now.UnixNano()
+
+	// insertProc returns the new row id. exitNs <= 0 means a live (NULL exit_time_ns) row.
+	insertProc := func(forkNs, exitNs int64, snapshot bool) int64 {
+		t.Helper()
+		var exit any
+		if exitNs > 0 {
+			exit = exitNs
+		}
+		res, err := db.ExecContext(ctx, `
+			INSERT INTO processes (host_id, pid, ppid, path, fork_time_ns, exit_time_ns, is_snapshot)
+			VALUES ('host-ret', 0, 0, '/bin/x', ?, ?, ?)`,
+			forkNs, exit, snapshot)
+		require.NoError(t, err)
+		id, err := res.LastInsertId()
+		require.NoError(t, err)
+		return id
+	}
+
+	oldCompleted := insertProc(nowNs-40*dayNs, nowNs-31*dayNs, false)  // exited before cutoff -> prune
+	recentCompleted := insertProc(nowNs-2*dayNs, nowNs-1*dayNs, false) // exited after cutoff -> keep
+	oldLiveSnapshot := insertProc(nowNs-40*dayNs, 0, true)             // live snapshot baseline -> keep
+	oldLiveOrphan := insertProc(nowNs-40*dayNs, 0, false)              // live non-snapshot (NULL exit) -> keep
+	oldAlerted := insertProc(nowNs-40*dayNs, nowNs-31*dayNs, false)    // past cutoff but alert-referenced -> keep
+
+	// Reference oldAlerted from an alert so the FK guard (ON DELETE RESTRICT) must skip it.
+	_, err := db.ExecContext(ctx, `
+		INSERT INTO alerts (host_id, rule_id, severity, title, description, subject, process_id)
+		VALUES ('host-ret', 'r1', 'low', 't', 'd', ?, ?)`,
+		strconv.FormatInt(oldAlerted, 10), oldAlerted)
+	require.NoError(t, err)
+
+	rec := &recordingMetrics{}
+	runner := pipeline.NewRetention(db, pipeline.RetentionOptions{
+		RetentionDays: 30,
+		Metrics:       rec,
+		Now:           func() time.Time { return now },
+	})
+	deleted, err := runner.Run(ctx)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), deleted, "only the old completed alert-free process is pruned")
+
+	exists := func(id int64) bool {
+		var n int
+		require.NoError(t, db.QueryRowContext(ctx, `SELECT COUNT(*) FROM processes WHERE id = ?`, id).Scan(&n))
+		return n == 1
+	}
+	assert.False(t, exists(oldCompleted), "completed process older than the window is pruned")
+	assert.True(t, exists(recentCompleted), "completed process inside the window is kept")
+	assert.True(t, exists(oldLiveSnapshot), "live snapshot working-set row is never pruned")
+	assert.True(t, exists(oldLiveOrphan), "live (NULL-exit) non-snapshot row is never pruned")
+	assert.True(t, exists(oldAlerted), "alert-referenced process is retained (FK guard)")
+
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+	assert.Equal(t, int64(1), rec.processRowsDeleted, "process-prune metric counts the single deleted row")
 }
 
 func TestBootstrap_IntakeModeIsNoOp(t *testing.T) {

--- a/server/detection/migrations/00002_processes_retention_index.sql
+++ b/server/detection/migrations/00002_processes_retention_index.sql
@@ -1,0 +1,16 @@
+-- +goose Up
+-- Index backing the processes retention prune (issue #360). The retention runner deletes completed process rows whose exit_time_ns is
+-- older than the retention cutoff:
+--   DELETE FROM processes WHERE exit_time_ns IS NOT NULL AND exit_time_ns < ? AND NOT EXISTS (...) ORDER BY exit_time_ns LIMIT ?
+-- Without this index that ordered range delete is a full scan plus filesort of the processes table on every batch. The index turns it
+-- into a bounded range scan, mirroring idx_events_timestamp for the event retention delete. Live rows carry exit_time_ns IS NULL, which
+-- a B-tree index groups at one end, so the prune's range scan also skips the live working set cheaply.
+
+-- +goose StatementBegin
+CREATE INDEX idx_processes_exit_time ON processes (exit_time_ns);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP INDEX idx_processes_exit_time ON processes;
+-- +goose StatementEnd

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -51,12 +51,13 @@ type GaugeSource interface {
 // Recorder is the write surface instrumentation code uses. Every method is safe to call from any goroutine and safe on a nil receiver
 // (methods short-circuit) so call sites don't need defensive `if r != nil` blocks.
 type Recorder struct {
-	eventsIngested       metric.Int64Counter
-	alertsCreated        metric.Int64Counter
-	retentionRowsDeleted metric.Int64Counter
-	processesReconciled  metric.Int64Counter
-	queueDropped         metric.Int64Counter
-	httpRequestDuration  metric.Float64Histogram
+	eventsIngested              metric.Int64Counter
+	alertsCreated               metric.Int64Counter
+	retentionRowsDeleted        metric.Int64Counter
+	processRetentionRowsDeleted metric.Int64Counter
+	processesReconciled         metric.Int64Counter
+	queueDropped                metric.Int64Counter
+	httpRequestDuration         metric.Float64Histogram
 	// observable gauges retained only so the GC can't collect them; the callbacks run
 	// against the global meter provider.
 	enrolledGauge metric.Int64ObservableGauge
@@ -103,6 +104,11 @@ func New(gauges GaugeSource, opts Options) *Recorder {
 	r.retentionRowsDeleted, _ = meter.Int64Counter(
 		"edr.retention.rows_deleted",
 		metric.WithDescription("Total rows deleted by the event retention job since server start."),
+		metric.WithUnit("{row}"),
+	)
+	r.processRetentionRowsDeleted, _ = meter.Int64Counter(
+		"edr.retention.processes.rows_deleted",
+		metric.WithDescription("Total completed process rows deleted by the retention job since server start."),
 		metric.WithUnit("{row}"),
 	)
 	r.processesReconciled, _ = meter.Int64Counter(
@@ -212,6 +218,15 @@ func (r *Recorder) RetentionRowsDeleted(ctx context.Context, n int64) {
 		return
 	}
 	r.retentionRowsDeleted.Add(ctx, n)
+}
+
+// ProcessRetentionRowsDeleted satisfies api.MetricsRecorder. Counts completed process rows pruned past the retention window, kept
+// separate from RetentionRowsDeleted (event rows) so operators can see process-table churn distinctly.
+func (r *Recorder) ProcessRetentionRowsDeleted(ctx context.Context, n int64) {
+	if r == nil || r.processRetentionRowsDeleted == nil || n <= 0 {
+		return
+	}
+	r.processRetentionRowsDeleted.Add(ctx, n)
 }
 
 // ProcessesTTLReconciled satisfies processttl.MetricsRecorder. A non-zero rate of this indicates the fleet is losing exit events

--- a/server/metrics/metrics_test.go
+++ b/server/metrics/metrics_test.go
@@ -131,6 +131,7 @@ func TestRecorder_RecordsCounters(t *testing.T) {
 	r.EventsIngested(ctx, "host-b", 2)
 	r.AlertCreated(ctx, "dyld_insert", "high")
 	r.RetentionRowsDeleted(ctx, 42)
+	r.ProcessRetentionRowsDeleted(ctx, 7)
 	r.QueueDropped(ctx, 3, false)
 	r.QueueDropped(ctx, 5, true)
 
@@ -140,6 +141,7 @@ func TestRecorder_RecordsCounters(t *testing.T) {
 	assert.Equal(t, int64(2), findSum(t, rm, "edr.events.ingested", map[string]any{"host_id": "host-b"}))
 	assert.Equal(t, int64(1), findSum(t, rm, "edr.alerts.created", map[string]any{"rule_id": "dyld_insert", "severity": "high"}))
 	assert.Equal(t, int64(42), findSum(t, rm, "edr.retention.rows_deleted", nil))
+	assert.Equal(t, int64(7), findSum(t, rm, "edr.retention.processes.rows_deleted", nil))
 	assert.Equal(t, int64(3), findSum(t, rm, "edr.agent.queue.dropped", map[string]any{"lossy": false}))
 	assert.Equal(t, int64(5), findSum(t, rm, "edr.agent.queue.dropped", map[string]any{"lossy": true}))
 	assert.Equal(t, int64(3), findGauge(t, rm, "edr.enrolled.hosts"))
@@ -185,6 +187,7 @@ func TestNilRecorder_AllMethodsSafe(t *testing.T) {
 		r.EventsIngested(ctx, "h", 1)
 		r.AlertCreated(ctx, "r", "s")
 		r.RetentionRowsDeleted(ctx, 1)
+		r.ProcessRetentionRowsDeleted(ctx, 1)
 		r.QueueDropped(ctx, 1, false)
 		r.QueueDropped(ctx, 1, true)
 	})


### PR DESCRIPTION
The retention runner only deleted from events; the processes table had no retention and grew without bound (275K rows on one dev host tripped the /tree slow-request warning at 1.1s). Extend RetentionRunner to also delete completed process rows on the same EDR_RETENTION_DAYS cadence and cutoff.

The prune keys on exit_time_ns, never fork_time_ns: a still-running record (NULL exit, including the live snapshot working set) is never deleted, and a long-running process that only recently exited is retained for the full window measured from its exit. Stale missed-exit rows are force-closed by the freshness-TTL reconciler (#6, default-on) and swept here once their synthesized exit ages past the window: TTL marks dead, retention deletes old-dead. The alerts.process_id FK is ON DELETE RESTRICT, so the batch DELETE skips alert-referenced rows via NOT EXISTS.

- retention.go: batched processes DELETE, shared pruneBatched helper.
- migration 00002: idx_processes_exit_time backing the ordered range delete.
- metrics: dedicated edr.retention.processes.rows_deleted counter.
- spec: server-process-graph-builder requirement + 3 scenarios; openspec change proposal add-processes-retention.
- integration test asserts prune/keep across completed, live (snapshot and non-snapshot), and alert-referenced rows.

<!-- Keep this short. Delete sections that do not apply. -->

## What & why



## Checklist

- [ ] **OpenSpec updated for behavior changes.** If this PR changes observable behavior (a detection rule, the event
      wire schema, persistence semantics, an API/wire shape, or an emitted event), `openspec/specs/**` is updated (and
      an `openspec/changes/` proposal added), with a `spec:<id>` test marker for any new/renamed scenario. Only if this
      PR changes NO observable behavior (a comment / refactor / gofmt / dep bump that happens to touch a scoped path)
      may you assert `no-behavior-change` (label or `[no-behavior-change]` in the title) to clear the OpenSpec-sync gate.
      That is an assertion a reviewer will check, not a way to skip the spec for a real behavior change.
- [ ] Tests added/updated for the change (unit / integration / efficacy / UI as applicable).
- [ ] Agent/extension change touching ESF, XPC, or the event wire format: exercised on a live macOS VM before RC
      (flagged below).

## VM / RC notes (if applicable)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Automated cleanup of old completed processes is now enabled, using the same retention window as event retention (EDR_RETENTION_DAYS).
  * Active processes and those referenced by alerts are automatically protected from deletion.
  * New observability metric added to monitor process retention activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->