### PR TITLE
409 process optional alert detail

### DIFF
--- a/openspec/changes/launchd-persistence-provenance/proposal.md
+++ b/openspec/changes/launchd-persistence-provenance/proposal.md
@@ -1,0 +1,26 @@
+# Provenance for LaunchDaemon persistence alerts
+
+## Why
+
+`privilege_launchd_plist_write` ("LaunchDaemon persistence", T1543.004) fires on a `btm_launch_item_add` registration event and classifies the registered executable by its code signing (high precision). But the BTM instigator for a daemon registration is Apple's `smd`, not the actor, so the rule deliberately attributes no process (`process_id = 0`). The result is a process-optional alert with no link to who actually established the persistence. The companion UI change (process-optional-alert-detail) makes that alert legible, but its graph is necessarily empty: there is no related-process data to show.
+
+Industry practice for a persistence detection (CrowdStrike Falcon, Microsoft Defender for Endpoint, SentinelOne, Elastic) is artifact-centric: lead with the persistence object, then anchor on the **responsible process** (the one that wrote the artifact) and its lineage, with the process graph as a scoped pivot into that lineage. We have the artifact (BTM gives the plist path + executable signing) but not the responsible process.
+
+The responsible process is observable: the same write-mode `open` telemetry the `sudoers_tamper` rule already consumes captures who wrote a file under a watched path. We do not watch the LaunchDaemon/LaunchAgent directories yet. Extending the existing dedicated, target-muted file-tamper Endpoint Security client to those directories (the ADR-0008-sanctioned pattern, not the rejected broad-open firehose) gives us the plist writer. Correlating that write to the BTM registration yields the genuinely relevant process lineage to show in the alert.
+
+## What changes
+
+- **Telemetry (extension).** Extend the dedicated file-tamper Endpoint Security client's inverted target-path mute set to also cover `/Library/LaunchDaemons/`, `/Library/LaunchAgents/`, and per-user `~/Library/LaunchAgents/`, re-emitting CREATE/WRITE there as write-mode `open` events (identical mechanism and wire shape to the sudoers coverage). No new event type; no broad-open subscription.
+- **Correlation (server).** At alert-detail compose time (off the ingestion hot path, so event ordering and dedup are unaffected), for a process-optional alert correlate the registered plist path to the nearest-before write-mode `open` event on that path for the same host, resolve its PID to a process row, and resolve the registered executable path to that binary's own process runs. Return these as `related_process_ids` on the alert-detail response, each tagged with its role (`artifact_writer`, `persisted_executable`). The alert stays `process_id = 0` for dedup stability; correlation is additive.
+- **UI.** When `related_process_ids` is present, the process tree seeds its focus from that set (role-labelled) instead of showing the empty-state explanation. When it is absent (no write captured, binary never ran), the process-optional explanation from the companion change still applies.
+
+## Residual gap (documented, not closed)
+
+Atomic-rename writes (write a temp file, `rename(2)` onto the plist) evade the write-mode-`open` provenance, the same blind spot already documented on `sudoers_tamper` (ESF `NOTIFY_RENAME` is not subscribed; watching rename on the launchd directories is noisy because legitimate installers use it). A sophisticated actor can still land a process-optional alert with no writer; the companion change's explanation + opt-in remains the permanent fallback for that case.
+
+## Impact
+
+- Affected specs: `endpoint-event-collection` (file-tamper coverage extended to the launchd directories), `server-detection-rules-engine` (process-optional provenance correlation + `related_process_ids`), `web-ui` (render related-process context).
+- Affected code: `extension/edr/extension/FileTamperSubscriber.swift` (mute-set extension), `server/detection/internal/service` + `server/detection/internal/mysql` (correlation query + alert-detail field), `server/detection/internal/operator/handler.go` (response field), `ui/src/components/ProcessTree.tsx` + `ui/src/types.ts` (render related processes).
+- **VM-gated.** The ESF change touches event collection and MUST be exercised on a live macOS VM (system / VM test layer) before RC, per the project testing strategy. This proposal precedes that implementation; implementation lands once a VM validation window is available.
+- Depends on: the process-optional-alert-detail change (the UI base this builds on).

--- a/openspec/changes/launchd-persistence-provenance/specs/endpoint-event-collection/spec.md
+++ b/openspec/changes/launchd-persistence-provenance/specs/endpoint-event-collection/spec.md
@@ -1,0 +1,21 @@
+# Endpoint event collection: launchd file-tamper coverage delta
+
+## MODIFIED Requirements
+
+### Requirement: Sensitive-path file-modification capture
+
+The system SHALL emit a write-mode `open` event when a process creates or writes a file under a fixed set of sensitive target paths (currently `/etc/sudoers` and any direct child of `/etc/sudoers.d/`, and any file under the system LaunchDaemon/LaunchAgent directories `/Library/LaunchDaemons/` and `/Library/LaunchAgents/` and the per-user `~/Library/LaunchAgents/` directory of the active console user), carrying the writing process PID, the file path, and write-mode access flags. The system SHALL NOT forward a broad stream of file opens: collection is scoped at the source to those sensitive target paths via a dedicated Endpoint Security client with inverted target-path muting, kept separate from the process-authorization client so the scoping never affects exec authorization (ADR-0008). Writes to paths outside the sensitive set MUST NOT be collected.
+
+#### Scenario: A write to a sensitive path is captured
+
+- **GIVEN** the extension is running with the sensitive-path file-modification client active
+- **WHEN** a process writes to `/etc/sudoers` (or a direct child of `/etc/sudoers.d/`)
+- **THEN** a write-mode `open` event is emitted carrying the writing process PID, the file path, and the write-mode access flags
+- **AND** the event reaches the server and is available to the detection pipeline
+
+#### Scenario: A LaunchDaemon plist write is captured for provenance
+
+- **GIVEN** the extension is running with the sensitive-path file-modification client active
+- **WHEN** a process writes a plist under `/Library/LaunchDaemons/` or `/Library/LaunchAgents/`
+- **THEN** a write-mode `open` event is emitted carrying the writing process PID, the plist path, and the write-mode access flags
+- **AND** the event reaches the server so the detection pipeline can correlate the writer to the LaunchDaemon registration

