### PR TITLE
Fix issues with demo seed data

### DIFF
--- a/server/cmd/fleet-edr-demo-seed/db_test.go
+++ b/server/cmd/fleet-edr-demo-seed/db_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"database/sql"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -192,6 +193,104 @@ func TestRunSeedsEndToEnd(t *testing.T) {
 	require.NoError(t, db.QueryRowContext(ctx,
 		`SELECT COUNT(*) FROM users WHERE email = 'demo@fleet-edr.local'`).Scan(&userCount))
 	assert.Equal(t, 1, userCount, "SSO demo user provisioned")
+}
+
+// TestRefreshTimestamps confirms the already-seeded restart path slides every replayed timestamp forward by one delta: the newest
+// process row lands ~recentTailOffset before now, relative offsets are preserved, NULL exit columns stay NULL, and the alert
+// "fired at" slides with the events so the UI's alert -> tree pivot keeps working.
+func TestRefreshTimestamps(t *testing.T) {
+	db := full.Open(t)
+	ctx := t.Context()
+	s := newSeeder(config{}, db, testHTTPClient(), discardLogger())
+
+	// Two processes 30s apart, both stamped ~6 days ago, one still running (NULL exit). last_seen mirrors fork here.
+	const sixDaysNs = int64(6*24*60*60) * int64(time.Second)
+	staleNewest := time.Now().UnixNano() - sixDaysNs
+	staleOlder := staleNewest - int64(30*time.Second)
+	_, err := db.ExecContext(ctx,
+		`INSERT INTO processes (host_id, pid, ppid, path, fork_time_ns, fork_ingested_at_ns, last_seen_ns, exit_time_ns)
+		 VALUES (?, ?, 1, '/bin/older', ?, ?, ?, ?), (?, ?, 1, '/bin/newest', ?, ?, ?, NULL)`,
+		"HOST-R", 100, staleOlder, staleOlder, staleOlder, staleOlder+int64(time.Second),
+		"HOST-R", 200, staleNewest, staleNewest, staleNewest)
+	require.NoError(t, err)
+	insertAlert(t, db, "HOST-R", "sudoers_tamper", "detection", "high")
+
+	require.NoError(t, s.refreshTimestamps(ctx))
+
+	var newestFork, olderFork, lastSeen int64
+	var olderExit sql.NullInt64
+	var newestExit sql.NullInt64
+	require.NoError(t, db.QueryRowContext(ctx,
+		`SELECT fork_time_ns, last_seen_ns, exit_time_ns FROM processes WHERE host_id = 'HOST-R' AND pid = 200`).
+		Scan(&newestFork, &lastSeen, &newestExit))
+	require.NoError(t, db.QueryRowContext(ctx,
+		`SELECT fork_time_ns, exit_time_ns FROM processes WHERE host_id = 'HOST-R' AND pid = 100`).Scan(&olderFork, &olderExit))
+
+	// Newest fork now lands ~recentTailOffset before now (allow a generous slop for test wall-clock drift).
+	wantNewest := time.Now().Add(-recentTailOffset).UnixNano()
+	assert.InDelta(t, wantNewest, newestFork, float64(2*time.Minute), "newest fork slid to ~now-offset")
+	assert.Equal(t, newestFork, lastSeen, "last_seen slid by the same delta as fork")
+	assert.False(t, newestExit.Valid, "running process keeps NULL exit after the shift")
+	// Relative spacing is preserved: the older fork stays 30s behind the newest.
+	assert.Equal(t, int64(30*time.Second), newestFork-olderFork, "30s gap preserved")
+	require.True(t, olderExit.Valid)
+	assert.Equal(t, olderFork+int64(time.Second), olderExit.Int64, "exited process keeps its 1s lifetime")
+
+	// The alert's created_at slid into the recent past (was ~6 days stale).
+	var alertAgeSec int64
+	require.NoError(t, db.QueryRowContext(ctx,
+		`SELECT TIMESTAMPDIFF(SECOND, created_at, NOW()) FROM alerts WHERE host_id = 'HOST-R'`).Scan(&alertAgeSec))
+	assert.Less(t, alertAgeSec, int64(10*time.Minute/time.Second), "alert fired-at is recent after refresh")
+}
+
+// TestRefreshTimestampsIgnoresSynthesizedExit is the regression for the empty-1h-window bug: the process-TTL reconciler
+// force-exits stale processes at fork + maxAge, so a long-stale demo carries an exit_time_ns ~maxAge PAST the real device tail.
+// The anchor must ignore the exit columns (else the delta shrinks by maxAge and every fork stays stale), and the synthesized exit
+// must be cleared so the refreshed process reads as still-running rather than landing a future-dated exit.
+func TestRefreshTimestampsIgnoresSynthesizedExit(t *testing.T) {
+	db := full.Open(t)
+	ctx := t.Context()
+	s := newSeeder(config{}, db, testHTTPClient(), discardLogger())
+
+	// Fork ~6h stale; the TTL reconciler synthesized an exit at fork + 6h maxAge (past the device tail). A second, genuinely
+	// exited process keeps its real (small-lifetime) captured exit.
+	const sixHoursNs = int64(6*60*60) * int64(time.Second)
+	staleFork := time.Now().UnixNano() - sixHoursNs
+	_, err := db.ExecContext(ctx,
+		`INSERT INTO processes (host_id, pid, ppid, path, fork_time_ns, exec_time_ns, exit_time_ns, exit_reason)
+		 VALUES (?, ?, 1, '/bin/ttl', ?, ?, ?, ?), (?, ?, 1, '/bin/real', ?, ?, ?, 'exited')`,
+		"HOST-T", 300, staleFork, staleFork, staleFork+sixHoursNs, "ttl_reconciliation",
+		"HOST-T", 400, staleFork, staleFork, staleFork+int64(2*time.Second))
+	require.NoError(t, err)
+
+	require.NoError(t, s.refreshTimestamps(ctx))
+
+	var ttlFork int64
+	var ttlExit, ttlReason sql.NullString
+	require.NoError(t, db.QueryRowContext(ctx,
+		`SELECT fork_time_ns, exit_time_ns, exit_reason FROM processes WHERE host_id='HOST-T' AND pid=300`).
+		Scan(&ttlFork, &ttlExit, &ttlReason))
+	// Anchor ignored the synthesized exit, so the fork slid all the way to ~now-offset (within the 1h window), not 6h stale.
+	wantFork := time.Now().Add(-recentTailOffset).UnixNano()
+	assert.InDelta(t, wantFork, ttlFork, float64(2*time.Minute), "fork slid recent despite the future-dated TTL exit")
+	assert.False(t, ttlExit.Valid, "synthesized TTL exit cleared to NULL (process reads as still-running)")
+	assert.False(t, ttlReason.Valid, "synthesized TTL exit_reason cleared")
+
+	// The genuinely-exited process keeps a real exit that slid into the recent past with its fork.
+	var realFork, realExit int64
+	require.NoError(t, db.QueryRowContext(ctx,
+		`SELECT fork_time_ns, exit_time_ns FROM processes WHERE host_id='HOST-T' AND pid=400`).Scan(&realFork, &realExit))
+	assert.Equal(t, realFork+int64(2*time.Second), realExit, "real captured exit kept its 2s lifetime")
+	assert.Less(t, realExit, time.Now().UnixNano(), "real exit stayed in the past")
+}
+
+// TestRefreshTimestampsNoRows is a no-op when no replayed event/process rows exist (an alert alone must not trigger a shift).
+func TestRefreshTimestampsNoRows(t *testing.T) {
+	db := full.Open(t)
+	ctx := t.Context()
+	s := newSeeder(config{}, db, testHTTPClient(), discardLogger())
+	insertAlert(t, db, "HOST-EMPTY", "sudoers_tamper", "detection", "high")
+	require.NoError(t, s.refreshTimestamps(ctx))
 }
 
 func TestRunSkipsWhenAlreadySeeded(t *testing.T) {

--- a/server/cmd/fleet-edr-demo-seed/db_test.go
+++ b/server/cmd/fleet-edr-demo-seed/db_test.go
@@ -202,6 +202,7 @@ func TestRefreshTimestamps(t *testing.T) {
 	db := full.Open(t)
 	ctx := t.Context()
 	s := newSeeder(config{}, db, testHTTPClient(), discardLogger())
+	hostID := firstDemoHostID(t) // refresh is scoped to the demo's own host_ids, so seed under a real one.
 
 	// Two processes 30s apart, both stamped ~6 days ago, one still running (NULL exit). last_seen mirrors fork here.
 	const sixDaysNs = int64(6*24*60*60) * int64(time.Second)
@@ -210,10 +211,16 @@ func TestRefreshTimestamps(t *testing.T) {
 	_, err := db.ExecContext(ctx,
 		`INSERT INTO processes (host_id, pid, ppid, path, fork_time_ns, fork_ingested_at_ns, last_seen_ns, exit_time_ns)
 		 VALUES (?, ?, 1, '/bin/older', ?, ?, ?, ?), (?, ?, 1, '/bin/newest', ?, ?, ?, NULL)`,
-		"HOST-R", 100, staleOlder, staleOlder, staleOlder, staleOlder+int64(time.Second),
-		"HOST-R", 200, staleNewest, staleNewest, staleNewest)
+		hostID, 100, staleOlder, staleOlder, staleOlder, staleOlder+int64(time.Second),
+		hostID, 200, staleNewest, staleNewest, staleNewest)
 	require.NoError(t, err)
-	insertAlert(t, db, "HOST-R", "sudoers_tamper", "detection", "high")
+	// Seed the alert ~6 days stale so the test actually exercises the alert shift (a NOW()-stamped alert would pass even if the
+	// refresh ignored alerts, and could be shifted into the future undetected).
+	insertAlert(t, db, hostID, "sudoers_tamper", "detection", "high")
+	_, err = db.ExecContext(ctx,
+		`UPDATE alerts SET created_at = DATE_SUB(NOW(), INTERVAL 6 DAY), updated_at = DATE_SUB(NOW(), INTERVAL 6 DAY)
+		 WHERE host_id = ?`, hostID)
+	require.NoError(t, err)
 
 	require.NoError(t, s.refreshTimestamps(ctx))
 
@@ -221,10 +228,10 @@ func TestRefreshTimestamps(t *testing.T) {
 	var olderExit sql.NullInt64
 	var newestExit sql.NullInt64
 	require.NoError(t, db.QueryRowContext(ctx,
-		`SELECT fork_time_ns, last_seen_ns, exit_time_ns FROM processes WHERE host_id = 'HOST-R' AND pid = 200`).
+		`SELECT fork_time_ns, last_seen_ns, exit_time_ns FROM processes WHERE host_id = ? AND pid = 200`, hostID).
 		Scan(&newestFork, &lastSeen, &newestExit))
 	require.NoError(t, db.QueryRowContext(ctx,
-		`SELECT fork_time_ns, exit_time_ns FROM processes WHERE host_id = 'HOST-R' AND pid = 100`).Scan(&olderFork, &olderExit))
+		`SELECT fork_time_ns, exit_time_ns FROM processes WHERE host_id = ? AND pid = 100`, hostID).Scan(&olderFork, &olderExit))
 
 	// Newest fork now lands ~recentTailOffset before now (allow a generous slop for test wall-clock drift).
 	wantNewest := time.Now().Add(-recentTailOffset).UnixNano()
