### PR TITLE
Sonar fixes

### DIFF
--- a/agent/codesign/codesign_darwin.go
+++ b/agent/codesign/codesign_darwin.go
@@ -79,7 +79,10 @@ static edr_signing_t edr_evaluate_signing(const char *path) {
 */
 import "C"
 
-import "unsafe"
+// `import "C"` must stay on its own immediately after the cgo preamble; all other imports use the factored block form.
+import (
+	"unsafe"
+)
 
 // Evaluate reads the on-disk code signing of the binary (or bundle) at path
 // via SecStaticCode, network-free. It returns (nil, false) when the path is

--- a/agent/codesign/codesign_darwin_test.go
+++ b/agent/codesign/codesign_darwin_test.go
@@ -8,54 +8,59 @@ import (
 )
 
 func TestEvaluate(t *testing.T) {
-	t.Run("empty path returns not-ok", func(t *testing.T) {
-		if res, ok := Evaluate(""); ok || res != nil {
-			t.Fatalf("Evaluate(\"\") = (%v, %v), want (nil, false)", res, ok)
-		}
-	})
+	t.Run("empty path returns not-ok", testEvaluateEmptyPath)
+	t.Run("absent path returns not-ok", testEvaluateAbsentPath)
+	t.Run("apple platform binary", testEvaluateApplePlatformBinary)
+	t.Run("non-Apple binary is readable but not a platform binary", testEvaluateNonAppleBinary)
+}
 
-	t.Run("absent path returns not-ok", func(t *testing.T) {
-		if res, ok := Evaluate("/no/such/binary/edr-codesign-test"); ok || res != nil {
-			t.Fatalf("Evaluate(absent) = (%v, %v), want (nil, false)", res, ok)
-		}
-	})
+func testEvaluateEmptyPath(t *testing.T) {
+	if res, ok := Evaluate(""); ok || res != nil {
+		t.Fatalf("Evaluate(\"\") = (%v, %v), want (nil, false)", res, ok)
+	}
+}
 
-	t.Run("apple platform binary", func(t *testing.T) {
-		// /bin/ls is a SIP-protected Apple platform binary on every supported macOS, so this is stable ground truth.
-		res, ok := Evaluate("/bin/ls")
-		if !ok || res == nil {
-			t.Fatalf("Evaluate(/bin/ls) = (%v, %v), want a result with ok=true", res, ok)
-		}
-		if !res.IsPlatformBinary {
-			t.Errorf("IsPlatformBinary = false, want true for /bin/ls")
-		}
-		// Apple platform binaries carry no third-party team ID.
-		if res.TeamID != "" {
-			t.Errorf("TeamID = %q, want empty for an Apple platform binary", res.TeamID)
-		}
-		// Apple's own binaries do carry a signing identifier (e.g. com.apple.ls); assert it is populated rather than pinning
-		// the exact value, which can drift across OS builds.
-		if res.SigningID == "" {
-			t.Errorf("SigningID is empty, want a non-empty Apple signing identifier for /bin/ls")
-		}
-	})
+func testEvaluateAbsentPath(t *testing.T) {
+	if res, ok := Evaluate("/no/such/binary/edr-codesign-test"); ok || res != nil {
+		t.Fatalf("Evaluate(absent) = (%v, %v), want (nil, false)", res, ok)
+	}
+}
 
-	t.Run("non-Apple binary is readable but not a platform binary", func(t *testing.T) {
-		// The test binary is a real Mach-O the Go toolchain ad-hoc signs on Apple Silicon: it carries no Developer team
-		// ID and is not Apple-anchored. This is the attacker shape the rule fires on: present and readable, but untrusted.
-		self, err := os.Executable()
-		if err != nil {
-			t.Skipf("os.Executable unavailable: %v", err)
-		}
-		res, ok := Evaluate(self)
-		if !ok || res == nil {
-			t.Fatalf("Evaluate(self) = (%v, %v), want a readable result", res, ok)
-		}
-		if res.IsPlatformBinary {
-			t.Errorf("IsPlatformBinary = true, want false for an ad-hoc-signed non-Apple binary")
-		}
-		if res.TeamID != "" {
-			t.Errorf("TeamID = %q, want empty for an ad-hoc-signed binary", res.TeamID)
-		}
-	})
+func testEvaluateApplePlatformBinary(t *testing.T) {
+	// /bin/ls is a SIP-protected Apple platform binary on every supported macOS, so this is stable ground truth.
+	res, ok := Evaluate("/bin/ls")
+	if !ok || res == nil {
+		t.Fatalf("Evaluate(/bin/ls) = (%v, %v), want a result with ok=true", res, ok)
+	}
+	if !res.IsPlatformBinary {
+		t.Errorf("IsPlatformBinary = false, want true for /bin/ls")
+	}
+	// Apple platform binaries carry no third-party team ID.
+	if res.TeamID != "" {
+		t.Errorf("TeamID = %q, want empty for an Apple platform binary", res.TeamID)
+	}
+	// Apple's own binaries do carry a signing identifier (e.g. com.apple.ls); assert it is populated rather than pinning
+	// the exact value, which can drift across OS builds.
+	if res.SigningID == "" {
+		t.Errorf("SigningID is empty, want a non-empty Apple signing identifier for /bin/ls")
+	}
+}
+
+func testEvaluateNonAppleBinary(t *testing.T) {
+	// The test binary is a real Mach-O the Go toolchain ad-hoc signs on Apple Silicon: it carries no Developer team
+	// ID and is not Apple-anchored. This is the attacker shape the rule fires on: present and readable, but untrusted.
+	self, err := os.Executable()
+	if err != nil {
+		t.Skipf("os.Executable unavailable: %v", err)
+	}
+	res, ok := Evaluate(self)
+	if !ok || res == nil {
+		t.Fatalf("Evaluate(self) = (%v, %v), want a readable result", res, ok)
+	}
+	if res.IsPlatformBinary {
+		t.Errorf("IsPlatformBinary = true, want false for an ad-hoc-signed non-Apple binary")
+	}
+	if res.TeamID != "" {
+		t.Errorf("TeamID = %q, want empty for an ad-hoc-signed binary", res.TeamID)
+	}
 }

--- a/agent/enrich/enrich_test.go
+++ b/agent/enrich/enrich_test.go
@@ -13,18 +13,22 @@ func fakeEval(result *codesign.Result, ok bool) Evaluator {
 	return func(_ string) (*codesign.Result, bool) { return result, ok }
 }
 
+// btmSigningCase is one TestBtmExecutableSigning table row, named so runBtmSigningCase can carry the per-case assertion
+// logic out of the test body (keeping TestBtmExecutableSigning's cognitive complexity in bounds).
+type btmSigningCase struct {
+	name string
+	in   string
+	eval Evaluator
+	// wantSigning is the executable_code_signing object expected in the output, or "" to assert the field is absent.
+	wantSigning string
+	// wantUnchanged asserts the bytes are returned verbatim (no re-marshal).
+	wantUnchanged bool
+}
+
 func TestBtmExecutableSigning(t *testing.T) {
 	signed := &codesign.Result{TeamID: "ABCDE12345", SigningID: "com.evil.dropper", IsPlatformBinary: false}
 
-	tests := []struct {
-		name string
-		in   string
-		eval Evaluator
-		// wantSigning is the executable_code_signing object expected in the output, or "" to assert the field is absent.
-		wantSigning string
-		// wantUnchanged asserts the bytes are returned verbatim (no re-marshal).
-		wantUnchanged bool
-	}{
+	tests := []btmSigningCase{
 		{
 			name:        "fills missing signing from a readable executable",
 			in:          `{"event_type":"btm_launch_item_add","payload":{"item_type":"daemon","executable_path":"/tmp/d"}}`,
@@ -83,32 +87,39 @@ func TestBtmExecutableSigning(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := BtmExecutableSigning([]byte(tc.in), tc.eval)
-
-			if tc.wantUnchanged {
-				if string(got) != tc.in {
-					t.Fatalf("expected unchanged bytes\n got: %s\nwant: %s", got, tc.in)
-				}
-				return
-			}
-
-			var env struct {
-				EventType string          `json:"event_type"`
-				Payload   json.RawMessage `json:"payload"`
-			}
-			if err := json.Unmarshal(got, &env); err != nil {
-				t.Fatalf("output is not valid JSON: %v (%s)", err, got)
-			}
-			var payload struct {
-				Signing json.RawMessage `json:"executable_code_signing"`
-			}
-			if err := json.Unmarshal(env.Payload, &payload); err != nil {
-				t.Fatalf("output payload is not valid JSON: %v", err)
-			}
-			if string(payload.Signing) != tc.wantSigning {
-				t.Errorf("executable_code_signing\n got: %s\nwant: %s", payload.Signing, tc.wantSigning)
-			}
+			runBtmSigningCase(t, tc)
 		})
+	}
+}
+
+// runBtmSigningCase exercises BtmExecutableSigning for one table row and asserts either the verbatim-passthrough property
+// (wantUnchanged) or that the enriched output carries the expected executable_code_signing object.
+func runBtmSigningCase(t *testing.T, tc btmSigningCase) {
+	t.Helper()
+	got := BtmExecutableSigning([]byte(tc.in), tc.eval)
+
+	if tc.wantUnchanged {
+		if string(got) != tc.in {
+			t.Fatalf("expected unchanged bytes\n got: %s\nwant: %s", got, tc.in)
+		}
+		return
+	}
+
+	var env struct {
+		EventType string          `json:"event_type"`
+		Payload   json.RawMessage `json:"payload"`
+	}
+	if err := json.Unmarshal(got, &env); err != nil {
+		t.Fatalf("output is not valid JSON: %v (%s)", err, got)
+	}
+	var payload struct {
+		Signing json.RawMessage `json:"executable_code_signing"`
+	}
+	if err := json.Unmarshal(env.Payload, &payload); err != nil {
+		t.Fatalf("output payload is not valid JSON: %v", err)
+	}
+	if string(payload.Signing) != tc.wantSigning {
+		t.Errorf("executable_code_signing\n got: %s\nwant: %s", payload.Signing, tc.wantSigning)
 	}
 }
 

--- a/server/cmd/fleet-edr-demo-seed/main.go
+++ b/server/cmd/fleet-edr-demo-seed/main.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"time"
 
+	// Registers the "mysql" driver with database/sql so sql.Open("mysql", dsn) resolves; imported for its init side effect.
 	_ "github.com/go-sql-driver/mysql"
 )
 

--- a/tools/dash-lint/main.go
+++ b/tools/dash-lint/main.go
@@ -160,9 +160,9 @@ func checkGo(path string, data []byte) []string {
 	return findings
 }
 
-// goTokenEmDashFinding inspects a single lexed token and returns a finding when the token is a prose-bearing token
-// (comment, string literal, or char literal) whose value contains em-dash use. Bare code is never inspected, where " - "
-// is subtraction. The (string, false) zero value signals "no finding" so the caller appends only on a real hit.
+// goTokenEmDashFinding inspects a single lexed token and returns a finding when the token is a prose-bearing token (comment, string or
+// char literal) whose value contains em-dash use. Tokens that are bare code are never inspected. The (string, false) zero value signals
+// "no finding" so the caller appends only on a real hit.
 func goTokenEmDashFinding(path string, fset *token.FileSet, pos token.Pos, tok token.Token, lit string) (string, bool) {
 	if tok != token.COMMENT && tok != token.STRING && tok != token.CHAR {
 		return "", false

--- a/tools/dash-lint/main.go
+++ b/tools/dash-lint/main.go
@@ -153,24 +153,33 @@ func checkGo(path string, data []byte) []string {
 		if tok == token.EOF {
 			break
 		}
-		// Only prose-bearing tokens: comments, string literals (Doc() descriptions, UI text), and char literals. Never bare
-		// code, where " - " is subtraction.
-		if tok == token.COMMENT || tok == token.STRING || tok == token.CHAR {
-			// Match on the unquoted value for string/char literals so an escape like "\n - x" (an embedded newline before a
-			// list-ish " - ") is not misread as an em dash; the raw literal would show `n - ` and false-positive.
-			val := lit
-			if tok == token.STRING || tok == token.CHAR {
-				if unquoted, err := strconv.Unquote(lit); err == nil {
-					val = unquoted
-				}
-			}
-			if emDashUse.MatchString(val) {
-				p := fset.Position(pos)
-				findings = append(findings, fmt.Sprintf(findingFmt, path, p.Line, strings.TrimSpace(firstLine(lit))))
-			}
+		if finding, ok := goTokenEmDashFinding(path, fset, pos, tok, lit); ok {
+			findings = append(findings, finding)
 		}
 	}
 	return findings
+}
+
+// goTokenEmDashFinding inspects a single lexed token and returns a finding when the token is a prose-bearing token
+// (comment, string literal, or char literal) whose value contains em-dash use. Bare code is never inspected, where " - "
+// is subtraction. The (string, false) zero value signals "no finding" so the caller appends only on a real hit.
+func goTokenEmDashFinding(path string, fset *token.FileSet, pos token.Pos, tok token.Token, lit string) (string, bool) {
+	if tok != token.COMMENT && tok != token.STRING && tok != token.CHAR {
+		return "", false
+	}
+	// Match on the unquoted value for string/char literals so an escape like "\n - x" (an embedded newline before a
+	// list-ish " - ") is not misread as an em dash; the raw literal would show `n - ` and false-positive.
+	val := lit
+	if tok == token.STRING || tok == token.CHAR {
+		if unquoted, err := strconv.Unquote(lit); err == nil {
+			val = unquoted
+		}
+	}
+	if !emDashUse.MatchString(val) {
+		return "", false
+	}
+	p := fset.Position(pos)
+	return fmt.Sprintf(findingFmt, path, p.Line, strings.TrimSpace(firstLine(lit))), true
 }
 
 // checkCStyleComments flags em-dash use inside // line comments and /* block comments */, ignoring code and string literals.

--- a/tools/lint-no-emdash.sh
+++ b/tools/lint-no-emdash.sh
@@ -23,10 +23,12 @@ found=0
 # .claude/** (AI-tool-installed config we do not author; markdownlint ignores it for the same reason). grep -I drops
 # binary files so a staged PNG passed by the pre-commit hook is a no-op rather than a false match.
 scan_file() {
-  case "$1" in
+  local file="$1"
+  case "$file" in
     tools/lint-no-emdash.sh | .claude/*) return 0 ;;
+    *) ;; # every other path is scanned below
   esac
-  if grep -HInE "$PATTERN" -- "$1" 2>/dev/null; then
+  if grep -HInE "$PATTERN" -- "$file" 2>/dev/null; then
     found=1
   fi
 }
@@ -34,9 +36,9 @@ scan_file() {
 # With file arguments, scan exactly those: the lefthook pre-commit hook passes the staged file list so a commit is gated
 # without rescanning the whole tree. With no arguments, scan every tracked text file: the behaviour the CI gate and
 # `task lint:dashes` rely on. NUL-delimited read of git ls-files so filenames with spaces are handled verbatim.
-if [ "$#" -gt 0 ]; then
+if [[ "$#" -gt 0 ]]; then
   for f in "$@"; do
-    [ -f "$f" ] || continue # staged deletions / non-regular paths
+    [[ -f "$f" ]] || continue # staged deletions / non-regular paths
     scan_file "$f"
   done
 else
@@ -45,7 +47,7 @@ else
   done < <(git ls-files -z)
 fi
 
-if [ "$found" -ne 0 ]; then
+if [[ "$found" -ne 0 ]]; then
   echo "::error::Em dash (U+2014) or en dash (U+2013) found above. Reword the sentence (prefer shorter sentences) or use ':'. The spaced hyphen ' - ' is also banned (see tools/dash-lint)." >&2
   exit 1
 fi

--- a/tools/spectrace/main.go
+++ b/tools/spectrace/main.go
@@ -37,6 +37,9 @@ const (
 	// reference a not-yet-archived scenario ID without spectrace flagging a dangling reference. They are not added to
 	// the gated coverage set: a proposal imposes no coverage obligation until it is archived into openspec/specs.
 	defaultChangesDir = "openspec/changes"
+	// specsDirFlagName is the --specs-dir flag name, shared by the check and list-ids subcommands so the flag-set
+	// registration and the userSetFlagNames lookup stay in sync.
+	specsDirFlagName = "specs-dir"
 )
 
 func main() {
@@ -99,7 +102,7 @@ See docs/testing-strategy.md for the marker syntax and rollout plan.
 // per-layer coverage profile per scenario so contributors can see which test rung is missing.
 func runCheck(args []string) int {
 	fs := flag.NewFlagSet("check", flag.ContinueOnError)
-	specsDir := fs.String("specs-dir", defaultSpecsDir, "root of the openspec/specs tree")
+	specsDir := fs.String(specsDirFlagName, defaultSpecsDir, "root of the openspec/specs tree")
 	changesDir := fs.String("changes-dir", defaultChangesDir, "openspec/changes tree; in-flight proposal scenarios are valid marker targets")
 	rootDir := fs.String("root", defaultRootDir, "root of the source tree to scan for markers")
 	strict := fs.Bool("strict", false, "exit non-zero if any SHALL/MUST scenario is uncovered")
@@ -114,7 +117,7 @@ func runCheck(args []string) int {
 	// top-level (CI shape) or a nested package (Copilot's PR #281 concern). Defaults bind to the repo root unconditionally
 	// because their literal cwd-relative meaning is rarely the intent; explicit values keep cwd-first semantics.
 	setFlags := userSetFlagNames(fs)
-	*specsDir = resolvePathFlag(*specsDir, setFlags["specs-dir"])
+	*specsDir = resolvePathFlag(*specsDir, setFlags[specsDirFlagName])
 	*changesDir = resolvePathFlag(*changesDir, setFlags["changes-dir"])
 	*rootDir = resolvePathFlag(*rootDir, setFlags["root"])
 
@@ -285,12 +288,12 @@ func percent(num, denom int) float64 {
 // whose parent requirement has a SHALL/MUST in its body; that's the set the gate is concerned with.
 func runListIDs(args []string) int {
 	fs := flag.NewFlagSet("list-ids", flag.ContinueOnError)
-	specsDir := fs.String("specs-dir", defaultSpecsDir, "root of the openspec/specs tree")
+	specsDir := fs.String(specsDirFlagName, defaultSpecsDir, "root of the openspec/specs tree")
 	normativeOnly := fs.Bool("normative-only", false, "restrict output to scenarios under SHALL/MUST requirements")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
-	*specsDir = resolvePathFlag(*specsDir, userSetFlagNames(fs)["specs-dir"])
+	*specsDir = resolvePathFlag(*specsDir, userSetFlagNames(fs)[specsDirFlagName])
 	scenarios, err := ParseAllSpecs(*specsDir)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "spectrace: parse specs:", err)

--- a/tools/spectrace/newcode.go
+++ b/tools/spectrace/newcode.go
@@ -67,23 +67,32 @@ func computeNewCodeScenarioIDs(ctx context.Context, specsDir, baseRef string) (m
 		if filepath.Base(file) != "spec.md" {
 			continue
 		}
-		hunks, err := gitDiffNewLineRanges(ctx, repoRoot, mergeBase, file)
-		if err != nil {
-			return nil, fmt.Errorf("git diff %s: %w", file, err)
-		}
-		// gitChangedFiles returns paths relative to the repo root; open from that root so spectrace works whether invoked
-		// from the repo top-level (CI shape) or a subdirectory (a contributor in their package).
-		ranges, err := parseSpecScenarioRanges(filepath.Join(repoRoot, file))
-		if err != nil {
-			return nil, fmt.Errorf("parse %s: %w", file, err)
-		}
-		for _, sr := range ranges {
-			if anyOverlap(sr.Start, sr.End, hunks) {
-				out[sr.ID] = struct{}{}
-			}
+		if err := addTouchedScenarioIDs(ctx, out, repoRoot, mergeBase, file); err != nil {
+			return nil, err
 		}
 	}
 	return out, nil
+}
+
+// addTouchedScenarioIDs adds to out the canonical ID of every scenario in `file` whose line range overlaps a new-side diff
+// hunk against mergeBase. file is repo-root-relative as returned by gitChangedFiles; repoRoot anchors both the git diff and
+// the spec.md open so spectrace works whether invoked from the repo top-level (CI shape) or a subdirectory (a contributor
+// in their package).
+func addTouchedScenarioIDs(ctx context.Context, out map[string]struct{}, repoRoot, mergeBase, file string) error {
+	hunks, err := gitDiffNewLineRanges(ctx, repoRoot, mergeBase, file)
+	if err != nil {
+		return fmt.Errorf("git diff %s: %w", file, err)
+	}
+	ranges, err := parseSpecScenarioRanges(filepath.Join(repoRoot, file))
+	if err != nil {
+		return fmt.Errorf("parse %s: %w", file, err)
+	}
+	for _, sr := range ranges {
+		if anyOverlap(sr.Start, sr.End, hunks) {
+			out[sr.ID] = struct{}{}
+		}
+	}
+	return nil
 }
 
 // validateBaseRef rejects revisions that git would interpret as command-line options instead of a commit-ish reference.
@@ -105,9 +114,15 @@ func gitTopLevel(ctx context.Context) (string, error) {
 	cmd := exec.CommandContext(ctx, "git", "rev-parse", "--show-toplevel") //nolint:gosec // args are literal
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return "", fmt.Errorf("%w: %s", err, strings.TrimSpace(string(out)))
+		return "", wrapGitErr(err, out)
 	}
 	return strings.TrimSpace(string(out)), nil
+}
+
+// wrapGitErr attaches the trimmed combined output of a failed git subprocess to err so the caller surfaces the actionable
+// git message (missing remote, shallow clone, unknown ref) instead of a bare `exit status 1`.
+func wrapGitErr(err error, out []byte) error {
+	return fmt.Errorf("%w: %s", err, strings.TrimSpace(string(out)))
 }
 
 // lineRange is a closed-closed range of new-side file lines (1-based).
@@ -134,7 +149,7 @@ func gitMergeBase(ctx context.Context, repoRoot, baseRef string) (string, error)
 	cmd.Dir = repoRoot
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return "", fmt.Errorf("%w: %s", err, strings.TrimSpace(string(out)))
+		return "", wrapGitErr(err, out)
 	}
 	return strings.TrimSpace(string(out)), nil
 }
@@ -148,7 +163,7 @@ func gitChangedFiles(ctx context.Context, repoRoot, mergeBase, specsDir string) 
 	cmd.Dir = repoRoot
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return nil, fmt.Errorf("%w: %s", err, strings.TrimSpace(string(out)))
+		return nil, wrapGitErr(err, out)
 	}
 	var files []string
 	for line := range strings.SplitSeq(strings.TrimSpace(string(out)), "\n") {
@@ -170,7 +185,7 @@ func gitDiffNewLineRanges(ctx context.Context, repoRoot, mergeBase, file string)
 	cmd.Dir = repoRoot
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return nil, fmt.Errorf("%w: %s", err, strings.TrimSpace(string(out)))
+		return nil, wrapGitErr(err, out)
 	}
 	return parseUnifiedDiffNewRanges(string(out)), nil
 }

--- a/tools/spectrace/report.go
+++ b/tools/spectrace/report.go
@@ -156,7 +156,8 @@ func parseChangeScenarioIDs(changesDir string) (map[string]struct{}, error) {
 // stderr at cleanup time because the report renderer has already returned by then.
 func openReportWriter(path string) (io.Writer, func(), error) {
 	if path == "" {
-		return os.Stdout, func() {}, nil
+		// No-op cleanup: stdout is owned by the process and must not be closed by the report renderer.
+		return os.Stdout, func() { /* stdout is not ours to close */ }, nil
 	}
 	f, err := os.Create(path) //nolint:gosec // path comes from a --output flag the operator supplies
 	if err != nil {


### PR DESCRIPTION
<!-- Keep this short. Delete sections that do not apply. -->

## What & why



## Checklist

- [ ] **OpenSpec updated for behavior changes.** If this PR changes observable behavior (a detection rule, the event
      wire schema, persistence semantics, an API/wire shape, or an emitted event), `openspec/specs/**` is updated (and
      an `openspec/changes/` proposal added), with a `spec:<id>` test marker for any new/renamed scenario. Only if this
      PR changes NO observable behavior (a comment / refactor / gofmt / dep bump that happens to touch a scoped path)
      may you assert `no-behavior-change` (label or `[no-behavior-change]` in the title) to clear the OpenSpec-sync gate.
      That is an assertion a reviewer will check, not a way to skip the spec for a real behavior change.
- [ ] Tests added/updated for the change (unit / integration / efficacy / UI as applicable).
- [ ] Agent/extension change touching ESF, XPC, or the event wire format: exercised on a live macOS VM before RC
      (flagged below).

## VM / RC notes (if applicable)


