### PR TITLE
Fixes dealing with session expiration

### DIFF
--- a/openspec/changes/ui-redirect-on-session-expiry/proposal.md
+++ b/openspec/changes/ui-redirect-on-session-expiry/proposal.md
@@ -1,0 +1,16 @@
+# UI redirects to login when a session expires mid-use
+
+## Why
+
+When an operator's session lapses while the app is open, the UI strands them on a dead page instead of returning them to login. The fetch wrapper already detects the server's 401 (`Unauthorized401Error`), but that error is only ever caught in one place: the one-shot session probe in `AuthedApp`'s mount `useEffect` (`ui/src/App.tsx`). That probe runs once on load and never again, so a 401 from a background `/api/*` call made hours later (after the 8h idle / 24h absolute timeout for SSO sessions, or the 15m idle / 1h absolute timeout for break-glass sessions) is caught by the individual component's generic `catch` and rendered as an inline "API error: 401 Unauthorized" message. Auth state never flips, so no redirect happens. A code comment in `App.tsx` even claimed call sites "surface that to flip auth -> 'anon'", but no call site did: a grep for everything that sets `status: "anon"` returned only the mount probe and explicit logout. The 403 authz-denial path already has a global signal (`setForbiddenHandler`); the 401 path had no equivalent.
+
+## What changes
+
+- **A global 401 signal in the API layer.** `api.ts` gains `setUnauthorizedHandler`, mirroring the existing `setForbiddenHandler`. Both 401 throw sites (`fetchJSON` for safe-method reads and `appControlMutationEndpoint` for unsafe-method mutations) now funnel through one `raiseUnauthorized` chokepoint that clears the stale CSRF token, fires the registered handler, and throws `Unauthorized401Error` so existing callers keep working unchanged.
+- **`AuthedApp` registers the handler.** On mount it registers a handler that flips auth state to `anon` (guarded so it only fires from an authed state, idempotent under the burst of in-flight fetches that all 401 when a session lapses). The existing `anon` render path already routes to `/login` carrying the current path as `?next=`, so a successful re-login returns the operator where they were. The stale comment in the mount probe is corrected to describe the real mechanism.
+- **Reconcile the session-lifetime spec to the shipped behavior.** Investigating the redirect surfaced that the canonical `ui-authentication-session` spec still described a flat "Sessions expire 12 hours after issue" model that never matched the implementation (the `#257` drift, already acknowledged in test markers). The implementation bounds each session by a class-specific idle + absolute pair (`sessions.Timeouts`: normal 8h/24h, break-glass 15m/1h) with a sliding idle window and a cookie `Expires`/`Max-Age` pinned to the absolute cap. That requirement is replaced with an accurate one, and the two existing test markers (plus three previously-unmarked tests that already cover idle expiry, sliding extension, and the break-glass pair) are pointed at the new scenarios. This is a documentation reconciliation: no runtime behavior changes.
+
+### Not in this change
+
+- Any change to server-side session lifetimes or the 401 response shape; the server already returns 401 on an expired session.
+- A proactive client-side expiry timer or idle warning. Redirect is reactive: it fires on the first 401 after expiry, which is the moment the operator's next action would have failed anyway.