@@ -236,10 +243,12 @@ func TestRefreshTimestamps(t *testing.T) {
 	require.True(t, olderExit.Valid)
 	assert.Equal(t, olderFork+int64(time.Second), olderExit.Int64, "exited process keeps its 1s lifetime")
 
-	// The alert's created_at slid into the recent past (was ~6 days stale).
+	// The alert's created_at slid into the recent past: recent AND not future-dated (a future created_at yields a negative
+	// TIMESTAMPDIFF, which the upper-bound check alone would not catch).
 	var alertAgeSec int64
 	require.NoError(t, db.QueryRowContext(ctx,
-		`SELECT TIMESTAMPDIFF(SECOND, created_at, NOW()) FROM alerts WHERE host_id = 'HOST-R'`).Scan(&alertAgeSec))
+		`SELECT TIMESTAMPDIFF(SECOND, created_at, NOW()) FROM alerts WHERE host_id = ?`, hostID).Scan(&alertAgeSec))
+	assert.GreaterOrEqual(t, alertAgeSec, int64(0), "alert fired-at must not be in the future")
 	assert.Less(t, alertAgeSec, int64(10*time.Minute/time.Second), "alert fired-at is recent after refresh")
 }
 
@@ -251,6 +260,7 @@ func TestRefreshTimestampsIgnoresSynthesizedExit(t *testing.T) {
 	db := full.Open(t)
 	ctx := t.Context()
 	s := newSeeder(config{}, db, testHTTPClient(), discardLogger())
+	hostID := firstDemoHostID(t)
 
 	// Fork ~6h stale; the TTL reconciler synthesized an exit at fork + 6h maxAge (past the device tail). A second, genuinely
 	// exited process keeps its real (small-lifetime) captured exit.
@@ -259,8 +269,8 @@ func TestRefreshTimestampsIgnoresSynthesizedExit(t *testing.T) {
 	_, err := db.ExecContext(ctx,
 		`INSERT INTO processes (host_id, pid, ppid, path, fork_time_ns, exec_time_ns, exit_time_ns, exit_reason)
 		 VALUES (?, ?, 1, '/bin/ttl', ?, ?, ?, ?), (?, ?, 1, '/bin/real', ?, ?, ?, 'exited')`,
-		"HOST-T", 300, staleFork, staleFork, staleFork+sixHoursNs, "ttl_reconciliation",
-		"HOST-T", 400, staleFork, staleFork, staleFork+int64(2*time.Second))
+		hostID, 300, staleFork, staleFork, staleFork+sixHoursNs, "ttl_reconciliation",
+		hostID, 400, staleFork, staleFork, staleFork+int64(2*time.Second))
 	require.NoError(t, err)
 
 	require.NoError(t, s.refreshTimestamps(ctx))
@@ -268,7 +278,7 @@ func TestRefreshTimestampsIgnoresSynthesizedExit(t *testing.T) {
 	var ttlFork int64
 	var ttlExit, ttlReason sql.NullString
 	require.NoError(t, db.QueryRowContext(ctx,
-		`SELECT fork_time_ns, exit_time_ns, exit_reason FROM processes WHERE host_id='HOST-T' AND pid=300`).
+		`SELECT fork_time_ns, exit_time_ns, exit_reason FROM processes WHERE host_id=? AND pid=300`, hostID).
 		Scan(&ttlFork, &ttlExit, &ttlReason))
 	// Anchor ignored the synthesized exit, so the fork slid all the way to ~now-offset (within the 1h window), not 6h stale.
 	wantFork := time.Now().Add(-recentTailOffset).UnixNano()
@@ -279,18 +289,39 @@ func TestRefreshTimestampsIgnoresSynthesizedExit(t *testing.T) {
 	// The genuinely-exited process keeps a real exit that slid into the recent past with its fork.
 	var realFork, realExit int64
 	require.NoError(t, db.QueryRowContext(ctx,
-		`SELECT fork_time_ns, exit_time_ns FROM processes WHERE host_id='HOST-T' AND pid=400`).Scan(&realFork, &realExit))
+		`SELECT fork_time_ns, exit_time_ns FROM processes WHERE host_id=? AND pid=400`, hostID).Scan(&realFork, &realExit))
 	assert.Equal(t, realFork+int64(2*time.Second), realExit, "real captured exit kept its 2s lifetime")
 	assert.Less(t, realExit, time.Now().UnixNano(), "real exit stayed in the past")
 }
 
