### PR TITLE
Add 0.2.1 changelog entry and point demo to v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 Notable changes to Fleet EDR, newest first. This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html) (pre-1.0).
 
+## [0.2.1] (2026-06-16)
+
+Patch release on top of 0.2.0. Fixes the Mac-free Docker demo (`docker-compose.demo.yml`) so it presents correctly to evaluators. No agent or server runtime behavior changes; the fixes are confined to the demo seeder.
+
+### Fixed
+
+- **Demo process view stays populated across restarts.** On a restart against the persisted demo volume the seeder now slides the seeded timestamps forward, so the host process graph still falls inside the UI's default one-hour window instead of aging out and rendering empty. The shift is scoped to the demo's own hosts.
+- **Demo alerts show a realistic process chain.** Woven attack scenarios are now re-parented under the captured host's interactive shell session instead of rooting directly at launchd, so an alert's process tree shows the full ancestry (for example `sshd -> zsh -> /usr/bin/security`) the way a real detection would.
+
 ## [0.2.0] (2026-06-16)
 
 Incremental release on top of 0.1.1. Highlights: release signing modernized to the cosign v3 Sigstore bundle format, a detection-pipeline stall fixed, and the macOS system extensions now show recognizable names during a manual install.
@@ -55,5 +64,6 @@ First stable release. The product ships as two components, released together for
 - **Flexible deployment.** The server is a standard Linux container image, so it runs on any container host (a Docker VM, Kubernetes, AWS ECS/EKS, GCP, Azure, or on-prem), with a one-click Render blueprint for the fastest start. Agents reach Macs through any MDM (Fleet, Jamf, Kandji, Intune, mosyle).
 - **Supply-chain-hardened releases.** Every release ships a Developer ID-signed, Apple-notarized package alongside SBOMs, cosign signatures, and build provenance attestations.
 
+[0.2.1]: https://github.com/getvictor/fleet-edr/releases/tag/v0.2.1
 [0.2.0]: https://github.com/getvictor/fleet-edr/releases/tag/v0.2.0
 [0.1.1]: https://github.com/getvictor/fleet-edr/releases/tag/v0.1.1

--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -81,7 +81,7 @@ services:
       - tls:/tls
 
   server:
-    image: ghcr.io/getvictor/fleet-edr-server:${EDR_VERSION:-v0.2.0}
+    image: ghcr.io/getvictor/fleet-edr-server:${EDR_VERSION:-v0.2.1}
     restart: unless-stopped
     depends_on:
       mysql:
@@ -115,7 +115,7 @@ services:
       - tls:/tls:ro
 
   seeder:
-    image: ghcr.io/getvictor/fleet-edr-demo-seed:${EDR_VERSION:-v0.2.0}
+    image: ghcr.io/getvictor/fleet-edr-demo-seed:${EDR_VERSION:-v0.2.1}
     # One-shot: enrolls hosts, replays the corpus, verifies, then exits 0.
     restart: "no"
     depends_on:


### PR DESCRIPTION
0.2.1 ships the demo-seed fixes from #394: the demo process view stays populated across restarts (timestamp refresh scoped to demo hosts) and attack alerts nest under a realistic shell session instead of launchd. Bumps the docker-compose.demo.yml EDR_VERSION default to v0.2.1 now that the release images are published on ghcr.

<!-- Keep this short. Delete sections that do not apply. -->

## What & why



## Checklist

- [ ] **OpenSpec updated for behavior changes.** If this PR changes observable behavior (a detection rule, the event
      wire schema, persistence semantics, an API/wire shape, or an emitted event), `openspec/specs/**` is updated (and
      an `openspec/changes/` proposal added), with a `spec:<id>` test marker for any new/renamed scenario. Only if this
      PR changes NO observable behavior (a comment / refactor / gofmt / dep bump that happens to touch a scoped path)
      may you assert `no-behavior-change` (label or `[no-behavior-change]` in the title) to clear the OpenSpec-sync gate.
      That is an assertion a reviewer will check, not a way to skip the spec for a real behavior change.
- [ ] Tests added/updated for the change (unit / integration / efficacy / UI as applicable).
- [ ] Agent/extension change touching ESF, XPC, or the event wire format: exercised on a live macOS VM before RC
      (flagged below).

## VM / RC notes (if applicable)