--- a/openspec/changes/ui-redirect-on-session-expiry/specs/ui-authentication-session/spec.md
+++ b/openspec/changes/ui-redirect-on-session-expiry/specs/ui-authentication-session/spec.md
@@ -1,0 +1,48 @@
+# UI Authentication Session Specification (delta)
+
+## ADDED Requirements
+
+### Requirement: Sessions expire on idle and absolute timeouts per class
+
+The system SHALL bound every session by two timeouts: an idle timeout measured from the last activity and an absolute timeout measured from session creation. The pair is chosen by session class. Normal (SSO/OIDC) sessions use the lenient pair: idle 8 hours, absolute 24 hours. Break-glass (local-password) sessions use the strict pair: idle 15 minutes, absolute 1 hour, so a stolen recovery cookie expires before the end of an incident shift. The absolute cap SHALL be pinned at mint time (stored on the session row) so a later configuration change does not retroactively extend or shorten existing sessions. The session cookie's `Expires` and `Max-Age` attributes SHALL reflect the absolute cap so the browser stops sending the cookie once it elapses. The idle timeout SHALL slide on use: activity within the idle window extends the session, but never past the absolute cap. A request whose session has crossed either timeout MUST be treated as expired and rejected with 401; a session past its absolute cap is never extended on use.
+
+#### Scenario: Cookie carries the absolute timeout on login
+
+- **GIVEN** the operator logs in successfully
+- **WHEN** the response sets the session cookie
+- **THEN** the cookie's `Expires` attribute equals the session's absolute expiry (creation time plus the class's absolute timeout)
+- **AND** the cookie's `Max-Age` attribute is the number of seconds remaining until that expiry
+
+#### Scenario: A request after the absolute cap is rejected
+
+- **GIVEN** a session whose absolute cap has elapsed
+- **WHEN** the client uses that session cookie on any session-required endpoint
+- **THEN** the server treats the session as expired and returns 401
+- **AND** the request is not authenticated as the original operator
+
+#### Scenario: A request after the idle window is rejected
+
+- **GIVEN** a session that is still within its absolute cap but whose last activity is older than the class's idle timeout
+- **WHEN** the client uses that session cookie on any session-required endpoint
+- **THEN** the server treats the session as expired and returns 401
+
+#### Scenario: Activity within the idle window slides the session
+
+- **GIVEN** a session whose operator keeps interacting within the idle window
+- **WHEN** each request advances the session's last-activity time
+- **THEN** the session stays valid past what would otherwise be the idle-timeout cutoff
+- **AND** the session is still rejected once the absolute cap elapses, regardless of activity
+
+#### Scenario: Break-glass sessions use the strict timeout pair
+
+- **GIVEN** a session minted through the break-glass surface (`auth_method='local_password'`)
+- **WHEN** its idle gate is evaluated
+- **THEN** the strict break-glass pair applies (15-minute idle, 1-hour absolute), not the normal pair
+
+## REMOVED Requirements
+
+### Requirement: Sessions expire 12 hours after issue
+
+**Reason**: The flat 12-hour-from-issue model never matched the implementation, which bounds each session by a class-specific idle + absolute timeout pair (`sessions.Timeouts`: normal 8h/24h, break-glass 15m/1h) with a sliding idle window. The drift was tracked in #257 and acknowledged in the test markers. This change reconciles the canonical spec to the shipped behavior; the replacement requirement "Sessions expire on idle and absolute timeouts per class" carries the accurate contract.
+
+**Migration**: None. This is a documentation reconciliation of already-shipped behavior, not a behavior change. The existing tests already pinned the real idle/absolute/sliding/per-class behavior; their spec markers are repointed to the new scenarios in the same change.

--- a/openspec/changes/ui-redirect-on-session-expiry/specs/web-ui/spec.md
+++ b/openspec/changes/ui-redirect-on-session-expiry/specs/web-ui/spec.md
@@ -1,0 +1,35 @@
+# Web UI Specification (delta)
+
+## MODIFIED Requirements
+
+### Requirement: Authenticated entry to the application
+
+The UI SHALL probe the server's session endpoint on application load and SHALL render the login page when the probe indicates no active session. A successful login MUST establish a session and route the user to the application's home view; an invalid login MUST surface a generic error without revealing whether the email or the password was wrong. When the session lapses while the app is already open (an idle or absolute timeout, or a server-side revocation) and any subsequent request to the server is rejected as unauthenticated, the UI MUST return the operator to the login page rather than leaving them on a page that renders a raw transport error such as `API error: 401`. The redirect SHALL preserve the operator's current location so a successful re-login returns them to where they were.
+
+The change from the prior requirement is the addition of the mid-session expiry behavior: redirect-to-login is no longer limited to the load-time probe; a 401 on any later request also returns the operator to login.
+
+#### Scenario: Anonymous user lands on the login page
+
+- **GIVEN** a browser with no active session cookie
+- **WHEN** the user navigates to the application
+- **THEN** the UI renders the login page with the configured sign-in controls (SSO and a break-glass entry point)
+
+#### Scenario: Successful login routes to the home view
+
+- **GIVEN** the login page is displayed
+- **WHEN** the user submits a valid email and password
+- **THEN** the server establishes a session and the UI re-renders into the host list as the home view
+
+#### Scenario: Failed login shows a non-enumerating error
+
+- **GIVEN** the login page is displayed
+- **WHEN** the user submits credentials the server rejects
+- **THEN** the UI shows a single generic error such as "invalid email or password"
+- **AND** the UI does not distinguish between unknown email and wrong password
+
+#### Scenario: Mid-session expiry returns the operator to login
+
+- **GIVEN** an authenticated operator viewing any page after the load-time session probe has already succeeded
+- **WHEN** a subsequent request to the server is rejected as unauthenticated because the session has expired or been revoked
+- **THEN** the UI returns the operator to the login page rather than rendering a raw `API error: 401` on the current page
+- **AND** the operator's current location is preserved so a successful re-login returns them to where they were

--- a/openspec/changes/ui-redirect-on-session-expiry/tasks.md
+++ b/openspec/changes/ui-redirect-on-session-expiry/tasks.md
@@ -10,6 +10,7 @@
 - [x] `App.tsx`: import `setUnauthorizedHandler`; register a mount-time handler that flips auth `authed -> anon` (functional update, idempotent), with cleanup on unmount.
 - [x] `App.tsx`: correct the now-stale mount-probe comment that claimed call sites flip auth on background 401s.
 - [x] `App.tsx`: export `AuthedApp` so the redirect behavior can be tested in isolation.
+- [x] `api.ts` + `auth.ts`: extend the 401 signal to the session-protected break-glass reauth path (`/api/auth/reauth/*`). `api.ts` exposes a non-throwing `notifyUnauthorized`; `auth.ts`'s `requestJSON` calls it on a reauth-path 401 (a mid-reauth session expiry) so the app redirects to login, while the pre-auth break-glass login/setup 401 (a bad credential) is left untouched. Covered by the existing "Mid-session expiry returns the operator to login" scenario.
 
 ## 3. Spec
 

--- a/openspec/changes/ui-redirect-on-session-expiry/tasks.md
+++ b/openspec/changes/ui-redirect-on-session-expiry/tasks.md
@@ -1,0 +1,34 @@
+# UI redirects to login when a session expires mid-use: tasks
+
+## 1. API layer
+
+- [x] `api.ts`: add `unauthorizedHandler` module state + `setUnauthorizedHandler(handler | null)` setter, mirroring the existing `setForbiddenHandler`.
+- [x] `api.ts`: add a `raiseUnauthorized` chokepoint (clear CSRF, fire handler, throw `Unauthorized401Error`) and funnel both 401 throw sites (`fetchJSON`, `appControlMutationEndpoint`) through it.
+
+## 2. App wiring
+
+- [x] `App.tsx`: import `setUnauthorizedHandler`; register a mount-time handler that flips auth `authed -> anon` (functional update, idempotent), with cleanup on unmount.
+- [x] `App.tsx`: correct the now-stale mount-probe comment that claimed call sites flip auth on background 401s.
+- [x] `App.tsx`: export `AuthedApp` so the redirect behavior can be tested in isolation.
+
+## 3. Spec
+
+- [x] `web-ui` spec: MODIFY "Authenticated entry to the application" to cover mid-session expiry, with a new scenario "Mid-session expiry returns the operator to login".
+- [x] `ui-authentication-session` spec: REMOVE "Sessions expire 12 hours after issue" (Reason + Migration) and ADD "Sessions expire on idle and absolute timeouts per class" with five scenarios (cookie/absolute/idle/sliding/break-glass) reflecting the shipped `sessions.Timeouts` model.
+- [x] Repoint the two existing session-expiry test markers and add markers to the three previously-unmarked tests (idle expiry, sliding extension, break-glass pair) so every new scenario is covered.
+
+## 4. Tests
+
+- [x] `api.test.ts`: the unauthorized handler fires on a 401 from a safe-method fetch and from an unsafe-method (mutation) fetch, and does NOT fire once cleared with null. Scenario marker on the cases.
+- [x] `App.test.tsx`: rendering `AuthedApp` with a session probe that succeeds then a background fetch that 401s lands on the login page. Scenario marker on the case.
+
+## 5. Archive follow-up (post-merge)
+
+- [ ] When running `openspec archive ui-redirect-on-session-expiry`, also delete the two transitional `sessions-expire-12-hours-after-issue/*` markers (in `server/identity/internal/sessions/sessions_test.go` and `server/identity/internal/oidc/handler_test.go`). They cover the old canonical scenarios that spectrace gates until archive rewrites the requirement; once the requirement is renamed in canonical, those slugs no longer exist and the lines become invalid references. The new `sessions-expire-on-idle-and-absolute-timeouts-per-class/*` markers already in place cover the replacement scenarios.
+
+## 6. Verification
+
+- [x] `cd ui && npx tsc --noEmit` clean.
+- [x] `cd ui && npx vitest run` green (full suite).
+- [x] `cd ui && npx eslint` clean on changed files.
+- [x] `openspec validate ui-redirect-on-session-expiry --strict`; spectrace; dash + markdown lints.

--- a/server/identity/internal/oidc/handler_test.go
+++ b/server/identity/internal/oidc/handler_test.go
@@ -164,15 +164,19 @@ func TestWriteStateCookie(t *testing.T) {
 }
 
 // spec:ui-authentication-session/session-cookie-is-http-only-and-same-site/cookie-attributes-on-login
+// spec:ui-authentication-session/sessions-expire-on-idle-and-absolute-timeouts-per-class/cookie-carries-the-absolute-timeout-on-login
+// Transitional marker below: spectrace gates the canonical spec tree, which still carries the pre-reconciliation "12-hours"
+// slug until `openspec archive ui-redirect-on-session-expiry` rewrites the requirement. Drop the 12-hours line on archive
+// (see the change's tasks.md).
 // spec:ui-authentication-session/sessions-expire-12-hours-after-issue/cookie-carries-a-12-hour-expiry-on-login
 //
 // Direct unit test for writeSessionCookie's full attribute set. Mirrors TestWriteStateCookie's shape for the OIDC state cookie.
 // The session-cookie path is "/" (broader than the state cookie's /api/auth/ scope) because every authed admin endpoint reads it;
 // the rest of the attributes (HttpOnly, SameSiteLax, Secure) match the state cookie's hardening. Value is the base64url-encoded
-// session token; MaxAge reflects time-until-ExpiresAt in seconds. The 12-hour-expiry scenario is pinned transitively: the test
-// seeds expires := time.Now().Add(12 * time.Hour), then asserts c.MaxAge is positive and c.Expires is within 1s of the seeded
-// value (line 199-200). A regression that shortened or lengthened the session window would either trip WithinDuration or push
-// MaxAge to zero. Multi-test demonstrator with TestHandleCallback_HappyPath_JITNewUser in callback_integration_test.go (pins
+// session token; MaxAge reflects time-until-ExpiresAt in seconds, and Expires equals the session's absolute expiry. The cookie
+// scenario is pinned by seeding a representative expiry, then asserting c.MaxAge is positive and c.Expires is within 1s of the
+// seeded value (line 199-200). A regression that shortened or lengthened the session window would either trip WithinDuration or
+// push MaxAge to zero. Multi-test demonstrator with TestHandleCallback_HappyPath_JITNewUser in callback_integration_test.go (pins
 // HttpOnly on the assembled OIDC callback response); this test pins the FULL attribute set in isolation.
 func TestWriteSessionCookie(t *testing.T) {
 	t.Parallel()
@@ -185,7 +189,9 @@ func TestWriteSessionCookie(t *testing.T) {
 	for i := range rawID {
 		rawID[i] = byte(i)
 	}
-	expires := time.Now().Add(12 * time.Hour)
+	// A representative absolute expiry (the normal-class 24h cap); writeSessionCookie reads ExpiresAt verbatim, so the exact
+	// value only needs to be a positive future instant the assertions below can match against.
+	expires := time.Now().Add(24 * time.Hour)
 	sess := &sessions.Session{ID: rawID, ExpiresAt: expires}
 
 	h.writeSessionCookie(w, sess)

--- a/server/identity/internal/sessions/sessions_test.go
+++ b/server/identity/internal/sessions/sessions_test.go
@@ -146,15 +146,18 @@ func TestGet_UnknownIDReturnsNotFound(t *testing.T) {
 	require.ErrorIs(t, err, sessions.ErrNotFound)
 }
 
+// spec:ui-authentication-session/sessions-expire-on-idle-and-absolute-timeouts-per-class/a-request-after-the-absolute-cap-is-rejected
+// Transitional second marker below: spectrace gates the canonical spec tree, which still carries the pre-reconciliation
+// "12-hours" slug until `openspec archive ui-redirect-on-session-expiry` rewrites the requirement. Keep both markers green
+// across the merge; drop the 12-hours line as part of archiving (see the change's tasks.md).
 // spec:ui-authentication-session/sessions-expire-12-hours-after-issue/a-request-after-the-12-hour-window-is-rejected
 //
 // Pins the expired-session-rejection clause: a session whose absolute cap has elapsed returns
 // ErrNotFound from Get, which the Session middleware translates into 401 on the wire (covered by
-// TestSession_MissingCookieReturns401's same response shape). The spec scenario speaks of a flat 12h
-// window; the impl uses configurable Idle + Absolute timeouts per session class (see
-// sessions.Timeouts in sessions.go). This test uses a 1h cap for speed; the load-bearing contract
-// the spec asserts is "after expiry the request is rejected," which is what the ErrNotFound below
-// pins. The flat-12h-vs-configurable-timeouts difference is the spec/impl drift tracked in #257.
+// TestSession_MissingCookieReturns401's same response shape). The impl uses configurable Idle +
+// Absolute timeouts per session class (see sessions.Timeouts in sessions.go); this test uses a 1h
+// cap for speed. The load-bearing contract is "after the absolute cap the request is rejected,"
+// which is what the ErrNotFound below pins.
 func TestGet_ExpiredReturnsNotFound(t *testing.T) {
 	t.Parallel()
 	// Drive the clock backwards so the row we just created is already past its expires_at when Get runs. This is more reliable than
@@ -175,6 +178,8 @@ func TestGet_ExpiredReturnsNotFound(t *testing.T) {
 	require.ErrorIs(t, err, sessions.ErrNotFound)
 }
 
+// spec:ui-authentication-session/sessions-expire-on-idle-and-absolute-timeouts-per-class/a-request-after-the-idle-window-is-rejected
+//
 // TestGet_IdleExpiryReturnsNotFound covers the idle-cap branch: created recently (so absolute hasn't elapsed) but last_seen_at hasn't
 // been touched in longer than Idle. Real-world shape: operator opens a tab, walks away without interacting for the idle window.
 func TestGet_IdleExpiryReturnsNotFound(t *testing.T) {
@@ -195,6 +200,8 @@ func TestGet_IdleExpiryReturnsNotFound(t *testing.T) {
 	require.ErrorIs(t, err, sessions.ErrNotFound)
 }
 
+// spec:ui-authentication-session/sessions-expire-on-idle-and-absolute-timeouts-per-class/break-glass-sessions-use-the-strict-timeout-pair
+//
 // TestGet_BreakglassUsesStrictTimeouts pins the per-class behaviour: a session minted with auth_method="local_password" expires under
 // the break-glass pair, not the normal pair. The Idle here would be inside the break-glass cap if normal applied; under break-glass
 // it's past.
@@ -217,6 +224,8 @@ func TestGet_BreakglassUsesStrictTimeouts(t *testing.T) {
 	require.ErrorIs(t, err, sessions.ErrNotFound, "break-glass session must enforce the strict pair")
 }
 
+// spec:ui-authentication-session/sessions-expire-on-idle-and-absolute-timeouts-per-class/activity-within-the-idle-window-slides-the-session
+//
 // TestTouch_SlidingExtensionWithinAbsoluteCap proves the user-visible behaviour: a continuously-active session stays alive past the
 // idle window because each Touch advances last_seen_at. The absolute cap still wins.
 func TestTouch_SlidingExtensionWithinAbsoluteCap(t *testing.T) {

--- a/ui/src/App.test.tsx
+++ b/ui/src/App.test.tsx
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+import { AuthedApp } from "./App";
+import { setUnauthorizedHandler, setForbiddenHandler } from "./api";
+
+// AuthedApp gates the app on a live session. On mount it probes GET /api/session; on a 401 there it
+// renders the login page. The regression this suite pins: a session that lapses MID-USE (a background
+// /api/* fetch returns 401 after the mount probe already succeeded) must also return the operator to
+// login, via the global unauthorized handler AuthedApp registers. Before the fix the 401 was caught
+// inline by each component and the operator was stranded on a dead page.
+
+interface FakeResponse {
+  ok: boolean;
+  status: number;
+  statusText: string;
+  headers: { get(name: string): string | null };
+  clone(): FakeResponse;
+  json(): Promise<unknown>;
+}
+
+function makeResponse(body: unknown, status: number): FakeResponse {
+  const res: FakeResponse = {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: "",
+    headers: { get: (): string | null => null },
+    clone(): FakeResponse {
+      return res;
+    },
+    json(): Promise<unknown> {
+      return Promise.resolve(body);
+    },
+  };
+  return res;
+}
+
+const authedSession = {
+  user: { id: 1, email: "operator@example.com" },
+  csrf_token: "csrf-abc",
+  auth_method: "oidc",
+  permissions: [],
+};
+
+// stubSessionThen401 routes GET /api/session to a 200 authed session (so AuthedApp's mount probe
+// succeeds and renders the home view) and every other /api/* call to 401 (so the home view's first
+// background fetch trips session expiry). fetchJSON calls fetch with a URL instance, so the first arg
+// is stringified to read the path.
+function stubSessionThen401(): ReturnType<typeof vi.fn> {
+  const mock = vi.fn((input: unknown): Promise<FakeResponse> => {
+    const url = String(input);
+    if (url.includes("/api/session")) return Promise.resolve(makeResponse(authedSession, 200));
+    return Promise.resolve(makeResponse(null, 401));
+  });
+  vi.stubGlobal("fetch", mock);
+  return mock;
+}
+
+function renderAuthedApp() {
+  return render(
+    <MemoryRouter initialEntries={["/"]}>
+      <Routes>
+        <Route path="/login" element={<div>LOGIN PAGE</div>} />
+        <Route path="/*" element={<AuthedApp />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+afterEach(() => {
+  setUnauthorizedHandler(null);
+  setForbiddenHandler(null);
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("AuthedApp mid-session expiry", () => {
+  // spec:web-ui/authenticated-entry-to-the-application/mid-session-expiry-returns-the-operator-to-login
+  it("redirects to login when a background fetch returns 401 after a successful session probe", async () => {
+    stubSessionThen401();
+    renderAuthedApp();
+    // The mount probe authenticates, the home view renders, its first /api/hosts fetch 401s, the
+    // registered unauthorized handler flips auth -> anon, and AuthedApp navigates to /login.
+    expect(await screen.findByText("LOGIN PAGE")).toBeInTheDocument();
+  });
+});

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -10,7 +10,7 @@ import { Login } from "./components/Login";
 import { BreakGlassSetup } from "./components/BreakGlassSetup";
 import { BreakGlassLogin } from "./components/BreakGlassLogin";
 import { TopNav } from "./components/ui/TopNav";
-import { currentSession, logout, Unauthorized401Error, SessionInfo, setForbiddenHandler } from "./api";
+import { currentSession, logout, Unauthorized401Error, SessionInfo, setForbiddenHandler, setUnauthorizedHandler } from "./api";
 import { PermissionsProvider, RequirePermission } from "./permissions";
 import { PermissionAction } from "./permissions-core";
 import { createDedupedRunner } from "./dedupe";
@@ -48,7 +48,7 @@ export function App() {
 // probes the session; on 401 it redirects to /ui/login carrying the
 // attempted path as ?next= so a successful sign-in returns the
 // operator to where they were heading.
-function AuthedApp() {
+export function AuthedApp() {
   const [auth, setAuth] = useState<AuthState>({ status: "loading" });
   const location = useLocation();
   const navigate = useNavigate();
@@ -79,11 +79,24 @@ function AuthedApp() {
     })();
     return () => { controller.abort(); };
     // One-shot probe on mount. Background 401s from individual
-    // /api/* fetches already throw Unauthorized401Error and call
-    // sites surface that to flip auth -> 'anon'; re-running on every
-    // route change cost an extra /api/session round-trip per
-    // navigation and made the app flicker back to 'loading'
-    // mid-route.
+    // /api/* fetches are handled by the global unauthorized handler
+    // registered below (setUnauthorizedHandler), which flips auth ->
+    // 'anon'; re-running this probe on every route change cost an
+    // extra /api/session round-trip per navigation and made the app
+    // flicker back to 'loading' mid-route.
+  }, []);
+
+  useEffect(() => {
+    // A 401 on any background /api/* fetch means the session lapsed (idle or absolute timeout)
+    // or was revoked mid-use. Flip to 'anon' so the render below routes to /login carrying the
+    // current path as ?next=. The functional update only fires from an authed state: a 401 during
+    // the initial loading probe is already handled by that probe's own catch, and anon -> anon is a
+    // no-op, so the handler is idempotent under the burst of in-flight fetches that all 401 when a
+    // session lapses.
+    setUnauthorizedHandler(() => {
+      setAuth((prev) => (prev.status === "authed" ? { status: "anon" } : prev));
+    });
+    return () => { setUnauthorizedHandler(null); };
   }, []);
 
   useEffect(() => {

--- a/ui/src/api.test.ts
+++ b/ui/src/api.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { listAlerts, setForbiddenHandler, ReauthRequiredError } from "./api";
+import { listAlerts, createAppControlRule, setForbiddenHandler, setUnauthorizedHandler, Unauthorized401Error, ReauthRequiredError } from "./api";
 
 // listAlerts URL-composition tests. The AlertList component test
 // suite mocks api.listAlerts directly via vi.spyOn, so the real
@@ -152,5 +152,39 @@ describe("forbidden handler signalling", () => {
     setForbiddenHandler(onForbidden);
     await expect(listAlerts()).rejects.toBeTruthy();
     expect(onForbidden).not.toHaveBeenCalled();
+  });
+});
+
+describe("unauthorized handler signalling", () => {
+  afterEach(() => { setUnauthorizedHandler(null); });
+
+  // spec:web-ui/authenticated-entry-to-the-application/mid-session-expiry-returns-the-operator-to-login
+  it("fires on a 401 from a safe-method fetch so the app can redirect to login", async () => {
+    stubFetch(null, 401);
+    const onUnauthorized = vi.fn();
+    setUnauthorizedHandler(onUnauthorized);
+    await expect(listAlerts()).rejects.toBeInstanceOf(Unauthorized401Error);
+    expect(onUnauthorized).toHaveBeenCalledTimes(1);
+  });
+
+  // spec:web-ui/authenticated-entry-to-the-application/mid-session-expiry-returns-the-operator-to-login
+  it("fires on a 401 from an unsafe-method (mutation) fetch too", async () => {
+    // The app-control mutation endpoint is a second 401 throw site; both funnel through raiseUnauthorized so a
+    // session that lapses mid-mutation redirects exactly like one that lapses on a read.
+    stubFetch(null, 401);
+    const onUnauthorized = vi.fn();
+    setUnauthorizedHandler(onUnauthorized);
+    await expect(createAppControlRule(1, { rule_type: "team_id", identifier: "ABCDE12345", reason: "test" }))
+      .rejects.toBeInstanceOf(Unauthorized401Error);
+    expect(onUnauthorized).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fire once cleared with null", async () => {
+    stubFetch(null, 401);
+    const onUnauthorized = vi.fn();
+    setUnauthorizedHandler(onUnauthorized);
+    setUnauthorizedHandler(null);
+    await expect(listAlerts()).rejects.toBeInstanceOf(Unauthorized401Error);
+    expect(onUnauthorized).not.toHaveBeenCalled();
   });
 });

--- a/ui/src/api.test.ts
+++ b/ui/src/api.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { listAlerts, createAppControlRule, setForbiddenHandler, setUnauthorizedHandler, Unauthorized401Error, ReauthRequiredError } from "./api";
+import {
+  listAlerts,
+  createAppControlRule,
+  setForbiddenHandler,
+  setUnauthorizedHandler,
+  Unauthorized401Error,
+  ReauthRequiredError,
+} from "./api";
 
 // listAlerts URL-composition tests. The AlertList component test
 // suite mocks api.listAlerts directly via vi.spyOn, so the real

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -183,6 +183,27 @@ export function setForbiddenHandler(handler: (() => void) | null): void {
   forbiddenHandler = handler;
 }
 
+// unauthorizedHandler is an optional callback invoked when the server returns 401 on ANY /api/* fetch: the session expired (idle or
+// absolute timeout) or was revoked mid-use. The app registers one (see App.tsx) so a background 401 flips global auth state to anon
+// and routes to the login page, instead of each call site rendering a stale inline "API error: 401" and leaving the operator stranded
+// on a dead page. The mount-time session probe and explicit logout already drive that same anon transition; this closes the gap for a
+// session that lapses while the app is open. The handler MUST be idempotent: a burst of in-flight fetches can all 401 at once.
+let unauthorizedHandler: (() => void) | null = null;
+
+// setUnauthorizedHandler registers (or clears, with null) the 401 callback.
+export function setUnauthorizedHandler(handler: (() => void) | null): void {
+  unauthorizedHandler = handler;
+}
+
+// raiseUnauthorized is the single 401 chokepoint both fetch helpers funnel through. It clears the now-stale CSRF token so it cannot
+// linger into the next login, fires the global 401 signal so the app can redirect to login, then throws the typed error so the calling
+// site still rejects (callers that already catch Unauthorized401Error keep working unchanged).
+function raiseUnauthorized(): never {
+  clearCsrfToken();
+  unauthorizedHandler?.();
+  throw new Unauthorized401Error();
+}
+
 async function fetchJSON<T>(path: string, init?: RequestInit): Promise<T> {
   assertSafeAPIPath(path);
   const headers: Record<string, string> = {
@@ -205,10 +226,8 @@ async function fetchJSON<T>(path: string, init?: RequestInit): Promise<T> {
     credentials: "include",
   });
   if (res.status === HTTP_STATUS_UNAUTHORIZED) {
-    // Session expired or never existed. Clear local CSRF so a stale token doesn't
-    // linger and trip us up on the next login.
-    clearCsrfToken();
-    throw new Unauthorized401Error();
+    // Session expired or never existed: clear stale CSRF, signal the app to redirect to login, and throw so the caller still rejects.
+    raiseUnauthorized();
   }
   if (res.status === HTTP_STATUS_FORBIDDEN) {
     // The chokepoint denies destructive actions outside the
@@ -523,8 +542,7 @@ async function appControlMutationEndpoint<T>(
     body: JSON.stringify(body),
   });
   if (res.status === HTTP_STATUS_UNAUTHORIZED) {
-    clearCsrfToken();
-    throw new Unauthorized401Error();
+    raiseUnauthorized();
   }
   if (res.status === HTTP_STATUS_FORBIDDEN) {
     const reauth = await readReauthChallenge(res);

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -183,11 +183,13 @@ export function setForbiddenHandler(handler: (() => void) | null): void {
   forbiddenHandler = handler;
 }
 
-// unauthorizedHandler is an optional callback invoked when the server returns 401 on ANY /api/* fetch: the session expired (idle or
-// absolute timeout) or was revoked mid-use. The app registers one (see App.tsx) so a background 401 flips global auth state to anon
-// and routes to the login page, instead of each call site rendering a stale inline "API error: 401" and leaving the operator stranded
-// on a dead page. The mount-time session probe and explicit logout already drive that same anon transition; this closes the gap for a
-// session that lapses while the app is open. The handler MUST be idempotent: a burst of in-flight fetches can all 401 at once.
+// unauthorizedHandler is an optional callback invoked when the server returns 401 on an authenticated request: the session expired
+// (idle or absolute timeout) or was revoked mid-use. The app registers one (see App.tsx) so a background 401 flips global auth state to
+// anon and routes to the login page, instead of a call site rendering a stale inline "API error: 401" and leaving the operator stranded
+// on a dead page. Both fetch chokepoints here (fetchJSON, appControlMutationEndpoint) and the session-protected break-glass reauth path
+// (auth.ts, via notifyUnauthorized) feed it; the PRE-auth break-glass login/setup surface does NOT, since a 401 there is a bad
+// credential, not an expired session. The mount-time session probe and explicit logout drive the same anon transition. The handler
+// MUST be idempotent: a burst of in-flight fetches can all 401 at once.
 let unauthorizedHandler: (() => void) | null = null;
 
 // setUnauthorizedHandler registers (or clears, with null) the 401 callback.
@@ -195,12 +197,18 @@ export function setUnauthorizedHandler(handler: (() => void) | null): void {
   unauthorizedHandler = handler;
 }
 
-// raiseUnauthorized is the single 401 chokepoint both fetch helpers funnel through. It clears the now-stale CSRF token so it cannot
-// linger into the next login, fires the global 401 signal so the app can redirect to login, then throws the typed error so the calling
-// site still rejects (callers that already catch Unauthorized401Error keep working unchanged).
-function raiseUnauthorized(): never {
+// notifyUnauthorized clears the now-stale CSRF token (so it cannot linger into the next login) and fires the global 401 signal so the
+// app can redirect to login. It does NOT throw, so a call site that raises its own typed error after a session-expiry 401 (the
+// break-glass reauth path in auth.ts) can signal the redirect and still reject with its own error type.
+export function notifyUnauthorized(): void {
   clearCsrfToken();
   unauthorizedHandler?.();
+}
+
+// raiseUnauthorized is the single 401 chokepoint both fetch helpers funnel through: it signals the app (notifyUnauthorized) then throws
+// the typed error so the calling site still rejects (callers that already catch Unauthorized401Error keep working unchanged).
+function raiseUnauthorized(): never {
+  notifyUnauthorized();
   throw new Unauthorized401Error();
 }
 

--- a/ui/src/auth.test.ts
+++ b/ui/src/auth.test.ts
@@ -288,15 +288,33 @@ describe("reauthBreakglass", () => {
   });
 
   // spec:web-ui/authenticated-entry-to-the-application/mid-session-expiry-returns-the-operator-to-login
-  it("fires the global unauthorized handler on a 401 from the session-protected reauth path", async () => {
-    // A 401 on /api/auth/reauth/challenge means the session expired mid-reauth: signal the redirect-to-login handler
-    // (so the app flips to anon) AND still reject with BreakglassError.
-    const fetchSpy = stubFetch({}, 401, "invalid_session");
+  it("fires the global unauthorized handler on a middleware 401 (no X-Edr-Auth-Reason) from the reauth path", async () => {
+    // A session that lapses mid-reauth is rejected by the Session middleware, which short-circuits via WriteCookieAuthFailure
+    // and never sets X-Edr-Auth-Reason. The absent header is the discriminator: signal the redirect-to-login handler (so the app
+    // flips to anon) AND still reject with BreakglassError. stubFetch with no reason models the headerless middleware response.
+    const fetchSpy = stubFetch({}, 401);
     vi.stubGlobal("fetch", fetchSpy);
     const onUnauthorized = vi.fn();
     setUnauthorizedHandler(onUnauthorized);
     await expect(reauthBreakglass("pw")).rejects.toBeInstanceOf(BreakglassError);
     expect(onUnauthorized).toHaveBeenCalledTimes(1);
+    expect(mockedStartAuthentication).not.toHaveBeenCalled();
+  });
+
+  it("does NOT fire the unauthorized handler on a 401 invalid_credentials (wrong password, session still valid)", async () => {
+    // The reauth handler returns 401 with X-Edr-Auth-Reason: invalid_credentials on a wrong password/assertion. The session is
+    // still valid, so the operator must be able to retry in the modal: the present header means do NOT flip to anon / redirect.
+    // It still rejects with BreakglassError so the modal renders its inline "wrong credentials" error.
+    const fetchSpy = stubFetch({}, 401, "invalid_credentials");
+    vi.stubGlobal("fetch", fetchSpy);
+    const onUnauthorized = vi.fn();
+    setUnauthorizedHandler(onUnauthorized);
+    await expect(reauthBreakglass("pw")).rejects.toMatchObject({
+      name: "BreakglassError",
+      status: 401,
+      reason: "invalid_credentials",
+    });
+    expect(onUnauthorized).not.toHaveBeenCalled();
     expect(mockedStartAuthentication).not.toHaveBeenCalled();
   });
 });

--- a/ui/src/auth.test.ts
+++ b/ui/src/auth.test.ts
@@ -9,6 +9,7 @@ import {
   reauthBreakglass,
   reauthOIDC,
 } from "./auth";
+import { setUnauthorizedHandler } from "./api";
 
 // The auth.ts surface covers the pre-auth break-glass + OIDC redirect helpers. These tests pin the
 // observable contract of each helper: URL shape, fetch wire shape (method + headers + body + credentials), error mapping
@@ -68,6 +69,7 @@ afterEach(() => {
   vi.restoreAllMocks();
   vi.clearAllMocks();
   vi.unstubAllGlobals();
+  setUnauthorizedHandler(null);
 });
 
 describe("BreakglassError", () => {
@@ -225,6 +227,18 @@ describe("breakglassFinishLogin", () => {
       reason: "invalid_credentials",
     });
   });
+
+  // spec:web-ui/authenticated-entry-to-the-application/mid-session-expiry-returns-the-operator-to-login
+  it("does NOT fire the global unauthorized handler on a pre-auth break-glass 401", async () => {
+    // The pre-auth /admin/break-glass/* surface returns 401 on a wrong credential, not an expired session, so it must
+    // not trigger the login redirect (the operator is already on the sign-in surface).
+    const fetchSpy = stubFetch({}, 401, "invalid_credentials");
+    vi.stubGlobal("fetch", fetchSpy);
+    const onUnauthorized = vi.fn();
+    setUnauthorizedHandler(onUnauthorized);
+    await expect(breakglassFinishLogin("o", "p", {})).rejects.toBeInstanceOf(BreakglassError);
+    expect(onUnauthorized).not.toHaveBeenCalled();
+  });
 });
 
 describe("reauthBreakglass", () => {
@@ -270,6 +284,19 @@ describe("reauthBreakglass", () => {
       reason: "rate_limited",
     });
     // Should NOT have run startAuthentication when the challenge call itself rejected.
+    expect(mockedStartAuthentication).not.toHaveBeenCalled();
+  });
+
+  // spec:web-ui/authenticated-entry-to-the-application/mid-session-expiry-returns-the-operator-to-login
+  it("fires the global unauthorized handler on a 401 from the session-protected reauth path", async () => {
+    // A 401 on /api/auth/reauth/challenge means the session expired mid-reauth: signal the redirect-to-login handler
+    // (so the app flips to anon) AND still reject with BreakglassError.
+    const fetchSpy = stubFetch({}, 401, "invalid_session");
+    vi.stubGlobal("fetch", fetchSpy);
+    const onUnauthorized = vi.fn();
+    setUnauthorizedHandler(onUnauthorized);
+    await expect(reauthBreakglass("pw")).rejects.toBeInstanceOf(BreakglassError);
+    expect(onUnauthorized).toHaveBeenCalledTimes(1);
     expect(mockedStartAuthentication).not.toHaveBeenCalled();
   });
 });

--- a/ui/src/auth.ts
+++ b/ui/src/auth.ts
@@ -21,7 +21,8 @@ import {
   type PublicKeyCredentialCreationOptionsJSON,
   type PublicKeyCredentialRequestOptionsJSON,
 } from "@simplewebauthn/browser";
-import { attachCsrfHeader } from "./api";
+import { attachCsrfHeader, notifyUnauthorized } from "./api";
+import { HTTP_STATUS_UNAUTHORIZED } from "./constants";
 
 // HTTP status threshold above which the response is an error.
 const HTTP_BAD_REQUEST = 400;
@@ -97,6 +98,13 @@ async function requestJSON<T>(
   });
   if (res.status >= HTTP_BAD_REQUEST) {
     const reason = res.headers.get("X-Edr-Auth-Reason") ?? `http_${String(res.status)}`;
+    // A 401 on the session-protected reauth path (/api/auth/reauth/*) means the operator's session expired mid-reauth, not a bad
+    // break-glass credential (the pre-auth /admin/break-glass/* surface is also 401 on a wrong password). Signal the global handler so
+    // the app flips to anon and routes to /login, matching the fetchJSON 401 behavior; the BreakglassError still throws so the modal's
+    // own teardown runs while the redirect takes over.
+    if (res.status === HTTP_STATUS_UNAUTHORIZED && path.startsWith("/api/auth/reauth")) {
+      notifyUnauthorized();
+    }
     throw new BreakglassError(res.status, reason);
   }
   // Guard against 204 / empty / non-JSON 2xx bodies. Today every

--- a/ui/src/auth.ts
+++ b/ui/src/auth.ts
@@ -97,12 +97,15 @@ async function requestJSON<T>(
     credentials: "include",
   });
   if (res.status >= HTTP_BAD_REQUEST) {
-    const reason = res.headers.get("X-Edr-Auth-Reason") ?? `http_${String(res.status)}`;
-    // A 401 on the session-protected reauth path (/api/auth/reauth/*) means the operator's session expired mid-reauth, not a bad
-    // break-glass credential (the pre-auth /admin/break-glass/* surface is also 401 on a wrong password). Signal the global handler so
-    // the app flips to anon and routes to /login, matching the fetchJSON 401 behavior; the BreakglassError still throws so the modal's
-    // own teardown runs while the redirect takes over.
-    if (res.status === HTTP_STATUS_UNAUTHORIZED && path.startsWith("/api/auth/reauth")) {
+    const reasonHeader = res.headers.get("X-Edr-Auth-Reason");
+    const reason = reasonHeader ?? `http_${String(res.status)}`;
+    // The session-protected reauth path (/api/auth/reauth/*) returns 401 in two opposite cases that we must NOT conflate: a wrong
+    // password/assertion (the handler's invalid_credentials, session still valid, operator should retry in the modal) vs. the session
+    // lapsing mid-reauth (the Session middleware short-circuits via WriteCookieAuthFailure, which never sets X-Edr-Auth-Reason). Only the
+    // latter should flip the app to anon and route to /login. Discriminate on the header: present (invalid_credentials and friends) means
+    // the handler ran and the session is fine, so leave it to the modal; absent means a middleware session failure, so signal the global
+    // handler. The BreakglassError still throws either way so the modal's own teardown runs.
+    if (res.status === HTTP_STATUS_UNAUTHORIZED && path.startsWith("/api/auth/reauth") && reasonHeader === null) {
       notifyUnauthorized();
     }
     throw new BreakglassError(res.status, reason);


### PR DESCRIPTION
<!-- Keep this short. Delete sections that do not apply. -->

## What & why



## Checklist

- [ ] **OpenSpec updated for behavior changes.** If this PR changes observable behavior (a detection rule, the event
      wire schema, persistence semantics, an API/wire shape, or an emitted event), `openspec/specs/**` is updated (and
      an `openspec/changes/` proposal added), with a `spec:<id>` test marker for any new/renamed scenario. Only if this
      PR changes NO observable behavior (a comment / refactor / gofmt / dep bump that happens to touch a scoped path)
      may you assert `no-behavior-change` (label or `[no-behavior-change]` in the title) to clear the OpenSpec-sync gate.
      That is an assertion a reviewer will check, not a way to skip the spec for a real behavior change.
- [ ] Tests added/updated for the change (unit / integration / efficacy / UI as applicable).
- [ ] Agent/extension change touching ESF, XPC, or the event wire format: exercised on a live macOS VM before RC
      (flagged below).

## VM / RC notes (if applicable)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sessions that expire during active use now automatically redirect to the login page, preserving your current location for seamless return after re-authentication.

* **Documentation**
  * Updated session timeout specifications to document idle and absolute timeout behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->