--- a/openspec/changes/launchd-persistence-provenance/specs/server-detection-rules-engine/spec.md
+++ b/openspec/changes/launchd-persistence-provenance/specs/server-detection-rules-engine/spec.md
@@ -1,0 +1,25 @@
+# Detection rules engine: process-optional provenance correlation delta
+
+## ADDED Requirements
+
+### Requirement: Process-optional alert provenance correlation
+
+For an alert that is not attributed to a single process (a process-optional finding such as a LaunchDaemon registration, persisted with `process_id = 0`), the system SHALL, when serving the alert detail, attempt to correlate the alert to the processes genuinely related to the detected artifact and return them as a set of related processes, each tagged with its role. Correlation MUST be performed at read time (alert-detail compose), MUST NOT alter the alert's persisted `process_id` or dedup identity, and MUST degrade gracefully to an empty set when no correlation is found.
+
+For a LaunchDaemon/LaunchAgent registration finding the system SHALL derive related processes from the finding's linked registration event by:
+
+- correlating the registered plist path to the nearest-preceding write-mode `open` event on that path for the same host, resolving the writing PID to a process and tagging it `artifact_writer`; and
+- correlating the registered executable path to that executable's own process runs on the host, tagging them `persisted_executable`.
+
+#### Scenario: Writer is correlated to a LaunchDaemon registration
+
+- **GIVEN** a process-optional `privilege_launchd_plist_write` alert whose plist path was written by an observed process captured as a write-mode `open` event
+- **WHEN** the operator requests the alert detail
+- **THEN** the response includes the writing process among the related processes tagged `artifact_writer`
+
+#### Scenario: No provenance is available
+
+- **GIVEN** a process-optional alert whose plist was not captured as a write-mode `open` event (for example an atomic-rename write) and whose registered executable has no observed process run
+- **WHEN** the operator requests the alert detail
+- **THEN** the response returns an empty related-process set rather than an error
+- **AND** the alert's persisted `process_id` remains zero

--- a/openspec/changes/launchd-persistence-provenance/specs/web-ui/spec.md
+++ b/openspec/changes/launchd-persistence-provenance/specs/web-ui/spec.md
@@ -1,0 +1,20 @@
+# Web UI: related-process context for process-optional alerts delta
+
+## ADDED Requirements
+
+### Requirement: Related-process context for process-optional alerts
+
+When a process-optional alert's detail carries a non-empty set of related processes (the artifact's writer, the persisted executable's runs), the process tree page SHALL render those processes as the scoped focus of the graph, labelled by their role, instead of the "not attributed to a single process" explanation. The page SHALL NOT expand to the full host tree to surface them; it scopes to the related set, preserving the opt-in to widen. When the related set is empty, the page SHALL fall back to the explicit explanation and opt-in defined by the process-optional alert pivot.
+
+#### Scenario: Related processes are shown when available
+
+- **GIVEN** a process-optional alert whose detail includes related processes (for example the process that wrote the LaunchDaemon plist)
+- **WHEN** the operator pivots into the host's process tree from that alert
+- **THEN** the graph is scoped to the related processes, labelled by their role
+- **AND** the full host tree is not auto-expanded
+
+#### Scenario: Falls back to the explanation when no related processes exist
+
+- **GIVEN** a process-optional alert whose detail includes no related processes
+- **WHEN** the operator pivots into the host's process tree from that alert
+- **THEN** the page renders the explicit "not attributed to a single process" explanation with the opt-in to widen to the surrounding host activity

--- a/openspec/changes/launchd-persistence-provenance/tasks.md
+++ b/openspec/changes/launchd-persistence-provenance/tasks.md
@@ -1,0 +1,25 @@
+# Tasks
+
+## Extension (VM-gated)
+
+- [ ] `extension/edr/extension/FileTamperSubscriber.swift`: extend the inverted target-path mute set to include `/Library/LaunchDaemons/` (TARGET_PREFIX), `/Library/LaunchAgents/` (TARGET_PREFIX), and per-user `~/Library/LaunchAgents/` (resolved per console user). Re-emit CREATE/WRITE as write-mode `open` events, identical to the sudoers path.
+- [ ] Extension unit tests (`EDRExtensionLogicTests`): a write under each launchd directory produces a write-mode `open` event carrying the writer PID + path; a write outside the watched set does not.
+- [ ] Live macOS VM validation (edr-dev): register a non-Apple daemon, confirm both the `btm_launch_item_add` event AND the write-mode `open` on the plist arrive, carrying the writer PID. Flag in the PR description (ESF change).
+
+## Server
+
+- [ ] `server/detection/internal/mysql`: query for the nearest-before write-mode `open` event on a given path for a host within a window, returning the writer PID; resolve a PID to its process row id; resolve an executable path to its process row ids.
+- [ ] `server/detection/internal/service`: at alert-detail compose, for a process-optional alert derive `related_process_ids` (role-tagged `artifact_writer` / `persisted_executable`) from the linked `btm_launch_item_add` event payload (plist path + executable path). Additive; `process_id` stays 0.
+- [ ] `server/detection/internal/operator/handler.go`: add `related_processes` to the alert-detail response.
+- [ ] Server tests: synthetic write-mode `open` + BTM events correlate to the expected writer; executable-path correlation finds the persisted binary's runs; no correlation yields an empty set (graceful).
+
+## UI
+
+- [ ] `ui/src/types.ts`: add `related_processes` to `AlertDetail`.
+- [ ] `ui/src/components/ProcessTree.tsx`: when `related_processes` is present, seed focus from that set (role-labelled) instead of the empty-state explanation; fall back to the explanation when absent.
+- [ ] `ui/src/components/ProcessTree.test.tsx`: a process-optional alert with related processes focuses them; without them, the explanation still shows.
+
+## Docs / spec
+
+- [ ] Note the launchd directories in the detection-rule docs for `privilege_launchd_plist_write` (false-positive sources / provenance).
+- [ ] Archive this change after merge (`openspec archive launchd-persistence-provenance`).

