### PR TITLE
docs(install): an extension-version upgrade needs a reboot for the NE…

### DIFF
--- a/docs/install-agent-manual.md
+++ b/docs/install-agent-manual.md
@@ -198,6 +198,8 @@ sudo installer -pkg fleet-edr-v0.2.0.pkg -target /
 
 The preinstall script stops the old daemon, the postinstall script starts the new one. The persisted host token at `/var/db/fleet-edr/enrolled.plist` survives, so the agent keeps its existing enrollment; no re-approval needed.
 
+**Reboot to finish the upgrade.** When the pkg replaces a system extension with a newer version, macOS does not remove the old version immediately: `systemextensionsctl list` shows the previous version as `terminated waiting to uninstall on reboot` alongside the new `activated enabled` one. Until you reboot, the Network Extension's XPC service (`group.com.fleetdm.edr.networkextension`, registered by `nesessionmanager`) stays bound to the old, terminated extension, so the agent cannot reach the live one. The symptom is a repeating `receiver connect` / `xpc_bridge_connect failed for group.com.fleetdm.edr.networkextension` warning and no network or DNS events (process and file events from the Endpoint Security extension are unaffected, because it re-registers its own Mach service on activation). Reboot to complete the cutover; afterward `systemextensionsctl list | grep fleetdm` shows only the new version and the warnings stop. A fresh (first-time) install does not need this reboot.
+
 ## Uninstall
 
 ```sh


### PR DESCRIPTION
… to reconnect

When the pkg replaces a system extension, macOS defers removing the old version until reboot (`terminated waiting to uninstall on reboot`), and the Network Extension's nesessionmanager-owned Mach service (group.com.fleetdm.edr.networkextension) stays bound to the old extension until then. The agent can't reach the live NE, so it logs repeating `xpc_bridge_connect failed` and drops network/DNS capture (ES events unaffected) until a reboot completes the cutover.

Observed on a real v0.1.1 -> v0.2.1 upgrade. A fresh install is unaffected.

<!-- Keep this short. Delete sections that do not apply. -->

## What & why



## Checklist

- [ ] **OpenSpec updated for behavior changes.** If this PR changes observable behavior (a detection rule, the event
      wire schema, persistence semantics, an API/wire shape, or an emitted event), `openspec/specs/**` is updated (and
      an `openspec/changes/` proposal added), with a `spec:<id>` test marker for any new/renamed scenario. Only if this
      PR changes NO observable behavior (a comment / refactor / gofmt / dep bump that happens to touch a scoped path)
      may you assert `no-behavior-change` (label or `[no-behavior-change]` in the title) to clear the OpenSpec-sync gate.
      That is an assertion a reviewer will check, not a way to skip the spec for a real behavior change.
- [ ] Tests added/updated for the change (unit / integration / efficacy / UI as applicable).
- [ ] Agent/extension change touching ESF, XPC, or the event wire format: exercised on a live macOS VM before RC
      (flagged below).

## VM / RC notes (if applicable)


