### PR TITLE
fix(agent): keep good telemetry queued on a blanket endpoint rejection (#398)

### DIFF
--- a/agent/metrics/metrics.go
+++ b/agent/metrics/metrics.go
@@ -41,6 +41,7 @@ type QueueDepthSource interface {
 type Recorder struct {
 	queueDropped          metric.Int64Counter
 	eventsDroppedTooLarge metric.Int64Counter
+	endpointRejected      metric.Int64Counter
 	queueDepth            metric.Int64ObservableGauge
 }
 
@@ -64,6 +65,11 @@ func NewWithMeter(depthSrc QueueDepthSource, m metric.Meter) *Recorder {
 		"edr.agent.uploader.events_dropped_too_large",
 		metric.WithDescription("Events the uploader dropped after a single-event batch was rejected by the server with HTTP 413 `body_too_large`. A non-zero rate indicates an agent producing events larger than the server's per-request cap."),
 		metric.WithUnit(unitEvent),
+	)
+	r.endpointRejected, _ = m.Int64Counter(
+		"edr.agent.uploader.endpoint_rejected",
+		metric.WithDescription("Drain ticks on which the ingest endpoint returned a blanket rejection (a 4xx the EDR server never emits itself, e.g. 403/404/429), by `status_code`. Non-zero means the agent is queueing telemetry it cannot deliver: the endpoint URL is wrong, the origin is unhealthy, or an edge/WAF is blocking. The batch is kept queued, not dropped."),
+		metric.WithUnit("{rejection}"),
 	)
 	if depthSrc != nil {
 		r.queueDepth, _ = m.Int64ObservableGauge(
@@ -105,4 +111,14 @@ func (r *Recorder) EventsDroppedTooLarge(ctx context.Context, n int64) {
 		return
 	}
 	r.eventsDroppedTooLarge.Add(ctx, n)
+}
+
+// UploadRejected increments the endpoint-rejected counter once per drain tick on which the ingest endpoint returned a blanket
+// rejection (a 4xx the EDR server never emits itself: 403/404/429/...). The batch is kept queued, not dropped; this counter is the
+// operator signal that the endpoint is unreachable or misconfigured (#398). Nil-safe.
+func (r *Recorder) UploadRejected(ctx context.Context, statusCode int) {
+	if r == nil || r.endpointRejected == nil {
+		return
+	}
+	r.endpointRejected.Add(ctx, 1, metric.WithAttributes(attribute.Int("status_code", statusCode)))
 }

--- a/agent/uploader/uploader.go
+++ b/agent/uploader/uploader.go
@@ -32,8 +32,9 @@ const (
 	// up and falls through to the next drain tick.
 	defaultMaxRetries = 5
 
-	// defaultClientErrorQuarantineThreshold caps the number of consecutive drain ticks a row's batch may return a non-401 4xx
-	// before the row is quarantined (uploaded=1, removed from the dequeue set, audit log emitted). 10 matches the spec's
+	// defaultClientErrorQuarantineThreshold caps the number of consecutive drain ticks a row's batch may return an HTTP 400 (the
+	// only content-poison status; other 4xx are kept queued, see endpointRejectedError) before the row is quarantined (uploaded=1,
+	// removed from the dequeue set, audit log emitted). 10 matches the spec's
 	// "after the configured maximum retry budget is exhausted" clause and gives operators ~10 seconds at the default tick
 	// rate to roll back a bad server change before client events start dropping.
 	defaultClientErrorQuarantineThreshold = 10
@@ -70,9 +71,9 @@ type Config struct {
 	// MaxRetries is the maximum number of retries per batch on failure.
 	MaxRetries int
 
-	// ClientErrorQuarantineThreshold is the count of consecutive drain ticks a row's batch returning a non-401 4xx
+	// ClientErrorQuarantineThreshold is the count of consecutive drain ticks a row's batch returning an HTTP 400
 	// must reach before the row is marked uploaded so it stops being dequeued. 0 disables quarantine (the legacy
-	// behaviour: 4xx batches stay in the queue forever and re-fail every tick). Default applied by DefaultConfig is
+	// behaviour: 400 batches stay in the queue forever and re-fail every tick). Default applied by DefaultConfig is
 	// 10, which gives the server ~10 drain-ticks (~10s with the default 1s tick) to recover from a transient
 	// validation glitch before the agent gives up on the events.
 	ClientErrorQuarantineThreshold int
@@ -220,7 +221,8 @@ func (u *Uploader) drainBatch(ctx context.Context) (int, error) {
 //  4. 413 (requestEntityTooLargeError) with len(batch) == 1: drop the event. MarkUploaded so the queue stops surfacing it, emit
 //     a WARN log with the event id, and increment the events_dropped_too_large counter. Per the spec, 413 does NOT
 //     consume the quarantine budget because the recovery shape differs (size signal, not "malformed event" signal).
-//  5. Other 4xx: route through recordClientErrorAndAudit (the existing #253 quarantine path).
+//  5. 400: route through recordClientErrorAndAudit (the #253 quarantine path). Any other 4xx (403/404/429/...) is an
+//     endpointRejectedError: logged + counted and left queued (#398), never quarantined.
 //  6. 5xx / network / timeout (the non-clientError return from uploadWithRetry after MaxRetries): logged + returned, the
 //     batch stays queued for the next drain tick.
 //

--- a/agent/uploader/uploader.go
+++ b/agent/uploader/uploader.go
@@ -95,6 +95,11 @@ type MetricsRecorder interface {
 	// caller MUST have already MarkUploaded'd the row before this fires (drop is durable before the metric is recorded so
 	// a crash between metric + DB write doesn't manifest as a counter rate without a matching audit log).
 	EventsDroppedTooLarge(ctx context.Context, n int64)
+
+	// UploadRejected is called once per drain tick on which the ingest endpoint returned a blanket rejection (a 4xx the
+	// EDR server never emits itself, e.g. 403/404/429): the batch is kept queued, NOT dropped. statusCode labels the
+	// rejection so an operator can dashboard the "endpoint rejecting uploads" state (#398).
+	UploadRejected(ctx context.Context, statusCode int)
 }
 
 // Uploader reads from a Queue and uploads to the ingestion server.
@@ -246,9 +251,9 @@ func (u *Uploader) uploadBatch(ctx context.Context, batch []queue.QueuedEvent) e
 	return nil
 }
 
-// handleUploadErr routes a non-nil uploadWithRetry return to the appropriate recovery path: 401 leaves queued, 413
-// splits or drops, other 4xx records-and-audits, 5xx/network logs-and-returns. Extracted so uploadBatch stays under the
-// cognitive-complexity budget (Sonar S3776).
+// handleUploadErr routes a non-nil uploadWithRetry return to the appropriate recovery path: 401 leaves the batch queued for
+// re-enroll, 413 splits or drops, a 400 records-and-audits (the quarantine path), any other 4xx is a blanket endpoint rejection
+// kept queued with a loud signal, and 5xx/network logs-and-returns. Extracted so uploadBatch stays under the Sonar S3776 budget.
 func (u *Uploader) handleUploadErr(ctx context.Context, batch []queue.QueuedEvent, ids []int64, err error) error {
 	var tooLargeErr *requestEntityTooLargeError
 	if errors.As(err, &tooLargeErr) {
@@ -264,8 +269,24 @@ func (u *Uploader) handleUploadErr(ctx context.Context, batch []queue.QueuedEven
 			"batch_size", len(batch))
 		return err
 	}
-	// Non-401 4xx is a permanent client error for this batch (malformed event, schema-rejected payload, etc.). Without
-	// the quarantine path, the batch would stay queued and re-fail every drain tick forever (#253).
+	// A blanket endpoint rejection (any 4xx the ingest route never emits itself: 403/404/429/...) is an infrastructure
+	// signal, not a per-batch content verdict (#398). Keep the batch queued and back off to the next tick like a 5xx;
+	// emit a distinct loud signal so an operator sees "endpoint rejecting uploads" (wrong URL, unhealthy origin, WAF)
+	// instead of a silent quarantine-and-drop.
+	var rejectedErr *endpointRejectedError
+	if errors.As(err, &rejectedErr) {
+		u.logger.WarnContext(ctx, "uploader endpoint rejecting uploads; batch kept queued",
+			"audit", "uploader.endpoint_rejecting",
+			"status_code", rejectedErr.statusCode,
+			"batch_size", len(batch))
+		if u.metrics != nil {
+			u.metrics.UploadRejected(ctx, rejectedErr.statusCode)
+		}
+		return err
+	}
+	// HTTP 400 is the only status the ingest contract emits to mean "this batch's content is bad" (invalid_json,
+	// host_id_mismatch, missing_fields_at_<i>). Without the quarantine path, the poison batch would stay queued and
+	// re-fail every drain tick forever (#253).
 	if errors.As(err, &clientErr) && u.cfg.ClientErrorQuarantineThreshold > 0 {
 		u.recordClientErrorAndAudit(ctx, ids, clientErr.statusCode, len(batch))
 	}
@@ -384,6 +405,12 @@ func (u *Uploader) uploadWithRetry(ctx context.Context, body []byte) error {
 		if errors.As(err, &clientErr) {
 			return clientErr
 		}
+		// A blanket endpoint rejection is sustained (a down / misconfigured edge), so within-cycle retries would just
+		// hammer it; return immediately and let the per-tick drain cadence back off (#398).
+		var rejectedErr *endpointRejectedError
+		if errors.As(err, &rejectedErr) {
+			return rejectedErr
+		}
 
 		backoff := time.Duration(math.Pow(2, float64(attempt))) * 100 * time.Millisecond
 		u.logger.WarnContext(ctx, "uploader attempt failed",
@@ -401,13 +428,28 @@ func (u *Uploader) uploadWithRetry(ctx context.Context, body []byte) error {
 	return fmt.Errorf("all %d attempts failed", u.cfg.MaxRetries)
 }
 
-// clientError represents a non-retryable HTTP 4xx response other than 413.
+// clientError represents a non-retryable HTTP 4xx response the EDR ingest route itself emits as a per-batch verdict: 400 (poison
+// content, routes to the quarantine path) or 401 (stale token, routes to re-enroll). 413 is handled by its own type, and every
+// other 4xx is an endpointRejectedError.
 type clientError struct {
 	statusCode int
 }
 
 func (e *clientError) Error() string {
 	return fmt.Sprintf("server returned %d", e.statusCode)
+}
+
+// endpointRejectedError represents a non-2xx response that the EDR ingest route never emits as a per-batch content
+// verdict: any 4xx other than 400 / 401 / 413. On POST /api/events the server returns only 200 / 400 / 413 (intake) and
+// 401 / 503 (host-token middleware), so a 403 / 404 / 429 / etc. is always injected by an edge / proxy / WAF or a wrong
+// or unhealthy origin (#398): the batch content is fine, the endpoint is rejecting everything. The recovery is to keep
+// the batch queued and back off (resuming on 2xx), NOT to quarantine it as poison.
+type endpointRejectedError struct {
+	statusCode int
+}
+
+func (e *endpointRejectedError) Error() string {
+	return fmt.Sprintf("endpoint rejected upload with %d", e.statusCode)
 }
 
 // requestEntityTooLargeError represents an HTTP 413 (Request Entity Too Large) response. The server uses this status for
@@ -458,8 +500,18 @@ func (u *Uploader) doUpload(ctx context.Context, url string, body []byte) error 
 		return &requestEntityTooLargeError{}
 	}
 
-	if resp.StatusCode >= 400 && resp.StatusCode < 500 {
+	// 401 (re-enroll) and 400 (poison content) are the only 4xx the EDR ingest contract emits as a per-batch verdict: the
+	// host-token middleware returns 401/503 and the intake handler returns 200/400/413. clientError carries them to the
+	// re-enroll (401) and quarantine (400) paths in handleUploadErr.
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusBadRequest {
 		return &clientError{statusCode: resp.StatusCode}
+	}
+
+	// Any other 4xx (403, 404, 405, 408, 429, 451, ...) on POST /api/events is never the server's own content verdict; it
+	// is a blanket rejection injected by an edge/proxy/WAF or a wrong/unhealthy origin (#398). Keep the batch queued and
+	// back off rather than quarantine good telemetry.
+	if resp.StatusCode >= 400 && resp.StatusCode < 500 {
+		return &endpointRejectedError{statusCode: resp.StatusCode}
 	}
 
 	return fmt.Errorf("server returned %d", resp.StatusCode)

--- a/agent/uploader/uploader_test.go
+++ b/agent/uploader/uploader_test.go
@@ -467,11 +467,18 @@ func openTestQueue(t *testing.T) *queue.Queue {
 // read (the OTel collection cycle does not run here, but defensive against future httptest.Server work that fires the metric
 // from a worker goroutine).
 type fakeMetrics struct {
-	droppedTooLarge atomic.Int64
+	droppedTooLarge  atomic.Int64
+	endpointRejected atomic.Int64
+	lastRejectStatus atomic.Int64
 }
 
 func (f *fakeMetrics) EventsDroppedTooLarge(_ context.Context, n int64) {
 	f.droppedTooLarge.Add(n)
+}
+
+func (f *fakeMetrics) UploadRejected(_ context.Context, statusCode int) {
+	f.endpointRejected.Add(1)
+	f.lastRejectStatus.Store(int64(statusCode))
 }
 
 // tooLarge413Server stands up an httptest.Server that returns HTTP 413 with the body_too_large diagnostic when the
@@ -859,5 +866,121 @@ func TestUpload_GracefulShutdownDrainsRemaining(t *testing.T) {
 	depth, _ := q.Depth(parentCtx)
 	if depth != 0 {
 		t.Fatalf("graceful-shutdown drain must mark queued events uploaded before Run returns; depth=%d", depth)
+	}
+}
+
+// spec:agent-event-uploader/blanket-endpoint-rejections-keep-the-queue/sustained-403-preserves-the-queue-and-resumes-on-recovery
+//
+// The #398 regression: a sustained 403 (edge/WAF/unhealthy origin) must NOT quarantine good telemetry. Drive the uploader
+// well past the default quarantine threshold against a 403-everytime endpoint; every queued event must survive (the old
+// behaviour sealed the batch after 10 ticks). The endpoint-rejected counter fires, labelled with the 403. When the endpoint
+// recovers to 200, the preserved queue drains.
+func TestUpload_Sustained403PreservesQueueAndResumesOnRecovery(t *testing.T) {
+	q := openTestQueue(t)
+	ctx := t.Context()
+	for i := range 3 {
+		require.NoError(t, q.Enqueue(ctx, fmt.Appendf(nil, `{"event_id":"keep-%d"}`, i)))
+	}
+
+	var status atomic.Int32
+	status.Store(http.StatusForbidden) // the edge rejects every upload with 403
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(int(status.Load()))
+	}))
+	defer srv.Close()
+
+	fm := &fakeMetrics{}
+	cfg := DefaultConfig() // ClientErrorQuarantineThreshold == 10
+	cfg.ServerURL = srv.URL
+	u := New(q, cfg, nil, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	u.SetMetrics(fm)
+
+	for range cfg.ClientErrorQuarantineThreshold + 5 {
+		_ = u.drainOnce(ctx)
+	}
+	depth, _ := q.Depth(ctx)
+	assert.Equal(t, int64(3), depth, "sustained 403 must NOT seal or drop any event, even past the quarantine threshold")
+	assert.Positive(t, fm.endpointRejected.Load(), "the endpoint-rejected counter must fire on the 403s")
+	assert.Equal(t, int64(http.StatusForbidden), fm.lastRejectStatus.Load(), "the counter must be labelled with the 403 status")
+
+	status.Store(http.StatusOK) // endpoint recovers
+	u.drainUntilCaughtUp(ctx)
+	depth, _ = q.Depth(ctx)
+	assert.Equal(t, int64(0), depth, "the preserved queue must drain once the endpoint returns 2xx")
+}
+
+// spec:agent-event-uploader/permanent-client-errors-are-not-infinitely-retained/a-poison-batch-quarantines-while-sibling-batches-deliver
+//
+// A genuine poison batch (HTTP 400 content rejection) must still quarantine after the threshold, and it must not block its
+// siblings: with one event per batch, good-1 delivers, the poison burns its 3-tick budget and is sealed, then good-2
+// delivers. A 400 is content poison, so it must NOT trip the endpoint-rejected counter (that is the blanket-rejection path).
+func TestUpload_PoisonBatchQuarantinesWhileSiblingDelivers(t *testing.T) {
+	q := openTestQueue(t)
+	ctx := t.Context()
+	require.NoError(t, q.Enqueue(ctx, []byte(`{"event_id":"good-1"}`)))
+	require.NoError(t, q.Enqueue(ctx, []byte(`{"event_id":"poison"}`)))
+	require.NoError(t, q.Enqueue(ctx, []byte(`{"event_id":"good-2"}`)))
+
+	var goodDelivered atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		if bytes.Contains(body, []byte("poison")) {
+			w.WriteHeader(http.StatusBadRequest) // genuine poison-content 400
+			return
+		}
+		goodDelivered.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	fm := &fakeMetrics{}
+	cfg := DefaultConfig()
+	cfg.ServerURL = srv.URL
+	cfg.BatchSize = 1 // one event per batch so the poison batch is isolated from its siblings
+	cfg.ClientErrorQuarantineThreshold = 3
+	u := New(q, cfg, nil, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	u.SetMetrics(fm)
+
+	for range 6 { // deliver good-1, burn the poison's 3-tick budget, deliver good-2
+		_ = u.drainOnce(ctx)
+	}
+
+	depth, _ := q.Depth(ctx)
+	assert.Equal(t, int64(0), depth, "queue must be empty: both good events delivered, poison sealed")
+	assert.Equal(t, int32(2), goodDelivered.Load(), "both sibling good events must be delivered (200) despite the poison")
+	assert.Equal(t, int64(0), fm.endpointRejected.Load(), "a 400 is poison content, NOT a blanket endpoint rejection")
+}
+
+// spec:agent-event-uploader/blanket-endpoint-rejections-keep-the-queue/a-non-400-4xx-does-not-consume-the-quarantine-budget
+//
+// Generalises the 403 fix: any non-400 4xx the ingest route never emits itself (404, 429, ...) is a blanket rejection, so
+// it must be kept queued past the quarantine threshold rather than sealed.
+func TestUpload_Non400ClientErrorsKeepQueue(t *testing.T) {
+	for _, status := range []int{http.StatusNotFound, http.StatusTooManyRequests} {
+		t.Run(fmt.Sprintf("status_%d", status), func(t *testing.T) {
+			q := openTestQueue(t)
+			ctx := t.Context()
+			require.NoError(t, q.Enqueue(ctx, []byte(`{"event_id":"keep"}`)))
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(status)
+			}))
+			defer srv.Close()
+
+			fm := &fakeMetrics{}
+			cfg := DefaultConfig()
+			cfg.ServerURL = srv.URL
+			cfg.ClientErrorQuarantineThreshold = 3
+			u := New(q, cfg, nil, slog.New(slog.NewTextHandler(io.Discard, nil)))
+			u.SetMetrics(fm)
+
+			for range cfg.ClientErrorQuarantineThreshold + 2 {
+				_ = u.drainOnce(ctx)
+			}
+			depth, _ := q.Depth(ctx)
+			assert.Equal(t, int64(1), depth, "a non-400 4xx must be kept queued, never quarantined")
+			assert.Positive(t, fm.endpointRejected.Load(), "the endpoint-rejected counter must fire")
+			assert.Equal(t, int64(status), fm.lastRejectStatus.Load())
+		})
 	}
 }

--- a/openspec/changes/uploader-edge-rejection-no-quarantine/proposal.md
+++ b/openspec/changes/uploader-edge-rejection-no-quarantine/proposal.md
@@ -1,0 +1,21 @@
+# Keep good telemetry queued when the ingest endpoint blanket-rejects uploads
+
+## Why
+
+The agent uploader treats a sustained HTTP 403 on `POST /api/events` like a malformed-payload 4xx: after `ClientErrorQuarantineThreshold` consecutive failed drain ticks (default 10) it seals the batch (`uploaded=1`), stops dequeuing it (#253 quarantine), and silently drops good telemetry. But the EDR ingest route never itself returns 403. The host-token middleware (`server/endpoint/internal/middleware/hosttoken.go`) returns only 401 / 503, and the intake handler (`server/detection/internal/intake/handler.go`) returns only 200 / 400 / 413. A 403 the agent sees is therefore always injected by an edge/proxy/WAF or a wrong/unhealthy origin: the batch content is fine, the endpoint is rejecting everything. The same holds for every 4xx other than 400 (poison content), 401 (re-enroll), and 413 (too large): 404, 405, 408, 429, 451, and the rest are all infrastructure signals on this route, not per-batch content verdicts.
+
+This was a real incident (2026-06-16): a fresh Render deploy returned 403 at the edge while the origin was unhealthy; every batch burned its 10-tick budget and was dropped while the endpoint was unreachable (#398). A "back off and keep the queue" recovery would have preserved that telemetry.
+
+## What changes
+
+- **The quarantine budget is reserved for HTTP 400 only.** 400 is the single status the ingest contract emits to mean "this batch's content is bad" (`invalid_json` / `host_id_mismatch` / `missing_fields_at_<i>`). A persistent 400 still seals the batch after the threshold, exactly as today.
+- **Every other non-2xx the route never legitimately emits as a content verdict (any 4xx except 400/401/413) is treated as a transient endpoint rejection.** The batch is kept queued (`uploaded=0`), the uploader backs off to the next drain cycle, and uploads resume automatically when the endpoint returns 2xx. Retention during the rejection window is bounded only by the existing `EDR_AGENT_QUEUE_MAX_BYTES` lossy cap, not by the quarantine budget.
+- **A distinct, loud signal marks the "endpoint rejecting uploads" state.** A dedicated WARN (`audit=uploader.endpoint_rejecting`, with `status_code`) and an OTel counter (`edr.agent.uploader.endpoint_rejected`, by `status_code`) fire so an operator sees "server unreachable / misconfigured" rather than a quiet drop.
+- 401 (re-enroll) and 413 (split-and-retry) keep their existing handling unchanged.
+
+Affected code: `agent/uploader/uploader.go` (status classification + recovery routing) and `agent/metrics/metrics.go` plus the uploader's `MetricsRecorder` interface (the new counter). Agent-side persistence/recovery only: no wire-format, schema, server, or migration change.
+
+### Not in this change
+
+- No change to the 400 quarantine path, the 401 re-enroll path, or the 413 split-and-retry path.
+- No change to the queue's lossy `EDR_AGENT_QUEUE_MAX_BYTES` cap: a long outage still bounds agent memory by dropping the oldest rows at the cap (lossy, counted in `edr.agent.queue.dropped`), which is a separate, already-signalled mechanism from quarantine.

--- a/openspec/changes/uploader-edge-rejection-no-quarantine/specs/agent-event-uploader/spec.md
+++ b/openspec/changes/uploader-edge-rejection-no-quarantine/specs/agent-event-uploader/spec.md
@@ -1,0 +1,41 @@
+# Agent Event Uploader Specification (delta)
+
+## MODIFIED Requirements
+
+### Requirement: Permanent client errors are not infinitely retained
+
+The system SHALL stop retrying batches that consistently produce an HTTP 400 (bad request) response after the configured maximum and SHALL emit an audit log entry so the operator can investigate why the server rejected those events. HTTP 400 is the only status the ingestion route emits to signal that a batch's content is bad (`invalid_json`, `host_id_mismatch`, `missing_fields_at_<i>`), so it is the only status that consumes the quarantine budget. A 401 (re-enroll) and a 413 (split-and-retry) keep their own recovery paths and do not consume the quarantine budget; any other status is handled as a blanket endpoint rejection (see "Blanket endpoint rejections keep the queue").
+
+#### Scenario: Server consistently returns 4xx for a malformed event
+
+- **GIVEN** the server returns HTTP 400 (the only malformed-content 4xx the ingest route emits) for a batch on every attempt
+- **WHEN** the configured maximum retry budget is exhausted
+- **THEN** the uploader records an audit log entry identifying the failure
+- **AND** the batch is not retransmitted indefinitely
+
+#### Scenario: A poison batch quarantines while sibling batches deliver
+
+- **GIVEN** one batch consistently returns HTTP 400 while other batches return 2xx
+- **WHEN** the poison batch crosses the quarantine threshold
+- **THEN** only the poison batch is sealed
+- **AND** the sibling batches are delivered and marked uploaded
+
+## ADDED Requirements
+
+### Requirement: Blanket endpoint rejections keep the queue
+
+The ingestion route (`POST /api/events`) emits only 200, 400, 413 (intake handler) and 401, 503 (host-token middleware). Any other status the uploader observes (in particular 403, and likewise 404, 405, 408, 429, 451, and other non-2xx 4xx) is therefore not a per-batch content verdict from the EDR server but a blanket rejection injected by an edge/proxy/WAF or a wrong/unhealthy origin. The system MUST treat such a response as a transient endpoint rejection: it SHALL keep the batch queued (neither sealing it nor consuming the quarantine budget), back off to the next drain cycle, and resume delivery automatically when the endpoint returns 2xx. Retention during the rejection window is bounded only by the queue's `EDR_AGENT_QUEUE_MAX_BYTES` lossy cap. The system MUST emit a distinct WARN log and increment a dedicated counter labelled by status code so an operator can distinguish "the endpoint is rejecting every upload" from a quiet success.
+
+#### Scenario: Sustained 403 preserves the queue and resumes on recovery
+
+- **GIVEN** the endpoint returns HTTP 403 for every upload across many drain cycles
+- **WHEN** the uploader drains repeatedly
+- **THEN** no batch is sealed or dropped and the queued events remain (bounded only by the queue byte cap)
+- **AND** the uploader emits the endpoint-rejection WARN and increments the endpoint-rejected counter
+- **AND** when the endpoint later returns 2xx, the queued events are delivered and marked uploaded
+
+#### Scenario: A non-400 4xx does not consume the quarantine budget
+
+- **GIVEN** the endpoint returns HTTP 429 (or 404) for a batch on every attempt
+- **WHEN** the uploader drains more times than the quarantine threshold
+- **THEN** the batch is not sealed and remains queued for a future cycle

--- a/openspec/changes/uploader-edge-rejection-no-quarantine/specs/agent-event-uploader/spec.md
+++ b/openspec/changes/uploader-edge-rejection-no-quarantine/specs/agent-event-uploader/spec.md
@@ -1,4 +1,4 @@
-# Agent Event Uploader Specification (delta)
+# Agent event uploader specification (delta)
 
 ## MODIFIED Requirements
 

--- a/openspec/changes/uploader-edge-rejection-no-quarantine/tasks.md
+++ b/openspec/changes/uploader-edge-rejection-no-quarantine/tasks.md
@@ -1,0 +1,22 @@
+# Keep good telemetry queued on blanket endpoint rejection: tasks
+
+## 1. Uploader
+
+- [ ] `agent/uploader/uploader.go`: add `endpointRejectedError{statusCode}`. In `doUpload`, classify 401 and 400 as `clientError` (re-enroll / quarantine paths unchanged), 413 as `requestEntityTooLargeError`, and every other 4xx as `endpointRejectedError`. `uploadWithRetry` returns `endpointRejectedError` immediately (non-retryable within the cycle, like the other 4xx). `handleUploadErr` routes `endpointRejectedError` to a WARN (`audit=uploader.endpoint_rejecting`, `status_code`) plus the new counter and keeps the batch queued; the quarantine branch now only ever sees 400.
+
+## 2. Metrics
+
+- [ ] `agent/metrics/metrics.go`: add the `edr.agent.uploader.endpoint_rejected` counter (labelled by `status_code`) and the `UploadRejected(ctx, statusCode)` method; add `UploadRejected` to the uploader's `MetricsRecorder` interface. Nil-safe.
+
+## 3. Spec
+
+- [ ] `agent-event-uploader` delta: MODIFY "Permanent client errors are not infinitely retained" to scope quarantine to HTTP 400; ADD "Blanket endpoint rejections keep the queue" with the sustained-403 / resume-on-2xx and the non-400-4xx scenarios.
+
+## 4. Tests
+
+- [ ] `agent/uploader/uploader_test.go`: sustained 403 keeps the queue and resumes on 200; a persistent 400 still quarantines while a sibling batch delivers; 404/429 are kept queued. Extend `fakeMetrics` with `UploadRejected`. Scenario markers on the new tests; update the renamed 400-quarantine marker.
+
+## 5. Verification
+
+- [ ] `go test ./agent/...` green; gofmt + `task lint:go` on touched packages; `openspec validate uploader-edge-rejection-no-quarantine --strict`; `tools/spectrace`; dash + markdown lints.
+- [ ] Manual E2E: agent against the dev server, inject a sustained 403 at an edge shim, confirm the queue is preserved + `edr.agent.uploader.endpoint_rejected` shows in SigNoz + no drop; restore 200 and confirm the backlog drains.


### PR DESCRIPTION
## Summary

Fixes #398. The agent uploader treated any non-401 4xx on `POST /api/events` as a per-batch content error: after `ClientErrorQuarantineThreshold` consecutive failed drain ticks (default 10) it sealed the batch (`uploaded=1`) and dropped it (#253 quarantine). But the EDR ingest route only ever emits **200/400/413** (intake) and **401/503** (host-token middleware), so a **403** (or 404/429/...) is always an edge/proxy/WAF or unhealthy-origin signal, never "this batch is bad". A real Render incident (2026-06-16) dropped good telemetry this way.

## What changed

- **Quarantine is now reserved for HTTP 400** (the only content-poison status the ingest contract emits). A persistent 400 still seals the batch after the threshold, exactly as before.
- **Every other non-2xx the route never emits itself (any 4xx except 400/401/413) becomes a transient `endpointRejectedError`**: the batch stays queued (`uploaded=0`), the uploader backs off per drain tick, and uploads resume automatically on 2xx. Retention during the rejection window is bounded only by the existing `EDR_AGENT_QUEUE_MAX_BYTES` lossy cap, not by the quarantine budget.
- **A distinct, loud signal** marks the state: a WARN (`audit=uploader.endpoint_rejecting`, with `status_code`) plus a new OTel counter `edr.agent.uploader.endpoint_rejected` (by `status_code`).
- 401 (re-enroll) and 413 (split-and-retry) are unchanged.

## Spec

`openspec/changes/uploader-edge-rejection-no-quarantine/` narrows the "Permanent client errors" requirement to 400 and adds "Blanket endpoint rejections keep the queue". `openspec validate --strict` passes.

## Tests

`agent/uploader/uploader_test.go`: sustained 403 preserves the queue and resumes on 200; a persistent 400 still quarantines while a sibling batch delivers; 404/429 are kept queued. `-race` green; `task lint:go` clean; `spectrace check --strict` 419/419.

## Manual verification (live)

Ran the real patched agent binary against the live dev server through a toggleable 403 edge, exporting to SigNoz (`deployment.environment=dev-local`):

- **Sustained 403: 70 drain ticks, 0 events dropped, 0 quarantine lines** (old behavior dropped at tick 10). Each tick logged `uploader endpoint rejecting uploads`.
- The new `edr.agent.uploader.endpoint_rejected` counter reached SigNoz.
- **Recovery (flip to 200): all 200 preserved events delivered** to the dev server (`SELECT COUNT(*) ... = 200`), agent went quiet, no quarantine/errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)