### PR TITLE
feat(detection): correlate network/DNS flows to processes by pid+pidv…

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -78,11 +78,11 @@ Key files:
 
 ### Network extension (`extension/edr/networkextension/`)
 
-A Swift system extension implementing `NEFilterDataProvider` for network connection monitoring. Captures outbound TCP/UDP socket flows with process attribution via audit tokens.
+A Swift system extension implementing `NEFilterDataProvider` for network connection monitoring. Captures outbound TCP/UDP socket flows with process attribution via audit tokens: the PID plus the kernel PID generation (`pidversion`), so the server can correlate a flow to the exact process generation by identity rather than a time window, immune to PID reuse (issue #403).
 
 Events produced:
 
-- `network_connect` -- remote address/port, local address/port, protocol, direction, hostname (from SNI), process path and PID
+- `network_connect` -- remote address/port, local address/port, protocol, direction, hostname (from SNI), process path, PID, and `pidversion` (kernel PID generation, when the flow carried an audit token)
 
 Also contains a `NEDNSProxyProvider` for DNS query capture (disabled by default). When enabled, it intercepts DNS queries, extracts query name/type, forwards to the upstream resolver, and emits `dns_query` events with response addresses.
 
@@ -183,13 +183,13 @@ type Rule interface {
 
 Each bounded context owns its own tables in the shared database; there are no cross-context foreign keys (ADR-0004). The data plane (`detection`) owns:
 
-| Table          | Purpose                                                                |
-| -------------- | ---------------------------------------------------------------------- |
-| `events`       | Raw event storage with processed flag for the claim/process/mark cycle |
-| `processes`    | Materialized process state (PID, path, args, fork/exec/exit times)     |
-| `alerts`       | Detection findings with deduplication (host_id, rule_id, process_id)   |
-| `alert_events` | Links alerts to triggering events                                      |
-| `hosts`        | Enrolled-host roster with last-seen / online status                    |
+| Table          | Purpose                                                                          |
+| -------------- | -------------------------------------------------------------------------------- |
+| `events`       | Raw event storage with processed flag for the claim/process/mark cycle           |
+| `processes`    | Materialized process state (PID, `pidversion`, path, args, fork/exec/exit times) |
+| `alerts`       | Detection findings with deduplication (host_id, rule_id, process_id)             |
+| `alert_events` | Links alerts to triggering events                                                |
+| `hosts`        | Enrolled-host roster with last-seen / online status                              |
 
 `commands` lives in `response`; `enrollments` in `endpoint`; the `app_control_*` policy tables in `rules`; `users`, `sessions`, `roles`, and `audit_events` in `identity`.
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -84,6 +84,26 @@ pre-commit:
         fi
       stage_fixed: true
 
+    dash-lint:
+      # Mirror the CI "No em dashes" gate (.github/workflows/no-emdash.yml) at commit time, scoped to staged files like
+      # every other hook here. tools/lint-no-emdash.sh bans em/en dashes (U+2014 / U+2013); tools/dash-lint bans the
+      # spaced ASCII hyphen ' - ' in Markdown prose and in code comments + string literals. This closes the gap that let
+      # PR #414's tasks.md em-dashes reach CI: `task lint:dashes` scans `git ls-files`, so the then-untracked new files
+      # were invisible to a manual run, and no pre-commit hook covered the rule. {staged_files} expands to every staged
+      # path regardless of glob; both tools filter internally (grep -I binary-skip / type-aware), so the raw list is safe.
+      # `go run ./tools/dash-lint` compiles once and is cached, so steady-state cost is ~1s alongside the markdown hooks.
+      # Capture each check's status into rc rather than relying on the block's last-command exit: lefthook takes the run
+      # script's final exit code, so a chained `lint-no-emdash.sh` (em-dash) failure would otherwise be masked by a
+      # passing `dash-lint` (spaced-hyphen) on the next line. Running both unconditionally also surfaces every violation
+      # in one pass instead of stopping at the first.
+      run: |
+        files=$(printf '%s\n' {staged_files})
+        if [ -z "$files" ]; then exit 0; fi
+        rc=0
+        printf '%s\n' "$files" | tr '\n' '\0' | xargs -0 bash tools/lint-no-emdash.sh || rc=1
+        printf '%s\n' "$files" | tr '\n' '\0' | go run ./tools/dash-lint || rc=1
+        exit $rc
+
     # Catch secrets before they land. `git secrets` or `trufflehog` could
     # fit here later. For now, a minimal regex guard against the obvious
     # patterns that shouldn't be in source.

--- a/openspec/changes/flow-process-identity/design.md
+++ b/openspec/changes/flow-process-identity/design.md
@@ -1,0 +1,47 @@
+# Design notes: flow-to-process identity correlation
+
+## Why a design doc
+
+Three decisions are non-obvious and cut across the Swift extension, the wire format, and the Go server. They are recorded here so the implementation and review have one reference.
+
+## 1. Which audit token, and is `sourceProcessAuditToken` available
+
+The NE reads `sourceAppAuditToken` today: `NEFilterFlow.sourceAppAuditToken` for the socket filter (`NetworkFilter.swift`) and `NEAppProxyFlow.metaData.sourceAppAuditToken` for the DNS proxy (`DNSProxyProvider.swift`). `sourceAppAuditToken` is the audit token of the app *responsible* for the flow, which for a helper process can be the parent app rather than the process that actually opened the socket.
+
+`pidversion` is a field of the audit token, so whatever token we read, the `(pid, pidversion)` pair is internally consistent with the PID we already report: extracting `pidversion` from the same `sourceAppAuditToken` cannot make correlation worse than today, it only makes the existing attribution exact against PID reuse.
+
+The issue asks us to also consider `sourceProcessAuditToken`. Action at implementation time: check the macOS 26 SDK on the build VM for a per-process flow token (`sourceProcessAuditToken` or equivalent on `NEFlowMetaData`). If it exists and resolves a more precise originator than `sourceAppAuditToken`, read it and prefer it, falling back to `sourceAppAuditToken` when nil. If it does not exist as public API, we ship with `sourceAppAuditToken` and record the proxied-originator gap as the documented Apple ask. Either way the wire/server design below is unchanged: the device emits one `(pid, pidversion)` per flow.
+
+The ES/NE agreement that makes the join sound: both ES (`es_process_t.audit_token`) and the NE flow token carry the kernel's `p_idversion` for the same live process, so a process materialized from an ES exec/fork and a flow attributed to that same process share `(pid, pidversion)`.
+
+## 2. Nullable end to end, never a zero sentinel
+
+`audit_token_to_pidversion` returns a `UInt32`. `0` is a legitimate value for some kernel-managed processes, so we cannot use `0` to mean "absent". The field is therefore:
+
+- Swift: an optional, encoded with `encodeIfPresent` (omitted from JSON when the token was unavailable).
+- Wire: an optional `pidversion` integer in `schema/events.json`.
+- DB: `pidversion INT UNSIGNED NULL` on `processes`.
+- Server payload structs: `*uint32` (`PIDVersion *uint32 \`json:"pidversion"\``).
+
+"Absent" routes correlation to the existing time-window path; "present" (including `0`) routes to the exact identity lookup.
+
+## 3. Join precedence and the skew pad
+
+New store method (`server/detection/internal/mysql/processes.go`):
+
+```
+GetProcessByPIDVersion(ctx, hostID, pid, pidversion) (*api.Process, error)
+```
+
+Exact match on `(host_id, pid, pidversion)`, backed by a new `idx_processes_host_pid_pidversion` index. Returns the single generation or nil.
+
+Correlation call sites (`dns_c2_beacon.go`, `suspicious_exec.go`, and `GetProcessDetail` in `graph/query.go`) resolve the triggering event's process as:
+
+1. If the event payload carries `pidversion`, call `GetProcessByPIDVersion`. On a hit, use it; the forward skew pad (`processLookupSkewPadNs`) is not applied because identity does not drift.
+2. On a miss, or when the payload has no `pidversion`, fall back to the existing `lookupProcessSkewTolerant` / `GetProcessByPID(atTimeNs)` window path, unchanged.
+
+This is a pure precision add: every existing event continues to resolve exactly as it does today, and only events that carry the new field gain the exact, reuse-immune, drift-free path. `GetNetworkEventsForProcess` (the within-process dns-to-connect scan) is left on `payload_pid` + ingest window; scoping it further by `pidversion` is unnecessary because it is already constrained to one PID within a 30s window, and the dominant mis-correlation risk is the flow-to-generation lookup, not the intra-process scan.
+
+## Rollout safety
+
+Mixed-version fleets are the normal state during an agent rollout. Because the field is optional and the window path is retained, a v0.2.x agent (no `pidversion`) and a v0.3.0 agent (with `pidversion`) both correlate correctly against the same server. The server requires no flag day; the migration is additive (nullable column + index).

--- a/openspec/changes/flow-process-identity/proposal.md
+++ b/openspec/changes/flow-process-identity/proposal.md
@@ -1,0 +1,38 @@
+# Correlate network/DNS flows to processes by audit-token identity (pid + pidversion)
+
+## Why
+
+The on-device network extension reduces a stable kernel process identity to a bare PID, and the server then re-correlates `network_connect` / `dns_query` flows back to a process by a time window. Both halves throw away an identity the platform already hands us on both event streams.
+
+Concretely, today:
+
+- `extension/edr/networkextension/ProcessInfo.swift` extracts only `pid` + `euid` from the flow's `sourceAppAuditToken` (`audit_token_to_pid` / `audit_token_to_euid`). The `pidversion` field of the same audit token is discarded.
+- The ES side already reads `target.audit_token` in `extension/edr/extension/ESFSubscriber.swift` for exec/fork, but likewise takes only `pid` via `audit_token_to_pid`; `pidversion` is dropped.
+- Server-side, `server/detection/internal/mysql/processes.go` resolves a flow to a process generation with `GetProcessByPID(host, pid, atTimeNs)`, which brackets `fork_time_ns <= atTimeNs <= exit_time_ns` and picks the latest fork. The detection rules add forward skew padding (`dns_c2_beacon.go` `processLookupSkewPadNs = 5s`, `ingestLookupPadNs = 10s`) purely to absorb ES/NE clock drift (issue #7).
+
+Two problems follow directly:
+
+- **PID reuse can mis-correlate a flow to the wrong process generation.** The kernel recycles PIDs; the field that disambiguates a recycled PID is exactly the `pidversion` we drop. A flow that lands near a fork/exit boundary can bracket to the neighbouring generation.
+- **The clock-drift padding exists only because we join on a window instead of on identity.** A stable shared identity already exists on both sides: ES `es_process_t.audit_token` and the NE flow's `sourceAppAuditToken`, both carrying the same kernel `pidversion` for a given live process. Carrying `(pid, pidversion)` through the wire turns the join into an exact lookup with no time window.
+
+These are self-inflicted: the platform gives us the identity on both ES and NE; we just are not carrying it through. Fixing it also earns the standing to raise the residual proxied-flow gap with Apple credibly, which is out of scope here (see below).
+
+## What changes
+
+- **Capture `pidversion` on the device, on both event sources.** The ES exec/fork handlers add `audit_token_to_pidversion(target.audit_token)` (and the child token for fork) alongside the existing PID extraction. The NE `extractProcessInfo` returns `pidversion` from the flow's audit token, and the `network_connect` / `dns_query` serializers include it.
+- **Carry `pidversion` through the wire format.** `schema/events.json` gains an optional `pidversion` (unsigned integer) on the `exec`, `fork`, `network_connect`, and `dns_query` payloads. The field is optional so an older agent that does not send it still ingests cleanly.
+- **Store `pidversion` on the process record.** A migration adds a nullable `pidversion INT UNSIGNED` column to `processes` plus a `(host_id, pid, pidversion)` index. The graph builder reads `pidversion` from `exec`/`fork` payloads and stores it on the generation it creates or updates.
+- **Join flows to processes on identity, with a time-window fallback.** A new store lookup resolves a process by exact `(host_id, pid, pidversion)`. When the triggering `network_connect` / `dns_query` event carries a `pidversion` and a matching process generation exists, correlation uses the exact identity and drops the forward skew pad. When either side lacks `pidversion` (older agent, or a flow whose audit token was unavailable), correlation falls back to the existing `GetProcessByPID` time-window path unchanged. This keeps mixed-version fleets correct during rollout.
+- **Tests.** A property-based round-trip for the new wire field; a unit test pinning the identity-vs-window lookup precedence; an integration test that materializes two process generations on the same PID with distinct `pidversion`s and asserts a flow tagged with one `pidversion` correlates to the correct generation (and that a flow with no `pidversion` still resolves by window).
+
+### Not in this change
+
+- **Proxied / delegated flows where `sourceAppAuditToken` names the delegating daemon (`nehelper` / `nesessionmanager` / a system proxy) or is `nil`.** Those carry no usable originator identity and remain a future Apple ask, which the issue explicitly defers. This change is a prerequisite for raising it.
+- **`sourceProcessAuditToken` as a distinct originator.** Whether the macOS 26 SDK exposes a per-process flow token that is more precise than `sourceAppAuditToken` is an implementation-time investigation (see design.md). If it is available and more precise we prefer it; if not, `sourceAppAuditToken` is the identity we carry and behaviour is unchanged from today apart from being exact on `(pid, pidversion)`.
+- **Parent-edge identity (`ppidversion`).** The process forest still links parent to child on bare `ppid`. Making parent edges exact on `pidversion` is a separate graph-builder change; this issue is scoped to flow-to-process correlation.
+- **Removing the `ingested_at_ns` clock-drift columns or the within-process dns-to-connect temporal window.** The identity join removes the need for the forward *process-lookup* pad; the within-process correlation in `dns_c2_beacon` (a `dns_query` preceding a `network_connect` for the same process within 30s) stays a temporal relationship and is unchanged.
+
+## Resolved decisions
+
+1. **Optional, additive wire field rather than a breaking change.** `pidversion` is nullable end to end (payload omitted, DB column NULL). A present value of `0` is a valid identity; absence is "no identity, use the window". This is why the column and payload field are nullable rather than zero-sentinel, and why mixed-version fleets keep working through rollout.
+2. **Identity is preferred, window is the fallback, never the reverse.** When both sides carry `pidversion` the exact lookup wins and the skew pad is not applied. The window path is retained verbatim for events that lack `pidversion`, so this change adds precision without removing the existing correctness guarantee for legacy events.

--- a/openspec/changes/flow-process-identity/specs/endpoint-event-collection/spec.md
+++ b/openspec/changes/flow-process-identity/specs/endpoint-event-collection/spec.md
@@ -1,0 +1,54 @@
+# Endpoint event collection: carry audit-token pidversion on process and flow events delta
+
+## MODIFIED Requirements
+
+### Requirement: Process lifecycle event capture
+
+The system SHALL emit a `fork` event when a monitored process forks, an `exec` event when a process replaces its image, and an `exit` event when a process exits. Each event MUST carry the originating PID and any additional fields documented for that event type. The `exec` and `fork` events SHALL additionally carry the originating process's kernel PID generation (`pidversion`, read from the process's audit token) when it is available, so the server can disambiguate reused PIDs by identity rather than by time. The `pidversion` field is optional: when the audit token is unavailable the event is still emitted without it.
+
+#### Scenario: A user runs a shell command
+
+- **GIVEN** the endpoint event capture is running
+- **WHEN** a user launches `/bin/ls` from a shell
+- **THEN** the system emits an `exec` event whose payload includes the new image path, the argument vector, the parent PID, the effective UID and GID, and the code-signing identity (team ID, signing ID, platform-binary flag) when the binary is signed
+- **AND** the payload includes the process's `pidversion` from its audit token
+- **AND** the system later emits an `exit` event for the same PID with the process exit status
+
+#### Scenario: A daemon forks a worker
+
+- **GIVEN** the endpoint event capture is running
+- **WHEN** a process calls `fork(2)` without a subsequent exec
+- **THEN** the system emits a `fork` event whose payload identifies the parent PID and the child PID
+- **AND** the payload includes the child process's `pidversion` from its audit token
+
+### Requirement: Outbound socket flow capture
+
+The system SHALL emit a `network_connect` event for every outbound socket flow seen by the network filter, attributing the flow to the source process. Inbound flows SHALL be tagged with `direction = inbound`. The system MUST NOT block flows on the basis of capture; capture is observation-only. The `network_connect` payload SHALL additionally carry the source process's kernel PID generation (`pidversion`, read from the flow's audit token) when it is available, so the server can correlate the flow to the exact process generation. The `pidversion` field is optional: when the flow carries no usable audit token the event is still emitted without it.
+
+#### Scenario: A process opens an outbound TCP connection
+
+- **GIVEN** the network filter is enabled
+- **WHEN** a process initiates an outbound TCP connection to a remote endpoint
+- **THEN** the system emits a `network_connect` event whose payload identifies the source PID, the source binary path, the effective UID, the protocol (`tcp` or `udp`), the direction (`outbound`), the remote address, the remote port, the local address, the local port, and (when the system can derive it from the flow) the remote hostname
+- **AND** the payload includes the source process's `pidversion` when the flow's audit token is available
+- **AND** the flow is allowed to proceed unmodified
+
+### Requirement: DNS query capture
+
+When DNS proxying is enabled, the system SHALL emit a `dns_query` event for each DNS query seen by the DNS proxy and a follow-on `dns_query` event carrying the resolved addresses when the upstream resolver replies. DNS proxying is opt-in (see the host-app extension manager capability), so a host with the DNS proxy disabled emits no `dns_query` events at all and that absence is not a contract violation. The `dns_query` payload SHALL additionally carry the querying process's kernel PID generation (`pidversion`, read from the flow's audit token) when it is available. Capture failures MUST NOT prevent the query or its response from being forwarded to the originally-intended resolver.
+
+#### Scenario: An application resolves a hostname over UDP
+
+- **GIVEN** DNS proxying is enabled
+- **WHEN** an application sends a UDP DNS query for a hostname
+- **THEN** the system forwards the query unchanged to the originally-intended resolver
+- **AND** the system emits a `dns_query` event identifying the source PID, source path, effective UID, query name, query type, and protocol (`udp`)
+- **AND** the payload includes the source process's `pidversion` when the flow's audit token is available
+- **AND** when the resolver replies with one or more addresses the system emits a follow-on `dns_query` event carrying the resolved addresses in `response_addresses`
+
+#### Scenario: A DNS query that cannot be parsed is still forwarded
+
+- **GIVEN** DNS proxying is enabled
+- **WHEN** an application sends a DNS query whose payload the proxy cannot parse for telemetry
+- **THEN** the system forwards the query to the originally-intended resolver
+- **AND** the system does not emit a `dns_query` event for the unparsed payload

