### PR TITLE
feat(ui): Single sign-on admin settings page (#375)

### DIFF
--- a/docs/okta-setup.md
+++ b/docs/okta-setup.md
@@ -4,6 +4,14 @@ The EDR server speaks OIDC with PKCE. Okta is the reference IdP: every other con
 
 SSO covers everyday operator login. The break-glass account at `admin@fleet-edr.local` is the only path in when SSO is unavailable (see [`breakglass.md`](breakglass.md)).
 
+## Configure SSO in the UI (recommended)
+
+OIDC is configurable in-product under **Admin settings -> Single sign-on** (the account menu, top right; visible to operators with the `sso.manage` permission). An admin sets the issuer, client ID, client secret (write-only: enter a value to rotate, never displayed), the deployment external URL, the JIT toggle, and the default JIT role, then saves. Changes apply at runtime with no restart, and the test-connection button verifies the provider before saving.
+
+Precedence is env-seeds / DB-governs: the `EDR_OIDC_*` env vars below seed the stored config on first boot only; once a stored config exists the UI is the source of truth and env changes are inert. To configure SSO purely from the UI (no env), boot break-glass-only (`EDR_AUTH_ALLOW_NO_OIDC=1`), sign in via break-glass, and fill in the form. The redirect URI is derived from the external URL (`<external-url>/api/auth/callback`) and shown read-only; register that exact value at the IdP.
+
+The stored client secret is sealed with a key derived from `EDR_SECRET_KEY`. Rotating `EDR_SECRET_KEY` makes the stored secret undecryptable; after such a rotation, re-enter the client secret in the UI.
+
 ## Prerequisites
 
 - An Okta tenant with admin access. Free developer tenants (`*.okta.com`, `*.oktapreview.com`) work for staging; production deployments use the customer's existing tenant.

--- a/openspec/changes/sso-oidc-config-ui/tasks.md
+++ b/openspec/changes/sso-oidc-config-ui/tasks.md
@@ -35,13 +35,13 @@
 
 ## 6. UI: Admin settings shell + Single sign-on page
 
-- [ ] 6.1 Add the Admin settings area shell (account-menu entry + sub-nav) in `ui/src/`, gated on `sso.manage` via the existing `useCan()`/`Can` seam and the `/api/session` permission set
-- [ ] 6.2 Build the Single sign-on page using Fleet's existing component library + design tokens (do not port the prototype HTML): provider form, read-only redirect URL with copy, read-only scope chips, write-only secret-rotate field, JIT toggle, default-role select (Analyst/Auditor only), connection-status pill, test-connection button, break-glass callout
-- [ ] 6.3 Add the API client calls (read/update/test-connection) in `ui/src/`, sending CSRF on mutation; secret omitted from the form unless the admin enters a new value
-- [ ] 6.4 Vitest unit + component tests: page hidden without `sso.manage`; secret field never prefilled; save sends only changed fields; test-connection surfaces success/failure
+- [x] 6.1 Add the Admin settings area shell (account-menu entry + sub-nav) in `ui/src/`, gated on `sso.manage` via the existing `useCan()`/`Can` seam and the `/api/session` permission set
+- [x] 6.2 Build the Single sign-on page using Fleet's existing component library + design tokens (do not port the prototype HTML): provider form, read-only redirect URL with copy, read-only scope chips, write-only secret-rotate field, JIT toggle, default-role select (Analyst/Auditor only), connection-status pill, test-connection button, break-glass callout
+- [x] 6.3 Add the API client calls (read/update/test-connection) in `ui/src/`, sending CSRF on mutation; secret omitted from the form unless the admin enters a new value
+- [x] 6.4 Vitest unit + component tests: page hidden without `sso.manage`; secret field never prefilled; save sends only changed fields; test-connection surfaces success/failure
 
 ## 7. Docs and spec traceability
 
-- [ ] 7.1 Update `docs/okta-setup.md`: configuration now lives in the UI; document the env-seeds-DB-governs precedence and the `EDR_SECRET_KEY`-rotation coupling for the stored secret
-- [ ] 7.2 Add spectrace markers tying tests to the new `sso-configuration` scenarios and the modified authentication/authorization scenarios
-- [ ] 7.3 Run `openspec validate sso-oidc-config-ui --strict` and the no-emdash/dash + markdown-prose linters; fix any findings
+- [x] 7.1 Update `docs/okta-setup.md`: configuration now lives in the UI; document the env-seeds-DB-governs precedence and the `EDR_SECRET_KEY`-rotation coupling for the stored secret
+- [x] 7.2 Add spectrace markers tying tests to the new `sso-configuration` scenarios and the modified authentication/authorization scenarios
+- [x] 7.3 Run `openspec validate sso-oidc-config-ui --strict` and the no-emdash/dash + markdown-prose linters; fix any findings

--- a/server/cmd/fleet-edr-server/main.go
+++ b/server/cmd/fleet-edr-server/main.go
@@ -666,6 +666,9 @@ func registerSessionRoutes(mux *http.ServeMux, d muxDeps) {
 		// router needs each path enumerated here so the session-protected wrapper actually serves them. Otherwise requests
 		// fall through to the `/` catchall and 302 → /ui/, silently breaking the destructive-action reauth path.
 		"POST /api/auth/reauth/challenge", "POST /api/auth/reauth",
+		// SSO/OIDC configuration admin surface (issue #375). Mounted on apiMux via identityCtx.RegisterAuthedRoutes; enumerated
+		// here for the same reason as the app-control surface above (else the UI's GET parses the SPA index.html as JSON).
+		"GET /api/settings/sso", "PUT /api/settings/sso", "POST /api/settings/sso/test-connection",
 	} {
 		mux.Handle(p, sessionProtected)
 	}

--- a/server/identity/internal/ssoadmin/handler.go
+++ b/server/identity/internal/ssoadmin/handler.go
@@ -339,13 +339,14 @@ func validAbsoluteURL(raw string) bool {
 	if raw == "" {
 		return false
 	}
-	u, err := url.Parse(raw)
-	if err != nil {
+	// Reject any query string or fragment up front: an OIDC issuer per spec carries neither, and the redirect URI is derived from the
+	// external URL's origin + path. A raw scan also catches a bare trailing marker like "https://e?" (Go parses that into ForceQuery
+	// with an empty RawQuery), which would otherwise validate and then serialize a redirect URI with a stray "?".
+	if strings.ContainsAny(raw, "?#") {
 		return false
 	}
-	// Reject a query string or fragment: an OIDC issuer per spec carries neither, and the redirect URI is derived from the external
-	// URL's origin + path, so a "?x=1" would otherwise be dropped silently rather than round-tripped.
-	if u.RawQuery != "" || u.Fragment != "" {
+	u, err := url.Parse(raw)
+	if err != nil {
 		return false
 	}
 	return (u.Scheme == "http" || u.Scheme == "https") && u.Host != ""

--- a/server/identity/internal/ssoadmin/handler.go
+++ b/server/identity/internal/ssoadmin/handler.go
@@ -343,6 +343,11 @@ func validAbsoluteURL(raw string) bool {
 	if err != nil {
 		return false
 	}
+	// Reject a query string or fragment: an OIDC issuer per spec carries neither, and the redirect URI is derived from the external
+	// URL's origin + path, so a "?x=1" would otherwise be dropped silently rather than round-tripped.
+	if u.RawQuery != "" || u.Fragment != "" {
+		return false
+	}
 	return (u.Scheme == "http" || u.Scheme == "https") && u.Host != ""
 }
 

--- a/server/identity/internal/ssoadmin/handler_test.go
+++ b/server/identity/internal/ssoadmin/handler_test.go
@@ -231,6 +231,7 @@ func TestHandleUpdate_validationRejectsBeforeApply(t *testing.T) {
 		{"bad external url", updateRequest{Issuer: "https://i", ClientID: "c", ExternalURL: "nope", Scopes: []string{"openid"}, DefaultRole: "analyst"}, "invalid_external_url"},
 		{"external url with query", updateRequest{Issuer: "https://i", ClientID: "c", ExternalURL: "https://e?x=1", Scopes: []string{"openid"}, DefaultRole: "analyst"}, "invalid_external_url"},
 		{"external url with fragment", updateRequest{Issuer: "https://i", ClientID: "c", ExternalURL: "https://e#frag", Scopes: []string{"openid"}, DefaultRole: "analyst"}, "invalid_external_url"},
+		{"external url with bare trailing query marker", updateRequest{Issuer: "https://i", ClientID: "c", ExternalURL: "https://e?", Scopes: []string{"openid"}, DefaultRole: "analyst"}, "invalid_external_url"},
 		{"issuer with query", updateRequest{Issuer: "https://i?probe=1", ClientID: "c", ExternalURL: "https://e", Scopes: []string{"openid"}, DefaultRole: "analyst"}, "invalid_issuer"},
 		{"missing openid", updateRequest{Issuer: "https://i", ClientID: "c", ExternalURL: "https://e", Scopes: []string{"email"}, DefaultRole: "analyst"}, "missing_openid_scope"},
 		{"admin default role", updateRequest{Issuer: "https://i", ClientID: "c", ExternalURL: "https://e", Scopes: []string{"openid"}, JITEnabled: true, DefaultRole: "admin"}, "invalid_default_role"},

--- a/server/identity/internal/ssoadmin/handler_test.go
+++ b/server/identity/internal/ssoadmin/handler_test.go
@@ -229,6 +229,9 @@ func TestHandleUpdate_validationRejectsBeforeApply(t *testing.T) {
 		{"bad issuer", updateRequest{Issuer: "not a url", ClientID: "c", ExternalURL: "https://e", Scopes: []string{"openid"}, DefaultRole: "analyst"}, "invalid_issuer"},
 		{"missing client id", updateRequest{Issuer: "https://i", ClientID: "", ExternalURL: "https://e", Scopes: []string{"openid"}, DefaultRole: "analyst"}, "missing_client_id"},
 		{"bad external url", updateRequest{Issuer: "https://i", ClientID: "c", ExternalURL: "nope", Scopes: []string{"openid"}, DefaultRole: "analyst"}, "invalid_external_url"},
+		{"external url with query", updateRequest{Issuer: "https://i", ClientID: "c", ExternalURL: "https://e?x=1", Scopes: []string{"openid"}, DefaultRole: "analyst"}, "invalid_external_url"},
+		{"external url with fragment", updateRequest{Issuer: "https://i", ClientID: "c", ExternalURL: "https://e#frag", Scopes: []string{"openid"}, DefaultRole: "analyst"}, "invalid_external_url"},
+		{"issuer with query", updateRequest{Issuer: "https://i?probe=1", ClientID: "c", ExternalURL: "https://e", Scopes: []string{"openid"}, DefaultRole: "analyst"}, "invalid_issuer"},
 		{"missing openid", updateRequest{Issuer: "https://i", ClientID: "c", ExternalURL: "https://e", Scopes: []string{"email"}, DefaultRole: "analyst"}, "missing_openid_scope"},
 		{"admin default role", updateRequest{Issuer: "https://i", ClientID: "c", ExternalURL: "https://e", Scopes: []string{"openid"}, JITEnabled: true, DefaultRole: "admin"}, "invalid_default_role"},
 	}

--- a/server/identity/internal/ssoconfig/redirect_test.go
+++ b/server/identity/internal/ssoconfig/redirect_test.go
@@ -1,0 +1,32 @@
+package ssoconfig_test
+
+import (
+	"testing"
+
+	"github.com/fleetdm/edr/server/identity/internal/ssoconfig"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRedirectURLFor(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name     string
+		external string
+		want     string
+	}{
+		{"empty base is empty", "", ""},
+		{"plain base", "https://edr.acme.com", "https://edr.acme.com/api/auth/callback"},
+		{"single trailing slash tolerated", "https://edr.acme.com/", "https://edr.acme.com/api/auth/callback"},
+		{"multiple trailing slashes tolerated", "https://edr.acme.com///", "https://edr.acme.com/api/auth/callback"},
+		{"subpath preserved", "https://acme.com/edr", "https://acme.com/edr/api/auth/callback"},
+		{"query is dropped not concatenated", "https://edr.acme.com?x=1", "https://edr.acme.com/api/auth/callback"},
+		{"fragment is dropped not concatenated", "https://edr.acme.com#frag", "https://edr.acme.com/api/auth/callback"},
+		{"query and fragment both dropped", "https://edr.acme.com/?x=1#frag", "https://edr.acme.com/api/auth/callback"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, ssoconfig.RedirectURLFor(tc.external))
+		})
+	}
+}

--- a/server/identity/internal/ssoconfig/redirect_test.go
+++ b/server/identity/internal/ssoconfig/redirect_test.go
@@ -22,6 +22,7 @@ func TestRedirectURLFor(t *testing.T) {
 		{"query is dropped not concatenated", "https://edr.acme.com?x=1", "https://edr.acme.com/api/auth/callback"},
 		{"fragment is dropped not concatenated", "https://edr.acme.com#frag", "https://edr.acme.com/api/auth/callback"},
 		{"query and fragment both dropped", "https://edr.acme.com/?x=1#frag", "https://edr.acme.com/api/auth/callback"},
+		{"bare trailing query marker dropped", "https://edr.acme.com?", "https://edr.acme.com/api/auth/callback"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/server/identity/internal/ssoconfig/ssoconfig.go
+++ b/server/identity/internal/ssoconfig/ssoconfig.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"net/url"
 	"strings"
 	"time"
 
@@ -35,13 +36,23 @@ type Config struct {
 const CallbackPath = "/api/auth/callback"
 
 // RedirectURLFor derives the OIDC redirect URI from a deployment external URL: a single trailing slash on the base is tolerated so
-// "https://edr.acme.com" and "https://edr.acme.com/" both yield "https://edr.acme.com/api/auth/callback". Returns "" for an empty base
-// so callers can detect an unconfigured deployment.
+// "https://edr.acme.com" and "https://edr.acme.com/" both yield "https://edr.acme.com/api/auth/callback". A query string or fragment on
+// the base is dropped rather than concatenated into the path, so a stray "?x=1" can't produce a malformed callback. Returns "" for an
+// empty base so callers can detect an unconfigured deployment.
 func RedirectURLFor(externalURL string) string {
 	if externalURL == "" {
 		return ""
 	}
-	return strings.TrimRight(externalURL, "/") + CallbackPath
+	u, err := url.Parse(externalURL)
+	if err != nil || u.Host == "" {
+		// Unparseable base: fall back to the trim-and-concat form. The admin path validates the external URL before persisting, so
+		// this branch only covers legacy/env-seeded values.
+		return strings.TrimRight(externalURL, "/") + CallbackPath
+	}
+	u.RawQuery = ""
+	u.Fragment = ""
+	u.Path = strings.TrimRight(u.Path, "/") + CallbackPath
+	return u.String()
 }
 
 // row is the raw DB shape; client_secret_enc stays sealed until GetDecrypted opens it.

--- a/server/identity/internal/ssoconfig/ssoconfig.go
+++ b/server/identity/internal/ssoconfig/ssoconfig.go
@@ -51,6 +51,8 @@ func RedirectURLFor(externalURL string) string {
 	}
 	u.RawQuery = ""
 	u.Fragment = ""
+	// ForceQuery is set for a bare trailing "?"; clear it too so String() can't emit a stray trailing "?".
+	u.ForceQuery = false
 	u.Path = strings.TrimRight(u.Path, "/") + CallbackPath
 	return u.String()
 }

--- a/server/identity/internal/tests/sso_admin_integration_test.go
+++ b/server/identity/internal/tests/sso_admin_integration_test.go
@@ -163,7 +163,9 @@ func TestSSOAdmin_updateDeniedWithoutGrant(t *testing.T) {
 	analyst := &api.Actor{UserID: 2, AuthMethod: "oidc", SessionFresh: true, Roles: []api.RoleBinding{{
 		UserID: 2, RoleID: "analyst", ScopeType: api.RoleBindingScopeGlobal, ScopeID: api.RoleBindingScopeWildcard,
 	}}}
-	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/settings/sso", nil)
+	// Exercise the actual update verb so the test matches its name: the chokepoint must reject the PUT before any write.
+	body := strings.NewReader(`{"issuer":"https://idp.example.com","client_id":"x","external_url":"https://e.example.com","scopes":["openid"],"jit_enabled":true,"default_role":"analyst"}`)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPut, "/api/settings/sso", body)
 	req = req.WithContext(api.WithActor(req.Context(), analyst))
 	w := httptest.NewRecorder()
 	mux.ServeHTTP(w, req)

--- a/test/e2e/tests/qa/oidc-jit-disabled.spec.ts
+++ b/test/e2e/tests/qa/oidc-jit-disabled.spec.ts
@@ -6,31 +6,43 @@ import { openDB, resetDB } from "../../fixtures/db";
 //
 // JIT is DB-governed (issue #375): EDR_OIDC_ALLOW_JIT_PROVISIONING only seeds the stored oidc_config on first boot and is inert once a
 // row exists, so this test disables JIT by writing jit_enabled = 0 directly to the stored config (the provisioner reads it per OIDC
-// callback, so it applies without a restart) and restores it in afterAll so later phases that JIT-provision are unaffected.
+// callback, so it applies without a restart). resetDB() intentionally does not touch oidc_config, so the flag is persistent shared
+// state across specs; beforeAll captures the prior value and afterAll restores it exactly, leaving the suite's SSO posture unchanged.
 
 const dexPassword = "qa-password-123";
 
 test.describe("OIDC unknown subject rejected when JIT is disabled", () => {
-  test.afterAll(async () => {
+  let originalJIT = 1;
+
+  test.beforeAll(async () => {
     const db = await openDB();
     try {
-      await db.query("UPDATE oidc_config SET jit_enabled = 1");
+      const [rows] = (await db.query("SELECT jit_enabled FROM oidc_config WHERE id = 1")) as [Array<{ jit_enabled: number }>, unknown];
+      if (rows.length > 0) {
+        originalJIT = rows[0].jit_enabled;
+      }
+      await db.query("UPDATE oidc_config SET jit_enabled = 0");
     } finally {
       await db.end();
     }
   });
 
-  test("sign in with admin@qa.local (never seen) returns oidc.unknown_subject", async ({
-    page,
-  }) => {
+  test.afterAll(async () => {
+    const db = await openDB();
+    try {
+      await db.query("UPDATE oidc_config SET jit_enabled = ?", [originalJIT]);
+    } finally {
+      await db.end();
+    }
+  });
+
+  test("sign in with admin@qa.local (never seen) returns oidc.unknown_subject", async ({ page }) => {
     // Reset DB so admin@qa.local truly doesn't exist (the other
     // three dex users may have been JIT'd earlier; admin@qa.local
     // is reserved for this test).
     const db = await openDB();
     try {
       await resetDB(db);
-      // Disable JIT in the stored config (DB-governed; see file header).
-      await db.query("UPDATE oidc_config SET jit_enabled = 0");
     } finally {
       await db.end();
     }
@@ -53,10 +65,10 @@ test.describe("OIDC unknown subject rejected when JIT is disabled", () => {
     // No row should have been created for admin@qa.local.
     const verifyDB = await openDB();
     try {
-      const [users] = (await verifyDB.query(
-        "SELECT id FROM users WHERE email = ?",
-        ["admin@qa.local"],
-      )) as [Array<{ id: number }>, unknown];
+      const [users] = (await verifyDB.query("SELECT id FROM users WHERE email = ?", ["admin@qa.local"])) as [
+        Array<{ id: number }>,
+        unknown,
+      ];
       expect(users).toHaveLength(0);
 
       // Audit row records the precise reason.

--- a/test/e2e/tests/qa/oidc-jit-disabled.spec.ts
+++ b/test/e2e/tests/qa/oidc-jit-disabled.spec.ts
@@ -18,10 +18,11 @@ test.describe("OIDC unknown subject rejected when JIT is disabled", () => {
     const db = await openDB();
     try {
       const [rows] = (await db.query("SELECT jit_enabled FROM oidc_config WHERE id = 1")) as [Array<{ jit_enabled: number }>, unknown];
-      if (rows.length > 0) {
-        originalJIT = rows[0].jit_enabled;
-      }
-      await db.query("UPDATE oidc_config SET jit_enabled = 0");
+      // Fail fast if the singleton config row is missing: the UPDATE below would otherwise affect 0 rows and the test would
+      // silently stop exercising the JIT-disabled path (Dex-seeded config absent or migrations did not run).
+      expect(rows, "oidc_config singleton row (id = 1) must exist before this suite runs").toHaveLength(1);
+      originalJIT = rows[0].jit_enabled;
+      await db.query("UPDATE oidc_config SET jit_enabled = 0 WHERE id = 1");
     } finally {
       await db.end();
     }
@@ -30,7 +31,7 @@ test.describe("OIDC unknown subject rejected when JIT is disabled", () => {
   test.afterAll(async () => {
     const db = await openDB();
     try {
-      await db.query("UPDATE oidc_config SET jit_enabled = ?", [originalJIT]);
+      await db.query("UPDATE oidc_config SET jit_enabled = ? WHERE id = 1", [originalJIT]);
     } finally {
       await db.end();
     }

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -6,6 +6,7 @@ import { AlertList } from "./components/AlertList";
 import { AttackCoverage } from "./components/AttackCoverage";
 import { ApplicationControlRoutes } from "./components/ApplicationControl/ApplicationControlRoutes";
 import { RuleDetail } from "./components/RuleDetail";
+import { SSOSettings } from "./components/SSOSettings/SSOSettings";
 import { Login } from "./components/Login";
 import { BreakGlassSetup } from "./components/BreakGlassSetup";
 import { BreakGlassLogin } from "./components/BreakGlassLogin";
@@ -156,6 +157,14 @@ export function AuthedApp() {
             )}
           />
           <Route path="/coverage" element={<AttackCoverage />} />
+          <Route
+            path="/admin/settings/sso"
+            element={(
+              <RequirePermission action={PermissionAction.SSOManage} surface="Single sign-on settings">
+                <SSOSettings />
+              </RequirePermission>
+            )}
+          />
           <Route path="/rules/:ruleId" element={<RuleDetail />} />
           <Route path="/hosts/:hostId" element={<ProcessTreeView />} />
           <Route path="*" element={<Navigate to="/" replace />} />

--- a/ui/src/api.sso.test.ts
+++ b/ui/src/api.sso.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { getSSOConfig, updateSSOConfig, testSSOConnection, attachCsrfHeader } from "./api";
+
+interface FakeResponse {
+  ok: boolean;
+  status: number;
+  statusText: string;
+  headers: { get(name: string): string | null };
+  clone(): FakeResponse;
+  json(): Promise<unknown>;
+}
+
+function stubFetch(body: unknown, status = 200): ReturnType<typeof vi.fn> {
+  const fake: FakeResponse = {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: "",
+    headers: { get: () => null },
+    clone(): FakeResponse { return fake; },
+    json(): Promise<unknown> { return Promise.resolve(body); },
+  };
+  const mock = vi.fn().mockResolvedValue(fake);
+  vi.stubGlobal("fetch", mock);
+  return mock;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  sessionStorage.clear();
+});
+
+describe("SSO config API client", () => {
+  it("getSSOConfig GETs /api/settings/sso", async () => {
+    const mock = stubFetch({ configured: false });
+    await getSSOConfig();
+    const [target, init] = mock.mock.calls[0] as [URL, RequestInit | undefined];
+    expect(target.toString()).toContain("/api/settings/sso");
+    expect(init?.method ?? "GET").toBe("GET");
+  });
+
+  it("updateSSOConfig PUTs the body with the CSRF header attached", async () => {
+    sessionStorage.setItem("edr_csrf_token", "csrf-token-123");
+    const mock = stubFetch({ configured: true });
+    await updateSSOConfig({
+      issuer: "https://idp", client_id: "cid", external_url: "https://e",
+      scopes: ["openid"], jit_enabled: true, default_role: "analyst",
+    });
+    const [target, init] = mock.mock.calls[0] as [URL, RequestInit & { headers: Record<string, string> }];
+    expect(target.toString()).toContain("/api/settings/sso");
+    expect(init.method).toBe("PUT");
+    // Derive the expected CSRF header via the canonical helper rather than hardcoding the header name.
+    const expectedCsrf: Record<string, string> = {};
+    attachCsrfHeader(expectedCsrf, "PUT");
+    expect(Object.keys(expectedCsrf).length).toBeGreaterThan(0);
+    expect(init.headers).toMatchObject(expectedCsrf);
+    expect(JSON.parse(init.body as string)).toMatchObject({ issuer: "https://idp", default_role: "analyst" });
+  });
+
+  it("testSSOConnection POSTs the issuer", async () => {
+    const mock = stubFetch({ ok: true });
+    const res = await testSSOConnection("https://idp.example.com");
+    const [target, init] = mock.mock.calls[0] as [URL, RequestInit];
+    expect(target.toString()).toContain("/api/settings/sso/test-connection");
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body as string)).toEqual({ issuer: "https://idp.example.com" });
+    expect(res).toEqual({ ok: true });
+  });
+});

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -644,3 +644,52 @@ export async function createCommand(hostId: string, commandType: string, payload
 export async function getCommand(id: number): Promise<Command> {
   return fetchJSON<Command>(`/commands/${String(id)}`);
 }
+
+// --- SSO / OIDC configuration (issue #375) --------------------------------------
+
+// SSOConfig is the read shape from GET /api/settings/sso. The client secret is NEVER
+// returned (write-only); secret_set reports whether one is stored. redirect_url is
+// derived server-side from external_url and is read-only here. configured is false
+// before any provider has been set up.
+export interface SSOConfig {
+  configured: boolean;
+  issuer: string;
+  client_id: string;
+  external_url: string;
+  redirect_url: string;
+  scopes: string[];
+  jit_enabled: boolean;
+  default_role: string;
+  secret_set: boolean;
+}
+
+// SSOConfigUpdate is the PUT body. client_secret is OMITTED to keep the stored secret,
+// or set to a non-empty value to rotate it (write-only). redirect_url is not sent: the
+// server derives it from external_url.
+export interface SSOConfigUpdate {
+  issuer: string;
+  client_id: string;
+  client_secret?: string;
+  external_url: string;
+  scopes: string[];
+  jit_enabled: boolean;
+  default_role: string;
+}
+
+export async function getSSOConfig(): Promise<SSOConfig> {
+  return fetchJSON<SSOConfig>("/settings/sso");
+}
+
+export async function updateSSOConfig(req: SSOConfigUpdate): Promise<SSOConfig> {
+  return fetchJSON<SSOConfig>("/settings/sso", { method: "PUT", body: JSON.stringify(req) });
+}
+
+// testSSOConnection probes a candidate issuer's discovery + token endpoint without
+// persisting. It returns ok=false with a reason on failure (HTTP 200 either way), so
+// the caller renders the diagnostic inline rather than treating it as a thrown error.
+export async function testSSOConnection(issuer: string): Promise<{ ok: boolean; reason?: string }> {
+  return fetchJSON<{ ok: boolean; reason?: string }>("/settings/sso/test-connection", {
+    method: "POST",
+    body: JSON.stringify({ issuer }),
+  });
+}

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -657,7 +657,8 @@ export interface SSOConfig {
   client_id: string;
   external_url: string;
   redirect_url: string;
-  scopes: string[];
+  // scopes is null when the server marshals a nil slice (an unconfigured deployment); the page falls back to defaults.
+  scopes: string[] | null;
   jit_enabled: boolean;
   default_role: string;
   secret_set: boolean;
@@ -685,8 +686,10 @@ export async function updateSSOConfig(req: SSOConfigUpdate): Promise<SSOConfig> 
 }
 
 // testSSOConnection probes a candidate issuer's discovery + token endpoint without
-// persisting. It returns ok=false with a reason on failure (HTTP 200 either way), so
-// the caller renders the diagnostic inline rather than treating it as a thrown error.
+// persisting. A reachable-but-unhealthy provider returns HTTP 200 with ok=false + a reason,
+// so the caller renders that diagnostic inline. Pre-probe validation failures (malformed or
+// missing issuer => 400, store read error => 500) are thrown by fetchJSON instead; callers
+// either pre-validate the issuer or catch and surface the error.
 export async function testSSOConnection(issuer: string): Promise<{ ok: boolean; reason?: string }> {
   return fetchJSON<{ ok: boolean; reason?: string }>("/settings/sso/test-connection", {
     method: "POST",

--- a/ui/src/components/SSOSettings/SSOSettings.scss
+++ b/ui/src/components/SSOSettings/SSOSettings.scss
@@ -1,0 +1,141 @@
+@import "../../styles/var/colors.scss";
+
+.sso-settings {
+  display: block;
+  max-width: 880px;
+
+  &__status {
+    padding: 24px;
+    color: $ui-fleet-black-50;
+
+    &--error {
+      color: $ui-error;
+    }
+  }
+
+  & > .card {
+    margin-bottom: 20px;
+  }
+
+  &__card-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 20px;
+  }
+
+  &__card-title {
+    margin: 0;
+    font-size: 16px;
+    font-weight: 600;
+    color: $core-fleet-black;
+  }
+
+  &__grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 20px 24px;
+  }
+
+  &__field-full {
+    grid-column: 1 / -1;
+  }
+
+  &__help {
+    margin: 6px 0 0;
+    font-size: 12px;
+    color: $ui-fleet-black-50;
+  }
+
+  &__readonly-row {
+    display: flex;
+    gap: 8px;
+    align-items: stretch;
+  }
+
+  &__readonly {
+    flex: 1;
+    background: #f9fafc;
+    color: $ui-fleet-black-75;
+    font-family: "Source Code Pro", monospace;
+  }
+
+  &__chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-top: 4px;
+  }
+
+  &__chip {
+    padding: 4px 10px;
+    border-radius: 16px;
+    background: $ui-fleet-black-5;
+    color: $ui-fleet-black-75;
+    font-family: "Source Code Pro", monospace;
+    font-size: 12px;
+  }
+
+  &__test {
+    margin-bottom: 16px;
+    padding: 10px 12px;
+    border-radius: 4px;
+    font-size: 13px;
+
+    &--ok {
+      background: rgba(61, 182, 123, 0.15);
+      color: #2b7f56;
+    }
+
+    &--fail {
+      background: #fff0f3;
+      color: #cb3559;
+    }
+  }
+
+  &__jit {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 24px;
+  }
+
+  &__jit-role {
+    margin-top: 20px;
+    padding-top: 20px;
+    border-top: 1px solid $ui-fleet-black-10;
+  }
+
+  &__callout {
+    margin-bottom: 20px;
+    padding: 16px;
+    border-radius: 8px;
+    background: #fef7e0;
+    border: 1px solid #ece0bb;
+    color: #7a5e12;
+    font-size: 13px;
+
+    strong {
+      display: block;
+      margin-bottom: 4px;
+      color: #7a5e12;
+    }
+  }
+
+  &__save-error {
+    margin-bottom: 12px;
+    color: $ui-error;
+    font-size: 14px;
+  }
+
+  &__saved {
+    margin-bottom: 12px;
+    color: #2b7f56;
+    font-size: 14px;
+  }
+
+  &__footer {
+    display: flex;
+    gap: 12px;
+  }
+}

--- a/ui/src/components/SSOSettings/SSOSettings.test.tsx
+++ b/ui/src/components/SSOSettings/SSOSettings.test.tsx
@@ -171,6 +171,18 @@ describe("SSOSettings", () => {
     expect(upd).not.toHaveBeenCalled();
   });
 
+  it("blocks save on a bare trailing query marker in the external URL", async () => {
+    vi.spyOn(api, "getSSOConfig").mockResolvedValue(baseConfig);
+    const upd = vi.spyOn(api, "updateSSOConfig").mockResolvedValue(baseConfig);
+    render(<SSOSettings />);
+    await screen.findByLabelText("External URL");
+
+    fireEvent.change(screen.getByLabelText("External URL"), { target: { value: "https://edr.example.org?" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+    expect(await screen.findByRole("alert")).toHaveTextContent(/must not contain a query string or fragment/);
+    expect(upd).not.toHaveBeenCalled();
+  });
+
   it("omits a whitespace-only client_secret rather than rotating to blanks", async () => {
     vi.spyOn(api, "getSSOConfig").mockResolvedValue(baseConfig);
     const upd = vi.spyOn(api, "updateSSOConfig").mockResolvedValue(baseConfig);

--- a/ui/src/components/SSOSettings/SSOSettings.test.tsx
+++ b/ui/src/components/SSOSettings/SSOSettings.test.tsx
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import * as api from "../../api";
+import { SSOSettings } from "./SSOSettings";
+
+const baseConfig: api.SSOConfig = {
+  configured: true,
+  issuer: "https://acme.okta.com",
+  client_id: "0oa8x2k4mWq1ZpL5d7",
+  external_url: "https://edr.acme.com",
+  redirect_url: "https://edr.acme.com/api/auth/callback",
+  scopes: ["openid", "email", "profile"],
+  jit_enabled: true,
+  default_role: "analyst",
+  secret_set: true,
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("SSOSettings", () => {
+  // spec:sso-configuration/the-single-sign-on-admin-settings-page/secret-field-never-shows-the-stored-secret
+  it("loads and renders the provider config with a derived read-only redirect", async () => {
+    vi.spyOn(api, "getSSOConfig").mockResolvedValue(baseConfig);
+    render(<SSOSettings />);
+
+    expect(await screen.findByLabelText("Issuer URL")).toHaveValue("https://acme.okta.com");
+    expect(screen.getByLabelText("Client ID")).toHaveValue("0oa8x2k4mWq1ZpL5d7");
+    expect(screen.getByLabelText("External URL")).toHaveValue("https://edr.acme.com");
+    expect(screen.getByLabelText("Redirect URL")).toHaveValue("https://edr.acme.com/api/auth/callback");
+    expect(screen.getByLabelText("Redirect URL")).toHaveAttribute("readonly");
+    expect(screen.getByText("Configured")).toBeInTheDocument();
+    // Secret is write-only: the field is empty with a rotate affordance, never the stored value.
+    expect(screen.getByLabelText("Client secret")).toHaveValue("");
+    expect(screen.getByLabelText("Client secret")).toHaveAttribute("placeholder", expect.stringContaining("rotate"));
+    // Scopes render as read-only chips.
+    for (const s of baseConfig.scopes) expect(screen.getByText(s)).toBeInTheDocument();
+  });
+
+  it("derives the redirect URL live as the external URL changes", async () => {
+    vi.spyOn(api, "getSSOConfig").mockResolvedValue(baseConfig);
+    render(<SSOSettings />);
+    await screen.findByLabelText("External URL");
+    fireEvent.change(screen.getByLabelText("External URL"), { target: { value: "https://edr.example.org/" } });
+    // Trailing slash tolerated; callback appended.
+    expect(screen.getByLabelText("Redirect URL")).toHaveValue("https://edr.example.org/api/auth/callback");
+  });
+
+  it("omits client_secret on save when the field is left blank (keep)", async () => {
+    vi.spyOn(api, "getSSOConfig").mockResolvedValue(baseConfig);
+    const upd = vi.spyOn(api, "updateSSOConfig").mockResolvedValue(baseConfig);
+    render(<SSOSettings />);
+    await screen.findByLabelText("Issuer URL");
+
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+    await waitFor(() => { expect(upd).toHaveBeenCalledTimes(1); });
+    expect(upd.mock.calls[0][0]).not.toHaveProperty("client_secret");
+    expect(await screen.findByText("Settings saved.")).toBeInTheDocument();
+  });
+
+  it("includes client_secret on save when a new value is entered (rotate)", async () => {
+    vi.spyOn(api, "getSSOConfig").mockResolvedValue(baseConfig);
+    const upd = vi.spyOn(api, "updateSSOConfig").mockResolvedValue(baseConfig);
+    render(<SSOSettings />);
+    await screen.findByLabelText("Client secret");
+
+    fireEvent.change(screen.getByLabelText("Client secret"), { target: { value: "rotated-secret" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+    await waitFor(() => { expect(upd).toHaveBeenCalledTimes(1); });
+    expect(upd.mock.calls[0][0]).toMatchObject({ client_secret: "rotated-secret" });
+  });
+
+  it("blocks save and shows an error on an invalid issuer", async () => {
+    vi.spyOn(api, "getSSOConfig").mockResolvedValue(baseConfig);
+    const upd = vi.spyOn(api, "updateSSOConfig").mockResolvedValue(baseConfig);
+    render(<SSOSettings />);
+    await screen.findByLabelText("Issuer URL");
+
+    fireEvent.change(screen.getByLabelText("Issuer URL"), { target: { value: "not a url" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+    expect(await screen.findByRole("alert")).toHaveTextContent(/Issuer must be a valid/);
+    expect(upd).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a save error from the server", async () => {
+    vi.spyOn(api, "getSSOConfig").mockResolvedValue(baseConfig);
+    vi.spyOn(api, "updateSSOConfig").mockRejectedValue(new Error("API error: 409"));
+    render(<SSOSettings />);
+    await screen.findByLabelText("Issuer URL");
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+    expect(await screen.findByRole("alert")).toHaveTextContent("API error: 409");
+  });
+
+  it("runs a connection test and renders the verified result", async () => {
+    vi.spyOn(api, "getSSOConfig").mockResolvedValue(baseConfig);
+    const test = vi.spyOn(api, "testSSOConnection").mockResolvedValue({ ok: true });
+    render(<SSOSettings />);
+    await screen.findByLabelText("Issuer URL");
+
+    fireEvent.click(screen.getByRole("button", { name: "Test connection" }));
+    expect(await screen.findByText(/Connection verified/)).toBeInTheDocument();
+    expect(test).toHaveBeenCalledWith("https://acme.okta.com");
+  });
+
+  it("renders a failed connection test with its reason", async () => {
+    vi.spyOn(api, "getSSOConfig").mockResolvedValue(baseConfig);
+    vi.spyOn(api, "testSSOConnection").mockResolvedValue({ ok: false, reason: "discovery unreachable" });
+    render(<SSOSettings />);
+    await screen.findByLabelText("Issuer URL");
+    fireEvent.click(screen.getByRole("button", { name: "Test connection" }));
+    expect(await screen.findByText(/discovery unreachable/)).toBeInTheDocument();
+  });
+
+  it("toggles JIT and selects the default role", async () => {
+    vi.spyOn(api, "getSSOConfig").mockResolvedValue(baseConfig);
+    const upd = vi.spyOn(api, "updateSSOConfig").mockResolvedValue(baseConfig);
+    render(<SSOSettings />);
+    await screen.findByLabelText("Issuer URL");
+
+    const jit = screen.getByRole("switch", { name: "Just-in-time provisioning" });
+    expect(jit).toBeChecked();
+    fireEvent.click(jit);
+    fireEvent.change(screen.getByLabelText("Default role for new SSO users"), { target: { value: "auditor" } });
+
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+    await waitFor(() => { expect(upd).toHaveBeenCalledTimes(1); });
+    expect(upd.mock.calls[0][0]).toMatchObject({ jit_enabled: false, default_role: "auditor" });
+  });
+
+  it("shows Not configured when no provider is set up", async () => {
+    vi.spyOn(api, "getSSOConfig").mockResolvedValue({
+      ...baseConfig,
+      configured: false,
+      issuer: "",
+      client_id: "",
+      external_url: "",
+      secret_set: false,
+    });
+    render(<SSOSettings />);
+    expect(await screen.findByText("Not configured")).toBeInTheDocument();
+    expect(screen.getByLabelText("Client secret")).toHaveAttribute("placeholder", "enter the client secret");
+  });
+
+  it("renders the load error state", async () => {
+    vi.spyOn(api, "getSSOConfig").mockRejectedValue(new Error("boom"));
+    render(<SSOSettings />);
+    expect(await screen.findByText(/Error: boom/)).toBeInTheDocument();
+  });
+});

--- a/ui/src/components/SSOSettings/SSOSettings.test.tsx
+++ b/ui/src/components/SSOSettings/SSOSettings.test.tsx
@@ -35,7 +35,7 @@ describe("SSOSettings", () => {
     expect(screen.getByLabelText("Client secret")).toHaveValue("");
     expect(screen.getByLabelText("Client secret")).toHaveAttribute("placeholder", expect.stringContaining("rotate"));
     // Scopes render as read-only chips.
-    for (const s of baseConfig.scopes) expect(screen.getByText(s)).toBeInTheDocument();
+    for (const s of baseConfig.scopes ?? []) expect(screen.getByText(s)).toBeInTheDocument();
   });
 
   it("derives the redirect URL live as the external URL changes", async () => {
@@ -146,5 +146,107 @@ describe("SSOSettings", () => {
     vi.spyOn(api, "getSSOConfig").mockRejectedValue(new Error("boom"));
     render(<SSOSettings />);
     expect(await screen.findByText(/Error: boom/)).toBeInTheDocument();
+  });
+
+  it("falls back to default scopes when the server returns null scopes", async () => {
+    // A nil Go slice serializes to JSON null; the page must not crash dereferencing .length.
+    vi.spyOn(api, "getSSOConfig").mockResolvedValue({ ...baseConfig, scopes: null });
+    render(<SSOSettings />);
+    await screen.findByLabelText("Issuer URL");
+    for (const s of ["openid", "email", "profile"]) expect(screen.getByText(s)).toBeInTheDocument();
+  });
+
+  it("strips a query/fragment from the derived redirect and blocks save on such an external URL", async () => {
+    vi.spyOn(api, "getSSOConfig").mockResolvedValue(baseConfig);
+    const upd = vi.spyOn(api, "updateSSOConfig").mockResolvedValue(baseConfig);
+    render(<SSOSettings />);
+    await screen.findByLabelText("External URL");
+
+    fireEvent.change(screen.getByLabelText("External URL"), { target: { value: "https://edr.example.org/?x=1#frag" } });
+    // Redirect is derived from origin + path only; the query/fragment never leak into the callback.
+    expect(screen.getByLabelText("Redirect URL")).toHaveValue("https://edr.example.org/api/auth/callback");
+
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+    expect(await screen.findByRole("alert")).toHaveTextContent(/must not contain a query string or fragment/);
+    expect(upd).not.toHaveBeenCalled();
+  });
+
+  it("omits a whitespace-only client_secret rather than rotating to blanks", async () => {
+    vi.spyOn(api, "getSSOConfig").mockResolvedValue(baseConfig);
+    const upd = vi.spyOn(api, "updateSSOConfig").mockResolvedValue(baseConfig);
+    render(<SSOSettings />);
+    await screen.findByLabelText("Client secret");
+
+    fireEvent.change(screen.getByLabelText("Client secret"), { target: { value: "   " } });
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+    await waitFor(() => { expect(upd).toHaveBeenCalledTimes(1); });
+    expect(upd.mock.calls[0][0]).not.toHaveProperty("client_secret");
+  });
+
+  it("validates the issuer before calling the test-connection endpoint", async () => {
+    vi.spyOn(api, "getSSOConfig").mockResolvedValue(baseConfig);
+    const test = vi.spyOn(api, "testSSOConnection").mockResolvedValue({ ok: true });
+    render(<SSOSettings />);
+    await screen.findByLabelText("Issuer URL");
+
+    fireEvent.change(screen.getByLabelText("Issuer URL"), { target: { value: "not a url" } });
+    fireEvent.click(screen.getByRole("button", { name: "Test connection" }));
+    expect(await screen.findByText(/Issuer must be a valid/)).toBeInTheDocument();
+    expect(test).not.toHaveBeenCalled();
+  });
+
+  it("clears a stale connection-test result when a field is edited", async () => {
+    vi.spyOn(api, "getSSOConfig").mockResolvedValue(baseConfig);
+    vi.spyOn(api, "testSSOConnection").mockResolvedValue({ ok: true });
+    render(<SSOSettings />);
+    await screen.findByLabelText("Issuer URL");
+
+    fireEvent.click(screen.getByRole("button", { name: "Test connection" }));
+    expect(await screen.findByText(/Connection verified/)).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText("Issuer URL"), { target: { value: "https://other.okta.com" } });
+    expect(screen.queryByText(/Connection verified/)).not.toBeInTheDocument();
+  });
+
+  it("reverts edits on Cancel", async () => {
+    vi.spyOn(api, "getSSOConfig").mockResolvedValue(baseConfig);
+    render(<SSOSettings />);
+    await screen.findByLabelText("Issuer URL");
+
+    fireEvent.change(screen.getByLabelText("Issuer URL"), { target: { value: "https://edited.okta.com" } });
+    expect(screen.getByLabelText("Issuer URL")).toHaveValue("https://edited.okta.com");
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(screen.getByLabelText("Issuer URL")).toHaveValue("https://acme.okta.com");
+  });
+
+  it("surfaces a thrown error from the test-connection endpoint", async () => {
+    vi.spyOn(api, "getSSOConfig").mockResolvedValue(baseConfig);
+    vi.spyOn(api, "testSSOConnection").mockRejectedValue(new Error("network down"));
+    render(<SSOSettings />);
+    await screen.findByLabelText("Issuer URL");
+
+    fireEvent.click(screen.getByRole("button", { name: "Test connection" }));
+    expect(await screen.findByText(/network down/)).toBeInTheDocument();
+  });
+
+  it("copies the redirect URL when the clipboard API is available", async () => {
+    vi.spyOn(api, "getSSOConfig").mockResolvedValue(baseConfig);
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal("navigator", { clipboard: { writeText } });
+    render(<SSOSettings />);
+    await screen.findByLabelText("Issuer URL");
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy" }));
+    await waitFor(() => { expect(writeText).toHaveBeenCalledWith("https://edr.acme.com/api/auth/callback"); });
+    vi.unstubAllGlobals();
+  });
+
+  it("does not throw when copying without a clipboard API", async () => {
+    vi.spyOn(api, "getSSOConfig").mockResolvedValue(baseConfig);
+    vi.stubGlobal("navigator", {});
+    render(<SSOSettings />);
+    await screen.findByLabelText("Issuer URL");
+
+    expect(() => { fireEvent.click(screen.getByRole("button", { name: "Copy" })); }).not.toThrow();
+    vi.unstubAllGlobals();
   });
 });

--- a/ui/src/components/SSOSettings/SSOSettings.tsx
+++ b/ui/src/components/SSOSettings/SSOSettings.tsx
@@ -38,14 +38,11 @@ function isHTTPURL(raw: string): boolean {
 }
 
 // hasQueryOrFragment flags external URLs carrying a query string or fragment; the redirect URI is derived from the bare
-// origin + path, so a query/fragment can't be round-tripped and must be rejected before save.
+// origin + path, so a query/fragment can't be round-tripped and must be rejected before save. A raw scan (rather than
+// URL.search/hash, which drop a bare trailing "?"/"#") keeps this in lockstep with the server's validation.
 function hasQueryOrFragment(raw: string): boolean {
-  try {
-    const u = new URL(raw.trim());
-    return u.search !== "" || u.hash !== "";
-  } catch {
-    return false;
-  }
+  const trimmed = raw.trim();
+  return trimmed.includes("?") || trimmed.includes("#");
 }
 
 // editable mirrors the operator-editable fields; the secret is write-only (empty unless

--- a/ui/src/components/SSOSettings/SSOSettings.tsx
+++ b/ui/src/components/SSOSettings/SSOSettings.tsx
@@ -13,14 +13,36 @@ import "./SSOSettings.scss";
 const CALLBACK_PATH = "/api/auth/callback";
 
 function deriveRedirect(externalURL: string): string {
-  const base = externalURL.trim().replace(/\/+$/, "");
-  return base ? base + CALLBACK_PATH : "";
+  const raw = externalURL.trim();
+  if (raw === "") return "";
+  try {
+    // Parse rather than concatenate so a query string or fragment on the base can't bleed into the path and produce a
+    // malformed callback (e.g. "https://e.example.com?x=1/api/auth/callback"). Mirrors the server's RedirectURLFor.
+    const u = new URL(raw);
+    u.search = "";
+    u.hash = "";
+    u.pathname = u.pathname.replace(/\/+$/, "") + CALLBACK_PATH;
+    return u.toString();
+  } catch {
+    return "";
+  }
 }
 
 function isHTTPURL(raw: string): boolean {
   try {
     const u = new URL(raw.trim());
     return (u.protocol === "http:" || u.protocol === "https:") && u.host !== "";
+  } catch {
+    return false;
+  }
+}
+
+// hasQueryOrFragment flags external URLs carrying a query string or fragment; the redirect URI is derived from the bare
+// origin + path, so a query/fragment can't be round-tripped and must be rejected before save.
+function hasQueryOrFragment(raw: string): boolean {
+  try {
+    const u = new URL(raw.trim());
+    return u.search !== "" || u.hash !== "";
   } catch {
     return false;
   }
@@ -84,18 +106,22 @@ export function SSOSettings() {
   if (error) return <div className="sso-settings__status sso-settings__status--error">Error: {error}</div>;
   if (!form || !config) return <div className="sso-settings__status">No configuration available.</div>;
 
-  const scopes = config.scopes.length > 0 ? config.scopes : ["openid", "email", "profile"];
+  const scopes = config.scopes && config.scopes.length > 0 ? config.scopes : ["openid", "email", "profile"];
   const redirectURL = deriveRedirect(form.externalURL);
 
   function update<K extends keyof FormState>(key: K, value: FormState[K]) {
     setForm((prev) => (prev ? { ...prev, [key]: value } : prev));
     setSaved(false);
+    // A prior connection-test verdict was for the old issuer/external URL; clear it so the UI never shows a stale
+    // "verified" against fields the operator has since edited.
+    setTestResult(null);
   }
 
   function validate(f: FormState): string | null {
     if (!isHTTPURL(f.issuer)) return "Issuer must be a valid http(s) URL.";
     if (f.clientID.trim() === "") return "Client ID is required.";
     if (!isHTTPURL(f.externalURL)) return "External URL must be a valid http(s) URL.";
+    if (hasQueryOrFragment(f.externalURL)) return "External URL must not contain a query string or fragment.";
     return null;
   }
 
@@ -109,12 +135,15 @@ export function SSOSettings() {
     setSaving(true);
     setSaveError(null);
     setSaved(false);
+    // Trim before the rotate check so a whitespace-only entry is treated as "keep" rather than rotating the stored
+    // secret to blanks (which would silently break SSO logins).
+    const secret = form.secret.trim();
     try {
       const updated = await updateSSOConfig({
         issuer: form.issuer.trim(),
         client_id: form.clientID.trim(),
         // Omit the secret unless the operator entered a new value (write-only rotate).
-        ...(form.secret !== "" ? { client_secret: form.secret } : {}),
+        ...(secret !== "" ? { client_secret: secret } : {}),
         external_url: form.externalURL.trim(),
         scopes,
         jit_enabled: form.jitEnabled,
@@ -139,6 +168,11 @@ export function SSOSettings() {
 
   async function handleTest() {
     if (!form) return;
+    // Validate locally first so a malformed issuer surfaces a clear message instead of a generic 400 from the probe endpoint.
+    if (!isHTTPURL(form.issuer)) {
+      setTestResult({ ok: false, reason: "Issuer must be a valid http(s) URL." });
+      return;
+    }
     setTesting(true);
     setTestResult(null);
     try {
@@ -151,8 +185,12 @@ export function SSOSettings() {
   }
 
   async function handleCopyRedirect() {
+    // navigator.clipboard is undefined in insecure contexts / older browsers (the lib types declare it always-present, hence
+    // the cast); the field stays selectable as a fallback.
+    const clipboard = navigator.clipboard as Clipboard | undefined;
+    if (!clipboard) return;
     try {
-      await navigator.clipboard.writeText(redirectURL);
+      await clipboard.writeText(redirectURL);
     } catch {
       // Clipboard can be unavailable (insecure context); the field is selectable as a fallback.
     }

--- a/ui/src/components/SSOSettings/SSOSettings.tsx
+++ b/ui/src/components/SSOSettings/SSOSettings.tsx
@@ -1,0 +1,305 @@
+import { useEffect, useState } from "react";
+import { getSSOConfig, updateSSOConfig, testSSOConnection, type SSOConfig } from "../../api";
+import { PageHeader } from "../ui/PageHeader";
+import { Card } from "../ui/Card";
+import { Button } from "../ui/Button";
+import { Input, Select } from "../ui/Input";
+import { Toggle } from "../ui/Toggle";
+import { Badge } from "../ui/Badge";
+import "./SSOSettings.scss";
+
+// The redirect URI is derived from the external URL and shown read-only; the operator
+// registers exactly this value at the IdP. Mirrors the server's RedirectURLFor.
+const CALLBACK_PATH = "/api/auth/callback";
+
+function deriveRedirect(externalURL: string): string {
+  const base = externalURL.trim().replace(/\/+$/, "");
+  return base ? base + CALLBACK_PATH : "";
+}
+
+function isHTTPURL(raw: string): boolean {
+  try {
+    const u = new URL(raw.trim());
+    return (u.protocol === "http:" || u.protocol === "https:") && u.host !== "";
+  } catch {
+    return false;
+  }
+}
+
+// editable mirrors the operator-editable fields; the secret is write-only (empty unless
+// the operator is rotating it).
+interface FormState {
+  issuer: string;
+  clientID: string;
+  externalURL: string;
+  secret: string;
+  jitEnabled: boolean;
+  defaultRole: string;
+}
+
+function toForm(cfg: SSOConfig): FormState {
+  return {
+    issuer: cfg.issuer,
+    clientID: cfg.client_id,
+    externalURL: cfg.external_url,
+    secret: "",
+    jitEnabled: cfg.jit_enabled,
+    defaultRole: cfg.default_role || "analyst",
+  };
+}
+
+type TestResult = { ok: boolean; reason?: string } | null;
+
+export function SSOSettings() {
+  const [config, setConfig] = useState<SSOConfig | null>(null);
+  const [form, setForm] = useState<FormState | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [saved, setSaved] = useState(false);
+
+  const [testing, setTesting] = useState(false);
+  const [testResult, setTestResult] = useState<TestResult>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    getSSOConfig()
+      .then((cfg) => {
+        if (cancelled) return;
+        setConfig(cfg);
+        setForm(toForm(cfg));
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : "Failed to load SSO configuration");
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, []);
+
+  if (loading) return <div className="sso-settings__status">Loading...</div>;
+  if (error) return <div className="sso-settings__status sso-settings__status--error">Error: {error}</div>;
+  if (!form || !config) return <div className="sso-settings__status">No configuration available.</div>;
+
+  const scopes = config.scopes.length > 0 ? config.scopes : ["openid", "email", "profile"];
+  const redirectURL = deriveRedirect(form.externalURL);
+
+  function update<K extends keyof FormState>(key: K, value: FormState[K]) {
+    setForm((prev) => (prev ? { ...prev, [key]: value } : prev));
+    setSaved(false);
+  }
+
+  function validate(f: FormState): string | null {
+    if (!isHTTPURL(f.issuer)) return "Issuer must be a valid http(s) URL.";
+    if (f.clientID.trim() === "") return "Client ID is required.";
+    if (!isHTTPURL(f.externalURL)) return "External URL must be a valid http(s) URL.";
+    return null;
+  }
+
+  async function handleSave() {
+    if (!form) return;
+    const invalid = validate(form);
+    if (invalid) {
+      setSaveError(invalid);
+      return;
+    }
+    setSaving(true);
+    setSaveError(null);
+    setSaved(false);
+    try {
+      const updated = await updateSSOConfig({
+        issuer: form.issuer.trim(),
+        client_id: form.clientID.trim(),
+        // Omit the secret unless the operator entered a new value (write-only rotate).
+        ...(form.secret !== "" ? { client_secret: form.secret } : {}),
+        external_url: form.externalURL.trim(),
+        scopes,
+        jit_enabled: form.jitEnabled,
+        default_role: form.defaultRole,
+      });
+      setConfig(updated);
+      setForm(toForm(updated));
+      setSaved(true);
+    } catch (err: unknown) {
+      setSaveError(err instanceof Error ? err.message : "Failed to save settings.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  function handleCancel() {
+    if (config) setForm(toForm(config));
+    setSaveError(null);
+    setSaved(false);
+    setTestResult(null);
+  }
+
+  async function handleTest() {
+    if (!form) return;
+    setTesting(true);
+    setTestResult(null);
+    try {
+      setTestResult(await testSSOConnection(form.issuer.trim()));
+    } catch (err: unknown) {
+      setTestResult({ ok: false, reason: err instanceof Error ? err.message : "Connection test failed." });
+    } finally {
+      setTesting(false);
+    }
+  }
+
+  async function handleCopyRedirect() {
+    try {
+      await navigator.clipboard.writeText(redirectURL);
+    } catch {
+      // Clipboard can be unavailable (insecure context); the field is selectable as a fallback.
+    }
+  }
+
+  return (
+    <form className="sso-settings" onSubmit={(e) => { e.preventDefault(); void handleSave(); }}>
+      <PageHeader
+        title="Single sign-on"
+        subtitle="Operators sign in through your OpenID Connect provider. One identity provider is configured per deployment."
+        actions={config.configured
+          ? <Badge variant="success">Configured</Badge>
+          : <Badge variant="neutral">Not configured</Badge>}
+      />
+
+      <Card padding="large">
+        <div className="sso-settings__card-head">
+          <h2 className="sso-settings__card-title">OpenID Connect</h2>
+          <Button type="button" variant="inverse" size="small" onClick={() => { void handleTest(); }} isLoading={testing}>
+            Test connection
+          </Button>
+        </div>
+
+        {testResult !== null && (
+          <div
+            className={testResult.ok ? "sso-settings__test sso-settings__test--ok" : "sso-settings__test sso-settings__test--fail"}
+            role="status"
+          >
+            {testResult.ok ? "Connection verified: discovery and token endpoint reachable." : `Connection failed: ${testResult.reason ?? "unreachable"}`}
+          </div>
+        )}
+
+        <div className="sso-settings__grid">
+          <Input
+            id="sso-issuer"
+            label="Issuer URL"
+            type="text"
+            placeholder="https://acme.okta.com"
+            value={form.issuer}
+            onChange={(e) => { update("issuer", e.target.value); }}
+          />
+          <Input
+            id="sso-client-id"
+            label="Client ID"
+            type="text"
+            placeholder="0oa8x2k4mWq1ZpL5d7"
+            value={form.clientID}
+            onChange={(e) => { update("clientID", e.target.value); }}
+          />
+
+          <Input
+            id="sso-external-url"
+            label="External URL"
+            type="text"
+            placeholder="https://edr.acme.com"
+            value={form.externalURL}
+            onChange={(e) => { update("externalURL", e.target.value); }}
+            aria-describedby="sso-external-url-help"
+          />
+          <p id="sso-external-url-help" className="sso-settings__help">
+            Your deployment&apos;s externally-reachable base URL. The redirect URI below is derived from it.
+          </p>
+
+          <div className="sso-settings__field-full">
+            <span className="field__label">Redirect URL</span>
+            <div className="sso-settings__readonly-row">
+              <input
+                className="field__input sso-settings__readonly"
+                type="text"
+                readOnly
+                aria-label="Redirect URL"
+                value={redirectURL}
+              />
+              <Button type="button" variant="inverse" size="small" onClick={() => { void handleCopyRedirect(); }} disabled={redirectURL === ""}>
+                Copy
+              </Button>
+            </div>
+            <p className="sso-settings__help">
+              Register this exact value as a sign-in redirect URI on the provider. Trailing slashes and case must match.
+            </p>
+          </div>
+
+          <div className="sso-settings__field-full">
+            <Input
+              id="sso-secret"
+              label="Client secret"
+              type="password"
+              autoComplete="new-password"
+              placeholder={config.secret_set ? "•••••• enter a new value to rotate" : "enter the client secret"}
+              value={form.secret}
+              onChange={(e) => { update("secret", e.target.value); }}
+            />
+            <p className="sso-settings__help">Write-only. Enter a new value to rotate; leave blank to keep the current secret.</p>
+          </div>
+
+          <div className="sso-settings__field-full">
+            <span className="field__label">Scopes</span>
+            <div className="sso-settings__chips">
+              {scopes.map((s) => <span key={s} className="sso-settings__chip">{s}</span>)}
+            </div>
+            <p className="sso-settings__help">Group-to-role mapping (the groups scope) ships in a future release.</p>
+          </div>
+        </div>
+      </Card>
+
+      <Card padding="large">
+        <div className="sso-settings__jit">
+          <div>
+            <h2 className="sso-settings__card-title">Just-in-time provisioning</h2>
+            <p className="sso-settings__help">
+              When on, anyone who signs in through the provider is auto-created and given the default role. When off, an operator must be invited first.
+            </p>
+          </div>
+          <Toggle
+            id="sso-jit"
+            aria-label="Just-in-time provisioning"
+            checked={form.jitEnabled}
+            onChange={(e) => { update("jitEnabled", e.target.checked); }}
+          />
+        </div>
+        <div className="sso-settings__jit-role">
+          <Select
+            id="sso-default-role"
+            label="Default role for new SSO users"
+            value={form.defaultRole}
+            onChange={(e) => { update("defaultRole", e.target.value); }}
+            inline
+          >
+            <option value="analyst">Analyst</option>
+            <option value="auditor">Auditor</option>
+          </Select>
+          <p className="sso-settings__help">Never auto-grant admin from an SSO claim.</p>
+        </div>
+      </Card>
+
+      <div className="sso-settings__callout" role="note">
+        <strong>Break-glass account stays available.</strong> If the provider is unreachable, the break-glass admin can still sign in via the
+        Break-glass login link on the login page. The surface is IP-allowlist gated, so off-network callers never see it.
+      </div>
+
+      {saveError !== null && <div className="sso-settings__save-error" role="alert">{saveError}</div>}
+      {saved && <div className="sso-settings__saved" role="status">Settings saved.</div>}
+
+      <div className="sso-settings__footer">
+        <Button type="submit" variant="primary" isLoading={saving}>Save changes</Button>
+        <Button type="button" variant="inverse" onClick={handleCancel} disabled={saving}>Cancel</Button>
+      </div>
+    </form>
+  );
+}

--- a/ui/src/components/ui/AccountMenu.scss
+++ b/ui/src/components/ui/AccountMenu.scss
@@ -1,0 +1,115 @@
+@import "../../styles/var/colors.scss";
+
+.account-menu {
+  position: relative;
+  margin-left: auto;
+
+  &__trigger {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 4px 8px;
+    background: transparent;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    color: $core-fleet-white;
+    font: inherit;
+
+    &:hover {
+      background: rgba(255, 255, 255, 0.08);
+    }
+  }
+
+  &__avatar {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    background: $core-fleet-green;
+    color: $core-fleet-white;
+    font-size: 13px;
+    font-weight: 600;
+    text-transform: uppercase;
+  }
+
+  &__email {
+    font-family: "Source Code Pro", monospace;
+    font-size: 13px;
+  }
+
+  &__auth-method {
+    padding: 2px 6px;
+    border-radius: 4px;
+    background: rgba(235, 188, 67, 0.2);
+    color: #ebbc43;
+    font-size: 11px;
+  }
+
+  &__chevron {
+    width: 0;
+    height: 0;
+    border-left: 4px solid transparent;
+    border-right: 4px solid transparent;
+    border-top: 5px solid currentcolor;
+    opacity: 0.8;
+  }
+
+  &__dropdown {
+    position: absolute;
+    top: calc(100% + 8px);
+    right: 0;
+    width: 236px;
+    background: $core-fleet-white;
+    border-radius: 8px;
+    box-shadow: 0 8px 24px rgba(25, 33, 71, 0.16);
+    padding: 8px;
+    z-index: 100;
+  }
+
+  &__header {
+    padding: 8px 10px;
+    color: $ui-fleet-black-50;
+    font-family: "Source Code Pro", monospace;
+    font-size: 12px;
+    border-bottom: 1px solid $ui-fleet-black-10;
+    margin-bottom: 4px;
+    overflow-wrap: anywhere;
+  }
+
+  &__item {
+    display: block;
+    width: 100%;
+    text-align: left;
+    padding: 8px 10px;
+    border: none;
+    background: transparent;
+    border-radius: 4px;
+    color: $ui-fleet-black-75;
+    font: inherit;
+    font-size: 14px;
+    text-decoration: none;
+    cursor: pointer;
+
+    &:hover {
+      background: $ui-fleet-black-5;
+    }
+
+    &--highlight {
+      color: $core-fleet-green;
+      font-weight: 600;
+    }
+
+    &--logout {
+      color: $ui-fleet-black-75;
+    }
+  }
+
+  &__divider {
+    height: 1px;
+    background: $ui-fleet-black-10;
+    margin: 4px 0;
+  }
+}

--- a/ui/src/components/ui/AccountMenu.test.tsx
+++ b/ui/src/components/ui/AccountMenu.test.tsx
@@ -22,15 +22,15 @@ describe("AccountMenu", () => {
   it("shows the email and is collapsed by default", () => {
     renderMenu([PermissionAction.SSOManage]);
     expect(screen.getByText("mike@fleetdm.com")).toBeInTheDocument();
-    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Log out" })).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: /mike@fleetdm.com/ })).toHaveAttribute("aria-expanded", "false");
   });
 
   it("opens the dropdown and shows Admin settings when sso.manage is granted", () => {
     renderMenu([PermissionAction.SSOManage]);
     fireEvent.click(screen.getByRole("button", { name: /mike@fleetdm.com/ }));
-    expect(screen.getByRole("menu")).toBeInTheDocument();
-    const link = screen.getByRole("menuitem", { name: "Admin settings" });
+    expect(screen.getByRole("button", { name: /mike@fleetdm.com/ })).toHaveAttribute("aria-expanded", "true");
+    const link = screen.getByRole("link", { name: "Admin settings" });
     expect(link).toHaveAttribute("href", "/admin/settings/sso");
   });
 
@@ -38,22 +38,47 @@ describe("AccountMenu", () => {
   it("hides Admin settings when sso.manage is absent", () => {
     renderMenu([PermissionAction.HostRead]);
     fireEvent.click(screen.getByRole("button", { name: /mike@fleetdm.com/ }));
-    expect(screen.queryByRole("menuitem", { name: "Admin settings" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "Admin settings" })).not.toBeInTheDocument();
   });
 
   it("calls onLogout from the menu", () => {
     const { onLogout } = renderMenu([PermissionAction.SSOManage]);
     fireEvent.click(screen.getByRole("button", { name: /mike@fleetdm.com/ }));
-    fireEvent.click(screen.getByRole("menuitem", { name: "Log out" }));
+    fireEvent.click(screen.getByRole("button", { name: "Log out" }));
     expect(onLogout).toHaveBeenCalledTimes(1);
+  });
+
+  it("opens the Documentation link safely and closes the menu when clicked", () => {
+    renderMenu([PermissionAction.SSOManage]);
+    fireEvent.click(screen.getByRole("button", { name: /mike@fleetdm.com/ }));
+    const docs = screen.getByRole("link", { name: "Documentation" });
+    expect(docs).toHaveAttribute("target", "_blank");
+    expect(docs).toHaveAttribute("rel", "noopener noreferrer");
+    fireEvent.click(docs);
+    expect(screen.queryByRole("link", { name: "Documentation" })).not.toBeInTheDocument();
+  });
+
+  it("closes the menu when Admin settings is clicked", () => {
+    renderMenu([PermissionAction.SSOManage]);
+    fireEvent.click(screen.getByRole("button", { name: /mike@fleetdm.com/ }));
+    fireEvent.click(screen.getByRole("link", { name: "Admin settings" }));
+    expect(screen.queryByRole("button", { name: "Log out" })).not.toBeInTheDocument();
+  });
+
+  it("closes on an outside click", () => {
+    renderMenu([PermissionAction.SSOManage]);
+    fireEvent.click(screen.getByRole("button", { name: /mike@fleetdm.com/ }));
+    expect(screen.getByRole("button", { name: "Log out" })).toBeInTheDocument();
+    fireEvent.mouseDown(document.body);
+    expect(screen.queryByRole("button", { name: "Log out" })).not.toBeInTheDocument();
   });
 
   it("closes on Escape", () => {
     renderMenu([PermissionAction.SSOManage]);
     fireEvent.click(screen.getByRole("button", { name: /mike@fleetdm.com/ }));
-    expect(screen.getByRole("menu")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Log out" })).toBeInTheDocument();
     fireEvent.keyDown(document, { key: "Escape" });
-    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Log out" })).not.toBeInTheDocument();
   });
 
   it("shows a break-glass badge for a local_password session", () => {

--- a/ui/src/components/ui/AccountMenu.test.tsx
+++ b/ui/src/components/ui/AccountMenu.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import type { ReactNode } from "react";
+import { AccountMenu } from "./AccountMenu";
+import { PermissionsProvider } from "../../permissions";
+import { PermissionAction } from "../../permissions-core";
+
+function renderMenu(permissions: string[] | undefined, onLogout = vi.fn()) {
+  function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <MemoryRouter>
+        <PermissionsProvider permissions={permissions}>{children}</PermissionsProvider>
+      </MemoryRouter>
+    );
+  }
+  render(<AccountMenu user={{ id: 1, email: "mike@fleetdm.com" }} onLogout={onLogout} />, { wrapper: Wrapper });
+  return { onLogout };
+}
+
+describe("AccountMenu", () => {
+  it("shows the email and is collapsed by default", () => {
+    renderMenu([PermissionAction.SSOManage]);
+    expect(screen.getByText("mike@fleetdm.com")).toBeInTheDocument();
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /mike@fleetdm.com/ })).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("opens the dropdown and shows Admin settings when sso.manage is granted", () => {
+    renderMenu([PermissionAction.SSOManage]);
+    fireEvent.click(screen.getByRole("button", { name: /mike@fleetdm.com/ }));
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+    const link = screen.getByRole("menuitem", { name: "Admin settings" });
+    expect(link).toHaveAttribute("href", "/admin/settings/sso");
+  });
+
+  // spec:sso-configuration/the-single-sign-on-admin-settings-page/page-is-hidden-from-operators-without-the-grant
+  it("hides Admin settings when sso.manage is absent", () => {
+    renderMenu([PermissionAction.HostRead]);
+    fireEvent.click(screen.getByRole("button", { name: /mike@fleetdm.com/ }));
+    expect(screen.queryByRole("menuitem", { name: "Admin settings" })).not.toBeInTheDocument();
+  });
+
+  it("calls onLogout from the menu", () => {
+    const { onLogout } = renderMenu([PermissionAction.SSOManage]);
+    fireEvent.click(screen.getByRole("button", { name: /mike@fleetdm.com/ }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Log out" }));
+    expect(onLogout).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes on Escape", () => {
+    renderMenu([PermissionAction.SSOManage]);
+    fireEvent.click(screen.getByRole("button", { name: /mike@fleetdm.com/ }));
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+  });
+
+  it("shows a break-glass badge for a local_password session", () => {
+    function Wrapper({ children }: { children: ReactNode }) {
+      return (
+        <MemoryRouter>
+          <PermissionsProvider permissions={[]}>{children}</PermissionsProvider>
+        </MemoryRouter>
+      );
+    }
+    render(
+      <AccountMenu user={{ id: 1, email: "bg@fleetdm.com" }} authMethod="local_password" onLogout={vi.fn()} />,
+      { wrapper: Wrapper },
+    );
+    expect(screen.getByText("Break-glass")).toBeInTheDocument();
+  });
+});

--- a/ui/src/components/ui/AccountMenu.tsx
+++ b/ui/src/components/ui/AccountMenu.tsx
@@ -18,7 +18,9 @@ function authMethodLabel(authMethod?: string): string | null {
 // AccountMenu is the top-right avatar dropdown: it carries the entry point to the Admin
 // settings area (gated on sso.manage so only admins see it) plus Documentation and Log
 // out. The "Admin settings" link is the only way into the settings area, matching the
-// design. Closes on outside-click and Escape.
+// design. Closes on outside-click and Escape. Implemented as a disclosure (trigger carries
+// aria-expanded) rather than the ARIA menu pattern: the items are plain links/buttons, so
+// menu/menuitem roles would promise arrow-key navigation that this control does not provide.
 export function AccountMenu({ user, authMethod, onLogout }: AccountMenuProps) {
   const can = useCan();
   const [open, setOpen] = useState(false);
@@ -47,7 +49,7 @@ export function AccountMenu({ user, authMethod, onLogout }: AccountMenuProps) {
       <button
         type="button"
         className="account-menu__trigger"
-        aria-haspopup="menu"
+        aria-haspopup="true"
         aria-expanded={open}
         onClick={() => { setOpen((v) => !v); }}
       >
@@ -61,12 +63,11 @@ export function AccountMenu({ user, authMethod, onLogout }: AccountMenuProps) {
         <span className="account-menu__chevron" aria-hidden="true" />
       </button>
       {open && (
-        <div className="account-menu__dropdown" role="menu">
+        <div className="account-menu__dropdown">
           <div className="account-menu__header">{user.email}</div>
           {can(PermissionAction.SSOManage) && (
             <Link
               to="/admin/settings/sso"
-              role="menuitem"
               className="account-menu__item account-menu__item--highlight"
               onClick={() => { setOpen(false); }}
             >
@@ -76,16 +77,15 @@ export function AccountMenu({ user, authMethod, onLogout }: AccountMenuProps) {
           <a
             href="https://github.com/getvictor/fleet-edr/tree/main/docs"
             target="_blank"
-            rel="noreferrer"
-            role="menuitem"
+            rel="noopener noreferrer"
             className="account-menu__item"
+            onClick={() => { setOpen(false); }}
           >
             Documentation
           </a>
           <div className="account-menu__divider" />
           <button
             type="button"
-            role="menuitem"
             className="account-menu__item account-menu__item--logout"
             onClick={() => { setOpen(false); onLogout(); }}
           >

--- a/ui/src/components/ui/AccountMenu.tsx
+++ b/ui/src/components/ui/AccountMenu.tsx
@@ -1,0 +1,98 @@
+import { useEffect, useRef, useState } from "react";
+import { Link } from "react-router-dom";
+import { useCan, PermissionAction } from "../../permissions-core";
+import "./AccountMenu.scss";
+
+interface AccountMenuProps {
+  readonly user: { id: number; email: string };
+  // authMethod is the session's authn flow; "local_password" surfaces a break-glass badge.
+  readonly authMethod?: string;
+  readonly onLogout: () => void;
+}
+
+function authMethodLabel(authMethod?: string): string | null {
+  if (authMethod === "local_password") return "Break-glass";
+  return null;
+}
+
+// AccountMenu is the top-right avatar dropdown: it carries the entry point to the Admin
+// settings area (gated on sso.manage so only admins see it) plus Documentation and Log
+// out. The "Admin settings" link is the only way into the settings area, matching the
+// design. Closes on outside-click and Escape.
+export function AccountMenu({ user, authMethod, onLogout }: AccountMenuProps) {
+  const can = useCan();
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return undefined;
+    function onDocClick(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    }
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") setOpen(false);
+    }
+    document.addEventListener("mousedown", onDocClick);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDocClick);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  const badge = authMethodLabel(authMethod);
+
+  return (
+    <div className="account-menu" ref={ref}>
+      <button
+        type="button"
+        className="account-menu__trigger"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        onClick={() => { setOpen((v) => !v); }}
+      >
+        <span className="account-menu__avatar" aria-hidden="true">{user.email.charAt(0) || "?"}</span>
+        <span className="account-menu__email">{user.email}</span>
+        {badge !== null && (
+          <span className="account-menu__auth-method" title="This session was minted via the break-glass recovery flow.">
+            {badge}
+          </span>
+        )}
+        <span className="account-menu__chevron" aria-hidden="true" />
+      </button>
+      {open && (
+        <div className="account-menu__dropdown" role="menu">
+          <div className="account-menu__header">{user.email}</div>
+          {can(PermissionAction.SSOManage) && (
+            <Link
+              to="/admin/settings/sso"
+              role="menuitem"
+              className="account-menu__item account-menu__item--highlight"
+              onClick={() => { setOpen(false); }}
+            >
+              Admin settings
+            </Link>
+          )}
+          <a
+            href="https://github.com/getvictor/fleet-edr/tree/main/docs"
+            target="_blank"
+            rel="noreferrer"
+            role="menuitem"
+            className="account-menu__item"
+          >
+            Documentation
+          </a>
+          <div className="account-menu__divider" />
+          <button
+            type="button"
+            role="menuitem"
+            className="account-menu__item account-menu__item--logout"
+            onClick={() => { setOpen(false); onLogout(); }}
+          >
+            Log out
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/src/components/ui/Toggle.scss
+++ b/ui/src/components/ui/Toggle.scss
@@ -1,0 +1,67 @@
+@import "../../styles/var/colors.scss";
+
+.toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  cursor: pointer;
+
+  &__control {
+    position: relative;
+    display: inline-block;
+    width: 44px;
+    height: 24px;
+    flex-shrink: 0;
+  }
+
+  // The native checkbox sits invisibly over the track so it keeps focus + keyboard + AT semantics.
+  &__input {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    margin: 0;
+    opacity: 0;
+    cursor: pointer;
+  }
+
+  &__track {
+    position: absolute;
+    inset: 0;
+    border-radius: 16px;
+    background-color: $ui-fleet-black-25;
+    transition: background-color 0.15s ease;
+  }
+
+  &__knob {
+    position: absolute;
+    top: 3px;
+    left: 3px;
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    background-color: $core-fleet-white;
+    transition: transform 0.15s ease;
+  }
+
+  &__input:checked + &__track {
+    background-color: $core-fleet-green;
+  }
+
+  &__input:checked + &__track .toggle__knob {
+    transform: translateX(20px);
+  }
+
+  &__input:focus-visible + &__track {
+    box-shadow: 0 0 0 3px rgba(0, 154, 125, 0.15);
+  }
+
+  &__input:disabled + &__track {
+    opacity: 0.5;
+  }
+
+  &__label {
+    color: $ui-fleet-black-75;
+    font-size: 14px;
+  }
+}

--- a/ui/src/components/ui/Toggle.test.tsx
+++ b/ui/src/components/ui/Toggle.test.tsx
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { useState } from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { Toggle } from "./Toggle";
+
+describe("Toggle", () => {
+  it("renders as a switch reflecting the checked prop", () => {
+    render(<Toggle id="t" label="Enable" checked readOnly />);
+    const sw = screen.getByRole("switch", { name: "Enable" });
+    expect(sw).toBeChecked();
+    expect(screen.getByText("Enable")).toBeInTheDocument();
+  });
+
+  it("is unchecked when checked is false", () => {
+    render(<Toggle id="t" aria-label="Enable" checked={false} readOnly />);
+    expect(screen.getByRole("switch", { name: "Enable" })).not.toBeChecked();
+  });
+
+  it("drives controlled state on change", () => {
+    function Controlled() {
+      const [on, setOn] = useState(false);
+      return <Toggle id="t" aria-label="Enable" checked={on} onChange={(e) => { setOn(e.target.checked); }} />;
+    }
+    render(<Controlled />);
+    const sw = screen.getByRole("switch", { name: "Enable" });
+    expect(sw).not.toBeChecked();
+    fireEvent.click(sw);
+    expect(sw).toBeChecked();
+  });
+});

--- a/ui/src/components/ui/Toggle.tsx
+++ b/ui/src/components/ui/Toggle.tsx
@@ -1,0 +1,25 @@
+import type { InputHTMLAttributes } from "react";
+import "./Toggle.scss";
+
+interface ToggleProps extends Omit<InputHTMLAttributes<HTMLInputElement>, "type"> {
+  // label renders to the right of the switch and is associated via the wrapping <label>.
+  readonly label?: string;
+}
+
+// Toggle is an accessible on/off switch: a visually-hidden checkbox (role="switch") drives
+// a styled track + knob, so keyboard focus, the space key, and screen readers all work
+// while matching the Fleet design (44x24 pill, green when on). There is no native switch
+// element, so a checkbox is the correct ARIA base.
+export function Toggle({ label, id, ...rest }: ToggleProps) {
+  return (
+    <label className="toggle" htmlFor={id}>
+      <span className="toggle__control">
+        <input id={id} type="checkbox" role="switch" className="toggle__input" {...rest} />
+        <span className="toggle__track" aria-hidden="true">
+          <span className="toggle__knob" />
+        </span>
+      </span>
+      {label !== undefined && <span className="toggle__label">{label}</span>}
+    </label>
+  );
+}

--- a/ui/src/components/ui/TopNav.tsx
+++ b/ui/src/components/ui/TopNav.tsx
@@ -2,6 +2,7 @@ import classnames from "classnames";
 import { Link, useLocation } from "react-router-dom";
 import "./TopNav.scss";
 import { useCan, PermissionAction } from "../../permissions-core";
+import { AccountMenu } from "./AccountMenu";
 
 interface NavLink {
   to: string;
@@ -31,15 +32,6 @@ interface TopNavProps {
   // signals that the operator is NOT in a normal SSO session.
   readonly authMethod?: string;
   readonly onLogout?: () => void;
-}
-
-// authMethodLabel turns the wire-shape AuthMethod ("oidc" /
-// "local_password") into operator-friendly copy. break-glass is the
-// only case worth surfacing. An OIDC session is the default and
-// doesn't need a badge.
-function authMethodLabel(authMethod?: string): string | null {
-  if (authMethod === "local_password") return "Break-glass";
-  return null;
 }
 
 export function TopNav({ user, authMethod, onLogout }: TopNavProps) {
@@ -77,24 +69,7 @@ export function TopNav({ user, authMethod, onLogout }: TopNavProps) {
           })}
         </ul>
         {user && onLogout && (
-          <div className="top-nav__account">
-            <span className="top-nav__avatar" aria-hidden="true">
-              {user.email.charAt(0) || "?"}
-            </span>
-            <span className="top-nav__user">{user.email}</span>
-            {authMethodLabel(authMethod) && (
-              <span className="top-nav__auth-method" title="This session was minted via the break-glass recovery flow.">
-                {authMethodLabel(authMethod)}
-              </span>
-            )}
-            <button
-              type="button"
-              className="top-nav__logout"
-              onClick={onLogout}
-            >
-              Log out
-            </button>
-          </div>
+          <AccountMenu user={user} authMethod={authMethod} onLogout={onLogout} />
         )}
       </div>
     </nav>

--- a/ui/src/permissions-core.ts
+++ b/ui/src/permissions-core.ts
@@ -24,6 +24,7 @@ export const PermissionAction = {
   AlertReopen: "alert.reopen",
   HostKillProcess: "host.kill_process",
   AppControlRead: "application_control.read",
+  SSOManage: "sso.manage",
 } as const;
 
 export type PermissionActionValue = (typeof PermissionAction)[keyof typeof PermissionAction];


### PR DESCRIPTION
## Summary

The React admin UI for the SSO/OIDC configuration whose backend shipped in #461. **PR 2 of 2** for #375. Reached from a new account-menu dropdown, gated on the `sso.manage` permission. Live-QA'd end to end against a real Dex IdP (see "Verification").

## What changes

- **Account menu dropdown** (`AccountMenu`) replaces TopNav's inline logout block. Carries the **Admin settings** entry point (shown only with `sso.manage`), Documentation, and Log out; closes on outside-click / Escape.
- **Single sign-on page** (`SSOSettings`) under `/ui/admin/settings/sso`, gated via `RequirePermission`:
  - provider form (issuer, client id);
  - editable **External URL** with a live-derived **read-only Redirect URL** (`<external>/api/auth/callback`) + copy — mirrors the server's `RedirectURLFor`;
  - read-only scope chips; **write-only** client-secret rotate field (the stored secret is never shown);
  - JIT toggle, Analyst/Auditor default-role select;
  - **Test connection** with inline pass/fail; break-glass-stays-available callout; Save / Cancel.
- New accessible **`Toggle`** switch component (`role="switch"`; none existed).
- **API client** (`getSSOConfig` / `updateSSOConfig` / `testSSOConnection`) via the CSRF-aware `fetchJSON`; `client_secret` omitted unless the operator is rotating it.
- `permissions-core`: add `SSOManage = "sso.manage"`.
- **Routing fix** (`main.go`): mount `GET/PUT /api/settings/sso` + `POST /api/settings/sso/test-connection` on the session-protected mux. They were registered on `apiMux` but missing from `buildMux`'s explicit allowlist, so the UI's GET fell through to the SPA catchall and 302'd (parsed as JSON → `Unexpected token '<'`). Same class as the PR #158 app-control incident; follow-up guard filed as #463.
- **Folded-in review nits** from #461: the JIT-off E2E now captures + restores the prior `jit_enabled` (vs hard-reset); the SSO deny integration test uses `PUT` (the real verb) instead of `GET`.
- `docs/okta-setup.md`: document the in-UI config flow, env-seeds/DB-governs precedence, and the `EDR_SECRET_KEY` rotation coupling. All OpenSpec tasks for `sso-oidc-config-ui` are now complete.

## Scope

This wave is the **Single sign-on page only** (the #375 UI). The design's Users (#135) and Service-accounts (#376) sections are intentionally not built — their backends don't exist yet — but the account menu + settings area are structured so they slot in when those land.

## Testing

- **Vitest** (266 UI tests pass): SSOSettings (load, derived redirect, secret keep-vs-rotate, validation, save error, test-connection pass/fail, JIT + role, not-configured, load error), AccountMenu (gating, open/close, logout, Escape, break-glass badge), Toggle, and the SSO API client. spectrace markers tie tests to the `sso-configuration` UI scenarios.
- Local gates green: `tsc`, `eslint`, `vitest`, production `build`; the Go SSO denial test; `openspec validate --strict`; `spectrace` 423/423; dash-lint.

## Verification (live dev-server QA)

Drove the page through Chrome against a real Dex (`task qa:up` + `dev:server:qa-oidc`): SSO login → promote to super_admin → page loads the env-seeded config (secret never shown) → live-derived redirect updates with the external URL → **Test connection** verifies against Dex → **Save** persists to both stores (`oidc_config` + `app_config`, `config_version` bumped, secret preserved, `sso.config.updated` audit row with no secret). The routing fix above was found and fixed during this QA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hy8oHEVf7zDGKxg2adEDKP


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added SSO/OIDC configuration interface in admin settings, enabling in-product management of single sign-on settings with test-connection validation.
  * Introduced toggle for just-in-time user provisioning and configurable default roles.
  * Enhanced account menu with organized navigation options.
  * New toggle switch UI component.

* **Documentation**
  * Added comprehensive guide for configuring SSO in the admin interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->