### PR TITLE
docs(deploy): tighten install-server, mdm, and manual-agent guides

### DIFF
--- a/docs/install-agent-manual.md
+++ b/docs/install-agent-manual.md
@@ -35,7 +35,7 @@ Expect: `fleet-edr-v0.1.0.pkg: OK`.
 
 ## Step 2: verify the signature
 
-Before you run an installer you didn't build, confirm Gatekeeper trusts it. These checks pass without any developer tools installed; they use binaries shipped in the base macOS image.
+Before you run an installer you didn't build, confirm Gatekeeper trusts it. These checks need no developer tools; they use binaries in the base macOS image.
 
 ```sh
 # Signed by us + notarized by Apple

--- a/docs/install-agent-manual.md
+++ b/docs/install-agent-manual.md
@@ -57,7 +57,7 @@ If any of these fail, STOP. Don't install. File an issue at https://github.com/g
 
 ### Optional: verify the Sigstore signature
 
-Releases that ship Sigstore signatures also publish a `<file>.sig` and `<file>.pem` next to every artifact. The signature ties the artifact to the exact GitHub Actions workflow run that produced it, which catches the rare attack where a Developer ID cert is stolen but the attacker can't push to our GitHub repo. Skip this step if you don't have `cosign` installed; the Apple-signature checks above are sufficient for most pilots. (Older releases that pre-date the cosign roll-out won't have the `.sig` / `.pem` files: `curl` will return 404, and there's nothing to verify.)
+Releases that ship Sigstore signatures also publish a `<file>.sig` and `<file>.pem` next to every artifact. The signature ties the artifact to the exact GitHub Actions workflow run that produced it, which catches the rare attack where a Developer ID cert is stolen but the attacker can't push to our GitHub repo. Skip this step if you don't have `cosign` installed; the Apple-signature checks above are sufficient for most pilots.
 
 The example below uses the same `v0.1.1` placeholder as Step 1 above; substitute whatever release tag you actually downloaded.
 

--- a/docs/install-agent-manual.md
+++ b/docs/install-agent-manual.md
@@ -150,7 +150,7 @@ systemextensionsctl list | grep fleetdm
 #   ... com.fleetdm.edr.networkextension  ... [activated enabled]
 ```
 
-Until both extensions are activated, the agent runs but sees no events. The agent log repeats `receiver connect` warnings while it waits for the extensions' XPC service to come up. That's expected (if the warnings persist after activation, see Step 6).
+Each extension feeds its own receiver loop, so until a given extension is activated the agent simply misses that extension's events; a partially-approved install is partial coverage, not a full outage. The agent logs a `receiver connect` warning per unavailable service, and the `service` field says which one: `FDG8Q7N4CC.com.fleetdm.edr.securityextension.xpc` is the Endpoint Security extension (process and file events), `group.com.fleetdm.edr.networkextension` is the Network Extension (network and DNS events). That's expected before activation. A warning for the Endpoint Security service that persists after activation is the Full Disk Access boot-loop in Step 6; a persistent Network Extension warning means that extension still needs approval in Step 5.
 
 ## Step 6: grant Full Disk Access
 

--- a/docs/install-agent-manual.md
+++ b/docs/install-agent-manual.md
@@ -97,7 +97,7 @@ EOF
 sudo chmod 0600 /etc/fleet-edr.conf
 ```
 
-Replace `https://edr.example.com` with your server URL and `paste-the-enroll-secret-here` with the value from the server's `./secrets/enroll_secret` file.
+Replace `https://edr.example.com` with your server URL and `paste-the-enroll-secret-here` with the value from the server's `./secrets/enroll_secret` file or `EDR_ENROLL_SECRET` env var.
 
 ## Step 4: install the pkg
 
@@ -127,24 +127,30 @@ What the installer laid down:
 
 The postinstall script loads the LaunchDaemon. The agent starts immediately, reads `/etc/fleet-edr.conf`, enrolls with the server, and begins polling for commands.
 
-## Step 5: approve the system extension
+## Step 5: approve the system extensions
 
