### PR TITLE
feat(extension): DNS proxy forward deadline + self-heal watchdog

### DIFF
--- a/extension/edr/Package.swift
+++ b/extension/edr/Package.swift
@@ -96,6 +96,10 @@ let package = Package(
                 "extension/FileHashCache.swift",
                 "extension/SigningInfoFallback.swift",
                 "networkextension/DNSParser.swift",
+                // DNSProxyHealth.swift is the DNS proxy's self-heal watchdog: a sliding-window failure accumulator +
+                // claim/bypass decision. Pure Foundation (no NetworkExtension import), so its decision logic is
+                // unit-testable here without a live resolver. DNSProxyProvider (Xcode-only NE target) holds an instance.
+                "networkextension/DNSProxyHealth.swift",
                 // ProcessInfo.swift is pure Darwin (audit-token extraction + proc_pidpath), no NetworkExtension import, so it
                 // compiles in this logic library and its extractProcessInfo pidversion parsing is unit-testable (issue #403).
                 "networkextension/ProcessInfo.swift",

--- a/extension/edr/Package.swift
+++ b/extension/edr/Package.swift
@@ -100,6 +100,9 @@ let package = Package(
                 // claim/bypass decision. Pure Foundation (no NetworkExtension import), so its decision logic is
                 // unit-testable here without a live resolver. DNSProxyProvider (Xcode-only NE target) holds an instance.
                 "networkextension/DNSProxyHealth.swift",
+                // DNSForwardCompletion.swift is the once-only, atomic deadline-vs-receive resolver for a UDP forward.
+                // Pure Foundation, so its claim/fail state-machine transitions are unit-testable.
+                "networkextension/DNSForwardCompletion.swift",
                 // ProcessInfo.swift is pure Darwin (audit-token extraction + proc_pidpath), no NetworkExtension import, so it
                 // compiles in this logic library and its extractProcessInfo pidversion parsing is unit-testable (issue #403).
                 "networkextension/ProcessInfo.swift",

--- a/extension/edr/Tests/EDRExtensionLogicTests/DNSForwardCompletionTests.swift
+++ b/extension/edr/Tests/EDRExtensionLogicTests/DNSForwardCompletionTests.swift
@@ -1,0 +1,46 @@
+// DNSForwardCompletion tests: pin the deadline-vs-receive race semantics. onResolve must run exactly once, and the atomic
+// claim must guarantee that once the receive path claims a forward the deadline can no longer reclassify it as a failure
+// (the TOCTOU hole Qodo flagged on PR #471).
+
+import Foundation
+@testable import EDRExtensionLogic
+import XCTest
+
+final class DNSForwardCompletionTests: XCTestCase {
+    func testReceiveWinsThenDeadlineIsNoOp() {
+        var outcomes: [Bool] = []
+        let c = DNSForwardCompletion { outcomes.append($0) }
+        XCTAssertTrue(c.claimResponse())     // receive path claims first
+        c.failIfPending()                    // deadline fires after the claim -> must be a no-op
+        c.resolveResponse(ok: true)          // receive finalizes the success
+        XCTAssertEqual(outcomes, [true])     // resolved exactly once, as success (not reclassified to failure)
+    }
+
+    func testDeadlineWinsThenReceiveCannotClaim() {
+        var outcomes: [Bool] = []
+        let c = DNSForwardCompletion { outcomes.append($0) }
+        c.failIfPending()                    // deadline wins
+        XCTAssertFalse(c.claimResponse())    // late receive path cannot claim -> it must bail without touching the flow
+        c.resolveResponse(ok: true)          // and even if mis-called, it is a no-op
+        XCTAssertEqual(outcomes, [false])    // resolved exactly once, as failure
+    }
+
+    func testResolveOnlyFiresOnce() {
+        var count = 0
+        let c = DNSForwardCompletion { _ in count += 1 }
+        XCTAssertTrue(c.claimResponse())
+        c.resolveResponse(ok: true)
+        c.resolveResponse(ok: false)         // double finalize is ignored
+        c.failIfPending()                    // and the deadline after done is ignored
+        XCTAssertEqual(count, 1)
+    }
+
+    func testResolveResponseWithoutClaimIsNoOp() {
+        var outcomes: [Bool] = []
+        let c = DNSForwardCompletion { outcomes.append($0) }
+        c.resolveResponse(ok: true)          // never claimed -> cannot finalize
+        XCTAssertTrue(outcomes.isEmpty)
+        c.failIfPending()                    // still pending, so the deadline can resolve it
+        XCTAssertEqual(outcomes, [false])
+    }
+}

--- a/extension/edr/Tests/EDRExtensionLogicTests/DNSForwardCompletionTests.swift
+++ b/extension/edr/Tests/EDRExtensionLogicTests/DNSForwardCompletionTests.swift
@@ -11,7 +11,8 @@ final class DNSForwardCompletionTests: XCTestCase {
         var outcomes: [Bool] = []
         let c = DNSForwardCompletion { outcomes.append($0) }
         XCTAssertTrue(c.claimResponse())     // receive path claims first
-        c.failIfPending()                    // deadline fires after the claim -> must be a no-op
+        // Deadline fires after the claim: it loses, returns false (so the caller does NOT log "timed out"), and is a no-op.
+        XCTAssertFalse(c.failIfPending())
         c.resolveResponse(ok: true)          // receive finalizes the success
         XCTAssertEqual(outcomes, [true])     // resolved exactly once, as success (not reclassified to failure)
     }
@@ -19,7 +20,7 @@ final class DNSForwardCompletionTests: XCTestCase {
     func testDeadlineWinsThenReceiveCannotClaim() {
         var outcomes: [Bool] = []
         let c = DNSForwardCompletion { outcomes.append($0) }
-        c.failIfPending()                    // deadline wins
+        XCTAssertTrue(c.failIfPending())     // deadline wins -> returns true so the caller logs the genuine timeout
         XCTAssertFalse(c.claimResponse())    // late receive path cannot claim -> it must bail without touching the flow
         c.resolveResponse(ok: true)          // and even if mis-called, it is a no-op
         XCTAssertEqual(outcomes, [false])    // resolved exactly once, as failure

--- a/extension/edr/Tests/EDRExtensionLogicTests/DNSProxyHealthTests.swift
+++ b/extension/edr/Tests/EDRExtensionLogicTests/DNSProxyHealthTests.swift
@@ -8,18 +8,21 @@ import Foundation
 import XCTest
 
 final class DNSProxyHealthTests: XCTestCase {
-    /// A movable clock so tests advance time explicitly rather than sleeping.
+    /// A movable monotonic clock (seconds) so tests advance time explicitly rather than sleeping. Matches the production
+    /// seam, which is monotonic (ProcessInfo.systemUptime), not wall-clock.
     private final class FakeClock {
-        var t = Date(timeIntervalSince1970: 1_000_000)
-        func now() -> Date { t }
-        func advance(_ seconds: TimeInterval) { t = t.addingTimeInterval(seconds) }
+        var t: TimeInterval = 1_000_000
+        func now() -> TimeInterval { t }
+        func advance(_ seconds: TimeInterval) { t += seconds }
     }
 
     private func makeHealth(_ clock: FakeClock,
                             window: TimeInterval = 30,
                             minSamples: Int = 5,
-                            failureRate: Double = 0.8) -> DNSProxyHealth {
-        DNSProxyHealth(config: .init(window: window, minSamples: minSamples, failureRateToBypass: failureRate),
+                            failureRate: Double = 0.8,
+                            maxSamples: Int = 256) -> DNSProxyHealth {
+        DNSProxyHealth(config: .init(window: window, minSamples: minSamples, failureRateToBypass: failureRate,
+                                     maxSamples: maxSamples),
                        now: clock.now)
     }
 
@@ -114,6 +117,28 @@ final class DNSProxyHealthTests: XCTestCase {
         clock.advance(31)
         XCTAssertEqual(health.decide(policyActive: false), .init(verdict: .claim, transitioned: true))
         XCTAssertEqual(health.decide(policyActive: false), .init(verdict: .claim, transitioned: false))
+    }
+
+    func testInvalidMinSamplesDoesNotProduceNaN() {
+        let clock = FakeClock()
+        // minSamples == 0 would, without the max(1, ...) clamp, pass the guard on an empty window and divide by zero.
+        let health = makeHealth(clock, minSamples: 0)
+        // Empty window: claim, no crash, no NaN-driven misbehavior.
+        XCTAssertEqual(health.decide(policyActive: false).verdict, .claim)
+        // With real failures the clamped floor still trips bypass exactly as a sane config would.
+        for _ in 0..<5 { health.record(ok: false) }
+        XCTAssertEqual(health.decide(policyActive: false).verdict, .bypass)
+    }
+
+    func testSampleCapBoundsRetainedOutcomes() {
+        let clock = FakeClock()
+        // Cap at 10 within a generous window so the cap (not the window) is what bounds retention.
+        let health = makeHealth(clock, window: 10_000, minSamples: 5, failureRate: 0.8, maxSamples: 10)
+        // 100 successes then 10 failures, all inside the window. Without the cap the rate would be 10/110 = .09 (claim);
+        // with the cap only the last 10 (all failures) are retained -> rate 1.0 -> bypass. Proves the cap drops oldest.
+        for _ in 0..<100 { health.record(ok: true) }
+        for _ in 0..<10 { health.record(ok: false) }
+        XCTAssertEqual(health.decide(policyActive: false).verdict, .bypass)
     }
 
     func testPartialWindowExpiryRecomputesRate() {

--- a/extension/edr/Tests/EDRExtensionLogicTests/DNSProxyHealthTests.swift
+++ b/extension/edr/Tests/EDRExtensionLogicTests/DNSProxyHealthTests.swift
@@ -1,0 +1,132 @@
+// DNSProxyHealth tests: drive the watchdog with an injected clock so the sliding window is deterministic. These pin the
+// self-heal contract behind the DNS proxy's fail-open bypass (ADR-0014 / resilient-network-enforcement): a healthy proxy
+// claims, a sustainedly-failing proxy bypasses to the system resolver, an active enforcement policy never open-bypasses, and
+// the bypass clears on its own once failures age out of the window (the window IS the cooldown).
+
+import Foundation
+@testable import EDRExtensionLogic
+import XCTest
+
+final class DNSProxyHealthTests: XCTestCase {
+    /// A movable clock so tests advance time explicitly rather than sleeping.
+    private final class FakeClock {
+        var t = Date(timeIntervalSince1970: 1_000_000)
+        func now() -> Date { t }
+        func advance(_ seconds: TimeInterval) { t = t.addingTimeInterval(seconds) }
+    }
+
+    private func makeHealth(_ clock: FakeClock,
+                            window: TimeInterval = 30,
+                            minSamples: Int = 5,
+                            failureRate: Double = 0.8) -> DNSProxyHealth {
+        DNSProxyHealth(config: .init(window: window, minSamples: minSamples, failureRateToBypass: failureRate),
+                       now: clock.now)
+    }
+
+    func testClaimsWhenNoSamples() {
+        let clock = FakeClock()
+        let health = makeHealth(clock)
+        XCTAssertEqual(health.decide(policyActive: false).verdict, .claim)
+    }
+
+    func testClaimsBelowMinSamplesEvenIfAllFail() {
+        let clock = FakeClock()
+        let health = makeHealth(clock, minSamples: 5)
+        // Four failures: under the min-samples floor, so the watchdog must not trip on a couple of stray failures.
+        for _ in 0..<4 { health.record(ok: false) }
+        XCTAssertEqual(health.decide(policyActive: false).verdict, .claim)
+    }
+
+    func testBypassesOnSustainedFailure() {
+        let clock = FakeClock()
+        let health = makeHealth(clock, minSamples: 5, failureRate: 0.8)
+        for _ in 0..<5 { health.record(ok: false) }
+        XCTAssertEqual(health.decide(policyActive: false).verdict, .bypass)
+    }
+
+    func testStaysClaimingBelowFailureThreshold() {
+        let clock = FakeClock()
+        let health = makeHealth(clock, minSamples: 5, failureRate: 0.8)
+        // 3 of 5 failed = 0.6, under the 0.8 bypass threshold: occasional timeouts are not an outage.
+        health.record(ok: false); health.record(ok: false); health.record(ok: false)
+        health.record(ok: true); health.record(ok: true)
+        XCTAssertEqual(health.decide(policyActive: false).verdict, .claim)
+    }
+
+    func testActivePolicyNeverBypasses() {
+        let clock = FakeClock()
+        let health = makeHealth(clock, minSamples: 5)
+        for _ in 0..<10 { health.record(ok: false) }
+        // Even though forwarding is fully wedged, an active enforcement policy forbids the open bypass (it would let a
+        // blocked domain resolve via the system resolver). The proxy keeps claiming.
+        XCTAssertEqual(health.decide(policyActive: true).verdict, .claim)
+        // And the same state with no policy active does bypass, proving the policy flag is the only difference.
+        XCTAssertEqual(health.decide(policyActive: false).verdict, .bypass)
+    }
+
+    func testFailuresAgeOutOfWindowEndingBypass() {
+        let clock = FakeClock()
+        let health = makeHealth(clock, window: 30, minSamples: 5)
+        for _ in 0..<5 { health.record(ok: false) }
+        XCTAssertEqual(health.decide(policyActive: false).verdict, .bypass)
+        // While bypassing the proxy records nothing; the failures simply age out. Past the window they are gone, so the
+        // watchdog probes again (claim). This is the self-heal: no explicit cooldown timer, the window is the cooldown.
+        clock.advance(31)
+        XCTAssertEqual(health.decide(policyActive: false).verdict, .claim)
+    }
+
+    func testRecoveryAfterProbeSucceeds() {
+        let clock = FakeClock()
+        let health = makeHealth(clock, window: 30, minSamples: 5)
+        for _ in 0..<5 { health.record(ok: false) }
+        XCTAssertEqual(health.decide(policyActive: false).verdict, .bypass)
+        clock.advance(31) // old failures age out -> probe
+        XCTAssertEqual(health.decide(policyActive: false).verdict, .claim)
+        // Upstream recovered: probe queries succeed. The proxy stays claiming, no re-trip.
+        for _ in 0..<5 { health.record(ok: true) }
+        XCTAssertEqual(health.decide(policyActive: false).verdict, .claim)
+    }
+
+    func testReTripsIfStillWedgedAfterProbe() {
+        let clock = FakeClock()
+        let health = makeHealth(clock, window: 30, minSamples: 5)
+        for _ in 0..<5 { health.record(ok: false) }
+        XCTAssertEqual(health.decide(policyActive: false).verdict, .bypass)
+        clock.advance(31)
+        XCTAssertEqual(health.decide(policyActive: false).verdict, .claim)
+        // Still wedged: the probe burst fails fast (via the proxy's forward deadline) and re-trips within minSamples.
+        for _ in 0..<5 { health.record(ok: false) }
+        XCTAssertEqual(health.decide(policyActive: false).verdict, .bypass)
+    }
+
+    func testTransitionFlagIsOneShotAcrossBypassEntryAndExit() {
+        let clock = FakeClock()
+        let health = makeHealth(clock, window: 30, minSamples: 5)
+        // Healthy steady state: claim, no transition reported.
+        XCTAssertEqual(health.decide(policyActive: false), .init(verdict: .claim, transitioned: false))
+        for _ in 0..<5 { health.record(ok: false) }
+        // First bypass decision reports the transition (the caller logs "entering bypass" once here)...
+        XCTAssertEqual(health.decide(policyActive: false), .init(verdict: .bypass, transitioned: true))
+        // ...and subsequent bypass decisions do NOT, so a per-flow log cannot flood during the bypass window.
+        XCTAssertEqual(health.decide(policyActive: false), .init(verdict: .bypass, transitioned: false))
+        XCTAssertEqual(health.decide(policyActive: false), .init(verdict: .bypass, transitioned: false))
+        // Failures age out: the exit back to claim reports the transition once (the caller logs "resuming").
+        clock.advance(31)
+        XCTAssertEqual(health.decide(policyActive: false), .init(verdict: .claim, transitioned: true))
+        XCTAssertEqual(health.decide(policyActive: false), .init(verdict: .claim, transitioned: false))
+    }
+
+    func testPartialWindowExpiryRecomputesRate() {
+        let clock = FakeClock()
+        let health = makeHealth(clock, window: 30, minSamples: 5, failureRate: 0.8)
+        // Five old failures at t0.
+        for _ in 0..<5 { health.record(ok: false) }
+        // 20s later, five successes. Window still holds all ten: 5/10 = 0.5 < 0.8 -> claim.
+        clock.advance(20)
+        for _ in 0..<5 { health.record(ok: true) }
+        XCTAssertEqual(health.decide(policyActive: false).verdict, .claim)
+        // 11s further (t0+31): the five old failures aged out, only the five successes remain -> still claim.
+        clock.advance(11)
+        XCTAssertEqual(health.decide(policyActive: false).verdict, .claim)
+    }
+}

--- a/extension/edr/networkextension/DNSForwardCompletion.swift
+++ b/extension/edr/networkextension/DNSForwardCompletion.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+/// DNSForwardCompletion resolves a single UDP DNS forward exactly once, and makes the deadline-vs-receive race atomic.
+///
+/// Two callbacks race for every forward: the bounded deadline (`DispatchWorkItem`) and the upstream `receiveMessage`
+/// completion. A plain "check isFinished, then act" guard is a TOCTOU hole: the deadline can fire in the gap between the
+/// receive path's check and its work, close the flow as a failure underneath an in-flight successful reply, and feed a
+/// false failure into the health watchdog (potentially tripping a bypass). This type closes that race with a three-state
+/// machine: the receive path must `claimResponse()` (pending -> responding) before it touches the flow; once claimed, the
+/// deadline's `failIfPending()` is a no-op. Whichever side transitions out of `pending` first wins; the loser does nothing.
+///
+/// Pure Foundation (no NetworkExtension import) so the transition semantics are unit-testable.
+final class DNSForwardCompletion {
+    private enum State {
+        case pending     // no outcome yet
+        case responding  // the receive path has claimed the forward and is writing the reply back
+        case done        // resolved; onResolve has run
+    }
+
+    private let lock = NSLock()
+    private var state: State = .pending
+    private let onResolve: (Bool) -> Void
+
+    /// onResolve runs exactly once, on the winning path, with the final outcome (true == upstream answered and the reply
+    /// was written back). It carries the cleanup: record the health sample, tear down the connection, and on failure close
+    /// the flow.
+    init(_ onResolve: @escaping (Bool) -> Void) { self.onResolve = onResolve }
+
+    /// Receive path: atomically claim the forward so the racing deadline becomes a no-op. Returns true if claimed (the
+    /// caller then writes the reply and calls `resolveResponse`), false if the deadline (or another terminal path) already
+    /// resolved it first, in which case the caller must not touch the flow.
+    func claimResponse() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        guard state == .pending else { return false }
+        state = .responding
+        return true
+    }
+
+    /// Deadline / connection-failure / send-error path: resolve as a failure only if still pending. If the receive path has
+    /// already claimed (`responding`) or the forward is `done`, this is a no-op, so a near-deadline success is never
+    /// reclassified as a failure and the flow is never closed out from under the receive path.
+    func failIfPending() {
+        lock.lock()
+        guard state == .pending else {
+            lock.unlock()
+            return
+        }
+        state = .done
+        lock.unlock()
+        onResolve(false)
+    }
+
+    /// Receive path: finalize a forward this caller already claimed via `claimResponse`, once the reply has (or has not)
+    /// been written back. A no-op unless the forward is in the `responding` state this caller put it in.
+    func resolveResponse(ok: Bool) {
+        lock.lock()
+        guard state == .responding else {
+            lock.unlock()
+            return
+        }
+        state = .done
+        lock.unlock()
+        onResolve(ok)
+    }
+}

--- a/extension/edr/networkextension/DNSForwardCompletion.swift
+++ b/extension/edr/networkextension/DNSForwardCompletion.swift
@@ -39,16 +39,20 @@ final class DNSForwardCompletion {
 
     /// Deadline / connection-failure / send-error path: resolve as a failure only if still pending. If the receive path has
     /// already claimed (`responding`) or the forward is `done`, this is a no-op, so a near-deadline success is never
-    /// reclassified as a failure and the flow is never closed out from under the receive path.
-    func failIfPending() {
+    /// reclassified as a failure and the flow is never closed out from under the receive path. Returns true only when this
+    /// call actually won the race (pending -> done), so the deadline caller can log "timed out" only when it genuinely
+    /// timed out rather than on every near-deadline success (a misleading operator signal otherwise).
+    @discardableResult
+    func failIfPending() -> Bool {
         lock.lock()
         guard state == .pending else {
             lock.unlock()
-            return
+            return false
         }
         state = .done
         lock.unlock()
         onResolve(false)
+        return true
     }
 
     /// Receive path: finalize a forward this caller already claimed via `claimResponse`, once the reply has (or has not)

--- a/extension/edr/networkextension/DNSProxyHealth.swift
+++ b/extension/edr/networkextension/DNSProxyHealth.swift
@@ -1,0 +1,107 @@
+import Foundation
+
+/// DNSProxyHealth is the self-heal watchdog for the DNS proxy. An `NEDNSProxyProvider` that returns `true` from
+/// `handleNewFlow` becomes the sole resolver for the host: once it claims a flow the operating system does not resolve it
+/// anywhere else, so an upstream-forwarding wedge takes down ALL name resolution while ICMP and direct-IP traffic keep
+/// working. That is the 2026-06-20 incident (974 `Upstream UDP connection failed` errors clustered in one minute, only a
+/// reboot cleared it). This type lets the proxy fail open: it accounts upstream-forward outcomes over a sliding time window
+/// and, when forwarding is sustainedly failing, tells `handleNewFlow` to BYPASS (return `false`) so the OS hands resolution
+/// back to the system resolver. Bypassing costs `dns_query` telemetry for the bypass window, which is the correct trade for a
+/// monitoring tap (observation fails open; see ADR-0014).
+///
+/// Pure Foundation, no NetworkExtension import, so the decision logic is unit-testable without a live resolver. The clock is
+/// injected (`now`) so tests drive the window deterministically, mirroring the agent's dropReporter seam.
+///
+/// Self-heal without extra state: the failure window is time-based, so while bypassing the proxy records nothing and the old
+/// failure samples simply age out. Once they do, `verdict` returns `.claim` again, which probes the upstream; if it is still
+/// wedged the probe queries fail (fast, via the proxy's forward deadline) and re-trip the bypass within `minSamples`; if it
+/// recovered the probe succeeds and the proxy stays claiming. No explicit cooldown timer is needed: the window IS the cooldown.
+final class DNSProxyHealth {
+    /// Verdict for a single `handleNewFlow` call. `.claim` => return `true` (the proxy resolves the flow). `.bypass` =>
+    /// return `false` (the OS resolves via the system resolver).
+    enum Verdict: Equatable {
+        case claim
+        case bypass
+    }
+
+    /// Decision returned to handleNewFlow: the verdict plus whether it flipped from the previously-returned value.
+    /// `transitioned` lets the caller log the bypass entry/exit exactly once instead of on every flow. A per-flow log
+    /// would re-create the very log-flood this watchdog exists to prevent (every DNS lookup hits handleNewFlow).
+    struct Decision: Equatable {
+        let verdict: Verdict
+        let transitioned: Bool
+    }
+
+    struct Config {
+        /// Sliding window over which forward outcomes are counted. Old samples age out, which is also what ends a bypass.
+        var window: TimeInterval = 30
+        /// Minimum outcomes in the window before the watchdog will trip. Guards against tripping on one or two stray
+        /// failures (a single unreachable resolver, a slow first query) and bounds the probe burst when re-tripping.
+        var minSamples: Int = 5
+        /// Failure fraction over the window at or above which the proxy bypasses. 0.8 means "4 of every 5 recent forwards
+        /// failed": a real outage, not the occasional benign timeout.
+        var failureRateToBypass: Double = 0.8
+    }
+
+    private let config: Config
+    private let now: () -> Date
+    private let lock = NSLock()
+    // Forward outcomes within the window, oldest first. `true` == upstream answered, `false` == failed or timed out.
+    private var outcomes: [(at: Date, ok: Bool)] = []
+    // The verdict last returned by decide(), for one-shot transition logging. Starts .claim (the proxy claims by default),
+    // so the first decide() does not report a spurious transition.
+    private var lastVerdict: Verdict = .claim
+
+    init(config: Config = Config(), now: @escaping () -> Date = Date.init) {
+        self.config = config
+        self.now = now
+    }
+
+    /// record registers one upstream-forward outcome. Called from the proxy's forward completion / deadline paths.
+    func record(ok: Bool) {
+        lock.lock()
+        defer { lock.unlock() }
+        let t = now()
+        outcomes.append((at: t, ok: ok))
+        prune(asOf: t)
+    }
+
+    /// decide chooses whether the next flow should be claimed or bypassed, and reports whether that flips the previous
+    /// verdict (for one-shot transition logging). `policyActive` is the network-response enforcement switch (a domain
+    /// blocklist or host-containment ruleset): when an enforcement policy is active the watchdog MUST NOT open-bypass,
+    /// because bypassing would let a blocked domain resolve via the system resolver. Until the network-response policy
+    /// plane lands (deferred, see the resilient-network-enforcement proposal) the call site passes `false`, so this
+    /// parameter is wired but always inert today.
+    func decide(policyActive: Bool) -> Decision {
+        lock.lock()
+        defer { lock.unlock() }
+        prune(asOf: now())
+        let verdict = computeVerdict(policyActive: policyActive)
+        let transitioned = verdict != lastVerdict
+        lastVerdict = verdict
+        return Decision(verdict: verdict, transitioned: transitioned)
+    }
+
+    /// computeVerdict is the pure decision, caller holds the lock.
+    private func computeVerdict(policyActive: Bool) -> Verdict {
+        if policyActive {
+            // Never silently allow a blocked domain to resolve. The spec's recovery for this case is rebuild-not-bypass;
+            // the rebuild path ships with the enforcement policy plane, so for now we simply keep claiming.
+            return .claim
+        }
+        guard outcomes.count >= config.minSamples else { return .claim }
+        let failures = outcomes.reduce(0) { $0 + ($1.ok ? 0 : 1) }
+        let failureRate = Double(failures) / Double(outcomes.count)
+        return failureRate >= config.failureRateToBypass ? .bypass : .claim
+    }
+
+    /// prune drops samples older than the window. Caller holds the lock.
+    private func prune(asOf t: Date) {
+        let cutoff = t.addingTimeInterval(-config.window)
+        if let firstFresh = outcomes.firstIndex(where: { $0.at >= cutoff }) {
+            if firstFresh > 0 { outcomes.removeFirst(firstFresh) }
+        } else {
+            outcomes.removeAll(keepingCapacity: true)
+        }
+    }
+}

--- a/extension/edr/networkextension/DNSProxyHealth.swift
+++ b/extension/edr/networkextension/DNSProxyHealth.swift
@@ -41,18 +41,25 @@ final class DNSProxyHealth {
         /// Failure fraction over the window at or above which the proxy bypasses. 0.8 means "4 of every 5 recent forwards
         /// failed": a real outage, not the occasional benign timeout.
         var failureRateToBypass: Double = 0.8
+        /// Hard cap on retained samples, so a high DNS query rate cannot make the per-forward prune / failure-rate scans
+        /// (run under the lock on the DNS hot path) grow unbounded. A few hundred recent forwards is a representative
+        /// failure-rate sample; older ones are dropped even if still inside the time window.
+        var maxSamples: Int = 256
     }
 
     private let config: Config
-    private let now: () -> Date
+    // Monotonic seconds, NOT wall-clock: the window is "recent activity", so it must be immune to NTP steps and manual
+    // clock changes (a wall-clock jump would otherwise age samples out early or make them linger, distorting when the
+    // bypass clears). Production uses ProcessInfo.systemUptime; tests inject a fake monotonic clock.
+    private let now: () -> TimeInterval
     private let lock = NSLock()
     // Forward outcomes within the window, oldest first. `true` == upstream answered, `false` == failed or timed out.
-    private var outcomes: [(at: Date, ok: Bool)] = []
+    private var outcomes: [(at: TimeInterval, ok: Bool)] = []
     // The verdict last returned by decide(), for one-shot transition logging. Starts .claim (the proxy claims by default),
     // so the first decide() does not report a spurious transition.
     private var lastVerdict: Verdict = .claim
 
-    init(config: Config = Config(), now: @escaping () -> Date = Date.init) {
+    init(config: Config = Config(), now: @escaping () -> TimeInterval = { ProcessInfo.processInfo.systemUptime }) {
         self.config = config
         self.now = now
     }
@@ -61,9 +68,8 @@ final class DNSProxyHealth {
     func record(ok: Bool) {
         lock.lock()
         defer { lock.unlock() }
-        let t = now()
-        outcomes.append((at: t, ok: ok))
-        prune(asOf: t)
+        outcomes.append((at: now(), ok: ok))
+        prune()
     }
 
     /// decide chooses whether the next flow should be claimed or bypassed, and reports whether that flips the previous
@@ -75,7 +81,7 @@ final class DNSProxyHealth {
     func decide(policyActive: Bool) -> Decision {
         lock.lock()
         defer { lock.unlock() }
-        prune(asOf: now())
+        prune()
         let verdict = computeVerdict(policyActive: policyActive)
         let transitioned = verdict != lastVerdict
         lastVerdict = verdict
@@ -89,19 +95,25 @@ final class DNSProxyHealth {
             // the rebuild path ships with the enforcement policy plane, so for now we simply keep claiming.
             return .claim
         }
-        guard outcomes.count >= config.minSamples else { return .claim }
+        // Clamp to >= 1 so a misconfigured minSamples (0 or negative) cannot pass the guard with an empty window and then
+        // divide by zero into a NaN failure rate below.
+        let minSamples = max(1, config.minSamples)
+        guard outcomes.count >= minSamples else { return .claim }
         let failures = outcomes.reduce(0) { $0 + ($1.ok ? 0 : 1) }
         let failureRate = Double(failures) / Double(outcomes.count)
         return failureRate >= config.failureRateToBypass ? .bypass : .claim
     }
 
-    /// prune drops samples older than the window. Caller holds the lock.
-    private func prune(asOf t: Date) {
-        let cutoff = t.addingTimeInterval(-config.window)
+    /// prune drops samples older than the window, then enforces the maxSamples cap so the scans above stay bounded under a
+    /// high query rate. Caller holds the lock; reads the monotonic clock once.
+    private func prune() {
+        let cutoff = now() - config.window
         if let firstFresh = outcomes.firstIndex(where: { $0.at >= cutoff }) {
             if firstFresh > 0 { outcomes.removeFirst(firstFresh) }
         } else {
             outcomes.removeAll(keepingCapacity: true)
         }
+        let cap = max(1, config.maxSamples)
+        if outcomes.count > cap { outcomes.removeFirst(outcomes.count - cap) }
     }
 }

--- a/extension/edr/networkextension/DNSProxyProvider.swift
+++ b/extension/edr/networkextension/DNSProxyProvider.swift
@@ -170,8 +170,12 @@ final class DNSProxyProvider: NEDNSProxyProvider {
         // The deadline races the receive: failIfPending resolves to a failure only if the receive path has not already
         // claimed the forward, so a near-deadline success is never reclassified as a failure.
         let deadline = DispatchWorkItem {
-            logger.error("Upstream UDP forward timed out after \(DNSProxy.udpForwardDeadlineSeconds, format: .fixed(precision: 0))s")
-            completion.failIfPending()
+            // Log only when this deadline actually wins (genuinely timed out). DispatchWorkItem.cancel() is cooperative, so
+            // a deadline that starts running just as the receive path cancels it must not emit a "timed out" line on a
+            // forward that ultimately succeeded: that would be a misleading operator signal / false alert.
+            if completion.failIfPending() {
+                logger.error("Upstream UDP forward timed out after \(DNSProxy.udpForwardDeadlineSeconds, format: .fixed(precision: 0))s")
+            }
         }
         DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + DNSProxy.udpForwardDeadlineSeconds,
                                                              execute: deadline)

--- a/extension/edr/networkextension/DNSProxyProvider.swift
+++ b/extension/edr/networkextension/DNSProxyProvider.swift
@@ -33,6 +33,14 @@ private final class DNSForwardCompletion {
 
     init(_ onResolve: @escaping (Bool) -> Void) { self.onResolve = onResolve }
 
+    /// Whether this forward has already resolved. Lets the receive path bail out when the deadline already fired, so a
+    /// late upstream reply does not emit a spurious dns_query event or write to an already-closed flow.
+    var isFinished: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return done
+    }
+
     func finish(ok: Bool) {
         lock.lock()
         if done {
@@ -179,6 +187,10 @@ final class DNSProxyProvider: NEDNSProxyProvider {
         // the health watchdog, which bypasses to the system resolver once enough forwards fail in a row.
         let completion = DNSForwardCompletion { [weak self, weak flow] ok in
             self?.health.record(ok: ok)
+            // Break the retain cycle before cancelling: connection -> stateUpdateHandler closure -> UDPForward ->
+            // completion -> (this closure captures connection). Without clearing the handler, connection, completion, and
+            // the NEAppProxyUDPFlow all leak on every query. Clearing it drops the closure's strong refs.
+            connection.stateUpdateHandler = nil
             connection.cancel()
             if !ok {
                 flow?.closeReadWithError(nil)
@@ -230,6 +242,10 @@ final class DNSProxyProvider: NEDNSProxyProvider {
     private func receiveUDPResponse(_ forward: UDPForward) {
         forward.connection.receiveMessage { [weak self] responseData, _, _, recvError in
             forward.deadline.cancel()
+
+            // The deadline path may have already resolved this forward (fail-open) and closed the flow. If so, a late
+            // upstream reply must not emit a spurious dns_query event or write to the closed flow: bail out.
+            guard !forward.completion.isFinished else { return }
 
             if let recvError {
                 logger.debug("UDP receive error: \(recvError.localizedDescription)")

--- a/extension/edr/networkextension/DNSProxyProvider.swift
+++ b/extension/edr/networkextension/DNSProxyProvider.swift
@@ -23,36 +23,6 @@ private enum DNSProxy {
     static let udpForwardDeadlineSeconds: Double = 3
 }
 
-/// DNSForwardCompletion makes a single UDP forward record exactly one health outcome and run its cleanup once, whether the
-/// upstream answered, errored, or blew the deadline. The deadline timer and the receive completion race; whichever fires
-/// first wins and the loser is a no-op.
-private final class DNSForwardCompletion {
-    private let lock = NSLock()
-    private var done = false
-    private let onResolve: (Bool) -> Void
-
-    init(_ onResolve: @escaping (Bool) -> Void) { self.onResolve = onResolve }
-
-    /// Whether this forward has already resolved. Lets the receive path bail out when the deadline already fired, so a
-    /// late upstream reply does not emit a spurious dns_query event or write to an already-closed flow.
-    var isFinished: Bool {
-        lock.lock()
-        defer { lock.unlock() }
-        return done
-    }
-
-    func finish(ok: Bool) {
-        lock.lock()
-        if done {
-            lock.unlock()
-            return
-        }
-        done = true
-        lock.unlock()
-        onResolve(ok)
-    }
-}
-
 /// Process attribution context for a single DNS flow. Bundled to keep function
 /// parameter counts manageable.
 private struct FlowContext {
@@ -197,10 +167,11 @@ final class DNSProxyProvider: NEDNSProxyProvider {
                 flow?.closeWriteWithError(nil)
             }
         }
-        // The deadline races the receive: whichever fires first wins via DNSForwardCompletion's once-guard.
+        // The deadline races the receive: failIfPending resolves to a failure only if the receive path has not already
+        // claimed the forward, so a near-deadline success is never reclassified as a failure.
         let deadline = DispatchWorkItem {
             logger.error("Upstream UDP forward timed out after \(DNSProxy.udpForwardDeadlineSeconds, format: .fixed(precision: 0))s")
-            completion.finish(ok: false)
+            completion.failIfPending()
         }
         DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + DNSProxy.udpForwardDeadlineSeconds,
                                                              execute: deadline)
@@ -214,7 +185,7 @@ final class DNSProxyProvider: NEDNSProxyProvider {
             case .failed(let error):
                 logger.error("Upstream UDP connection failed: \(error.localizedDescription)")
                 deadline.cancel()
-                completion.finish(ok: false)
+                completion.failIfPending()
             case .cancelled:
                 break
             default:
@@ -229,7 +200,7 @@ final class DNSProxyProvider: NEDNSProxyProvider {
             if let error {
                 logger.error("Failed to send UDP datagram: \(error.localizedDescription)")
                 forward.deadline.cancel()
-                forward.completion.finish(ok: false)
+                forward.completion.failIfPending()
                 return
             }
             self?.receiveUDPResponse(forward)
@@ -243,17 +214,18 @@ final class DNSProxyProvider: NEDNSProxyProvider {
         forward.connection.receiveMessage { [weak self] responseData, _, _, recvError in
             forward.deadline.cancel()
 
-            // The deadline path may have already resolved this forward (fail-open) and closed the flow. If so, a late
-            // upstream reply must not emit a spurious dns_query event or write to the closed flow: bail out.
-            guard !forward.completion.isFinished else { return }
+            // Atomically claim the forward before touching the flow. If the deadline already won (fail-open, flow closed),
+            // claimResponse returns false and a late reply emits no spurious telemetry and does not write to the closed
+            // flow. Once claimed, the deadline's failIfPending is a no-op, so this success cannot be reclassified.
+            guard forward.completion.claimResponse() else { return }
 
             if let recvError {
                 logger.debug("UDP receive error: \(recvError.localizedDescription)")
-                forward.completion.finish(ok: false)
+                forward.completion.resolveResponse(ok: false)
                 return
             }
             guard let responseData, !responseData.isEmpty else {
-                forward.completion.finish(ok: false)
+                forward.completion.resolveResponse(ok: false)
                 return
             }
 
@@ -263,11 +235,11 @@ final class DNSProxyProvider: NEDNSProxyProvider {
             forward.flow.writeDatagrams([(responseData, forward.responseEndpoint)]) { writeError in
                 if let writeError {
                     logger.error("Failed to write UDP response: \(writeError.localizedDescription)")
-                    forward.completion.finish(ok: false)
+                    forward.completion.resolveResponse(ok: false)
                     return
                 }
                 // Upstream answered and the client received it: a healthy forward.
-                forward.completion.finish(ok: true)
+                forward.completion.resolveResponse(ok: true)
             }
         }
     }

--- a/extension/edr/networkextension/DNSProxyProvider.swift
+++ b/extension/edr/networkextension/DNSProxyProvider.swift
@@ -15,6 +15,34 @@ private enum DNSProxy {
     /// upstream. 30s is past any sane resolver round-trip but bounded enough that a
     /// misbehaving upstream cannot pin our flow + NWConnection pair forever.
     static let tcpUpstreamLingerSeconds: Double = 30
+    /// Deadline for a single UDP DNS forward (connect + send + receive). Past this the upstream is treated as failed: the
+    /// flow is released (fail-open) and the failure is recorded so the health watchdog can bypass a wedged upstream. 3s is
+    /// past a sane resolver round-trip but short enough that a stuck upstream cannot pin the client's resolution. Before
+    /// this existed the UDP path waited on `receiveMessage` with no timeout, so a wedged upstream hung every claimed query
+    /// indefinitely and took down all DNS (the 2026-06-20 incident).
+    static let udpForwardDeadlineSeconds: Double = 3
+}
+
+/// DNSForwardCompletion makes a single UDP forward record exactly one health outcome and run its cleanup once, whether the
+/// upstream answered, errored, or blew the deadline. The deadline timer and the receive completion race; whichever fires
+/// first wins and the loser is a no-op.
+private final class DNSForwardCompletion {
+    private let lock = NSLock()
+    private var done = false
+    private let onResolve: (Bool) -> Void
+
+    init(_ onResolve: @escaping (Bool) -> Void) { self.onResolve = onResolve }
+
+    func finish(ok: Bool) {
+        lock.lock()
+        if done {
+            lock.unlock()
+            return
+        }
+        done = true
+        lock.unlock()
+        onResolve(ok)
+    }
 }
 
 /// Process attribution context for a single DNS flow. Bundled to keep function
@@ -25,6 +53,18 @@ private struct FlowContext {
     let path: String
     /// Kernel PID generation of the querying process when the flow carried an audit token; nil otherwise (issue #403).
     let pidVersion: UInt32?
+}
+
+/// Per-datagram UDP forward state, bundled so the send / receive helpers stay under the parameter-count limit (same reason
+/// FlowContext exists). One UDPForward exists per outbound query: it carries the upstream connection, the flow to write the
+/// answer back to, the once-guarded completion, and the deadline timer.
+private struct UDPForward {
+    let connection: Network.NWConnection
+    let responseEndpoint: Network.NWEndpoint
+    let flow: NEAppProxyUDPFlow
+    let ctx: FlowContext
+    let completion: DNSForwardCompletion
+    let deadline: DispatchWorkItem
 }
 
 /// DNSProxyProvider intercepts DNS queries, captures metadata for EDR telemetry,
@@ -40,6 +80,9 @@ private struct FlowContext {
 /// chain, so there's no infinite loop.
 final class DNSProxyProvider: NEDNSProxyProvider {
     private let serializer = NetworkEventSerializer()
+    /// Self-heal watchdog. Accounts UDP upstream-forward outcomes; when forwarding is sustainedly failing it tells
+    /// handleNewFlow to stop claiming DNS flows so the system resolver takes over (fail-open). See DNSProxyHealth + ADR-0014.
+    private let health = DNSProxyHealth()
 
     override func startProxy(options _: [String: Any]? = nil, completionHandler: @escaping (Error?) -> Void) {
         logger.info("DNS proxy started")
@@ -52,6 +95,24 @@ final class DNSProxyProvider: NEDNSProxyProvider {
     }
 
     override func handleNewFlow(_ flow: NEAppProxyFlow) -> Bool {
+        // Self-heal: if upstream forwarding is sustainedly wedged, do NOT claim the flow. Returning false hands the flow
+        // to the system resolver, so a broken proxy fails open instead of taking down all DNS (the 2026-06-20 incident).
+        // We lose dns_query telemetry for the bypass window, which is the correct trade for a monitoring tap. policyActive
+        // is false until the network-response enforcement plane lands; an active policy will force claim + rebuild instead
+        // of bypass so a blocked domain can never resolve via the system resolver (see resilient-network-enforcement).
+        let decision = health.decide(policyActive: false)
+        if decision.verdict == .bypass {
+            if decision.transitioned {
+                logger.error("DNS proxy entering bypass: upstream forwarding sustainedly failing; handing DNS to the system resolver")
+            }
+            return false
+        }
+        if decision.transitioned {
+            // verdict flipped back to .claim: we just exited a bypass window (upstream recovered, or the failure samples
+            // aged out so we are probing again). Logged once, not per flow.
+            logger.info("DNS proxy resuming: claiming DNS flows again after a bypass window")
+        }
+
         if let udpFlow = flow as? NEAppProxyUDPFlow {
             handleUDPFlow(udpFlow)
             return true
@@ -112,14 +173,36 @@ final class DNSProxyProvider: NEDNSProxyProvider {
         // extension's own connections from the DNS proxy chain, so there's no
         // infinite loop.
         let connection = Network.NWConnection(to: endpoint, using: .udp)
+
+        // One outcome per forward, recorded once. On failure we fail open: cancel the upstream connection and release the
+        // flow so the client retries or rolls over instead of being pinned on a wedged proxy. The recorded failure feeds
+        // the health watchdog, which bypasses to the system resolver once enough forwards fail in a row.
+        let completion = DNSForwardCompletion { [weak self, weak flow] ok in
+            self?.health.record(ok: ok)
+            connection.cancel()
+            if !ok {
+                flow?.closeReadWithError(nil)
+                flow?.closeWriteWithError(nil)
+            }
+        }
+        // The deadline races the receive: whichever fires first wins via DNSForwardCompletion's once-guard.
+        let deadline = DispatchWorkItem {
+            logger.error("Upstream UDP forward timed out after \(DNSProxy.udpForwardDeadlineSeconds, format: .fixed(precision: 0))s")
+            completion.finish(ok: false)
+        }
+        DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + DNSProxy.udpForwardDeadlineSeconds,
+                                                             execute: deadline)
+
+        let forward = UDPForward(connection: connection, responseEndpoint: endpoint, flow: flow, ctx: ctx,
+                                 completion: completion, deadline: deadline)
         connection.stateUpdateHandler = { [weak self] state in
             switch state {
             case .ready:
-                self?.sendUDPAndReceive(connection: connection, datagram: datagram,
-                                        responseEndpoint: endpoint, flow: flow, ctx: ctx)
+                self?.sendUDPAndReceive(forward, datagram: datagram)
             case .failed(let error):
                 logger.error("Upstream UDP connection failed: \(error.localizedDescription)")
-                connection.cancel()
+                deadline.cancel()
+                completion.finish(ok: false)
             case .cancelled:
                 break
             default:
@@ -129,41 +212,46 @@ final class DNSProxyProvider: NEDNSProxyProvider {
         connection.start(queue: .global(qos: .userInitiated))
     }
 
-    private func sendUDPAndReceive(connection: Network.NWConnection, datagram: Data,
-                                   responseEndpoint: Network.NWEndpoint, flow: NEAppProxyUDPFlow,
-                                   ctx: FlowContext) {
-        connection.send(content: datagram, completion: .contentProcessed { [weak self] error in
+    private func sendUDPAndReceive(_ forward: UDPForward, datagram: Data) {
+        forward.connection.send(content: datagram, completion: .contentProcessed { [weak self] error in
             if let error {
                 logger.error("Failed to send UDP datagram: \(error.localizedDescription)")
-                connection.cancel()
+                forward.deadline.cancel()
+                forward.completion.finish(ok: false)
                 return
             }
-            self?.receiveUDPResponse(connection: connection, responseEndpoint: responseEndpoint,
-                                     flow: flow, ctx: ctx)
+            self?.receiveUDPResponse(forward)
         })
     }
 
     /// receiveUDPResponse reads the upstream DNS reply and forwards it back to the
     /// originating flow. Split out of sendUDPAndReceive so each closure holds only one
     /// level of nested asynchronous work.
-    private func receiveUDPResponse(connection: Network.NWConnection, responseEndpoint: Network.NWEndpoint,
-                                    flow: NEAppProxyUDPFlow, ctx: FlowContext) {
-        connection.receiveMessage { [weak self] responseData, _, _, recvError in
-            defer { connection.cancel() }
+    private func receiveUDPResponse(_ forward: UDPForward) {
+        forward.connection.receiveMessage { [weak self] responseData, _, _, recvError in
+            forward.deadline.cancel()
 
             if let recvError {
                 logger.debug("UDP receive error: \(recvError.localizedDescription)")
+                forward.completion.finish(ok: false)
                 return
             }
-            guard let responseData, !responseData.isEmpty else { return }
+            guard let responseData, !responseData.isEmpty else {
+                forward.completion.finish(ok: false)
+                return
+            }
 
             // Enrich telemetry with response addresses.
-            self?.emitDNSResponseTelemetry(response: responseData, ctx: ctx, proto: "udp")
+            self?.emitDNSResponseTelemetry(response: responseData, ctx: forward.ctx, proto: "udp")
 
-            flow.writeDatagrams([(responseData, responseEndpoint)]) { writeError in
+            forward.flow.writeDatagrams([(responseData, forward.responseEndpoint)]) { writeError in
                 if let writeError {
                     logger.error("Failed to write UDP response: \(writeError.localizedDescription)")
+                    forward.completion.finish(ok: false)
+                    return
                 }
+                // Upstream answered and the client received it: a healthy forward.
+                forward.completion.finish(ok: true)
             }
         }
     }

--- a/openspec/changes/resilient-network-enforcement/specs/extension-network-response/spec.md
+++ b/openspec/changes/resilient-network-enforcement/specs/extension-network-response/spec.md
@@ -37,7 +37,7 @@ When a DNS query matches an active block rule, the system SHALL answer it locall
 
 ### Requirement: DNS proxy health watchdog with policy-aware bypass
 
-The system SHALL monitor upstream-forwarding health and SHALL recover from sustained forwarding failure without operator intervention. When no enforcement policy is active, recovery MAY bypass DNS proxying so resolution returns to the system resolver (availability is preserved), and the system SHALL periodically attempt to restore proxying. When an enforcement policy is active, the system MUST NOT bypass in a way that lets a blocked domain resolve; it SHALL instead rebuild the proxy and continue denying blocked domains throughout recovery. A monitoring-path wedge MUST NOT require a host reboot to clear.
+The system SHALL monitor upstream-forwarding health and SHALL recover from sustained forwarding failure without operator intervention. When no enforcement policy is active, recovery MAY bypass DNS proxying so resolution returns to the system resolver (availability is preserved), and the system SHALL periodically attempt to restore proxying. When an enforcement policy is active, the system MUST NOT bypass in a way that lets a blocked domain resolve; it SHALL instead rebuild the proxy and continue denying blocked domains throughout recovery. A monitoring-path wedge MUST NOT require a host reboot to clear. While bypassed, the system does not see the bypassed DNS flows, so it emits no `dns_query` telemetry for them; that telemetry gap is the accepted cost of failing open (observation never gates availability) and is not a contract violation.
 
 #### Scenario: Sustained forwarding failure with no active policy bypasses and retries
 
@@ -45,6 +45,7 @@ The system SHALL monitor upstream-forwarding health and SHALL recover from susta
 - **WHEN** the watchdog evaluates proxy health
 - **THEN** the system bypasses DNS proxying so the system resolver handles resolution
 - **AND** the system periodically attempts to restore proxying
+- **AND** no `dns_query` telemetry is emitted for flows handled by the system resolver during the bypass window
 
 #### Scenario: Sustained failure with an active blocklist does not open-bypass
 

--- a/openspec/changes/resilient-network-enforcement/tasks.md
+++ b/openspec/changes/resilient-network-enforcement/tasks.md
@@ -2,16 +2,16 @@
 
 ## 1. DNS proxy forwarding resilience (the incident fix)
 
-- [ ] `extension/edr/networkextension/DNSProxyProvider.swift`: add a bounded forward deadline to the UDP path (today only the TCP path has a 30s linger; UDP waits on `receiveMessage` with no deadline). On deadline or upstream failure for a non-blocked query, close the flow cleanly (`closeReadWithError(nil)` / `closeWriteWithError(nil)`) so the client can retry or roll over, instead of leaving it pinned.
-- [ ] Keep telemetry strictly best-effort on both the query and response paths: a serialization or send failure MUST NOT affect forwarding or the fail-open close.
-- [ ] Make the forward deadline a named constant alongside `tcpUpstreamLingerSeconds`, with a comment tying it to the resolver round-trip budget.
+- [x] `extension/edr/networkextension/DNSProxyProvider.swift`: bounded forward deadline on the UDP path (`udpForwardDeadlineSeconds = 3`; previously only the TCP path had a 30s linger and UDP waited on `receiveMessage` with no deadline). On deadline or upstream failure the flow is released (`closeReadWithError(nil)` / `closeWriteWithError(nil)`) so the client retries or rolls over instead of being pinned. A `DNSForwardCompletion` once-guard records exactly one outcome per forward whether the upstream answered, errored, or blew the deadline.
+- [x] Telemetry stays strictly best-effort on the query and response paths: serialization / send failure does not affect forwarding or the fail-open close.
+- [x] Forward deadline is a named constant alongside `tcpUpstreamLingerSeconds` with a comment tying it to the resolver round-trip budget.
 
 ## 2. Health watchdog with policy-aware bypass
 
-- [ ] Add a health accumulator in the network extension that records upstream-forward outcomes over a sliding window (success / failure / timeout), behind an injectable seam so the decision logic is unit-testable without a live resolver.
-- [ ] Pure decision function: given (failure rate over window, enforcement-policy-active bool), return one of {keep, bypass-to-system-resolver, rebuild-proxy}. No policy active + sustained failure -> bypass; policy active + sustained failure -> rebuild (never open-bypass).
-- [ ] Wire the decision to the proxy lifecycle: bypass flips the DNS proxy off (system resolver takes over) and schedules a periodic restore attempt; rebuild tears down and re-establishes proxy connections without bypassing.
-- [ ] Emit a distinct operator-facing log line on each transition (degraded -> bypass, bypass -> restored) so the bypass window is observable.
+- [x] Health accumulator `extension/edr/networkextension/DNSProxyHealth.swift`: sliding-window forward-outcome counter behind an injected clock so the decision is unit-testable without a live resolver (`DNSProxyHealthTests`, 10 cases).
+- [x] Pure decision: `decide(policyActive:) -> Decision`. No policy active + sustained failure (>= `minSamples`, failure rate >= `failureRateToBypass`) -> bypass; policy active -> always claim (the rebuild path ships with the enforcement policy plane, deferred to Section 3, so we never open-bypass while enforcing).
+- [x] Wire to the proxy: bypass is implemented as `handleNewFlow` returning `false`, which hands the flow to the system resolver (cleaner than toggling `NEDNSProxyManager` config from inside the extension, and the spec's intent). Restore is automatic: the time-based window ages out the failure samples, so the proxy probes again with no separate timer (the window IS the cooldown). Rebuild-not-bypass-while-enforcing is deferred with the policy plane.
+- [x] One-shot transition logging: `Decision.transitioned` flips only when the verdict changes, so the proxy logs "entering bypass" / "resuming" once rather than on every flow (a per-flow log would re-create the log-flood this fix exists to prevent).
 
 ## 3. Network-response enforcement decision surface (default-forward, deferred policy input)
 
@@ -32,8 +32,9 @@
 
 ## 6. Tests
 
-- [ ] `extension/edr/Tests/EDRExtensionLogicTests/`: forward-deadline outcome (timeout -> flow released), telemetry-failure-does-not-block, block decision returns local denial without upstream, watchdog decision table (no-policy+fail -> bypass; policy+fail -> rebuild), containment ruleset persist/restore, bounded-toggle timeout outcome.
-- [ ] System / VM layer: on a live macOS VM with the proxy enabled, induce sustained upstream failure and assert DNS recovers automatically (no reboot), and that a contained host still reaches the server. This is the regression guard for the 2026-06-20 incident.
+- [x] `extension/edr/Tests/EDRExtensionLogicTests/DNSProxyHealthTests.swift`: watchdog decision table (10 cases) via an injected clock: claim below min-samples, bypass on sustained failure, claim under the rate threshold, active-policy-never-bypasses, failures-age-out-ends-bypass, recovery after a successful probe, re-trip if still wedged, partial-window rate recompute, and the one-shot transition flag across bypass entry/exit.
+- [ ] Watchdog `decide` covered by unit tests; the NE-side forward deadline + fail-open close + bypass wiring in `DNSProxyProvider.swift` are not unit-testable (NetworkExtension-only target) and are verified on the VM (next item).
+- [ ] System / VM layer: on edr-dev with the proxy enabled, induce sustained upstream failure and assert DNS recovers automatically via the system-resolver bypass (no reboot), the forward deadline fires, and `dns_query` telemetry resumes after recovery. This is the regression guard for the 2026-06-20 incident. Needs a GUI re-activation of the NE (binary swap breaks `dns_query` delivery).
 
 ## 7. Follow-ups (out of scope here, tracked separately)
 


### PR DESCRIPTION
## What

Implements Sections 1-2 of the `resilient-network-enforcement` proposal (merged in #470): the fix for the 2026-06-20 DNS-proxy wedge that took down all name resolution on an endpoint with reboot-only recovery (974 `Upstream UDP connection failed` errors clustered in one minute; `ping` by IP worked, every lookup failed).

Root cause: the `NEDNSProxyProvider` claims every DNS flow and becomes the sole resolver, but the UDP path had no forward deadline and no health-driven recovery, so a wedged upstream hung every claimed query forever.

## Changes

- **`DNSProxyHealth.swift`** (new, pure Foundation, unit-tested): a self-heal watchdog. Sliding-window forward-outcome accumulator + `decide(policyActive:) -> {claim, bypass}` behind an injected clock. The time window is the cooldown: while bypassing, failure samples age out and the proxy probes again automatically, so a wedge clears without a reboot. `policyActive` is wired but inert until the enforcement policy plane lands (it forbids open-bypass while enforcing, so a blocked domain can never resolve via the system resolver).
- **`DNSProxyProvider.swift`**: bounded UDP forward deadline (`udpForwardDeadlineSeconds = 3`). On deadline or upstream failure the flow is released (fail-open) and the outcome recorded. `handleNewFlow` consults the watchdog and returns `false` when degraded, handing DNS to the system resolver. A `DNSForwardCompletion` once-guard records exactly one outcome per forward. One-shot transition logging (`entering bypass` / `resuming`) so the bypass window is observable without flooding the log.

## Test

- `DNSProxyHealthTests` (10 cases) drive the watchdog with an injected clock: bypass on sustained failure, claim under threshold / below min-samples, active-policy-never-bypasses, failures-age-out-ends-bypass, recovery after probe, re-trip if still wedged, and one-shot transition flag.
- `swift test` green, SwiftLint clean, `xcodebuild` BUILD SUCCEEDED.
- **Live VM test pending**: the NE-side deadline + bypass wiring is not unit-testable (NetworkExtension-only target); it is verified on edr-dev (induce sustained upstream failure, confirm fail-fast deadline, bypass to system resolver without reboot, and self-heal resume). Tracked in `tasks.md` Section 6.

## Deferred to follow-up PRs

- Section 3 (host containment) - needs the network-response policy plane.
- Section 4 (host-app bounded DNS-proxy toggle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpoVn1EV4k25fVLq3KkCnY


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added intelligent health monitoring to the DNS proxy that automatically fails over to the system resolver when sustained forwarding failures are detected.
  * Implemented a 3-second timeout for DNS forwards with automatic recovery when failures subside.

* **Tests**
  * Added comprehensive test coverage for DNS proxy health decision logic under various failure conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->