### PR TITLE
fix(render): bootstrap bundled MySQL via the image entrypoint + subdi…

### DIFF
--- a/docs/deploy-render.md
+++ b/docs/deploy-render.md
@@ -9,7 +9,7 @@ For a self-hosted server with your own TLS certificates instead, see the product
 The [`render.yaml`](../render.yaml) blueprint provisions two services:
 
 - **`fleet-edr-server`** (web): the `ghcr.io/getvictor/fleet-edr-server` image behind Render's TLS-terminating edge. It listens plaintext HTTP inside Render's network (`EDR_TLS_TERMINATED_BY_PROXY=1`) while agents reach it over Render's publicly-trusted `https://…onrender.com` URL, so the data plane is encrypted end to edge with zero certificate management. Schema migrations apply automatically on boot.
-- **`fleet-edr-mysql`** (private service): a MySQL 8.4 instance (the official image, matching the version the rest of the stack builds and tests against) with a 10 GB disk, reachable only from the server. Good for pilots; swap to a managed database later by setting `EDR_DSN` on the server and removing this service.
+- **`fleet-edr-mysql`** (private service): a MySQL 8.4 instance (the official image, matching the version the rest of the stack builds and tests against) with a 100 GB disk, reachable only from the server. Good for pilots; swap to a managed database later by setting `EDR_DSN` on the server and removing this service.
 
 No Redis is needed: the server is stateless (ADR-0010) and keeps all durable state in MySQL.
 

--- a/render.yaml
+++ b/render.yaml
@@ -89,12 +89,25 @@ services:
     plan: standard
     image:
       url: 'docker.io/library/mysql:8.4.9@sha256:c36050afdca850f23cef85703f84c7531a5ae155a11b5ee1c60acb09937c4084'
-    # Cap binary logging. This is a single MySQL with no replica, so binlog only
-    # buys point-in-time recovery; at the MySQL 8.4 defaults it retains 30 days
-    # of logs and roughly doubles disk use on the insert-heavy ingest workload.
-    # Keep ~1 day of binlog, 256M per file. The image entrypoint still runs first-
-    # boot init because the command starts with `mysqld`.
-    dockerCommand: mysqld --binlog_expire_logs_seconds=86400 --max-binlog-size=256M
+    # Invoke the image's docker-entrypoint.sh EXPLICITLY. On Render a
+    # dockerCommand replaces the image ENTRYPOINT, so a bare `mysqld ...` skips
+    # the first-boot init AND the datadir chown + privilege-drop the entrypoint
+    # performs; mysqld then drops to the mysql user and cannot write the
+    # root-owned disk (errno 13 on binlog.index, the symptom we hit). Prepending
+    # docker-entrypoint.sh restores that startup; it is harmless if Render ever
+    # keeps the entrypoint, because the script's final `exec "$@"` re-execs it.
+    #
+    # --datadir is a SUBDIRECTORY of the mounted disk, not its root. Render
+    # formats the disk ext4, so the mount root contains a `lost+found`; MySQL 8
+    # `mysqld --initialize` refuses a non-empty datadir (the 5.x ignore-db-dir
+    # knob is gone), so initializing into an empty subdir is the standard fix.
+    # Data + binlog both live under it, on the persistent disk.
+    #
+    # Cap binary logging: single MySQL, no replica, so binlog only buys
+    # point-in-time recovery; the 8.4 default retains 30 days uncapped and
+    # roughly doubles disk use on the insert-heavy ingest workload. Keep ~1 day
+    # of binlog, 256M per file.
+    dockerCommand: docker-entrypoint.sh mysqld --datadir=/var/lib/mysql/data --binlog_expire_logs_seconds=86400 --max-binlog-size=256M
     disk:
       name: mysql
       mountPath: /var/lib/mysql


### PR DESCRIPTION
…r datadir

Fresh Render deploys failed with `mysqld: File './binlog.index' not found (OS errno 13 - Permission denied)` and a restart loop.

Root cause: #377 added `dockerCommand: mysqld --binlog...` to the fleet-edr-mysql service. On Render a dockerCommand replaces the image ENTRYPOINT, so `mysqld` ran directly and skipped docker-entrypoint.sh, which is what initializes the datadir on first boot and chowns it before dropping to the mysql user. mysqld then ran as mysql against the root-owned disk mount and could not write binlog.index (errno 13). It worked before #377 because the default ENTRYPOINT (docker-entrypoint.sh)
+ CMD (mysqld) ran unmodified.

Fix: invoke `docker-entrypoint.sh mysqld ...` explicitly (restores init + chown; harmless even if Render preserves the entrypoint, since the script re-execs via `exec "$@"`), and point --datadir at a subdirectory of the disk. Render formats the disk ext4, so the mount root holds a lost+found; MySQL 8 `mysqld --initialize` refuses a non-empty datadir, so initializing into an empty subdir is the standard fix. Data + binlog live under it on the persistent disk.

Also corrects the stale "10 GB disk" in docs/deploy-render.md (100 GB since #377).

<!-- Keep this short. Delete sections that do not apply. -->

## What & why



## Checklist

- [ ] **OpenSpec updated for behavior changes.** If this PR changes observable behavior (a detection rule, the event
      wire schema, persistence semantics, an API/wire shape, or an emitted event), `openspec/specs/**` is updated (and
      an `openspec/changes/` proposal added), with a `spec:<id>` test marker for any new/renamed scenario. Only if this
      PR changes NO observable behavior (a comment / refactor / gofmt / dep bump that happens to touch a scoped path)
      may you assert `no-behavior-change` (label or `[no-behavior-change]` in the title) to clear the OpenSpec-sync gate.
      That is an assertion a reviewer will check, not a way to skip the spec for a real behavior change.
- [ ] Tests added/updated for the change (unit / integration / efficacy / UI as applicable).
- [ ] Agent/extension change touching ESF, XPC, or the event wire format: exercised on a live macOS VM before RC
      (flagged below).

## VM / RC notes (if applicable)


