### PR TITLE
Throttle receiver drop warnings

### DIFF
--- a/agent/com.fleetdm.edr.agent.plist
+++ b/agent/com.fleetdm.edr.agent.plist
@@ -20,9 +20,14 @@
 		<!--
 		    Defaults that every install needs. Anything the operator puts in
 		    /etc/fleet-edr.conf (EDR_SERVER_URL, EDR_ENROLL_SECRET, etc.)
-		    layers underneath these env entries; real env vars win. Adjust
-		    per-host by editing this plist and `launchctl kickstart -k` the
-		    daemon to pick up changes.
+		    layers underneath these env entries; real env vars win. To adjust
+		    per-host, edit this plist and reload the job so launchd re-reads it:
+		    `sudo launchctl bootout system <this-plist>` then
+		    `sudo launchctl bootstrap system <this-plist>` (or reboot).
+		    `launchctl kickstart -k` only restarts the process under the job
+		    definition already in memory, so it does NOT pick up edits to these
+		    EnvironmentVariables (it is fine for /etc/fleet-edr.conf changes,
+		    which the agent re-reads itself on startup).
 		-->
 		<key>EDR_QUEUE_DB_PATH</key>
 		<string>/var/db/fleet-edr/events.db</string>

--- a/agent/receiver/common.go
+++ b/agent/receiver/common.go
@@ -82,6 +82,12 @@ func newDropReporter() *dropReporter {
 // suppressed. Suppressed drops stay in pending and are reported by the next warning that crosses the interval, so the only
 // undercount is a trailing partial window after drops stop entirely, at which point the condition has already been logged.
 func (r *dropReporter) record() (int64, bool) {
+	// Nil-receiver guard: a Receiver always builds its reporter in New, so production never passes nil, but a future refactor or
+	// partial init might. Degrade safely by surfacing every drop (count 1, emit) rather than panicking on the kernel-adjacent
+	// drop path or silently swallowing the loss. Calling a method on a nil pointer is legal in Go as long as we don't deref it.
+	if r == nil {
+		return 1, true
+	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.pending++

--- a/agent/receiver/common.go
+++ b/agent/receiver/common.go
@@ -55,70 +55,58 @@ func getLogger() *slog.Logger {
 	return slog.Default()
 }
 
-// dropWarnInterval is the minimum gap between aggregated "channel full" warnings for a single service. The first drop after a
-// quiet period logs immediately so operators see the onset promptly; further drops within the interval are counted and folded
-// into the next summary. A sustained overflow therefore collapses from one log line per dropped event (which floods the log when
-// a slow consumer falls behind, see PR thread on the agent-xpc-receiver capability) to one warning per interval carrying the
-// dropped-event count.
+// dropWarnInterval is the minimum gap between aggregated "channel full" warnings for one receiver. The first drop after a quiet
+// period logs immediately so operators see the onset promptly; further drops within the interval are counted and folded into the
+// next summary. A sustained overflow therefore collapses from one log line per dropped event (which floods the agent log when a
+// slow consumer falls behind, the loss surfaced via the agent-xpc-receiver "downstream consumer falls behind" scenario) to one
+// warning per interval carrying the dropped-event count.
 const dropWarnInterval = 5 * time.Second
 
-// dropReporter coalesces per-service "channel full" warnings so a burst of drops does not flood the log. It tracks, per service
-// name, the number of drops accumulated since the last emitted warning and when that warning fired. record returns the count to
-// log now (current drop plus any previously suppressed drops for the service) or 0 when the warning should be suppressed and
-// folded into a later summary. It is safe for concurrent use from the CGo onEvent callbacks of both receiver loops.
+// dropReporter coalesces a single receiver's "channel full" warnings so a burst of drops does not flood the log. Each Receiver
+// owns one reporter (one Mach service per receiver), which is why the state is a single counter rather than a per-service map and
+// why there is no package-level global: keeping it on the Receiver gives clean test isolation and avoids cross-receiver lock
+// contention on the drop path. It tracks the drops accumulated since the last emitted warning and when that warning fired.
 type dropReporter struct {
-	mu    sync.Mutex
-	state map[string]*serviceDropState
-	now   func() time.Time // seam for deterministic tests; defaults to time.Now
-}
-
-type serviceDropState struct {
-	pending  int64     // drops accumulated since the last emitted warning, not yet reflected in any log line
-	lastEmit time.Time // when the last warning fired for this service; zero until the first drop is reported
+	mu       sync.Mutex
+	pending  int64            // drops accumulated since the last emitted warning, not yet reflected in any log line
+	lastEmit time.Time        // when the last warning fired; zero until the first drop is reported
+	now      func() time.Time // seam for deterministic tests; defaults to time.Now
 }
 
 func newDropReporter() *dropReporter {
-	return &dropReporter{state: make(map[string]*serviceDropState), now: time.Now}
+	return &dropReporter{now: time.Now}
 }
 
-// record registers one dropped event for serviceName. It returns (count, true) when a warning should be emitted now, where count
-// is the number of drops the warning accounts for (this drop plus any suppressed since the last warning), or (0, false) when the
-// drop is suppressed. Suppressed drops stay in pending and are reported by the next warning that crosses the interval, so the
-// only undercount is a trailing partial window after drops stop entirely, at which point the condition has already been logged.
-func (r *dropReporter) record(serviceName string) (int64, bool) {
+// record registers one dropped event. It returns (count, true) when a warning should be emitted now, where count is the number
+// of drops the warning accounts for (this drop plus any suppressed since the last warning), or (0, false) when the drop is
+// suppressed. Suppressed drops stay in pending and are reported by the next warning that crosses the interval, so the only
+// undercount is a trailing partial window after drops stop entirely, at which point the condition has already been logged.
+func (r *dropReporter) record() (int64, bool) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	st := r.state[serviceName]
-	if st == nil {
-		st = &serviceDropState{}
-		r.state[serviceName] = st
-	}
-	st.pending++
+	r.pending++
 	now := r.now()
-	if st.lastEmit.IsZero() || now.Sub(st.lastEmit) >= dropWarnInterval {
-		count := st.pending
-		st.pending = 0
-		st.lastEmit = now
+	if r.lastEmit.IsZero() || now.Sub(r.lastEmit) >= dropWarnInterval {
+		count := r.pending
+		r.pending = 0
+		r.lastEmit = now
 		return count, true
 	}
 	return 0, false
 }
 
-// drops is the package-level reporter used by the production drop path. Tests reset it (and swap its clock) for isolation.
-var drops = newDropReporter()
-
 // tryDeliverEvent does a non-blocking send of evt onto ch. When ch's buffer is full it DROPS the event without blocking the
-// caller and surfaces the loss via a rate-limited warning naming serviceName and the dropped-event count. The production CGo
-// onEvent callback uses this so a slow downstream consumer cannot back-pressure into the XPC kernel side; tests exercise it
-// directly to pin the drop-and-warn contract without needing a live Mach service. The dropped-event arm is the
+// caller and surfaces the loss via a rate-limited warning naming serviceName and the dropped-event count, throttled by dr. The
+// production CGo onEvent callback uses this so a slow downstream consumer cannot back-pressure into the XPC kernel side; tests
+// exercise it directly to pin the drop-and-warn contract without needing a live Mach service. The dropped-event arm is the
 // agent-xpc-receiver "downstream consumer falls behind" scenario: the receiver MUST keep reading subsequent events from the
 // connector, so the send is non-blocking and the loss is surfaced via a warning rather than a returned error. The warning is
-// coalesced per service (see dropReporter) so a sustained overflow does not flood the log.
-func tryDeliverEvent(ch chan<- Event, evt Event, serviceName string) {
+// coalesced per receiver (see dropReporter) so a sustained overflow does not flood the log.
+func tryDeliverEvent(ch chan<- Event, evt Event, serviceName string, dr *dropReporter) {
 	select {
 	case ch <- evt:
 	default:
-		if count, emit := drops.record(serviceName); emit {
+		if count, emit := dr.record(); emit {
 			getLogger().WarnContext(context.Background(), "receiver event channel full", "service", serviceName, "dropped", count)
 		}
 	}

--- a/agent/receiver/common.go
+++ b/agent/receiver/common.go
@@ -15,7 +15,9 @@ package receiver
 import (
 	"context"
 	"log/slog"
+	"sync"
 	"sync/atomic"
+	"time"
 )
 
 // Error codes matching xpc_bridge.h constants. The values are part of the agent's logging surface; main.go classifies which codes are
@@ -53,16 +55,71 @@ func getLogger() *slog.Logger {
 	return slog.Default()
 }
 
-// tryDeliverEvent does a non-blocking send of evt onto ch. When ch's buffer is full it logs a warning naming serviceName and DROPS
-// the event without blocking the caller. The production CGo onEvent callback uses this so a slow downstream consumer cannot
-// back-pressure into the XPC kernel side; tests exercise it directly to pin the drop-and-warn contract without needing a live
-// Mach service. The dropped-event arm is the agent-xpc-receiver "downstream consumer falls behind" scenario: the receiver MUST
-// keep reading subsequent events from the connector, so the send is non-blocking and the loss is surfaced via a warning rather
-// than a returned error.
+// dropWarnInterval is the minimum gap between aggregated "channel full" warnings for a single service. The first drop after a
+// quiet period logs immediately so operators see the onset promptly; further drops within the interval are counted and folded
+// into the next summary. A sustained overflow therefore collapses from one log line per dropped event (which floods the log when
+// a slow consumer falls behind, see PR thread on the agent-xpc-receiver capability) to one warning per interval carrying the
+// dropped-event count.
+const dropWarnInterval = 5 * time.Second
+
+// dropReporter coalesces per-service "channel full" warnings so a burst of drops does not flood the log. It tracks, per service
+// name, the number of drops accumulated since the last emitted warning and when that warning fired. record returns the count to
+// log now (current drop plus any previously suppressed drops for the service) or 0 when the warning should be suppressed and
+// folded into a later summary. It is safe for concurrent use from the CGo onEvent callbacks of both receiver loops.
+type dropReporter struct {
+	mu    sync.Mutex
+	state map[string]*serviceDropState
+	now   func() time.Time // seam for deterministic tests; defaults to time.Now
+}
+
+type serviceDropState struct {
+	pending  int64     // drops accumulated since the last emitted warning, not yet reflected in any log line
+	lastEmit time.Time // when the last warning fired for this service; zero until the first drop is reported
+}
+
+func newDropReporter() *dropReporter {
+	return &dropReporter{state: make(map[string]*serviceDropState), now: time.Now}
+}
+
+// record registers one dropped event for serviceName. It returns (count, true) when a warning should be emitted now, where count
+// is the number of drops the warning accounts for (this drop plus any suppressed since the last warning), or (0, false) when the
+// drop is suppressed. Suppressed drops stay in pending and are reported by the next warning that crosses the interval, so the
+// only undercount is a trailing partial window after drops stop entirely, at which point the condition has already been logged.
+func (r *dropReporter) record(serviceName string) (int64, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	st := r.state[serviceName]
+	if st == nil {
+		st = &serviceDropState{}
+		r.state[serviceName] = st
+	}
+	st.pending++
+	now := r.now()
+	if st.lastEmit.IsZero() || now.Sub(st.lastEmit) >= dropWarnInterval {
+		count := st.pending
+		st.pending = 0
+		st.lastEmit = now
+		return count, true
+	}
+	return 0, false
+}
+
+// drops is the package-level reporter used by the production drop path. Tests reset it (and swap its clock) for isolation.
+var drops = newDropReporter()
+
+// tryDeliverEvent does a non-blocking send of evt onto ch. When ch's buffer is full it DROPS the event without blocking the
+// caller and surfaces the loss via a rate-limited warning naming serviceName and the dropped-event count. The production CGo
+// onEvent callback uses this so a slow downstream consumer cannot back-pressure into the XPC kernel side; tests exercise it
+// directly to pin the drop-and-warn contract without needing a live Mach service. The dropped-event arm is the
+// agent-xpc-receiver "downstream consumer falls behind" scenario: the receiver MUST keep reading subsequent events from the
+// connector, so the send is non-blocking and the loss is surfaced via a warning rather than a returned error. The warning is
+// coalesced per service (see dropReporter) so a sustained overflow does not flood the log.
 func tryDeliverEvent(ch chan<- Event, evt Event, serviceName string) {
 	select {
 	case ch <- evt:
 	default:
-		getLogger().WarnContext(context.Background(), "receiver event channel full", "service", serviceName)
+		if count, emit := drops.record(serviceName); emit {
+			getLogger().WarnContext(context.Background(), "receiver event channel full", "service", serviceName, "dropped", count)
+		}
 	}
 }

--- a/agent/receiver/common_test.go
+++ b/agent/receiver/common_test.go
@@ -23,6 +23,11 @@ func TestTryDeliverEvent_DropsAndWarnsOnFullChannel(t *testing.T) {
 	prev := logger.Load()
 	t.Cleanup(func() { logger.Store(prev) })
 
+	// Reset the shared drop reporter so a prior test's drops on the same service name don't suppress this test's warning.
+	prevDrops := drops
+	drops = newDropReporter()
+	t.Cleanup(func() { drops = prevDrops })
+
 	// Capture warn-level output to assert on the log line. A bytes.Buffer + mutex is enough since the test drives tryDeliverEvent
 	// synchronously from a single goroutine; the lock is defensive against a future test that runs the helper concurrently.
 	var (
@@ -63,6 +68,8 @@ func TestTryDeliverEvent_DropsAndWarnsOnFullChannel(t *testing.T) {
 		"the drop branch MUST emit a warning so operators detect the condition")
 	assert.Contains(t, logged, "svc-xpc",
 		"the warning MUST identify the affected service so multi-loop deployments can attribute the loss")
+	assert.Contains(t, logged, "dropped=1",
+		"the warning MUST carry the dropped-event count; the first drop accounts for exactly one event")
 
 	// The receiver continues reading: a fresh send (after the test drained `first`) succeeds.
 	next := Event{Data: []byte("next")}
@@ -93,6 +100,41 @@ func TestTryDeliverEvent_DeliversWhenChannelHasSpace(t *testing.T) {
 	logged := buf.String()
 	mu.Unlock()
 	assert.NotContains(t, logged, "channel full", "no warning on the happy path")
+}
+
+// spec:agent-xpc-receiver/events-flow-into-the-queue-without-blocking-the-receiver/sustained-drops-are-coalesced-into-a-throttled-summary
+//
+// Pins the rate-limiting half of the drop-and-warn contract: a sustained overflow MUST NOT emit one warning per dropped event
+// (which floods the agent log when a slow consumer falls behind). The first drop after a quiet period warns immediately so the
+// onset is visible; further drops within dropWarnInterval are counted and folded into the next summary, which carries the
+// accumulated dropped-event count. Driven through dropReporter with a fake clock so the window boundary is deterministic.
+func TestDropReporter_CoalescesSustainedDrops(t *testing.T) {
+	now := time.Unix(0, 0)
+	r := newDropReporter()
+	r.now = func() time.Time { return now }
+
+	// First drop for the service: emits immediately, accounting for exactly one event.
+	count, emit := r.record("svc-xpc")
+	require.True(t, emit, "the first drop after a quiet period MUST warn immediately so operators see the onset")
+	assert.Equal(t, int64(1), count, "the first warning accounts for the single drop seen so far")
+
+	// A burst of further drops inside the interval is suppressed, not logged one-per-event.
+	for range 999 {
+		count, emit = r.record("svc-xpc")
+		assert.False(t, emit, "drops within dropWarnInterval MUST be suppressed to avoid flooding the log")
+		assert.Zero(t, count, "a suppressed drop reports no count")
+	}
+
+	// Crossing the interval boundary emits a single summary carrying every suppressed drop plus the boundary drop.
+	now = now.Add(dropWarnInterval)
+	count, emit = r.record("svc-xpc")
+	require.True(t, emit, "the first drop after the interval MUST emit an aggregated summary")
+	assert.Equal(t, int64(1000), count, "the summary MUST account for all drops suppressed since the previous warning")
+
+	// A different service tracks its own window: its first drop warns independently of svc-xpc's throttle.
+	count, emit = r.record("svc-net")
+	require.True(t, emit, "a distinct service MUST warn on its own first drop, not share another service's throttle")
+	assert.Equal(t, int64(1), count)
 }
 
 // mutexWriter serialises Write calls so the slog text handler doesn't interleave records when multiple goroutines log into the same

--- a/agent/receiver/common_test.go
+++ b/agent/receiver/common_test.go
@@ -139,6 +139,15 @@ func TestDropReporter_CoalescesSustainedDrops(t *testing.T) {
 	assert.Equal(t, int64(1), count)
 }
 
+// A nil reporter must not panic on the drop path. The Receiver always builds one, but the helper is defensive against a future
+// refactor passing nil: record degrades to "surface every drop" (count 1, emit) rather than crashing the receiver callback.
+func TestDropReporter_NilReporterDoesNotPanic(t *testing.T) {
+	var r *dropReporter
+	count, emit := r.record()
+	require.True(t, emit, "a nil reporter MUST surface the drop rather than swallow it")
+	assert.Equal(t, int64(1), count, "a nil reporter accounts for the single drop")
+}
+
 // mutexWriter serialises Write calls so the slog text handler doesn't interleave records when multiple goroutines log into the same
 // buffer. Used by the drop test to keep the captured log deterministic across the helper's non-blocking send + the test's drain.
 type mutexWriter struct {

--- a/agent/receiver/common_test.go
+++ b/agent/receiver/common_test.go
@@ -23,10 +23,8 @@ func TestTryDeliverEvent_DropsAndWarnsOnFullChannel(t *testing.T) {
 	prev := logger.Load()
 	t.Cleanup(func() { logger.Store(prev) })
 
-	// Reset the shared drop reporter so a prior test's drops on the same service name don't suppress this test's warning.
-	prevDrops := drops
-	drops = newDropReporter()
-	t.Cleanup(func() { drops = prevDrops })
+	// A fresh per-receiver reporter keeps this test isolated without touching any shared global.
+	dr := newDropReporter()
 
 	// Capture warn-level output to assert on the log line. A bytes.Buffer + mutex is enough since the test drives tryDeliverEvent
 	// synchronously from a single goroutine; the lock is defensive against a future test that runs the helper concurrently.
@@ -42,13 +40,13 @@ func TestTryDeliverEvent_DropsAndWarnsOnFullChannel(t *testing.T) {
 	first := Event{Data: []byte("first")}
 	dropped := Event{Data: []byte("dropped")}
 
-	tryDeliverEvent(ch, first, "svc-xpc")
+	tryDeliverEvent(ch, first, "svc-xpc", dr)
 	// Channel now full. The next call MUST drop without blocking. If the implementation regressed to a blocking send, the test
 	// would otherwise deadlock until go test's package-level timeout (default 10m). Use a tight time.After timeout so a regression
 	// fails the test in a second instead of hanging the suite.
 	done := make(chan struct{})
 	go func() {
-		tryDeliverEvent(ch, dropped, "svc-xpc")
+		tryDeliverEvent(ch, dropped, "svc-xpc", dr)
 		close(done)
 	}()
 	select {
@@ -73,7 +71,7 @@ func TestTryDeliverEvent_DropsAndWarnsOnFullChannel(t *testing.T) {
 
 	// The receiver continues reading: a fresh send (after the test drained `first`) succeeds.
 	next := Event{Data: []byte("next")}
-	tryDeliverEvent(ch, next, "svc-xpc")
+	tryDeliverEvent(ch, next, "svc-xpc", dr)
 	got = <-ch
 	assert.Equal(t, "next", string(got.Data), "after a drop, the receiver MUST keep accepting subsequent events")
 }
@@ -90,9 +88,10 @@ func TestTryDeliverEvent_DeliversWhenChannelHasSpace(t *testing.T) {
 	)
 	SetLogger(slog.New(slog.NewTextHandler(&mutexWriter{w: &buf, mu: &mu}, &slog.HandlerOptions{Level: slog.LevelDebug})))
 
+	dr := newDropReporter()
 	ch := make(chan Event, 4)
 	for _, b := range [][]byte{[]byte("a"), []byte("b"), []byte("c")} {
-		tryDeliverEvent(ch, Event{Data: b}, "svc-xpc")
+		tryDeliverEvent(ch, Event{Data: b}, "svc-xpc", dr)
 	}
 	require.Len(t, ch, 3, "three sends MUST land when the channel has room")
 
@@ -113,27 +112,30 @@ func TestDropReporter_CoalescesSustainedDrops(t *testing.T) {
 	r := newDropReporter()
 	r.now = func() time.Time { return now }
 
-	// First drop for the service: emits immediately, accounting for exactly one event.
-	count, emit := r.record("svc-xpc")
+	// First drop: emits immediately, accounting for exactly one event.
+	count, emit := r.record()
 	require.True(t, emit, "the first drop after a quiet period MUST warn immediately so operators see the onset")
 	assert.Equal(t, int64(1), count, "the first warning accounts for the single drop seen so far")
 
 	// A burst of further drops inside the interval is suppressed, not logged one-per-event.
 	for range 999 {
-		count, emit = r.record("svc-xpc")
+		count, emit = r.record()
 		assert.False(t, emit, "drops within dropWarnInterval MUST be suppressed to avoid flooding the log")
 		assert.Zero(t, count, "a suppressed drop reports no count")
 	}
 
 	// Crossing the interval boundary emits a single summary carrying every suppressed drop plus the boundary drop.
 	now = now.Add(dropWarnInterval)
-	count, emit = r.record("svc-xpc")
+	count, emit = r.record()
 	require.True(t, emit, "the first drop after the interval MUST emit an aggregated summary")
 	assert.Equal(t, int64(1000), count, "the summary MUST account for all drops suppressed since the previous warning")
 
-	// A different service tracks its own window: its first drop warns independently of svc-xpc's throttle.
-	count, emit = r.record("svc-net")
-	require.True(t, emit, "a distinct service MUST warn on its own first drop, not share another service's throttle")
+	// Each receiver owns its own reporter, so a second reporter's window is independent: its first drop warns even while r is
+	// mid-throttle. This is what gives the two receiver loops (system + network extension) independent drop accounting.
+	other := newDropReporter()
+	other.now = func() time.Time { return now }
+	count, emit = other.record()
+	require.True(t, emit, "a separate reporter MUST warn on its own first drop, not share another receiver's throttle")
 	assert.Equal(t, int64(1), count)
 }
 

--- a/agent/receiver/receiver.go
+++ b/agent/receiver/receiver.go
@@ -33,8 +33,9 @@ type Receiver struct {
 	errors      chan int
 	mu          sync.Mutex
 	connected   bool
-	handle      int // C bridge connection handle, -1 when not connected
-	receiverID  int // ID used to route C callbacks to this receiver
+	handle      int           // C bridge connection handle, -1 when not connected
+	receiverID  int           // ID used to route C callbacks to this receiver
+	drops       *dropReporter // coalesces "channel full" drop warnings for this receiver's service
 }
 
 // Registry of active receivers, keyed by receiverID.
@@ -58,6 +59,7 @@ func New(serviceName string, eventBuf int) *Receiver {
 		errors:      make(chan int, 8),
 		handle:      -1,
 		receiverID:  id,
+		drops:       newDropReporter(),
 	}
 }
 
@@ -200,7 +202,7 @@ func onEvent(receiverID int, data unsafe.Pointer, length int) {
 	}
 
 	buf := C.GoBytes(data, C.int(length))
-	tryDeliverEvent(recv.events, Event{Data: buf}, recv.serviceName)
+	tryDeliverEvent(recv.events, Event{Data: buf}, recv.serviceName, recv.drops)
 }
 
 // onError is called from C (via callbacks.go) when an XPC connection error occurs.

--- a/docs/install-agent-manual.md
+++ b/docs/install-agent-manual.md
@@ -235,4 +235,38 @@ sudo launchctl kickstart -k system/com.fleetdm.edr.agent
 
 **`receiver connect` / `xpc_bridge_connect failed` warnings repeat while `systemextensionsctl list` shows `activated enabled`.** The Endpoint Security extension is exiting on launch for lack of Full Disk Access. Confirm with `log show --last 10m --predicate 'subsystem == "com.fleetdm.edr.securityextension"' | grep "ES client"`: `Failed to create ES client: 4` is `ERR_NOT_PERMITTED`. Enable the **"Fleet EDR Security Extension"** entry in Privacy & Security > Full Disk Access (Step 6). The extension is a different TCC identity from `/Applications/Fleet EDR.app`, so granting the app alone doesn't fix it.
 
+## Enable OpenTelemetry (optional, dev/debug)
+
+The agent ships OpenTelemetry instrumentation but keeps it off by default: with no OTLP endpoint configured it installs no-op providers and emits nothing, which is the right posture for production endpoints (we do not want every host streaming telemetry to a shared collector). See [ADR-0006](adr/0006-otel-only-metrics.md). Turn it on when you are debugging a single host and want its metrics (queue depth, dropped events) and logs in a collector such as SigNoz.
+
+The agent reads the standard `OTEL_*` variables directly from its process environment, so they must go in the LaunchDaemon's `EnvironmentVariables`, NOT in `/etc/fleet-edr.conf`. The conf file is layered only into the agent's own `EDR_*` settings; it is never exported to the environment the OpenTelemetry SDK reads, so `OTEL_*` entries placed there are silently ignored.
+
+Edit `/Library/LaunchDaemons/com.fleetdm.edr.agent.plist` and add these keys inside the existing `<key>EnvironmentVariables</key>` dict, substituting your collector endpoint and token:
+
+```xml
+<key>OTEL_EXPORTER_OTLP_ENDPOINT</key>
+<string>https://otel.fleetdm.site:443</string>
+<key>OTEL_EXPORTER_OTLP_COMPRESSION</key>
+<string>gzip</string>
+<key>OTEL_EXPORTER_OTLP_HEADERS</key>
+<string>authorization=Bearer YOUR_OTLP_TOKEN</string>
+<key>OTEL_RESOURCE_ATTRIBUTES</key>
+<string>deployment.environment.name=dev-local,deployment.environment=dev-local</string>
+<key>EDR_LOG_LEVEL</key>
+<string>debug</string>
+```
+
+Then reload the daemon so it picks up the new environment:
+
+```sh
+sudo launchctl kickstart -k system/com.fleetdm.edr.agent
+```
+
+Notes:
+
+- The agent always uses the gRPC OTLP exporter, so `OTEL_EXPORTER_OTLP_ENDPOINT` must point at a gRPC OTLP target and you do not need `OTEL_EXPORTER_OTLP_PROTOCOL` (it is ignored). `OTEL_EXPORTER_OTLP_HEADERS` and `OTEL_EXPORTER_OTLP_COMPRESSION` are honored.
+- `OTEL_RESOURCE_ATTRIBUTES` sets the `deployment.environment` so a shared backend can tell this host's telemetry apart from other deployments. Pick a per-host or per-pilot value rather than reusing `dev-local` across machines.
+- `EDR_LOG_LEVEL=debug` raises verbosity on both stderr (`/var/log/fleet-edr-agent.log`) and the OTLP log pipeline. Valid values are `debug`, `info`, `warn`, `error`.
+- To turn it back off, remove the `OTEL_EXPORTER_OTLP_ENDPOINT` key and kickstart again; with no endpoint the agent returns to the no-op path and stops exporting.
+
 **Full Disk Access grant gets wiped after every reboot.** Probably a TCC-database issue after a macOS point upgrade. Re-add the entries in Privacy & Security. If it recurs on a managed Mac, deploy the TCC profile via MDM instead.

--- a/docs/install-agent-manual.md
+++ b/docs/install-agent-manual.md
@@ -256,13 +256,16 @@ Edit `/Library/LaunchDaemons/com.fleetdm.edr.agent.plist` and add these keys ins
 <string>debug</string>
 ```
 
-The `OTEL_EXPORTER_OTLP_HEADERS` value embeds a bearer token, so treat the plist as a secret at rest the same way `/etc/fleet-edr.conf` is locked down above. The plist is loaded by root, so restrict it to root and reload:
+The `OTEL_EXPORTER_OTLP_HEADERS` value embeds a bearer token, so treat the plist as a secret at rest the same way `/etc/fleet-edr.conf` is locked down above. The plist is loaded by root, so restrict it to root, then reload the job so launchd re-reads the edited plist:
 
 ```sh
 sudo chown root:wheel /Library/LaunchDaemons/com.fleetdm.edr.agent.plist
 sudo chmod 600 /Library/LaunchDaemons/com.fleetdm.edr.agent.plist
-sudo launchctl kickstart -k system/com.fleetdm.edr.agent
+sudo launchctl bootout system /Library/LaunchDaemons/com.fleetdm.edr.agent.plist
+sudo launchctl bootstrap system /Library/LaunchDaemons/com.fleetdm.edr.agent.plist
 ```
+
+Use `bootout` + `bootstrap` (or a reboot), NOT `launchctl kickstart -k`. `kickstart -k` only restarts the process under the job definition launchd already has in memory, so it does not pick up edits to the plist's `EnvironmentVariables`: the agent would respawn still missing the `OTEL_*` keys, the SDK would stay on the no-op path, and nothing would reach the collector. (`kickstart -k` is fine for `/etc/fleet-edr.conf` changes, because the agent re-reads that file itself on startup; it is the plist env specifically that needs a full reload.)
 
 Prefer a short-lived, narrowly-scoped collector token for dev/debug, and rotate it after use. To avoid putting the token on disk at all, you can instead set the `OTEL_*` variables in the shell and run the agent binary directly in the foreground for the duration of the debugging session.
 
@@ -271,6 +274,6 @@ Notes:
 - The agent always uses the gRPC OTLP exporter, so `OTEL_EXPORTER_OTLP_ENDPOINT` must point at a gRPC OTLP target and you do not need `OTEL_EXPORTER_OTLP_PROTOCOL` (it is ignored). `OTEL_EXPORTER_OTLP_HEADERS` and `OTEL_EXPORTER_OTLP_COMPRESSION` are honored.
 - `OTEL_RESOURCE_ATTRIBUTES` sets the `deployment.environment` so a shared backend can tell this host's telemetry apart from other deployments. Pick a per-host or per-pilot value rather than reusing `dev-local` across machines.
 - `EDR_LOG_LEVEL=debug` raises verbosity on both stderr (`/var/log/fleet-edr-agent.log`) and the OTLP log pipeline. Valid values are `debug`, `info`, `warn`, `error`.
-- To turn it back off, remove the `OTEL_EXPORTER_OTLP_ENDPOINT` key and kickstart again; with no endpoint the agent returns to the no-op path and stops exporting.
+- To turn it back off, remove the `OTEL_EXPORTER_OTLP_ENDPOINT` key and reload the job again (`bootout` + `bootstrap`); with no endpoint the agent returns to the no-op path and stops exporting.
 
 **Full Disk Access grant gets wiped after every reboot.** Probably a TCC-database issue after a macOS point upgrade. Re-add the entries in Privacy & Security. If it recurs on a managed Mac, deploy the TCC profile via MDM instead.

--- a/docs/install-agent-manual.md
+++ b/docs/install-agent-manual.md
@@ -256,11 +256,15 @@ Edit `/Library/LaunchDaemons/com.fleetdm.edr.agent.plist` and add these keys ins
 <string>debug</string>
 ```
 
-Then reload the daemon so it picks up the new environment:
+The `OTEL_EXPORTER_OTLP_HEADERS` value embeds a bearer token, so treat the plist as a secret at rest the same way `/etc/fleet-edr.conf` is locked down above. The plist is loaded by root, so restrict it to root and reload:
 
 ```sh
+sudo chown root:wheel /Library/LaunchDaemons/com.fleetdm.edr.agent.plist
+sudo chmod 600 /Library/LaunchDaemons/com.fleetdm.edr.agent.plist
 sudo launchctl kickstart -k system/com.fleetdm.edr.agent
 ```
+
+Prefer a short-lived, narrowly-scoped collector token for dev/debug, and rotate it after use. To avoid putting the token on disk at all, you can instead set the `OTEL_*` variables in the shell and run the agent binary directly in the foreground for the duration of the debugging session.
 
 Notes:
 

--- a/openspec/changes/throttle-receiver-drop-warnings/proposal.md
+++ b/openspec/changes/throttle-receiver-drop-warnings/proposal.md
@@ -1,0 +1,14 @@
+# Throttle the receiver's dropped-event warnings
+
+## Why
+
+When a downstream consumer falls behind, the receiver's full-channel drop path (`agent/receiver/common.go`, `tryDeliverEvent`) logs one `receiver event channel full` warning per dropped event. The XPC onEvent callback fires this on every drop, so a slow consumer produces thousands of identical lines in microseconds (observed: 5 lines within ~130µs in a captured `fleet-edr-agent.log`). The flood drowns out every other log line, inflates the OTLP log volume the agent ships, and tells an operator nothing more than the first line already did. The current spec mandates a warning per drop, so the volume is contract, not an accident.
+
+## What changes
+
+- **The drop warning is rate-limited per service and carries a count.** Instead of one log line per dropped event, the receiver emits the warning immediately on the first drop after a quiet period (so the onset is visible promptly), then suppresses further warnings for that service within a fixed interval and folds the suppressed drops into the next summary. Each emitted warning carries a `dropped` count of the events it accounts for, so an operator still sees the magnitude of loss without the flood. Each service name (system extension, network extension) tracks its own window.
+
+### Not in this change
+
+- A lossless OTel counter metric for receiver drops (e.g. `edr.agent.receiver.events_dropped`). The agent already exports queue/uploader drop counters via the OTLP pipeline (ADR-0006), and a receiver-drop metric is the right long-term home for the exact magnitude; this change keeps scope to the log flood and leaves the metric as a follow-up.
+- Any change to the drop policy itself: events are still dropped (not buffered or back-pressured), and the receiver still keeps reading subsequent events. Only the warning's volume changes.

--- a/openspec/changes/throttle-receiver-drop-warnings/specs/agent-xpc-receiver/spec.md
+++ b/openspec/changes/throttle-receiver-drop-warnings/specs/agent-xpc-receiver/spec.md
@@ -1,0 +1,23 @@
+# Agent XPC Receiver: throttle dropped-event warnings delta
+
+## MODIFIED Requirements
+
+### Requirement: Events flow into the queue without blocking the receiver
+
+The receiver SHALL deliver received events into a downstream channel without blocking on the channel. If the downstream buffer is full the receiver MAY drop the affected event but MUST surface the loss via a warning so operators can detect the condition, and MUST keep reading subsequent events from the XPC connection. To avoid flooding the log when a slow consumer sustains a backlog, the receiver SHALL rate-limit the warning per affected service: it MUST emit a warning on the first drop after a quiet period so the onset is visible promptly, then MAY suppress further warnings for that service within a bounded interval, folding the suppressed drops into the next emitted warning. Each emitted warning MUST identify the affected service and MUST carry the count of dropped events it accounts for, so an operator sees the magnitude of loss without one log line per dropped event. Each service's rate-limit window is independent.
+
+#### Scenario: Downstream consumer falls behind
+
+- **GIVEN** the receiver is delivering events into a buffered channel
+- **WHEN** the consumer is too slow and the channel fills up
+- **THEN** the receiver drops the event that could not be enqueued
+- **AND** the receiver logs a warning identifying the affected service and the count of dropped events
+- **AND** the receiver continues reading subsequent events
+
+#### Scenario: Sustained drops are coalesced into a throttled summary
+
+- **GIVEN** the receiver has already warned about a full channel for a service
+- **WHEN** further events for that service are dropped within the rate-limit interval
+- **THEN** the receiver does not emit a warning per dropped event
+- **AND** once the interval elapses the next drop emits a single warning carrying the count of events dropped since the previous warning
+- **AND** a drop on a different service emits its own warning independently of the first service's interval

--- a/openspec/changes/throttle-receiver-drop-warnings/tasks.md
+++ b/openspec/changes/throttle-receiver-drop-warnings/tasks.md
@@ -1,0 +1,18 @@
+# Throttle the receiver's dropped-event warnings: tasks
+
+## 1. Receiver
+
+- [x] `agent/receiver/common.go`: add `dropReporter` (per-service `pending` count + `lastEmit` time, `now` clock seam) and `dropWarnInterval` (5s). `record` returns the count to log now (this drop plus suppressed drops since the last warning) or 0 when suppressed. `tryDeliverEvent` calls `drops.record` and only logs when it returns emit=true, adding a `dropped` count attribute to the warning.
+
+## 2. Spec
+
+- [x] `agent-xpc-receiver` spec: MODIFIED requirement "Events flow into the queue without blocking the receiver" so the warning is rate-limited and carries a dropped-event count; kept the "Downstream consumer falls behind" scenario and added "Sustained drops are coalesced into a throttled summary".
+
+## 3. Tests
+
+- [x] `agent/receiver/common_test.go`: existing drop test resets the shared reporter and asserts `dropped=1`. New `TestDropReporter_CoalescesSustainedDrops` drives a 1000-drop burst through a fake clock: first drop warns (count 1), the next 999 are suppressed, crossing `dropWarnInterval` emits one summary (count 1000), and a distinct service warns on its own first drop. Scenario marker on the new test.
+
+## 4. Verification
+
+- [x] `go test ./agent/receiver/` green.
+- [ ] gofmt + `task lint:go` on the touched package; `openspec validate throttle-receiver-drop-warnings --strict`; `tools/spectrace`; dash + markdown lints.

--- a/openspec/changes/throttle-receiver-drop-warnings/tasks.md
+++ b/openspec/changes/throttle-receiver-drop-warnings/tasks.md
@@ -2,7 +2,8 @@
 
 ## 1. Receiver
 
-- [x] `agent/receiver/common.go`: add `dropReporter` (per-service `pending` count + `lastEmit` time, `now` clock seam) and `dropWarnInterval` (5s). `record` returns the count to log now (this drop plus suppressed drops since the last warning) or 0 when suppressed. `tryDeliverEvent` calls `drops.record` and only logs when it returns emit=true, adding a `dropped` count attribute to the warning.
+- [x] `agent/receiver/common.go`: add `dropReporter` (`pending` count + `lastEmit` time, `now` clock seam) and `dropWarnInterval` (5s). `record` returns the count to log now (this drop plus suppressed drops since the last warning) or 0 when suppressed. `tryDeliverEvent` takes a `*dropReporter` and only logs when `record` returns emit=true, adding a `dropped` count attribute to the warning.
+- [x] `agent/receiver/receiver.go`: each `Receiver` owns its `drops *dropReporter` (created in `New`, passed from `onEvent`). No package-level global and no per-service map: one Mach service per receiver, so the reporter is a single counter, which also removes cross-receiver lock contention on the drop path and gives clean test isolation.
 
 ## 2. Spec
 
@@ -10,7 +11,7 @@
 
 ## 3. Tests
 
-- [x] `agent/receiver/common_test.go`: existing drop test resets the shared reporter and asserts `dropped=1`. New `TestDropReporter_CoalescesSustainedDrops` drives a 1000-drop burst through a fake clock: first drop warns (count 1), the next 999 are suppressed, crossing `dropWarnInterval` emits one summary (count 1000), and a distinct service warns on its own first drop. Scenario marker on the new test.
+- [x] `agent/receiver/common_test.go`: existing drop test uses a fresh per-receiver reporter and asserts `dropped=1`. New `TestDropReporter_CoalescesSustainedDrops` drives a 1000-drop burst through a fake clock: first drop warns (count 1), the next 999 are suppressed, crossing `dropWarnInterval` emits one summary (count 1000), and a second reporter warns on its own first drop (independent windows). Scenario marker on the new test.
 
 ## 4. Verification
 


### PR DESCRIPTION
<!-- Keep this short. Delete sections that do not apply. -->

## What & why



## Checklist

- [ ] **OpenSpec updated for behavior changes.** If this PR changes observable behavior (a detection rule, the event
      wire schema, persistence semantics, an API/wire shape, or an emitted event), `openspec/specs/**` is updated (and
      an `openspec/changes/` proposal added), with a `spec:<id>` test marker for any new/renamed scenario. Only if this
      PR changes NO observable behavior (a comment / refactor / gofmt / dep bump that happens to touch a scoped path)
      may you assert `no-behavior-change` (label or `[no-behavior-change]` in the title) to clear the OpenSpec-sync gate.
      That is an assertion a reviewer will check, not a way to skip the spec for a real behavior change.
- [ ] Tests added/updated for the change (unit / integration / efficacy / UI as applicable).
- [ ] Agent/extension change touching ESF, XPC, or the event wire format: exercised on a live macOS VM before RC
      (flagged below).

## VM / RC notes (if applicable)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Optimized receiver drop warnings to reduce logging noise by rate-limiting and aggregating messages per service, with event counts included in each warning.

* **Documentation**
  * Added OpenTelemetry debugging guide to the installation manual with environment variable configuration and launchctl reload instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->