--- a/openspec/changes/flow-process-identity/specs/server-process-graph-builder/spec.md
+++ b/openspec/changes/flow-process-identity/specs/server-process-graph-builder/spec.md
@@ -1,0 +1,46 @@
+# Server process graph builder: pidversion identity for flow correlation delta
+
+## ADDED Requirements
+
+### Requirement: Process records carry the kernel PID generation
+
+The system SHALL store the originating process's kernel PID generation (`pidversion`) on the process record when an `exec` or `fork` event provides it, so that a process generation is identifiable by the exact `(host_id, pid, pidversion)` triple in addition to its fork-to-exit lifetime. The field is optional: an event that does not carry `pidversion` (a legacy agent, or a flow whose audit token was unavailable) MUST still materialize a process record, with the `pidversion` left unset. A re-exec generation on the same PID inherits the same `pidversion` as its predecessor, because the kernel generation does not change across `execve` without an intervening fork.
+
+#### Scenario: An exec event carrying pidversion stores it on the record
+
+- **GIVEN** the graph builder is processing a batch
+- **WHEN** an `exec` event for a host and PID carries a `pidversion`
+- **THEN** the materialized process record stores that `pidversion`
+- **AND** the record is retrievable by the exact `(host_id, pid, pidversion)` triple
+
+#### Scenario: An exec event without pidversion still materializes a record
+
+- **GIVEN** the graph builder is processing a batch
+- **WHEN** an `exec` event for a host and PID carries no `pidversion`
+- **THEN** the materialized process record is created with its `pidversion` left unset
+- **AND** the record remains retrievable by host, PID, and event-time lifetime as before
+
+## MODIFIED Requirements
+
+### Requirement: Network and DNS events are linked to the process at event time
+
+The system SHALL link `network_connect` and `dns_query` events to the process record for the originating host and PID. When the event carries a `pidversion` and a process generation exists with the exact same `(host_id, pid, pidversion)`, the system MUST link the event to that generation by identity, independently of any clock-drift padding, and MUST NOT link it to a different generation merely because of timestamp proximity. When the event carries no `pidversion`, or no generation matches that exact identity, the system MUST fall back to linking the event to the process record that was alive on that host and PID at the event's timestamp, and a network or DNS event MUST NOT be associated with a stale generation that exited before the event or with a future generation that had not yet forked.
+
+#### Scenario: A short-lived process opens a connection
+
+- **GIVEN** a process record with a known fork-to-exit lifetime on a host
+- **WHEN** the per-process detail view is requested
+- **THEN** the network and DNS events surfaced for that record are limited to those whose host and PID match and whose timestamps fall inside the process lifetime
+
+#### Scenario: A flow with pidversion correlates to the exact generation across PID reuse
+
+- **GIVEN** two process generations on the same host and PID with distinct `pidversion`s, one exited and one alive
+- **WHEN** a `network_connect` event carrying the alive generation's `pidversion` is correlated
+- **THEN** the event is linked to the generation whose `pidversion` matches
+- **AND** the link does not depend on the connect timestamp falling inside that generation's lifetime window
+
+#### Scenario: A flow without pidversion falls back to the event-time window
+
+- **GIVEN** a `network_connect` event that carries no `pidversion`
+- **WHEN** the event is correlated to a process on the same host and PID
+- **THEN** the system links it to the generation that was alive at the event's timestamp using the event-time lifetime rule

