### PR TITLE
Added trigger-dns-c2.sh script for demo

### DIFF
--- a/docs/install-agent-manual.md
+++ b/docs/install-agent-manual.md
@@ -245,7 +245,7 @@ Edit `/Library/LaunchDaemons/com.fleetdm.edr.agent.plist` and add these keys ins
 
 ```xml
 <key>OTEL_EXPORTER_OTLP_ENDPOINT</key>
-<string>https://otel.fleetdm.site:443</string>
+<string>https://otel.example.com:443</string>
 <key>OTEL_EXPORTER_OTLP_COMPRESSION</key>
 <string>gzip</string>
 <key>OTEL_EXPORTER_OTLP_HEADERS</key>

--- a/scripts/demo/README.md
+++ b/scripts/demo/README.md
@@ -22,4 +22,4 @@ Simulates the classic "malware phones home" chain: a payload staged to `/tmp` re
 ./trigger-dns-c2.sh high       # high:     ordinary short domain        -> T1071.004
 ```
 
-Within a few seconds a **DNS C2 beacon** alert should appear in the EDR UI, attributed to the `/tmp/beacon` process, citing both the DNS lookup and the outbound connection. The script copies `/usr/bin/curl` to `/tmp/beacon` and re-signs it ad-hoc (a plain copy of an Apple platform binary is SIGKILLed when run from `/tmp`, so it would emit no telemetry), then removes it on exit.
+Within a few seconds a **DNS C2 beacon** alert should appear in the EDR UI, attributed to the staged `/tmp/beacon.*` process, citing both the DNS lookup and the outbound connection. The script copies `/usr/bin/curl` to a unique `mktemp` path under `/tmp` and re-signs it ad-hoc (a plain copy of an Apple platform binary is SIGKILLed when run from `/tmp`, so it would emit no telemetry), then removes it on exit.