-// TestRefreshTimestampsNoRows is a no-op when no replayed event/process rows exist (an alert alone must not trigger a shift).
+// TestRefreshTimestampsNoRows is a no-op when no replayed event/process rows exist (an alert alone must not trigger a shift). The
+// before/after compare pins the no-op: the assertion would catch a refresh that shifted alert-only data.
 func TestRefreshTimestampsNoRows(t *testing.T) {
 	db := full.Open(t)
 	ctx := t.Context()
 	s := newSeeder(config{}, db, testHTTPClient(), discardLogger())
-	insertAlert(t, db, "HOST-EMPTY", "sudoers_tamper", "detection", "high")
+	hostID := firstDemoHostID(t)
+	insertAlert(t, db, hostID, "sudoers_tamper", "detection", "high")
+
+	var before time.Time
+	require.NoError(t, db.QueryRowContext(ctx,
+		`SELECT created_at FROM alerts WHERE host_id = ?`, hostID).Scan(&before))
+
 	require.NoError(t, s.refreshTimestamps(ctx))
+
+	var after time.Time
+	require.NoError(t, db.QueryRowContext(ctx,
+		`SELECT created_at FROM alerts WHERE host_id = ?`, hostID).Scan(&after))
+	assert.Equal(t, before, after, "alert-only data must not be shifted when no replayed rows exist")
+}
+
+// firstDemoHostID returns a captured demo host UUID, the scope refreshTimestamps applies its shift to.
+func firstDemoHostID(t *testing.T) string {
+	t.Helper()
+	ids, err := demoHostIDs()
+	require.NoError(t, err)
+	require.NotEmpty(t, ids)
+	return ids[0]
 }
 
 func TestRunSkipsWhenAlreadySeeded(t *testing.T) {

--- a/server/cmd/fleet-edr-demo-seed/hosts.go
+++ b/server/cmd/fleet-edr-demo-seed/hosts.go
@@ -152,6 +152,11 @@ func (s *seeder) replayHost(ctx context.Context, host demoHost) error {
 	if err != nil {
 		return err
 	}
+	// Anchor woven attacks under a real process from this capture (a shell) so their alerts read as commands run in a session
+	// nested in the host's genuine tree, not lone processes hanging off launchd. Derived from the captured pids, so it survives a
+	// corpus re-scrub; 0 when the capture has no shell, in which case the attacks keep their launchd root.
+	anchorPID := pickAttackAnchorPID(envs)
+
 	// One clock read for the whole host: the ambient tail and every woven attack are placed relative to this same now, so
 	// per-batch network latency cannot drift the attacks forward relative to the ambient events (deterministic relative timing).
 	now := time.Now()
@@ -163,26 +168,79 @@ func (s *seeder) replayHost(ctx context.Context, host demoHost) error {
 		}
 	}
 	s.logger.InfoContext(ctx, "replayed captured host",
-		"file", host.File, "host_id", hostID, "hostname", host.Hostname, "events", len(envs))
+		"file", host.File, "host_id", hostID, "hostname", host.Hostname, "events", len(envs), "attack_anchor_pid", anchorPID)
 
 	for i, atk := range host.Attacks {
-		if err := s.weaveAttack(ctx, hostID, token, atk, i, now); err != nil {
+		if err := s.weaveAttack(ctx, hostID, token, atk, i, now, anchorPID); err != nil {
 			return fmt.Errorf("weave %s onto %s: %w", atk.File, host.File, err)
 		}
 	}
 	return nil
 }
 
