### PR TITLE
fix(ci): unbreak main: bump undici past advisories, raise E2E enroll …

### DIFF
--- a/scripts/test-e2e-coverage.sh
+++ b/scripts/test-e2e-coverage.sh
@@ -60,6 +60,11 @@ COMMON_ENV=(
   EDR_LOG_FORMAT=text
   EDR_HOST_TOKEN_LIFETIME=24h
   EDR_HOST_TOKEN_GRACE=5m
+  # Raise the per-IP enroll cap well above the suite's enroll volume. Every spec enrolls its hosts from the one CI runner IP,
+  # so the production default (30/min, burst 30) is occasionally exhausted mid-suite and a setup enroll gets a 429, flaking
+  # an unrelated test. No E2E spec asserts the enroll limiter (the rate-limit specs cover break-glass, a separate limiter), so
+  # raising it here removes the flake without weakening coverage.
+  EDR_ENROLL_RATE_PER_MIN=100000
   EDR_SECRET_KEY=dev-only-secret-key-do-not-use-in-production-xyz
   EDR_BREAKGLASS_RP_ID=localhost
   EDR_BREAKGLASS_RP_ORIGINS=https://localhost:8088

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -5143,9 +5143,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.26.0.tgz",
-      "integrity": "sha512-3O9Tf67pGhgOv9jM35AbhkXAKi13f3oy3aE4CSgr+TckGeY+/iu97ZXN+J7DpHPzLbVApFd1IFhcnBjREYXYcg==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -21,6 +21,9 @@
     "react-router-dom": "^7.16.0",
     "sass": "^1.100.0"
   },
+  "overrides": {
+    "undici": "^7.28.0"
+  },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
     "@testing-library/jest-dom": "^6.9.1",


### PR DESCRIPTION
…rate

Two independent red checks on main, fixed together.

1. OSV-Scanner (failing): undici 7.26.0, pulled in transitively by jsdom (a dev/test-only dependency), is affected by GHSA-vmh5-mc38-953g (High, 7.4) and GHSA-pr7r-676h-xcf6 (Medium, 5.9), both fixed in 7.28.0. jsdom pins the older line, so per the ui/osv-scanner.toml policy ("prefer fixing the dependency over ignoring it") an npm override forces undici ^7.28.0. osv-scanner now reports no issues; the UI build and all 244 vitest tests pass on the bumped version.

2. E2E "Tests" job (flaky failure): the per-IP enroll limiter defaults to 30/min (burst 30) and the E2E pipeline never overrode it. Every spec enrolls its hosts from the single CI runner IP, so under timing/parallelism the suite exhausts the bucket mid-run and a setup enroll gets HTTP 429, flaking an unrelated test (seen as the process-tree-deep host-page spec on the #429 run, whose own diff only swapped two UI assertions). Raise EDR_ENROLL_RATE_PER_MIN in the pipeline's common env. No E2E spec asserts the enroll limiter (the rate-limit specs cover break-glass, a separate limiter), and the product default is unchanged, so this removes the flake class without weakening coverage.

<!-- Keep this short. Delete sections that do not apply. -->

## What & why



## Checklist

- [ ] **OpenSpec updated for behavior changes.** If this PR changes observable behavior (a detection rule, the event
      wire schema, persistence semantics, an API/wire shape, or an emitted event), `openspec/specs/**` is updated (and
      an `openspec/changes/` proposal added), with a `spec:<id>` test marker for any new/renamed scenario. Only if this
      PR changes NO observable behavior (a comment / refactor / gofmt / dep bump that happens to touch a scoped path)
      may you assert `no-behavior-change` (label or `[no-behavior-change]` in the title) to clear the OpenSpec-sync gate.
      That is an assertion a reviewer will check, not a way to skip the spec for a real behavior change.
- [ ] Tests added/updated for the change (unit / integration / efficacy / UI as applicable).
- [ ] Agent/extension change touching ESF, XPC, or the event wire format: exercised on a live macOS VM before RC
      (flagged below).

## VM / RC notes (if applicable)


