### PR TITLE
docs(maintenance): log todo-fixme-sweep + observability-review runs

### DIFF
--- a/docs/maintenance/log.md
+++ b/docs/maintenance/log.md
@@ -28,4 +28,6 @@ or change the cadence - running tasks with no record is the same as not running 
 2026-05-28  doc-accuracy-sweep  done  branch `stale-impl-refs-sweep-2026-05-28` (atop #293)  fixed auth-refactor doc rot (OIDC/break-glass), `EDR_*` env drift, dead paths (`agent/wire`, `server/admin`); aspirational `[ ]` items left
 2026-06-09  doc-accuracy-sweep  done  branches `doc-accuracy-{broken,renamed}-2026-06-09` + issue #340  fixed `testing-strategy.md` baseline path + ADR-0007 `XPCServer`->`shared/XPCEventServer` rename; rewrote `architecture.md` pre-ADR-0004 layout
 2026-06-18  memory-and-claudemd-audit  done  branch `claude-md-audit-2026-06-18`  CLAUDE.md: `uat:e2e`->`test:e2e`, dev server is HTTPS on `0.0.0.0:8088` since #140. MEMORY.md (uncommitted): rewrote decayed #408 dev-DB entry (now merged to main). All other claims/refs verified clean
+2026-06-18  todo-fixme-sweep  done  no findings  only marker is upstream's in vendored `server/apidocs/embed/redoc.standalone.js`; `.build/` hits are untracked. Repo clean
+2026-06-18  observability-review  done  no code changes; gap tracked by #348  OTel route coverage complete (shared middleware records route-templated `http.server.request.duration`); prometheus policy clean; 2 EDR dashboards healthy (auth dash env default pinned to `prod-render`, minor); 0 alert rules, telemetry-loss/MTTD alerting already in #348
 


### PR DESCRIPTION
Two monthly maintenance tasks, both no-code-change outcomes:

- todo-fixme-sweep: no findings. The only TODO/FIXME marker in tracked source is upstream's inside the vendored redoc.standalone.js bundle; the .build/ hits are untracked SwiftPM cache.
- observability-review (first run): OTel route coverage is complete via shared middleware (route-templated http.server.request.duration), the no-Prometheus policy holds, and both EDR SigNoz dashboards are healthy. No alert rules are configured; that gap is already tracked by #348.

<!-- Keep this short. Delete sections that do not apply. -->

## What & why



## Checklist

- [ ] **OpenSpec updated for behavior changes.** If this PR changes observable behavior (a detection rule, the event
      wire schema, persistence semantics, an API/wire shape, or an emitted event), `openspec/specs/**` is updated (and
      an `openspec/changes/` proposal added), with a `spec:<id>` test marker for any new/renamed scenario. Only if this
      PR changes NO observable behavior (a comment / refactor / gofmt / dep bump that happens to touch a scoped path)
      may you assert `no-behavior-change` (label or `[no-behavior-change]` in the title) to clear the OpenSpec-sync gate.
      That is an assertion a reviewer will check, not a way to skip the spec for a real behavior change.
- [ ] Tests added/updated for the change (unit / integration / efficacy / UI as applicable).
- [ ] Agent/extension change touching ESF, XPC, or the event wire format: exercised on a live macOS VM before RC
      (flagged below).

## VM / RC notes (if applicable)