+// interactiveShellExecs are the captured exec paths a woven attack is re-parented under, so its alert reads as "commands run in a
+// shell" instead of a lone process hanging off launchd. Matched against the captured host stream, never the attack scenario.
+var interactiveShellExecs = map[string]bool{
+	"/bin/zsh":  true,
+	"/bin/bash": true,
+	"/bin/sh":   true,
+}
+
+// pickAttackAnchorPID returns the pid of the last interactive-shell exec in a captured host stream, to use as the parent of the
+// attacks woven onto that host (see reparentAttackToHost). "Last" so the anchor is the most recent shell in the timeline, the one
+// an operator reads as the current session. Returns 0 when the capture has no shell, leaving the attacks rooted at launchd.
+func pickAttackAnchorPID(envs []fakeagent.Envelope) int {
+	anchor := 0
+	for i := range envs {
+		if envs[i].EventType != "exec" {
+			continue
+		}
+		var p struct {
+			PID  int    `json:"pid"`
+			Path string `json:"path"`
+		}
+		if err := json.Unmarshal(envs[i].Payload, &p); err != nil {
+			continue
+		}
+		if interactiveShellExecs[p.Path] {
+			anchor = p.PID
+		}
+	}
+	return anchor
+}
+
+// reparentAttackToHost re-points the woven attack's launchd-rooted top (the events still referencing the pid-1 sentinel after
+// offsetScenarioPIDs) at a real captured process, so the attack hangs off the host's genuine process tree instead of floating as a
+// lone subtree under launchd. anchorPID is a captured pid (a shell, see pickAttackAnchorPID); a value <= 1 means no anchor was
+// found and the attack keeps its launchd root. The catalog rules these attacks trip match on exec path/args, never on ppid, so the
+// re-parent changes the tree shape the analyst sees without affecting whether the detection fires.
+func reparentAttackToHost(sc *fakeagent.Scenario, anchorPID int) {
+	if anchorPID <= 1 {
+		return
+	}
+	for i := range sc.Timeline {
+		ev := &sc.Timeline[i]
+		if ev.PPID == 1 {
+			ev.PPID = anchorPID
+		}
+		if ev.ParentPID == 1 {
+			ev.ParentPID = anchorPID
+		}
+	}
+}
+
 // weaveAttack re-hosts an attack scenario onto a captured host: it offsets the scenario's pids (so they can't collide with the
