### PR TITLE
Host page improvements

### DIFF
--- a/openspec/changes/hosts-page-refinement/proposal.md
+++ b/openspec/changes/hosts-page-refinement/proposal.md
@@ -1,0 +1,18 @@
+# Refine the hosts page with a fleet summary and enrollment-backed host columns
+
+## Why
+
+The hosts page is the operator's landing view, but it keys every row on the raw hardware UUID and shows no fleet-level overview. Operators recognize machines by hostname, not UUID, and have no at-a-glance read on how much of the fleet is online. The enrollment hostname and OS version are already collected and stored at enrollment (`enrollments.hostname`, `enrollments.os_version`); they are simply not surfaced on the hosts list, which selects only `host_id`, `event_count`, and `last_seen_ns`.
+
+## What changes
+
+- **`GET /api/hosts` carries the enrollment hostname and OS version.** `detection.api.HostSummary` gains `hostname` and `os_version`, and `detection`'s `ListHosts` query LEFT JOINs the endpoint context's `enrollments` table on the shared `host_id`. LEFT (not INNER) so a host that has sent events but never enrolled still appears, with empty hostname/OS version; `COALESCE` folds the outer-join NULLs into empty strings.
+- **The hosts page opens with a fleet-overview summary strip.** Three stat cards (Online / Offline / Total hosts) computed from the existing `isOnline(last_seen_ns)` classification, rendered above the table. The page header is dropped so the page opens directly into the summary.
+- **The host table is enriched.** The `Host ID` column becomes a `Host` column showing the enrollment hostname over the full hardware UUID (UUID alone when no hostname is known); a new `Platform` column shows the OS version; the `Events` column is right-aligned with tabular figures. Status, last-seen, and row-click-to-process-tree are unchanged.
+- **A shared `StatCard` / `SummaryStrip` UI primitive is extracted.** The summary strip reuses one component rather than bespoke markup; the existing inline stat cards on the ATT&CK coverage page are refactored onto the same primitive, removing the duplicated `.attack-coverage__summary` / `__metric` styling.
+
+### Not in this change
+
+- No change to enrollment collection or the `enrollments` schema; hostname and OS version are already stored.
+- No new hosts-page filtering, search, or sorting; the row set and ordering (`last_seen_ns DESC`) are unchanged.
+- `host_id` remains the stable key and routing param; hostname is display-only.

--- a/openspec/changes/hosts-page-refinement/specs/server-rest-api/spec.md
+++ b/openspec/changes/hosts-page-refinement/specs/server-rest-api/spec.md
@@ -1,0 +1,23 @@
+# Server REST API Specification (delta)
+
+## MODIFIED Requirements
+
+### Requirement: List enrolled hosts
+
+The system SHALL expose `GET /api/hosts` returning a JSON array of enrolled hosts. Each entry SHALL include the host identifier, the count of events seen for that host, the most recent timestamp at which any event from the host was observed, and the host's enrollment hostname and operating-system version. The hostname and OS version SHALL be sourced from the host's enrollment record; a host that has sent events but has no enrollment record SHALL still appear in the array with an empty hostname and an empty OS version rather than being omitted.
+
+The change from the prior requirement is the addition of the enrollment hostname and OS version to each entry, sourced by joining the enrollment record on the shared host identifier, with empty values (not omission) for an un-enrolled host.
+
+#### Scenario: An operator opens the hosts dashboard
+
+- **GIVEN** a logged-in operator
+- **WHEN** the client calls `GET /api/hosts`
+- **THEN** the system responds with HTTP 200 and a JSON array
+- **AND** every entry contains the host identifier, an event count, and a last-seen timestamp
+
+#### Scenario: Host list rows carry enrollment hostname and OS version
+
+- **GIVEN** one host with an enrollment record (hostname and OS version) and one host that has sent events but has no enrollment record
+- **WHEN** the client calls `GET /api/hosts`
+- **THEN** the enrolled host's entry carries its enrollment hostname and OS version
+- **AND** the un-enrolled host still appears with an empty hostname and an empty OS version

--- a/openspec/changes/hosts-page-refinement/specs/web-ui/spec.md
+++ b/openspec/changes/hosts-page-refinement/specs/web-ui/spec.md
@@ -1,0 +1,28 @@
+# Web UI Specification (delta)
+
+## MODIFIED Requirements
+
+### Requirement: Host list is the home view
+
+The UI SHALL render an enrolled host list as the home view of the authenticated application. The page SHALL open with a fleet-overview summary of how many hosts are online, how many are offline, and the total host count, computed from the same online/offline classification used by the rows. Each row MUST identify the host by its enrollment hostname over its full hardware identifier (falling back to the hardware identifier alone when no enrollment hostname is known), show the host's operating-system platform, show whether it is online or offline by comparing the host's last-seen timestamp to the current time, and show the host's running event count. A host MUST be classified online when its last-seen timestamp is within the last 5 minutes and offline otherwise. Activating a row MUST navigate to that host's process tree.
+
+The change from the prior requirement is the addition of the fleet-overview summary, the enrollment hostname + full hardware identifier in the host cell, and the operating-system platform column; the online/offline classification, event count, and row-activation behavior are unchanged.
+
+#### Scenario: Host list renders rows for enrolled hosts
+
+- **GIVEN** the server has at least one enrolled host
+- **WHEN** the operator opens the home view
+- **THEN** the UI renders a row per host with the host identity, an online/offline pill, the event count, and a relative last-seen label
+
+#### Scenario: Host list shows hostname, platform and a fleet summary
+
+- **GIVEN** the server returns hosts with enrollment hostnames and OS versions, plus one host with no enrollment hostname
+- **WHEN** the operator opens the home view
+- **THEN** the UI shows a summary of online, offline, and total host counts
+- **AND** each host cell shows the enrollment hostname over the full hardware identifier, the platform column shows the OS version, and a host with no enrollment hostname shows the hardware identifier alone
+
+#### Scenario: Clicking a host opens its process tree
+
+- **GIVEN** the host list is displayed
+- **WHEN** the operator activates a host row
+- **THEN** the UI navigates to the process tree page scoped to that host id