-The pkg's activation LaunchAgent (`com.fleetdm.edr.activate`) runs the host app's `activate` right after install (and again at every login), but on a Mac that isn't MDM-managed the activation still requires a human click. macOS shows a "System Extension Blocked" notification when the host app tries to activate it.
+Fleet EDR ships two system extensions: an Endpoint Security extension (`com.fleetdm.edr.securityextension`, process and file events) and a Network Extension (`com.fleetdm.edr.networkextension`, network and DNS events). The pkg's activation LaunchAgent (`com.fleetdm.edr.activate`) runs the host app's `activate` right after install (and again at every login), but on a Mac that isn't MDM-managed each extension needs a human to approve it. macOS posts a notification when the host app requests activation.
 
-1. Open **System Settings > Privacy & Security**.
-2. Scroll to "Security". You'll see _"System extension blocked. Click to allow"_ or a similar message.
-3. Click **Allow**. Authenticate with your user password.
-4. The sysext enters `activated waiting for user` → `activated enabled`.
+On macOS 15 (Sequoia) and later:
+
+1. Open **System Settings > General > Login Items & Extensions**.
+2. Under **Extensions**, open **Endpoint Security Extensions**, enable **Fleet EDR**, and authenticate with your user password.
+3. Open **Network Extensions** and enable **Fleet EDR** the same way. macOS also prompts to allow it to filter network content; click **Allow**.
+
+On macOS 13 and 14 (Ventura and Sonoma), the controls live under **System Settings > Privacy & Security > Security** instead: click **Allow** on the _"System extension blocked"_ message for each extension and authenticate.
+
+Each extension moves `activated waiting for user` → `activated enabled`.
 
 Verify:
 
 ```sh
-systemextensionsctl list
-# Expect a row showing:
-#   * * FDG8Q7N4CC com.fleetdm.edr.securityextension (x.y.z) Fleet EDR Security Extension [activated enabled]
+systemextensionsctl list | grep fleetdm
+# Expect two rows, both ending [activated enabled]:
+#   ... com.fleetdm.edr.securityextension ... [activated enabled]
+#   ... com.fleetdm.edr.networkextension  ... [activated enabled]
 ```
 
-Until the sysext is activated, the agent runs but sees no ES events. The agent log repeats `receiver reconnecting ...` while it waits for the sysext's XPC service to come up. That's expected.
+Until both extensions are activated, the agent runs but sees no events. The agent log repeats `receiver reconnecting ...` while it waits for the extensions' XPC service to come up. That's expected.
 
 ## Step 6: grant Full Disk Access
 

