### PR TITLE
fix: surface a reboot-required signal after a sysext upgrade strands NE telemetry (#399)

### DIFF
--- a/agent/cmd/fleet-edr-agent/main.go
+++ b/agent/cmd/fleet-edr-agent/main.go
@@ -168,9 +168,10 @@ func run() error {
 	go coalescer.Run(ctx)
 
 	pidTable := proctable.New()
-	go startReceiverLoop(ctx, logger, cfg.XPCService, coalescer.Handle, pidTable, true, esfDispatcher)
+	go startReceiverLoop(ctx, logger, cfg.XPCService, coalescer.Handle, pidTable, true, esfDispatcher, nil)
 	if cfg.NetXPCService != "" {
-		go startReceiverLoop(ctx, logger, cfg.NetXPCService, coalescer.Handle, pidTable, false, nil)
+		go startReceiverLoop(ctx, logger, cfg.NetXPCService, coalescer.Handle, pidTable, false, nil,
+			func() bool { return receiver.NEUpgradePending(ctx) })
 	}
 	go runUploader(ctx, up, logger)
 
@@ -374,6 +375,7 @@ func startReceiverLoop(
 	pt *proctable.Table,
 	updateTable bool,
 	dispatcher *receiver.Dispatcher,
+	upgradeProbe func() bool,
 ) {
 	factory := func() receiver.Connector {
 		return receiver.New(xpcService, receiverEventBuffer)
@@ -396,6 +398,10 @@ func startReceiverLoop(
 		hooks.OnConnected = dispatcher.Set
 		hooks.OnDisconnected = dispatcher.Clear
 	}
+	// Only the network-extension loop wires UpgradeProbe (nil for ESF): after a staged upgrade the NE's nesessionmanager-owned
+	// Mach service stays bound to the terminated old version until reboot, so a sustained NE connect failure paired with a
+	// pending-uninstall old version means "reboot required", not "needs approval" (#399).
+	hooks.UpgradeProbe = upgradeProbe
 	loop := receiver.NewLoop(factory, receiver.LoopConfig{
 		ServiceName:       xpcService,
 		HeartbeatInterval: xpcHeartbeatInterval,

--- a/agent/receiver/loop.go
+++ b/agent/receiver/loop.go
@@ -31,6 +31,10 @@ const (
 	// defaultHeartbeatTimeout is the per-ping wait for a "hello-ack". Aligned with HELLO_ACK_TIMEOUT_NS in agent/xpcbridge/xpc_bridge.c
 	// and comfortably above the observed round-trip latency on edr-dev.
 	defaultHeartbeatTimeout = 5 * time.Second
+	// staleProbeAfterFailures is the consecutive-connect-failure grace before the UpgradeProbe is consulted. With the
+	// 1s/2s/4s... backoff this is several seconds of sustained failure, long enough to skip a transient blip but short
+	// enough that an operator sees the actionable reboot hint promptly after a staged sysext upgrade (#399).
+	staleProbeAfterFailures = 3
 )
 
 // Connector represents a single XPC connection's lifecycle. Production code satisfies it with *Receiver; tests pass a deterministic
@@ -83,6 +87,13 @@ type LoopHooks struct {
 	// observable without real wall-clock waits. The function returns false if ctx was cancelled during the wait, true if the
 	// duration elapsed normally.
 	Sleep func(ctx context.Context, d time.Duration) bool
+
+	// UpgradeProbe, when non-nil, is consulted after staleProbeAfterFailures consecutive connect failures to decide whether the
+	// failure is a stale network-extension registration left by a staged sysext upgrade (the OS reports a previous NE version
+	// "waiting to uninstall on reboot") rather than a not-yet-approved extension. Wired ONLY on the network-extension loop
+	// (#399); nil on the ESF loop. Returning true switches the connect-failure log to a distinct, actionable reboot-required
+	// hint, emitted once per stale episode.
+	UpgradeProbe func() bool
 }
 
 // Loop runs a single XPC service's connect/reconnect/event-pump cycle. Build one with NewLoop and call Run(ctx) in its own goroutine.
@@ -92,6 +103,12 @@ type Loop struct {
 	cfg     LoopConfig
 	hooks   LoopHooks
 	logger  *slog.Logger
+
+	// consecutiveFailures counts connect failures since the last successful session; it gates the UpgradeProbe so a
+	// transient blip does not trigger the reboot hint. staleHintLogged keeps the distinct hint to once per stale episode.
+	// Both are touched only from the single Run goroutine, so they need no synchronization.
+	consecutiveFailures int
+	staleHintLogged     bool
 }
 
 // NewLoop constructs a Loop. The factory MUST return a fresh Connector per call. A nil logger falls back to slog.Default(). Zero-valued
@@ -164,9 +181,14 @@ func (l *Loop) Run(ctx context.Context) {
 func (l *Loop) runOnce(ctx context.Context) (reconnect, connected bool) {
 	conn := l.factory()
 	if err := conn.Connect(); err != nil {
-		l.logger.WarnContext(ctx, "receiver connect", "service", l.cfg.ServiceName, "err", err)
+		l.consecutiveFailures++
+		l.logConnectFailure(ctx, err)
 		return true, false
 	}
+	// Successful connect ends any stale episode: reset the failure counter and re-arm the one-shot reboot hint so a future
+	// upgrade is reported again.
+	l.consecutiveFailures = 0
+	l.staleHintLogged = false
 	l.logger.InfoContext(ctx, "receiver connected", "service", l.cfg.ServiceName)
 
 	if l.hooks.OnConnected != nil {
@@ -178,6 +200,22 @@ func (l *Loop) runOnce(ctx context.Context) (reconnect, connected bool) {
 	}
 	conn.Disconnect()
 	return reconnect, true
+}
+
+// logConnectFailure emits the per-attempt connect-failure log. Once the failure has persisted past staleProbeAfterFailures
+// consecutive attempts AND an UpgradeProbe is wired (the network-extension loop) AND it reports a previous version pending
+// removal on reboot, it emits a distinct, actionable reboot-required hint once per stale episode (#399) instead of the bare
+// "receiver connect" warning. The bare warning stays for the genuine not-yet-approved case, where no UpgradeProbe is wired or
+// no old version is pending removal, so an operator can still tell "needs approval" from "needs reboot after upgrade".
+func (l *Loop) logConnectFailure(ctx context.Context, err error) {
+	if l.hooks.UpgradeProbe != nil && l.consecutiveFailures >= staleProbeAfterFailures && !l.staleHintLogged && l.hooks.UpgradeProbe() {
+		l.staleHintLogged = true
+		l.logger.WarnContext(ctx,
+			"network extension XPC registration is stale after an upgrade; reboot to complete the extension cutover",
+			"service", l.cfg.ServiceName, "err", err, "hint", "reboot_required_after_upgrade")
+		return
+	}
+	l.logger.WarnContext(ctx, "receiver connect", "service", l.cfg.ServiceName, "err", err)
 }
 
 // pipeEvents reads from the connector's event + error channels and dispatches

--- a/agent/receiver/loop_test.go
+++ b/agent/receiver/loop_test.go
@@ -1,6 +1,7 @@
 package receiver
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io"
@@ -539,4 +540,86 @@ func TestLoop_CleanShutdownOnContextCancellation(t *testing.T) {
 	built := conns()
 	require.GreaterOrEqual(t, len(built), 1)
 	assert.True(t, built[0].disconnected.Load(), "Disconnect must run on shutdown")
+}
+
+func bufferLogger() (*slog.Logger, *bytes.Buffer) {
+	buf := &bytes.Buffer{}
+	return slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug})), buf
+}
+
+// spec:agent-xpc-receiver/distinct-signal-when-a-sysext-upgrade-leaves-the-ne-registration-stale/ne-connect-keeps-failing-while-a-prior-version-waits-to-uninstall-on-reboot
+// spec:agent-xpc-receiver/distinct-signal-when-a-sysext-upgrade-leaves-the-ne-registration-stale/a-not-yet-approved-network-extension-keeps-the-generic-warning
+//
+// TestLoop_ConnectFailureLog pins the #399 message selection: the distinct reboot-required hint fires only when an
+// UpgradeProbe is wired (the NE loop) AND the failure has persisted past the grace threshold AND the probe reports a pending
+// uninstall; otherwise the bare "receiver connect" warning is logged. The hint fires at most once per stale episode.
+func TestLoop_ConnectFailureLog(t *testing.T) {
+	const distinct = "stale after an upgrade"
+	const bare = "receiver connect"
+	connErr := errors.New("xpc_bridge_connect failed")
+	nilFactory := func() Connector { return nil } // never invoked: these subtests call logConnectFailure directly
+
+	t.Run("no probe (ESF loop) always logs the bare warning", func(t *testing.T) {
+		logger, buf := bufferLogger()
+		l := NewLoop(nilFactory, LoopConfig{ServiceName: "sys"}, LoopHooks{}, logger)
+		l.consecutiveFailures = staleProbeAfterFailures + 5
+		l.logConnectFailure(context.Background(), connErr)
+		assert.Contains(t, buf.String(), bare)
+		assert.NotContains(t, buf.String(), distinct)
+	})
+
+	t.Run("under the grace threshold logs the bare warning", func(t *testing.T) {
+		logger, buf := bufferLogger()
+		l := NewLoop(nilFactory, LoopConfig{ServiceName: "net"},
+			LoopHooks{UpgradeProbe: func() bool { return true }}, logger)
+		l.consecutiveFailures = staleProbeAfterFailures - 1
+		l.logConnectFailure(context.Background(), connErr)
+		assert.Contains(t, buf.String(), bare)
+		assert.NotContains(t, buf.String(), distinct)
+	})
+
+	t.Run("probe false (not approved) logs the bare warning past the threshold", func(t *testing.T) {
+		logger, buf := bufferLogger()
+		l := NewLoop(nilFactory, LoopConfig{ServiceName: "net"},
+			LoopHooks{UpgradeProbe: func() bool { return false }}, logger)
+		l.consecutiveFailures = staleProbeAfterFailures + 1
+		l.logConnectFailure(context.Background(), connErr)
+		assert.Contains(t, buf.String(), bare)
+		assert.NotContains(t, buf.String(), distinct)
+	})
+
+	t.Run("upgrade pending past the threshold logs the distinct hint once", func(t *testing.T) {
+		logger, buf := bufferLogger()
+		var probeCalls int
+		l := NewLoop(nilFactory, LoopConfig{ServiceName: "net"},
+			LoopHooks{UpgradeProbe: func() bool { probeCalls++; return true }}, logger)
+		l.consecutiveFailures = staleProbeAfterFailures
+		l.logConnectFailure(context.Background(), connErr)
+		assert.Contains(t, buf.String(), distinct)
+		assert.Contains(t, buf.String(), "reboot_required_after_upgrade")
+
+		buf.Reset()
+		l.consecutiveFailures++
+		l.logConnectFailure(context.Background(), connErr)
+		assert.NotContains(t, buf.String(), distinct, "the reboot hint fires once per stale episode")
+		assert.Contains(t, buf.String(), bare)
+		assert.Equal(t, 1, probeCalls, "probe is not consulted again once the hint has fired")
+	})
+}
+
+// TestLoop_SuccessResetsStaleTracking verifies a successful connect clears the stale-after-upgrade state so a later upgrade
+// is reported again (#399).
+func TestLoop_SuccessResetsStaleTracking(t *testing.T) {
+	factory, _ := scriptedFactory([]stubScript{{
+		onConnect: func(c *stubConnector) { c.emitError(1) }, // end the session promptly so runOnce returns
+	}})
+	l := NewLoop(factory, LoopConfig{ServiceName: "net", HeartbeatInterval: time.Hour, HeartbeatTimeout: time.Second},
+		LoopHooks{Sleep: (&recordingSleep{}).Sleep, UpgradeProbe: func() bool { return true }}, discardLogger())
+	l.consecutiveFailures = staleProbeAfterFailures + 2
+	l.staleHintLogged = true
+
+	_, connected := l.runOnce(context.Background())
+	assert.True(t, connected)
+	assert.Equal(t, 0, l.consecutiveFailures, "a successful connect resets the failure counter")
+	assert.False(t, l.staleHintLogged, "a successful connect re-arms the one-shot reboot hint")
 }

--- a/agent/receiver/upgradeprobe.go
+++ b/agent/receiver/upgradeprobe.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os/exec"
 	"strings"
+	"time"
 )
 
 // neExtensionBundleID is the network extension's bundle identifier as systemextensionsctl reports it (NOT the app-group Mach
@@ -14,13 +15,25 @@ const neExtensionBundleID = "com.fleetdm.edr.networkextension"
 // uninstallOnRebootMarker is the state phrase systemextensionsctl prints for a version macOS will remove on the next reboot.
 const uninstallOnRebootMarker = "waiting to uninstall on reboot"
 
+// systemextensionsctlPath is the ABSOLUTE path to the system-extension CLI. Invoking it by absolute path (not a bare command
+// resolved via PATH) both hardens the root LaunchDaemon against a hijacked / writable PATH entry (gosec G204, Sonar go:S4036)
+// and guarantees the probe runs under the minimal PATH a LaunchDaemon inherits, where a bare "systemextensionsctl" could fail
+// and silently suppress the reboot hint.
+const systemextensionsctlPath = "/usr/bin/systemextensionsctl"
+
+// neUpgradeProbeTimeout bounds the probe so a hung systemextensionsctl cannot stall the receiver's connect loop: the probe is
+// called synchronously from the loop goroutine, so an unbounded exec would freeze reconnect/heartbeat for that service.
+const neUpgradeProbeTimeout = 5 * time.Second
+
 // NEUpgradePending reports whether the OS has a previous network-extension version staged for removal on reboot, the condition
 // that strands the NE's Mach service registration on the dead version until reboot (#399). Best-effort: any error running
 // systemextensionsctl (including on non-darwin, where the binary is absent) returns false, so the agent falls back to the
 // generic connect-failure warning rather than a misleading reboot hint. Wired as the network-extension Loop's UpgradeProbe;
 // the ESF loop does not use it.
 func NEUpgradePending(ctx context.Context) bool {
-	out, err := exec.CommandContext(ctx, "systemextensionsctl", "list").CombinedOutput()
+	ctx, cancel := context.WithTimeout(ctx, neUpgradeProbeTimeout)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, systemextensionsctlPath, "list").CombinedOutput()
 	if err != nil {
 		return false
 	}

--- a/agent/receiver/upgradeprobe.go
+++ b/agent/receiver/upgradeprobe.go
@@ -1,0 +1,41 @@
+package receiver
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+)
+
+// neExtensionBundleID is the network extension's bundle identifier as systemextensionsctl reports it (NOT the app-group Mach
+// service name the agent connects to). A staged upgrade leaves the previous version of this bundle waiting to uninstall on
+// reboot while the new version is active, which strands the NE's Mach service registration on the dead version (#399).
+const neExtensionBundleID = "com.fleetdm.edr.networkextension"
+
+// uninstallOnRebootMarker is the state phrase systemextensionsctl prints for a version macOS will remove on the next reboot.
+const uninstallOnRebootMarker = "waiting to uninstall on reboot"
+
+// NEUpgradePending reports whether the OS has a previous network-extension version staged for removal on reboot, the condition
+// that strands the NE's Mach service registration on the dead version until reboot (#399). Best-effort: any error running
+// systemextensionsctl (including on non-darwin, where the binary is absent) returns false, so the agent falls back to the
+// generic connect-failure warning rather than a misleading reboot hint. Wired as the network-extension Loop's UpgradeProbe;
+// the ESF loop does not use it.
+func NEUpgradePending(ctx context.Context) bool {
+	out, err := exec.CommandContext(ctx, "systemextensionsctl", "list").CombinedOutput()
+	if err != nil {
+		return false
+	}
+	return parseNEUpgradePending(string(out), neExtensionBundleID)
+}
+
+// parseNEUpgradePending is the pure core: true when any single line names the network-extension bundle AND carries the
+// waiting-to-uninstall-on-reboot marker. Per-line matching on those two stable tokens isolates the old, terminated version
+// (which carries the marker) from the new, active version (same bundle id, no marker) and stays robust to the surrounding
+// columns (team id, version, display name, enabled/active flags) that vary across macOS versions and install states.
+func parseNEUpgradePending(systemextensionsctlOutput, bundleID string) bool {
+	for line := range strings.SplitSeq(systemextensionsctlOutput, "\n") {
+		if strings.Contains(line, bundleID) && strings.Contains(line, uninstallOnRebootMarker) {
+			return true
+		}
+	}
+	return false
+}

--- a/agent/receiver/upgradeprobe_test.go
+++ b/agent/receiver/upgradeprobe_test.go
@@ -1,0 +1,56 @@
+package receiver
+
+import "testing"
+
+// TestParseNEUpgradePending pins the systemextensionsctl-output parsing that distinguishes a staged upgrade (a previous NE
+// version "waiting to uninstall on reboot") from every other state, so the agent only emits the reboot-required hint when a
+// reboot is genuinely the fix (#399). The marker must land on a line that also names OUR network-extension bundle.
+func TestParseNEUpgradePending(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name   string
+		output string
+		want   bool
+	}{
+		{
+			name: "staged upgrade: old version waiting to uninstall on reboot",
+			output: "2 extension(s)\n" +
+				"--- com.apple.system_extension.network_extension\n" +
+				"enabled\tactive\tteamID\tbundleID (version)\tname\t[state]\n" +
+				"*\t*\tFDG8Q7N4CC\tcom.fleetdm.edr.networkextension (0.2.1/1)\tFleet EDR Network Extension\t[activated enabled]\n" +
+				"\t*\tFDG8Q7N4CC\tcom.fleetdm.edr.networkextension (0.1.1/1)\tnetworkextension\t[terminated waiting to uninstall on reboot]\n",
+			want: true,
+		},
+		{
+			name: "single active version: no pending uninstall",
+			output: "1 extension(s)\n" +
+				"*\t*\tFDG8Q7N4CC\tcom.fleetdm.edr.networkextension (0.2.1/1)\tFleet EDR Network Extension\t[activated enabled]\n",
+			want: false,
+		},
+		{
+			name: "not approved yet: NE present but no reboot marker",
+			output: "1 extension(s)\n" +
+				"\t\tFDG8Q7N4CC\tcom.fleetdm.edr.networkextension (0.2.1/1)\tFleet EDR Network Extension\t[activated waiting for user]\n",
+			want: false,
+		},
+		{
+			name: "a different vendor's NE waiting to uninstall must not match",
+			output: "1 extension(s)\n" +
+				"\t*\tOTHERTEAM\tcom.othervendor.networkextension (1.0/1)\tOther\t[terminated waiting to uninstall on reboot]\n",
+			want: false,
+		},
+		{
+			name:   "empty output",
+			output: "",
+			want:   false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := parseNEUpgradePending(tc.output, neExtensionBundleID); got != tc.want {
+				t.Fatalf("parseNEUpgradePending = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/extension/edr/Tests/EDRExtensionLogicTests/HostAppExtensionManagerTests.swift
+++ b/extension/edr/Tests/EDRExtensionLogicTests/HostAppExtensionManagerTests.swift
@@ -292,4 +292,20 @@ final class HostAppExtensionManagerTests: XCTestCase {
         XCTAssertTrue(usage.lowercased().contains("extra positional"),
                       "usage message must call out the extra-positional rejection rule")
     }
+
+    // spec:host-app-extension-manager/a-staged-upgrade-surfaces-a-reboot-required-signal/activation-will-complete-after-reboot
+    // spec:host-app-extension-manager/a-staged-upgrade-surfaces-a-reboot-required-signal/fresh-activation-does-not-prompt-for-reboot
+    //
+    // #399: a staged upgrade (.rebootRequired on activate) must surface an operator-facing reboot message, while a fresh
+    // install (.allSucceeded), a failure, and any deactivate path must not, so a fresh install never shows a spurious prompt.
+    func testRebootRequiredMessageOnlyForActivateRebootRequired() {
+        XCTAssertNotNil(rebootRequiredMessage(for: .activate, verdict: .rebootRequired),
+                        "a staged upgrade on activate must surface a reboot message")
+        XCTAssertNil(rebootRequiredMessage(for: .activate, verdict: .allSucceeded),
+                     "a fresh install (allSucceeded) must not prompt for reboot")
+        XCTAssertNil(rebootRequiredMessage(for: .activate, verdict: .anyFailed),
+                     "a failed activation must not prompt for reboot")
+        XCTAssertNil(rebootRequiredMessage(for: .deactivate, verdict: .rebootRequired),
+                     "deactivate never warrants a reboot message")
+    }
 }

--- a/extension/edr/edr/ExtensionManagerLogic.swift
+++ b/extension/edr/edr/ExtensionManagerLogic.swift
@@ -171,6 +171,17 @@ func postAggregateStep(for action: HostAppAction, verdict: AggregateVerdict) -> 
     return .exitImmediately
 }
 
+/// rebootRequiredMessage returns the operator-facing message the host app surfaces when an activation will complete only
+/// after a reboot, or nil when no reboot signal is warranted. A `.rebootRequired` verdict on the activate path means the OS
+/// is deferring removal of a previous extension version until reboot; during that window the network extension's Mach
+/// service stays bound to the terminated old version, so the agent loses network + DNS telemetry until the host reboots
+/// (#399). A fresh install reports `.allSucceeded` (no prior version to evict) and so gets no message, which keeps the
+/// fresh-install path free of a spurious reboot prompt. Deactivate and failure paths never warrant a reboot message.
+func rebootRequiredMessage(for action: HostAppAction, verdict: AggregateVerdict) -> String? {
+    guard action == .activate, verdict == .rebootRequired else { return nil }
+    return "Fleet EDR upgrade staged; reboot to finish the extension cutover and restore network + DNS coverage."
+}
+
 /// SubcommandIntent is the typed side-effect a single host-app subcommand invocation produces. The
 /// production code in main.swift translates each subcommand into the equivalent OSSystemExtensionRequest
 /// or NEManager mutation; the intents here are a pure-data view of that contract so tests can assert

--- a/extension/edr/edr/main.swift
+++ b/extension/edr/edr/main.swift
@@ -83,6 +83,13 @@ final class ExtensionManager: NSObject, OSSystemExtensionRequestDelegate {
     /// body has nothing to do with. The collision would be a compile error if both kept the same selector.
     private func finalizeAggregate() {
         let verdict = aggregator.verdict
+        // A staged upgrade (the OS defers removing a previous extension version until reboot) leaves the network
+        // extension's Mach service bound to the terminated old version, so the agent loses network + DNS telemetry until
+        // the host reboots. Surface a distinct, operator-facing log line so a reboot is recognizably the fix rather than a
+        // generic "will complete after reboot" info line (#399). A fresh install reports .allSucceeded and gets nothing.
+        if let message = rebootRequiredMessage(for: action, verdict: verdict) {
+            logger.warning("\(message, privacy: .public)")
+        }
         switch postAggregateStep(for: action, verdict: verdict) {
         case .enableContentFilterThenDNSProxy:
             // Enable the content filter, then chain into the DNS proxy so a freshly activated host emits all

--- a/openspec/changes/ne-upgrade-reboot-signal/proposal.md
+++ b/openspec/changes/ne-upgrade-reboot-signal/proposal.md
@@ -1,0 +1,24 @@
+# Surface "reboot required" after a sysext upgrade leaves the NE registration stale
+
+## Why
+
+After a signed-pkg **upgrade** replaces the system extensions, macOS defers removing the previous version until reboot. During that window the network extension's Mach service `group.com.fleetdm.edr.networkextension` (owned by `nesessionmanager`, not the extension process) stays bound to the OLD, `terminated waiting to uninstall on reboot` extension. The new NE runs and captures, but the agent's `xpc_connection_create_mach_service` resolves the stale registration and never gets a hello-ack. The agent silently loses all network + DNS telemetry until the host reboots, and the only signal is a bare `xpc_bridge_connect failed` WARN that is indistinguishable from the benign "NE not approved yet" state (#399).
+
+The Endpoint Security extension is unaffected: it vends a team-prefixed `NSEndpointSecurityMachServiceName` it re-registers itself on activation, so it cuts over without a reboot. Only the NE (nesessionmanager-owned service) is stuck. Observed live on a v0.1.1 to v0.2.1 upgrade.
+
+## What changes
+
+- **Host app surfaces a reboot-required signal.** The `OSSystemExtensionRequest` delegate already reports `.willCompleteAfterReboot`, which the host app folds into an `AggregateVerdict.rebootRequired`. On that verdict the activate path emits a distinct, operator-facing log line ("Fleet EDR upgrade staged; reboot to finish the extension cutover and restore network + DNS coverage") instead of only the generic info log. A fresh install reports `.allSucceeded` (no prior version to evict), so it gets no prompt.
+- **Agent emits an actionable hint instead of the bare warning.** When the NE receiver has failed to connect for more than a grace period (a small number of consecutive reconnect failures) AND a pending-uninstall old NE version exists, the agent logs a distinct WARN ("Network Extension XPC registration is stale after an upgrade; reboot to complete the cutover") and (optionally) increments a counter, so the "endpoint rejecting / stale after upgrade" state reaches the server-side log/telemetry surface. The bare warning stays for the genuine not-yet-approved case, which has no pending-uninstall version.
+- The agent learns "a pending-uninstall old NE version exists" by reading the OS's own system-extension state (`systemextensionsctl list`, matched on the NE bundle id + the `waiting to uninstall on reboot` phrase). The detection is behind an injectable probe so it is unit-testable and so a future host-app marker could replace it without touching the receiver logic.
+
+### Not in this change
+
+- The GUI user-notification popup (`UNUserNotificationCenter`). The host app is a short-lived CLI-style process whose lifecycle + notification authorization make a reliable popup a separate effort; the reliable operator signal here is the os_log line (which the manual-install docs and MDM reference). Tracked as a follow-up.
+- Forcing `nesessionmanager` to rebind without a reboot (issue stretch goal). Disable/enable-filter and bouncing `nesessionmanager` are confirmed non-fixes; on SIP-on there is no known way to evict an extension already waiting to uninstall short of reboot. Investigation only, out of scope for the code change.
+
+## Impact
+
+- Affected capabilities: `agent-xpc-receiver`, `host-app-extension-manager`.
+- Affected code: `agent/receiver/` (grace-period tracking + the upgrade-pending probe + the distinct log), `agent/cmd/fleet-edr-agent/main.go` (wire the probe into the NE loop only), `extension/edr/edr/ExtensionManagerLogic.swift` + `main.swift` (the reboot-required decision + log line).
+- No wire-format, schema, or server change. Verification needs a signed-pkg upgrade on the edr-qa VM (two notarized builds), which is the legitimate upgrade path (not the binary-swap method).

--- a/openspec/changes/ne-upgrade-reboot-signal/specs/agent-xpc-receiver/spec.md
+++ b/openspec/changes/ne-upgrade-reboot-signal/specs/agent-xpc-receiver/spec.md
@@ -1,0 +1,22 @@
+# Agent XPC receiver specification (delta)
+
+## ADDED Requirements
+
+### Requirement: Distinct signal when a sysext upgrade leaves the NE registration stale
+
+When the agent cannot establish the network-extension XPC connection AND the operating system reports a previous network-extension version pending removal on reboot (a staged upgrade), the agent SHALL emit a distinct, actionable signal indicating that a reboot is required to complete the extension cutover, rather than the generic connect-failure warning. The generic warning SHALL remain for the not-yet-approved case, where no previous version is pending removal. The distinct signal SHALL be emitted at most once per stale episode and SHALL reset when the connection is next established.
+
+#### Scenario: NE connect keeps failing while a prior version waits to uninstall on reboot
+
+- **GIVEN** a system-extension upgrade has been staged and the previous network-extension version is waiting to uninstall on reboot
+- **AND** the agent's network-extension receiver cannot establish its XPC connection
+- **WHEN** the receiver has failed to connect past the grace threshold
+- **THEN** the agent emits the distinct reboot-required signal
+- **AND** it does not repeat the signal on every subsequent failed attempt within the same episode
+
+#### Scenario: A not-yet-approved network extension keeps the generic warning
+
+- **GIVEN** no previous network-extension version is pending removal on reboot
+- **AND** the agent's network-extension receiver cannot establish its XPC connection
+- **WHEN** the receiver fails to connect
+- **THEN** the agent emits the generic connect-failure warning and not the upgrade-reboot signal

--- a/openspec/changes/ne-upgrade-reboot-signal/specs/host-app-extension-manager/spec.md
+++ b/openspec/changes/ne-upgrade-reboot-signal/specs/host-app-extension-manager/spec.md
@@ -1,0 +1,20 @@
+# Host app extension manager specification (delta)
+
+## ADDED Requirements
+
+### Requirement: A staged upgrade surfaces a reboot-required signal
+
+When an activation request reports that it will complete after reboot (the operating system is deferring removal of a previous extension version), the host app SHALL surface a distinct operator-facing signal that a reboot is required to finish the upgrade and restore network and DNS coverage. A fresh activation that completes without a deferred reboot SHALL NOT surface this signal.
+
+#### Scenario: Activation will complete after reboot
+
+- **GIVEN** an activate invocation
+- **WHEN** at least one extension request reports it will complete after reboot
+- **THEN** the host app surfaces the reboot-required signal
+- **AND** the host app still exits successfully so the activation is not retried prematurely
+
+#### Scenario: Fresh activation does not prompt for reboot
+
+- **GIVEN** an activate invocation
+- **WHEN** every extension request completes without a deferred reboot
+- **THEN** the host app does not surface the reboot-required signal

--- a/openspec/changes/ne-upgrade-reboot-signal/tasks.md
+++ b/openspec/changes/ne-upgrade-reboot-signal/tasks.md
@@ -1,0 +1,30 @@
+# NE upgrade reboot signal: tasks
+
+## 1. Agent: distinguish stale-after-upgrade from not-approved
+
+- [x] `agent/receiver/upgradeprobe.go`: pure `parseNEUpgradePending(systemextensionsctlOutput, bundleID string) bool` (matches a line carrying the NE bundle id AND `waiting to uninstall on reboot`) + a thin `NEUpgradePending(ctx)` that runs `systemextensionsctl list` and feeds the parser. The exec wrapper is untested; the parser is table-tested.
+- [x] `agent/receiver/loop.go`: track consecutive connect failures; add an optional `UpgradeProbe func() bool` hook + `staleProbeAfterFailures` gate. On a connect failure past the gate with the probe true, log the distinct WARN once per stale episode; otherwise keep the bare `receiver connect` WARN. Reset on a successful connect.
+- [x] `agent/cmd/fleet-edr-agent/main.go`: wire `NEUpgradePending` as the NE loop's `UpgradeProbe` only (the ES loop is unchanged).
+
+## 2. Host app: reboot-required signal
+
+- [x] `extension/edr/edr/ExtensionManagerLogic.swift`: pure `rebootRequiredMessage(for:verdict:) -> String?` (non-nil only for activate + `.rebootRequired`).
+- [x] `extension/edr/edr/main.swift`: in `finalizeAggregate`, emit the distinct operator-facing log line when `rebootRequiredMessage` is non-nil.
+- [ ] (follow-up) GUI `UNUserNotificationCenter` popup, gated on host-app lifecycle + notification authorization.
+
+## 3. Spec
+
+- [x] `agent-xpc-receiver` delta: ADD "Distinct signal when a sysext upgrade leaves the NE registration stale".
+- [x] `host-app-extension-manager` delta: ADD "A staged upgrade surfaces a reboot-required signal".
+
+## 4. Tests
+
+- [x] `agent/receiver/upgradeprobe_test.go`: table-driven parser tests (pending vs not-pending vs not-approved-no-old-version sample outputs).
+- [x] `agent/receiver/loop_test.go`: bare WARN when no probe / probe false / under the failure gate; distinct WARN once when probe true past the gate; reset after a successful connect.
+- [x] `extension/edr/Tests/EDRExtensionLogicTests/`: `rebootRequiredMessage` returns the message for activate+`.rebootRequired`, nil otherwise (fresh-install `.allSucceeded`, deactivate, failure).
+
+## 5. Verification
+
+- [x] `go test ./agent/...` + `task lint:go` + `spectrace --strict` + `openspec validate ne-upgrade-reboot-signal --strict`.
+- [x] `swift test` for the host-app logic package.
+- [ ] (gated on a release build) edr-qa signed-pkg upgrade: install vN, confirm NE telemetry, upgrade to vN+1, confirm the host-app log line + the agent distinct WARN fire and a fresh install does NOT prompt; reboot restores NE telemetry. Add "NE receiver reconnects after a sysext upgrade" to the edr-qa upgrade checklist.


### PR DESCRIPTION
## Summary

Fixes #399. After a signed-pkg **upgrade** replaces the system extensions, macOS defers removing the previous version until reboot. The network extension's `nesessionmanager`-owned Mach service stays bound to the terminated old version, so the agent's XPC connect resolves a stale registration and never gets a hello-ack: the host silently loses all network + DNS telemetry until reboot, with only a bare `xpc_bridge_connect failed` warning indistinguishable from "NE not approved yet". (ES is unaffected: it re-registers its own team-prefixed service on activation.)

## What changed

- **Host app** (`ExtensionManagerLogic.swift` + `main.swift`): on the OS's `.willCompleteAfterReboot` activation verdict, emit a distinct operator-facing log line ("Fleet EDR upgrade staged; reboot to finish the extension cutover ...") instead of only the generic info line. A fresh install reports `.allSucceeded` and gets nothing, so no spurious reboot prompt. New pure `rebootRequiredMessage(for:verdict:)`.
- **Agent** (`agent/receiver/`): after several consecutive NE connect failures, consult an injectable `UpgradeProbe`; when it reports a previous NE version `waiting to uninstall on reboot` (read from `systemextensionsctl list`), log a distinct, actionable reboot-required WARN once per stale episode instead of the bare warning. The bare warning stays for the genuine not-yet-approved case. Wired only on the NE loop; the ESF loop is unchanged. The `systemextensionsctl` parser is pure + table-tested; the exec wrapper is best-effort (errors -> false -> bare warning).

## Spec

`openspec/changes/ne-upgrade-reboot-signal` adds the `agent-xpc-receiver` and `host-app-extension-manager` deltas. `openspec validate --strict` passes.

## Tests

`go test -race ./agent/...`, `task lint:go` (0 issues), `swift test` (host-app logic), `swiftlint`, `spectrace --strict` (419/419, 0 invalid refs).

## Deferred (tracked in the change's tasks.md + QA issue #450)

- GUI `UNUserNotificationCenter` popup (host-app lifecycle + notification authorization); the reliable signal here is the os_log line + the agent WARN.
- **Live edr-qa signed-pkg upgrade verification** (two notarized builds): tracked in the v0.3.0 RC-QA checklist #450. Not verified in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)