--- a/openspec/changes/hosts-page-refinement/tasks.md
+++ b/openspec/changes/hosts-page-refinement/tasks.md
@@ -1,0 +1,31 @@
+# Refine the hosts page: tasks
+
+## 1. Server
+
+- [x] `server/detection/api/types.go`: add `Hostname` + `OSVersion` to `HostSummary` with `db`/`json` tags; document them as enrollment-sourced and empty for un-enrolled hosts.
+- [x] `server/detection/internal/mysql/hosts.go`: `ListHosts` LEFT JOINs `enrollments` on `host_id`, COALESCEs hostname/os_version to `''`; comment the cross-context (shared-DB) join.
+- [x] `server/detection/internal/tests/integration_test.go`: `TestListHosts_DecoratesWithEnrollment` seeds an enrollment row + an un-enrolled host and asserts the decoration and the LEFT-not-INNER fallback. Marker on the new server-rest-api scenario.
+
+## 2. UI primitive
+
+- [x] `ui/src/components/ui/StatCard.tsx` (+ `.scss`): `StatCard` ({ value, label, accent }) + `SummaryStrip`; accent enum (`green`/`red`/`neutral`) maps to border tokens, no raw hex.
+- [x] `ui/src/components/ui/StatCard.test.tsx`: value/label render + accent-class mapping + strip wrapping.
+
+## 3. Hosts page
+
+- [x] `ui/src/types.ts`: add optional `hostname` + `os_version` to `HostSummary`.
+- [x] `ui/src/components/HostList.tsx` (+ `.scss`): drop `PageHeader`; render `SummaryStrip` (online/offline/total via memoised `isOnline`); columns `Host | Platform | Status | Events | Last seen` with hostname-over-UUID (UUID fallback), platform fallback dash, right-aligned events.
+- [x] `ui/src/components/HostList.test.tsx`: hostname-vs-UUID fallback, platform fallback, summary counts, row navigation, empty/error states. Marker on the new web-ui scenario.
+
+## 4. Coverage-page reuse
+
+- [x] `ui/src/components/AttackCoverage.tsx` (+ `.scss`): replace inline `.attack-coverage__summary`/`__metric` with `SummaryStrip` + `StatCard`; delete the dead SCSS.
+- [x] `ui/src/components/AttackCoverage.test.tsx`: pin the three summary stat cards (none existed before).
+
+## 5. Verification
+
+- [x] `go test -tags=integration ./server/detection/internal/tests/` (ListHosts JOIN tests) green.
+- [x] `cd ui && npx vitest run` green for changed files; `tsc --noEmit` + `eslint` clean.
+- [x] `cd ui && npm run build` compiles SCSS + bundles.
+- [x] `openspec validate hosts-page-refinement --strict`; spectrace `--strict`; dash + markdown-prose lints all clean.
+- [x] Real dev-server QA in Chrome (summary counts 3/2/5, hostname+UUID cell, un-enrolled UUID-only fallback, Platform column, right-aligned events, row-click navigation). Caught and fixed an Events left-align bug (class outranked by `.table td`).

--- a/server/detection/api/types.go
+++ b/server/detection/api/types.go
@@ -93,9 +93,12 @@ const (
 )
 
 // HostSummary is the lightweight per-host activity row the operator list endpoint returns. Distinct from Host so future extensions
-// (alert counts, status pill) can land without touching Host's wire shape.
+// (alert counts, status pill) can land without touching Host's wire shape. Hostname and OSVersion are sourced from the endpoint
+// context's enrollments table (LEFT JOIN in ListHosts) and are empty for a host that has sent events but carries no enrollment row.
 type HostSummary struct {
 	HostID     string `db:"host_id" json:"host_id"`
+	Hostname   string `db:"hostname" json:"hostname"`
+	OSVersion  string `db:"os_version" json:"os_version"`
 	EventCount int64  `db:"event_count" json:"event_count"`
 	LastSeenNs int64  `db:"last_seen_ns" json:"last_seen_ns"`
 }

--- a/server/detection/internal/mysql/hosts.go
+++ b/server/detection/internal/mysql/hosts.go
@@ -9,13 +9,18 @@ import (
 	"github.com/fleetdm/edr/server/detection/api"
 )
 