--- a/docs/install-agent-manual.md
+++ b/docs/install-agent-manual.md
@@ -17,21 +17,21 @@ For production deployments of more than a handful of Macs, use [mdm-deployment.m
 
 ## Step 1: download the pkg
 
-Pick a release from https://github.com/getvictor/fleet-edr/releases and download the `.pkg` to the target Mac. Example for v0.1.0:
+Pick a release from https://github.com/getvictor/fleet-edr/releases and download the `.pkg` to the target Mac. Example for v0.1.1:
 
 ```sh
 cd ~/Downloads
-curl -fLO https://github.com/getvictor/fleet-edr/releases/download/v0.1.0/fleet-edr-v0.1.0.pkg
+curl -fLO https://github.com/getvictor/fleet-edr/releases/download/v0.1.1/fleet-edr-v0.1.1.pkg
 ```
 
 Verify the download against the published SHA256SUMS:
 
 ```sh
-curl -fLO https://github.com/getvictor/fleet-edr/releases/download/v0.1.0/SHA256SUMS
+curl -fLO https://github.com/getvictor/fleet-edr/releases/download/v0.1.1/SHA256SUMS
 shasum -a 256 -c SHA256SUMS --ignore-missing
 ```
 
-Expect: `fleet-edr-v0.1.0.pkg: OK`.
+Expect: `fleet-edr-v0.1.1.pkg: OK`.
 
 ## Step 2: verify the signature
 
@@ -39,17 +39,17 @@ Before you run an installer you didn't build, confirm Gatekeeper trusts it. Thes
 
 ```sh
 # Signed by us + notarized by Apple
-pkgutil --check-signature fleet-edr-v0.1.0.pkg
+pkgutil --check-signature fleet-edr-v0.1.1.pkg
 # Expect:
 #   Status: signed by a developer certificate issued by Apple for distribution
 #   Notarization: trusted by the Apple notary service
 
 # Stapled ticket embedded (works offline)
-xcrun stapler validate fleet-edr-v0.1.0.pkg
+xcrun stapler validate fleet-edr-v0.1.1.pkg
 # Expect: "The validate action worked!"
 
 # Gatekeeper's install assessment
-spctl -a -v --type install fleet-edr-v0.1.0.pkg
+spctl -a -v --type install fleet-edr-v0.1.1.pkg
 # Expect: "accepted / source=Notarized Developer ID"
 ```
 
@@ -59,23 +59,23 @@ If any of these fail, STOP. Don't install. File an issue at https://github.com/g
 
 Releases that ship Sigstore signatures also publish a `<file>.sig` and `<file>.pem` next to every artifact. The signature ties the artifact to the exact GitHub Actions workflow run that produced it, which catches the rare attack where a Developer ID cert is stolen but the attacker can't push to our GitHub repo. Skip this step if you don't have `cosign` installed; the Apple-signature checks above are sufficient for most pilots. (Older releases that pre-date the cosign roll-out won't have the `.sig` / `.pem` files: `curl` will return 404, and there's nothing to verify.)
 
-The example below uses the same `v0.1.0` placeholder as Step 1 above; substitute whatever release tag you actually downloaded.
+The example below uses the same `v0.1.1` placeholder as Step 1 above; substitute whatever release tag you actually downloaded.
 
 ```sh
 # Install cosign if you don't have it: brew install cosign
-curl -fLO https://github.com/getvictor/fleet-edr/releases/download/v0.1.0/fleet-edr-v0.1.0.pkg.sig
-curl -fLO https://github.com/getvictor/fleet-edr/releases/download/v0.1.0/fleet-edr-v0.1.0.pkg.pem
+curl -fLO https://github.com/getvictor/fleet-edr/releases/download/v0.1.1/fleet-edr-v0.1.1.pkg.sig
+curl -fLO https://github.com/getvictor/fleet-edr/releases/download/v0.1.1/fleet-edr-v0.1.1.pkg.pem
 
 cosign verify-blob \
-    --certificate fleet-edr-v0.1.0.pkg.pem \
-    --signature fleet-edr-v0.1.0.pkg.sig \
+    --certificate fleet-edr-v0.1.1.pkg.pem \
+    --signature fleet-edr-v0.1.1.pkg.sig \
     --certificate-identity-regexp '^https://github\.com/getvictor/fleet-edr/\.github/workflows/release\.yml@refs/tags/v' \
     --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
-    fleet-edr-v0.1.0.pkg
+    fleet-edr-v0.1.1.pkg
 # Expect: "Verified OK"
 ```
 
-The same pattern (`<file>.sig` + `<file>.pem`) covers `SHA256SUMS` and both `.mobileconfig` profiles. If you're verifying the server image instead, use `cosign verify ghcr.io/getvictor/fleet-edr-server:v0.1.0` with the same identity / issuer flags.
+The same pattern (`<file>.sig` + `<file>.pem`) covers `SHA256SUMS` and both `.mobileconfig` profiles. If you're verifying the server image instead, use `cosign verify ghcr.io/getvictor/fleet-edr-server:v0.1.1` with the same identity / issuer flags.
 
 ## Step 3: write the config file
 
@@ -100,7 +100,7 @@ Replace `https://edr.example.com` with your server URL and `paste-the-enroll-sec
 ## Step 4: install the pkg
 
 ```sh
-sudo installer -pkg ~/Downloads/fleet-edr-v0.1.0.pkg -target /
+sudo installer -pkg ~/Downloads/fleet-edr-v0.1.1.pkg -target /
 ```
 
 Expect:
@@ -182,7 +182,7 @@ In the admin UI (https://edr.example.com/ui/):
 Download the newer `.pkg` and run `installer -pkg` again. The installer detects the existing receipts and performs an upgrade:
 
 ```sh
-sudo installer -pkg fleet-edr-v0.1.1.pkg -target /
+sudo installer -pkg fleet-edr-v0.1.2.pkg -target /
 ```
 
 The preinstall script stops the old daemon, the postinstall script starts the new one. The persisted host token at `/var/db/fleet-edr/enrolled.plist` survives, so the agent keeps its existing enrollment; no re-approval needed.

--- a/docs/install-agent-manual.md
+++ b/docs/install-agent-manual.md
@@ -150,17 +150,18 @@ systemextensionsctl list | grep fleetdm
 #   ... com.fleetdm.edr.networkextension  ... [activated enabled]
 ```
 
-Until both extensions are activated, the agent runs but sees no events. The agent log repeats `receiver reconnecting ...` while it waits for the extensions' XPC service to come up. That's expected.
+Until both extensions are activated, the agent runs but sees no events. The agent log repeats `receiver connect` warnings while it waits for the extensions' XPC service to come up. That's expected (if the warnings persist after activation, see Step 6).
 
 ## Step 6: grant Full Disk Access
 
-The sysext's Endpoint Security client requires Full Disk Access to observe file events. Without it, `es_new_client` returns `ERR_NOT_PERMITTED` and no events flow.
+The Endpoint Security extension creates its ES client with `es_new_client`, which requires Full Disk Access. The extension is a separate TCC identity from the host app, so granting FDA to `/Applications/Fleet EDR.app` does NOT cover it. Without its own grant, `es_new_client` returns `ERR_NOT_PERMITTED`, the extension exits and relaunches in a loop, and the agent logs repeated `receiver connect` / `xpc_bridge_connect failed` warnings even though `systemextensionsctl` shows `activated enabled`.
 
 1. Open **System Settings > Privacy & Security > Full Disk Access**.
-2. Click the `+` button. Authenticate.
-3. Navigate to `/Applications/Fleet EDR.app` and add it.
-4. Also add `/usr/local/bin/fleet-edr-agent` (use Cmd+Shift+G in the file picker to type the path directly).
-5. Toggle both entries ON.
+2. After Step 5's activation the extension appears in the list as **"extension"** (its bundle display name, not "Fleet EDR"). Toggle **"extension"** ON and authenticate. This is the entry that lets `es_new_client` succeed.
+3. Add the agent: click **+**, press Cmd+Shift+G, enter `/usr/local/bin/fleet-edr-agent`, and toggle it ON.
+4. If no **"extension"** entry is listed, reset its TCC state and reboot to force a fresh prompt: `sudo tccutil reset SystemPolicyAllFiles com.fleetdm.edr.securityextension`.
+
+Granting FDA mid-loop lets the next relaunch succeed within a few seconds; if the warnings don't clear, reboot. You don't need to grant FDA to the Network Extension ("networkextension") or to `/Applications/Fleet EDR.app`.
 
 ## Step 7: verify end-to-end
 
@@ -174,7 +175,7 @@ sudo launchctl print system/com.fleetdm.edr.agent | grep state
 # Expect: "state = running"
 
 # Recent log
-sudo tail -n 20 /var/log/fleet-edr-agent.log
+sudo tail -n 100 /var/log/fleet-edr-agent.log
 # Expect an "agent enrolled" line near the top, then periodic
 # "http request" lines as the commander polls.
 ```
@@ -227,5 +228,7 @@ sudo launchctl kickstart -k system/com.fleetdm.edr.agent
 **Agent log shows `tls: failed to verify certificate: x509: ...`.** Server's TLS cert isn't trusted by the system. Either install the CA that signed it into the system trust store, or use the `EDR_SERVER_FINGERPRINT` pin. Compute the value with `openssl x509 -in fullchain.pem -noout -fingerprint -sha256` and paste the hex output into the config file (optionally with a `sha256:` prefix; the `:` separators between bytes are accepted too). Don't set `EDR_ALLOW_INSECURE=1` unless you're in a lab.
 
 **System extension stays in `activated waiting for user` forever.** Someone disabled Automation + extensions in the OS. Easiest fix: revoke the install, reinstall with the MDM path (which pushes the sysext-allow-list profile so the prompt doesn't appear).
+
+**`receiver connect` / `xpc_bridge_connect failed` warnings repeat while `systemextensionsctl list` shows `activated enabled`.** The Endpoint Security extension is exiting on launch for lack of Full Disk Access. Confirm with `log show --last 10m --predicate 'subsystem == "com.fleetdm.edr.securityextension"' | grep "ES client"`: `Failed to create ES client: 4` is `ERR_NOT_PERMITTED`. Enable the **"extension"** entry in Privacy & Security > Full Disk Access (Step 6). The extension is a different TCC identity from `/Applications/Fleet EDR.app`, so granting the app alone doesn't fix it.
 
 **Full Disk Access grant gets wiped after every reboot.** Probably a TCC-database issue after a macOS point upgrade. Re-add the entries in Privacy & Security. If it recurs on a managed Mac, deploy the TCC profile via MDM instead.

--- a/docs/install-agent-manual.md
+++ b/docs/install-agent-manual.md
@@ -57,7 +57,7 @@ If any of these fail, STOP. Don't install. File an issue at https://github.com/g
 
 ### Optional: verify the Sigstore signature
 
-Releases that ship Sigstore signatures also publish a `<file>.sig` and `<file>.pem` next to every artifact. The signature ties the artifact to the exact GitHub Actions workflow run that produced it, which catches the rare attack where a Developer ID cert is stolen but the attacker can't push to our GitHub repo. Skip this step if you don't have `cosign` installed; the Apple-signature checks above are sufficient for most pilots.
+Releases publish a `<file>.sig` and `<file>.pem` next to every artifact. The signature ties the artifact to the exact GitHub Actions workflow run that produced it, which catches the rare attack where a Developer ID cert is stolen but the attacker can't push to our GitHub repo. Skip this step if you don't have `cosign` installed; the Apple-signature checks above are sufficient for most pilots.
 
 The example below uses the same `v0.1.1` placeholder as Step 1 above; substitute whatever release tag you actually downloaded.
 
@@ -74,6 +74,8 @@ cosign verify-blob \
     fleet-edr-v0.1.1.pkg
 # Expect: "Verified OK"
 ```
+
+On cosign v2.6+ the `--certificate` and `--signature` flags print a deprecation warning; verification still succeeds. v0.1.1 ships the `.sig` / `.pem` pair these flags expect, so the warning is harmless. Migrating signing to the single-bundle format is tracked in [#369](https://github.com/getvictor/fleet-edr/issues/369).
 
 The same pattern (`<file>.sig` + `<file>.pem`) covers `SHA256SUMS` and both `.mobileconfig` profiles. If you're verifying the server image instead, use `cosign verify ghcr.io/getvictor/fleet-edr-server:v0.1.1` with the same identity / issuer flags.
 

--- a/docs/install-server.md
+++ b/docs/install-server.md
@@ -22,7 +22,7 @@ One server replica + MySQL, from the root `docker-compose.prod.yml`. Simplest to
 
 The control-plane availability target for the multi-replica topology is **99.9%** (the management, query, ingest, and alerting plane: the UI, the API, and `/api/events` ingestion). The full architecture rationale is in [ADR-0011](adr/0011-ha-architecture.md).
 
-How it reaches that: a replica can crash, drain, or roll to a new version without taking the control plane down, because the load balancer routes around any replica not reporting `/readyz` ready and MySQL-backed sessions let any replica serve any request. A [rolling upgrade](operations.md#rolling-upgrade-multi-replica) is therefore not a maintenance window.
+How it reaches that: a replica can crash, drain, or roll to a new version without taking the control plane down, because MySQL-backed sessions let any replica serve any request and the load balancer pulls a draining replica from rotation. With the HAProxy config (or NGINX Plus) that pull is active, driven by `/readyz` polling, so a replica is removed before a request fails; the default open-source NGINX has only passive failover (it marks a replica down after failed forwards). A [rolling upgrade](operations.md#rolling-upgrade-multi-replica) is therefore not a maintenance window.
 
 **Endpoint protection does not depend on control-plane availability:**
 

--- a/docs/install-server.md
+++ b/docs/install-server.md
@@ -32,8 +32,8 @@ How it reaches that: a replica can crash, drain, or roll to a new version withou
 Three caveats on the SLA:
 
 1. **It is the control plane, not your infrastructure.** The 99.9% target is the EDR server tier. It is conditional on the load balancer and MySQL you operate being available; the EDR does not monitor or guarantee those.
-2. **MySQL is a single point of failure in the reference stack.** v0.1.0 ships a single MySQL; the customer brings a replicated or managed MySQL for a fully HA datastore. A MySQL outage takes the control plane down regardless of how many server replicas are running (endpoint enforcement still continues, per above).
-3. **Single region, single MySQL writer.** There is no multi-region or active-active deployment in v0.1.0; geo-distribution and read-routing are deferred to a later release.
+2. **MySQL is a single point of failure in the reference stack.** v0.1.1 ships a single MySQL; the customer brings a replicated or managed MySQL for a fully HA datastore. A MySQL outage takes the control plane down regardless of how many server replicas are running (endpoint enforcement still continues, per above).
+3. **Single region, single MySQL writer.** There is no multi-region or active-active deployment in v0.1.1; geo-distribution and read-routing are deferred to a later release.
 
 ## Prerequisites
 
@@ -122,7 +122,7 @@ EDR_TLS_KEY_FILE=/tls/privkey.pem
 
 ```sh
 cat > .env <<'EOF'
-EDR_VERSION=v0.1.0
+EDR_VERSION=v0.1.1
 OTEL_EXPORTER_OTLP_ENDPOINT=
 EOF
 ```
@@ -162,7 +162,7 @@ Expect:
 ```json
 {
   "status": "ok",
-  "version": "v0.1.0",
+  "version": "v0.1.1",
   "uptime_seconds": 12,
   "checks": {
     "db": { "status": "ok", "latency_ms": 2 }

--- a/docs/install-server.md
+++ b/docs/install-server.md
@@ -8,7 +8,7 @@ The server tier is stateless: it holds no in-process state that outlives a reque
 
 ### Multi-replica (high availability): reference
 
-Two or more server replicas behind a load balancer, in front of one MySQL. This is the recommended topology: a replica can be drained and restarted (or rolled to a new version) without a maintenance window, because the load balancer routes around a draining replica and sessions are MySQL-backed, so there are no sticky sessions to strand. Use `packaging/docker-compose-multi-replica.yml` (two replicas + MySQL + an NGINX proxy); `packaging/haproxy/multi-replica.cfg` is a drop-in HAProxy alternative to the NGINX proxy that adds active `/readyz` health checks. The setup steps below apply unchanged except that you also generate a shared `session_signing_key` secret (`openssl rand -hex 32 > secrets/session_signing_key`), which every replica must share so a session minted on one validates on another.
+Two or more server replicas behind a load balancer, in front of one MySQL. This is the recommended topology: a replica can be drained and restarted (or rolled to a new version) without a maintenance window, because the load balancer routes around a draining replica and sessions are MySQL-backed, so there are no sticky sessions to strand. Use `packaging/docker-compose-multi-replica.yml` (two replicas + MySQL + an NGINX proxy); `packaging/haproxy/multi-replica.cfg` is a drop-in HAProxy alternative that adds active `/readyz` health checks. The setup steps below apply unchanged except that you also generate a shared `session_signing_key` secret (`openssl rand -hex 32 > secrets/session_signing_key`), which every replica must share so a session minted on one validates on another.
 
 Properties this topology relies on, each pinned by a test in the `server-availability` spec: the processor scales across replicas via `SKIP LOCKED`; sessions and CSRF tokens validate on any replica; the periodic maintenance tasks run on exactly one replica via MySQL advisory locking; and schema migrations are applied under an advisory lock so a rolling upgrade never runs two migration applies against one database at once.
 
@@ -22,14 +22,14 @@ One server replica + MySQL, from the root `docker-compose.prod.yml`. Simplest to
 
 The control-plane availability target for the multi-replica topology is **99.9%** (the management, query, ingest, and alerting plane: the UI, the API, and `/api/events` ingestion). The full architecture rationale is in [ADR-0011](adr/0011-ha-architecture.md).
 
-How the topology reaches it: N stateless replicas behind a load balancer mean a single replica can crash, be drained, or be rolled to a new version without the control plane going down, because the LB routes around any replica that is not reporting `/readyz` ready and sessions are MySQL-backed (any replica serves any request). Rolling upgrade (see [operations.md](operations.md#rolling-upgrade-multi-replica)) is therefore not a maintenance window.
+How it reaches that: a replica can crash, drain, or roll to a new version without taking the control plane down, because the load balancer routes around any replica not reporting `/readyz` ready and MySQL-backed sessions let any replica serve any request. A [rolling upgrade](operations.md#rolling-upgrade-multi-replica) is therefore not a maintenance window.
 
-**Endpoint protection does not depend on control-plane availability.** This is the honest resilience story for a customer:
+**Endpoint protection does not depend on control-plane availability:**
 
 - **Enforcement continues during an outage.** Application-control block decisions are made in the macOS system extension from a cached policy snapshot, not by a server round-trip, so a server or network outage does not open a hole in enforcement.
 - **No endpoint data is lost (up to the queue cap).** When the server is unreachable the agent buffers events in its local SQLite queue and uploads them when the server returns; `edr.agent.queue.dropped` increments only if the queue hits its cap. Detection and alerting run server-side, so alerts for events captured during an outage are generated when the backlog uploads (delayed, not lost).
 
-Three caveats on the SLA, stated plainly:
+Three caveats on the SLA:
 
 1. **It is the control plane, not your infrastructure.** The 99.9% target is the EDR server tier. It is conditional on the load balancer and MySQL you operate being available; the EDR does not monitor or guarantee those.
 2. **MySQL is a single point of failure in the reference stack.** v0.1.0 ships a single MySQL; the customer brings a replicated or managed MySQL for a fully HA datastore. A MySQL outage takes the control plane down regardless of how many server replicas are running (endpoint enforcement still continues, per above).
@@ -155,7 +155,7 @@ Local dev deployment (`task dev:server`, issue #140: TLS by default with the sel
 curl -sk https://localhost:8088/readyz | jq .
 ```
 
-`-k` is acceptable here because the cert is a known self-signed dev cert; never ship `-k` in an automation script against a real deployment; install mkcert locally for warning-free dev (`brew install mkcert nss && mkcert -install`) and the cert validates without the flag.
+`-k` is acceptable here because the cert is a known self-signed dev cert. Install mkcert for warning-free dev (`brew install mkcert nss && mkcert -install`) and it validates without the flag.
 
 Expect:
 

--- a/docs/mdm-deployment.md
+++ b/docs/mdm-deployment.md
@@ -8,7 +8,7 @@ For the Fleet-specific recipe see [fleet-deployment.md](fleet-deployment.md). Fo
 
 Three artifacts, delivered in this order:
 
-1. **Two unsigned `.mobileconfig` profiles** pushed via MDM "custom settings". Pre-approves the ES system extension and grants Full Disk Access. These must arrive BEFORE the pkg so the sysext activates silently on install. The profiles ship unsigned on purpose: every supported MDM signs profiles itself at delivery time, and Fleet rejects a pre-signed upload outright.
+1. **Two unsigned `.mobileconfig` profiles** pushed via MDM "custom settings". Pre-approves the Endpoint Security and Network system extensions and grants Full Disk Access. These must arrive BEFORE the pkg so the extensions activate silently on install. The profiles ship unsigned on purpose: every supported MDM signs profiles itself at delivery time, and Fleet rejects a pre-signed upload outright.
 2. **An install script** your MDM runs before the pkg installer. It writes `/etc/fleet-edr.conf` with the enroll secret + server URL.
 3. **The signed `.pkg`** pushed via MDM "software installer".
 
@@ -35,10 +35,10 @@ Download all four, verify checksums, then upload the three artifacts into your M
 
 ```sh
 cd ~/Downloads
-curl -fLO https://github.com/getvictor/fleet-edr/releases/download/v0.1.0/fleet-edr-v0.1.0.pkg
-curl -fLO https://github.com/getvictor/fleet-edr/releases/download/v0.1.0/edr-system-extension.mobileconfig
-curl -fLO https://github.com/getvictor/fleet-edr/releases/download/v0.1.0/edr-tcc-fda.mobileconfig
-curl -fLO https://github.com/getvictor/fleet-edr/releases/download/v0.1.0/SHA256SUMS
+curl -fLO https://github.com/getvictor/fleet-edr/releases/download/v0.1.1/fleet-edr-v0.1.1.pkg
+curl -fLO https://github.com/getvictor/fleet-edr/releases/download/v0.1.1/edr-system-extension.mobileconfig
+curl -fLO https://github.com/getvictor/fleet-edr/releases/download/v0.1.1/edr-tcc-fda.mobileconfig
+curl -fLO https://github.com/getvictor/fleet-edr/releases/download/v0.1.1/SHA256SUMS
 shasum -a 256 -c SHA256SUMS --ignore-missing
 # All three artifacts should print "OK".
 ```
@@ -47,7 +47,7 @@ shasum -a 256 -c SHA256SUMS --ignore-missing
 
 Upload `edr-system-extension.mobileconfig` to your MDM as a custom configuration profile and scope it to the Macs that will run the agent.
 
-What the profile does: pre-approves the bundle ID `com.fleetdm.edr.securityextension` under team ID `FDG8Q7N4CC` in the `com.apple.system-extension-policy` payload. When the pkg's activation LaunchAgent runs the host app's sysext-activation request, macOS finds the pre-approval, skips the user prompt, and activates the sysext immediately.
+What the profile does: pre-approves the bundle IDs `com.fleetdm.edr.securityextension` and `com.fleetdm.edr.networkextension` under team ID `FDG8Q7N4CC` in the `com.apple.system-extension-policy` payload. When the pkg's activation LaunchAgent runs the host app's sysext-activation request, macOS finds the pre-approval, skips the user prompt, and activates both extensions immediately.
 
 Verify on a target Mac:
 
@@ -102,7 +102,7 @@ EOF
 
 ## Step 4: push the pkg
 
-Upload `fleet-edr-<version>.pkg` to your MDM as a software installer and scope to the same Macs. The release tag is part of the filename verbatim (e.g., tag `v0.1.0` ships as `fleet-edr-v0.1.0.pkg`).
+Upload `fleet-edr-<version>.pkg` to your MDM as a software installer and scope to the same Macs. The release tag is part of the filename verbatim (e.g., tag `v0.1.1` ships as `fleet-edr-v0.1.1.pkg`).
 
 The pkg's install flow:
 
@@ -119,9 +119,9 @@ Verify on a target Mac:
 sudo launchctl print system/com.fleetdm.edr.agent | grep 'state ='
 # Expect: "state = running"
 
-# Sysext activated
+# Both system extensions activated
 systemextensionsctl list | grep fleetdm
-# Expect a row ending "[activated enabled]"
+# Expect two rows, both ending "[activated enabled]"
 
 # Recent log
 sudo tail -n 20 /var/log/fleet-edr-agent.log

--- a/docs/mdm-deployment.md
+++ b/docs/mdm-deployment.md
@@ -1,6 +1,6 @@
 # MDM deployment (vendor-neutral)
 
-Fleet EDR is designed to ship through any MDM that can deliver a `.pkg` + two `.mobileconfig` profiles + a one-line install script. This works with Jamf Pro, Kandji, Intune, mosyle, Fleet, and any equivalent platform.
+Fleet EDR ships through any MDM that can deliver a `.pkg` + two `.mobileconfig` profiles + a one-line install script: Jamf Pro, Kandji, Intune, mosyle, Fleet, or any equivalent platform.
 
 For the Fleet-specific recipe see [fleet-deployment.md](fleet-deployment.md). For single-Mac eval without an MDM see [install-agent-manual.md](install-agent-manual.md).
 
@@ -12,7 +12,7 @@ Three artifacts, delivered in this order:
 2. **An install script** your MDM runs before the pkg installer. It writes `/etc/fleet-edr.conf` with the enroll secret + server URL.
 3. **The signed `.pkg`** pushed via MDM "software installer".
 
-Every MDM exposes these three primitives under different names. The mapping is in the vendor-specific section at the bottom.
+Each MDM names these three primitives differently; the mapping is in the vendor-specific section below.
 
 ## Why this shape
 


### PR DESCRIPTION
Conciseness pass over the three deployment guides. Every factual claim (env vars, defaults, bundle IDs, paths, metric names, compose files, installer behavior) was cross-checked against the code and found accurate, so this changes wording only, no documented behavior:

- install-server: drop the SLA-section restatement of the HA mechanism already covered under Deployment topology; remove filler ("stated plainly", "the honest resilience story"); de-duplicate the -k self-signed-cert warning between the two readiness probes.
- mdm-deployment: tighten the intro and the primitives-mapping pointer.
- install-agent-manual: trim the signature-check preamble.

[no-behavior-change]

<!-- Keep this short. Delete sections that do not apply. -->

## What & why



## Checklist

- [ ] **OpenSpec updated for behavior changes.** If this PR changes observable behavior (a detection rule, the event
      wire schema, persistence semantics, an API/wire shape, or an emitted event), `openspec/specs/**` is updated (and
      an `openspec/changes/` proposal added), with a `spec:<id>` test marker for any new/renamed scenario. Only if this
      PR changes NO observable behavior (a comment / refactor / gofmt / dep bump that happens to touch a scoped path)
      may you assert `no-behavior-change` (label or `[no-behavior-change]` in the title) to clear the OpenSpec-sync gate.
      That is an assertion a reviewer will check, not a way to skip the spec for a real behavior change.
- [ ] Tests added/updated for the change (unit / integration / efficacy / UI as applicable).
- [ ] Agent/extension change touching ESF, XPC, or the event wire format: exercised on a live macOS VM before RC
      (flagged below).

## VM / RC notes (if applicable)


