### PR TITLE
test(audit): deterministic test for the AsyncWriter drain-deadline sp…

### DIFF
--- a/server/identity/internal/audit/async.go
+++ b/server/identity/internal/audit/async.go
@@ -51,14 +51,22 @@ const shutdownDrainPerEvent = 5 * time.Second
 // queued past it spill to slog as the dual-emit fallback.
 const shutdownDrainGlobal = 30 * time.Second
 
+// auditRecorder is the one method AsyncWriter needs from *Store: persist a single event. Declared as an interface (not *Store
+// directly) so a test can inject a deliberately-slow recorder and exercise the global drain deadline without a genuinely degraded DB.
+// Production always supplies *Store via NewAsyncWriter.
+type auditRecorder interface {
+	Record(ctx context.Context, e api.AuditEvent) error
+}
+
 // AsyncWriter implements api.AsyncAuditWriter. Construct via NewAsyncWriter and call Run from a goroutine owned by the host context's
 // Run method.
 type AsyncWriter struct {
-	store   *Store
-	queue   chan api.AuditEvent
-	logger  *slog.Logger
-	dropped uint64
-	dropMu  sync.Mutex
+	store         auditRecorder
+	queue         chan api.AuditEvent
+	logger        *slog.Logger
+	drainDeadline time.Duration
+	dropped       uint64
+	dropMu        sync.Mutex
 
 	// submitMu serializes Submit (RLock) against shutdown (Lock). shutdown.Lock() blocks until every in-flight Submit has released its
 	// RLock, then sets closed=true under the write lock so subsequent Submits see the closed flag and return false without queuing.
@@ -74,6 +82,10 @@ type AsyncOptions struct {
 	// Logger receives drop / shutdown / panic warnings. Zero ->
 	// slog.Default.
 	Logger *slog.Logger
+	// DrainDeadline overrides the global wall-clock budget the shutdown drain runs under. Values <= 0 mean the production default
+	// (shutdownDrainGlobal). This is a test-only seam: a tiny deadline plus a slow store lets a unit test hit the spill-to-slog path
+	// deterministically instead of waiting out the 30s default against a degraded DB.
+	DrainDeadline time.Duration
 }
 
 // NewAsyncWriter constructs an AsyncWriter. The returned writer is
@@ -86,6 +98,12 @@ func NewAsyncWriter(store *Store, opts AsyncOptions) *AsyncWriter {
 	if store == nil {
 		panic("audit.NewAsyncWriter: store must not be nil")
 	}
+	return newAsyncWriter(store, opts)
+}
+
+// newAsyncWriter builds the writer around any auditRecorder. NewAsyncWriter is the production entry point (store is always *Store); the
+// interface seam exists so an internal test can inject a slow recorder to drive the drain-deadline spill path.
+func newAsyncWriter(store auditRecorder, opts AsyncOptions) *AsyncWriter {
 	queueCap := opts.QueueCap
 	if queueCap <= 0 {
 		queueCap = DefaultAsyncQueueCap
@@ -94,10 +112,15 @@ func NewAsyncWriter(store *Store, opts AsyncOptions) *AsyncWriter {
 	if logger == nil {
 		logger = slog.Default()
 	}
+	drainDeadline := opts.DrainDeadline
+	if drainDeadline <= 0 {
+		drainDeadline = shutdownDrainGlobal
+	}
 	return &AsyncWriter{
-		store:  store,
-		queue:  make(chan api.AuditEvent, queueCap),
-		logger: logger,
+		store:         store,
+		queue:         make(chan api.AuditEvent, queueCap),
+		logger:        logger,
+		drainDeadline: drainDeadline,
 	}
 }
 
@@ -190,7 +213,7 @@ func (w *AsyncWriter) writeOne(e api.AuditEvent) {
 //
 //nolint:contextcheck
 func (w *AsyncWriter) drain() {
-	deadline := time.Now().Add(shutdownDrainGlobal)
+	deadline := time.Now().Add(w.drainDeadline)
 	for {
 		if !time.Now().Before(deadline) {
 			w.logUndrainedTail()

--- a/server/identity/internal/audit/async_internal_test.go
+++ b/server/identity/internal/audit/async_internal_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"log/slog"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -69,8 +70,12 @@ func TestAsyncWriter_DrainGlobalDeadline_SpillsToSlog(t *testing.T) {
 		"a 1ms deadline against a 40ms recorder must drain at most one event before spilling the rest")
 
 	logs := buf.String()
-	assert.Contains(t, logs, `"reason":"drain_deadline_exceeded"`,
-		"spilled events must carry the drain_deadline_exceeded reason")
 	assert.Contains(t, logs, `"undrained-payload"`, "the spill line must carry the undrained event payload")
 	assert.Contains(t, logs, "h-spill", "the spill line must carry the undrained payload fields")
+	// logUndrainedTail emits one drain_deadline_exceeded record PER still-queued event, so the count of spill lines must equal Dropped().
+	// Counting (rather than a single Contains) pins the per-event semantics: a regression that logged only the first undrained event, or
+	// logged the tail once in aggregate, would still satisfy a bare Contains but fail this equality.
+	spillLines := strings.Count(logs, `"reason":"drain_deadline_exceeded"`)
+	assert.Equal(t, int(spilled), spillLines, //nolint:gosec // spilled <= queued (4), no overflow
+		"each still-queued event must emit its own drain_deadline_exceeded slog record")
 }

--- a/server/identity/internal/audit/async_internal_test.go
+++ b/server/identity/internal/audit/async_internal_test.go
@@ -1,0 +1,76 @@
+package audit
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fleetdm/edr/server/identity/api"
+)
+
+// slowRecorder is an auditRecorder whose Record blocks for a fixed duration, simulating a degraded DB. Used to make the shutdown drain
+// overrun a tiny global deadline deterministically so the spill-to-slog tail (logUndrainedTail) fires without a real slow MySQL.
+type slowRecorder struct {
+	block time.Duration
+	calls atomic.Int64
+}
+
+func (s *slowRecorder) Record(_ context.Context, _ api.AuditEvent) error {
+	s.calls.Add(1)
+	// Bounded sleep, not an unbounded block: shutdown() calls drain() synchronously, so Record MUST return for the drain loop to advance
+	// past the first event and reach the deadline check that spills the rest.
+	time.Sleep(s.block)
+	return nil
+}
+
+// The global drain deadline path: when the shutdown drain runs out of wall-clock with events still queued, logUndrainedTail emits one
+// "drain_deadline_exceeded" slog WARN per still-queued event, each carrying the event payload so post-incident log scraping can
+// reconstruct what never reached the DB. This is the dual-emit fallback for the case the package-level shutdownDrainGlobal const guards
+// in production. The test injects a tiny DrainDeadline plus a slow recorder so the first drained event overruns the budget and the rest
+// spill, deterministically and in milliseconds rather than the 30s production default. shutdown() is invoked directly (not via Run +
+// ctx cancel) because Run's select over ctx.Done() and the queue is intentionally non-deterministic; driving the drain directly is the
+// only way to pin exactly which events remain queued when the deadline expires.
+func TestAsyncWriter_DrainGlobalDeadline_SpillsToSlog(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	// 1ms budget vs a 40ms-per-event recorder: the first drained event alone overruns the deadline, so every event behind it spills.
+	rec := &slowRecorder{block: 40 * time.Millisecond}
+	w := newAsyncWriter(rec, AsyncOptions{
+		QueueCap:      8,
+		Logger:        logger,
+		DrainDeadline: time.Millisecond,
+	})
+
+	const queued = 4
+	payload := map[string]any{"marker": "undrained-payload", "host_id": "h-spill"}
+	for range queued {
+		require.True(t, w.Submit(context.Background(), api.AuditEvent{
+			Action:  "authz.host.read",
+			Payload: payload,
+		}))
+	}
+
+	// shutdown() flips closed under the write lock and then drains synchronously. With a 1ms deadline the loop drains at most the first
+	// event (the recorder makes it take 40ms) before the deadline check trips and the tail spills.
+	w.shutdown()
+
+	spilled := w.Dropped()
+	assert.Positive(t, spilled, "at least one queued event must spill once the drain deadline is exceeded")
+	assert.LessOrEqual(t, spilled, uint64(queued), "cannot spill more than were queued")
+	assert.LessOrEqual(t, rec.calls.Load(), int64(1),
+		"a 1ms deadline against a 40ms recorder must drain at most one event before spilling the rest")
+
+	logs := buf.String()
+	assert.Contains(t, logs, `"reason":"drain_deadline_exceeded"`,
+		"spilled events must carry the drain_deadline_exceeded reason")
+	assert.Contains(t, logs, `"undrained-payload"`, "the spill line must carry the undrained event payload")
+	assert.Contains(t, logs, "h-spill", "the spill line must carry the undrained payload fields")
+}


### PR DESCRIPTION
…ill path

The drain-deadline spill path (logUndrainedTail emitting `drain_deadline_exceeded` per still-queued event when the global drain deadline expires) had no dedicated test. The only prior coverage was a hollow, permanently-skipped placeholder whose skip reason was wrong: TestAsyncWriter_ShutdownRace_NoLostEvents asserts the opposite property (every accepted Submit lands an INSERT, i.e. nothing left undrained).

The deadline was the package constant shutdownDrainGlobal (30s), not injectable, so the only way to hit it was a genuinely slow run against a degraded DB. Add an optional DrainDeadline override to AsyncOptions (test-only seam, values <= 0 keep the production default unchanged) and a small auditRecorder interface so a test can inject a deliberately-slow recorder.

TestAsyncWriter_DrainGlobalDeadline_SpillsToSlog now drives the path in milliseconds: a 1ms deadline against a 40ms-per-event recorder makes the first drained event overrun the budget so the rest spill, and it asserts the drain_deadline_exceeded slog line carries the undrained payload. The test drives shutdown() directly rather than Run + ctx cancel because Run's select over ctx.Done() and the queue is intentionally non-deterministic.

No production behavior change: the default drain deadline is unchanged.

Closes #445

<!-- Keep this short. Delete sections that do not apply. -->

## What & why



## Checklist

- [ ] **OpenSpec updated for behavior changes.** If this PR changes observable behavior (a detection rule, the event
      wire schema, persistence semantics, an API/wire shape, or an emitted event), `openspec/specs/**` is updated (and
      an `openspec/changes/` proposal added), with a `spec:<id>` test marker for any new/renamed scenario. Only if this
      PR changes NO observable behavior (a comment / refactor / gofmt / dep bump that happens to touch a scoped path)
      may you assert `no-behavior-change` (label or `[no-behavior-change]` in the title) to clear the OpenSpec-sync gate.
      That is an assertion a reviewer will check, not a way to skip the spec for a real behavior change.
- [ ] Tests added/updated for the change (unit / integration / efficacy / UI as applicable).
- [ ] Agent/extension change touching ESF, XPC, or the event wire format: exercised on a live macOS VM before RC
      (flagged below).

## VM / RC notes (if applicable)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for audit logging behavior during shutdown with deadline constraints.

* **Chores**
  * Refactored internal audit logging architecture to improve flexibility and maintainability during system shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->