### PR TITLE
feat(rules): generate committed ATT&CK Navigator layer from the catalog (#433)

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -137,6 +137,11 @@ tasks:
     cmds:
       - go run ./tools/gen-rule-docs
 
+  docs:attack-layer:
+    desc: Regenerate docs/attack-navigator-layer.json from the registered rule catalogue.
+    cmds:
+      - go run ./tools/gen-attack-layer
+
   # -------- test --------
 
   test:

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -890,8 +890,8 @@ components:
           type: object
           additionalProperties: {type: string}
           example:
-            attack: "14"
-            navigator: "4.9.1"
+            attack: "19"
+            navigator: "5.2.0"
             layer: "4.5"
         domain:
           type: string

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -881,7 +881,7 @@ components:
     NavigatorLayer:
       type: object
       description: MITRE ATT&CK Navigator 4.5 layer document.
-      required: [name, versions, domain, techniques]
+      required: [name, versions, domain, filters, techniques]
       properties:
         name:
           type: string
@@ -897,6 +897,17 @@ components:
           type: string
           example: "enterprise-attack"
         description: {type: string}
+        filters:
+          type: object
+          description: >-
+            Navigator layer filters. Scopes the rendered matrix to the platforms Fleet EDR supports;
+            Fleet EDR is macOS-only, so the layer always carries `platforms: ["macOS"]`.
+          required: [platforms]
+          properties:
+            platforms:
+              type: array
+              items: {type: string}
+              example: ["macOS"]
         techniques:
           type: array
           items:

--- a/docs/attack-navigator-layer.json
+++ b/docs/attack-navigator-layer.json
@@ -1,0 +1,89 @@
+{
+  "name": "Fleet EDR coverage",
+  "versions": {
+    "attack": "14",
+    "layer": "4.5",
+    "navigator": "4.9.1"
+  },
+  "domain": "enterprise-attack",
+  "description": "MITRE ATT&CK techniques covered by currently-registered Fleet EDR detection rules.",
+  "filters": {
+    "platforms": [
+      "macOS"
+    ]
+  },
+  "techniques": [
+    {
+      "techniqueID": "T1059",
+      "score": 1,
+      "color": "#31a354",
+      "comment": "Covered by: suspicious_exec"
+    },
+    {
+      "techniqueID": "T1059.002",
+      "score": 1,
+      "color": "#31a354",
+      "comment": "Covered by: osascript_network_exec"
+    },
+    {
+      "techniqueID": "T1059.004",
+      "score": 1,
+      "color": "#31a354",
+      "comment": "Covered by: shell_from_office"
+    },
+    {
+      "techniqueID": "T1071.004",
+      "score": 1,
+      "color": "#31a354",
+      "comment": "Covered by: dns_c2_beacon"
+    },
+    {
+      "techniqueID": "T1105",
+      "score": 1,
+      "color": "#31a354",
+      "comment": "Covered by: osascript_network_exec, suspicious_exec"
+    },
+    {
+      "techniqueID": "T1543.001",
+      "score": 1,
+      "color": "#31a354",
+      "comment": "Covered by: persistence_launchagent"
+    },
+    {
+      "techniqueID": "T1543.004",
+      "score": 1,
+      "color": "#31a354",
+      "comment": "Covered by: privilege_launchd_plist_write"
+    },
+    {
+      "techniqueID": "T1548.003",
+      "score": 1,
+      "color": "#31a354",
+      "comment": "Covered by: sudoers_tamper"
+    },
+    {
+      "techniqueID": "T1555.001",
+      "score": 1,
+      "color": "#31a354",
+      "comment": "Covered by: credential_keychain_dump"
+    },
+    {
+      "techniqueID": "T1566.001",
+      "score": 1,
+      "color": "#31a354",
+      "comment": "Covered by: shell_from_office"
+    },
+    {
+      "techniqueID": "T1568.002",
+      "score": 1,
+      "color": "#31a354",
+      "comment": "Covered by: dns_c2_beacon"
+    },
+    {
+      "techniqueID": "T1574.006",
+      "score": 1,
+      "color": "#31a354",
+      "comment": "Covered by: dyld_insert"
+    }
+  ]
+}

--- a/docs/attack-navigator-layer.json
+++ b/docs/attack-navigator-layer.json
@@ -1,9 +1,9 @@
 {
   "name": "Fleet EDR coverage",
   "versions": {
-    "attack": "14",
+    "attack": "19",
     "layer": "4.5",
-    "navigator": "4.9.1"
+    "navigator": "5.2.0"
   },
   "domain": "enterprise-attack",
   "description": "MITRE ATT&CK techniques covered by currently-registered Fleet EDR detection rules.",

--- a/openspec/changes/attack-navigator-layer-artifact/proposal.md
+++ b/openspec/changes/attack-navigator-layer-artifact/proposal.md
@@ -1,0 +1,20 @@
+# Generate a committed ATT&CK Navigator layer from the detection catalog
+
+## Why
+
+Every detection rule already declares the MITRE ATT&CK techniques it maps to, and the server exposes that mapping live at `GET /api/attack-coverage` as a Navigator layer document. But there is no committed artifact: to hand someone a coverage map (a buyer's procurement questionnaire, a SOC analyst comparing vendors, an ATT&CKcon talk submission) you have to stand up a server and hit the endpoint. A checked-in `docs/attack-navigator-layer.json`, regenerated from the catalog the same way `docs/detection-rules.md` is, makes the coverage map a first-class repo artifact that reviewers can diff and anyone can drop straight into the upstream Navigator.
+
+Two smaller gaps surface alongside it. The live endpoint builds the layer inline, so a committed file built by a separate code path could drift from what the server actually serves. And the endpoint never scoped the layer to a platform: Fleet EDR is macOS-only, yet the layer rendered the full cross-platform enterprise matrix.
+
+## What changes
+
+- **Shared builder.** The Navigator layer construction moves into `rules/api.BuildNavigatorLayer`, a pure function over the rule metadata. The `GET /api/attack-coverage` handler and the new generator both call it, so the live endpoint and the committed file are produced by one code path and cannot drift.
+- **macOS platform scoping.** The layer now carries `filters.platforms: ["macOS"]`, so the Navigator renders only the macOS matrix Fleet EDR actually covers. This is an additive field on the existing endpoint response (and on the documented `NavigatorLayer` schema); existing clients that ignore unknown fields are unaffected.
+- **Generator + committed artifact.** A new `tools/gen-attack-layer` (sibling to `tools/gen-rule-docs`) writes `docs/attack-navigator-layer.json`. A `task docs:attack-layer` regenerates it.
+- **Drift gate.** A server-side test rebuilds the layer from the live catalog and byte-compares it to the committed file, failing CI when a rule's technique mapping changes without regenerating the artifact.
+
+## Impact
+
+- Affected spec: `server-admin-surface` (the ATT&CK coverage layer endpoint requirement gains a macOS-platform-scoping scenario).
+- Affected code: `server/rules/api` (new builder), `server/rules/internal/operator` (handler delegates to it), `tools/gen-attack-layer` (new), `server/rules/bootstrap` (drift test), `docs/attack-navigator-layer.json` (new committed artifact), `Taskfile.yml`, `server/apidocs/embed/openapi.yaml`, `ui/src/api.ts`.
+- No change to the agent, the wire/event format, or persistence. The endpoint change is additive and backward-compatible.

--- a/openspec/changes/attack-navigator-layer-artifact/specs/server-admin-surface/spec.md
+++ b/openspec/changes/attack-navigator-layer-artifact/specs/server-admin-surface/spec.md
@@ -1,0 +1,27 @@
+# Server admin surface: ATT&CK coverage layer macOS scoping delta
+
+## MODIFIED Requirements
+
+### Requirement: ATT&CK coverage layer endpoint
+
+The system SHALL expose `GET /api/attack-coverage` returning a MITRE ATT&CK Navigator layer JSON document that enumerates the techniques covered by the registered detection rules. The document MUST be importable directly into the upstream MITRE ATT&CK Navigator. Each covered technique MUST identify the rule (or rules) that cover it. The document MUST scope the rendered matrix to the macOS platform via a `filters.platforms` array containing `macOS`, since Fleet EDR is a macOS-only product.
+
+#### Scenario: Coverage when rules are registered
+
+- **GIVEN** at least one detection rule registered with one or more ATT&CK techniques
+- **WHEN** the operator requests `GET /api/attack-coverage`
+- **THEN** the server returns a Navigator layer JSON whose `techniques` array contains an entry for every covered technique
+- **AND** each entry identifies the rule ids that cover that technique
+
+#### Scenario: Coverage with no rules
+
+- **GIVEN** a server with no rules registered
+- **WHEN** the operator requests `GET /api/attack-coverage`
+- **THEN** the server returns a Navigator layer JSON with an empty `techniques` array rather than an error
+
+#### Scenario: Layer is scoped to the macOS platform
+
+- **GIVEN** a server serving the ATT&CK coverage layer
+- **WHEN** the operator requests `GET /api/attack-coverage`
+- **THEN** the returned Navigator layer JSON carries `filters.platforms` equal to `["macOS"]`
+- **AND** the upstream Navigator renders only the macOS matrix when the layer is imported

--- a/openspec/changes/attack-navigator-layer-artifact/tasks.md
+++ b/openspec/changes/attack-navigator-layer-artifact/tasks.md
@@ -1,0 +1,24 @@
+# Tasks
+
+## Server
+
+- [x] `server/rules/api/navigator.go`: add exported `NavigatorLayer` / `NavigatorTechnique` / `NavigatorFilters` types, `BuildNavigatorLayer([]RuleMetadata)`, and `MarshalNavigatorLayerIndented`. The builder emits `filters.platforms: ["macOS"]` and a non-nil empty `techniques` slice for the no-rules case.
+- [x] `server/rules/internal/operator/handler.go`: `handleATTACKCoverage` delegates to `api.BuildNavigatorLayer`; drop the inline structs and the now-unused `slices` / `strings` imports.
+
+## Tooling + artifact
+
+- [x] `tools/gen-attack-layer/main.go`: new generator that writes `docs/attack-navigator-layer.json` via the shared builder.
+- [x] `Taskfile.yml`: add `docs:attack-layer`.
+- [x] `docs/attack-navigator-layer.json`: generated and committed.
+- [x] `server/rules/bootstrap/navigator_layer_test.go`: drift gate (runs in the `./server/...` CI job) byte-comparing the committed file to a fresh build.
+
+## Contract docs
+
+- [x] `server/apidocs/embed/openapi.yaml`: document `filters` on the `NavigatorLayer` schema.
+- [x] `ui/src/api.ts`: add `filters` to the `AttackNavigatorLayer` interface; fix the `AttackCoverage.test.tsx` fixture.
+
+## Verification
+
+- [x] `go build ./...`, server rules/api + operator + bootstrap tests, integration `TestOperator_GetAttackCoverage` (asserts `filters.platforms == ["macOS"]`, carries the new scenario marker).
+- [x] UI typecheck + `AttackCoverage` test.
+- [x] `openspec validate attack-navigator-layer-artifact --strict`.

--- a/server/apidocs/embed/openapi.yaml
+++ b/server/apidocs/embed/openapi.yaml
@@ -890,8 +890,8 @@ components:
           type: object
           additionalProperties: {type: string}
           example:
-            attack: "14"
-            navigator: "4.9.1"
+            attack: "19"
+            navigator: "5.2.0"
             layer: "4.5"
         domain:
           type: string

--- a/server/apidocs/embed/openapi.yaml
+++ b/server/apidocs/embed/openapi.yaml
@@ -881,7 +881,7 @@ components:
     NavigatorLayer:
       type: object
       description: MITRE ATT&CK Navigator 4.5 layer document.
-      required: [name, versions, domain, techniques]
+      required: [name, versions, domain, filters, techniques]
       properties:
         name:
           type: string
@@ -897,6 +897,17 @@ components:
           type: string
           example: "enterprise-attack"
         description: {type: string}
+        filters:
+          type: object
+          description: >-
+            Navigator layer filters. Scopes the rendered matrix to the platforms Fleet EDR supports;
+            Fleet EDR is macOS-only, so the layer always carries `platforms: ["macOS"]`.
+          required: [platforms]
+          properties:
+            platforms:
+              type: array
+              items: {type: string}
+              example: ["macOS"]
         techniques:
           type: array
           items:

--- a/server/rules/api/navigator.go
+++ b/server/rules/api/navigator.go
@@ -27,6 +27,16 @@ const (
 	// navigatorPlatformMacOS is the canonical ATT&CK platform string Fleet EDR scopes the layer to. Fleet EDR is a macOS-only
 	// product, so the layer filters the matrix to the macOS columns rather than rendering the full cross-platform enterprise grid.
 	navigatorPlatformMacOS = "macOS"
+	// navigatorATTACKVersion is the ATT&CK content version the layer is authored against. BUMP THIS on each ATT&CK release
+	// (https://attack.mitre.org/resources/versions/): a stale value makes the Navigator prompt the operator to upgrade the
+	// layer on import. The catalog's mapped technique IDs are verified to still exist (not deprecated/revoked) at this
+	// version. Currently ATT&CK v19 (v19.1, released 2026-04-28).
+	navigatorATTACKVersion = "19"
+	// navigatorAppVersion is the Navigator application version the layer declares compatibility with. The v4.5 layer spec
+	// requires >= "4.9.0"; track the current Navigator release so a v19 layer doesn't advertise a pre-v19 tool version.
+	navigatorAppVersion = "5.2.0"
+	// navigatorLayerFormatVersion is the Navigator layer file-format version. Still "4.5" as of Navigator 5.x / ATT&CK v19.
+	navigatorLayerFormatVersion = "4.5"
 )
 
 // NavigatorTechnique is one technique entry in a Navigator layer document. Field tags are the layer-4.5 wire shape the upstream
@@ -92,7 +102,7 @@ func BuildNavigatorLayer(rules []RuleMetadata) NavigatorLayer {
 
 	return NavigatorLayer{
 		Name:        navigatorLayerName,
-		Versions:    map[string]string{"attack": "14", "navigator": "4.9.1", "layer": "4.5"},
+		Versions:    map[string]string{"attack": navigatorATTACKVersion, "navigator": navigatorAppVersion, "layer": navigatorLayerFormatVersion},
 		Domain:      navigatorDomain,
 		Description: navigatorLayerDescription,
 		Filters:     NavigatorFilters{Platforms: []string{navigatorPlatformMacOS}},

--- a/server/rules/api/navigator.go
+++ b/server/rules/api/navigator.go
@@ -78,7 +78,8 @@ func BuildNavigatorLayer(rules []RuleMetadata) NavigatorLayer {
 
 	techniques := make([]NavigatorTechnique, 0, len(techniqueIDs))
 	for _, tid := range techniqueIDs {
-		ruleIDs := slices.Clone(coverage[tid])
+		// coverage is a throwaway local map, so sorting and compacting its slices in place is safe and avoids a per-technique clone.
+		ruleIDs := coverage[tid]
 		slices.Sort(ruleIDs)
 		ruleIDs = slices.Compact(ruleIDs)
 		techniques = append(techniques, NavigatorTechnique{
@@ -101,9 +102,11 @@ func BuildNavigatorLayer(rules []RuleMetadata) NavigatorLayer {
 
 // MarshalNavigatorLayerIndented renders a layer as the two-space-indented, newline-terminated JSON the committed artifact uses.
 // The generator (tools/gen-attack-layer) and the drift test both call this, so the bytes they compare are produced by one code
-// path. HTML escaping is disabled so the description's literal `&` (ATT&CK) survives as `&` rather than `&` in the committed
-// file; the result is still valid JSON the Navigator imports cleanly. The live endpoint marshals the same struct compactly via
-// its own JSON writer (HTML-escaped); both decode to the same document.
+// path. HTML escaping is disabled so the ampersand in the description (ATT&CK) is written as a literal `&`; with encoding/json's
+// default HTML escaping it would be emitted as a six-character unicode escape sequence (backslash-u-0-0-2-6), which is valid but
+// noisy in a committed, human-diffed file. The result is still valid JSON the Navigator imports cleanly. The live endpoint
+// marshals the same struct compactly via its own JSON writer with HTML escaping left on, so it serves the escaped form; both
+// decode to the same document.
 func MarshalNavigatorLayerIndented(layer NavigatorLayer) ([]byte, error) {
 	var buf bytes.Buffer
 	enc := json.NewEncoder(&buf)

--- a/server/rules/api/navigator.go
+++ b/server/rules/api/navigator.go
@@ -55,8 +55,9 @@ type NavigatorFilters struct {
 }
 
 // NavigatorLayer is a MITRE ATT&CK Navigator layer-4.5 document. It is the response body of GET /api/attack-coverage and the
-// content of the committed docs/attack-navigator-layer.json artifact; both are produced by BuildNavigatorLayer so they stay
-// byte-equivalent (modulo whitespace). The UI's AttackNavigatorLayer interface mirrors this shape.
+// content of the committed docs/attack-navigator-layer.json artifact; both are produced by BuildNavigatorLayer so they decode
+// to the same document (the serialized bytes differ: the endpoint is compact + HTML-escaped, the committed file is indented +
+// HTML-unescaped). The UI's AttackNavigatorLayer interface mirrors this shape.
 type NavigatorLayer struct {
 	Name        string               `json:"name"`
 	Versions    map[string]string    `json:"versions"`

--- a/server/rules/api/navigator.go
+++ b/server/rules/api/navigator.go
@@ -1,0 +1,116 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"slices"
+	"strings"
+)
+
+// MITRE ATT&CK Navigator layer-document constants. Centralised here (rather than inlined at the build site) so the live
+// GET /api/attack-coverage endpoint and the committed docs/attack-navigator-layer.json artifact share one source of truth and
+// cannot drift in name, versions, or colour.
+const (
+	// navigatorLayerName is the layer's display title in the Navigator UI.
+	navigatorLayerName = "Fleet EDR coverage"
+	// navigatorLayerDescription is the layer's human-readable subtitle.
+	navigatorLayerDescription = "MITRE ATT&CK techniques covered by currently-registered Fleet EDR detection rules."
+	// navigatorDomain pins the layer to the enterprise matrix; combined with the macOS platform filter this renders only the
+	// macOS columns Fleet EDR actually covers.
+	navigatorDomain = "enterprise-attack"
+	// navigatorCoveredScore is the score a technique gets when any rule covers it. Binary coverage (1) rather than a graded heat:
+	// the catalog has no notion of "partial" coverage of a technique today.
+	navigatorCoveredScore = 1
+	// navigatorCoveredColor is the swatch the Navigator paints a covered technique. A mid green that reads as "we have this" on the
+	// matrix without being garish.
+	navigatorCoveredColor = "#31a354"
+	// navigatorPlatformMacOS is the canonical ATT&CK platform string Fleet EDR scopes the layer to. Fleet EDR is a macOS-only
+	// product, so the layer filters the matrix to the macOS columns rather than rendering the full cross-platform enterprise grid.
+	navigatorPlatformMacOS = "macOS"
+)
+
+// NavigatorTechnique is one technique entry in a Navigator layer document. Field tags are the layer-4.5 wire shape the upstream
+// Navigator imports verbatim; renaming one is a contract break for both the endpoint and the committed artifact.
+type NavigatorTechnique struct {
+	TechniqueID string `json:"techniqueID"`
+	Score       int    `json:"score"`
+	Color       string `json:"color,omitempty"`
+	Comment     string `json:"comment,omitempty"`
+}
+
+// NavigatorFilters carries the layer's platform scoping. Fleet EDR sets Platforms to the single macOS value so the Navigator
+// renders only the macOS matrix.
+type NavigatorFilters struct {
+	Platforms []string `json:"platforms"`
+}
+
+// NavigatorLayer is a MITRE ATT&CK Navigator layer-4.5 document. It is the response body of GET /api/attack-coverage and the
+// content of the committed docs/attack-navigator-layer.json artifact; both are produced by BuildNavigatorLayer so they stay
+// byte-equivalent (modulo whitespace). The UI's AttackNavigatorLayer interface mirrors this shape.
+type NavigatorLayer struct {
+	Name        string               `json:"name"`
+	Versions    map[string]string    `json:"versions"`
+	Domain      string               `json:"domain"`
+	Description string               `json:"description"`
+	Filters     NavigatorFilters     `json:"filters"`
+	Techniques  []NavigatorTechnique `json:"techniques"`
+}
+
+// BuildNavigatorLayer assembles the Navigator layer document from the registered rule metadata. Output is deterministic:
+// technique IDs and the per-technique covering-rule lists are sorted, and duplicate rule IDs (a rule declaring the same
+// technique twice) are compacted, so the JSON is byte-identical across runs and safe to snapshot, ETag, and diff. A rules slice
+// that declares no techniques yields a non-nil empty Techniques slice, so the document serialises `"techniques": []` rather than
+// `null`, which the spec's no-rules contract requires.
+func BuildNavigatorLayer(rules []RuleMetadata) NavigatorLayer {
+	// technique -> rule IDs that cover it.
+	coverage := make(map[string][]string)
+	for _, rule := range rules {
+		for _, t := range rule.Techniques {
+			coverage[t] = append(coverage[t], rule.ID)
+		}
+	}
+
+	techniqueIDs := make([]string, 0, len(coverage))
+	for tid := range coverage {
+		techniqueIDs = append(techniqueIDs, tid)
+	}
+	slices.Sort(techniqueIDs)
+
+	techniques := make([]NavigatorTechnique, 0, len(techniqueIDs))
+	for _, tid := range techniqueIDs {
+		ruleIDs := slices.Clone(coverage[tid])
+		slices.Sort(ruleIDs)
+		ruleIDs = slices.Compact(ruleIDs)
+		techniques = append(techniques, NavigatorTechnique{
+			TechniqueID: tid,
+			Score:       navigatorCoveredScore,
+			Color:       navigatorCoveredColor,
+			Comment:     "Covered by: " + strings.Join(ruleIDs, ", "),
+		})
+	}
+
+	return NavigatorLayer{
+		Name:        navigatorLayerName,
+		Versions:    map[string]string{"attack": "14", "navigator": "4.9.1", "layer": "4.5"},
+		Domain:      navigatorDomain,
+		Description: navigatorLayerDescription,
+		Filters:     NavigatorFilters{Platforms: []string{navigatorPlatformMacOS}},
+		Techniques:  techniques,
+	}
+}
+
+// MarshalNavigatorLayerIndented renders a layer as the two-space-indented, newline-terminated JSON the committed artifact uses.
+// The generator (tools/gen-attack-layer) and the drift test both call this, so the bytes they compare are produced by one code
+// path. HTML escaping is disabled so the description's literal `&` (ATT&CK) survives as `&` rather than `&` in the committed
+// file; the result is still valid JSON the Navigator imports cleanly. The live endpoint marshals the same struct compactly via
+// its own JSON writer (HTML-escaped); both decode to the same document.
+func MarshalNavigatorLayerIndented(layer NavigatorLayer) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(layer); err != nil { // Encode appends the trailing newline.
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}

--- a/server/rules/api/navigator_test.go
+++ b/server/rules/api/navigator_test.go
@@ -67,9 +67,9 @@ func TestMarshalNavigatorLayerIndented(t *testing.T) {
 	const wantEmptyLayer = `{
   "name": "Fleet EDR coverage",
   "versions": {
-    "attack": "14",
+    "attack": "19",
     "layer": "4.5",
-    "navigator": "4.9.1"
+    "navigator": "5.2.0"
   },
   "domain": "enterprise-attack",
   "description": "MITRE ATT&CK techniques covered by currently-registered Fleet EDR detection rules.",

--- a/server/rules/api/navigator_test.go
+++ b/server/rules/api/navigator_test.go
@@ -57,17 +57,36 @@ func TestBuildNavigatorLayer(t *testing.T) {
 	})
 }
 
-// TestMarshalNavigatorLayerIndented checks the committed-artifact encoding: two-space indentation, a trailing newline, and the
-// ampersand in the description left unescaped (encoding/json's default HTML escaping is disabled for the file).
+// TestMarshalNavigatorLayerIndented pins the committed-artifact encoding against the literal expected bytes for the deterministic
+// no-rules layer: two-space indentation, a trailing newline, the description's ampersand left unescaped (encoding/json's default
+// HTML escaping is disabled for the file), and an empty `techniques` array. This is the example-based wire-shape pin; the
+// catalog-driven full-document pin lives in the bootstrap drift test against docs/attack-navigator-layer.json.
 func TestMarshalNavigatorLayerIndented(t *testing.T) {
 	t.Parallel()
+
+	const wantEmptyLayer = `{
+  "name": "Fleet EDR coverage",
+  "versions": {
+    "attack": "14",
+    "layer": "4.5",
+    "navigator": "4.9.1"
+  },
+  "domain": "enterprise-attack",
+  "description": "MITRE ATT&CK techniques covered by currently-registered Fleet EDR detection rules.",
+  "filters": {
+    "platforms": [
+      "macOS"
+    ]
+  },
+  "techniques": []
+}
+`
+
 	b, err := api.MarshalNavigatorLayerIndented(api.BuildNavigatorLayer(nil))
 	require.NoError(t, err)
-
-	out := string(b)
-	require.NotEmpty(t, out)
-	assert.Equal(t, byte('\n'), out[len(out)-1], "must end with a trailing newline")
-	assert.Contains(t, out, "\n  \"domain\"", "must be two-space indented")
-	// With HTML escaping on, encoding/json would emit ATT&CK, so the presence of the literal ATT&CK proves escaping is off.
-	assert.Contains(t, out, "ATT&CK", "the ampersand must be left as a literal & (HTML escaping disabled)")
+	// Literal byte comparison, not assert.JSONEq: this test pins the exact wire bytes (indentation, trailing newline, unescaped
+	// ampersand). JSONEq compares JSON semantically and would ignore precisely the formatting this assertion exists to lock.
+	//nolint:testifylint // intentional literal-bytes pin; JSONEq would mask the formatting drift this test guards
+	assert.Equal(t, wantEmptyLayer, string(b),
+		"committed-artifact encoding drifted: indentation, trailing newline, unescaped ampersand, or empty techniques array changed")
 }

--- a/server/rules/api/navigator_test.go
+++ b/server/rules/api/navigator_test.go
@@ -1,0 +1,73 @@
+package api_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fleetdm/edr/server/rules/api"
+)
+
+// TestBuildNavigatorLayer pins the builder's invariants: the document is always scoped to the macOS platform, the no-rules case
+// yields a non-nil empty techniques slice (not null), and per-technique coverage is sorted + deduplicated so the output is
+// deterministic. These back the GET /api/attack-coverage contract and the committed docs/attack-navigator-layer.json artifact.
+func TestBuildNavigatorLayer(t *testing.T) {
+	t.Parallel()
+
+	t.Run("scopes the layer to macOS and pins the enterprise domain", func(t *testing.T) {
+		t.Parallel()
+		layer := api.BuildNavigatorLayer(nil)
+		assert.Equal(t, "enterprise-attack", layer.Domain)
+		assert.Equal(t, []string{"macOS"}, layer.Filters.Platforms)
+	})
+
+	t.Run("no rules yields a non-nil empty techniques slice", func(t *testing.T) {
+		t.Parallel()
+		layer := api.BuildNavigatorLayer(nil)
+		require.NotNil(t, layer.Techniques, "techniques must serialise as [] not null")
+		assert.Empty(t, layer.Techniques)
+
+		// The empty slice must marshal to a JSON array, which the no-rules endpoint contract depends on.
+		b, err := json.Marshal(layer)
+		require.NoError(t, err)
+		assert.Contains(t, string(b), `"techniques":[]`)
+	})
+
+	t.Run("sorts techniques and deduplicates covering rule IDs", func(t *testing.T) {
+		t.Parallel()
+		// Two rules cover T1059 (one of them twice); a third covers T1003. Inputs are out of order so the sort is exercised.
+		rules := []api.RuleMetadata{
+			{ID: "rule_b", Techniques: []string{"T1059", "T1059"}},
+			{ID: "rule_a", Techniques: []string{"T1059"}},
+			{ID: "rule_c", Techniques: []string{"T1003"}},
+		}
+		layer := api.BuildNavigatorLayer(rules)
+
+		require.Len(t, layer.Techniques, 2)
+		// Technique IDs are sorted ascending.
+		assert.Equal(t, "T1003", layer.Techniques[0].TechniqueID)
+		assert.Equal(t, "T1059", layer.Techniques[1].TechniqueID)
+		// Covering rule IDs are sorted and the duplicate rule_b is compacted away.
+		assert.Equal(t, "Covered by: rule_c", layer.Techniques[0].Comment)
+		assert.Equal(t, "Covered by: rule_a, rule_b", layer.Techniques[1].Comment)
+		// Every covered technique scores 1.
+		assert.Equal(t, 1, layer.Techniques[1].Score)
+	})
+}
+
+// TestMarshalNavigatorLayerIndented checks the committed-artifact encoding: two-space indentation, a trailing newline, and the
+// ampersand in the description left unescaped (encoding/json's default HTML escaping is disabled for the file).
+func TestMarshalNavigatorLayerIndented(t *testing.T) {
+	t.Parallel()
+	b, err := api.MarshalNavigatorLayerIndented(api.BuildNavigatorLayer(nil))
+	require.NoError(t, err)
+
+	out := string(b)
+	require.NotEmpty(t, out)
+	assert.Equal(t, byte('\n'), out[len(out)-1], "must end with a trailing newline")
+	assert.Contains(t, out, "\n  \"domain\"", "must be two-space indented")
+	// With HTML escaping on, encoding/json would emit ATT&CK, so the presence of the literal ATT&CK proves escaping is off.
+	assert.Contains(t, out, "ATT&CK", "the ampersand must be left as a literal & (HTML escaping disabled)")
+}

--- a/server/rules/bootstrap/navigator_layer_test.go
+++ b/server/rules/bootstrap/navigator_layer_test.go
@@ -1,0 +1,48 @@
+package bootstrap_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	rulesapi "github.com/fleetdm/edr/server/rules/api"
+	rulesbootstrap "github.com/fleetdm/edr/server/rules/bootstrap"
+)
+
+// repoRoot ascends from the test's working directory (the bootstrap package dir under `go test`) until it finds the module's
+// go.mod, so the drift test can locate the repo-root docs/ artifact regardless of where the test binary runs.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	require.NoError(t, err)
+	for {
+		if _, statErr := os.Stat(filepath.Join(dir, "go.mod")); statErr == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		require.NotEqual(t, dir, parent, "ascended to the filesystem root without finding go.mod")
+		dir = parent
+	}
+}
+
+// TestNavigatorLayerArtifactInSync is the CI drift gate for the committed ATT&CK Navigator layer. It rebuilds the layer from the
+// live rule catalog with the same builder and marshaler the generator (tools/gen-attack-layer) uses, then byte-compares against
+// the checked-in docs/attack-navigator-layer.json. Adding, removing, or re-mapping a rule's techniques without regenerating the
+// file fails here. This test lives in server/rules/ rather than the tool package because CI's Go test job globs ./server/... and
+// does not descend into ./tools/...; placing the gate here is what makes it actually run on every PR.
+func TestNavigatorLayerArtifactInSync(t *testing.T) {
+	t.Parallel()
+
+	layer := rulesapi.BuildNavigatorLayer(rulesbootstrap.CatalogOnly(rulesapi.RegistryOptions{}).List())
+	want, err := rulesapi.MarshalNavigatorLayerIndented(layer)
+	require.NoError(t, err)
+
+	path := filepath.Join(repoRoot(t), "docs", "attack-navigator-layer.json")
+	got, err := os.ReadFile(path) //nolint:gosec // test-controlled path under the repo
+	require.NoError(t, err, "read committed Navigator layer; run `task docs:attack-layer` to generate it")
+
+	require.Equal(t, string(want), string(got),
+		"docs/attack-navigator-layer.json is stale: run `task docs:attack-layer` and commit the result")
+}

--- a/server/rules/internal/operator/handler.go
+++ b/server/rules/internal/operator/handler.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"log/slog"
 	"net/http"
-	"slices"
-	"strings"
 
 	"github.com/fleetdm/edr/server/httpserver"
 	identityapi "github.com/fleetdm/edr/server/identity/api"
@@ -85,66 +83,14 @@ func (h *Handler) handleListRules(w http.ResponseWriter, r *http.Request) {
 
 // handleATTACKCoverage returns a MITRE ATT&CK Navigator layer document that enumerates the techniques covered by the registered
 // detection rules. The output is dropped directly into https://mitre-attack.github.io/attack-navigator/ to render as a heatmap on the
-// matrix. Score is 1 for "any rule covers it"; the list of covering rule IDs is in the technique's `comment`.
+// matrix. The layer is assembled by api.BuildNavigatorLayer, the same builder tools/gen-attack-layer uses to produce the committed
+// docs/attack-navigator-layer.json artifact, so the live endpoint and the checked-in file cannot drift.
 func (h *Handler) handleATTACKCoverage(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	if !identityapi.HTTPGate(ctx, w, h.authz, h.logger, identityapi.ActionAlertRead, identityapi.Resource{Type: "alert"}) {
 		return
 	}
-	rules := h.svc.List()
-
-	// technique -> rule IDs that cover it.
-	coverage := make(map[string][]string)
-	for _, rule := range rules {
-		for _, t := range rule.Techniques {
-			coverage[t] = append(coverage[t], rule.ID)
-		}
-	}
-
-	type navigatorTechnique struct {
-		TechniqueID string `json:"techniqueID"`
-		Score       int    `json:"score"`
-		Color       string `json:"color,omitempty"`
-		Comment     string `json:"comment,omitempty"`
-	}
-	type navigatorLayer struct {
-		Name        string               `json:"name"`
-		Versions    map[string]string    `json:"versions"`
-		Domain      string               `json:"domain"`
-		Description string               `json:"description"`
-		Techniques  []navigatorTechnique `json:"techniques"`
-	}
-
-	// Emit techniques + per-technique rule lists in sorted order so the JSON is byte-identical across requests. This makes the endpoint
-	// safe to ETag, diff, and snapshot-test. Dedup rule IDs so a rule declaring the same technique twice doesn't produce a noisy "Covered
-	// by: X, X" comment.
-	techniqueIDs := make([]string, 0, len(coverage))
-	for tid := range coverage {
-		techniqueIDs = append(techniqueIDs, tid)
-	}
-	slices.Sort(techniqueIDs)
-
-	techniques := make([]navigatorTechnique, 0, len(techniqueIDs))
-	for _, tid := range techniqueIDs {
-		ruleIDs := slices.Clone(coverage[tid])
-		slices.Sort(ruleIDs)
-		ruleIDs = slices.Compact(ruleIDs)
-		techniques = append(techniques, navigatorTechnique{
-			TechniqueID: tid,
-			Score:       1,
-			Color:       "#31a354",
-			Comment:     "Covered by: " + strings.Join(ruleIDs, ", "),
-		})
-	}
-
-	layer := navigatorLayer{
-		Name:        "Fleet EDR coverage",
-		Versions:    map[string]string{"attack": "14", "navigator": "4.9.1", "layer": "4.5"},
-		Domain:      "enterprise-attack",
-		Description: "MITRE ATT&CK techniques covered by currently-registered Fleet EDR detection rules.",
-		Techniques:  techniques,
-	}
-	writeJSON(ctx, h.logger, w, http.StatusOK, layer)
+	writeJSON(ctx, h.logger, w, http.StatusOK, api.BuildNavigatorLayer(h.svc.List()))
 }
 
 func writeJSON(ctx context.Context, logger *slog.Logger, w http.ResponseWriter, status int, body any) {

--- a/server/rules/internal/tests/integration_test.go
+++ b/server/rules/internal/tests/integration_test.go
@@ -208,13 +208,15 @@ func TestOperator_GetRules(t *testing.T) {
 }
 
 // spec:server-admin-surface/att-ck-coverage-layer-endpoint/coverage-when-rules-are-registered
+// spec:server-admin-surface/att-ck-coverage-layer-endpoint/layer-is-scoped-to-the-macos-platform
 //
 // GET /api/attack-coverage MUST return a Navigator-layer JSON document whose top-level shape matches
 // the upstream MITRE format (domain="enterprise-attack"); the test seeds the default rule catalog so
 // the "techniques array contains an entry for every covered technique" clause is satisfied by the
 // presence of a non-empty techniques array (every shipped catalog rule declares at least one technique).
-// The byte-identical-across-requests assertion is a stronger invariant than the spec requires but it
-// catches any non-deterministic ordering that would break snapshot-based dashboards.
+// The document MUST also scope the matrix to the macOS platform via filters.platforms, since Fleet EDR
+// is macOS-only. The byte-identical-across-requests assertion is a stronger invariant than the spec
+// requires but it catches any non-deterministic ordering that would break snapshot-based dashboards.
 func TestOperator_GetAttackCoverage(t *testing.T) {
 	t.Parallel()
 	r := newRules(t)
@@ -233,6 +235,10 @@ func TestOperator_GetAttackCoverage(t *testing.T) {
 		var body map[string]any
 		require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
 		assert.Equal(t, "enterprise-attack", body["domain"])
+		filters, ok := body["filters"].(map[string]any)
+		require.True(t, ok, "filters object must be present")
+		assert.Equal(t, []any{"macOS"}, filters["platforms"],
+			"layer must scope the matrix to the macOS platform Fleet EDR covers")
 		techniques, ok := body["techniques"].([]any)
 		require.True(t, ok, "techniques must be present and an array")
 		assert.NotEmpty(t, techniques, "with the default catalog wired in, techniques must be non-empty per spec")

--- a/tools/gen-attack-layer/main.go
+++ b/tools/gen-attack-layer/main.go
@@ -1,0 +1,47 @@
+// gen-attack-layer renders docs/attack-navigator-layer.json: a MITRE ATT&CK Navigator layer-4.5 document enumerating the
+// techniques the detection rule catalog covers. Run via:
+//
+//	go run ./tools/gen-attack-layer
+//
+// The layer is built by rulesapi.BuildNavigatorLayer, the same function that backs the live GET /api/attack-coverage endpoint,
+// so the committed artifact and the running server cannot drift. Output is deterministic (sorted techniques + covering-rule
+// lists, no timestamps) so the file is diff-friendly; a server-side test (TestNavigatorLayerArtifactInSync) fails CI on drift.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+
+	rulesapi "github.com/fleetdm/edr/server/rules/api"
+	rulesbootstrap "github.com/fleetdm/edr/server/rules/bootstrap"
+)
+
+// allRegisteredRules delegates to rules.bootstrap.CatalogOnly so this generator and the production server's main.go walk the same
+// set of rules in the same order. Coverage is not a function of a deployment's tuning, so we pass the zero RegistryOptions:
+// allowlists default to empty, which the rule structs treat as "no operator tuning yet."
+func allRegisteredRules() []rulesapi.RuleMetadata {
+	return rulesbootstrap.CatalogOnly(rulesapi.RegistryOptions{}).List()
+}
+
+func main() {
+	out := flag.String("out", "docs/attack-navigator-layer.json", "destination Navigator layer JSON file")
+	flag.Parse()
+
+	if err := generate(*out); err != nil {
+		log.Fatalf("%v", err)
+	}
+}
+
+func generate(out string) error {
+	b, err := rulesapi.MarshalNavigatorLayerIndented(rulesapi.BuildNavigatorLayer(allRegisteredRules()))
+	if err != nil {
+		return fmt.Errorf("marshal layer: %w", err)
+	}
+	// 0o644: the layer is a generated, world-readable documentation artifact committed to the repo, not a secret.
+	if err := os.WriteFile(out, b, 0o644); err != nil { //nolint:gosec // generated public doc, path is operator-controlled
+		return fmt.Errorf("write %s: %w", out, err)
+	}
+	return nil
+}

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -370,6 +370,9 @@ export interface AttackNavigatorLayer {
   versions: Record<string, string>;
   domain: string;
   description: string;
+  // filters scopes the rendered matrix to the platforms Fleet EDR supports. Fleet EDR is macOS-only,
+  // so the server always emits platforms: ["macOS"].
+  filters: { platforms: string[] };
   techniques: Array<{
     techniqueID: string;
     score: number;

--- a/ui/src/components/AttackCoverage.test.tsx
+++ b/ui/src/components/AttackCoverage.test.tsx
@@ -16,8 +16,10 @@ const layer: AttackNavigatorLayer = {
   description: "",
   filters: { platforms: ["macOS"] },
   techniques: [
-    { techniqueID: "T1555.001", score: 100, comment: "Covered by: rule_a, rule_b" },
-    { techniqueID: "T1059", score: 100, comment: "Covered by: rule_a" },
+    // score is 1 (binary coverage) to match the server's Navigator layer builder; the component ignores score, but the fixture
+    // should still reflect the real wire value.
+    { techniqueID: "T1555.001", score: 1, comment: "Covered by: rule_a, rule_b" },
+    { techniqueID: "T1059", score: 1, comment: "Covered by: rule_a" },
   ],
 };
 

--- a/ui/src/components/AttackCoverage.test.tsx
+++ b/ui/src/components/AttackCoverage.test.tsx
@@ -14,6 +14,7 @@ const layer: AttackNavigatorLayer = {
   versions: { layer: "4.5", navigator: "5.0.0" },
   domain: "enterprise-attack",
   description: "",
+  filters: { platforms: ["macOS"] },
   techniques: [
     { techniqueID: "T1555.001", score: 100, comment: "Covered by: rule_a, rule_b" },
     { techniqueID: "T1059", score: 100, comment: "Covered by: rule_a" },

--- a/ui/src/components/AttackCoverage.test.tsx
+++ b/ui/src/components/AttackCoverage.test.tsx
@@ -11,9 +11,11 @@ import type { AttackNavigatorLayer } from "../api";
 // distinct-rule and tactic counts derived from the layer.
 const layer: AttackNavigatorLayer = {
   name: "Fleet EDR coverage",
-  versions: { layer: "4.5", navigator: "5.0.0" },
+  // Mirror what the server's BuildNavigatorLayer emits (attack v19, navigator 5.2.0) so the fixture stays representative of
+  // the real wire shape, even though this component only reads `techniques`.
+  versions: { attack: "19", navigator: "5.2.0", layer: "4.5" },
   domain: "enterprise-attack",
-  description: "",
+  description: "MITRE ATT&CK techniques covered by currently-registered Fleet EDR detection rules.",
   filters: { platforms: ["macOS"] },
   techniques: [
     // score is 1 (binary coverage) to match the server's Navigator layer builder; the component ignores score, but the fixture


### PR DESCRIPTION
Closes #433.

## What

Adds `tools/gen-attack-layer`, a sibling to `tools/gen-rule-docs`, that renders `docs/attack-navigator-layer.json` from the registered detection rule catalog so the ATT&CK coverage map is a committed, diff-friendly repo artifact (useful for procurement questionnaires, SOC comparisons, and the ATT&CKcon talk submission).

## Key design decision

The Navigator layer was already built live inside `GET /api/attack-coverage`, with the types inlined privately in the handler. Rather than write a second parallel implementation that could drift from what the server serves, the construction moves into a shared `rules/api.BuildNavigatorLayer`. The endpoint and the generator now share one code path and cannot drift.

## Changes

- `server/rules/api/navigator.go`: exported `BuildNavigatorLayer` + `MarshalNavigatorLayerIndented` + layer types (single source of truth).
- `server/rules/internal/operator/handler.go`: `handleATTACKCoverage` delegates to the shared builder (inline logic removed).
- `tools/gen-attack-layer` + `task docs:attack-layer`: generates the committed `docs/attack-navigator-layer.json`.
- **macOS scoping**: the layer now carries `filters.platforms: ["macOS"]` (the standard Navigator way to satisfy "scoped to macOS"), so the live endpoint gains it too. Additive and backward-compatible.
- **Drift gate**: a byte-compare test in `server/rules/bootstrap`. Placed there deliberately, not in the tool package: CI's Go job globs `./server/...` and does not descend into `./tools/...`, so a test in the tool would never run.
- OpenAPI `NavigatorLayer` schema (canonical + `go:generate`d embed copy) and the UI `AttackNavigatorLayer` interface document the new `filters` field.

## Spec

Ships an `openspec/changes/attack-navigator-layer-artifact/` delta modifying the ATT&CK coverage endpoint requirement with a macOS-platform scenario, referenced by a spectrace marker on the integration test. The endpoint change is additive/backward-compatible; no agent, wire/event, or persistence change.

## Verification

`go build ./...`, rules api/operator/bootstrap tests, DB-backed integration test (asserts `filters.platforms == ["macOS"]`), UI typecheck + AttackCoverage test, redocly OpenAPI lint, `openspec validate --strict`, `spectrace check` (0 invalid refs), custom golangci-lint, dash-lint, markdown lint. Verified the drift gate fails on drift and passes in sync.

Not mechanically verified: "loads cleanly in ATT&CK Navigator" (the JSON is valid layer-4.5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)