--- a/openspec/changes/process-optional-alert-detail/proposal.md
+++ b/openspec/changes/process-optional-alert-detail/proposal.md
@@ -1,0 +1,25 @@
+# Explain process-optional alerts in the host process tree
+
+## Why
+
+A process-optional detection (one that keys on an artifact rather than a live process, e.g. `privilege_launchd_plist_write` / "LaunchDaemon persistence") opens into a completely blank process graph with no on-screen explanation. The alert link lands on `/ui/hosts/<host>?alert=<id>&process=0&at=<ts>`; the process tree defaults to focus mode and filters the forest down to the alerted process's chain, but with `process_id = 0` that chain is empty, so the entire forest is hidden and the analyst sees a silent blank canvas. They cannot tell whether the EDR is broken, the data was lost, or nothing happened. The forensic detail that explains the alert (the registered executable and the LaunchDaemon plist path, the MITRE technique) is carried on the alert but never rendered in this view.
+
+The fix is not to fall back to the full host tree (that dumps thousands of unrelated processes). It is to make the process-optional case a first-class, explained state: render the finding's detail regardless of graph state, and replace the silent blank canvas with an explicit explanation plus an opt-in to widen to the surrounding host activity.
+
+## What changes
+
+- The process tree page renders the alert's **description and MITRE technique tags** under the breadcrumb, for every alert. This is the primary "what and why" surface and the only meaningful content for a process-optional alert whose graph is intentionally empty.
+- For a process-optional alert (`process_id === 0`) in focus mode, the page renders an **explicit explanation** ("This detection isn't attributed to a single process...") in place of the blank canvas, with an **opt-in control** to widen to the full host tree. The forest is never auto-expanded.
+- The focus toggle label is honest for process-optional alerts ("Focused on alert" rather than the misleading "Focused on chain").
+- The explanation derives from the alert's `process_id` and description, both reloaded from the alert on every navigation, so it survives a page reload (it does not depend on a non-persisted toggle).
+
+This is a UI-only change: the server already carries the alert's description, severity, rule id, MITRE techniques, and `process_id` on the existing alert-detail response. No server, agent, wire, or persistence change.
+
+## Scope
+
+This change closes the "blank canvas, no explanation" bug. It does NOT populate the graph with the processes genuinely related to the detection (the process that wrote the persistence artifact, or the persisted executable's own runs); for `privilege_launchd_plist_write` the registration instigator is Apple's `smd`, not the actor, and the writer-provenance telemetry does not exist yet. Surfacing related processes is a separate follow-up (provenance correlation + the file-tamper subscriber extension) tracked alongside this change.
+
+## Impact
+
+- Affected spec: `web-ui` (the "Alert pivots to the host process tree" requirement gains a process-optional scenario).
+- Affected code: `ui/src/components/ProcessTree.tsx`, `ui/src/components/ProcessTree.scss`, `ui/src/types.ts` (adds `techniques` to the `Alert` interface), `ui/src/components/ProcessTree.test.tsx` (new).

--- a/openspec/changes/process-optional-alert-detail/specs/web-ui/spec.md
+++ b/openspec/changes/process-optional-alert-detail/specs/web-ui/spec.md
@@ -1,0 +1,24 @@
+# Web UI: process-optional alert pivot delta
+
+## MODIFIED Requirements
+
+### Requirement: Alert pivots to the host process tree
+
+The UI SHALL provide a control on each alert in the list that pivots into the alerted host's process tree page anchored at the moment the alert fired. The receiving page MUST present the alert's metadata (severity, title, time) as a breadcrumb and MUST default the time window to one wide enough to display historical alerts. The receiving page MUST also render the finding's description and MITRE technique tags so the analyst sees what fired and why independent of the graph state.
+
+When the alert is not attributed to a single process (a process-optional finding, where the attacker has no live process and the alert keys on an artifact such as a LaunchDaemon registration), the page MUST NOT render a silent blank canvas. It MUST instead present an explicit explanation that the detection is not tied to a running process, alongside an opt-in control that widens the view to the surrounding host activity. The page MUST NOT auto-expand to the full host tree. The explanation MUST survive a page reload of the alert link rather than depending on a non-persisted view toggle.
+
+#### Scenario: Operator pivots from an alert to the host context
+
+- **GIVEN** an alert is visible in the alert list
+- **WHEN** the operator activates the alert's primary link
+- **THEN** the UI navigates to the host's process tree pinned to the alert's time
+- **AND** the receiving page renders an alert breadcrumb identifying severity, title, and time
+
+#### Scenario: Operator pivots from a process-optional alert
+
+- **GIVEN** an alert that is not attributed to a single process (its process id is zero)
+- **WHEN** the operator pivots into the host's process tree from that alert
+- **THEN** the page renders the finding's description and MITRE technique tags
+- **AND** the page presents an explicit explanation that the detection is not attributed to a single process instead of a blank canvas
+- **AND** the page offers an opt-in control to widen the view to the surrounding host activity rather than auto-expanding the full host tree

--- a/openspec/changes/process-optional-alert-detail/tasks.md
+++ b/openspec/changes/process-optional-alert-detail/tasks.md
@@ -1,0 +1,16 @@
+# Tasks
+
+## UI
+
+- [x] `ui/src/types.ts`: add optional `techniques?: string[]` to the `Alert` interface (the server already sends it).
+- [x] `ui/src/components/ProcessTree.tsx`: derive `isProcessOptionalAlert` from `alertDetail.process_id === 0`; render the description + technique tags under the breadcrumb; honest focus-toggle label for process-optional alerts; render an explicit explanation + opt-in "Show surrounding host activity" in place of the blank canvas, taking precedence over the generic "No processes in this time range" message.
+- [x] `ui/src/components/ProcessTree.scss`: styles for the finding-detail panel and the `--info` status state.
+
+## Tests
+
+- [x] `ui/src/components/ProcessTree.test.tsx`: process-optional alert renders description + technique + explanation (not the generic empty message); the opt-in flips out of the focused view; a process-backed alert (`process_id !== 0`) never shows the explanation even when its chain is empty.
+
+## Verification
+
+- [x] `tsc --noEmit`, eslint clean on changed files, full vitest suite green (282 tests).
+- [ ] Real-tool QA against `task dev:server`: open the LaunchDaemon-persistence alert (the agent's own daemon registration produces one), confirm the description + technique render, the explanation replaces the blank canvas, the opt-in widens to the host tree, and a reload preserves the explanation. (Pending; run before merge.)

--- a/openspec/changes/process-optional-alert-detail/tasks.md
+++ b/openspec/changes/process-optional-alert-detail/tasks.md
@@ -13,4 +13,4 @@
 ## Verification
 
 - [x] `tsc --noEmit`, eslint clean on changed files, full vitest suite green (282 tests).
-- [ ] Real-tool QA against `task dev:server`: open the LaunchDaemon-persistence alert (the agent's own daemon registration produces one), confirm the description + technique render, the explanation replaces the blank canvas, the opt-in widens to the host tree, and a reload preserves the explanation. (Pending; run before merge.)
+- [x] Real-tool QA against `task dev:server` (Chrome, edr-dev VM agent data): opened real process-optional `privilege_launchd_plist_write` alerts (agent daemon + synthetic-dropper registrations, `process_id = 0`). Confirmed the description + `T1543.004` tag render, the "not attributed to a single process" explanation replaces the blank canvas, "Show surrounding host activity" widens to the full host tree, and a reload restores the explanation. Regression: a process-backed `suspicious_exec` alert still focuses its chain with no explanation.

--- a/ui/src/components/ProcessTree.scss
+++ b/ui/src/components/ProcessTree.scss
@@ -200,6 +200,20 @@
     &--error {
       color: $core-vibrant-red;
     }
+
+    // Process-optional alert explanation: a neutral framed note, not an error. Sits where the empty canvas would be and
+    // carries the opt-in to widen to the full host tree.
+    &--info {
+      display: flex;
+      align-items: center;
+      gap: $pad-medium;
+      padding: $pad-medium;
+      background-color: $ui-fleet-black-5;
+      border: 1px solid $ui-fleet-black-10;
+      border-radius: $border-radius;
+
+      p { margin: 0; }
+    }
   }
 
   &__layout {
@@ -301,6 +315,26 @@
 
   &__spacer {
     flex: 1;
+  }
+}
+
+// Finding detail: the alert's description + technique tags, rendered under the breadcrumb. The primary "what and why"
+// surface, and the only meaningful content for a process-optional alert whose graph is intentionally empty.
+.alert-detail-panel {
+  margin-bottom: $pad-medium;
+  padding: 0 $pad-medium;
+
+  &__description {
+    margin: 0 0 $pad-small;
+    color: $core-fleet-black;
+    font-size: $x-small;
+    line-height: 1.5;
+  }
+
+  &__techniques {
+    display: flex;
+    flex-wrap: wrap;
+    gap: $pad-xsmall;
   }
 }
 

--- a/ui/src/components/ProcessTree.test.tsx
+++ b/ui/src/components/ProcessTree.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { MemoryRouter, Routes, Route } from "react-router-dom";
 import { beforeAll, beforeEach, afterEach, describe, it, expect, vi } from "vitest";
 import * as api from "../api";
@@ -77,11 +77,14 @@ describe("ProcessTreeView process-optional alert", () => {
     expect(screen.getByText(/isn’t attributed to a single process/i)).toBeInTheDocument();
     // The generic "no processes" message must NOT be what the analyst sees here.
     expect(screen.queryByText(/No processes in this time range/i)).not.toBeInTheDocument();
+    // Single control: the generic breadcrumb chain toggle is hidden for process-optional alerts, leaving only the info-bar
+    // button below, so the analyst isn't faced with two controls that do the same thing.
+    expect(screen.queryByRole("button", { name: /show full tree|focused on chain/i })).not.toBeInTheDocument();
   });
 
-  it("offers an opt-in that widens out of the focused (empty) view", async () => {
+  it("widens and collapses via the single info-bar control", async () => {
     // Empty host tree so widening doesn't trigger the d3/SVG render path (jsdom lacks the SVG geometry APIs d3 needs); the
-    // assertion is about the focus state flipping off, not about drawing the forest.
+    // assertion is about the focus state flipping, not about drawing the forest.
     vi.spyOn(api, "getProcessTree").mockResolvedValue({ roots: [] });
     vi.spyOn(api, "getAlertDetail").mockResolvedValue(launchDaemonAlert);
     renderTree("?alert=7&process=0&at=1750248000000");
@@ -89,10 +92,15 @@ describe("ProcessTreeView process-optional alert", () => {
     const widen = await screen.findByRole("button", { name: /show surrounding host activity/i });
     fireEvent.click(widen);
 
-    // After opting in, focus mode is off so the process-optional explanation is gone.
-    await waitFor(() => {
-      expect(screen.queryByText(/isn’t attributed to a single process/i)).not.toBeInTheDocument();
-    });
+    // After widening: the explanation is gone and the single control flips to a collapse-back affordance.
+    const collapse = await screen.findByRole("button", { name: /show alert detail only/i });
+    expect(collapse).toBeInTheDocument();
+    expect(screen.queryByText(/isn’t attributed to a single process/i)).not.toBeInTheDocument();
+
+    // Collapsing returns to the explanation, and there is never a second (breadcrumb) chain toggle.
+    fireEvent.click(collapse);
+    expect(await screen.findByText(/isn’t attributed to a single process/i)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /show full tree|focused on chain/i })).not.toBeInTheDocument();
   });
 });
 
@@ -113,5 +121,7 @@ describe("ProcessTreeView process-backed alert", () => {
     expect(await screen.findByText(/registered as system LaunchDaemon/i)).toBeInTheDocument();
     // But the process-optional explanation must not appear.
     expect(screen.queryByText(/isn’t attributed to a single process/i)).not.toBeInTheDocument();
+    // And the generic chain toggle IS present for a process-backed alert (it is only hidden for process-optional ones).
+    expect(screen.getByRole("button", { name: /focused on chain/i })).toBeInTheDocument();
   });
 });