-// captured stream or another woven attack), overrides the host_id to the captured host, and posts the events at a recent,
-// per-attack-staggered time. For an app-control scenario it then posts the fabricated block event against the offset pid (after
-// the process materialises), exactly as the standalone path used to.
-func (s *seeder) weaveAttack(ctx context.Context, hostID, token string, atk wovenAttack, idx int, now time.Time) error {
+// captured stream or another woven attack), re-parents the attack's root onto a real captured process (anchorPID, a shell) so it
+// nests in the host's genuine tree instead of rooting at launchd, overrides the host_id to the captured host, and posts the events
+// at a recent, per-attack-staggered time. For an app-control scenario it then posts the fabricated block event against the offset
+// pid (after the process materialises), exactly as the standalone path used to.
+func (s *seeder) weaveAttack(ctx context.Context, hostID, token string, atk wovenAttack, idx int, now time.Time, anchorPID int) error {
 	sc, err := loadAttackScenario(atk.File)
 	if err != nil {
 		return err
 	}
 	offsetScenarioPIDs(sc, attackPIDOffsetBase+idx*attackPIDOffsetStride)
+	reparentAttackToHost(sc, anchorPID)
 
 	// Place the attack just before the captured tail, staggered per attack, so it reads as recent activity on the host. now is
 	// the caller's single clock read (see replayHost) so the attack's offset from the ambient tail stays stable across replays.

--- a/server/cmd/fleet-edr-demo-seed/hosts.go
+++ b/server/cmd/fleet-edr-demo-seed/hosts.go
@@ -120,6 +120,22 @@ func decodeHostEnvelopes(raw []byte, file string) ([]fakeagent.Envelope, string,
 	return envs, hostID, nil
 }
 
+// demoHostIDs returns the captured host UUID of every manifest host. refreshTimestamps scopes its UPDATEs to these so a
+// mis-pointed DSN can only ever shift the demo's own rows: the seeder takes an operator-supplied DSN and the already-seeded check
+// keys on a real production rule id (credential_keychain_dump), so without this scope the refresh could rewrite a real
+// deployment's timelines.
+func demoHostIDs() ([]string, error) {
+	ids := make([]string, 0, len(hostManifest))
+	for _, h := range hostManifest {
+		_, hostID, err := loadHostEnvelopes(h.File)
+		if err != nil {
+			return nil, fmt.Errorf("load host ids %s: %w", h.File, err)
+		}
+		ids = append(ids, hostID)
+	}
+	return ids, nil
+}
+
 // shiftEnvelopesToRecent rewrites every envelope's timestamp so the latest event lands recentTailOffset before now, preserving the
 // inter-event deltas of the original capture. This makes the replayed graph read as recent activity without compressing the
 // timeline, so the UI's time structure and the per-process event ordering stay faithful to the real capture. Returns the input
@@ -186,11 +202,13 @@ var interactiveShellExecs = map[string]bool{
 	"/bin/sh":   true,
 }
 
-// pickAttackAnchorPID returns the pid of the last interactive-shell exec in a captured host stream, to use as the parent of the
-// attacks woven onto that host (see reparentAttackToHost). "Last" so the anchor is the most recent shell in the timeline, the one
-// an operator reads as the current session. Returns 0 when the capture has no shell, leaving the attacks rooted at launchd.
+// pickAttackAnchorPID returns the pid of the most recent interactive-shell exec in a captured host stream, to use as the parent of
+// the attacks woven onto that host (see reparentAttackToHost). Selection is by the event's TimestampNs, not file order: the scrubbed
+// captures are not stored time-sorted, so the last line is not necessarily the latest event. Sentinel pids (<= 1) are never chosen.
+// Returns 0 when the capture has no shell, leaving the attacks rooted at launchd.
 func pickAttackAnchorPID(envs []fakeagent.Envelope) int {
 	anchor := 0
+	var anchorTS int64
 	for i := range envs {
 		if envs[i].EventType != "exec" {
 			continue
@@ -202,8 +220,9 @@ func pickAttackAnchorPID(envs []fakeagent.Envelope) int {
 		if err := json.Unmarshal(envs[i].Payload, &p); err != nil {
 			continue
 		}
-		if interactiveShellExecs[p.Path] {
-			anchor = p.PID
+		// >= keeps the later-in-file entry on a timestamp tie, a deterministic tiebreak against the fixed embedded corpus.
+		if interactiveShellExecs[p.Path] && p.PID > 1 && (anchor == 0 || envs[i].TimestampNs >= anchorTS) {
+			anchor, anchorTS = p.PID, envs[i].TimestampNs
 		}
 	}
 	return anchor

--- a/server/cmd/fleet-edr-demo-seed/hosts_test.go
+++ b/server/cmd/fleet-edr-demo-seed/hosts_test.go
@@ -95,16 +95,38 @@ func TestPickAttackAnchorPID(t *testing.T) {
 		require.NoError(t, err)
 		return fakeagent.Envelope{EventType: "exec", Payload: payload}
 	}
+	execAt := func(pid int, path string, ts int64) fakeagent.Envelope {
+		e := exec(pid, path)
+		e.TimestampNs = ts
+		return e
+	}
 
-	t.Run("last shell exec wins", func(t *testing.T) {
+	t.Run("latest shell exec by timestamp wins", func(t *testing.T) {
 		t.Parallel()
 		envs := []fakeagent.Envelope{
-			exec(100, "/usr/sbin/sshd"),
-			exec(200, "/bin/zsh"),
-			exec(300, "/usr/bin/security"), // not a shell, must not win
-			exec(400, "/bin/bash"),         // latest shell
+			execAt(100, "/usr/sbin/sshd", 10),
+			execAt(200, "/bin/zsh", 20),
+			execAt(300, "/usr/bin/security", 30), // not a shell, must not win
+			execAt(400, "/bin/bash", 40),         // latest shell by timestamp
 		}
 		assert.Equal(t, 400, pickAttackAnchorPID(envs))
+	})
+
+	t.Run("most recent by timestamp wins, not file order", func(t *testing.T) {
+		t.Parallel()
+		// The scrubbed captures are not stored time-sorted: a later line can carry an earlier timestamp. Selection must follow
+		// the timestamp, not the file position.
+		envs := []fakeagent.Envelope{
+			execAt(200, "/bin/zsh", 500),  // later event, earlier in file
+			execAt(400, "/bin/bash", 100), // earlier event, later in file
+		}
+		assert.Equal(t, 200, pickAttackAnchorPID(envs))
+	})
+
+	t.Run("sentinel pid is never anchored", func(t *testing.T) {
+		t.Parallel()
+		envs := []fakeagent.Envelope{exec(1, "/bin/zsh"), exec(0, "/bin/bash")}
+		assert.Zero(t, pickAttackAnchorPID(envs))
 	})
 
 	t.Run("non-exec events ignored", func(t *testing.T) {

--- a/server/cmd/fleet-edr-demo-seed/hosts_test.go
+++ b/server/cmd/fleet-edr-demo-seed/hosts_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -82,4 +83,96 @@ func TestOffsetScenarioPIDs(t *testing.T) {
 	assert.Equal(t, 5_000_050, sc.Timeline[1].InstigatorPID, "instigator pid is offset too")
 	assert.Equal(t, 1, sc.Timeline[2].PID, "pid <= 1 preserved")
 	assert.Equal(t, 1, sc.Timeline[2].PPID)
+}
+
+// TestPickAttackAnchorPID confirms the anchor is the last interactive shell in the capture, that non-shell execs and non-exec
+// events are ignored, and that a shell-less capture yields 0 (so the attack falls back to its launchd root).
+func TestPickAttackAnchorPID(t *testing.T) {
+	t.Parallel()
+
+	exec := func(pid int, path string) fakeagent.Envelope {
+		payload, err := json.Marshal(map[string]any{"pid": pid, "path": path})
+		require.NoError(t, err)
+		return fakeagent.Envelope{EventType: "exec", Payload: payload}
+	}
+
+	t.Run("last shell exec wins", func(t *testing.T) {
+		t.Parallel()
+		envs := []fakeagent.Envelope{
+			exec(100, "/usr/sbin/sshd"),
+			exec(200, "/bin/zsh"),
+			exec(300, "/usr/bin/security"), // not a shell, must not win
+			exec(400, "/bin/bash"),         // latest shell
+		}
+		assert.Equal(t, 400, pickAttackAnchorPID(envs))
+	})
+
+	t.Run("non-exec events ignored", func(t *testing.T) {
+		t.Parallel()
+		envs := []fakeagent.Envelope{
+			{EventType: "dns_query", Payload: []byte(`{"pid":999}`)},
+			exec(200, "/bin/zsh"),
+			{EventType: "network_connect", Payload: []byte(`{"pid":888}`)},
+		}
+		assert.Equal(t, 200, pickAttackAnchorPID(envs))
+	})
+
+	t.Run("no shell yields zero", func(t *testing.T) {
+		t.Parallel()
+		envs := []fakeagent.Envelope{exec(100, "/usr/sbin/sshd"), exec(300, "/usr/bin/security")}
+		assert.Zero(t, pickAttackAnchorPID(envs))
+	})
+
+	t.Run("malformed payload skipped", func(t *testing.T) {
+		t.Parallel()
+		envs := []fakeagent.Envelope{{EventType: "exec", Payload: []byte("not json")}, exec(200, "/bin/zsh")}
+		assert.Equal(t, 200, pickAttackAnchorPID(envs))
+	})
+}
+
+// TestReparentAttackToHost confirms the launchd-rooted top of an offset attack subtree is re-pointed at the captured anchor pid,
+// while deeper (already-offset) parent links and a missing anchor (<= 1) are left alone.
+func TestReparentAttackToHost(t *testing.T) {
+	t.Parallel()
+
+	t.Run("launchd-rooted top is re-pointed at the anchor", func(t *testing.T) {
+		t.Parallel()
+		// Mirrors a scenario after offsetScenarioPIDs: the root fork/exec still reference the pid-1 sentinel; a deeper child keeps
+		// its offset parent.
+		sc := &fakeagent.Scenario{Timeline: []fakeagent.Event{
+			{Type: "fork", ChildPID: 5004555, ParentPID: 1},
+			{Type: "exec", PID: 5004555, PPID: 1},
+			{Type: "fork", ChildPID: 5004600, ParentPID: 5004555}, // grandchild: parent is the attack root, not launchd
+		}}
+		reparentAttackToHost(sc, 11439)
+
+		assert.Equal(t, 11439, sc.Timeline[0].ParentPID, "root fork now parented to the captured shell")
+		assert.Equal(t, 11439, sc.Timeline[1].PPID, "root exec ppid now the captured shell")
+		assert.Equal(t, 5004555, sc.Timeline[2].ParentPID, "deeper parent link untouched")
+	})
+
+	t.Run("missing anchor keeps the launchd root", func(t *testing.T) {
+		t.Parallel()
+		sc := &fakeagent.Scenario{Timeline: []fakeagent.Event{{Type: "exec", PID: 5004555, PPID: 1}}}
+		reparentAttackToHost(sc, 0)
+		assert.Equal(t, 1, sc.Timeline[0].PPID, "no anchor: attack stays rooted at launchd")
+	})
+}
+
+// TestManifestCapturesHaveAttackAnchor guards the demo promise that woven attacks nest in a real session: every captured host that
+// carries attacks must expose an interactive-shell pid for them to hang off, else they would silently fall back to a lone
+// launchd-rooted subtree.
+func TestManifestCapturesHaveAttackAnchor(t *testing.T) {
+	t.Parallel()
+	for _, host := range hostManifest {
+		if len(host.Attacks) == 0 {
+			continue
+		}
+		t.Run(host.File, func(t *testing.T) {
+			t.Parallel()
+			envs, _, err := loadHostEnvelopes(host.File)
+			require.NoError(t, err)
+			assert.Positive(t, pickAttackAnchorPID(envs), "capture must carry a shell for woven attacks to nest under")
+		})
+	}
 }

--- a/server/cmd/fleet-edr-demo-seed/seed.go
+++ b/server/cmd/fleet-edr-demo-seed/seed.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"crypto/tls"
 	"crypto/x509"
+	"database/sql"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -15,6 +16,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/fleetdm/edr/server/detection/api"
 	"github.com/fleetdm/edr/test/fakeagent"
 )
 
@@ -75,7 +77,8 @@ func newHTTPClient(caCertPath string) (*http.Client, error) {
 	return &http.Client{Timeout: httpClientTimeout, Transport: tr}, nil
 }
 
-// run executes the full seed. It is safe to re-run: replay is skipped when demo data is already present unless cfg.force is set.
+// run executes the full seed. It is safe to re-run: replay is skipped when demo data is already present unless cfg.force is set,
+// and on that skip path the existing timestamps are slid forward so the graph still reads as recent activity (refreshTimestamps).
 func (s *seeder) run(ctx context.Context) error {
 	if err := s.waitReady(ctx); err != nil {
 		return fmt.Errorf("server did not become ready: %w", err)
@@ -87,7 +90,13 @@ func (s *seeder) run(ctx context.Context) error {
 			return fmt.Errorf("check already-seeded: %w", err)
 		}
 		if seeded {
-			s.logger.InfoContext(ctx, "demo data already present, skipping replay (pass --force to re-seed)")
+			// Don't re-replay, but slide the existing rows forward so the graph still reads as recent activity. The persisted
+			// demo volume survives restarts, so without this the timestamps stay frozen at the first seed and age out of the UI's
+			// last-hour process-tree window, leaving the host view empty after a day or a restart.
+			if err := s.refreshTimestamps(ctx); err != nil {
+				return fmt.Errorf("refresh demo timestamps: %w", err)
+			}
+			s.logger.InfoContext(ctx, "demo data already present, refreshed timestamps to recent (pass --force to re-seed)")
 			return s.seedUserIfConfigured(ctx)
 		}
 	}
@@ -251,6 +260,77 @@ func (s *seeder) alreadySeeded(ctx context.Context) (bool, error) {
 		return false, err
 	}
 	return n > 0, nil
+}
+
+// refreshTimestamps slides every replayed nanosecond timestamp (and the alert "fired at" times stamped from the same wall clock)
+// forward so the newest one lands recentTailOffset before now. The replay's shiftEnvelopesToRecent only runs on a fresh seed; on a
+// restart against the persisted demo volume the rows keep their original timestamps, which age out of the UI's last-hour
+// process-tree window and leave the host view empty. Re-deriving one delta and adding it to every column preserves all relative
+// timing (and the device-vs-ingest and event-vs-alert ordering the detail/correlation views depend on), so the demo reads as
+// recent activity after every `up` without re-replaying. No-op when no replayed event/process rows exist yet.
+func (s *seeder) refreshTimestamps(ctx context.Context) error {
+	var newestNs sql.NullInt64
+	// Anchor the delta on the device-clock tail only: fork/exec/event timestamps and their ingest stamps. The exit columns are
+	// deliberately excluded because the process-TTL reconciler (pipeline.ProcessTTLRunner) force-exits long-running processes at
+	// fork + maxAge, so a stale demo's synthesized exit_time_ns sits ~maxAge PAST the real tail. Anchoring on it would shrink the
+	// delta by maxAge and leave every fork that-much stale, which is exactly the empty-1h-window symptom this guards against.
+	const newestQuery = `
+		SELECT GREATEST(
+			COALESCE((SELECT MAX(timestamp_ns) FROM events), 0),
+			COALESCE((SELECT MAX(ingested_at_ns) FROM events), 0),
+			COALESCE((SELECT MAX(fork_time_ns) FROM processes), 0),
+			COALESCE((SELECT MAX(fork_ingested_at_ns) FROM processes), 0),
+			COALESCE((SELECT MAX(exec_time_ns) FROM processes), 0)
+		)`
+	if err := s.db.QueryRowContext(ctx, newestQuery).Scan(&newestNs); err != nil {
+		return fmt.Errorf("read newest demo timestamp: %w", err)
+	}
+	if !newestNs.Valid || newestNs.Int64 == 0 {
+		return nil // no replayed rows yet; nothing to slide
+	}
+	deltaNs := time.Now().Add(-recentTailOffset).UnixNano() - newestNs.Int64
+	if deltaNs == 0 {
+		return nil
+	}
+	// alerts carry SQL TIMESTAMPs (second resolution); the UI anchors the alert -> process-tree window on created_at, so they must
+	// slide with the events or that pivot breaks. Whole-second granularity is ample against the multi-minute window.
+	deltaSec := deltaNs / int64(time.Second)
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin refresh tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }() // no-op once Commit succeeds
+
+	// NULL + delta stays NULL, so still-running processes keep their open exit columns.
+	updates := []struct {
+		query string
+		args  []any
+	}{
+		{`UPDATE events SET timestamp_ns = timestamp_ns + ?, ingested_at_ns = ingested_at_ns + ?`, []any{deltaNs, deltaNs}},
+		{`UPDATE processes SET fork_time_ns = fork_time_ns + ?, fork_ingested_at_ns = fork_ingested_at_ns + ?,
+			exec_time_ns = exec_time_ns + ?, exit_time_ns = exit_time_ns + ?, exit_ingested_at_ns = exit_ingested_at_ns + ?,
+			last_seen_ns = last_seen_ns + ?`, []any{deltaNs, deltaNs, deltaNs, deltaNs, deltaNs, deltaNs}},
+		// Drop the synthesized force-exits: anchoring on the fork tail slides them maxAge into the future, and for a just-refreshed
+		// demo the honest reading is "still running" (the forks are now minutes old). The reconciler re-creates them after maxAge,
+		// long after anyone is looking at this `up`. Real captured exits (any other reason) keep their shifted, in-the-past values.
+		{`UPDATE processes SET exit_time_ns = NULL, exit_ingested_at_ns = NULL, exit_reason = NULL WHERE exit_reason = ?`,
+			[]any{api.ExitReasonTTLReconciliation}},
+		{`UPDATE hosts SET last_seen_ns = last_seen_ns + ?`, []any{deltaNs}},
+		{`UPDATE alerts SET created_at = DATE_ADD(created_at, INTERVAL ? SECOND),
+			updated_at = DATE_ADD(updated_at, INTERVAL ? SECOND),
+			resolved_at = DATE_ADD(resolved_at, INTERVAL ? SECOND)`, []any{deltaSec, deltaSec, deltaSec}},
+	}
+	for _, u := range updates {
+		if _, err := tx.ExecContext(ctx, u.query, u.args...); err != nil {
+			return fmt.Errorf("slide demo timestamps: %w", err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit timestamp refresh: %w", err)
+	}
+	s.logger.InfoContext(ctx, "refreshed demo timestamps to recent", "delta_ns", deltaNs)
+	return nil
 }
 
 // waitForProcess polls until at least one process row exists for the host/pid, or verifyTimeout elapses.

--- a/server/cmd/fleet-edr-demo-seed/seed.go
+++ b/server/cmd/fleet-edr-demo-seed/seed.go
@@ -14,6 +14,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/fleetdm/edr/server/detection/api"
@@ -269,32 +270,54 @@ func (s *seeder) alreadySeeded(ctx context.Context) (bool, error) {
 // timing (and the device-vs-ingest and event-vs-alert ordering the detail/correlation views depend on), so the demo reads as
 // recent activity after every `up` without re-replaying. No-op when no replayed event/process rows exist yet.
 func (s *seeder) refreshTimestamps(ctx context.Context) error {
+	// Scope every read and write below to the demo's own hosts. The seeder takes an operator-supplied DSN and alreadySeeded keys
+	// on a real rule id (credential_keychain_dump), so an unscoped refresh pointed at a live DB would rewrite real timelines. The
+	// IN clause bounds the blast radius to the embedded corpus's host UUIDs, which a real deployment will never contain.
+	hostIDs, err := demoHostIDs()
+	if err != nil {
+		return err
+	}
+	if len(hostIDs) == 0 {
+		return nil
+	}
+	inClause := "host_id IN (" + strings.Repeat("?,", len(hostIDs)-1) + "?)"
+	hostArgs := make([]any, len(hostIDs))
+	for i, id := range hostIDs {
+		hostArgs[i] = id
+	}
+
 	var newestNs sql.NullInt64
 	// Anchor the delta on the device-clock tail only: fork/exec/event timestamps and their ingest stamps. The exit columns are
 	// deliberately excluded because the process-TTL reconciler (pipeline.ProcessTTLRunner) force-exits long-running processes at
 	// fork + maxAge, so a stale demo's synthesized exit_time_ns sits ~maxAge PAST the real tail. Anchoring on it would shrink the
 	// delta by maxAge and leave every fork that-much stale, which is exactly the empty-1h-window symptom this guards against.
-	const newestQuery = `
+	newestQuery := `
 		SELECT GREATEST(
-			COALESCE((SELECT MAX(timestamp_ns) FROM events), 0),
-			COALESCE((SELECT MAX(ingested_at_ns) FROM events), 0),
-			COALESCE((SELECT MAX(fork_time_ns) FROM processes), 0),
-			COALESCE((SELECT MAX(fork_ingested_at_ns) FROM processes), 0),
-			COALESCE((SELECT MAX(exec_time_ns) FROM processes), 0)
+			COALESCE((SELECT MAX(timestamp_ns) FROM events WHERE ` + inClause + `), 0),
+			COALESCE((SELECT MAX(ingested_at_ns) FROM events WHERE ` + inClause + `), 0),
+			COALESCE((SELECT MAX(fork_time_ns) FROM processes WHERE ` + inClause + `), 0),
+			COALESCE((SELECT MAX(fork_ingested_at_ns) FROM processes WHERE ` + inClause + `), 0),
+			COALESCE((SELECT MAX(exec_time_ns) FROM processes WHERE ` + inClause + `), 0)
 		)`
-	if err := s.db.QueryRowContext(ctx, newestQuery).Scan(&newestNs); err != nil {
+	anchorArgs := make([]any, 0, len(hostArgs)*5) // newestQuery references inClause five times
+	for range 5 {
+		anchorArgs = append(anchorArgs, hostArgs...)
+	}
+	if err := s.db.QueryRowContext(ctx, newestQuery, anchorArgs...).Scan(&newestNs); err != nil {
 		return fmt.Errorf("read newest demo timestamp: %w", err)
 	}
 	if !newestNs.Valid || newestNs.Int64 == 0 {
 		return nil // no replayed rows yet; nothing to slide
 	}
 	deltaNs := time.Now().Add(-recentTailOffset).UnixNano() - newestNs.Int64
-	if deltaNs == 0 {
+	// alerts carry SQL TIMESTAMP(6) columns; we slide them at whole-second granularity (the alert -> process-tree window the UI
+	// anchors on created_at spans minutes, so sub-second precision is irrelevant). deltaSec <= 0 means the data is already at or
+	// newer than the target (a quick restart after a fresh seed, or clock skew): nothing to slide, and a backward shift would only
+	// un-recent the graph, so skip the redundant writes.
+	deltaSec := deltaNs / int64(time.Second)
+	if deltaSec <= 0 {
 		return nil
 	}
-	// alerts carry SQL TIMESTAMPs (second resolution); the UI anchors the alert -> process-tree window on created_at, so they must
-	// slide with the events or that pivot breaks. Whole-second granularity is ample against the multi-minute window.
-	deltaSec := deltaNs / int64(time.Second)
 
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
@@ -302,24 +325,27 @@ func (s *seeder) refreshTimestamps(ctx context.Context) error {
 	}
 	defer func() { _ = tx.Rollback() }() // no-op once Commit succeeds
 
-	// NULL + delta stays NULL, so still-running processes keep their open exit columns.
+	// NULL + delta stays NULL, so still-running processes keep their open exit columns. Every statement carries the host scope.
 	updates := []struct {
 		query string
 		args  []any
 	}{
-		{`UPDATE events SET timestamp_ns = timestamp_ns + ?, ingested_at_ns = ingested_at_ns + ?`, []any{deltaNs, deltaNs}},
+		{`UPDATE events SET timestamp_ns = timestamp_ns + ?, ingested_at_ns = ingested_at_ns + ? WHERE ` + inClause,
+			append([]any{deltaNs, deltaNs}, hostArgs...)},
 		{`UPDATE processes SET fork_time_ns = fork_time_ns + ?, fork_ingested_at_ns = fork_ingested_at_ns + ?,
 			exec_time_ns = exec_time_ns + ?, exit_time_ns = exit_time_ns + ?, exit_ingested_at_ns = exit_ingested_at_ns + ?,
-			last_seen_ns = last_seen_ns + ?`, []any{deltaNs, deltaNs, deltaNs, deltaNs, deltaNs, deltaNs}},
+			last_seen_ns = last_seen_ns + ? WHERE ` + inClause,
+			append([]any{deltaNs, deltaNs, deltaNs, deltaNs, deltaNs, deltaNs}, hostArgs...)},
 		// Drop the synthesized force-exits: anchoring on the fork tail slides them maxAge into the future, and for a just-refreshed
 		// demo the honest reading is "still running" (the forks are now minutes old). The reconciler re-creates them after maxAge,
 		// long after anyone is looking at this `up`. Real captured exits (any other reason) keep their shifted, in-the-past values.
-		{`UPDATE processes SET exit_time_ns = NULL, exit_ingested_at_ns = NULL, exit_reason = NULL WHERE exit_reason = ?`,
-			[]any{api.ExitReasonTTLReconciliation}},
-		{`UPDATE hosts SET last_seen_ns = last_seen_ns + ?`, []any{deltaNs}},
+		{`UPDATE processes SET exit_time_ns = NULL, exit_ingested_at_ns = NULL, exit_reason = NULL WHERE exit_reason = ? AND ` + inClause,
+			append([]any{api.ExitReasonTTLReconciliation}, hostArgs...)},
+		{`UPDATE hosts SET last_seen_ns = last_seen_ns + ? WHERE ` + inClause, append([]any{deltaNs}, hostArgs...)},
 		{`UPDATE alerts SET created_at = DATE_ADD(created_at, INTERVAL ? SECOND),
 			updated_at = DATE_ADD(updated_at, INTERVAL ? SECOND),
-			resolved_at = DATE_ADD(resolved_at, INTERVAL ? SECOND)`, []any{deltaSec, deltaSec, deltaSec}},
+			resolved_at = DATE_ADD(resolved_at, INTERVAL ? SECOND) WHERE ` + inClause,
+			append([]any{deltaSec, deltaSec, deltaSec}, hostArgs...)},
 	}
 	for _, u := range updates {
 		if _, err := tx.ExecContext(ctx, u.query, u.args...); err != nil {

--- a/server/cmd/fleet-edr-demo-seed/user.go
+++ b/server/cmd/fleet-edr-demo-seed/user.go
@@ -11,6 +11,9 @@ import (
 type dbExecQuerier interface {
 	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
 	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
+	// BeginTx lets refreshTimestamps slide every replayed column atomically: a partial shift would desync the
+	// device-vs-ingest and event-vs-alert ordering the detail/correlation views depend on.
+	BeginTx(ctx context.Context, opts *sql.TxOptions) (*sql.Tx, error)
 }
 
 // seedDemoUser idempotently provisions the SSO demo user so first login lands at a full-capability role instead of the OIDC JIT


### PR DESCRIPTION
<!-- Keep this short. Delete sections that do not apply. -->

## What & why



## Checklist

- [ ] **OpenSpec updated for behavior changes.** If this PR changes observable behavior (a detection rule, the event
      wire schema, persistence semantics, an API/wire shape, or an emitted event), `openspec/specs/**` is updated (and
      an `openspec/changes/` proposal added), with a `spec:<id>` test marker for any new/renamed scenario. Only if this
      PR changes NO observable behavior (a comment / refactor / gofmt / dep bump that happens to touch a scoped path)
      may you assert `no-behavior-change` (label or `[no-behavior-change]` in the title) to clear the OpenSpec-sync gate.
      That is an assertion a reviewer will check, not a way to skip the spec for a real behavior change.
- [ ] Tests added/updated for the change (unit / integration / efficacy / UI as applicable).
- [ ] Agent/extension change touching ESF, XPC, or the event wire format: exercised on a live macOS VM before RC
      (flagged below).

## VM / RC notes (if applicable)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Demo seed data now automatically refreshes timestamps when re-running on existing data, keeping demo scenarios current without manual reset.
  * Attack scenarios now properly anchor to captured interactive shells, improving realism of replayed attack demonstrations.

* **Tests**
  * Added comprehensive test coverage for timestamp refresh logic, attack anchor selection, and scenario reparenting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->