--- a/openspec/changes/flow-process-identity/tasks.md
+++ b/openspec/changes/flow-process-identity/tasks.md
@@ -1,0 +1,60 @@
+# Correlate network/DNS flows to processes by audit-token identity: tasks
+
+Sequencing decision: server-first. PR 1 (this branch, `flow-process-identity`) lands the wire field handling, schema, migration, store, builder, correlation precedence, and tests, all dev-DB testable and a no-op for current agents (they emit no pidversion). PR 2 adds the Swift ES + NE emission and the live VM + SigNoz + Chrome verification.
+
+## 1. Wire format
+
+- [x] `schema/events.json`: optional `pidversion` (`integer`, `minimum: 0`) added to `exec`, `fork`, `network_connect`, `dns_query` payloads. Not `required`.
+
+## 2. Server: model, migration, store
+
+- [x] `server/detection/migrations/00004_processes_pidversion.sql`: `ADD COLUMN pidversion INT UNSIGNED NULL` + `CREATE INDEX idx_processes_host_pid_pidversion (host_id, pid, pidversion)`. Forward-only Down.
+- [x] `server/detection/api/types.go`: `Process.PIDVersion *uint32` (`db:"pidversion"`, `omitempty`).
+- [x] `server/detection/internal/mysql/processes.go`: pidversion threaded through `InsertProcess`, `ReExec` insert, `UpdateProcessExec` (via `COALESCE(?, pidversion)` so a fork-set value is never clobbered to NULL), and all process SELECT column lists. New `GetProcessByPIDVersion(host, pid, pidversion)` exact lookup; `GetProcessByPID` unchanged.
+- [x] `server/detection/api/service.go`: `GetProcessByPIDVersion` added to the `GraphReader` interface; test stubs updated.
+
+## 3. Server: graph builder
+
+- [x] `server/detection/internal/graph/builder.go`: `pidversion` parsed from `forkPayload` (child generation) and `execPayload`; stored on fork, exec-without-fork, and re-exec rows. `pickPIDVersion` inherits the prior generation's value on re-exec (execve keeps the kernel generation). NULL preserved for legacy events.
+
+## 4. Server: correlation precedence
+
+- [x] `server/rules/internal/catalog/dns_c2_beacon.go`: `resolveFlowProcess` prefers `GetProcessByPIDVersion` when the `network_connect` carries `pidversion` (no skew pad), else falls back to `lookupProcessSkewTolerant`. Wired into `evalEvent`.
+- [x] `server/rules/internal/catalog/suspicious_exec.go`: `pidversion` added to the shared `networkConnectPayload`.
+- [ ] DEFERRED to a follow-up: thread identity into `suspicious_exec`'s ancestor-walk entry lookup. The walk resolves parents by bare `ppid` (parent-edge identity / `ppidversion` is out of scope here), so the entry-lookup refactor is separable and lower value than the canonical `dns_c2_beacon` path. Tracked in proposal "Not in this change".
+- [x] `GetProcessDetail` (`graph/query.go`) intentionally unchanged: its per-process network/DNS scan stays on `payload_pid` + ingest window (the `payload_pidversion` events generated column is explicitly deferred). This is the spec's documented window fallback; the UI does not yet pass `pidversion`.
+
+## 7. Tests (with spectrace markers)
+
+- [x] PBT round-trip for the wire field, present + absent: `networkConnectPayload` (`flow_identity_test.go`), `execPayload` / `forkPayload` (`builder_pidversion_test.go`). Absent key decodes to nil; present 0 preserved.
+- [x] Unit test: identity-vs-window precedence in `resolveFlowProcess` (`flow_identity_test.go`), markers on the two correlation scenarios.
+- [x] Integration test (real MySQL): `TestGetProcessByPIDVersion` (`processes_pidversion_test.go`) covers PID reuse (distinct pidversion per lifetime), NULL-pidversion non-match + window reachability, no-match nil, and re-exec-chain current-generation selection. Markers on the storage + correlation scenarios.
+- [x] `go test ./server/detection/... ./server/rules/...` green; `task lint:go` (custom binary) clean; `openspec validate flow-process-identity --strict` passes.
+- [ ] PR 2: Swift unit tests for `extractProcessInfo` pidversion + encoder present/omitted.
+
+## 8. Docs
+
+- [x] `docs/architecture.md`: network-extension capture, `network_connect` fields, and the `processes` table now note `pidversion` + identity correlation.
+
+## 5. Extension: Endpoint Security (exec/fork) — PR 2
+
+- [ ] `ESFSubscriber.swift`: `audit_token_to_pidversion` on exec target + fork child, threaded into payloads.
+- [ ] `EventSerializer.swift`: optional `pidVersion` (`encodeIfPresent`, CodingKey `pidversion`) on `ExecPayload` + `ForkPayload`.
+
+## 6. Extension: Network Extension (network_connect/dns_query) — PR 2
+
+- [ ] `ProcessInfo.swift`: `extractProcessInfo` returns `pidversion`; investigate `sourceProcessAuditToken` on the macOS 26 SDK (design.md item 1).
+- [ ] `NetworkFilter.swift` + `DNSProxyProvider.swift`: pass pidversion through.
+- [ ] `NetworkEventSerializer.swift`: optional `pidVersion` on `NetworkConnectPayload` + `DNSQueryPayload`.
+
+## 9. Manual testing + telemetry verification — PR 2 (needs the emitting extension)
+
+- [ ] Build + deploy the updated extension to `edr-dev`; run real traffic (DNS C2 beacon trigger + ordinary activity).
+- [ ] Confirm `pidversion` populated on exec/fork/network_connect/dns_query at the dev server (DB + rows).
+- [ ] Force PID reuse; confirm a flow correlates to the correct generation by identity.
+- [ ] SigNoz MCP: no new ingest/parse errors; `dns_c2_beacon` still fires end to end.
+- [ ] Chrome MCP: host process graph + a DNS C2 beacon alert render with the new field present.
+
+## 10. Archive (after BOTH PRs merge)
+
+- [ ] `openspec archive flow-process-identity` (no `--skip-specs`).

--- a/openspec/changes/flow-process-identity/tasks.md
+++ b/openspec/changes/flow-process-identity/tasks.md
@@ -20,8 +20,8 @@ Sequencing decision: server-first. PR 1 (this branch, `flow-process-identity`) l
 ## 4. Server: correlation precedence
 
 - [x] `server/rules/internal/catalog/dns_c2_beacon.go`: `resolveFlowProcess` prefers `GetProcessByPIDVersion` when the `network_connect` carries `pidversion` (no skew pad), else falls back to `lookupProcessSkewTolerant`. Wired into `evalEvent`.
-- [x] `server/rules/internal/catalog/suspicious_exec.go`: `pidversion` added to the shared `networkConnectPayload`.
-- [ ] DEFERRED to a follow-up: thread identity into `suspicious_exec`'s ancestor-walk entry lookup. The walk resolves parents by bare `ppid` (parent-edge identity / `ppidversion` is out of scope here), so the entry-lookup refactor is separable and lower value than the canonical `dns_c2_beacon` path. Tracked in proposal "Not in this change".
+- [x] `server/rules/internal/catalog/suspicious_exec.go`: `pidversion` added to the shared `networkConnectPayload`; the network arm now resolves the connecting process via `resolveFlowProcess` (identity-first) for finding attribution.
+- [ ] DEFERRED to a follow-up: the ancestor walk (`findShellWithNonShellAncestor`) still resolves the shell and its parent by bare `ppid` + time window. Making parent edges identity-aware (`ppidversion`) is out of scope (proposal "Not in this change").
 - [x] `GetProcessDetail` (`graph/query.go`) intentionally unchanged: its per-process network/DNS scan stays on `payload_pid` + ingest window (the `payload_pidversion` events generated column is explicitly deferred). This is the spec's documented window fallback; the UI does not yet pass `pidversion`.
 
 ## 7. Tests (with spectrace markers)
@@ -36,18 +36,18 @@ Sequencing decision: server-first. PR 1 (this branch, `flow-process-identity`) l
 
 - [x] `docs/architecture.md`: network-extension capture, `network_connect` fields, and the `processes` table now note `pidversion` + identity correlation.
 