--- a/ui/src/components/ProcessTree.test.tsx
+++ b/ui/src/components/ProcessTree.test.tsx
@@ -79,7 +79,7 @@ describe("ProcessTreeView process-optional alert", () => {
     expect(screen.queryByText(/No processes in this time range/i)).not.toBeInTheDocument();
     // Single control: the generic breadcrumb chain toggle is hidden for process-optional alerts, leaving only the info-bar
     // button below, so the analyst isn't faced with two controls that do the same thing.
-    expect(screen.queryByRole("button", { name: /show full tree|focused on chain/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /full host tree|focused on chain/i })).not.toBeInTheDocument();
   });
 
   it("widens and collapses via the single info-bar control", async () => {
@@ -100,7 +100,19 @@ describe("ProcessTreeView process-optional alert", () => {
     // Collapsing returns to the explanation, and there is never a second (breadcrumb) chain toggle.
     fireEvent.click(collapse);
     expect(await screen.findByText(/isn’t attributed to a single process/i)).toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: /show full tree|focused on chain/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /full host tree|focused on chain/i })).not.toBeInTheDocument();
+  });
+
+  it("still explains the alert (no blank canvas) when getAlertDetail fails", async () => {
+    // The focus filter empties the forest from ?process=0 on mount, before (or even if never) alertDetail loads. Keying the
+    // process-optional classification on the URL param means the explanation still renders, so a slow or failed
+    // getAlertDetail never leaves a silent blank canvas. Regression guard for the Gemini/Qodo race finding on PR #466.
+    vi.spyOn(api, "getProcessTree").mockResolvedValue({ roots: forest });
+    vi.spyOn(api, "getAlertDetail").mockRejectedValue(new Error("alert detail unavailable"));
+    renderTree("?alert=7&process=0&at=1750248000000");
+
+    expect(await screen.findByText(/isn’t attributed to a single process/i)).toBeInTheDocument();
+    expect(screen.queryByText(/No processes in this time range/i)).not.toBeInTheDocument();
   });
 });
 

