### PR TITLE
fix(rules): correct stale MITRE ID in launchagent rule comment [no-behavior-change]

### DIFF
--- a/server/rules/internal/catalog/persistence_launchagent.go
+++ b/server/rules/internal/catalog/persistence_launchagent.go
@@ -15,7 +15,7 @@ import (
 // `/Library/LaunchAgents/`, the canonical macOS persistence mechanism. Operators can
 // silence expected plists via `EDR_LAUNCHAGENT_ALLOWLIST` (comma-separated absolute paths).
 //
-// MITRE ATT&CK: T1547.011 (Boot or Logon Autostart Execution: Launch Agent)
+// MITRE ATT&CK: T1543.001 (Create or Modify System Process: Launch Agent)
 type PersistenceLaunchAgent struct {
 	// AllowedPlists is the set of plist paths the operator has pre-blessed. The rule
 	// skips findings whose target plist matches any entry (exact string match).


### PR DESCRIPTION
…havior-change]

The header comment cited T1547.011 (Boot or Logon Autostart Execution: Launch Agent), which is wrong on two counts: T1547.011 was revoked in ATT&CK v11 (it was Plist Modification, replaced by T1647), and it was never named Launch Agent. Align the comment with the actual mapping returned by Techniques(): T1543.001 (Create or Modify System Process: Launch Agent).

<!-- Keep this short. Delete sections that do not apply. -->

## What & why



## Checklist

- [ ] **OpenSpec updated for behavior changes.** If this PR changes observable behavior (a detection rule, the event
      wire schema, persistence semantics, an API/wire shape, or an emitted event), `openspec/specs/**` is updated (and
      an `openspec/changes/` proposal added), with a `spec:<id>` test marker for any new/renamed scenario. Only if this
      PR changes NO observable behavior (a comment / refactor / gofmt / dep bump that happens to touch a scoped path)
      may you assert `no-behavior-change` (label or `[no-behavior-change]` in the title) to clear the OpenSpec-sync gate.
      That is an assertion a reviewer will check, not a way to skip the spec for a real behavior change.
- [ ] Tests added/updated for the change (unit / integration / efficacy / UI as applicable).
- [ ] Agent/extension change touching ESF, XPC, or the event wire format: exercised on a live macOS VM before RC
      (flagged below).

## VM / RC notes (if applicable)