-// ListHosts returns a summary of all hosts that have sent events.
+// ListHosts returns a summary of all hosts that have sent events. The LEFT JOIN reaches into the endpoint context's `enrollments`
+// table (same MySQL database, keyed on the shared host_id) to decorate each row with the enrollment hostname and OS version. LEFT so
+// a host that has sent events but never enrolled still returns; COALESCE folds the outer-join NULL into "" so the scan targets stay
+// plain strings.
 func (s *Store) ListHosts(ctx context.Context) ([]api.HostSummary, error) {
 	var hosts []api.HostSummary
 	err := s.db.SelectContext(ctx, &hosts, `
-		SELECT host_id, event_count, last_seen_ns
-		FROM hosts
-		ORDER BY last_seen_ns DESC`)
+		SELECT h.host_id, COALESCE(e.hostname, '') AS hostname, COALESCE(e.os_version, '') AS os_version,
+		       h.event_count, h.last_seen_ns
+		FROM hosts h
+		LEFT JOIN enrollments e ON e.host_id = h.host_id
+		ORDER BY h.last_seen_ns DESC`)
 	if err != nil {
 		return nil, fmt.Errorf("query hosts: %w", err)
 	}

--- a/server/detection/internal/mysql/perf_test.go
+++ b/server/detection/internal/mysql/perf_test.go
@@ -19,7 +19,8 @@ import (
 // --- #91: bulk hosts upsert ------------------------------------------------
 
 func TestUpsertHosts_BatchAcrossManyHosts(t *testing.T) {
-	s := newTestStore(t)
+	// Full-schema fixture: this test calls ListHosts, which LEFT JOINs the endpoint enrollments table.
+	s := newFullSchemaStore(t)
 	ctx := t.Context()
 
 	const n = 32
@@ -61,7 +62,8 @@ func TestUpsertHosts_BatchAcrossManyHosts(t *testing.T) {
 }
 
 func TestUpsertHosts_EmptyBatchNoOp(t *testing.T) {
-	s := newTestStore(t)
+	// Full-schema fixture: this test calls ListHosts, which LEFT JOINs the endpoint enrollments table.
+	s := newFullSchemaStore(t)
 	require.NoError(t, s.UpsertHosts(t.Context(), nil))
 	require.NoError(t, s.UpsertHosts(t.Context(), []api.Event{}))
 	hosts, err := s.ListHosts(t.Context())

--- a/server/detection/internal/mysql/store_test.go
+++ b/server/detection/internal/mysql/store_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/fleetdm/edr/server/detection/internal/mysql"
 	"github.com/fleetdm/edr/server/detection/testkit"
 	"github.com/fleetdm/edr/server/testdb"
+	"github.com/fleetdm/edr/server/testdb/full"
 )
 
 // newTestStore wraps testdb.Open with detection's ApplySchema and
@@ -33,6 +34,17 @@ func newTestStore(tb testing.TB) *mysql.Store {
 	require.NoError(tb, testkit.ApplySchema(ctx, db))
 	s, err := mysql.New(db)
 	require.NoError(tb, err)
+	return s
+}
+
+// newFullSchemaStore is newTestStore's cross-context sibling for the handful of store tests that exercise ListHosts, which LEFT JOINs
+// the endpoint context's enrollments table. The detection-only schema newTestStore applies lacks that table, so those tests open a
+// full-schema fixture (every bounded context's DDL) via testdb/full instead. testdb/full is the sanctioned cross-context schema surface
+// (arch-go allows **.testdb here); it takes *testing.T, so this helper is test-only (no benchmark variant needed).
+func newFullSchemaStore(t *testing.T) *mysql.Store {
+	t.Helper()
+	s, err := mysql.New(full.Open(t))
+	require.NoError(t, err)
 	return s
 }
 

--- a/server/detection/internal/tests/integration_test.go
+++ b/server/detection/internal/tests/integration_test.go
@@ -1387,10 +1387,14 @@ func TestListHosts_DecoratesWithEnrollment(t *testing.T) {
 
 	hosts, err := d.Service().ListHosts(ctx)
 	require.NoError(t, err)
+	// Exactly the two seeded hosts, no more: a LEFT JOIN regression (e.g. a duplicate enrollment row or a bad join predicate fanning
+	// out rows) would inflate the count, which the byID map below would otherwise silently collapse.
+	require.Len(t, hosts, 2, "one row per host; the LEFT JOIN must not fan out duplicates")
 	byID := make(map[string]api.HostSummary, len(hosts))
 	for _, h := range hosts {
 		byID[h.HostID] = h
 	}
+	require.Len(t, byID, 2, "host_ids are unique across the returned rows")
 
 	require.Contains(t, byID, enrolledHost)
 	assert.Equal(t, "eng-lopez-mbp.local", byID[enrolledHost].Hostname, "enrolled host carries its enrollment hostname")

--- a/server/detection/internal/tests/integration_test.go
+++ b/server/detection/internal/tests/integration_test.go
@@ -1361,6 +1361,46 @@ func TestRecordHostSeen_AdvancesLastSeen(t *testing.T) {
 	assert.Equal(t, later.UnixNano(), hosts[0].LastSeenNs, "earlier RecordHostSeen must not regress")
 }
 
+// spec:server-rest-api/list-enrolled-hosts/host-list-rows-carry-enrollment-hostname-and-os-version
+//
+// ListHosts LEFT JOINs the endpoint context's enrollments table to decorate each row with the enrollment hostname + OS version. A
+// host that has been seen but never enrolled still returns, with both fields empty. Pins the cross-context decoration the refined
+// hosts page renders (hostname over UUID, Platform column) and the LEFT-not-INNER join semantics that keep bare hosts visible.
+func TestListHosts_DecoratesWithEnrollment(t *testing.T) {
+	t.Parallel()
+	d := newDetection(t, detectionOpts{mode: bootstrap.ModeFull})
+	ctx := t.Context()
+
+	const enrolledHost = "ENROLLED-UUID-0001"
+	const bareHost = "BARE-UUID-0002"
+	require.NoError(t, d.Service().RecordHostSeen(ctx, enrolledHost, time.Now()))
+	require.NoError(t, d.Service().RecordHostSeen(ctx, bareHost, time.Now().Add(-time.Minute)))
+
+	// Seed an enrollment row directly (the endpoint enroll handler is out of scope for this detection-side test). Only the NOT NULL
+	// columns without a default need values; host_token_issued_at / enrolled_at default to CURRENT_TIMESTAMP.
+	_, err := d.Store().DB().ExecContext(ctx, `
+		INSERT INTO enrollments (host_id, host_token_id, host_token_hash, hostname, agent_version, os_version, source_ip)
+		VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		enrolledHost, []byte("token-id-0001"), []byte("token-hash"),
+		"eng-lopez-mbp.local", "1.2.3", "macOS 26.0", "203.0.113.7")
+	require.NoError(t, err)
+
+	hosts, err := d.Service().ListHosts(ctx)
+	require.NoError(t, err)
+	byID := make(map[string]api.HostSummary, len(hosts))
+	for _, h := range hosts {
+		byID[h.HostID] = h
+	}
+
+	require.Contains(t, byID, enrolledHost)
+	assert.Equal(t, "eng-lopez-mbp.local", byID[enrolledHost].Hostname, "enrolled host carries its enrollment hostname")
+	assert.Equal(t, "macOS 26.0", byID[enrolledHost].OSVersion, "enrolled host carries its enrollment OS version")
+
+	require.Contains(t, byID, bareHost, "a host with events but no enrollment row must still appear (LEFT JOIN, not INNER)")
+	assert.Empty(t, byID[bareHost].Hostname, "un-enrolled host has an empty hostname")
+	assert.Empty(t, byID[bareHost].OSVersion, "un-enrolled host has an empty OS version")
+}
+
 func TestService_CountOfflineHosts(t *testing.T) {
 	t.Parallel()
 	d := newDetection(t, detectionOpts{mode: bootstrap.ModeFull})

--- a/test/e2e/tests/qa/host-list-and-process-tree.spec.ts
+++ b/test/e2e/tests/qa/host-list-and-process-tree.spec.ts
@@ -93,8 +93,10 @@ test.describe.serial("L4 (M6): host list + process tree UI specs", () => {
       .poll(() => p.locator("tbody tr").count(), { timeout: 10_000, message: "host list never reached expected row count" })
       .toBe(BATCH_SIZE);
 
-    // Spot-check one enrolled host_id appears in a cell. This proves we're rendering THESE rows, not a leftover from a prior run.
-    await expect(p.getByRole("cell", { name: hosts[0].hostId, exact: true })).toBeVisible();
+    // Spot-check one enrolled host_id appears, proving we're rendering THESE rows, not a leftover from a prior run. The Host cell now
+    // stacks the enrollment hostname over the full hardware UUID (two lines), so the UUID is no longer the cell's whole accessible
+    // name; match the UUID text directly instead of an exact cell-name match.
+    await expect(p.getByText(hosts[0].hostId, { exact: true })).toBeVisible();
   });
 
   test("event count: hosts.event_count column shows the per-scenario timeline length", async ({ agent }) => {

--- a/test/e2e/tests/qa/host-list-and-process-tree.spec.ts
+++ b/test/e2e/tests/qa/host-list-and-process-tree.spec.ts
@@ -153,10 +153,11 @@ test.describe.serial("L4 (M6): host list + process tree UI specs", () => {
     for (const d of driven) {
       const row = p.locator("tr").filter({ has: p.getByText(d.hostId, { exact: true }) });
       await expect(row).toBeVisible({ timeout: 10_000 });
-      // Events column is the 3rd <td> (0-indexed 2): Host ID | Status | Events | Last seen.
+      // Target the Events cell by its class rather than a positional index: the column order is Host | Platform | Status | Events |
+      // Last seen, and a positional nth() silently lands on the wrong cell whenever the columns are reordered.
       // HostList.tsx renders event_count via .toLocaleString() so counts >= 1000 get locale separators ("1,000" not "1000").
       // Mirror that here so the assertion stays correct if the scenario count ever crosses that threshold.
-      await expect(row.locator("td").nth(2)).toHaveText(d.expected.toLocaleString());
+      await expect(row.locator("td.host-list__events-col")).toHaveText(d.expected.toLocaleString());
     }
   });
 

--- a/ui/src/components/AttackCoverage.scss
+++ b/ui/src/components/AttackCoverage.scss
@@ -3,39 +3,6 @@
 @use "../styles/var/padding" as *;
 
 .attack-coverage {
-  &__summary {
-    display: flex;
-    gap: $pad-large;
-    margin: $pad-medium 0 $pad-large;
-    flex-wrap: wrap;
-  }
-
-  &__metric {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-    gap: $pad-xxsmall;
-    padding: $pad-medium $pad-large;
-    background: $ui-fleet-black-5;
-    border-left: 4px solid $core-fleet-green;
-    border-radius: 4px;
-    min-width: 180px;
-  }
-
-  &__metric-num {
-    font-size: 2rem;
-    font-weight: $bold;
-    color: $core-fleet-black;
-    line-height: 1;
-  }
-
-  &__metric-label {
-    font-size: 0.85rem;
-    color: $ui-fleet-black-50;
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-  }
-
   // Single-table layout. table-layout:fixed makes the colgroup widths
   // authoritative so every section's columns line up - without it, each
   // tactic group inside the table would still default-size from its widest

--- a/ui/src/components/AttackCoverage.test.tsx
+++ b/ui/src/components/AttackCoverage.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, waitFor, within } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { AttackCoverage } from "./AttackCoverage";
+import * as api from "../api";
+import type { AttackNavigatorLayer } from "../api";
+
+// AttackCoverage had no component test before the StatCard extraction. These
+// pin the summary strip (now the shared StatCard/SummaryStrip primitive) so the
+// refactor stays covered: three metric cards with the covered-technique,
+// distinct-rule and tactic counts derived from the layer.
+const layer: AttackNavigatorLayer = {
+  name: "Fleet EDR coverage",
+  versions: { layer: "4.5", navigator: "5.0.0" },
+  domain: "enterprise-attack",
+  description: "",
+  techniques: [
+    { techniqueID: "T1555.001", score: 100, comment: "Covered by: rule_a, rule_b" },
+    { techniqueID: "T1059", score: 100, comment: "Covered by: rule_a" },
+  ],
+};
+
+beforeEach(() => {
+  vi.spyOn(api, "fetchAttackNavigatorLayer").mockResolvedValue(layer);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("AttackCoverage summary strip", () => {
+  it("renders three stat cards with the derived counts", async () => {
+    render(
+      <MemoryRouter>
+        <AttackCoverage />
+      </MemoryRouter>,
+    );
+    const strip = await waitFor(() => {
+      const el = document.querySelector(".summary-strip");
+      expect(el).toBeInTheDocument();
+      return el as HTMLElement;
+    });
+    const cards = strip.querySelectorAll(".stat-card");
+    expect(cards).toHaveLength(3);
+
+    const cardFor = (label: string) =>
+      within(strip).getByText(label).closest(".stat-card") as HTMLElement;
+    expect(within(cardFor("techniques covered")).getByText("2")).toBeInTheDocument();
+    // rule_a + rule_b are the two distinct covering rules across both techniques.
+    expect(within(cardFor("detection rules")).getByText("2")).toBeInTheDocument();
+    expect(within(cardFor("tactics with coverage")).getByText("2")).toBeInTheDocument();
+  });
+});

--- a/ui/src/components/AttackCoverage.tsx
+++ b/ui/src/components/AttackCoverage.tsx
@@ -4,6 +4,7 @@ import { fetchAttackNavigatorLayer, type AttackNavigatorLayer } from "../api";
 import { Table, EmptyState } from "./ui/Table";
 import { PageHeader } from "./ui/PageHeader";
 import { Button } from "./ui/Button";
+import { StatCard, SummaryStrip } from "./ui/StatCard";
 import { TECHNIQUE_CATALOG, type TechniqueMeta } from "./attack-techniques";
 import "./AttackCoverage.scss";
 
@@ -110,20 +111,11 @@ export function AttackCoverage() {
 
       {!loading && layer && (
         <>
-          <div className="attack-coverage__summary">
-            <div className="attack-coverage__metric">
-              <span className="attack-coverage__metric-num">{totalCovered}</span>
-              <span className="attack-coverage__metric-label">techniques covered</span>
-            </div>
-            <div className="attack-coverage__metric">
-              <span className="attack-coverage__metric-num">{distinctRules.size}</span>
-              <span className="attack-coverage__metric-label">detection rules</span>
-            </div>
-            <div className="attack-coverage__metric">
-              <span className="attack-coverage__metric-num">{groups.length}</span>
-              <span className="attack-coverage__metric-label">tactics with coverage</span>
-            </div>
-          </div>
+          <SummaryStrip>
+            <StatCard accent="green" value={totalCovered} label="techniques covered" />
+            <StatCard accent="green" value={distinctRules.size} label="detection rules" />
+            <StatCard accent="green" value={groups.length} label="tactics with coverage" />
+          </SummaryStrip>
 
           {groups.length === 0
             ? <EmptyState>No coverage data yet.</EmptyState>

--- a/ui/src/components/HostList.scss
+++ b/ui/src/components/HostList.scss
@@ -1,0 +1,33 @@
+@use "../styles/var/colors" as *;
+@use "../styles/var/fonts" as *;
+
+$font-mono: ui-monospace, SFMono-Regular, Menlo, monospace;
+
+.host-list {
+  // Host cell: enrollment hostname over the full hardware UUID, both monospace.
+  &__hostname {
+    font-family: $font-mono;
+    font-weight: $bold;
+    color: $core-fleet-black;
+  }
+
+  &__uuid {
+    font-family: $font-mono;
+    font-size: $xx-small;
+    color: $ui-fleet-black-50;
+    margin-top: 1px;
+  }
+
+  &__platform {
+    color: $ui-fleet-black-75;
+  }
+}
+
+// Events is a count: right-align header + cell and use tabular figures so the
+// digits line up column-wise. Scoped under the table class so the selector
+// outranks Table.scss's `.table th` / `.table td` left-align (which is more
+// specific than a bare class).
+.host-list__table .host-list__events-col {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}

--- a/ui/src/components/HostList.test.tsx
+++ b/ui/src/components/HostList.test.tsx
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+import { HostList } from "./HostList";
+import * as api from "../api";
+import type { HostSummary } from "../types";
+import { NANOSECONDS_PER_MILLISECOND } from "../constants";
+
+// A last_seen this many ms ago decides online vs offline (HostList's threshold
+// is 5 min). Build ns timestamps relative to now so isOnline is deterministic.
+const minutesAgoNs = (mins: number): number =>
+  (Date.now() - mins * 60 * 1000) * NANOSECONDS_PER_MILLISECOND;
+
+const makeHost = (over: Partial<HostSummary> = {}): HostSummary => ({
+  host_id: "UUID-DEFAULT",
+  hostname: "host.local",
+  os_version: "macOS 26.0",
+  event_count: 1234,
+  last_seen_ns: minutesAgoNs(1),
+  ...over,
+});
+
+const renderList = () =>
+  render(
+    <MemoryRouter initialEntries={["/hosts"]}>
+      <Routes>
+        <Route path="/hosts" element={<HostList />} />
+        <Route path="/hosts/:id" element={<div>detail page</div>} />
+      </Routes>
+    </MemoryRouter>,
+  );
+
+beforeEach(() => {
+  vi.spyOn(api, "listHosts");
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+const mockHosts = (hosts: HostSummary[]) => {
+  (api.listHosts as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(hosts);
+};
+
+describe("HostList rendering", () => {
+  it("shows the hostname over the full UUID when enrollment metadata exists", async () => {
+    mockHosts([makeHost({ host_id: "F4A2-UUID", hostname: "ci-builder.local" })]);
+    renderList();
+    await waitFor(() => {
+      expect(screen.getByText("ci-builder.local")).toBeInTheDocument();
+    });
+    // The full hardware UUID appears as the secondary line, not collapsed away.
+    expect(screen.getByText("F4A2-UUID")).toBeInTheDocument();
+  });
+
+  it("falls back to the UUID as the primary line when hostname is empty", async () => {
+    mockHosts([makeHost({ host_id: "BARE-UUID", hostname: "" })]);
+    renderList();
+    await waitFor(() => {
+      expect(screen.getByText("BARE-UUID")).toBeInTheDocument();
+    });
+    // Only one line is rendered: the UUID is the hostname element, no separate uuid line.
+    expect(document.querySelector(".host-list__uuid")).not.toBeInTheDocument();
+  });
+
+  it("renders a placeholder dash when os_version is empty", async () => {
+    mockHosts([makeHost({ os_version: "" })]);
+    renderList();
+    await waitFor(() => {
+      const platform = document.querySelector(".host-list__platform");
+      expect(platform).toHaveTextContent("-");
+    });
+  });
+
+  it("formats the event count with thousands separators in a right-aligned column", async () => {
+    mockHosts([makeHost({ event_count: 128944 })]);
+    renderList();
+    const cell = await screen.findByText("128,944");
+    expect(cell).toHaveClass("host-list__events-col");
+  });
+});
+
+describe("HostList summary strip", () => {
+  // spec:web-ui/host-list-is-the-home-view/host-list-shows-hostname-platform-and-a-fleet-summary
+  it("counts online, offline and total hosts", async () => {
+    mockHosts([
+      makeHost({ host_id: "a", last_seen_ns: minutesAgoNs(1) }), // online
+      makeHost({ host_id: "b", last_seen_ns: minutesAgoNs(2) }), // online
+      makeHost({ host_id: "c", last_seen_ns: minutesAgoNs(30) }), // offline
+    ]);
+    renderList();
+    const strip = await waitFor(() => {
+      const el = document.querySelector(".summary-strip");
+      expect(el).toBeInTheDocument();
+      return el as HTMLElement;
+    });
+    const cardFor = (label: string) =>
+      within(strip).getByText(label).closest(".stat-card") as HTMLElement;
+    expect(within(cardFor("Online")).getByText("2")).toBeInTheDocument();
+    expect(within(cardFor("Offline")).getByText("1")).toBeInTheDocument();
+    expect(within(cardFor("Total hosts")).getByText("3")).toBeInTheDocument();
+  });
+});
+
+describe("HostList navigation", () => {
+  it("navigates to the host detail route on row click", async () => {
+    mockHosts([makeHost({ host_id: "click-me", hostname: "click.local" })]);
+    renderList();
+    const row = (await screen.findByText("click.local")).closest("tr");
+    expect(row).not.toBeNull();
+    fireEvent.click(row as HTMLElement);
+    await waitFor(() => {
+      expect(screen.getByText("detail page")).toBeInTheDocument();
+    });
+  });
+});
+
+describe("HostList states", () => {
+  it("shows the empty state when no hosts report", async () => {
+    mockHosts([]);
+    renderList();
+    await waitFor(() => {
+      expect(screen.getByText(/no hosts reporting yet/i)).toBeInTheDocument();
+    });
+  });
+
+  it("surfaces fetch failures", async () => {
+    (api.listHosts as unknown as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("boom"));
+    renderList();
+    await waitFor(() => {
+      expect(screen.getByText(/error: boom/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/ui/src/components/HostList.tsx
+++ b/ui/src/components/HostList.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { listHosts } from "../api";
 import type { HostSummary } from "../types";
@@ -35,12 +35,15 @@ export function HostList() {
       });
   }, []);
 
-  // Fleet-overview counts. isOnline calls Date.now(), so memoise the whole
-  // tally per hosts change rather than re-walking the array on every render.
-  const { online, offline, total } = useMemo(() => {
-    const onlineCount = hosts.filter((h) => isOnline(h.last_seen_ns)).length;
-    return { online: onlineCount, offline: hosts.length - onlineCount, total: hosts.length };
-  }, [hosts]);
+  // Fleet-overview counts, derived inline on every render rather than memoised on `hosts`.
+  // isOnline() reads Date.now(), and each row re-evaluates it per render for its pill; a
+  // useMemo keyed on `hosts` alone would let the summary cards show a stale online/offline
+  // split (after the 5-min threshold elapses with no refetch) while the row pills had already
+  // flipped. Recomputing inline keeps the cards and the rows derived from one classification
+  // pass. The host list is small, so the re-walk is negligible.
+  const online = hosts.filter((h) => isOnline(h.last_seen_ns)).length;
+  const offline = hosts.length - online;
+  const total = hosts.length;
 
   return (
     <>

--- a/ui/src/components/HostList.tsx
+++ b/ui/src/components/HostList.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { listHosts } from "../api";
 import type { HostSummary } from "../types";
@@ -9,7 +9,8 @@ import {
   NANOSECONDS_PER_MILLISECOND,
 } from "../constants";
 import { Table, EmptyState } from "./ui/Table";
-import { PageHeader } from "./ui/PageHeader";
+import { StatCard, SummaryStrip } from "./ui/StatCard";
+import "./HostList.scss";
 
 // "offline" is last_seen > 5 min old. The agent polls every 5 s, so 5 min
 // is 60× the polling interval: well past any transient network blip but
@@ -34,52 +35,78 @@ export function HostList() {
       });
   }, []);
 
+  // Fleet-overview counts. isOnline calls Date.now(), so memoise the whole
+  // tally per hosts change rather than re-walking the array on every render.
+  const { online, offline, total } = useMemo(() => {
+    const onlineCount = hosts.filter((h) => isOnline(h.last_seen_ns)).length;
+    return { online: onlineCount, offline: hosts.length - onlineCount, total: hosts.length };
+  }, [hosts]);
+
   return (
     <>
-      <PageHeader title="Hosts" subtitle="Endpoints reporting events" />
       {loading && <EmptyState>Loading hosts...</EmptyState>}
       {error && !loading && <EmptyState>Error: {error}</EmptyState>}
       {!loading && !error && hosts.length === 0 && (
         <EmptyState>No hosts reporting yet.</EmptyState>
       )}
       {!loading && !error && hosts.length > 0 && (
-        <Table className="table--clickable">
-          <thead>
-            <tr>
-              <th>Host ID</th>
-              <th>Status</th>
-              <th>Events</th>
-              <th>Last seen</th>
-            </tr>
-          </thead>
-          <tbody>
-            {hosts.map((h) => {
-              // Compute online once per row: isOnline calls Date.now(), so calling it
-              // twice (for className and label) could theoretically flip the two reads
-              // at the exact threshold boundary and render an "online" class with an
-              // "offline" label.
-              const online = isOnline(h.last_seen_ns);
-              const pillClass = online ? "status-pill status-pill--online" : "status-pill status-pill--offline";
-              return (
-                <tr
-                  key={h.host_id}
-                  onClick={() => {
-                    const result = navigate(`/hosts/${encodeURIComponent(h.host_id)}`);
-                    // navigate() may return void or Promise<void> in react-router v7.
-                    if (result instanceof Promise) result.catch(() => { /* ignored */ });
-                  }}
-                >
-                  <td>{h.host_id}</td>
-                  <td>
-                    <span className={pillClass}>{online ? "online" : "offline"}</span>
-                  </td>
-                  <td>{h.event_count.toLocaleString()}</td>
-                  <td>{formatRelative(h.last_seen_ns)}</td>
-                </tr>
-              );
-            })}
-          </tbody>
-        </Table>
+        <>
+          <SummaryStrip>
+            <StatCard accent="green" value={online} label="Online" />
+            <StatCard accent="red" value={offline} label="Offline" />
+            <StatCard accent="neutral" value={total} label="Total hosts" />
+          </SummaryStrip>
+          <Table className="table--clickable host-list__table">
+            <thead>
+              <tr>
+                <th>Host</th>
+                <th>Platform</th>
+                <th>Status</th>
+                <th className="host-list__events-col">Events</th>
+                <th>Last seen</th>
+              </tr>
+            </thead>
+            <tbody>
+              {hosts.map((h) => {
+                // Compute online once per row: isOnline calls Date.now(), so calling it
+                // twice (for className and label) could theoretically flip the two reads
+                // at the exact threshold boundary and render an "online" class with an
+                // "offline" label.
+                const rowOnline = isOnline(h.last_seen_ns);
+                const pillClass = rowOnline ? "status-pill status-pill--online" : "status-pill status-pill--offline";
+                return (
+                  <tr
+                    key={h.host_id}
+                    onClick={() => {
+                      const result = navigate(`/hosts/${encodeURIComponent(h.host_id)}`);
+                      // navigate() may return void or Promise<void> in react-router v7.
+                      if (result instanceof Promise) result.catch(() => { /* ignored */ });
+                    }}
+                  >
+                    <td>
+                      {/* hostname (from enrollment) over the full hardware UUID. Older rows with no enrollment
+                          metadata fall back to the UUID on the primary line and omit the secondary line. */}
+                      {h.hostname ? (
+                        <>
+                          <div className="host-list__hostname">{h.hostname}</div>
+                          <div className="host-list__uuid">{h.host_id}</div>
+                        </>
+                      ) : (
+                        <div className="host-list__hostname">{h.host_id}</div>
+                      )}
+                    </td>
+                    <td className="host-list__platform">{h.os_version || "-"}</td>
+                    <td>
+                      <span className={pillClass}>{rowOnline ? "online" : "offline"}</span>
+                    </td>
+                    <td className="host-list__events-col">{h.event_count.toLocaleString()}</td>
+                    <td>{formatRelative(h.last_seen_ns)}</td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </Table>
+        </>
       )}
     </>
   );

--- a/ui/src/components/ui/StatCard.scss
+++ b/ui/src/components/ui/StatCard.scss
@@ -1,0 +1,50 @@
+@use "../../styles/var/colors" as *;
+@use "../../styles/var/fonts" as *;
+@use "../../styles/var/padding" as *;
+@use "../../styles/var/global" as *;
+
+.summary-strip {
+  display: flex;
+  gap: $pad-medium;
+  margin-bottom: $pad-large;
+  flex-wrap: wrap;
+}
+
+.stat-card {
+  display: flex;
+  flex-direction: column;
+  gap: $pad-xxsmall;
+  padding: 14px 20px;
+  min-width: 160px;
+  background: $core-fleet-white;
+  border: 1px solid $ui-fleet-black-10;
+  border-left: 4px solid $ui-fleet-black-25;
+  border-radius: $border-radius-large;
+
+  &--green {
+    border-left-color: $core-fleet-green;
+  }
+
+  &--red {
+    border-left-color: $ui-error;
+  }
+
+  &--neutral {
+    border-left-color: $ui-fleet-black-25;
+  }
+
+  &__value {
+    font-size: 28px;
+    font-weight: $bold;
+    color: $core-fleet-black;
+    line-height: 1;
+    font-variant-numeric: tabular-nums;
+  }
+
+  &__label {
+    font-size: $xx-small;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: $ui-fleet-black-50;
+  }
+}

--- a/ui/src/components/ui/StatCard.test.tsx
+++ b/ui/src/components/ui/StatCard.test.tsx
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { StatCard, SummaryStrip } from "./StatCard";
+
+describe("StatCard", () => {
+  it("renders the value and label", () => {
+    render(<StatCard value={42} label="Online" />);
+    expect(screen.getByText("42")).toBeInTheDocument();
+    expect(screen.getByText("Online")).toBeInTheDocument();
+  });
+
+  it("defaults to the neutral accent when none is given", () => {
+    const { container } = render(<StatCard value={0} label="Total" />);
+    expect(container.querySelector(".stat-card")).toHaveClass("stat-card--neutral");
+  });
+
+  it.each(["green", "red", "neutral"] as const)(
+    "maps the %s accent to its modifier class",
+    (accent) => {
+      const { container } = render(<StatCard value={1} label="x" accent={accent} />);
+      expect(container.querySelector(".stat-card")).toHaveClass(`stat-card--${accent}`);
+    },
+  );
+
+  it("wraps children in a summary strip", () => {
+    const { container } = render(
+      <SummaryStrip>
+        <StatCard value={1} label="a" />
+        <StatCard value={2} label="b" />
+      </SummaryStrip>,
+    );
+    const strip = container.querySelector(".summary-strip");
+    expect(strip).toBeInTheDocument();
+    expect(strip?.querySelectorAll(".stat-card")).toHaveLength(2);
+  });
+});

--- a/ui/src/components/ui/StatCard.tsx
+++ b/ui/src/components/ui/StatCard.tsx
@@ -1,0 +1,31 @@
+import type { ReactNode } from "react";
+import classnames from "classnames";
+import "./StatCard.scss";
+
+// Accent maps to a left-border colour token, never a raw hex. Kept colour-role
+// rather than page-semantic so the card reuses across surfaces: the Hosts page
+// strip uses green/red/neutral for online/offline/total, and the ATT&CK
+// coverage strip uses green throughout.
+export type StatCardAccent = "green" | "red" | "neutral";
+
+interface StatCardProps {
+  readonly value: ReactNode;
+  readonly label: ReactNode;
+  readonly accent?: StatCardAccent;
+}
+
+// StatCard is a single labelled metric tile (big tabular number over an
+// uppercase caption) with a coloured left accent border. SummaryStrip lays a
+// row of them out above a table.
+export function StatCard({ value, label, accent = "neutral" }: Readonly<StatCardProps>) {
+  return (
+    <div className={classnames("stat-card", `stat-card--${accent}`)}>
+      <span className="stat-card__value">{value}</span>
+      <span className="stat-card__label">{label}</span>
+    </div>
+  );
+}
+
+export function SummaryStrip({ children }: { readonly children: ReactNode }) {
+  return <div className="summary-strip">{children}</div>;
+}

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -1,5 +1,10 @@
 export interface HostSummary {
   host_id: string;
+  // hostname + os_version come from the endpoint enrollment row joined into the
+  // hosts summary; both are empty for a host that has sent events but never
+  // enrolled, so the UI falls back to host_id / a placeholder dash.
+  hostname?: string;
+  os_version?: string;
   event_count: number;
   last_seen_ns: number;
 }

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -1,10 +1,11 @@
 export interface HostSummary {
   host_id: string;
   // hostname + os_version come from the endpoint enrollment row joined into the
-  // hosts summary; both are empty for a host that has sent events but never
-  // enrolled, so the UI falls back to host_id / a placeholder dash.
-  hostname?: string;
-  os_version?: string;
+  // hosts summary. The server always sends them (COALESCE to ""), so they are
+  // required, not optional: an un-enrolled host carries empty strings, and the
+  // UI falls back to host_id / a placeholder dash on the empty value.
+  hostname: string;
+  os_version: string;
   event_count: number;
   last_seen_ns: number;
 }


### PR DESCRIPTION
<!-- Keep this short. Delete sections that do not apply. -->

## What & why



## Checklist

- [ ] **OpenSpec updated for behavior changes.** If this PR changes observable behavior (a detection rule, the event
      wire schema, persistence semantics, an API/wire shape, or an emitted event), `openspec/specs/**` is updated (and
      an `openspec/changes/` proposal added), with a `spec:<id>` test marker for any new/renamed scenario. Only if this
      PR changes NO observable behavior (a comment / refactor / gofmt / dep bump that happens to touch a scoped path)
      may you assert `no-behavior-change` (label or `[no-behavior-change]` in the title) to clear the OpenSpec-sync gate.
      That is an assertion a reviewer will check, not a way to skip the spec for a real behavior change.
- [ ] Tests added/updated for the change (unit / integration / efficacy / UI as applicable).
- [ ] Agent/extension change touching ESF, XPC, or the event wire format: exercised on a live macOS VM before RC
      (flagged below).

## VM / RC notes (if applicable)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced hosts page with fleet overview summary displaying online, offline, and total host counts.
  * Improved host table with enrollment hostname display, OS version information, and refined column organization.
  * New shared summary strip and stat card UI components for consistent metric presentation across the application.

* **Documentation**
  * Added OpenSpec specifications documenting hosts page refinement design and requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->