--- a/ui/src/components/ProcessTree.test.tsx
+++ b/ui/src/components/ProcessTree.test.tsx
@@ -121,6 +121,8 @@ describe("ProcessTreeView process-backed alert", () => {
     // An attributed alert (process_id !== 0) whose target happens to be outside the loaded window: the graph is empty, but
     // the process-optional explanation must NOT appear. This guards the regression that the explanation is gated on
     // process-optional-ness, not merely on "the focused chain came back empty".
+    // Empty host tree so toggling focus off doesn't trigger the d3/SVG render path (jsdom lacks the SVG geometry APIs).
+    vi.spyOn(api, "getProcessTree").mockResolvedValue({ roots: [] });
     vi.spyOn(api, "getAlertDetail").mockResolvedValue({
       ...launchDaemonAlert,
       rule_id: "suspicious_exec",
@@ -133,7 +135,11 @@ describe("ProcessTreeView process-backed alert", () => {
     expect(await screen.findByText(/registered as system LaunchDaemon/i)).toBeInTheDocument();
     // But the process-optional explanation must not appear.
     expect(screen.queryByText(/isn’t attributed to a single process/i)).not.toBeInTheDocument();
-    // And the generic chain toggle IS present for a process-backed alert (it is only hidden for process-optional ones).
-    expect(screen.getByRole("button", { name: /focused on chain/i })).toBeInTheDocument();
+
+    // The generic chain toggle IS present for a process-backed alert (it is only hidden for process-optional ones), and it
+    // is a state label that flips between "Focused on chain" and "Full host tree" rather than reading as a stale action.
+    const toggle = screen.getByRole("button", { name: /focused on chain/i });
+    fireEvent.click(toggle);
+    expect(await screen.findByRole("button", { name: /full host tree/i })).toBeInTheDocument();
   });
 });

--- a/ui/src/components/ProcessTree.test.tsx
+++ b/ui/src/components/ProcessTree.test.tsx
@@ -1,0 +1,117 @@
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+import { beforeAll, beforeEach, afterEach, describe, it, expect, vi } from "vitest";
+import * as api from "../api";
+import type { AlertDetail, ProcessNode } from "../types";
+import { ProcessTreeView } from "./ProcessTree";
+
+// spec:web-ui/alert-pivots-to-the-host-process-tree/operator-pivots-from-a-process-optional-alert
+//
+// Covers the process-optional alert pivot: a finding with process_id === 0 (e.g. LaunchDaemon persistence, where the BTM
+// instigator is Apple's smd, not the actor) opens with no attributed process node. The receiving page MUST render the
+// finding detail (description + technique tags) and an explicit explanation instead of a silent blank canvas, with an
+// opt-in to widen to the surrounding host activity. A normal (process-backed) alert MUST still focus its chain.
+
+// d3 calls SVGElement.getBBox to size label backgrounds; jsdom does not implement it. Stub a benign box so the render
+// effect doesn't throw when a tree is laid out.
+beforeAll(() => {
+  (SVGElement.prototype as unknown as { getBBox: () => DOMRect }).getBBox = () =>
+    ({ x: 0, y: 0, width: 40, height: 12 }) as DOMRect;
+});
+
+function process(id: number, pid: number, ppid: number, path: string): ProcessNode {
+  return { id, host_id: "h1", pid, ppid, path, fork_time_ns: 1 };
+}
+
+const forest: ProcessNode[] = [
+  { ...process(1, 100, 1, "/sbin/launchd"), children: [process(2, 200, 100, "/usr/local/bin/fleet-edr-agent")] },
+];
+
+const launchDaemonAlert: AlertDetail = {
+  id: 7,
+  host_id: "h1",
+  rule_id: "privilege_launchd_plist_write",
+  source: "detection",
+  severity: "high",
+  title: "LaunchDaemon persistence",
+  description:
+    "Untrusted executable /usr/local/bin/fleet-edr-agent registered as system LaunchDaemon " +
+    "com.fleetdm.edr.agent.plist: persistence (MITRE T1543.004)",
+  techniques: ["T1543.004"],
+  process_id: 0,
+  status: "open",
+  created_at: "2026-06-18T12:00:00Z",
+  updated_at: "2026-06-18T12:00:00Z",
+  event_ids: ["evt-1"],
+};
+
+function renderTree(search: string) {
+  return render(
+    <MemoryRouter initialEntries={[`/hosts/h1${search}`]}>
+      <Routes>
+        <Route path="/hosts/:hostId" element={<ProcessTreeView />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.spyOn(api, "getProcessTree").mockResolvedValue({ roots: forest });
+  vi.spyOn(api, "listAlerts").mockResolvedValue([]);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("ProcessTreeView process-optional alert", () => {
+  it("renders the finding detail and an explanatory empty state instead of a blank canvas", async () => {
+    vi.spyOn(api, "getAlertDetail").mockResolvedValue(launchDaemonAlert);
+    renderTree("?alert=7&process=0&at=1750248000000");
+
+    // The finding description (the what + why) is rendered.
+    expect(await screen.findByText(/registered as system LaunchDaemon/i)).toBeInTheDocument();
+    // The MITRE technique tag is rendered.
+    expect(screen.getByText("T1543.004")).toBeInTheDocument();
+    // The explicit explanation replaces the silent blank canvas.
+    expect(screen.getByText(/isn’t attributed to a single process/i)).toBeInTheDocument();
+    // The generic "no processes" message must NOT be what the analyst sees here.
+    expect(screen.queryByText(/No processes in this time range/i)).not.toBeInTheDocument();
+  });
+
+  it("offers an opt-in that widens out of the focused (empty) view", async () => {
+    // Empty host tree so widening doesn't trigger the d3/SVG render path (jsdom lacks the SVG geometry APIs d3 needs); the
+    // assertion is about the focus state flipping off, not about drawing the forest.
+    vi.spyOn(api, "getProcessTree").mockResolvedValue({ roots: [] });
+    vi.spyOn(api, "getAlertDetail").mockResolvedValue(launchDaemonAlert);
+    renderTree("?alert=7&process=0&at=1750248000000");
+
+    const widen = await screen.findByRole("button", { name: /show surrounding host activity/i });
+    fireEvent.click(widen);
+
+    // After opting in, focus mode is off so the process-optional explanation is gone.
+    await waitFor(() => {
+      expect(screen.queryByText(/isn’t attributed to a single process/i)).not.toBeInTheDocument();
+    });
+  });
+});
+
+describe("ProcessTreeView process-backed alert", () => {
+  it("keys the explanation on process_id === 0, not on an empty graph", async () => {
+    // An attributed alert (process_id !== 0) whose target happens to be outside the loaded window: the graph is empty, but
+    // the process-optional explanation must NOT appear. This guards the regression that the explanation is gated on
+    // process-optional-ness, not merely on "the focused chain came back empty".
+    vi.spyOn(api, "getAlertDetail").mockResolvedValue({
+      ...launchDaemonAlert,
+      rule_id: "suspicious_exec",
+      title: "Shell spawn with outbound network connection",
+      process_id: 99,
+    });
+    renderTree("?alert=7&process=99&at=1750248000000");
+
+    // The finding detail still renders for a process-backed alert.
+    expect(await screen.findByText(/registered as system LaunchDaemon/i)).toBeInTheDocument();
+    // But the process-optional explanation must not appear.
+    expect(screen.queryByText(/isn’t attributed to a single process/i)).not.toBeInTheDocument();
+  });
+});

--- a/ui/src/components/ProcessTree.tsx
+++ b/ui/src/components/ProcessTree.tsx
@@ -495,19 +495,23 @@ export function ProcessTreeView() {
           <span className="alert-breadcrumb__time">
             {new Date(alertDetail.created_at).toLocaleString()}
           </span>
-          <span className="alert-breadcrumb__spacer" />
-          <Button
-            size="small"
-            variant={focusAlertChain ? "primary" : "inverse"}
-            onClick={() => { setFocusAlertChain((v) => !v); }}
-            title={focusAlertChain
-              ? "Showing only the processes related to this alert"
-              : "Showing the full host tree"}
-          >
-            {focusAlertChain
-              ? (isProcessOptionalAlert ? "Focused on alert" : "Focused on chain")
-              : "Show full tree"}
-          </Button>
+          {/* Process-optional alerts have no chain to focus, so this generic chain toggle would be a confusing second control
+              next to the info bar's widen/collapse button below. Show it only for process-backed alerts. */}
+          {!isProcessOptionalAlert && (
+            <>
+              <span className="alert-breadcrumb__spacer" />
+              <Button
+                size="small"
+                variant={focusAlertChain ? "primary" : "inverse"}
+                onClick={() => { setFocusAlertChain((v) => !v); }}
+                title={focusAlertChain
+                  ? "Showing only the processes related to this alert"
+                  : "Showing the full host tree"}
+              >
+                {focusAlertChain ? "Focused on chain" : "Show full tree"}
+              </Button>
+            </>
+          )}
         </div>
       )}
 
@@ -528,18 +532,29 @@ export function ProcessTreeView() {
 
       {loading && <p className="process-tree__status">Loading...</p>}
       {error && <p className="process-tree__status process-tree__status--error">Error: {error}</p>}
-      {/* Process-optional alert in focus mode: the graph is intentionally empty (there is no attributed process chain), so
-          explain that instead of leaving a silent blank canvas, and offer the opt-in to widen to the surrounding host
-          activity. This takes precedence over the generic empty message below. */}
-      {!loading && !error && isProcessOptionalAlert && focusAlertChain && (
+      {/* Process-optional alert: there is no attributed process chain, so this info bar is the SINGLE control for the graph
+          (the generic chain toggle in the breadcrumb is hidden above). Focused: explain the empty graph + offer to widen.
+          Widened: a short note + collapse back. Exactly one button in either state. */}
+      {!loading && !error && isProcessOptionalAlert && (
         <div className="process-tree__status process-tree__status--info">
-          <p>This detection isn’t attributed to a single process. See the detail above for what fired and why.</p>
-          <Button size="small" variant="inverse" onClick={() => { setFocusAlertChain(false); }}>
-            Show surrounding host activity
-          </Button>
+          {focusAlertChain ? (
+            <>
+              <p>This detection isn’t attributed to a single process. See the detail above for what fired and why.</p>
+              <Button size="small" variant="inverse" onClick={() => { setFocusAlertChain(false); }}>
+                Show surrounding host activity
+              </Button>
+            </>
+          ) : (
+            <>
+              <p>Showing the surrounding host activity for this detection.</p>
+              <Button size="small" variant="inverse" onClick={() => { setFocusAlertChain(true); }}>
+                Show alert detail only
+              </Button>
+            </>
+          )}
         </div>
       )}
-      {!loading && !error && !(isProcessOptionalAlert && focusAlertChain) && roots.length === 0 && (
+      {!loading && !error && !isProcessOptionalAlert && roots.length === 0 && (
         <p className="process-tree__status">No processes in this time range.</p>
       )}
 

--- a/ui/src/components/ProcessTree.tsx
+++ b/ui/src/components/ProcessTree.tsx
@@ -119,8 +119,12 @@ export function ProcessTreeView() {
   // A process-optional alert (process_id === 0) has no attributed process node to focus on: it keys on an artifact, not a
   // process (e.g. a LaunchDaemon registration, where the BTM instigator is Apple's smd, not the actor). Focus mode would
   // filter the forest to an empty chain and render a silent blank canvas, so these alerts get an explicit explanation +
-  // opt-in expansion instead. process_id is the authoritative signal (the ?process= URL param mirrors it).
-  const isProcessOptionalAlert = alertDetail !== null && alertDetail.process_id === 0;
+  // opt-in expansion instead. We key on the ?process=0 URL param FIRST (it mirrors process_id and is available on the very
+  // first render) so the explanation shows immediately: the focus filter already empties the forest from that same param on
+  // mount, so deriving this from the async alertDetail alone would leave a blank canvas during the fetch (or permanently if
+  // getAlertDetail fails) before the explanation appears. alertDetail.process_id is the fallback for any path that omits the
+  // param.
+  const isProcessOptionalAlert = searchParams.get("process") === "0" || (alertDetail !== null && alertDetail.process_id === 0);
 
   useEffect(() => {
     try { localStorage.setItem(SHOW_SYSTEM_STORAGE_KEY, String(showSystem)); } catch { /* ignore */ }
@@ -505,10 +509,12 @@ export function ProcessTreeView() {
                 variant={focusAlertChain ? "primary" : "inverse"}
                 onClick={() => { setFocusAlertChain((v) => !v); }}
                 title={focusAlertChain
-                  ? "Showing only the processes related to this alert"
-                  : "Showing the full host tree"}
+                  ? "Showing only the processes related to this alert; click to show the full host tree"
+                  : "Showing the full host tree; click to focus the alert's process chain"}
               >
-                {focusAlertChain ? "Focused on chain" : "Show full tree"}
+                {/* State label, not an action: both cases describe what's currently shown (the click action is in the
+                    tooltip), so the toggle isn't read as "Show full tree" while it actually enables focus mode. */}
+                {focusAlertChain ? "Focused on chain" : "Full host tree"}
               </Button>
             </>
           )}

--- a/ui/src/components/ProcessTree.tsx
+++ b/ui/src/components/ProcessTree.tsx
@@ -116,6 +116,12 @@ export function ProcessTreeView() {
   );
   const [alertDetail, setAlertDetail] = useState<AlertDetail | null>(null);
 
+  // A process-optional alert (process_id === 0) has no attributed process node to focus on: it keys on an artifact, not a
+  // process (e.g. a LaunchDaemon registration, where the BTM instigator is Apple's smd, not the actor). Focus mode would
+  // filter the forest to an empty chain and render a silent blank canvas, so these alerts get an explicit explanation +
+  // opt-in expansion instead. process_id is the authoritative signal (the ?process= URL param mirrors it).
+  const isProcessOptionalAlert = alertDetail !== null && alertDetail.process_id === 0;
+
   useEffect(() => {
     try { localStorage.setItem(SHOW_SYSTEM_STORAGE_KEY, String(showSystem)); } catch { /* ignore */ }
   }, [showSystem]);
@@ -495,17 +501,45 @@ export function ProcessTreeView() {
             variant={focusAlertChain ? "primary" : "inverse"}
             onClick={() => { setFocusAlertChain((v) => !v); }}
             title={focusAlertChain
-              ? "Showing only the alert's process chain"
+              ? "Showing only the processes related to this alert"
               : "Showing the full host tree"}
           >
-            {focusAlertChain ? "Focused on chain" : "Show full tree"}
+            {focusAlertChain
+              ? (isProcessOptionalAlert ? "Focused on alert" : "Focused on chain")
+              : "Show full tree"}
           </Button>
+        </div>
+      )}
+
+      {/* The finding detail (description + technique tags) is the "what and why" of the alert. It renders for every alert,
+          and is the primary surface for a process-optional alert whose graph is intentionally empty. */}
+      {alertDetail && (
+        <div className="alert-detail-panel">
+          <p className="alert-detail-panel__description">{alertDetail.description}</p>
+          {alertDetail.techniques && alertDetail.techniques.length > 0 && (
+            <div className="alert-detail-panel__techniques">
+              {alertDetail.techniques.map((t) => (
+                <Badge key={t} variant="neutral">{t}</Badge>
+              ))}
+            </div>
+          )}
         </div>
       )}
 
       {loading && <p className="process-tree__status">Loading...</p>}
       {error && <p className="process-tree__status process-tree__status--error">Error: {error}</p>}
-      {!loading && roots.length === 0 && (
+      {/* Process-optional alert in focus mode: the graph is intentionally empty (there is no attributed process chain), so
+          explain that instead of leaving a silent blank canvas, and offer the opt-in to widen to the surrounding host
+          activity. This takes precedence over the generic empty message below. */}
+      {!loading && !error && isProcessOptionalAlert && focusAlertChain && (
+        <div className="process-tree__status process-tree__status--info">
+          <p>This detection isn’t attributed to a single process. See the detail above for what fired and why.</p>
+          <Button size="small" variant="inverse" onClick={() => { setFocusAlertChain(false); }}>
+            Show surrounding host activity
+          </Button>
+        </div>
+      )}
+      {!loading && !error && !(isProcessOptionalAlert && focusAlertChain) && roots.length === 0 && (
         <p className="process-tree__status">No processes in this time range.</p>
       )}
 

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -116,6 +116,9 @@ export interface Alert {
   severity: string;
   title: string;
   description: string;
+  // techniques are the MITRE ATT&CK ids the rule maps to (e.g. ["T1543.004"]). Omitted by the server when the rule
+  // declares none, so optional here.
+  techniques?: string[];
   process_id: number;
   status: string;
   created_at: string;


### PR DESCRIPTION
<!-- Keep this short. Delete sections that do not apply. -->

## What & why



## Checklist

- [ ] **OpenSpec updated for behavior changes.** If this PR changes observable behavior (a detection rule, the event
      wire schema, persistence semantics, an API/wire shape, or an emitted event), `openspec/specs/**` is updated (and
      an `openspec/changes/` proposal added), with a `spec:<id>` test marker for any new/renamed scenario. Only if this
      PR changes NO observable behavior (a comment / refactor / gofmt / dep bump that happens to touch a scoped path)
      may you assert `no-behavior-change` (label or `[no-behavior-change]` in the title) to clear the OpenSpec-sync gate.
      That is an assertion a reviewer will check, not a way to skip the spec for a real behavior change.
- [ ] Tests added/updated for the change (unit / integration / efficacy / UI as applicable).
- [ ] Agent/extension change touching ESF, XPC, or the event wire format: exercised on a live macOS VM before RC
      (flagged below).

## VM / RC notes (if applicable)