--- a/scripts/demo/README.md
+++ b/scripts/demo/README.md
@@ -1,0 +1,25 @@
+# Demo scripts
+
+Self-contained scripts that fire a real Fleet EDR detection on a live host, for demos and hands-on walkthroughs. Unlike the synthetic efficacy corpus (`test/efficacy/corpus/`, which replays events through the fakeagent library with no host) and the SSH-driven QA harness (`scripts/qa/`, `scripts/uat/`, which drive a VM from your workstation), each script here runs **directly on the enrolled Mac** and narrates what it is doing as it goes.
+
+| Script              | Detection it triggers | ATT&CK                  |
+| ------------------- | --------------------- | ----------------------- |
+| `trigger-dns-c2.sh` | `dns_c2_beacon`       | T1071.004 (+ T1568.002) |
+
+## Prerequisites
+
+- An Apple Silicon Mac on macOS 13+ with the agent installed, the system + network extensions active, and Full Disk Access granted. See [`docs/install-agent-manual.md`](../../docs/install-agent-manual.md).
+- Outbound internet from that host: the beacon resolves a [nip.io](https://nip.io) name over plain UDP DNS (which the proxy sees, unlike DoH/DoT) and opens a real outbound TCP connection to the resolved address.
+- The Fleet EDR server reachable with this host enrolled, so the alert surfaces in the UI.
+
+## `trigger-dns-c2.sh`
+
+Simulates the classic "malware phones home" chain: a payload staged to `/tmp` resolves a domain and then connects to the address that lookup returned, all from the same process. The `dns_c2_beacon` rule correlates the temp-path `exec`, the `dns_query`, and the `network_connect` into a single finding.
+
+```sh
+# On the enrolled Mac:
+./trigger-dns-c2.sh            # critical: high-entropy DGA-like domain -> T1071.004 + T1568.002
+./trigger-dns-c2.sh high       # high:     ordinary short domain        -> T1071.004
+```
+
+Within a few seconds a **DNS C2 beacon** alert should appear in the EDR UI, attributed to the `/tmp/beacon` process, citing both the DNS lookup and the outbound connection. The script copies `/usr/bin/curl` to `/tmp/beacon` and re-signs it ad-hoc (a plain copy of an Apple platform binary is SIGKILLed when run from `/tmp`, so it would emit no telemetry), then removes it on exit.

--- a/scripts/demo/trigger-dns-c2.sh
+++ b/scripts/demo/trigger-dns-c2.sh
@@ -26,10 +26,13 @@ esac
 say() { printf '\n\033[1;36m==> %s\033[0m\n' "$1"; }   # cyan step banner
 sub() { printf '    %s\n' "$1"; }                       # indented detail
 
-# Stage the payload at a fixed temp path and guarantee it is removed on ANY exit. Step 4 narrates the cleanup as part of
-# the demo; this trap covers the early-failure paths (e.g. the exec check below) so a failed run never leaves an
-# executable copy of curl behind in /tmp. rm -f is idempotent, so the trap and the Step 4 narrative do not conflict.
-BEACON=/tmp/beacon
+# Stage the payload at a UNIQUE temp path and guarantee it is removed on ANY exit. mktemp gives a name we own, so two
+# concurrent runs never collide and the cleanup never clobbers a pre-existing /tmp/beacon the script did not create. The
+# rule's suspicious-path gate is a /tmp prefix match, not an exact name, so a randomized /tmp/beacon.* path still fires.
+# Step 4 narrates the cleanup as part of the demo; this trap also covers the early-failure paths (e.g. the exec check
+# below) so a failed run never leaves an executable copy of curl behind. rm -f is idempotent, so the trap and the Step 4
+# narrative do not conflict.
+BEACON=$(mktemp /tmp/beacon.XXXXXX)
 cleanup() { rm -f "$BEACON"; }
 trap cleanup EXIT
 
@@ -41,11 +44,18 @@ sub "  exec (Endpoint Security) + dns_query (DNS proxy) + network_connect (netwo
 # --- Step 1: stage the payload in a suspicious location -----------------------------
 say "Step 1/4  Drop the payload into a world-writable temp directory"
 cp /usr/bin/curl "$BEACON"
+chmod +x "$BEACON"   # mktemp created the file 0600; restore the execute bit a fresh `cp` to a new path would have set
 # /usr/bin/curl is an Apple *platform binary*. A plain copy executed from /tmp is SIGKILLed by AMFI on
 # macOS (the process dies with exit 137 = 128+9 before it can resolve or connect), so no dns_query or
 # network_connect telemetry is ever emitted and the rule has nothing to join. Re-signing ad-hoc strips
 # the platform-binary designation and applies a valid signature, so the copy runs from /tmp.
-codesign --force --sign - "$BEACON" >/dev/null 2>&1
+# Check the result explicitly: under `set -e` a silent codesign failure (e.g. missing Command Line Tools)
+# would abort the script with no message, leaving the operator to guess why the demo did nothing.
+if ! codesign --force --sign - "$BEACON" >/dev/null 2>&1; then
+  echo "ERROR: failed to re-sign ${BEACON} (is the Command Line Tools 'codesign' available?)." >&2
+  echo "       Without a valid signature macOS SIGKILLs the /tmp copy, so no telemetry is emitted." >&2
+  exit 1
+fi
 sub "Copied a network client to ${BEACON} (re-signed ad-hoc so macOS will run it from /tmp)"
 # Fail loudly if the staged payload still cannot execute, rather than silently emitting no telemetry.
 if ! "$BEACON" --version >/dev/null 2>&1; then
@@ -71,7 +81,7 @@ if [ "$MODE" = "critical" ]; then
   sub "finding to CRITICAL and adding ATT&CK T1568.002 (Domain Generation Algorithms)."
 else
   # short label (<12 chars) -> no DGA -> stays High; random to dodge DNS cache.
-  rand=$(head -c 256 /dev/urandom | LC_ALL=C tr -dc '[:lower:]')
+  rand=$(head -c 1024 /dev/urandom | LC_ALL=C tr -dc '[:lower:]')
   LABEL="app-${rand:0:5}"
   sub "Using a short, ordinary-looking hostname (no DGA)."
   sub "Why it matters: the finding stays HIGH with ATT&CK T1071.004 (DNS) only."
@@ -89,8 +99,18 @@ sub "with the resolved address) and then the outbound connection to that address
 sub "filter emits network_connect). Resolve-then-connect, same PID, inside the 30s window."
 # -4 forces IPv4 so the connected address equals the captured A-record answer (${SINK_IP}); without it
 # curl may use an AAAA result and the connect IP won't match the dns_query response_addresses the rule joins on.
-"$BEACON" -4 -s -m 5 -o /dev/null "https://${DOMAIN}/" || true   # connect is enough; app-layer result irrelevant
-sub "Beacon sent (the TLS/HTTP result does not matter; the connection attempt is the signal)."
+# Capture curl's exit. Any non-zero is fine EXCEPT a DNS-resolution failure (CURLE_COULDNT_RESOLVE_HOST, exit 6): on
+# exit 6 there is no lookup answer and no outbound connection, so neither dns_query nor network_connect was emitted and
+# NO alert fires. Warn instead of the misleading "Beacon sent"; any other result still emitted the connect SYN signal.
+beacon_rc=0
+"$BEACON" -4 -s -m 5 -o /dev/null "https://${DOMAIN}/" || beacon_rc=$?
+if [ "$beacon_rc" -eq 6 ]; then
+  echo "WARNING: DNS resolution failed for ${DOMAIN} (curl exit 6); no connection was attempted." >&2
+  echo "         No dns_query/network_connect was emitted, so the EDR alert will NOT fire." >&2
+  echo "         Check this host's internet/DNS connectivity and re-run." >&2
+else
+  sub "Beacon sent (the TLS/HTTP result does not matter; the connection attempt is the signal)."
+fi
 
 # --- Step 4: clean up and hand off to the EDR ---------------------------------------
 say "Step 4/4  Clean up"
@@ -105,6 +125,6 @@ if [ "$MODE" = "critical" ]; then
 else
   sub "  Severity: High       ATT&CK: T1071.004"
 fi
-sub "  Detail:   /tmp/beacon resolved ${DOMAIN} and connected to ${SINK_IP}"
+sub "  Detail:   ${BEACON} resolved ${DOMAIN} and connected to ${SINK_IP}"
 sub "The single finding cites the dns_query and the network_connect, attributed to the"
-sub "/tmp/beacon process: launch -> lookup -> connection joined across all three streams."
+sub "${BEACON} process: launch -> lookup -> connection joined across all three streams."

--- a/scripts/demo/trigger-dns-c2.sh
+++ b/scripts/demo/trigger-dns-c2.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Trigger the dns_c2_beacon detection on a live Fleet EDR agent.
+#
+# Run this ON the enrolled Mac (the host whose agent + system/network extensions are active). It simulates the classic
+# "malware phones home" chain so the EDR can correlate three separate telemetry streams into ONE alert:
+#   exec (Endpoint Security) + dns_query (DNS proxy) + network_connect (network filter).
+#
+# Detection target: catalog rule dns_c2_beacon (server/rules/internal/catalog/dns_c2_beacon.go).
+# Synthetic equivalent: test/efficacy/corpus/T1071.004-dns-c2-beacon (fakeagent, no live host).
+#
+# Prerequisites: an Apple Silicon Mac on macOS 13+ with the agent installed, the system + network extensions active, and
+# Full Disk Access granted. The host must reach the internet: the beacon resolves a nip.io name (plain UDP DNS, which the
+# proxy sees) and opens a real outbound TCP connection to the resolved address.
+#
+# Usage: ./trigger-dns-c2.sh [critical|high]
+#   critical (default): high-entropy DGA-like domain -> Critical, ATT&CK T1071.004 + T1568.002.
+#   high:               ordinary short domain        -> High,     ATT&CK T1071.004.
+set -euo pipefail
+
+MODE="${1:-critical}"
+case "$MODE" in
+  critical|high) ;;
+  *) echo "usage: $0 [critical|high]" >&2; exit 2 ;;
+esac
+
+say() { printf '\n\033[1;36m==> %s\033[0m\n' "$1"; }   # cyan step banner
+sub() { printf '    %s\n' "$1"; }                       # indented detail
+
+# Stage the payload at a fixed temp path and guarantee it is removed on ANY exit. Step 4 narrates the cleanup as part of
+# the demo; this trap covers the early-failure paths (e.g. the exec check below) so a failed run never leaves an
+# executable copy of curl behind in /tmp. rm -f is idempotent, so the trap and the Step 4 narrative do not conflict.
+BEACON=/tmp/beacon
+cleanup() { rm -f "$BEACON"; }
+trap cleanup EXIT
+
+say "DNS C2 beacon demo  (mode: ${MODE})"
+sub "Simulating the classic 'malware phones home' chain on this host."
+sub "Fleet EDR should correlate three separate signals into ONE alert:"
+sub "  exec (Endpoint Security) + dns_query (DNS proxy) + network_connect (network filter)."
+
+# --- Step 1: stage the payload in a suspicious location -----------------------------
+say "Step 1/4  Drop the payload into a world-writable temp directory"
+cp /usr/bin/curl "$BEACON"
+# /usr/bin/curl is an Apple *platform binary*. A plain copy executed from /tmp is SIGKILLed by AMFI on
+# macOS (the process dies with exit 137 = 128+9 before it can resolve or connect), so no dns_query or
+# network_connect telemetry is ever emitted and the rule has nothing to join. Re-signing ad-hoc strips
+# the platform-binary designation and applies a valid signature, so the copy runs from /tmp.
+codesign --force --sign - "$BEACON" >/dev/null 2>&1
+sub "Copied a network client to ${BEACON} (re-signed ad-hoc so macOS will run it from /tmp)"
+# Fail loudly if the staged payload still cannot execute, rather than silently emitting no telemetry.
+if ! "$BEACON" --version >/dev/null 2>&1; then
+  echo "ERROR: ${BEACON} cannot execute (SIGKILLed by macOS code-signing enforcement)." >&2
+  echo "       Without a running payload no dns_query/network_connect is emitted, so no alert can fire." >&2
+  exit 1
+fi
+sub "Why it matters: the rule's isSuspiciousPath() gate only considers processes launched"
+sub "from /tmp, /var/tmp, /private/tmp, or /dev/shm. A browser resolving+connecting never fires;"
+sub "a binary running out of /tmp does. This is the 'dropped payload' shape."
+
+# --- Step 2: choose the command-and-control domain ----------------------------------
+say "Step 2/4  Pick the command-and-control (C2) domain"
+SINK_IP=1.1.1.1   # any routable IP; the outbound TCP SYN alone emits network_connect
+if [ "$MODE" = "critical" ]; then
+  # high-entropy 18-char label -> looksLikeDGADomain() -> Critical + ATT&CK T1568.002.
+  # Read a finite chunk of /dev/urandom and slice in bash; piping urandom into `head -c`
+  # closes the pipe early and kills `tr` with SIGPIPE (exit 141) under `set -o pipefail`.
+  rand=$(head -c 1024 /dev/urandom | LC_ALL=C tr -dc '[:lower:][:digit:]')
+  LABEL=${rand:0:18}
+  sub "Generated a high-entropy, algorithm-looking hostname (a DGA domain)."
+  sub "Why it matters: a long random label trips the entropy check, escalating the"
+  sub "finding to CRITICAL and adding ATT&CK T1568.002 (Domain Generation Algorithms)."
+else
+  # short label (<12 chars) -> no DGA -> stays High; random to dodge DNS cache.
+  rand=$(head -c 256 /dev/urandom | LC_ALL=C tr -dc '[:lower:]')
+  LABEL="app-${rand:0:5}"
+  sub "Using a short, ordinary-looking hostname (no DGA)."
+  sub "Why it matters: the finding stays HIGH with ATT&CK T1071.004 (DNS) only."
+fi
+DOMAIN="${LABEL}.${SINK_IP}.nip.io"
+sub "C2 domain: ${DOMAIN}"
+sub "(nip.io resolves <label>.<ip>.nip.io to <ip>, so the lookup returns ${SINK_IP},"
+sub " which is exactly where the payload will connect: a self-contained beacon.)"
+
+# --- Step 3: resolve then connect, from the same process ----------------------------
+say "Step 3/4  Beacon home: resolve the domain, then connect to the resolved address"
+sub "Running: ${BEACON} https://${DOMAIN}/"
+sub "Why it matters: the SAME /tmp process does the DNS lookup (-> DNS proxy emits dns_query"
+sub "with the resolved address) and then the outbound connection to that address (-> network"
+sub "filter emits network_connect). Resolve-then-connect, same PID, inside the 30s window."
+# -4 forces IPv4 so the connected address equals the captured A-record answer (${SINK_IP}); without it
+# curl may use an AAAA result and the connect IP won't match the dns_query response_addresses the rule joins on.
+"$BEACON" -4 -s -m 5 -o /dev/null "https://${DOMAIN}/" || true   # connect is enough; app-layer result irrelevant
+sub "Beacon sent (the TLS/HTTP result does not matter; the connection attempt is the signal)."
+
+# --- Step 4: clean up and hand off to the EDR ---------------------------------------
+say "Step 4/4  Clean up"
+rm -f "$BEACON"
+sub "Removed ${BEACON} (typical of malware covering its tracks)."
+
+say "Done. Now watch Fleet EDR."
+sub "Within a few seconds an alert should appear in the EDR UI:"
+sub "  Title:    DNS C2 beacon"
+if [ "$MODE" = "critical" ]; then
+  sub "  Severity: Critical   ATT&CK: T1071.004 + T1568.002"
+else
+  sub "  Severity: High       ATT&CK: T1071.004"
+fi
+sub "  Detail:   /tmp/beacon resolved ${DOMAIN} and connected to ${SINK_IP}"
+sub "The single finding cites the dns_query and the network_connect, attributed to the"
+sub "/tmp/beacon process: launch -> lookup -> connection joined across all three streams."


### PR DESCRIPTION
<!-- Keep this short. Delete sections that do not apply. -->

## What & why



## Checklist

- [ ] **OpenSpec updated for behavior changes.** If this PR changes observable behavior (a detection rule, the event
      wire schema, persistence semantics, an API/wire shape, or an emitted event), `openspec/specs/**` is updated (and
      an `openspec/changes/` proposal added), with a `spec:<id>` test marker for any new/renamed scenario. Only if this
      PR changes NO observable behavior (a comment / refactor / gofmt / dep bump that happens to touch a scoped path)
      may you assert `no-behavior-change` (label or `[no-behavior-change]` in the title) to clear the OpenSpec-sync gate.
      That is an assertion a reviewer will check, not a way to skip the spec for a real behavior change.
- [ ] Tests added/updated for the change (unit / integration / efficacy / UI as applicable).
- [ ] Agent/extension change touching ESF, XPC, or the event wire format: exercised on a live macOS VM before RC
      (flagged below).

## VM / RC notes (if applicable)


