### PR TITLE
fix(server): derive the session-protected route allowlist (#463)

### DIFF
--- a/openspec/changes/derive-authed-route-allowlist/.openspec.yaml
+++ b/openspec/changes/derive-authed-route-allowlist/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-21

--- a/openspec/changes/derive-authed-route-allowlist/design.md
+++ b/openspec/changes/derive-authed-route-allowlist/design.md
@@ -1,0 +1,26 @@
+# Design: derive the authed-route allowlist (#463)
+
+## The constraint that shapes the fix
+
+Go's `http.ServeMux` exposes no API to enumerate the patterns registered on it (the pattern map is unexported, and Go 1.22's method+path routing did not add introspection). So neither "derive the allowlist" nor "test that every registered route is reachable" can inspect the API mux after the fact. Both have to capture patterns *at registration time*. The only way to capture them is to have `RegisterAuthedRoutes` register onto something we control instead of a concrete `*http.ServeMux`.
+
+## Decision: a Router interface + a recording wrapper, then derive
+
+- `httpserver.Router` is the minimal subset the registration bodies use: `Handle` + `HandleFunc`. `*http.ServeMux` already satisfies it, so changing the parameter type from `*http.ServeMux` to `httpserver.Router` leaves every call site compiling and every method body unchanged. The change is wide (every authed registration method, and the operator-handler `RegisterRoutes` the context bootstraps delegate to) but shallow and mechanical.
+- `httpserver.RecordingRouter` wraps a `Router`, forwards every `Handle`/`HandleFunc` to it, and records the pattern. `buildMux` registers all contexts through one `RecordingRouter` over the API mux, then mounts exactly `Patterns()` on the session-protected boundary.
+
+Because the mounted set *is* the registered set, a route can no longer be registered-but-not-mounted. The bug class is eliminated, not merely guarded, which is why this is preferred over a test that only asserts the hand-maintained list stays in sync.
+
+## Alternatives considered
+
+- **A test that re-lists the routes.** Moves the drift into the test (the test's route list can fall out of sync just like the slice did). Rejected: it does not make drift impossible.
+- **A data-driven route table per context** (`var routes = []Route{...}` consumed by both registration and an exporter). More invasive than the interface seam (rewrites how every handler registers) for no extra safety over recording.
+- **Reflecting/AST-parsing the source for patterns.** Fragile and indirect. Rejected.
+
+## Testability
+
+`registerSessionRoutes` takes concrete context types, which are expensive to construct in a unit test (DB, signing keys, OPA engine). The derive-and-mount core is therefore extracted into `mountAuthed(outer, protect, register)`, which `registerSessionRoutes` calls with the real dependencies and the test calls with a stub `protect` (returns 401 JSON) and a `register` that registers a probe route. The test asserts the probe route is reachable as the auth failure (JSON), not the SPA HTML catch-all, and that a never-registered route still falls through to the SPA. That exercises the real composition path, not a re-implementation.
+
+## Out of scope
+
+The agent-token allowlist in `registerHostRoutes` is the same hand-maintained shape but smaller, stable, and not the reported bug (an agent does not parse the SPA shell). The same `RecordingRouter` primitive can derive it later.

--- a/openspec/changes/derive-authed-route-allowlist/proposal.md
+++ b/openspec/changes/derive-authed-route-allowlist/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+`buildMux` mounts the session-protected API onto the outer router through a hand-maintained allowlist (a `for _, p := range []string{...}` slice in `server/cmd/fleet-edr-server/main.go`). Each bounded context registers its authed routes on the API mux via `RegisterAuthedRoutes`, but a route only actually serves traffic if its exact pattern is *also* in that slice. The two silently drift: a route registered but missing from the slice falls through to the `/` single-page-app catch-all and returns the SPA HTML (302 / index.html), which the UI's `fetch` then parses as JSON and surfaces as `Unexpected token '<'`.
+
+This has bitten twice (#158 app-control list endpoint, #375 SSO settings), each time caught only by live dev-server QA because the unit/integration tests mount `RegisterAuthedRoutes` on a bare mux and bypass the composed allowlist entirely. Issue #463 asks for a durable guard so it cannot recur a third time.
+
+## What Changes
+
+- Add a `httpserver.Router` interface (`Handle` + `HandleFunc`, satisfied by `*http.ServeMux`) and a `httpserver.RecordingRouter` that forwards registrations to an inner router while recording the registered patterns.
+- Change every authed route-registration method to accept `httpserver.Router` instead of `*http.ServeMux` (the 5 contexts' `RegisterAuthedRoutes` and the operator handlers' `RegisterRoutes` they delegate to). `*http.ServeMux` satisfies the interface, so every call site compiles unchanged and the method bodies are untouched.
+- Derive the session-protected allowlist in `buildMux`: register every context's authed routes through one `RecordingRouter`, then mount exactly the recorded patterns on the session-protected boundary. Delete the hand-maintained slice. A registered authed route is now mounted automatically, so the drift is structurally impossible rather than guarded after the fact.
+- Add a `buildMux`-level test that a route registered through the authed-route registration path is reachable through the composed router as the session auth failure (JSON), not the SPA HTML catch-all.
+
+Out of scope: the agent-token allowlist in `registerHostRoutes` follows the same hand-maintained pattern but is smaller, stable, and not the reported bug (an agent does not parse the SPA shell as JSON); the same `RecordingRouter` primitive could derive it in a follow-up.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `server-rest-api`: the session-protected route surface is derived from what the contexts register, so every registered authed route is reachable through the composed router with its session-authentication boundary applied and never falls through to the SPA catch-all.
+
+## Impact
+
+- Code: `server/httpserver` (new `Router` + `RecordingRouter`), the route-registration signatures across all five bounded contexts (`*http.ServeMux` to `httpserver.Router`, bodies unchanged), and `server/cmd/fleet-edr-server/main.go` (`registerSessionRoutes` derives the allowlist via `mountAuthed`; the hand-maintained slice is removed).
+- Behavior: no observable change to any existing route; the same routes serve the same responses. The only difference is that a future authed route can no longer be registered without being allowlisted.
+- Rollback is a code revert. No data, schema, wire-format, or agent-protocol change.

--- a/openspec/changes/derive-authed-route-allowlist/specs/server-rest-api/spec.md
+++ b/openspec/changes/derive-authed-route-allowlist/specs/server-rest-api/spec.md
@@ -1,0 +1,12 @@
+## ADDED Requirements
+
+### Requirement: Registered authed routes are reachable through the composed router
+
+Every authed API route a bounded context registers SHALL be reachable through the composed outer router with its session-authentication boundary applied. The set of session-protected routes SHALL be derived from what the contexts register rather than maintained as a separate hand-edited allowlist, so a registered authed route can never be omitted from the protected surface. An unauthenticated request to a registered authed route SHALL receive the session middleware's JSON authentication failure, never a fall-through to the single-page-app HTML catch-all.
+
+#### Scenario: A registered authed route is session-protected, not SPA fall-through
+
+- **GIVEN** a bounded context registers an authed API route
+- **WHEN** an unauthenticated request hits that route through the composed router
+- **THEN** the response is the session-authentication failure as JSON
+- **AND** it is not the single-page-app HTML catch-all

--- a/openspec/changes/derive-authed-route-allowlist/tasks.md
+++ b/openspec/changes/derive-authed-route-allowlist/tasks.md
@@ -1,0 +1,23 @@
+## 1. Recording primitive
+
+- [x] 1.1 Add `httpserver.Router` (Handle + HandleFunc; satisfied by `*http.ServeMux`)
+- [x] 1.2 Add `httpserver.RecordingRouter` (forwards to an inner Router, records patterns in order, `Patterns()` returns a copy)
+- [x] 1.3 Unit-test RecordingRouter (records + forwards; Patterns is a copy; `*http.ServeMux` satisfies Router)
+
+## 2. Thread the interface through registration
+
+- [x] 2.1 Change the five contexts' `RegisterAuthedRoutes` to accept `httpserver.Router`
+- [x] 2.2 Change the operator handlers' `RegisterRoutes` (response, endpoint, rules, appcontrol, detection) that the bootstraps delegate to
+- [x] 2.3 Bodies unchanged (HandleFunc only); add the httpserver import where missing; drop a now-unused net/http import
+
+## 3. Derive the allowlist
+
+- [x] 3.1 Extract `mountAuthed(outer, protect, register)`: register via a RecordingRouter, wrap the API mux, mount exactly the recorded patterns
+- [x] 3.2 `registerSessionRoutes` calls `mountAuthed`; delete the hand-maintained allowlist slice
+- [x] 3.3 `buildMux`-level test: a registered authed route is reachable as the session auth failure (JSON), not the SPA catch-all
+
+## 4. Docs + traceability + gates
+
+- [x] 4.1 spectrace marker tying the test to the `server-rest-api` scenario
+- [x] 4.2 `openspec validate derive-authed-route-allowlist --strict`; `go run ./tools/spectrace check --strict`
+- [x] 4.3 `go build ./...`, `go test` (httpserver + cmd + all five contexts), `task lint:go`, `task lint:dashes`

--- a/server/cmd/fleet-edr-server/main.go
+++ b/server/cmd/fleet-edr-server/main.go
@@ -632,74 +632,37 @@ func registerHostRoutes(mux *http.ServeMux, d muxDeps) {
 func registerSessionRoutes(mux *http.ServeMux, d muxDeps) {
 	sessionMW := d.identityCtx.SessionMiddleware()
 	csrfMW := d.identityCtx.CSRFMiddleware()
-	apiMux := http.NewServeMux()
-	d.detectionCtx.RegisterAuthedRoutes(apiMux)
-	d.rulesCtx.RegisterAuthedRoutes(apiMux)
-	d.endpointCtx.RegisterAuthedRoutes(apiMux)
-	d.responseCtx.RegisterAuthedRoutes(apiMux)
-	d.identityCtx.RegisterAuthedRoutes(apiMux)
 	// The operator API accepts two transports (ADR-0013): a service-account bearer token (verified statelessly, CSRF-exempt) or a
 	// browser cookie session + CSRF. APIAuthMiddleware composes both and pins an actor either way. It is nil only in minimal wiring
 	// with no service-account signing key, in which case fall back to the cookie-only chain.
-	var sessionProtected http.Handler
-	if apiAuth := d.identityCtx.APIAuthMiddleware(); apiAuth != nil {
-		sessionProtected = apiAuth(apiMux)
-	} else {
-		sessionProtected = sessionMW(csrfMW(apiMux))
+	protect := func(h http.Handler) http.Handler {
+		if apiAuth := d.identityCtx.APIAuthMiddleware(); apiAuth != nil {
+			return apiAuth(h)
+		}
+		return sessionMW(csrfMW(h))
 	}
-	for _, p := range []string{
-		"GET /api/hosts", "GET /api/hosts/{host_id}/tree", "GET /api/hosts/{host_id}/processes/{pid}",
-		"GET /api/alerts", "GET /api/alerts/{id}", "PUT /api/alerts/{id}",
-		"GET /api/commands/{id}", "POST /api/commands",
-		"GET /api/enrollments", "POST /api/enrollments/{host_id}/revoke", "POST /api/enrollments/{host_id}/rotate",
-		"GET /api/attack-coverage",
-		"GET /api/rules",
-		"GET /api/audit-events",
-		"GET /api/session",
-		// Application Control admin surface. rulesCtx.RegisterAuthedRoutes mounts these on apiMux; the outer router needs each
-		// path enumerated here so requests reach the session-protected wrapper instead of falling through to the `/` catchall
-		// and 302 → /ui/. Surfaced by the step-8 dry-run on PR #158: the list-policies API returned the SPA's index.html,
-		// which the UI fetch parsed as JSON and errored with "Unexpected token '<'". The Phase A close-out follow-on adds the
-		// five mutation routes + bulk upsert + cross-policy GET + host-groups CRUD + assignments are all enumerated here. Phase B
-		// editable host-group + assignment mutations will replace the 405 handlers at the same routes without churning this list.
-		"GET /api/v1/app-control/policies",
-		"GET /api/v1/app-control/policies/{id}",
-		"POST /api/v1/app-control/policies",
-		"PATCH /api/v1/app-control/policies/{id}",
-		"DELETE /api/v1/app-control/policies/{id}",
-		"POST /api/v1/app-control/policies/{id}/rules",
-		"POST /api/v1/app-control/policies/{id}/rules:bulkUpsert",
-		"PATCH /api/v1/app-control/rules/{id}",
-		"DELETE /api/v1/app-control/rules/{id}",
-		"GET /api/v1/app-control/rules",
-		// Host-groups + assignments surface. Read endpoints (GET) serve the real seed row; mutation endpoints (POST/PATCH/DELETE)
-		// are wired so the wire-shape contract is testable today but return 405 application_control.read_only_in_phase_a
-		// (closes tasks 11.4.8 + 11.4.9). Phase B replaces the 405 handlers with real mutation logic without changing routes.
-		"GET /api/v1/app-control/host-groups",
-		"GET /api/v1/app-control/host-groups/{id}",
-		"POST /api/v1/app-control/host-groups",
-		"PATCH /api/v1/app-control/host-groups/{id}",
-		"DELETE /api/v1/app-control/host-groups/{id}",
-		"GET /api/v1/app-control/policies/{id}/assignments",
-		"POST /api/v1/app-control/policies/{id}/assignments",
-		"DELETE /api/v1/app-control/policies/{id}/assignments/{group_id}",
-		// Break-glass reauth ceremony. The handlers are mounted on apiMux via identityCtx.RegisterAuthedRoutes, but the outer
-		// router needs each path enumerated here so the session-protected wrapper actually serves them. Otherwise requests
-		// fall through to the `/` catchall and 302 → /ui/, silently breaking the destructive-action reauth path.
-		"POST /api/auth/reauth/challenge", "POST /api/auth/reauth",
-		// SSO/OIDC configuration admin surface (issue #375). Mounted on apiMux via identityCtx.RegisterAuthedRoutes; enumerated
-		// here for the same reason as the app-control surface above (else the UI's GET parses the SPA index.html as JSON).
-		"GET /api/settings/sso", "PUT /api/settings/sso", "POST /api/settings/sso/test-connection",
-		// Service-account admin surface (issue #376). Mounted on apiMux via identityCtx.RegisterAuthedRoutes; enumerated here for the
-		// same reason as the surfaces above. The credential-exchange token endpoint (POST /api/oauth/token) is NOT here: it is a
-		// public route (no session/CSRF) registered via RegisterPublicRoutes.
-		"GET /api/settings/service-accounts", "POST /api/settings/service-accounts",
-		"POST /api/settings/service-accounts/{id}/rotate", "DELETE /api/settings/service-accounts/{id}",
-		// User + role management admin surface (issue #135). Mounted on apiMux via identityCtx.RegisterAuthedRoutes; enumerated here
-		// for the same reason as the surfaces above (else the UI's GET parses the SPA index.html as JSON).
-		"GET /api/settings/users", "PUT /api/settings/users/{id}/role", "PUT /api/settings/users/{id}/status",
-	} {
-		mux.Handle(p, sessionProtected)
+	mountAuthed(mux, protect, func(r httpserver.Router) {
+		d.detectionCtx.RegisterAuthedRoutes(r)
+		d.rulesCtx.RegisterAuthedRoutes(r)
+		d.endpointCtx.RegisterAuthedRoutes(r)
+		d.responseCtx.RegisterAuthedRoutes(r)
+		d.identityCtx.RegisterAuthedRoutes(r)
+	})
+}
+
+// mountAuthed derives the session-protected allowlist instead of hand-maintaining it (issue #463). It runs register against a
+// RecordingRouter over a fresh apiMux, wraps apiMux in protect (the session/bearer auth chain), and mounts EXACTLY the recorded
+// patterns on outer. Because the mounted set is whatever register actually registered, a new authed route is allowlisted
+// automatically: a route can no longer be registered-but-not-mounted, so it can never fall through to the `/` SPA catch-all and 302
+// (which the UI then parsed as JSON). The bug bit twice before deriving (app-control #158, SSO #375). The credential-exchange token
+// endpoint (POST /api/oauth/token) is intentionally NOT here; it is a public route registered via RegisterPublicRoutes.
+func mountAuthed(outer *http.ServeMux, protect func(http.Handler) http.Handler, register func(httpserver.Router)) {
+	apiMux := http.NewServeMux()
+	rec := httpserver.NewRecordingRouter(apiMux)
+	register(rec)
+	sessionProtected := protect(apiMux)
+	for _, p := range rec.Patterns() {
+		outer.Handle(p, sessionProtected)
 	}
 }
 

--- a/server/cmd/fleet-edr-server/main_test.go
+++ b/server/cmd/fleet-edr-server/main_test.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/fleetdm/edr/server/httpserver"
 )
 
 // TestRegisterUIRoutes_SPAFallback locks in the SPA-fallback contract: /ui/{deep-link} must return 200 with the index.html
@@ -211,4 +213,43 @@ func registerUIRoutesWithFS(
 		}
 		fileServer.ServeHTTP(w, r)
 	})
+}
+
+// TestMountAuthed_registeredRouteIsProtectedNotSPA locks in the issue #463 contract: a route registered through the authed-route
+// registration callback is mounted on the outer router and reaches the session-protected wrapper (401 / JSON when unauthenticated),
+// rather than falling through to the `/` SPA catch-all (which 302'd / served index.html and broke the UI's JSON fetch). Because
+// mountAuthed derives the mounted set from what is actually registered, a registered route can never be left off the allowlist.
+//
+// spec:server-rest-api/registered-authed-routes-are-reachable-through-the-composed-router/a-registered-authed-route-is-session-protected-not-spa-fall-through
+func TestMountAuthed_registeredRouteIsProtectedNotSPA(t *testing.T) {
+	t.Parallel()
+	outer := http.NewServeMux()
+	// SPA catch-all: what an un-allowlisted /api route used to fall through to (the bug).
+	outer.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte("<!doctype html>"))
+	})
+	// protect stands in for the session/bearer middleware: an unauthenticated request gets 401 JSON.
+	protect := func(http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"error":"invalid_session"}`))
+		})
+	}
+	mountAuthed(outer, protect, func(r httpserver.Router) {
+		r.HandleFunc("GET /api/probe", func(http.ResponseWriter, *http.Request) {})
+	})
+
+	// A registered authed route reaches the protected wrapper: 401 JSON, NOT the SPA shell.
+	pw := httptest.NewRecorder()
+	outer.ServeHTTP(pw, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/probe", nil))
+	assert.Equal(t, http.StatusUnauthorized, pw.Code)
+	assert.Equal(t, "application/json", pw.Header().Get("Content-Type"))
+	assert.NotContains(t, pw.Body.String(), "<!doctype html>")
+
+	// A route that was never registered still falls through to the SPA (control: derive mounts only what is registered).
+	mw := httptest.NewRecorder()
+	outer.ServeHTTP(mw, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/never-registered", nil))
+	assert.Equal(t, "text/html", mw.Header().Get("Content-Type"))
 }

--- a/server/detection/bootstrap/bootstrap.go
+++ b/server/detection/bootstrap/bootstrap.go
@@ -20,6 +20,7 @@ import (
 	"github.com/fleetdm/edr/server/detection/internal/pipeline"
 	"github.com/fleetdm/edr/server/detection/internal/service"
 	detectionmigrations "github.com/fleetdm/edr/server/detection/migrations"
+	"github.com/fleetdm/edr/server/httpserver"
 	identityapi "github.com/fleetdm/edr/server/identity/api"
 	"github.com/fleetdm/edr/server/migrations/runner"
 	rulesapi "github.com/fleetdm/edr/server/rules/api"
@@ -256,7 +257,7 @@ func (d *Detection) RegisterHealthRoutes(mux *http.ServeMux) {
 
 // RegisterAuthedRoutes wires the operator-facing read surface
 // (host / alert / tree). ModeIntake skips this.
-func (d *Detection) RegisterAuthedRoutes(mux *http.ServeMux) {
+func (d *Detection) RegisterAuthedRoutes(mux httpserver.Router) {
 	if d.operatorH == nil {
 		return
 	}

--- a/server/detection/internal/operator/handler.go
+++ b/server/detection/internal/operator/handler.go
@@ -87,7 +87,7 @@ func New(svc api.Service, authz identityapi.AuthZ, logger *slog.Logger) *Handler
 func (h *Handler) SetAudit(rec identityapi.AuditRecorder) { h.audit = rec }
 
 // RegisterRoutes registers the operator routes on the given mux.
-func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
+func (h *Handler) RegisterRoutes(mux httpserver.Router) {
 	mux.HandleFunc("GET /api/hosts", h.handleListHosts)
 	mux.HandleFunc("GET /api/hosts/{host_id}/tree", h.handleProcessTree)
 	mux.HandleFunc("GET /api/hosts/{host_id}/processes/{pid}", h.handleProcessDetail)

--- a/server/endpoint/bootstrap/bootstrap.go
+++ b/server/endpoint/bootstrap/bootstrap.go
@@ -20,6 +20,7 @@ import (
 	"github.com/fleetdm/edr/server/endpoint/internal/signedtoken"
 	"github.com/fleetdm/edr/server/endpoint/internal/token"
 	endpointmigrations "github.com/fleetdm/edr/server/endpoint/migrations"
+	"github.com/fleetdm/edr/server/httpserver"
 	identityapi "github.com/fleetdm/edr/server/identity/api"
 	"github.com/fleetdm/edr/server/migrations/runner"
 )
@@ -167,6 +168,6 @@ func (e *Endpoint) RegisterPublicRoutes(mux *http.ServeMux) {
 
 // RegisterAuthedRoutes wires the operator-facing routes: GET /api/enrollments and POST /api/enrollments/{host_id}/revoke. Caller wraps
 // in identity Session + CSRF middleware before mounting.
-func (e *Endpoint) RegisterAuthedRoutes(mux *http.ServeMux) {
+func (e *Endpoint) RegisterAuthedRoutes(mux httpserver.Router) {
 	e.operatorH.RegisterRoutes(mux)
 }

--- a/server/endpoint/internal/operator/handler.go
+++ b/server/endpoint/internal/operator/handler.go
@@ -59,7 +59,7 @@ func New(svc api.Service, authz identityapi.AuthZ, logger *slog.Logger) *Handler
 func (h *Handler) SetAudit(rec identityapi.AuditRecorder) { h.audit = rec }
 
 // RegisterRoutes wires the operator routes on the given mux.
-func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
+func (h *Handler) RegisterRoutes(mux httpserver.Router) {
 	mux.HandleFunc("GET /api/enrollments", h.handleList)
 	mux.HandleFunc("POST /api/enrollments/{host_id}/revoke", h.handleRevoke)
 	mux.HandleFunc("POST /api/enrollments/{host_id}/rotate", h.handleRotate)

--- a/server/httpserver/router.go
+++ b/server/httpserver/router.go
@@ -1,0 +1,48 @@
+package httpserver
+
+import (
+	"net/http"
+	"slices"
+)
+
+// Router is the subset of *http.ServeMux that route registration uses (Handle + HandleFunc). *http.ServeMux satisfies it, so a context's
+// RegisterAuthedRoutes can accept a Router without any call site change. Accepting the interface lets the outer router record every
+// pattern a context registers, so the session-protected allowlist is derived from what handlers actually register rather than
+// hand-maintained in a parallel slice (issue #463: a route registered on the API mux but missing from the slice fell through to the SPA
+// catch-all and 302'd, which the UI then parsed as JSON).
+type Router interface {
+	Handle(pattern string, handler http.Handler)
+	HandleFunc(pattern string, handler func(http.ResponseWriter, *http.Request))
+}
+
+// RecordingRouter wraps a Router, forwarding every registration to the inner Router while recording the registered patterns in order.
+// It is used at composition time: register every context's authed routes through one RecordingRouter, then mount exactly Patterns() on
+// the session-protected boundary. A route can no longer be registered without being mounted, so the drift that caused #463 is
+// structurally impossible rather than guarded after the fact.
+type RecordingRouter struct {
+	inner    Router
+	patterns []string
+}
+
+// NewRecordingRouter returns a RecordingRouter forwarding to inner.
+func NewRecordingRouter(inner Router) *RecordingRouter {
+	return &RecordingRouter{inner: inner}
+}
+
+// Handle records the pattern and forwards to the inner Router.
+func (r *RecordingRouter) Handle(pattern string, handler http.Handler) {
+	r.patterns = append(r.patterns, pattern)
+	r.inner.Handle(pattern, handler)
+}
+
+// HandleFunc records the pattern and forwards to the inner Router.
+func (r *RecordingRouter) HandleFunc(pattern string, handler func(http.ResponseWriter, *http.Request)) {
+	r.patterns = append(r.patterns, pattern)
+	r.inner.HandleFunc(pattern, handler)
+}
+
+// Patterns returns a copy of every pattern registered through this RecordingRouter, in registration order. Patterns are unique by
+// construction: the inner *http.ServeMux panics on a duplicate registration, so a duplicate would fail at composition time, not here.
+func (r *RecordingRouter) Patterns() []string {
+	return slices.Clone(r.patterns)
+}

--- a/server/httpserver/router.go
+++ b/server/httpserver/router.go
@@ -41,8 +41,10 @@ func (r *RecordingRouter) HandleFunc(pattern string, handler func(http.ResponseW
 	r.inner.HandleFunc(pattern, handler)
 }
 
-// Patterns returns a copy of every pattern registered through this RecordingRouter, in registration order. Patterns are unique by
-// construction: the inner *http.ServeMux panics on a duplicate registration, so a duplicate would fail at composition time, not here.
+// Patterns returns a copy of every pattern registered through this RecordingRouter, in registration order. Patterns are recorded
+// verbatim and would repeat if a caller registered the same pattern twice. In production the inner Router is *http.ServeMux, which
+// panics on a duplicate registration, so a duplicate fails at composition time rather than surfacing here; a Router that tolerates
+// duplicates would yield duplicate patterns, which the caller must handle.
 func (r *RecordingRouter) Patterns() []string {
 	return slices.Clone(r.patterns)
 }

--- a/server/httpserver/router_test.go
+++ b/server/httpserver/router_test.go
@@ -1,0 +1,49 @@
+package httpserver
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRecordingRouter_recordsAndForwards(t *testing.T) {
+	t.Parallel()
+	inner := http.NewServeMux()
+	rec := NewRecordingRouter(inner)
+
+	rec.HandleFunc("GET /api/a", func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusTeapot) })
+	rec.Handle("POST /api/b", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusAccepted) }))
+
+	// Patterns are recorded in registration order.
+	assert.Equal(t, []string{"GET /api/a", "POST /api/b"}, rec.Patterns())
+
+	// Registrations were forwarded to the inner mux: it actually serves them.
+	for _, tc := range []struct {
+		method, path string
+		want         int
+	}{
+		{http.MethodGet, "/api/a", http.StatusTeapot},
+		{http.MethodPost, "/api/b", http.StatusAccepted},
+	} {
+		r := httptest.NewRequestWithContext(t.Context(), tc.method, tc.path, nil)
+		w := httptest.NewRecorder()
+		inner.ServeHTTP(w, r)
+		assert.Equal(t, tc.want, w.Code, "%s %s", tc.method, tc.path)
+	}
+}
+
+func TestRecordingRouter_patternsIsACopy(t *testing.T) {
+	t.Parallel()
+	rec := NewRecordingRouter(http.NewServeMux())
+	rec.HandleFunc("GET /api/x", func(http.ResponseWriter, *http.Request) {})
+	got := rec.Patterns()
+	got[0] = "mutated"
+	// Mutating the returned slice must not affect the recorder's internal state.
+	require.Equal(t, []string{"GET /api/x"}, rec.Patterns())
+}
+
+// *http.ServeMux must satisfy Router so call sites that pass a concrete mux keep compiling.
+var _ Router = (*http.ServeMux)(nil)

--- a/server/identity/bootstrap/bootstrap.go
+++ b/server/identity/bootstrap/bootstrap.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/jmoiron/sqlx"
 
+	"github.com/fleetdm/edr/server/httpserver"
 	"github.com/fleetdm/edr/server/identity/api"
 	"github.com/fleetdm/edr/server/identity/internal/appconfig"
 	"github.com/fleetdm/edr/server/identity/internal/audit"
@@ -661,7 +662,7 @@ func (i *Identity) BreakglassUIMiddleware() func(http.Handler) http.Handler {
 
 // RegisterAuthedRoutes wires GET /api/session (who-am-i), GET /api/audit-events (operator-action history), the SSO settings API
 // (/api/settings/sso), and the break-glass reauth POST endpoints. Caller wraps in SessionMiddleware + CSRFMiddleware before mounting.
-func (i *Identity) RegisterAuthedRoutes(mux *http.ServeMux) {
+func (i *Identity) RegisterAuthedRoutes(mux httpserver.Router) {
 	i.loginHandler.RegisterAuthedRoutes(mux)
 	i.auditHandler.RegisterAuthedRoutes(mux)
 	if i.ssoAdminHandler != nil {

--- a/server/identity/internal/audit/handler.go
+++ b/server/identity/internal/audit/handler.go
@@ -48,7 +48,7 @@ func NewHandler(reader api.AuditReader, authz api.AuthZ, logger *slog.Logger) *H
 // of this route (audit.read is exempt from the read_sampling gate),
 // so the audit-of-audit invariant holds without any handler-level
 // emission.
-func (h *Handler) RegisterAuthedRoutes(mux *http.ServeMux) {
+func (h *Handler) RegisterAuthedRoutes(mux httpserver.Router) {
 	mux.HandleFunc("GET /api/audit-events", h.handleList)
 }
 

--- a/server/identity/internal/breakglass/handler.go
+++ b/server/identity/internal/breakglass/handler.go
@@ -160,7 +160,7 @@ func (h *Handler) RegisterPublicRoutes(mux *http.ServeMux) {
 //	POST /api/auth/reauth → verify password + assertion against the
 //	    current session's user; on success stamp last_auth_at
 //	    via the identity Service. No new cookie minted.
-func (h *Handler) RegisterAuthedRoutes(mux *http.ServeMux) {
+func (h *Handler) RegisterAuthedRoutes(mux httpserver.Router) {
 	if h.identity == nil {
 		panic("breakglass.RegisterAuthedRoutes: HandlerOptions.Identity is required")
 	}

--- a/server/identity/internal/login/handler.go
+++ b/server/identity/internal/login/handler.go
@@ -84,7 +84,7 @@ func (h *Handler) RegisterPublicRoutes(mux *http.ServeMux) {
 
 // RegisterAuthedRoutes wires GET /api/session on the given mux. Caller
 // wraps the mux in Session + CSRF middleware before mounting.
-func (h *Handler) RegisterAuthedRoutes(mux *http.ServeMux) {
+func (h *Handler) RegisterAuthedRoutes(mux httpserver.Router) {
 	mux.HandleFunc("GET /api/session", h.handleGet)
 }
 

--- a/server/identity/internal/saadmin/handler.go
+++ b/server/identity/internal/saadmin/handler.go
@@ -76,7 +76,7 @@ func NewHandler(store ManagementStore, authz api.AuthZ, audit AuditRecorder, log
 }
 
 // RegisterAuthedRoutes mounts the CRUD routes. The caller wraps the mux in the session/bearer auth + CSRF chain.
-func (h *Handler) RegisterAuthedRoutes(mux *http.ServeMux) {
+func (h *Handler) RegisterAuthedRoutes(mux httpserver.Router) {
 	mux.HandleFunc("GET /api/settings/service-accounts", h.handleList)
 	mux.HandleFunc("POST /api/settings/service-accounts", h.handleCreate)
 	mux.HandleFunc("POST /api/settings/service-accounts/{id}/rotate", h.handleRotate)

--- a/server/identity/internal/ssoadmin/handler.go
+++ b/server/identity/internal/ssoadmin/handler.go
@@ -90,7 +90,7 @@ func NewHandler(
 
 // RegisterAuthedRoutes mounts the SSO settings routes. The mux is expected to be wrapped in the session + CSRF middleware before being
 // mounted; the unsafe methods (PUT/POST) inherit the CSRF check from that wrapper.
-func (h *Handler) RegisterAuthedRoutes(mux *http.ServeMux) {
+func (h *Handler) RegisterAuthedRoutes(mux httpserver.Router) {
 	mux.HandleFunc("GET /api/settings/sso", h.handleGet)
 	mux.HandleFunc("PUT /api/settings/sso", h.handleUpdate)
 	mux.HandleFunc("POST /api/settings/sso/test-connection", h.handleTestConnection)

--- a/server/identity/internal/useradmin/handler.go
+++ b/server/identity/internal/useradmin/handler.go
@@ -82,7 +82,7 @@ func NewHandler(usersStore UsersStore, rolesStore RolesStore, authz api.AuthZ, a
 }
 
 // RegisterAuthedRoutes mounts the routes. The caller wraps the mux in the session auth + CSRF chain.
-func (h *Handler) RegisterAuthedRoutes(mux *http.ServeMux) {
+func (h *Handler) RegisterAuthedRoutes(mux httpserver.Router) {
 	mux.HandleFunc("GET /api/settings/users", h.handleList)
 	mux.HandleFunc("PUT /api/settings/users/{id}/role", h.handleSetRole)
 	mux.HandleFunc("PUT /api/settings/users/{id}/status", h.handleSetStatus)

--- a/server/response/bootstrap/bootstrap.go
+++ b/server/response/bootstrap/bootstrap.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/jmoiron/sqlx"
 
+	"github.com/fleetdm/edr/server/httpserver"
 	identityapi "github.com/fleetdm/edr/server/identity/api"
 	"github.com/fleetdm/edr/server/migrations/runner"
 	"github.com/fleetdm/edr/server/response/api"
@@ -118,6 +119,6 @@ func (r *Response) RegisterAgentRoutes(mux *http.ServeMux) {
 //
 // Caller wraps in identity.SessionMiddleware + identity.CSRFMiddleware
 // before mounting.
-func (r *Response) RegisterAuthedRoutes(mux *http.ServeMux) {
+func (r *Response) RegisterAuthedRoutes(mux httpserver.Router) {
 	r.operatorH.RegisterRoutes(mux)
 }

--- a/server/response/internal/operator/handler.go
+++ b/server/response/internal/operator/handler.go
@@ -55,7 +55,7 @@ func (h *Handler) SetAudit(rec identityapi.AuditRecorder) { h.audit = rec }
 
 // RegisterRoutes wires the two operator routes on the given mux.
 // Caller wraps in identity.Session + identity.CSRF before mounting.
-func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
+func (h *Handler) RegisterRoutes(mux httpserver.Router) {
 	mux.HandleFunc("POST /api/commands", h.handleCreate)
 	mux.HandleFunc("GET /api/commands/{id}", h.handleGet)
 }

--- a/server/rules/bootstrap/bootstrap.go
+++ b/server/rules/bootstrap/bootstrap.go
@@ -5,10 +5,10 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"net/http"
 
 	"github.com/jmoiron/sqlx"
 
+	"github.com/fleetdm/edr/server/httpserver"
 	identityapi "github.com/fleetdm/edr/server/identity/api"
 	"github.com/fleetdm/edr/server/migrations/runner"
 	"github.com/fleetdm/edr/server/rules/api"
@@ -167,7 +167,7 @@ func (r *Rules) ApplicationControlStore() api.ApplicationControlStore { return r
 // Caller wraps in identity Session + CSRF middleware before mounting.
 // rules has no public agent-facing routes, so RegisterPublicRoutes
 // does not exist.
-func (r *Rules) RegisterAuthedRoutes(mux *http.ServeMux) {
+func (r *Rules) RegisterAuthedRoutes(mux httpserver.Router) {
 	r.operatorH.RegisterRoutes(mux)
 	if r.appControlH != nil {
 		r.appControlH.RegisterRoutes(mux)

--- a/server/rules/internal/operator/appcontrol_handler.go
+++ b/server/rules/internal/operator/appcontrol_handler.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/fleetdm/edr/server/httpserver"
 	identityapi "github.com/fleetdm/edr/server/identity/api"
 	"github.com/fleetdm/edr/server/rules/api"
 	"github.com/fleetdm/edr/server/rules/internal/appcontrol"
@@ -107,7 +108,7 @@ func NewAppControl(svc *appcontrol.Service, authz identityapi.AuthZ, logger *slo
 //	DELETE /api/v1/app-control/policies/{id}/assignments/{group_id}   (Phase A: 405 read_only_in_phase_a)
 //
 // Caller wraps the mux in identity Session + CSRF middleware before mounting (the existing operator pattern in cmd/main).
-func (h *AppControlHandler) RegisterRoutes(mux *http.ServeMux) {
+func (h *AppControlHandler) RegisterRoutes(mux httpserver.Router) {
 	mux.HandleFunc("GET /api/v1/app-control/policies", h.handleListPolicies)
 	mux.HandleFunc("GET /api/v1/app-control/policies/{id}", h.handleGetPolicy)
 	mux.HandleFunc("POST /api/v1/app-control/policies", h.handleCreatePolicy)

--- a/server/rules/internal/operator/handler.go
+++ b/server/rules/internal/operator/handler.go
@@ -45,7 +45,7 @@ func New(svc Service, authz identityapi.AuthZ, logger *slog.Logger) *Handler {
 func (h *Handler) SetAudit(rec identityapi.AuditRecorder) { h.audit = rec }
 
 // RegisterRoutes wires the operator routes onto the given mux.
-func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
+func (h *Handler) RegisterRoutes(mux httpserver.Router) {
 	mux.HandleFunc("GET /api/rules", h.handleListRules)
 	mux.HandleFunc("GET /api/attack-coverage", h.handleATTACKCoverage)
 }


### PR DESCRIPTION
## Why

`buildMux` mounted the session-protected API via a hand-maintained allowlist slice (`for _, p := range []string{...}` in `server/cmd/fleet-edr-server/main.go`) that had to stay in sync with each context's `RegisterAuthedRoutes`. The two drifted twice (#158 app-control, #375 SSO): a route registered on the API mux but missing from the slice fell through to the `/` SPA catch-all and served `index.html`, which the UI's `fetch` parsed as JSON (`Unexpected token '<'`). Unit/integration tests mount `RegisterAuthedRoutes` on a bare mux and bypass the composed allowlist, so only live QA caught it. Closes #463.

## What changed

`http.ServeMux` can't enumerate its registered patterns, so the only way to stop the drift is to capture patterns at registration time.

- Add `httpserver.Router` (`Handle` + `HandleFunc`, satisfied by `*http.ServeMux`) and `httpserver.RecordingRouter` (forwards to an inner router while recording patterns).
- Change the authed registration methods (the 5 contexts' `RegisterAuthedRoutes` + the operator handlers' `RegisterRoutes` they delegate to) to accept `httpserver.Router`. `*http.ServeMux` satisfies it, so every call site compiles unchanged and the method bodies are untouched.
- `registerSessionRoutes` registers every context through one `RecordingRouter` (via the extracted, testable `mountAuthed`) and mounts exactly the recorded patterns on the session-protected boundary. The hand-maintained slice is deleted. A registered authed route is now allowlisted automatically, so the drift is structurally impossible rather than guarded after the fact.

**No observable change to any existing route** — same routes, same responses; only future drift is prevented.

## Out of scope

The agent-token allowlist in `registerHostRoutes` is the same hand-maintained shape but smaller, stable, and not the reported bug (an agent does not parse the SPA shell as JSON). The same `RecordingRouter` primitive can derive it in a follow-up.

## Testing

- `TestMountAuthed_…`: a route registered through the authed path is reachable as the session auth failure (JSON), not the SPA HTML catch-all; a never-registered route still falls through to the SPA.
- `RecordingRouter` unit tests (records + forwards; `Patterns()` is a copy; `*http.ServeMux` satisfies `Router`).
- Gates green locally: `go build ./...`, `go test` across httpserver + cmd + all five contexts, golangci-lint (custom) 0 issues, `spectrace check --strict` 423/423, `openspec validate --strict`, dash lint.

openspec change `derive-authed-route-allowlist` (delta to `server-rest-api`) documents the invariant; the test carries its spectrace marker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Automatically derive session-protected route allowlist from registered routes, eliminating manual maintenance and the risk of routes being registered but not properly protected.
  * Ensure unauthenticated requests to protected API routes return authentication-failure JSON responses instead of potentially falling through to the UI.

* **Refactor**
  * Updated route registration APIs across multiple services for consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->