### PR TITLE
fix(detection): widen processes uid/gid to unsigned, isolate poison e…

### DIFF
--- a/openspec/changes/fix-process-uid-gid-overflow/proposal.md
+++ b/openspec/changes/fix-process-uid-gid-overflow/proposal.md
@@ -1,0 +1,17 @@
+# Fix process uid/gid overflow wedging the detection pipeline
+
+## Why
+
+`processes.uid` and `processes.gid` are declared signed `INT` (max 2147483647), but macOS `uid_t`/`gid_t` are unsigned 32-bit. The `nobody` account is `4294967294` (-2 as uint32) and the unset sentinel `KAUTH_UID_NONE` is `4294967295` (-1); both overflow signed `INT`, so the process insert fails with MySQL error 1264 ("Out of range value for column 'uid'").
+
+That failure does not just drop one event. The graph builder fails the whole batch on any per-event error, and the processor then unclaims the batch and never marks it processed, so the poison event stays the oldest unprocessed row and is re-fetched and re-failed every cycle. Detection rule evaluation runs only after the batch succeeds, so it never runs. On the prod-render pilot (issue #379) this manifested as ~56k `event processing failed` / `graph builder failure, will retry batch` warnings in 6h (~2.6 retries/sec on one poisoned batch) with no new process-graph materialization or alerts: a fleet-wide stall of the detection plane triggered by a routine macOS uid, with no self-recovery.
+
+## What changes
+
+- **Schema.** Widen `processes.uid` and `processes.gid` to `INT UNSIGNED` so the full `uid_t`/`gid_t` range persists. Forward-only goose migration; existing rows hold only `0..2147483647` (the signed range that ever inserted successfully), so the change is lossless.
+- **Pipeline resilience.** The graph builder distinguishes a permanent (non-retryable) persistence error from a transient one. A permanent error (a data-integrity violation that recurs on every retry) drops the single offending event and lets the batch advance; only a transient fault (deadlock, lock-wait timeout, lost connection) fails the batch so the processor retries it. One unpersistable row can no longer wedge the pipeline.
+
+### Not in this change
+
+- A dedicated `edr.events.dropped` counter for quarantined events. The builder does not currently carry a metrics recorder; the drop is logged at WARN (`event dropped: permanent processing error`) for now, and the counter can land as a follow-up that threads a recorder through the builder.
+- Any agent-side change: the agent already serializes the full uint32 uid; only the column type was too narrow.

--- a/openspec/changes/fix-process-uid-gid-overflow/specs/server-process-graph-builder/spec.md
+++ b/openspec/changes/fix-process-uid-gid-overflow/specs/server-process-graph-builder/spec.md
@@ -14,7 +14,7 @@ The system SHALL persist process effective UID and GID values across the entire 
 
 ### Requirement: A single unpersistable event does not stall batch processing
 
-The system SHALL isolate a single event that fails with a permanent (non-retryable) persistence error so that it does not block the rest of its batch or any subsequent batch. Such an event MUST be dropped, and logged, while the remaining events in the batch are still materialized and the batch is reported successful so the processor marks it processed rather than re-fetching it. An event that fails with a transient (retryable) error MUST instead cause the batch to be reported as failed so the processor retries it and no data is lost to a recoverable fault.
+The system SHALL isolate a single event that fails with a permanent (non-retryable) error so that it does not block the rest of its batch or any subsequent batch. A permanent error is one that recurs identically on every retry: a payload that cannot be parsed (a JSON syntax or type error), or a value the database can never store (a data-integrity violation). Such an event MUST be dropped, and logged, while the remaining events in the batch are still materialized and the batch is reported successful so the processor marks it processed rather than re-fetching it. An event that fails with a transient (retryable) error MUST instead cause the batch to be reported as failed so the processor retries it and no data is lost to a recoverable fault.
 
 #### Scenario: A poison event is dropped and the batch advances
 
@@ -23,6 +23,14 @@ The system SHALL isolate a single event that fails with a permanent (non-retryab
 - **THEN** the valid event's process record is materialized
 - **AND** the batch is reported successful so the processor marks it processed and does not retry it
 - **AND** the poison event is not stored
+
+#### Scenario: A malformed event is dropped and the batch advances
+
+- **GIVEN** a batch containing one event whose payload cannot be parsed and one valid event
+- **WHEN** the builder processes the batch
+- **THEN** the valid event's process record is materialized
+- **AND** the batch is reported successful so the processor marks it processed and does not retry it
+- **AND** the malformed event is not stored
 
 #### Scenario: A transient failure retries the batch
 

--- a/openspec/changes/fix-process-uid-gid-overflow/specs/server-process-graph-builder/spec.md
+++ b/openspec/changes/fix-process-uid-gid-overflow/specs/server-process-graph-builder/spec.md
@@ -1,0 +1,31 @@
+# Server process graph builder: uid/gid range and poison-event isolation delta
+
+## ADDED Requirements
+
+### Requirement: Process records store the full macOS uid and gid range
+
+The system SHALL persist process effective UID and GID values across the entire macOS `uid_t`/`gid_t` range (unsigned 32-bit, 0 through 4294967295), including the conventional `nobody` value (4294967294) and the unset `KAUTH_UID_NONE` sentinel (4294967295). A UID or GID anywhere in that range MUST NOT cause the originating event to be rejected at persistence time.
+
+#### Scenario: A process owned by nobody is materialized
+
+- **GIVEN** an `exec` event whose UID is 4294967294 and GID is 4294967295
+- **WHEN** the builder processes the event
+- **THEN** the process record persists with UID 4294967294 and GID 4294967295
+
+### Requirement: A single unpersistable event does not stall batch processing
+
+The system SHALL isolate a single event that fails with a permanent (non-retryable) persistence error so that it does not block the rest of its batch or any subsequent batch. Such an event MUST be dropped, and logged, while the remaining events in the batch are still materialized and the batch is reported successful so the processor marks it processed rather than re-fetching it. An event that fails with a transient (retryable) error MUST instead cause the batch to be reported as failed so the processor retries it and no data is lost to a recoverable fault.
+
+#### Scenario: A poison event is dropped and the batch advances
+
+- **GIVEN** a batch containing one event that fails with a permanent data error and one valid event
+- **WHEN** the builder processes the batch
+- **THEN** the valid event's process record is materialized
+- **AND** the batch is reported successful so the processor marks it processed and does not retry it
+- **AND** the poison event is not stored
+
+#### Scenario: A transient failure retries the batch
+
+- **GIVEN** an event that fails with a transient, retryable database error
+- **WHEN** the builder classifies the failure
+- **THEN** the failure is reported as non-permanent so the batch is retried rather than the event being dropped

--- a/openspec/changes/fix-process-uid-gid-overflow/tasks.md
+++ b/openspec/changes/fix-process-uid-gid-overflow/tasks.md
@@ -8,6 +8,9 @@
 
 - [x] `internal/mysql/errors.go`: `IsPermanentDataError` classifying MySQL data-integrity error numbers (1264, 1265, 1292, 1366, 1406, 3819); unknown errors treated as transient.
 - [x] `internal/graph/builder.go` `ProcessBatch`: drop events that fail with a permanent error (log `event dropped: permanent processing error`); fail the batch only for transient errors so the processor retries them.
+- [x] `internal/graph/builder.go` `permanentError`: also classify deterministic parse failures (`*json.SyntaxError`, `*json.UnmarshalTypeError`) as permanent, so a malformed payload (or a uid that overflows the Go type on 32-bit) cannot wedge the batch (review follow-up).
+- [x] `internal/mysql/errors.go`: include 1048 (bad null), 1062 (dup entry), 1364 (no default) as permanent (review follow-up).
+- [x] Migration `00003`: Down is a documented no-op (narrowing back to signed INT would overflow rows that now hold values > 2147483647; forward-only per ADR-0009) (review follow-up).
 
 ## 3. Spec
 

--- a/openspec/changes/fix-process-uid-gid-overflow/tasks.md
+++ b/openspec/changes/fix-process-uid-gid-overflow/tasks.md
@@ -1,0 +1,24 @@
+# Fix process uid/gid overflow: tasks
+
+## 1. Schema
+
+- [x] Migration `00003_processes_uid_unsigned.sql`: `ALTER TABLE processes MODIFY uid INT UNSIGNED, MODIFY gid INT UNSIGNED` (goose up/down).
+
+## 2. Pipeline resilience
+
+- [x] `internal/mysql/errors.go`: `IsPermanentDataError` classifying MySQL data-integrity error numbers (1264, 1265, 1292, 1366, 1406, 3819); unknown errors treated as transient.
+- [x] `internal/graph/builder.go` `ProcessBatch`: drop events that fail with a permanent error (log `event dropped: permanent processing error`); fail the batch only for transient errors so the processor retries them.
+
+## 3. Spec
+
+- [x] `server-process-graph-builder`: ADDED "Process records store the full macOS uid and gid range" and "A single unpersistable event does not stall batch processing".
+
+## 4. Tests
+
+- [x] `internal/mysql/errors_test.go`: table-driven `IsPermanentDataError` (permanent vs transient vs wrapped vs non-mysql vs nil), with the transient-retry scenario marker.
+- [x] Integration (`internal/tests`, real MySQL): a `nobody` exec (uid 4294967294 / gid 4294967295) persists; a poison event (over-long host_id) is dropped while the valid event in the batch is materialized and the batch reports success.
+
+## 5. Verification
+
+- [ ] `go build ./server/...`; `go test ./server/detection/internal/mysql/...`; `go test -tags integration ./server/detection/internal/tests/...` (needs `EDR_TEST_DSN`).
+- [ ] gofmt, golangci-lint, `openspec validate fix-process-uid-gid-overflow --strict`, spectrace.

--- a/server/detection/internal/graph/builder.go
+++ b/server/detection/internal/graph/builder.go
@@ -3,6 +3,7 @@ package graph
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"slices"
@@ -141,7 +142,7 @@ func (b *Builder) ProcessBatch(ctx context.Context, events []api.Event) error {
 		// retry. Returning it here would make the processor unclaim and re-fetch the whole batch forever, wedging the pipeline
 		// fleet-wide on one poison event (the uid/gid-overflow incident, issue #379). Drop the offending event so the batch
 		// advances; only a transient fault (deadlock, lock-wait timeout, lost connection) fails the batch so it is retried.
-		if mysql.IsPermanentDataError(err) {
+		if permanentError(err) {
 			b.logger.WarnContext(ctx, "event dropped: permanent processing error", "event_id", evt.EventID, "type", evt.EventType, "err", err)
 			continue
 		}
@@ -152,6 +153,21 @@ func (b *Builder) ProcessBatch(ctx context.Context, events []api.Event) error {
 		return fmt.Errorf("graph: %d event(s) failed to process", transientFailCount)
 	}
 	return nil
+}
+
+// permanentError reports whether err is a deterministic per-event failure that recurs on every retry: a payload that cannot be parsed
+// (a JSON syntax or type error, including a number that overflows the target Go type) or a value the database can never store
+// (mysql.IsPermanentDataError). The builder drops such an event so one poison row cannot wedge the batch; any other error is treated
+// as a transient fault and the batch is retried. See issue #379.
+func permanentError(err error) bool {
+	var (
+		syntaxErr *json.SyntaxError
+		typeErr   *json.UnmarshalTypeError
+	)
+	if errors.As(err, &syntaxErr) || errors.As(err, &typeErr) {
+		return true
+	}
+	return mysql.IsPermanentDataError(err)
 }
 
 type snapshotHeartbeatPayload struct {

--- a/server/detection/internal/graph/builder.go
+++ b/server/detection/internal/graph/builder.go
@@ -121,7 +121,7 @@ func (b *Builder) ProcessBatch(ctx context.Context, events []api.Event) error {
 	// map, called per batch is plenty.
 	b.sweepPendingExits()
 
-	var failCount int
+	var transientFailCount int
 	for _, evt := range sorted {
 		var err error
 		switch evt.EventType {
@@ -134,13 +134,22 @@ func (b *Builder) ProcessBatch(ctx context.Context, events []api.Event) error {
 		case "snapshot_heartbeat":
 			err = b.handleSnapshotHeartbeat(ctx, evt)
 		}
-		if err != nil {
-			failCount++
-			b.logger.WarnContext(ctx, "event processing failed", "event_id", evt.EventID, "type", evt.EventType, "err", err)
+		if err == nil {
+			continue
 		}
+		// A permanent (non-retryable) persistence error, e.g. a value outside a column's range, fails identically on every
+		// retry. Returning it here would make the processor unclaim and re-fetch the whole batch forever, wedging the pipeline
+		// fleet-wide on one poison event (the uid/gid-overflow incident, issue #379). Drop the offending event so the batch
+		// advances; only a transient fault (deadlock, lock-wait timeout, lost connection) fails the batch so it is retried.
+		if mysql.IsPermanentDataError(err) {
+			b.logger.WarnContext(ctx, "event dropped: permanent processing error", "event_id", evt.EventID, "type", evt.EventType, "err", err)
+			continue
+		}
+		transientFailCount++
+		b.logger.WarnContext(ctx, "event processing failed, will retry", "event_id", evt.EventID, "type", evt.EventType, "err", err)
 	}
-	if failCount > 0 {
-		return fmt.Errorf("graph: %d event(s) failed to process", failCount)
+	if transientFailCount > 0 {
+		return fmt.Errorf("graph: %d event(s) failed to process", transientFailCount)
 	}
 	return nil
 }

--- a/server/detection/internal/graph/permanent_error_test.go
+++ b/server/detection/internal/graph/permanent_error_test.go
@@ -1,0 +1,39 @@
+package graph
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+
+	driver "github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestPermanentError pins which per-event failures the builder drops (so they cannot wedge the batch) versus retries. Parse failures
+// and MySQL data-integrity violations recur on every retry and must be permanent; transient DB faults and unclassified errors must
+// not be dropped. See issue #379.
+func TestPermanentError(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"json type error (e.g. uid overflow on 32-bit)", &json.UnmarshalTypeError{Value: "number", Type: nil}, true},
+		{"json syntax error", &json.SyntaxError{}, true},
+		{"wrapped json type error", fmt.Errorf("decode exec payload: %w", &json.UnmarshalTypeError{}), true},
+		{"mysql out-of-range is delegated as permanent", &driver.MySQLError{Number: 1264}, true},
+		{"transient mysql deadlock is not permanent", &driver.MySQLError{Number: 1213}, false},
+		{"generic error is not permanent", errors.New("dial tcp: connection refused"), false},
+		{"nil is not permanent", nil, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, permanentError(tc.err))
+		})
+	}
+}

--- a/server/detection/internal/mysql/errors.go
+++ b/server/detection/internal/mysql/errors.go
@@ -1,0 +1,32 @@
+package mysql
+
+import (
+	"errors"
+
+	driver "github.com/go-sql-driver/mysql"
+)
+
+// permanentDataErrors are MySQL server error numbers for values that can never be stored as written: the same row will fail
+// identically on every retry. They are distinguished from transient faults (deadlock, lock-wait timeout, dropped connection) that a
+// retry can clear.
+var permanentDataErrors = map[uint16]struct{}{
+	1264: {}, // ER_WARN_DATA_OUT_OF_RANGE: value outside the column's range (e.g. a uid_t past signed INT)
+	1265: {}, // ER_WARN_DATA_TRUNCATED
+	1292: {}, // ER_TRUNCATED_WRONG_VALUE
+	1366: {}, // ER_TRUNCATED_WRONG_VALUE_FOR_FIELD
+	1406: {}, // ER_DATA_TOO_LONG
+	3819: {}, // ER_CHECK_CONSTRAINT_VIOLATED
+}
+
+// IsPermanentDataError reports whether err (or any error it wraps) is a MySQL data-integrity violation that will recur on every
+// retry. The graph builder drops such an event instead of failing and retrying the whole batch, so one unpersistable row cannot wedge
+// the processing pipeline. Unknown errors return false (treated as transient) so genuinely retryable faults are never silently
+// discarded.
+func IsPermanentDataError(err error) bool {
+	var me *driver.MySQLError
+	if !errors.As(err, &me) {
+		return false
+	}
+	_, ok := permanentDataErrors[me.Number]
+	return ok
+}

--- a/server/detection/internal/mysql/errors.go
+++ b/server/detection/internal/mysql/errors.go
@@ -10,9 +10,12 @@ import (
 // identically on every retry. They are distinguished from transient faults (deadlock, lock-wait timeout, dropped connection) that a
 // retry can clear.
 var permanentDataErrors = map[uint16]struct{}{
+	1048: {}, // ER_BAD_NULL_ERROR: NULL into a NOT NULL column
+	1062: {}, // ER_DUP_ENTRY: duplicate value for a unique key (the row already exists; retrying never clears it)
 	1264: {}, // ER_WARN_DATA_OUT_OF_RANGE: value outside the column's range (e.g. a uid_t past signed INT)
 	1265: {}, // ER_WARN_DATA_TRUNCATED
 	1292: {}, // ER_TRUNCATED_WRONG_VALUE
+	1364: {}, // ER_NO_DEFAULT_FOR_FIELD: a required column with no default was omitted
 	1366: {}, // ER_TRUNCATED_WRONG_VALUE_FOR_FIELD
 	1406: {}, // ER_DATA_TOO_LONG
 	3819: {}, // ER_CHECK_CONSTRAINT_VIOLATED

--- a/server/detection/internal/mysql/errors_test.go
+++ b/server/detection/internal/mysql/errors_test.go
@@ -24,6 +24,9 @@ func TestIsPermanentDataError(t *testing.T) {
 		{"out-of-range uid (1264)", &driver.MySQLError{Number: 1264, Message: "Out of range value for column 'uid' at row 1"}, true},
 		{"data too long (1406)", &driver.MySQLError{Number: 1406, Message: "Data too long for column 'host_id'"}, true},
 		{"check constraint violated (3819)", &driver.MySQLError{Number: 3819}, true},
+		{"bad null (1048)", &driver.MySQLError{Number: 1048}, true},
+		{"duplicate entry (1062)", &driver.MySQLError{Number: 1062}, true},
+		{"no default for field (1364)", &driver.MySQLError{Number: 1364}, true},
 		{"wrapped out-of-range is still permanent", fmt.Errorf("insert process: %w", &driver.MySQLError{Number: 1264}), true},
 		// spec:server-process-graph-builder/a-single-unpersistable-event-does-not-stall-batch-processing/a-transient-failure-retries-the-batch
 		{"deadlock (1213) is transient", &driver.MySQLError{Number: 1213}, false},

--- a/server/detection/internal/mysql/errors_test.go
+++ b/server/detection/internal/mysql/errors_test.go
@@ -1,0 +1,41 @@
+package mysql
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	driver "github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestIsPermanentDataError pins which MySQL failures the graph builder treats as poison (drop the event, advance the batch) versus
+// transient (fail the batch so the processor retries). Getting this wrong in either direction is a regression: classifying a transient
+// fault as permanent silently drops good data, and classifying a permanent fault as transient re-introduces the uid/gid-overflow
+// wedge where one bad row stalls the pipeline forever.
+func TestIsPermanentDataError(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"out-of-range uid (1264)", &driver.MySQLError{Number: 1264, Message: "Out of range value for column 'uid' at row 1"}, true},
+		{"data too long (1406)", &driver.MySQLError{Number: 1406, Message: "Data too long for column 'host_id'"}, true},
+		{"check constraint violated (3819)", &driver.MySQLError{Number: 3819}, true},
+		{"wrapped out-of-range is still permanent", fmt.Errorf("insert process: %w", &driver.MySQLError{Number: 1264}), true},
+		// spec:server-process-graph-builder/a-single-unpersistable-event-does-not-stall-batch-processing/a-transient-failure-retries-the-batch
+		{"deadlock (1213) is transient", &driver.MySQLError{Number: 1213}, false},
+		{"lock wait timeout (1205) is transient", &driver.MySQLError{Number: 1205}, false},
+		{"non-mysql error is transient", errors.New("dial tcp: connection refused"), false},
+		{"nil error is not permanent", nil, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, IsPermanentDataError(tc.err))
+		})
+	}
+}

--- a/server/detection/internal/tests/uid_overflow_test.go
+++ b/server/detection/internal/tests/uid_overflow_test.go
@@ -45,8 +45,8 @@ func TestProcessGraph_HighUIDProcessPersists(t *testing.T) {
 	b, db := newBuilder(t)
 	ctx := t.Context()
 
-	const nobodyUID int64 = 4294967294 // -2 as uint32
-	const noneGID int64 = 4294967295   // KAUTH_UID_NONE, -1 as uint32
+	const nobodyUID int64 = 4294967294 // nobody, -2 as uint32
+	const noneGID int64 = 4294967295   // the unset-id sentinel, -1 as uint32
 	now := time.Now().UnixNano()
 	events := []api.Event{
 		{EventID: "fork-nobody", HostID: "h", TimestampNs: now, EventType: "fork",
@@ -94,4 +94,29 @@ func TestProcessBatch_PermanentErrorDoesNotWedgeBatch(t *testing.T) {
 	require.NoError(t, db.QueryRowContext(ctx,
 		`SELECT COUNT(*) FROM processes WHERE pid = 11`).Scan(&poison))
 	assert.Equal(t, 0, poison, "the poison event is dropped, not stored")
+}
+
+// spec:server-process-graph-builder/a-single-unpersistable-event-does-not-stall-batch-processing/a-malformed-event-is-dropped-and-the-batch-advances
+func TestProcessBatch_MalformedPayloadDoesNotWedgeBatch(t *testing.T) {
+	t.Parallel()
+	b, db := newBuilder(t)
+	ctx := t.Context()
+
+	now := time.Now().UnixNano()
+	// A non-MySQL poison: the exec payload's pid is a string where an int is expected, so json.Unmarshal returns a deterministic
+	// UnmarshalTypeError. Without classifying parse failures as permanent, this would fail the batch and wedge the pipeline the same
+	// way the uid overflow did (issue #379 review follow-up).
+	events := []api.Event{
+		{EventID: "good-fork-2", HostID: "good2", TimestampNs: now, EventType: "fork",
+			Payload: json.RawMessage(`{"child_pid":20,"parent_pid":1}`)},
+		{EventID: "malformed-exec", HostID: "good2", TimestampNs: now + 1, EventType: "exec",
+			Payload: json.RawMessage(`{"pid":"not-a-number"}`)},
+	}
+
+	require.NoError(t, b.ProcessBatch(ctx, events))
+
+	var good int
+	require.NoError(t, db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM processes WHERE host_id = 'good2' AND pid = 20`).Scan(&good))
+	assert.Equal(t, 1, good, "the valid event is materialized despite the malformed sibling")
 }

--- a/server/detection/internal/tests/uid_overflow_test.go
+++ b/server/detection/internal/tests/uid_overflow_test.go
@@ -1,0 +1,97 @@
+//go:build integration
+
+// Integration coverage for issue #379: macOS uid_t/gid_t are unsigned 32-bit, so values like `nobody` (4294967294) and the unset
+// sentinel KAUTH_UID_NONE (4294967295) overflowed the old signed-INT uid/gid columns and failed the insert with MySQL error 1264.
+// Because the graph builder failed the whole batch on any per-event error and the processor re-fetched it forever, one such event
+// wedged the detection pipeline fleet-wide. These tests pin both halves of the fix: the columns now hold the full range, and a
+// permanently-failing event is dropped so the batch still advances.
+
+package tests
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fleetdm/edr/server/detection/api"
+	"github.com/fleetdm/edr/server/detection/internal/graph"
+	"github.com/fleetdm/edr/server/detection/internal/mysql"
+	"github.com/fleetdm/edr/server/testdb/full"
+)
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func newBuilder(t *testing.T) (*graph.Builder, *sqlx.DB) {
+	t.Helper()
+	db := full.Open(t)
+	store, err := mysql.New(db)
+	require.NoError(t, err)
+	return graph.NewBuilder(store, discardLogger()), db
+}
+
+// spec:server-process-graph-builder/process-records-store-the-full-macos-uid-and-gid-range/a-process-owned-by-nobody-is-materialized
+func TestProcessGraph_HighUIDProcessPersists(t *testing.T) {
+	t.Parallel()
+	b, db := newBuilder(t)
+	ctx := t.Context()
+
+	const nobodyUID int64 = 4294967294 // -2 as uint32
+	const noneGID int64 = 4294967295   // KAUTH_UID_NONE, -1 as uint32
+	now := time.Now().UnixNano()
+	events := []api.Event{
+		{EventID: "fork-nobody", HostID: "h", TimestampNs: now, EventType: "fork",
+			Payload: json.RawMessage(`{"child_pid":4242,"parent_pid":1}`)},
+		{EventID: "exec-nobody", HostID: "h", TimestampNs: now + 1, EventType: "exec",
+			Payload: json.RawMessage(fmt.Sprintf(`{"pid":4242,"ppid":1,"path":"/usr/sbin/nobodyd","uid":%d,"gid":%d}`, nobodyUID, noneGID))},
+	}
+
+	require.NoError(t, b.ProcessBatch(ctx, events), "a uid/gid in the full uid_t range must not fail the batch")
+
+	var uid, gid int64
+	require.NoError(t, db.QueryRowContext(ctx,
+		`SELECT uid, gid FROM processes WHERE host_id = 'h' AND pid = 4242`).Scan(&uid, &gid))
+	assert.Equal(t, nobodyUID, uid)
+	assert.Equal(t, noneGID, gid)
+}
+
+// spec:server-process-graph-builder/a-single-unpersistable-event-does-not-stall-batch-processing/a-poison-event-is-dropped-and-the-batch-advances
+func TestProcessBatch_PermanentErrorDoesNotWedgeBatch(t *testing.T) {
+	t.Parallel()
+	b, db := newBuilder(t)
+	ctx := t.Context()
+
+	now := time.Now().UnixNano()
+	// A host_id past the column's VARCHAR(255) is a permanent ER_DATA_TOO_LONG (1406): it fails identically on every retry, the
+	// same poison-pill shape as the uid overflow. The valid event in the same batch must still be materialized.
+	poisonHost := strings.Repeat("h", 300)
+	events := []api.Event{
+		{EventID: "good-fork", HostID: "good", TimestampNs: now, EventType: "fork",
+			Payload: json.RawMessage(`{"child_pid":10,"parent_pid":1}`)},
+		{EventID: "poison-fork", HostID: poisonHost, TimestampNs: now + 1, EventType: "fork",
+			Payload: json.RawMessage(`{"child_pid":11,"parent_pid":1}`)},
+	}
+
+	// The batch must report success despite the poison event so the processor marks it processed and advances, instead of
+	// unclaiming and re-fetching it forever.
+	require.NoError(t, b.ProcessBatch(ctx, events))
+
+	var good int
+	require.NoError(t, db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM processes WHERE host_id = 'good' AND pid = 10`).Scan(&good))
+	assert.Equal(t, 1, good, "the valid event in the batch is materialized")
+
+	var poison int
+	require.NoError(t, db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM processes WHERE pid = 11`).Scan(&poison))
+	assert.Equal(t, 0, poison, "the poison event is dropped, not stored")
+}

--- a/server/detection/migrations/00003_processes_uid_unsigned.sql
+++ b/server/detection/migrations/00003_processes_uid_unsigned.sql
@@ -13,8 +13,6 @@ ALTER TABLE processes
 -- +goose StatementEnd
 
 -- +goose Down
--- +goose StatementBegin
-ALTER TABLE processes
-	MODIFY uid INT,
-	MODIFY gid INT;
--- +goose StatementEnd
+-- Intentionally a no-op. Narrowing uid/gid back to a signed INT would fail (or silently corrupt) on any row that has since stored a
+-- value above 2147483647, e.g. nobody = 4294967294, so a real rollback is unsafe and would reintroduce the overflow bug. Migrations
+-- are forward-only (ADR-0009); this Down deliberately does nothing.

--- a/server/detection/migrations/00003_processes_uid_unsigned.sql
+++ b/server/detection/migrations/00003_processes_uid_unsigned.sql
@@ -1,0 +1,20 @@
+-- +goose Up
+-- macOS uid_t/gid_t are unsigned 32-bit. The `nobody` account is 4294967294 (-2 as uint32) and the "no uid" sentinel
+-- KAUTH_UID_NONE is 4294967295 (-1); both overflow a signed INT (max 2147483647) and make the process insert fail with MySQL
+-- error 1264 (out of range). That failure previously wedged the graph-builder batch loop: the poison row was re-fetched and
+-- re-failed every cycle, so the detection pipeline stalled fleet-wide and produced no further process graph or alerts. Widen
+-- uid/gid to INT UNSIGNED to hold the full uid_t/gid_t range. Existing rows hold only 0..2147483647 (the signed range that ever
+-- inserted successfully), so the widening is lossless.
+
+-- +goose StatementBegin
+ALTER TABLE processes
+	MODIFY uid INT UNSIGNED,
+	MODIFY gid INT UNSIGNED;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE processes
+	MODIFY uid INT,
+	MODIFY gid INT;
+-- +goose StatementEnd


### PR DESCRIPTION
…vents

processes.uid/gid were signed INT (max 2147483647), but macOS uid_t/gid_t are unsigned 32-bit. nobody (4294967294) and KAUTH_UID_NONE (4294967295) overflowed and failed the insert with MySQL error 1264. The builder failed the whole batch on any per-event error and the processor re-fetched it forever, so one such event wedged the detection pipeline fleet-wide (no new process graph or alerts), with no self-recovery. See #379.

- migration 00003: ALTER processes MODIFY uid/gid INT UNSIGNED (lossless; stored values are all within the old signed range).
- mysql.IsPermanentDataError: classify data-integrity error numbers (1264/1265/1292/1366/1406/3819) that recur on every retry.
- builder.ProcessBatch: drop an event that fails permanently (log 'event dropped: permanent processing error') so the batch advances; fail the batch only for transient errors so the processor retries.
- tests: classifier unit test; integration tests proving a nobody-uid exec persists and a poison event is dropped while the batch still advances.
- openspec change delta for the gated migrations path.

<!-- Keep this short. Delete sections that do not apply. -->

## What & why



## Checklist

- [ ] **OpenSpec updated for behavior changes.** If this PR changes observable behavior (a detection rule, the event
      wire schema, persistence semantics, an API/wire shape, or an emitted event), `openspec/specs/**` is updated (and
      an `openspec/changes/` proposal added), with a `spec:<id>` test marker for any new/renamed scenario. Only if this
      PR changes NO observable behavior (a comment / refactor / gofmt / dep bump that happens to touch a scoped path)
      may you assert `no-behavior-change` (label or `[no-behavior-change]` in the title) to clear the OpenSpec-sync gate.
      That is an assertion a reviewer will check, not a way to skip the spec for a real behavior change.
- [ ] Tests added/updated for the change (unit / integration / efficacy / UI as applicable).
- [ ] Agent/extension change touching ESF, XPC, or the event wire format: exercised on a live macOS VM before RC
      (flagged below).

## VM / RC notes (if applicable)