-## 5. Extension: Endpoint Security (exec/fork) — PR 2
+## 5. Extension: Endpoint Security (exec/fork): PR 2
 
 - [ ] `ESFSubscriber.swift`: `audit_token_to_pidversion` on exec target + fork child, threaded into payloads.
 - [ ] `EventSerializer.swift`: optional `pidVersion` (`encodeIfPresent`, CodingKey `pidversion`) on `ExecPayload` + `ForkPayload`.
 
-## 6. Extension: Network Extension (network_connect/dns_query) — PR 2
+## 6. Extension: Network Extension (network_connect/dns_query): PR 2
 
 - [ ] `ProcessInfo.swift`: `extractProcessInfo` returns `pidversion`; investigate `sourceProcessAuditToken` on the macOS 26 SDK (design.md item 1).
 - [ ] `NetworkFilter.swift` + `DNSProxyProvider.swift`: pass pidversion through.
 - [ ] `NetworkEventSerializer.swift`: optional `pidVersion` on `NetworkConnectPayload` + `DNSQueryPayload`.
 
-## 9. Manual testing + telemetry verification — PR 2 (needs the emitting extension)
+## 9. Manual testing + telemetry verification: PR 2 (needs the emitting extension)
 
 - [ ] Build + deploy the updated extension to `edr-dev`; run real traffic (DNS C2 beacon trigger + ordinary activity).
 - [ ] Confirm `pidversion` populated on exec/fork/network_connect/dns_query at the dev server (DB + rows).

--- a/schema/events.json
+++ b/schema/events.json
@@ -84,6 +84,11 @@
         "gid": { "type": "integer" },
         "code_signing": { "$ref": "#/definitions/code_signing" },
         "sha256": { "type": "string" },
+        "pidversion": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Optional. Kernel PID generation (audit_token_to_pidversion) of the exec'd process, read from its audit token. Lets the server correlate flows to the exact process generation independently of PID reuse. Absent on agents that predate this field."
+        },
         "cdhash": {
           "type": "string",
           "pattern": "^[0-9a-f]{40}$",
@@ -100,7 +105,12 @@
       "required": ["child_pid", "parent_pid"],
       "properties": {
         "child_pid": { "type": "integer" },
-        "parent_pid": { "type": "integer" }
+        "parent_pid": { "type": "integer" },
+        "pidversion": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Optional. Kernel PID generation (audit_token_to_pidversion) of the CHILD process, read from its audit token. Stored on the new process generation so flows can correlate by exact identity. Absent on agents that predate this field."
+        }
       }
     },
     "exit_payload": {
@@ -138,7 +148,12 @@
         "local_port": { "type": "integer" },
         "remote_address": { "type": "string" },
         "remote_port": { "type": "integer" },
-        "remote_hostname": { "type": "string" }
+        "remote_hostname": { "type": "string" },
+        "pidversion": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Optional. Kernel PID generation (audit_token_to_pidversion) of the source process, read from the flow's audit token. Lets the server correlate the flow to the exact process generation independently of PID reuse. Absent on agents that predate this field or when the flow carried no usable audit token."
+        }
       }
     },
     "dns_query_payload": {
@@ -154,7 +169,12 @@
           "type": "array",
           "items": { "type": "string" }
         },
-        "protocol": { "type": "string", "enum": ["udp", "tcp"] }
+        "protocol": { "type": "string", "enum": ["udp", "tcp"] },
+        "pidversion": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Optional. Kernel PID generation (audit_token_to_pidversion) of the querying process, read from the flow's audit token. Lets the server correlate the query to the exact process generation independently of PID reuse. Absent on agents that predate this field or when the flow carried no usable audit token."
+        }
       }
     },
     "snapshot_heartbeat_payload": {

--- a/server/detection/api/service.go
+++ b/server/detection/api/service.go
@@ -55,6 +55,12 @@ type GraphReader interface {
 	// NULL).
 	GetProcessByPID(ctx context.Context, hostID string, pid int, atTimeNs int64) (*Process, error)
 
+	// GetProcessByPIDVersion returns the single row matching the exact (host, pid, pidversion) identity, or nil when none exists.
+	// Unlike GetProcessByPID it takes no time anchor: the kernel PID generation pins the generation directly, so the lookup is
+	// immune to PID reuse and needs no clock-drift padding. Correlation rules prefer this when a flow event carries a pidversion and
+	// fall back to GetProcessByPID otherwise (issue #403).
+	GetProcessByPIDVersion(ctx context.Context, hostID string, pid int, pidversion uint32) (*Process, error)
+
 	// GetChildProcesses returns all rows whose ppid matches the given
 	// parent PID and whose fork_time_ns falls inside the time range.
 	GetChildProcesses(ctx context.Context, hostID string, ppid int, tr TimeRange) ([]Process, error)

--- a/server/detection/api/types.go
+++ b/server/detection/api/types.go
@@ -59,7 +59,12 @@ type Process struct {
 	// CDHash is the 40-hex code-directory hash (sha1 of the CDDirectory blob) the agent extracts on Hardened-Runtime processes
 	// (issue #68 / PR #185). NULL for non-HR binaries since the ESF target tuple lacks a meaningful cdhash for them. Persisted
 	// alongside sha256 so incident response can correlate by either hash and so app-control's CDHASH rule matches replay nicely.
-	CDHash           *string `db:"cdhash" json:"cdhash,omitempty"`
+	CDHash *string `db:"cdhash" json:"cdhash,omitempty"`
+	// PIDVersion is the kernel PID generation (audit_token_to_pidversion) of this process, when the originating exec/fork event
+	// carried it. It pins process identity across PID reuse: a flow tagged with (host, pid, pidversion) correlates to the exact
+	// generation regardless of fork/exit timing. NULL for legacy-agent rows and for rows whose audit token was unavailable; a
+	// present 0 is a legitimate generation, so absence is NULL rather than a 0 sentinel (issue #403).
+	PIDVersion       *uint32 `db:"pidversion" json:"pidversion,omitempty"`
 	ForkTimeNs       int64   `db:"fork_time_ns" json:"fork_time_ns"`
 	ForkIngestedAtNs *int64  `db:"fork_ingested_at_ns" json:"fork_ingested_at_ns,omitempty"`
 	ExecTimeNs       *int64  `db:"exec_time_ns" json:"exec_time_ns,omitempty"`

--- a/server/detection/internal/graph/builder.go
+++ b/server/detection/internal/graph/builder.go
@@ -188,6 +188,10 @@ func (b *Builder) handleSnapshotHeartbeat(ctx context.Context, evt api.Event) er
 type forkPayload struct {
 	ChildPID  int `json:"child_pid"`
 	ParentPID int `json:"parent_pid"`
+	// PIDVersion is the CHILD process's kernel PID generation (audit_token_to_pidversion), when the agent provided it. Stored on
+	// the new generation so network/DNS flows correlate to it by exact identity rather than a fork-to-exit window. Nil for
+	// agents that predate this field (issue #403).
+	PIDVersion *uint32 `json:"pidversion"`
 }
 
 func (b *Builder) handleFork(ctx context.Context, evt api.Event) error {
@@ -213,6 +217,7 @@ func (b *Builder) handleFork(ctx context.Context, evt api.Event) error {
 		PID:              p.ChildPID,
 		PPID:             p.ParentPID,
 		Path:             parentPath,
+		PIDVersion:       p.PIDVersion,
 		ForkTimeNs:       evt.TimestampNs,
 		ForkIngestedAtNs: &forkIngested,
 	})
@@ -231,6 +236,10 @@ type execPayload struct {
 	// CDHash is the 40-hex code-directory hash; agent emits it only for Hardened-Runtime binaries (issue #68 / PR #185). Decoder
 	// tolerates absence: non-HR rows + pre-cdhash agents simply leave the field nil and the persisted column stays NULL.
 	CDHash *string `json:"cdhash"`
+	// PIDVersion is the exec'd process's kernel PID generation (audit_token_to_pidversion), when the agent provided it. Stored on
+	// the process record so flows correlate by exact identity. A re-exec keeps the same generation, so this matches the value the
+	// fork stored. Nil for agents that predate this field (issue #403).
+	PIDVersion *uint32 `json:"pidversion"`
 	// Snapshot is true for synthetic exec events emitted by the ESF startup baseline pass (issue #11). The graph builder uses this
 	// to avoid clobbering a richer live-event row with a sparse synthetic one when the snapshot pass and an early-startup live exec
 	// both arrive for the same PID.
@@ -271,6 +280,7 @@ func (b *Builder) handleExec(ctx context.Context, evt api.Event) error {
 			Path: p.Path, Args: p.Args,
 			UID: p.UID, GID: p.GID,
 			CodeSigning: p.CodeSigning, SHA256: p.SHA256, CDHash: p.CDHash,
+			PIDVersion: p.PIDVersion,
 		})
 	}
 	return b.insertReExec(ctx, evt, p, current)
@@ -295,6 +305,7 @@ func (b *Builder) insertExecWithoutFork(ctx context.Context, evt api.Event, p ex
 		CodeSigning:      p.CodeSigning,
 		SHA256:           p.SHA256,
 		CDHash:           p.CDHash,
+		PIDVersion:       p.PIDVersion,
 		ForkTimeNs:       evt.TimestampNs,
 		ForkIngestedAtNs: &forkIngested,
 		ExecTimeNs:       &evt.TimestampNs,
@@ -344,14 +355,17 @@ func (b *Builder) insertReExec(ctx context.Context, evt api.Event, p execPayload
 		PID:    p.PID,
 		// Preserve the parent linkage from the original fork: a re-exec doesn't change PPID on macOS. Falls back to whatever
 		// the exec event carries if the prior row somehow has ppid=0.
-		PPID:             pickPPID(prior.PPID, p.PPID),
-		Path:             p.Path,
-		Args:             p.Args,
-		UID:              p.UID,
-		GID:              p.GID,
-		CodeSigning:      p.CodeSigning,
-		SHA256:           p.SHA256,
-		CDHash:           p.CDHash,
+		PPID:        pickPPID(prior.PPID, p.PPID),
+		Path:        p.Path,
+		Args:        p.Args,
+		UID:         p.UID,
+		GID:         p.GID,
+		CodeSigning: p.CodeSigning,
+		SHA256:      p.SHA256,
+		CDHash:      p.CDHash,
+		// A re-exec (execve without an intervening fork) keeps the same kernel generation, so the chain shares one pidversion.
+		// Prefer the prior row's value (the established identity); fall back to the event's when the prior row predates capture.
+		PIDVersion:       pickPIDVersion(prior.PIDVersion, p.PIDVersion),
 		ForkTimeNs:       prior.ForkTimeNs, // chain preserves the original fork time
 		ForkIngestedAtNs: prior.ForkIngestedAtNs,
 		ExecTimeNs:       &evt.TimestampNs,
@@ -372,6 +386,16 @@ func (b *Builder) insertReExec(ctx context.Context, evt api.Event, p execPayload
 // same pid, but staying defensive: if prior has it and the event doesn't, use prior.
 func pickPPID(prior, fromEvent int) int {
 	if prior != 0 {
+		return prior
+	}
+	return fromEvent
+}
+
+// pickPIDVersion prefers the prior generation's pidversion for a re-exec: execve does not change the kernel PID generation, so a
+// same-PID re-exec chain shares one pidversion. Falls back to the exec event's value when the prior row predates pidversion
+// capture (a fork ingested before this field existed). Both nil yields nil, which leaves the row's pidversion unset.
+func pickPIDVersion(prior, fromEvent *uint32) *uint32 {
+	if prior != nil {
 		return prior
 	}
 	return fromEvent

--- a/server/detection/internal/graph/builder_pidversion_test.go
+++ b/server/detection/internal/graph/builder_pidversion_test.go
@@ -1,0 +1,50 @@
+package graph
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"pgregory.net/rapid"
+)
+
+// TestExecForkPayload_PIDVersionRoundTrip is the wire-field round-trip for the optional pidversion added to the exec and fork
+// payloads (issue #403). It pins that the field survives Marshal/Unmarshal across present and absent values and that an absent
+// JSON key decodes to nil (correlation falls back to the window) rather than 0.
+func TestExecForkPayload_PIDVersionRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	t.Run("exec absent key decodes to nil", func(t *testing.T) {
+		t.Parallel()
+		var got execPayload
+		require.NoError(t, json.Unmarshal([]byte(`{"pid":1,"ppid":2,"path":"/bin/ls","args":[],"cwd":"/","uid":0,"gid":0}`), &got))
+		assert.Nil(t, got.PIDVersion)
+	})
+
+	t.Run("fork present value round-trips", func(t *testing.T) {
+		t.Parallel()
+		in := forkPayload{ChildPID: 10, ParentPID: 1, PIDVersion: new(uint32(99))}
+		b, err := json.Marshal(in)
+		require.NoError(t, err)
+		var out forkPayload
+		require.NoError(t, json.Unmarshal(b, &out))
+		assert.Equal(t, in, out)
+	})
+
+	rapid.Check(t, func(rt *rapid.T) {
+		in := execPayload{
+			PID:  rapid.IntRange(1, 1<<20).Draw(rt, "pid"),
+			PPID: rapid.IntRange(0, 1<<20).Draw(rt, "ppid"),
+			Path: rapid.StringMatching(`/[a-z/]{1,12}`).Draw(rt, "path"),
+		}
+		if rapid.Bool().Draw(rt, "has_pidversion") {
+			in.PIDVersion = new(rapid.Uint32().Draw(rt, "pidversion"))
+		}
+		b, err := json.Marshal(in)
+		require.NoError(rt, err)
+		var out execPayload
+		require.NoError(rt, json.Unmarshal(b, &out))
+		assert.Equal(rt, in.PIDVersion, out.PIDVersion)
+	})
+}

--- a/server/detection/internal/mysql/processes.go
+++ b/server/detection/internal/mysql/processes.go
@@ -15,13 +15,13 @@ import (
 func (s *Store) InsertProcess(ctx context.Context, p api.Process) (int64, error) {
 	res, err := s.db.ExecContext(ctx, `
 		INSERT INTO processes
-			(host_id, pid, ppid, path, args, uid, gid, code_signing, sha256, cdhash,
+			(host_id, pid, ppid, path, args, uid, gid, code_signing, sha256, cdhash, pidversion,
 			 fork_time_ns, fork_ingested_at_ns, exec_time_ns, exit_time_ns,
 			 exit_ingested_at_ns, exit_reason, exit_code, previous_exec_id,
 			 is_snapshot, last_seen_ns)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		p.HostID, p.PID, p.PPID, p.Path, p.Args, p.UID, p.GID,
-		p.CodeSigning, p.SHA256, p.CDHash, p.ForkTimeNs, p.ForkIngestedAtNs, p.ExecTimeNs, p.ExitTimeNs,
+		p.CodeSigning, p.SHA256, p.CDHash, p.PIDVersion, p.ForkTimeNs, p.ForkIngestedAtNs, p.ExecTimeNs, p.ExitTimeNs,
 		p.ExitIngestedAtNs, p.ExitReason, p.ExitCode, p.PreviousExecID,
 		p.IsSnapshot, p.LastSeenNs,
 	)
@@ -62,16 +62,22 @@ type ProcessExecUpdate struct {
 	CodeSigning api.NullRawJSON
 	SHA256      *string
 	CDHash      *string
+	// PIDVersion is the kernel PID generation from the exec event, when present. A re-exec keeps the same generation as the
+	// forked process, so this normally equals what the fork already stored; the UPDATE fills it via COALESCE so a fork that
+	// arrived without pidversion (or a missed fork) still gets the identity from the exec, without a present value clobbering
+	// an existing one to NULL.
+	PIDVersion *uint32
 }
 
 // UpdateProcessExec updates an existing process record with exec-time
 // metadata.
 func (s *Store) UpdateProcessExec(ctx context.Context, u ProcessExecUpdate) error {
 	_, err := s.db.ExecContext(ctx, `
-		UPDATE processes SET path = ?, args = ?, uid = ?, gid = ?, code_signing = ?, sha256 = ?, cdhash = ?, exec_time_ns = ?
+		UPDATE processes SET path = ?, args = ?, uid = ?, gid = ?, code_signing = ?, sha256 = ?, cdhash = ?, exec_time_ns = ?,
+		                    pidversion = COALESCE(?, pidversion)
 		WHERE host_id = ? AND pid = ? AND exit_time_ns IS NULL
 		ORDER BY fork_time_ns DESC LIMIT 1`,
-		u.Path, u.Args, u.UID, u.GID, u.CodeSigning, u.SHA256, u.CDHash, u.ExecTimeNs,
+		u.Path, u.Args, u.UID, u.GID, u.CodeSigning, u.SHA256, u.CDHash, u.ExecTimeNs, u.PIDVersion,
 		u.HostID, u.PID,
 	)
 	return err
@@ -195,12 +201,12 @@ func (s *Store) ReExec(
 
 	ins, err := tx.ExecContext(ctx, `
 		INSERT INTO processes
-			(host_id, pid, ppid, path, args, uid, gid, code_signing, sha256, cdhash,
+			(host_id, pid, ppid, path, args, uid, gid, code_signing, sha256, cdhash, pidversion,
 			 fork_time_ns, fork_ingested_at_ns, exec_time_ns, exit_time_ns,
 			 exit_ingested_at_ns, exit_code, previous_exec_id)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		newRow.HostID, newRow.PID, newRow.PPID, newRow.Path, newRow.Args, newRow.UID, newRow.GID,
-		newRow.CodeSigning, newRow.SHA256, newRow.CDHash, newRow.ForkTimeNs, newRow.ForkIngestedAtNs,
+		newRow.CodeSigning, newRow.SHA256, newRow.CDHash, newRow.PIDVersion, newRow.ForkTimeNs, newRow.ForkIngestedAtNs,
 		newRow.ExecTimeNs, newRow.ExitTimeNs, newRow.ExitIngestedAtNs, newRow.ExitCode,
 		newRow.PreviousExecID,
 	)
@@ -244,7 +250,7 @@ func (s *Store) GetExecChain(ctx context.Context, current api.Process) ([]api.Pr
 	var chain []api.Process
 	err := s.db.SelectContext(ctx, &chain, `
 		WITH RECURSIVE chain AS (
-			SELECT id, host_id, pid, ppid, path, args, uid, gid, code_signing, sha256, cdhash,
+			SELECT id, host_id, pid, ppid, path, args, uid, gid, code_signing, sha256, cdhash, pidversion,
 			       fork_time_ns, fork_ingested_at_ns, exec_time_ns, exit_time_ns,
 			       exit_ingested_at_ns, exit_reason, exit_code, previous_exec_id,
 			       is_snapshot, last_seen_ns,
@@ -253,7 +259,7 @@ func (s *Store) GetExecChain(ctx context.Context, current api.Process) ([]api.Pr
 			WHERE id = ? AND host_id = ?
 			UNION ALL
 			SELECT p.id, p.host_id, p.pid, p.ppid, p.path, p.args, p.uid, p.gid,
-			       p.code_signing, p.sha256, p.cdhash, p.fork_time_ns, p.fork_ingested_at_ns,
+			       p.code_signing, p.sha256, p.cdhash, p.pidversion, p.fork_time_ns, p.fork_ingested_at_ns,
 			       p.exec_time_ns, p.exit_time_ns, p.exit_ingested_at_ns,
 			       p.exit_reason, p.exit_code, p.previous_exec_id,
 			       p.is_snapshot, p.last_seen_ns,
@@ -262,7 +268,7 @@ func (s *Store) GetExecChain(ctx context.Context, current api.Process) ([]api.Pr
 			JOIN chain c ON p.id = c.previous_exec_id AND p.host_id = c.host_id
 			WHERE c.depth < ?
 		)
-		SELECT id, host_id, pid, ppid, path, args, uid, gid, code_signing, sha256, cdhash,
+		SELECT id, host_id, pid, ppid, path, args, uid, gid, code_signing, sha256, cdhash, pidversion,
 		       fork_time_ns, fork_ingested_at_ns, exec_time_ns, exit_time_ns,
 		       exit_ingested_at_ns, exit_reason, exit_code, previous_exec_id,
 		       is_snapshot, last_seen_ns
@@ -309,7 +315,7 @@ func (s *Store) GetParentPath(ctx context.Context, hostID string, pid int) (stri
 func (s *Store) GetProcessTree(ctx context.Context, hostID string, tr api.TimeRange, limit int) ([]api.Process, error) {
 	var procs []api.Process
 	err := s.db.SelectContext(ctx, &procs, `
-		SELECT id, host_id, pid, ppid, path, args, uid, gid, code_signing, sha256, cdhash,
+		SELECT id, host_id, pid, ppid, path, args, uid, gid, code_signing, sha256, cdhash, pidversion,
 		       fork_time_ns, fork_ingested_at_ns, exec_time_ns, exit_time_ns,
 		       exit_ingested_at_ns, exit_reason, exit_code, previous_exec_id,
 		       is_snapshot, last_seen_ns
@@ -335,7 +341,7 @@ func (s *Store) GetProcessTree(ctx context.Context, hostID string, tr api.TimeRa
 func (s *Store) GetProcessByPID(ctx context.Context, hostID string, pid int, atTimeNs int64) (*api.Process, error) {
 	var proc api.Process
 	err := s.db.GetContext(ctx, &proc, `
-		SELECT id, host_id, pid, ppid, path, args, uid, gid, code_signing, sha256, cdhash,
+		SELECT id, host_id, pid, ppid, path, args, uid, gid, code_signing, sha256, cdhash, pidversion,
 		       fork_time_ns, fork_ingested_at_ns, exec_time_ns, exit_time_ns,
 		       exit_ingested_at_ns, exit_reason, exit_code, previous_exec_id,
 		       is_snapshot, last_seen_ns
@@ -355,12 +361,44 @@ func (s *Store) GetProcessByPID(ctx context.Context, hostID string, pid int, atT
 	return &proc, nil
 }
 
+// GetProcessByPIDVersion returns the single process generation matching the exact (host_id, pid, pidversion) identity, or nil
+// when none exists. Unlike GetProcessByPID it takes no time anchor: the kernel PID generation pins the process directly, so the
+// result is immune to PID reuse (a recycled PID gets a higher pidversion) and needs no clock-drift padding. Backed by
+// idx_processes_host_pid_pidversion. Rows whose pidversion is NULL (legacy agents, or a row whose audit token was unavailable)
+// never match here, so correlation falls back to GetProcessByPID for events that carry no pidversion (issue #403).
+//
+// A same-PID re-exec chain (issue #10) shares one pidversion across its generations, so more than one row can match. That is
+// the only multi-row case: distinct lifetimes of a reused PID carry distinct pidversions. The ORDER BY returns the current
+// generation of the chain (the live row, else the most recently inserted), matching what GetProcessByPID resolves for a live
+// process: alive rows first, then highest id.
+func (s *Store) GetProcessByPIDVersion(ctx context.Context, hostID string, pid int, pidversion uint32) (*api.Process, error) {
+	var proc api.Process
+	err := s.db.GetContext(ctx, &proc, `
+		SELECT id, host_id, pid, ppid, path, args, uid, gid, code_signing, sha256, cdhash, pidversion,
+		       fork_time_ns, fork_ingested_at_ns, exec_time_ns, exit_time_ns,
+		       exit_ingested_at_ns, exit_reason, exit_code, previous_exec_id,
+		       is_snapshot, last_seen_ns
+		FROM processes
+		WHERE host_id = ? AND pid = ? AND pidversion = ?
+		ORDER BY (exit_time_ns IS NULL) DESC, id DESC
+		LIMIT 1`,
+		hostID, pid, pidversion,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("query process by pidversion: %w", err)
+	}
+	return &proc, nil
+}
+
 // GetChildProcesses returns processes whose PPID matches the given PID and were forked within the given time range. Satisfies
 // api.GraphReader.
 func (s *Store) GetChildProcesses(ctx context.Context, hostID string, ppid int, tr api.TimeRange) ([]api.Process, error) {
 	var procs []api.Process
 	err := s.db.SelectContext(ctx, &procs, `
-		SELECT id, host_id, pid, ppid, path, args, uid, gid, code_signing, sha256, cdhash,
+		SELECT id, host_id, pid, ppid, path, args, uid, gid, code_signing, sha256, cdhash, pidversion,
 		       fork_time_ns, fork_ingested_at_ns, exec_time_ns, exit_time_ns,
 		       exit_ingested_at_ns, exit_reason, exit_code, previous_exec_id,
 		       is_snapshot, last_seen_ns

--- a/server/detection/internal/mysql/processes_pidversion_test.go
+++ b/server/detection/internal/mysql/processes_pidversion_test.go
@@ -1,0 +1,90 @@
+package mysql_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fleetdm/edr/server/detection/api"
+)
+
+// TestGetProcessByPIDVersion exercises the exact-identity process lookup that backs flow-to-process correlation (issue #403):
+// a process record persists its kernel PID generation, and a flow tagged with (host, pid, pidversion) resolves to the exact
+// generation regardless of fork/exit timing, immune to PID reuse. NULL-pidversion rows (legacy agents) never match the identity
+// lookup and remain reachable via the event-time window path.
+//
+// spec:server-process-graph-builder/process-records-carry-the-kernel-pid-generation/an-exec-event-carrying-pidversion-stores-it-on-the-record
+// spec:server-process-graph-builder/process-records-carry-the-kernel-pid-generation/an-exec-event-without-pidversion-still-materializes-a-record
+func TestGetProcessByPIDVersion(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+
+	const host = "h"
+	const pid = 4200
+
+	// Two lifetimes of the SAME pid with distinct pidversions: gen1 exited at 200, gen2 forked at 300 and is still alive. PID reuse
+	// recycles the pid; the kernel hands the second lifetime a higher generation.
+	exit := int64(200)
+	gen1, err := s.InsertProcess(ctx, api.Process{HostID: host, PID: pid, Path: "/gen1", PIDVersion: new(uint32(7)), ForkTimeNs: 100, ExitTimeNs: &exit})
+	require.NoError(t, err)
+	gen2, err := s.InsertProcess(ctx, api.Process{HostID: host, PID: pid, Path: "/gen2", PIDVersion: new(uint32(8)), ForkTimeNs: 300})
+	require.NoError(t, err)
+
+	// A legacy row carrying no pidversion (older agent, or unavailable token).
+	legacyPID := 5000
+	legacy, err := s.InsertProcess(ctx, api.Process{HostID: host, PID: legacyPID, Path: "/legacy", ForkTimeNs: 100})
+	require.NoError(t, err)
+
+	t.Run("spec:server-process-graph-builder/network-and-dns-events-are-linked-to-the-process-at-event-time/a-flow-with-pidversion-correlates-to-the-exact-generation-across-pid-reuse", func(t *testing.T) {
+		// Identity pins each generation exactly, with no time anchor: v7 -> the exited gen1, v8 -> the alive gen2.
+		g1, err := s.GetProcessByPIDVersion(ctx, host, pid, 7)
+		require.NoError(t, err)
+		require.NotNil(t, g1)
+		assert.Equal(t, gen1, g1.ID, "pidversion 7 must resolve to gen1")
+		require.NotNil(t, g1.PIDVersion)
+		assert.Equal(t, uint32(7), *g1.PIDVersion)
+
+		g2, err := s.GetProcessByPIDVersion(ctx, host, pid, 8)
+		require.NoError(t, err)
+		require.NotNil(t, g2)
+		assert.Equal(t, gen2, g2.ID, "pidversion 8 must resolve to gen2 even though gen1 shares the pid")
+	})
+
+	t.Run("no matching pidversion returns nil", func(t *testing.T) {
+		got, err := s.GetProcessByPIDVersion(ctx, host, pid, 999)
+		require.NoError(t, err)
+		assert.Nil(t, got)
+	})
+
+	t.Run("legacy NULL-pidversion row never matches identity but is reachable by window", func(t *testing.T) {
+		// A present 0 must not collide with a NULL row.
+		got, err := s.GetProcessByPIDVersion(ctx, host, legacyPID, 0)
+		require.NoError(t, err)
+		assert.Nil(t, got, "a NULL pidversion must not match an identity lookup, including for pidversion 0")
+
+		// The legacy row still resolves through the event-time window path (the fallback correlation uses this).
+		win, err := s.GetProcessByPID(ctx, host, legacyPID, 150)
+		require.NoError(t, err)
+		require.NotNil(t, win)
+		assert.Equal(t, legacy, win.ID)
+		assert.Nil(t, win.PIDVersion, "legacy row stores NULL pidversion")
+	})
+
+	t.Run("re-exec chain sharing one pidversion resolves to the current generation", func(t *testing.T) {
+		// A same-PID re-exec chain shares one pidversion across generations. The lookup returns the current generation: the
+		// live row (exit_time_ns NULL), else the most recently inserted.
+		const chainPID = 6000
+		chainExit := int64(500)
+		_, err := s.InsertProcess(ctx, api.Process{HostID: host, PID: chainPID, Path: "/old", PIDVersion: new(uint32(42)), ForkTimeNs: 400, ExitTimeNs: &chainExit})
+		require.NoError(t, err)
+		alive, err := s.InsertProcess(ctx, api.Process{HostID: host, PID: chainPID, Path: "/current", PIDVersion: new(uint32(42)), ForkTimeNs: 400})
+		require.NoError(t, err)
+
+		got, err := s.GetProcessByPIDVersion(ctx, host, chainPID, 42)
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, alive, got.ID, "the live generation of the chain must win")
+		assert.Equal(t, "/current", got.Path)
+	})
+}

--- a/server/detection/migrations/00004_processes_pidversion.sql
+++ b/server/detection/migrations/00004_processes_pidversion.sql
@@ -1,0 +1,24 @@
+-- +goose Up
+-- Carry the kernel PID generation (pidversion, from audit_token_to_pidversion) on each process record so network_connect /
+-- dns_query flows can correlate to the exact process generation by identity (host_id, pid, pidversion) rather than by a
+-- fork-to-exit time window. PID reuse recycles a pid; pidversion is the kernel field that disambiguates a recycled pid, so an
+-- exact (host_id, pid, pidversion) match is immune to the boundary mis-correlation the time-window join can suffer, and it
+-- removes the need for the ES/NE clock-drift forward pad on the lookup (issue #7, issue #403).
+--
+-- Nullable on purpose: an agent that predates this field, a snapshot/exec-without-fork row whose token was unavailable, or a
+-- flow with no usable audit token all leave pidversion NULL, and correlation falls back to the existing time-window path. A
+-- present value of 0 is a legitimate kernel generation, which is why absence is encoded as NULL, not a 0 sentinel. INT UNSIGNED
+-- matches the uid/gid widening rationale (audit_token_to_pidversion returns a uint32).
+
+-- +goose StatementBegin
+ALTER TABLE processes
+	ADD COLUMN pidversion INT UNSIGNED NULL;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE INDEX idx_processes_host_pid_pidversion ON processes (host_id, pid, pidversion);
+-- +goose StatementEnd
+
+-- +goose Down
+-- Forward-only migrations (ADR-0009). Dropping the column/index would lose the identity correlation on every existing row; this
+-- Down is intentionally a no-op.

--- a/server/rules/internal/catalog/application_control_block_test.go
+++ b/server/rules/internal/catalog/application_control_block_test.go
@@ -214,6 +214,16 @@ func (s *stubBlockGraphReader) GetProcessByPID(_ context.Context, _ string, _ in
 	return &api.Process{ID: s.procID}, nil
 }
 
+func (s *stubBlockGraphReader) GetProcessByPIDVersion(_ context.Context, _ string, _ int, _ uint32) (*api.Process, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	if !s.exists {
+		return nil, nil
+	}
+	return &api.Process{ID: s.procID}, nil
+}
+
 func (s *stubBlockGraphReader) GetChildProcesses(_ context.Context, _ string, _ int, _ api.TimeRange) ([]api.Process, error) {
 	return nil, nil
 }

--- a/server/rules/internal/catalog/dns_c2_beacon.go
+++ b/server/rules/internal/catalog/dns_c2_beacon.go
@@ -153,7 +153,7 @@ func (r *DNSC2Beacon) evalEvent(
 		return nil, 0, nil
 	}
 
-	proc, err := lookupProcessSkewTolerant(ctx, s, evt.HostID, conn.PID, evt.TimestampNs)
+	proc, err := resolveFlowProcess(ctx, s, evt.HostID, conn.PID, conn.PIDVersion, evt.TimestampNs)
 	if err != nil {
 		return nil, 0, fmt.Errorf("get pid %d: %w", conn.PID, err)
 	}
@@ -205,6 +205,27 @@ func (r *DNSC2Beacon) evalEvent(
 // the exact-time lookup misses. The connection carries the network-extension clock while the process row carries the Endpoint Security
 // clock; the two drift (issue #7), so a connect timestamp can land just before the ES fork/exec timestamp and bracket to no row. The
 // exact lookup is tried first (so a reused pid resolves to the right generation in the common case); the forward retry only runs on a miss.
+// resolveFlowProcess resolves the process a network/DNS flow belongs to. When the flow carried a kernel PID generation
+// (pidversion) it prefers an exact (host, pid, pidversion) identity match: that is immune to PID reuse and needs no clock-drift
+// padding, because the generation is pinned directly rather than inferred from the connect timestamp. On an identity miss (the
+// exec/fork that carries this pidversion has not materialised yet) or when the flow carried no pidversion (a legacy agent, or a
+// flow whose audit token was unavailable), it falls back to the skew-tolerant event-time window lookup, unchanged from the
+// pre-pidversion behaviour. See issue #403.
+func resolveFlowProcess(
+	ctx context.Context, s api.GraphReader, hostID string, pid int, pidversion *uint32, atNs int64,
+) (*api.Process, error) {
+	if pidversion != nil {
+		proc, err := s.GetProcessByPIDVersion(ctx, hostID, pid, *pidversion)
+		if err != nil {
+			return nil, err
+		}
+		if proc != nil {
+			return proc, nil
+		}
+	}
+	return lookupProcessSkewTolerant(ctx, s, hostID, pid, atNs)
+}
+
 func lookupProcessSkewTolerant(ctx context.Context, s api.GraphReader, hostID string, pid int, atNs int64) (*api.Process, error) {
 	proc, err := s.GetProcessByPID(ctx, hostID, pid, atNs)
 	if err != nil {

--- a/server/rules/internal/catalog/dns_c2_beacon.go
+++ b/server/rules/internal/catalog/dns_c2_beacon.go
@@ -201,10 +201,6 @@ func (r *DNSC2Beacon) evalEvent(
 	}, conn.PID, nil
 }
 
-// lookupProcessSkewTolerant resolves the process for (hostID, pid) at the connection's timestamp, retrying a short interval forward if
-// the exact-time lookup misses. The connection carries the network-extension clock while the process row carries the Endpoint Security
-// clock; the two drift (issue #7), so a connect timestamp can land just before the ES fork/exec timestamp and bracket to no row. The
-// exact lookup is tried first (so a reused pid resolves to the right generation in the common case); the forward retry only runs on a miss.
 // resolveFlowProcess resolves the process a network/DNS flow belongs to. When the flow carried a kernel PID generation
 // (pidversion) it prefers an exact (host, pid, pidversion) identity match: that is immune to PID reuse and needs no clock-drift
 // padding, because the generation is pinned directly rather than inferred from the connect timestamp. On an identity miss (the
@@ -226,6 +222,10 @@ func resolveFlowProcess(
 	return lookupProcessSkewTolerant(ctx, s, hostID, pid, atNs)
 }
 
+// lookupProcessSkewTolerant resolves the process for (hostID, pid) at the connection's timestamp, retrying a short interval forward if
+// the exact-time lookup misses. The connection carries the network-extension clock while the process row carries the Endpoint Security
+// clock; the two drift (issue #7), so a connect timestamp can land just before the ES fork/exec timestamp and bracket to no row. The
+// exact lookup is tried first (so a reused pid resolves to the right generation in the common case); the forward retry only runs on a miss.
 func lookupProcessSkewTolerant(ctx context.Context, s api.GraphReader, hostID string, pid int, atNs int64) (*api.Process, error) {
 	proc, err := s.GetProcessByPID(ctx, hostID, pid, atNs)
 	if err != nil {

--- a/server/rules/internal/catalog/flow_identity_test.go
+++ b/server/rules/internal/catalog/flow_identity_test.go
@@ -1,0 +1,133 @@
+package catalog
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"pgregory.net/rapid"
+
+	"github.com/fleetdm/edr/server/rules/api"
+)
+
+// recordingGraphReader is a GraphReader fake that returns configured processes for the identity and window lookups and records
+// which were called, so resolveFlowProcess's precedence can be asserted without a database.
+type recordingGraphReader struct {
+	byPIDVersion    *api.Process // returned by GetProcessByPIDVersion
+	byPID           *api.Process // returned by GetProcessByPID
+	calledByVersion bool
+	calledByPID     bool
+}
+
+func (r *recordingGraphReader) GetProcessByPID(_ context.Context, _ string, _ int, _ int64) (*api.Process, error) {
+	r.calledByPID = true
+	return r.byPID, nil
+}
+
+func (r *recordingGraphReader) GetProcessByPIDVersion(_ context.Context, _ string, _ int, _ uint32) (*api.Process, error) {
+	r.calledByVersion = true
+	return r.byPIDVersion, nil
+}
+
+func (r *recordingGraphReader) GetChildProcesses(_ context.Context, _ string, _ int, _ api.TimeRange) ([]api.Process, error) {
+	return nil, nil
+}
+
+func (r *recordingGraphReader) GetExecChain(_ context.Context, current api.Process) ([]api.Process, error) {
+	return []api.Process{current}, nil
+}
+
+func (r *recordingGraphReader) GetNetworkEventsForProcess(_ context.Context, _ string, _ int, _ api.TimeRange) ([]api.Event, error) {
+	return nil, nil
+}
+
+// TestNetworkConnectPayload_PIDVersionRoundTrip is the wire-field round-trip for the optional pidversion added to
+// network_connect (issue #403): Unmarshal(Marshal(p)) == p across present and absent values, and an absent JSON key decodes
+// to nil (the "no identity, use the window" signal) rather than 0.
+func TestNetworkConnectPayload_PIDVersionRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	t.Run("absent key decodes to nil, not zero", func(t *testing.T) {
+		t.Parallel()
+		var got networkConnectPayload
+		require.NoError(t, json.Unmarshal([]byte(`{"pid":1,"direction":"outbound","remote_address":"1.1.1.1","remote_port":443}`), &got))
+		assert.Nil(t, got.PIDVersion, "missing pidversion must decode to nil so correlation uses the window")
+	})
+
+	t.Run("present zero is preserved as a valid identity", func(t *testing.T) {
+		t.Parallel()
+		var got networkConnectPayload
+		require.NoError(t, json.Unmarshal([]byte(`{"pid":1,"direction":"outbound","remote_address":"1.1.1.1","remote_port":443,"pidversion":0}`), &got))
+		require.NotNil(t, got.PIDVersion)
+		assert.Equal(t, uint32(0), *got.PIDVersion, "a present 0 is a legitimate generation, distinct from absent")
+	})
+
+	rapid.Check(t, func(rt *rapid.T) {
+		in := networkConnectPayload{
+			PID:           rapid.IntRange(1, 1<<20).Draw(rt, "pid"),
+			Direction:     rapid.SampledFrom([]string{"outbound", "inbound"}).Draw(rt, "dir"),
+			RemoteAddress: rapid.StringMatching(`[0-9]{1,3}(\.[0-9]{1,3}){3}`).Draw(rt, "addr"),
+			RemotePort:    rapid.IntRange(0, 65535).Draw(rt, "port"),
+		}
+		if rapid.Bool().Draw(rt, "has_pidversion") {
+			in.PIDVersion = new(rapid.Uint32().Draw(rt, "pidversion"))
+		}
+		b, err := json.Marshal(in)
+		require.NoError(rt, err)
+		var out networkConnectPayload
+		require.NoError(rt, json.Unmarshal(b, &out))
+		assert.Equal(rt, in, out)
+	})
+}
+
+// TestResolveFlowProcess pins the identity-preferred-with-window-fallback contract that backs the server-process-graph-builder
+// "Network and DNS events are linked to the process at event time" requirement (issue #403). The exact-identity lookup wins when
+// the flow carries a pidversion and a generation matches; otherwise correlation falls back to the event-time window unchanged.
+func TestResolveFlowProcess(t *testing.T) {
+	t.Parallel()
+	const (
+		host = "H1"
+		pid  = 4200
+		atNs = 1_000
+	)
+	identityProc := &api.Process{ID: 11, PID: pid, PIDVersion: new(uint32(7))}
+	windowProc := &api.Process{ID: 22, PID: pid}
+
+	t.Run("spec:server-process-graph-builder/network-and-dns-events-are-linked-to-the-process-at-event-time/a-flow-with-pidversion-correlates-to-the-exact-generation-across-pid-reuse", func(t *testing.T) {
+		t.Parallel()
+		// pidversion present AND a generation matches: identity wins, the window lookup is never consulted.
+		gr := &recordingGraphReader{byPIDVersion: identityProc, byPID: windowProc}
+		got, err := resolveFlowProcess(context.Background(), gr, host, pid, new(uint32(7)), atNs)
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, int64(11), got.ID, "expected the identity-matched generation")
+		assert.True(t, gr.calledByVersion, "identity lookup must be attempted when pidversion is present")
+		assert.False(t, gr.calledByPID, "window lookup must not run on an identity hit")
+	})
+
+	t.Run("identity miss with pidversion falls back to the window", func(t *testing.T) {
+		t.Parallel()
+		// pidversion present but no generation matches yet (the exec/fork has not materialised): fall back to the window.
+		gr := &recordingGraphReader{byPIDVersion: nil, byPID: windowProc}
+		got, err := resolveFlowProcess(context.Background(), gr, host, pid, new(uint32(7)), atNs)
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, int64(22), got.ID, "expected the window-matched generation on identity miss")
+		assert.True(t, gr.calledByVersion)
+		assert.True(t, gr.calledByPID, "window lookup must run when identity misses")
+	})
+
+	t.Run("spec:server-process-graph-builder/network-and-dns-events-are-linked-to-the-process-at-event-time/a-flow-without-pidversion-falls-back-to-the-event-time-window", func(t *testing.T) {
+		t.Parallel()
+		// No pidversion on the flow (legacy agent / unavailable token): identity lookup is skipped entirely.
+		gr := &recordingGraphReader{byPIDVersion: identityProc, byPID: windowProc}
+		got, err := resolveFlowProcess(context.Background(), gr, host, pid, nil, atNs)
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, int64(22), got.ID, "expected the window-matched generation when no pidversion is carried")
+		assert.False(t, gr.calledByVersion, "identity lookup must be skipped when pidversion is absent")
+		assert.True(t, gr.calledByPID)
+	})
+}

--- a/server/rules/internal/catalog/privilege_launchd_plist_write_test.go
+++ b/server/rules/internal/catalog/privilege_launchd_plist_write_test.go
@@ -35,6 +35,9 @@ type stubGraphReader struct{}
 func (stubGraphReader) GetProcessByPID(context.Context, string, int, int64) (*api.Process, error) {
 	return nil, nil
 }
+func (stubGraphReader) GetProcessByPIDVersion(context.Context, string, int, uint32) (*api.Process, error) {
+	return nil, nil
+}
 func (stubGraphReader) GetChildProcesses(context.Context, string, int, api.TimeRange) ([]api.Process, error) {
 	return nil, nil
 }

--- a/server/rules/internal/catalog/suspicious_exec.go
+++ b/server/rules/internal/catalog/suspicious_exec.go
@@ -141,6 +141,10 @@ type networkConnectPayload struct {
 	Direction     string `json:"direction"`
 	RemoteAddress string `json:"remote_address"`
 	RemotePort    int    `json:"remote_port"`
+	// PIDVersion is the source process's kernel PID generation (audit_token_to_pidversion), when the agent provided it. Lets a
+	// correlation rule resolve the connecting process by exact (host, pid, pidversion) identity instead of a time window. Nil for
+	// legacy agents or flows whose audit token was unavailable (issue #403).
+	PIDVersion *uint32 `json:"pidversion"`
 }
 
 func (r *SuspiciousExec) Evaluate(ctx context.Context, events []api.Event, s api.GraphReader) ([]api.Finding, error) {

--- a/server/rules/internal/catalog/suspicious_exec.go
+++ b/server/rules/internal/catalog/suspicious_exec.go
@@ -350,9 +350,11 @@ func (r *SuspiciousExec) evalNetwork(
 		return nil, 0, nil
 	}
 
-	// Resolve the connecting process so the finding links there rather than
-	// at the shell. That's what an analyst clicking the alert wants to land on.
-	conn, err := s.GetProcessByPID(ctx, evt.HostID, c.PID, evt.TimestampNs)
+	// Resolve the connecting process so the finding links there rather than at the shell. That's what an analyst clicking the
+	// alert wants to land on. Prefer exact (host, pid, pidversion) identity when the flow carried a pidversion so the finding
+	// attributes to the right generation across PID reuse, falling back to the event-time window otherwise (issue #403). The
+	// ancestor walk above still uses the window for shell/parent generations; making parent edges identity-aware is out of scope.
+	conn, err := resolveFlowProcess(ctx, s, evt.HostID, c.PID, c.PIDVersion, evt.TimestampNs)
 	if err != nil {
 		return nil, 0, fmt.Errorf("get conn pid %d: %w", c.PID, err)
 	}

--- a/tools/lint-no-emdash.sh
+++ b/tools/lint-no-emdash.sh
@@ -18,20 +18,36 @@ PATTERN="${EM_DASH}|${EN_DASH}"
 # binary files. This script is skipped explicitly (defensive; it is ASCII-only, but never scan the scanner). NUL-delimited
 # (ls-files -z + read -d '') so filenames with spaces, quotes, or non-ASCII bytes are read verbatim, not Git-quoted.
 found=0
-while IFS= read -r -d '' f; do
-  case "$f" in
-    # Never scan the scanner (defensive; it is ASCII-only). .claude/** is AI-tool-installed config we do not author
-    # (markdownlint ignores it for the same reason), so it is out of scope for this gate.
-    tools/lint-no-emdash.sh | .claude/*) continue ;;
+
+# scan_file greps one file, setting found=1 on a hit. Skips the scanner itself (defensive; it is ASCII-only) and
+# .claude/** (AI-tool-installed config we do not author; markdownlint ignores it for the same reason). grep -I drops
+# binary files so a staged PNG passed by the pre-commit hook is a no-op rather than a false match.
+scan_file() {
+  case "$1" in
+    tools/lint-no-emdash.sh | .claude/*) return 0 ;;
   esac
-  if grep -HInE "$PATTERN" -- "$f" 2>/dev/null; then
+  if grep -HInE "$PATTERN" -- "$1" 2>/dev/null; then
     found=1
   fi
-done < <(git ls-files -z)
+}
+
+# With file arguments, scan exactly those: the lefthook pre-commit hook passes the staged file list so a commit is gated
+# without rescanning the whole tree. With no arguments, scan every tracked text file: the behaviour the CI gate and
+# `task lint:dashes` rely on. NUL-delimited read of git ls-files so filenames with spaces are handled verbatim.
+if [ "$#" -gt 0 ]; then
+  for f in "$@"; do
+    [ -f "$f" ] || continue # staged deletions / non-regular paths
+    scan_file "$f"
+  done
+else
+  while IFS= read -r -d '' f; do
+    scan_file "$f"
+  done < <(git ls-files -z)
+fi
 
 if [ "$found" -ne 0 ]; then
   echo "::error::Em dash (U+2014) or en dash (U+2013) found above. Reword the sentence (prefer shorter sentences) or use ':'. The spaced hyphen ' - ' is also banned (see tools/dash-lint)." >&2
   exit 1
 fi
 
-echo "no em/en dashes in tracked files"
+echo "no em/en dashes found"


### PR DESCRIPTION
…ersion (server) (#403)

Carry the kernel PID generation (pidversion, from audit_token_to_pidversion) on process records and prefer an exact (host_id, pid, pidversion) identity join over the fork-to-exit time window when a network_connect/dns_query flow provides it. Immune to PID reuse and needs no ES/NE clock-drift padding; falls back to the existing window join when a flow carries no pidversion, so mixed-version fleets stay correct through rollout.

Server-first slice of the flow-process-identity OpenSpec change:
- schema/events.json: optional pidversion on exec/fork/network_connect/dns_query
- migration 00004: nullable processes.pidversion + idx_processes_host_pid_pidversion
- store: persist pidversion (insert/re-exec/exec-update COALESCE); GetProcessByPIDVersion
- graph builder: parse + store pidversion; re-exec inherits the prior generation's
- dns_c2_beacon: resolveFlowProcess (identity-preferred, window fallback)
- GraphReader gains GetProcessByPIDVersion
- tests: PBT wire round-trip, precedence unit test, real-MySQL PID-reuse integration test
- docs: architecture.md

The Swift ES + NE emission and live VM/SigNoz/Chrome verification are the PR-2 follow-up (the field only flows once the extension emits it).

<!-- Keep this short. Delete sections that do not apply. -->

## What & why



## Checklist

- [ ] **OpenSpec updated for behavior changes.** If this PR changes observable behavior (a detection rule, the event
      wire schema, persistence semantics, an API/wire shape, or an emitted event), `openspec/specs/**` is updated (and
      an `openspec/changes/` proposal added), with a `spec:<id>` test marker for any new/renamed scenario. Only if this
      PR changes NO observable behavior (a comment / refactor / gofmt / dep bump that happens to touch a scoped path)
      may you assert `no-behavior-change` (label or `[no-behavior-change]` in the title) to clear the OpenSpec-sync gate.
      That is an assertion a reviewer will check, not a way to skip the spec for a real behavior change.
- [ ] Tests added/updated for the change (unit / integration / efficacy / UI as applicable).
- [ ] Agent/extension change touching ESF, XPC, or the event wire format: exercised on a live macOS VM before RC
      (flagged below).

## VM / RC notes (if applicable)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added kernel process generation tracking to improve network flow and DNS query correlation to the correct process, especially in PID reuse scenarios.

* **Documentation**
  * Updated architecture and process graph specifications documenting the new process generation-based correlation approach.

* **Tests**
  * Added test coverage for process generation serialization, correlation precedence logic, and PID reuse edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->