### PR TITLE
feat(detection-config): DB-backed config store + resolver foundation …

### DIFF
--- a/openspec/changes/detection-config-surface/proposal.md
+++ b/openspec/changes/detection-config-surface/proposal.md
@@ -1,0 +1,38 @@
+# DB-backed detection configuration surface
+
+## Why
+
+Detection-rule configuration (the four false-positive allowlists plus the disabled-rule list) is configured today as boot-time environment-variable CSVs: `EDR_LAUNCHAGENT_ALLOWLIST`, `EDR_LAUNCHDAEMON_TEAMID_ALLOWLIST`, `EDR_SUDOERS_WRITER_ALLOWLIST`, `EDR_SUSPICIOUS_EXEC_PARENT_ALLOWLIST`, `EDR_DISABLED_RULES` (issue #459). That is the wrong layer for a stateless multi-replica server (ADR-0010): changing it requires editing env and restarting every replica, there is no audit trail of who changed what, it cannot be scoped to a host group, and it puts durable cross-request operator state in per-replica boot env instead of MySQL.
+
+False-positive suppression is the number-one pilot pain for an EDR, and the detection catalog is growing: many future rules will need their own tunables (thresholds, windows, severity). We want one common, durable, governed config surface rather than a new env var per knob. The market has converged on this shape: CrowdStrike Falcon (prevention policies + host-group-scoped IOA/ML exclusions), Microsoft Defender (device-group-scoped indicators + custom detections), SentinelOne (policy inheritance + signer/path/hash exclusions), and Elastic Security (per-rule settings + first-class shared exception lists) all store detection config centrally, edit it through an API/console, scope it to groups, and audit every change. None use host-local or boot config.
+
+## What changes
+
+Introduce a DB-backed detection-configuration surface in the rules context (alongside the catalog rules, Application Control, and `host_groups` it already owns), edited through the admin REST API + UI, governed by the existing RBAC chokepoint and audit log, and consumed by the detection engine server-side with no agent fan-out.
+
+Two layers, mirroring industry practice:
+
+- **Per-rule settings.** One record per `(rule_id, scope)` carrying a `mode` (`alert` / `monitor` / `disabled`), an optional `severity_override`, and a JSON `settings` document validated against the rule's self-declared config schema (the existing `ConfigKnob` generalised). The three-value `mode` matches the universal EDR shape (Defender ASR audit mode, Falcon detect-vs-prevent, SentinelOne rule states): `alert` produces alerts as today, `disabled` evaluates nothing for that scope, and `monitor` evaluates the rule but emits an observability signal instead of an alert so an operator can gauge a rule's noise before promoting it to `alert`. Modelling state as an enum (not a boolean) means the audit/monitor third state the whole market has is available now without another migration. New detections get config by declaring their schema, with no new table and no new env var.
+- **Typed exclusions** (the allowlist layer). One record per entry: a `match_type` (`path_glob`, `parent_path_glob`, `team_id`, `signing_id`, `cdhash`, `sha256`, `command_substring`, `domain`), a `value`, an owning `rule_id` (or shared), a `reason`, `created_by`, and an optional `expires_at` (auto-expiry, as Elastic and SentinelOne do). The four current allowlists become exclusion records: launchagent -> `path_glob`, launchdaemon -> `team_id`, sudoers -> `path_glob`, suspicious_exec -> `parent_path_glob`.
+
+Both layers carry a `host_group_id` where `0` (the `GlobalScope` sentinel) means global and a real id scopes the record to a host group, from day one so the schema never has to be re-migrated when editable host groups arrive. Host-group editing is still Phase A immutable (only the seeded `all-hosts` group exists), so the operative scope today is global; the resolver and schema are group-ready for Phase B. The column is not FK-constrained to `host_groups` yet: group existence is validated at the app layer, and the FK plus cascade cleanup land with the editable-host-groups (Phase B) change (a sentinel-with-app-validation shape avoids InnoDB's restriction against an `ON DELETE` referential action on a column that also backs a uniqueness key, while keeping the global row unique per rule).
+
+Resolution is **per host at evaluation time** (how Falcon, SentinelOne, and Elastic evaluate exclusions, and the only correct way to honour host-group scope): the engine hands each rule an `ExclusionResolver`. Before a rule emits a finding for host H it asks the resolver whether an exclusion of the relevant `match_type` applies at global scope or for any host group H belongs to; a match suppresses the finding. The resolver indexes entries by `(rule_id, match_type)` and compiles match values once, so per-event cost is bounded to the handful of entries for that key rather than a scan of the whole allowlist (the industry pattern; addresses the hot-path concern). Per-rule `mode` and `severity_override` resolve most-specific-wins per host. A globally-disabled rule stays visible in the catalog (`GET /api/rules`) with its mode indicator and simply emits nothing, rather than disappearing.
+
+Config mutations bump a version and take effect without a restart: the rules context rebuilds the snapshot and the detection engine reloads it via the existing `Engine.LoadActive`. Each replica reads the snapshot from MySQL and may cache it keyed by version (a per-replica perf cache, safe to lose), so the stateless-multi-replica invariant holds.
+
+## Hard switch (no migration, no deprecation)
+
+Per the issue owner: this is a hard cutover. The five environment variables and their config plumbing (`config.Config` fields, `loadAllowlists`, the `RegistryOptions` allowlist fields populated from env) are **deleted**, not deprecated. There is no env-to-DB seeding and no fallback release. The DB surface starts empty (no entries, every rule enabled), and operators re-add any needed suppression through the UI/API after the switch.
+
+## Scope notes
+
+- Host-group-scoped *entries* are accepted by the schema/API now, but with only the immutable `all-hosts` group present the effective scope is global until editable host groups (Phase B) land. No re-migration is needed when they do.
+- This is the generic framework; the five existing knobs are its first tenant. It is explicitly designed so detection rule number eleven gets config (settings + exclusions + a generic UI row) without new DDL or new env vars.
+
+## Impact
+
+- Affected specs: `server-detection-rules-engine` (config is DB-backed + host-scoped + hot-reloaded; the boot-time toggling requirement is modified; the env knobs are removed), `web-ui` (admin surface to view/edit detection config).
+- Affected code: `server/rules/internal/<new detectionconfig package>` (store + service + REST handler), `server/rules/migrations` (new tables), `server/rules/internal/operator` (route registration), `server/rules/api` (generalised config schema + `ExclusionResolver` contract), `server/rules/internal/catalog` (rules consume the resolver instead of baked allowlist maps; `catalog.New` built from the DB snapshot), `server/detection` (engine threads the resolver + reload trigger), `server/config/config.go` (delete the five env knobs + `loadAllowlists`), `ui/src` (detection-config admin views), `docs/{detection-rules,operations,install-server}.md` (repoint at the new surface), and the session-protected route allowlist (new `/api/v1/detection-config/*` routes).
+- No agent, extension, wire-format, or schema/events change. Server + UI only.
+- Behavior change: a disabled rule remains listed in `GET /api/rules` (with its mode) instead of being removed from the catalog as `EDR_DISABLED_RULES` did. A new `monitor` mode evaluates a rule without raising alerts, emitting an observability signal instead.

--- a/openspec/changes/detection-config-surface/specs/server-detection-rules-engine/spec.md
+++ b/openspec/changes/detection-config-surface/specs/server-detection-rules-engine/spec.md
@@ -1,0 +1,64 @@
+# Server Detection Rules Engine Specification
+
+## MODIFIED Requirements
+
+### Requirement: Operator toggling of individual rules
+
+The system SHALL allow an operator to set an individual rule's mode to one of `alert`, `monitor`, or `disabled` through the durable detection-configuration surface (persisted in MySQL, edited via the admin API/UI), NOT through boot-time environment configuration. The mode MAY be set at global scope or scoped to a host group, and resolves per host most-specific-wins (a host-group setting overrides the global setting for hosts in that group). A rule that resolves to `disabled` for a host MUST NOT produce alerts for that host. A rule that resolves to `monitor` for a host MUST evaluate but MUST NOT persist an alert, emitting an observability signal instead so the would-be detection is visible without alerting. A rule that resolves to `alert` produces alerts as normal. A mode change MUST take effect without a server restart. A rule whose global mode is `disabled` MUST remain visible in the rule catalog surface (`GET /api/rules`) with its mode indicated rather than being removed from the catalog.
+
+#### Scenario: An operator disables a noisy rule for their environment
+
+- **GIVEN** a running engine and an operator who sets a rule's global mode to `disabled` through the detection-configuration API
+- **WHEN** a batch arrives that would otherwise satisfy that rule
+- **THEN** no alerts are produced for that rule
+- **AND** the remaining rules continue to evaluate normally
+- **AND** the disabled rule is still listed by `GET /api/rules`, marked disabled
+- **AND** the change took effect without a server restart
+
+#### Scenario: A rule set to monitor evaluates without alerting
+
+- **GIVEN** a rule whose global mode is set to `monitor`
+- **WHEN** a batch arrives that satisfies the rule for a host
+- **THEN** no alert is persisted for that rule and host
+- **AND** an observability signal records that the rule matched
+
+#### Scenario: An operator re-enables a previously disabled rule
+
+- **GIVEN** a rule whose global mode was previously set to `disabled`
+- **WHEN** the operator sets its mode back to `alert` through the API
+- **THEN** subsequent batches that satisfy the rule produce alerts again without a server restart
+
+## ADDED Requirements
+
+### Requirement: Durable detection configuration surface
+
+The system SHALL persist detection-rule configuration (per-rule enable state, optional severity override, per-rule settings, and false-positive exclusions) as durable state in MySQL, edited through the authenticated admin API and UI. Detection configuration MUST NOT be sourced from boot-time environment variables. Every mutation MUST pass through the RBAC authorization chokepoint and record an audit entry naming the actor. Each configuration record MAY carry a host-group scope (or be global); records also support an optional expiration after which they no longer apply. A configuration change MUST become effective for subsequent evaluations without a server restart.
+
+#### Scenario: An operator adds a false-positive exclusion without restarting
+
+- **GIVEN** a rule that is currently producing a benign finding for a known-good process
+- **WHEN** an operator adds an exclusion for that rule (by a typed match such as a parent-path glob or a signing team ID) through the detection-configuration API
+- **THEN** the exclusion is persisted in MySQL with the actor recorded in the audit log
+- **AND** subsequent batches no longer produce that finding, without a server restart
+
+#### Scenario: An expired exclusion stops applying
+
+- **GIVEN** an exclusion whose expiration timestamp is in the past
+- **WHEN** the engine evaluates a batch that the exclusion would otherwise suppress
+- **THEN** the exclusion does not apply and the finding is produced
+
+### Requirement: Per-host resolution of exclusions and rule settings
+
+The system SHALL resolve detection exclusions and per-rule settings per host at evaluation time. Before a rule produces a finding for a given host, the engine MUST suppress that finding when an exclusion of the relevant match type applies to the host, where an exclusion applies if its scope is global OR a host group the host belongs to, and it has not expired. An exclusion scoped to a host group MUST NOT suppress findings for hosts outside that group. Per-rule mode and severity override MUST resolve most-specific-wins (host-group scope overrides global scope) for the finding's host.
+
+#### Scenario: A host-group-scoped exclusion does not affect other hosts
+
+- **GIVEN** an exclusion for a rule scoped to a specific host group
+- **WHEN** the rule's pattern is satisfied on a host that is NOT a member of that group
+- **THEN** the finding is still produced for that host
+
+#### Scenario: A global exclusion suppresses the finding on every host
+
+- **GIVEN** an exclusion for a rule at global scope
+- **WHEN** the rule's pattern is satisfied on any host
+- **THEN** the finding is suppressed for that host

--- a/openspec/changes/detection-config-surface/specs/server-detection-rules-engine/spec.md
+++ b/openspec/changes/detection-config-surface/specs/server-detection-rules-engine/spec.md
@@ -32,7 +32,7 @@ The system SHALL allow an operator to set an individual rule's mode to one of `a
 
 ### Requirement: Durable detection configuration surface
 
-The system SHALL persist detection-rule configuration (per-rule enable state, optional severity override, per-rule settings, and false-positive exclusions) as durable state in MySQL, edited through the authenticated admin API and UI. Detection configuration MUST NOT be sourced from boot-time environment variables. Every mutation MUST pass through the RBAC authorization chokepoint and record an audit entry naming the actor. Each configuration record MAY carry a host-group scope (or be global); records also support an optional expiration after which they no longer apply. A configuration change MUST become effective for subsequent evaluations without a server restart.
+The system SHALL persist detection-rule configuration (per-rule mode, optional severity override, per-rule settings, and false-positive exclusions) as durable state in MySQL, edited through the authenticated admin API and UI. Detection configuration MUST NOT be sourced from boot-time environment variables. Every mutation MUST pass through the RBAC authorization chokepoint and record an audit entry naming the actor. Each configuration record MAY carry a host-group scope (or be global); records also support an optional expiration after which they no longer apply. A configuration change MUST become effective for subsequent evaluations without a server restart.
 
 #### Scenario: An operator adds a false-positive exclusion without restarting
 

--- a/openspec/changes/detection-config-surface/specs/web-ui/spec.md
+++ b/openspec/changes/detection-config-surface/specs/web-ui/spec.md
@@ -1,0 +1,20 @@
+# Web UI Specification
+
+## ADDED Requirements
+
+### Requirement: Detection configuration admin views
+
+The web UI SHALL provide an authenticated admin surface to view and edit detection configuration: per-rule enable state, optional severity override, per-rule settings, and false-positive exclusions. The per-rule settings form MUST be rendered generically from each rule's declared configuration schema so a newly added rule's settings appear without bespoke UI. The exclusion editor MUST let an operator create, edit, and delete exclusions with a typed match type, a value, a reason, an optional expiration, and a scope (global or a host group), and MUST surface the existing entries with their author and creation time. Mutations MUST go through the authenticated admin API and are subject to the same RBAC the API enforces.
+
+#### Scenario: An operator adds an exclusion from the UI
+
+- **GIVEN** an authenticated operator with permission to edit detection configuration
+- **WHEN** they open a rule's detection-configuration view and add an exclusion with a match type, value, and reason
+- **THEN** the exclusion is created through the admin API
+- **AND** it appears in the rule's exclusion list with its author and creation time
+
+#### Scenario: A rule's settings render from its declared schema
+
+- **GIVEN** a rule that declares configurable settings in its schema
+- **WHEN** an operator opens that rule's detection-configuration view
+- **THEN** the settings form renders the declared fields without UI changes specific to that rule

--- a/openspec/changes/detection-config-surface/specs/web-ui/spec.md
+++ b/openspec/changes/detection-config-surface/specs/web-ui/spec.md
@@ -4,7 +4,7 @@
 
 ### Requirement: Detection configuration admin views
 
-The web UI SHALL provide an authenticated admin surface to view and edit detection configuration: per-rule enable state, optional severity override, per-rule settings, and false-positive exclusions. The per-rule settings form MUST be rendered generically from each rule's declared configuration schema so a newly added rule's settings appear without bespoke UI. The exclusion editor MUST let an operator create, edit, and delete exclusions with a typed match type, a value, a reason, an optional expiration, and a scope (global or a host group), and MUST surface the existing entries with their author and creation time. Mutations MUST go through the authenticated admin API and are subject to the same RBAC the API enforces.
+The web UI SHALL provide an authenticated admin surface to view and edit detection configuration: per-rule mode (alert / monitor / disabled), optional severity override, per-rule settings, and false-positive exclusions. The per-rule settings form MUST be rendered generically from each rule's declared configuration schema so a newly added rule's settings appear without bespoke UI. The exclusion editor MUST let an operator create, edit, and delete exclusions with a typed match type, a value, a reason, an optional expiration, and a scope (global or a host group), and MUST surface the existing entries with their author and creation time. Mutations MUST go through the authenticated admin API and are subject to the same RBAC the API enforces.
 
 #### Scenario: An operator adds an exclusion from the UI
 

--- a/openspec/changes/detection-config-surface/tasks.md
+++ b/openspec/changes/detection-config-surface/tasks.md
@@ -3,7 +3,7 @@
 ## Data model (rules context)
 
 - [x] `server/rules/migrations`: add `detection_rule_settings` (`rule_id`, `host_group_id` NOT NULL DEFAULT 0 where 0=global, `mode` ENUM('alert','monitor','disabled') DEFAULT 'alert', `severity_override` NULL, `settings` JSON, audit columns; unique on `(rule_id, host_group_id)`) and `detection_exclusions` (`id`, `rule_id` (''=shared), `match_type` ENUM, `value`, `host_group_id` NOT NULL DEFAULT 0, `reason`, `created_by`, `created_at`, `expires_at` NULL, `enabled`) plus `detection_config_meta` version counter. `host_group_id` is validated app-side; the FK + cascade to `host_groups` lands with editable host groups (Phase B).
-- [ ] A monotonic config `version` (per the App Control pattern) bumped on every mutation, for replica cache invalidation + hot reload.
+- [x] A monotonic config `version` (per the App Control pattern) bumped on every mutation, for replica cache invalidation + hot reload (`detection_config_meta`; `bumpVersion` fails closed if the row is missing).
 
 ## Rule-facing contract (`server/rules/api`)
 
@@ -15,6 +15,7 @@
 
 - [ ] `catalog.New` is built from the DB snapshot instead of `RegistryOptions` env allowlists. Rules consult the injected `ExclusionResolver` per finding/host instead of a baked `map[string]struct{}`.
 - [ ] Rules with allowlists (`suspicious_exec`, `persistence_launchagent`, `privilege_launchd_plist_write`, `sudoers_tamper`) call the resolver; remove their `Allowed*` map fields.
+- [ ] Canonicalize paths consistently between the rule and the resolver for `path_glob` / `parent_path_glob` matches, so an exclusion written against one macOS path form (`/etc/...`) still applies when ESF reports the aliased form (`/private/etc/...`); reuse the existing canonicalization (PR #50 / #290). Deferred from Stage 1 (no path flows through the resolver until rules consume it here).
 - [ ] Engine routes each finding by the `(rule, host)` resolved mode: `disabled` drops it, `monitor` drops the alert but emits an observability signal (a counter + structured log/trace recording the match), `alert` persists. Applies `severity_override`. A globally-disabled rule stays in the catalog surface.
 - [ ] Mutations rebuild the snapshot + call `Engine.LoadActive`; each replica reads MySQL and caches by version (safe-to-lose per-replica cache). No restart.
 
@@ -30,7 +31,7 @@
 
 ## UI
 
-- [ ] `ui/src`: detection-config admin views (per-rule enable/severity/settings from the declared schema; exclusion list CRUD with match-type, value, reason, expiry, scope). Generic, schema-driven. Co-located `*.test.tsx`.
+- [ ] `ui/src`: detection-config admin views (per-rule mode (alert/monitor/disabled) + severity + settings from the declared schema; exclusion list CRUD with match-type, value, reason, expiry, scope). Generic, schema-driven. Co-located `*.test.tsx`.
 
 ## Tests + docs
 

--- a/openspec/changes/detection-config-surface/tasks.md
+++ b/openspec/changes/detection-config-surface/tasks.md
@@ -1,0 +1,52 @@
+# Tasks
+
+## Data model (rules context)
+
+- [x] `server/rules/migrations`: add `detection_rule_settings` (`rule_id`, `host_group_id` NOT NULL DEFAULT 0 where 0=global, `mode` ENUM('alert','monitor','disabled') DEFAULT 'alert', `severity_override` NULL, `settings` JSON, audit columns; unique on `(rule_id, host_group_id)`) and `detection_exclusions` (`id`, `rule_id` (''=shared), `match_type` ENUM, `value`, `host_group_id` NOT NULL DEFAULT 0, `reason`, `created_by`, `created_at`, `expires_at` NULL, `enabled`) plus `detection_config_meta` version counter. `host_group_id` is validated app-side; the FK + cascade to `host_groups` lands with editable host groups (Phase B).
+- [ ] A monotonic config `version` (per the App Control pattern) bumped on every mutation, for replica cache invalidation + hot reload.
+
+## Rule-facing contract (`server/rules/api`)
+
+- [ ] Generalise `ConfigKnob` into a typed per-rule config schema: declared setting keys (type, default, bounds) + the `match_type`s the rule honours. Drives validation + the generic UI.
+- [x] Define `ExclusionResolver` (narrow read surface, like `GraphReader`): `Excluded(ruleID, matchType, value, hostID) bool` resolving global + the host's groups, honouring `expires_at`. Index entries by `(rule_id, match_type)` so per-event cost is bounded to that key. Glob matching is now `api.GlobMatch` (canonical home; suspicious_exec's private copy is removed in the catalog-rewire task).
+- [x] Define the per-host settings resolution: `mode` (alert/monitor/disabled) + severity override, most-specific-wins (`detectionconfig.Snapshot`).
+
+## Engine + catalog
+
+- [ ] `catalog.New` is built from the DB snapshot instead of `RegistryOptions` env allowlists. Rules consult the injected `ExclusionResolver` per finding/host instead of a baked `map[string]struct{}`.
+- [ ] Rules with allowlists (`suspicious_exec`, `persistence_launchagent`, `privilege_launchd_plist_write`, `sudoers_tamper`) call the resolver; remove their `Allowed*` map fields.
+- [ ] Engine routes each finding by the `(rule, host)` resolved mode: `disabled` drops it, `monitor` drops the alert but emits an observability signal (a counter + structured log/trace recording the match), `alert` persists. Applies `severity_override`. A globally-disabled rule stays in the catalog surface.
+- [ ] Mutations rebuild the snapshot + call `Engine.LoadActive`; each replica reads MySQL and caches by version (safe-to-lose per-replica cache). No restart.
+
+## REST + governance
+
+- [ ] `server/rules/internal/detectionconfig` (store + service) + `server/rules/internal/operator` routes: list/create/update/delete exclusions; get/update per-rule settings; scoped to host groups. Mirror the App Control handler shape.
+- [ ] Every mutation goes through the existing RBAC chokepoint and writes an audit row (actor + reason).
+- [ ] Register the new `/api/v1/detection-config/*` routes in the session-protected route allowlist.
+
+## Delete the env surface (hard switch)
+
+- [ ] Remove `EDR_LAUNCHAGENT_ALLOWLIST`, `EDR_LAUNCHDAEMON_TEAMID_ALLOWLIST`, `EDR_SUDOERS_WRITER_ALLOWLIST`, `EDR_SUSPICIOUS_EXEC_PARENT_ALLOWLIST`, `EDR_DISABLED_RULES` and their `config.Config` fields + `loadAllowlists` + the `RegistryOptions` allowlist fields. No seeding, no fallback.
+
+## UI
+
+- [ ] `ui/src`: detection-config admin views (per-rule enable/severity/settings from the declared schema; exclusion list CRUD with match-type, value, reason, expiry, scope). Generic, schema-driven. Co-located `*.test.tsx`.
+
+## Tests + docs
+
+- [x] Store integration tests (real MySQL): CRUD, version bump, resolve-via-snapshot, invalid-input rejection (`store_test.go`). Pure snapshot tests: expiry, group scope, shared-rule, most-specific-wins mode/severity (`snapshot_test.go`).
+- [ ] Catalog tests: each migrated rule suppressed by a DB exclusion at global scope; disabled rule emits nothing but stays listed.
+- [ ] `docs/detection-rules.md`, `docs/operations.md`, `docs/install-server.md`: repoint from env vars to the new surface; regenerate `detection-rules.md` via `tools/gen-rule-docs`.
+- [ ] Spectrace markers for the new SHALL/MUST scenarios.
+
+## Gates
+
+- [ ] `go test`, `task lint:go`, `task lint:dashes`, `tools/spectrace check --strict`, `openspec validate detection-config-surface --strict`, `cd ui && npm test`.
+
+## Manual QA
+
+- [ ] dev:server + edr-dev + SigNoz: add an exclusion via API, confirm a previously-firing chain is suppressed without restart; disable a rule, confirm it stops emitting and stays listed in `GET /api/rules`.
+
+## Archive
+
+- [ ] Archive at release (`openspec archive detection-config-surface`), not per-merge.

--- a/server/rules/api/detectionconfig.go
+++ b/server/rules/api/detectionconfig.go
@@ -85,7 +85,11 @@ func MatchExclusionValue(mt ExclusionMatchType, entry, candidate string) bool {
 	case ExclusionMatchCommandSubstring:
 		return entry != "" && strings.Contains(candidate, entry)
 	case ExclusionMatchDomain:
-		return candidate == entry || strings.HasSuffix(candidate, "."+entry)
+		// DNS names are case-insensitive and may carry a trailing dot (the FQDN root); normalize both sides so an exclusion of
+		// `example.com` matches `Example.com`, `example.com.`, and `sub.example.com`.
+		e := strings.TrimSuffix(strings.ToLower(entry), ".")
+		c := strings.TrimSuffix(strings.ToLower(candidate), ".")
+		return c == e || strings.HasSuffix(c, "."+e)
 	case ExclusionMatchTeamID, ExclusionMatchSigningID, ExclusionMatchCDHash, ExclusionMatchSHA256:
 		return entry == candidate
 	}

--- a/server/rules/api/detectionconfig.go
+++ b/server/rules/api/detectionconfig.go
@@ -1,0 +1,175 @@
+package api
+
+import (
+	"strings"
+	"time"
+)
+
+// --- Detection configuration surface (issue #459) ----------------------------
+//
+// DB-backed replacement for the boot-time env-CSV allowlists + disabled-rule list. Two layers, mirroring industry practice (Falcon /
+// Defender / SentinelOne / Elastic): per-rule settings (mode + severity override + future JSON settings) and typed exclusions (the
+// allowlist layer). Both are scopable to a host group (or global) and resolved PER HOST at evaluation time. These types live on the
+// rules.api surface so catalog rules consume the resolver interfaces without importing the rules-internal detectionconfig package.
+
+// DetectionRuleMode is the per-(rule, scope) operating mode. Three values, the shape every major EDR converged on (Defender ASR audit
+// mode, Falcon detect-vs-prevent, SentinelOne rule states):
+//
+//   - alert:    the rule produces alerts as normal (the default when unset).
+//   - monitor:  the rule still evaluates, but a match emits an observability signal instead of persisting an alert, so an operator can
+//     gauge a rule's noise before promoting it to alert.
+//   - disabled: the rule produces nothing for the scope.
+type DetectionRuleMode string
+
+const (
+	DetectionRuleModeAlert    DetectionRuleMode = "alert"
+	DetectionRuleModeMonitor  DetectionRuleMode = "monitor"
+	DetectionRuleModeDisabled DetectionRuleMode = "disabled"
+)
+
+// IsValidDetectionRuleMode reports whether m is one of the defined modes. Used at the REST boundary to reject untrusted input before it
+// reaches the store.
+func IsValidDetectionRuleMode(m DetectionRuleMode) bool {
+	switch m {
+	case DetectionRuleModeAlert, DetectionRuleModeMonitor, DetectionRuleModeDisabled:
+		return true
+	}
+	return false
+}
+
+// ExclusionMatchType is the dimension a detection exclusion keys on. Typed (never free-form), and deliberately NOT keyed on IP/ASN for
+// shared CDNs (the best-practice note on suspicious_exec, and the industry guidance from Falcon and Defender). The four legacy
+// allowlists map onto a subset: launchagent -> path_glob, launchdaemon -> team_id, sudoers -> path_glob, suspicious_exec ->
+// parent_path_glob.
+type ExclusionMatchType string
+
+const (
+	// ExclusionMatchPathGlob matches an absolute filesystem path against a glob where `*` matches any run of characters including `/`
+	// (a pattern with no `*` is an exact match). Used for the executable / writer / plist path.
+	ExclusionMatchPathGlob ExclusionMatchType = "path_glob"
+	// ExclusionMatchParentPathGlob is path_glob applied to a chain's non-shell parent path (suspicious_exec).
+	ExclusionMatchParentPathGlob ExclusionMatchType = "parent_path_glob"
+	// ExclusionMatchTeamID matches an Apple Developer team ID exactly.
+	ExclusionMatchTeamID ExclusionMatchType = "team_id"
+	// ExclusionMatchSigningID matches a code-signing identifier exactly.
+	ExclusionMatchSigningID ExclusionMatchType = "signing_id"
+	// ExclusionMatchCDHash matches a code-directory hash exactly.
+	ExclusionMatchCDHash ExclusionMatchType = "cdhash"
+	// ExclusionMatchSHA256 matches a binary SHA-256 exactly.
+	ExclusionMatchSHA256 ExclusionMatchType = "sha256"
+	// ExclusionMatchCommandSubstring matches when the candidate command line contains the entry value as a substring.
+	ExclusionMatchCommandSubstring ExclusionMatchType = "command_substring"
+	// ExclusionMatchDomain matches a DNS name exactly or as a parent domain (entry `example.com` matches `example.com` and
+	// `sub.example.com`).
+	ExclusionMatchDomain ExclusionMatchType = "domain"
+)
+
+// IsValidExclusionMatchType reports whether mt is one of the defined match types. Used at the REST boundary to reject untrusted input.
+func IsValidExclusionMatchType(mt ExclusionMatchType) bool {
+	switch mt {
+	case ExclusionMatchPathGlob, ExclusionMatchParentPathGlob, ExclusionMatchTeamID,
+		ExclusionMatchSigningID, ExclusionMatchCDHash, ExclusionMatchSHA256,
+		ExclusionMatchCommandSubstring, ExclusionMatchDomain:
+		return true
+	}
+	return false
+}
+
+// MatchExclusionValue reports whether a stored exclusion of match type mt with value entry suppresses a candidate value the rule is
+// about to fire on. The per-type semantics live here so the resolver and any other consumer agree on what "matches" means for each
+// dimension.
+func MatchExclusionValue(mt ExclusionMatchType, entry, candidate string) bool {
+	switch mt {
+	case ExclusionMatchPathGlob, ExclusionMatchParentPathGlob:
+		return GlobMatch(entry, candidate)
+	case ExclusionMatchCommandSubstring:
+		return entry != "" && strings.Contains(candidate, entry)
+	case ExclusionMatchDomain:
+		return candidate == entry || strings.HasSuffix(candidate, "."+entry)
+	case ExclusionMatchTeamID, ExclusionMatchSigningID, ExclusionMatchCDHash, ExclusionMatchSHA256:
+		return entry == candidate
+	}
+	return false
+}
+
+// GlobMatch reports whether name matches pattern, where `*` matches any run of characters (including the empty run AND the path
+// separator) and every other byte is a literal. A pattern with no `*` reduces to exact string equality. `*` deliberately crosses `/`
+// (unlike a shell glob) so one `*/claude/versions/*` survives version churn. Standard linear-time wildcard match with single-star
+// backtracking. Canonical home for the matcher the suspicious_exec allowlist introduced; the detection-config resolver reuses it for
+// every path-glob exclusion.
+func GlobMatch(pattern, name string) bool {
+	var px, nx int
+	lastStar, lastStarNx := -1, 0
+	for nx < len(name) {
+		switch {
+		case px < len(pattern) && pattern[px] == name[nx]:
+			px++
+			nx++
+		case px < len(pattern) && pattern[px] == '*':
+			lastStar = px
+			lastStarNx = nx
+			px++
+		case lastStar != -1:
+			px = lastStar + 1
+			lastStarNx++
+			nx = lastStarNx
+		default:
+			return false
+		}
+	}
+	for px < len(pattern) && pattern[px] == '*' {
+		px++
+	}
+	return px == len(pattern)
+}
+
+// GlobalScope is the sentinel host-group id meaning "applies to every host" for a detection-config record whose scope is global. The
+// store uses 0 for the global row so (rule_id, host_group_id) uniqueness holds and callers reason about a single int space.
+const GlobalScope int64 = 0
+
+// DetectionExclusion mirrors a row in detection_exclusions. RuleID is empty for an exclusion shared across rules. HostGroupID is
+// GlobalScope for a global entry. ExpiresAt is nil for a non-expiring entry.
+type DetectionExclusion struct {
+	ID          int64              `db:"id" json:"id"`
+	RuleID      string             `db:"rule_id" json:"rule_id"`
+	MatchType   ExclusionMatchType `db:"match_type" json:"match_type"`
+	Value       string             `db:"value" json:"value"`
+	HostGroupID int64              `db:"host_group_id" json:"host_group_id"`
+	Reason      string             `db:"reason" json:"reason"`
+	Enabled     bool               `db:"enabled" json:"enabled"`
+	ExpiresAt   *time.Time         `db:"expires_at" json:"expires_at,omitempty"`
+	CreatedBy   string             `db:"created_by" json:"created_by"`
+	CreatedAt   time.Time          `db:"created_at" json:"created_at"`
+}
+
+// DetectionRuleSetting mirrors a row in detection_rule_settings: the per-(rule, scope) mode + optional severity override + JSON
+// settings document.
+type DetectionRuleSetting struct {
+	ID               int64             `db:"id" json:"id"`
+	RuleID           string            `db:"rule_id" json:"rule_id"`
+	HostGroupID      int64             `db:"host_group_id" json:"host_group_id"`
+	Mode             DetectionRuleMode `db:"mode" json:"mode"`
+	SeverityOverride string            `db:"severity_override" json:"severity_override,omitempty"`
+	Settings         NullRawJSON       `db:"settings" json:"settings,omitempty"`
+	UpdatedBy        string            `db:"updated_by" json:"updated_by"`
+	UpdatedAt        time.Time         `db:"updated_at" json:"updated_at"`
+}
+
+// ExclusionResolver is the narrow read surface a catalog rule consults before it emits a finding. It is backed by an in-memory
+// snapshot loaded from the detection-config store and swapped on reload, so Excluded is a pure in-memory lookup (no per-event DB round
+// trip). A nil resolver excludes nothing, which is the correct default for an empty configuration.
+type ExclusionResolver interface {
+	// Excluded reports whether an enabled, unexpired exclusion of matchType whose value matches `value` applies to hostID (global
+	// scope or a host group hostID belongs to).
+	Excluded(ruleID string, matchType ExclusionMatchType, value, hostID string) bool
+}
+
+// RuleModeResolver is the narrow read surface the engine consults to route a finding by the resolved per-host mode and to apply a
+// severity override. A nil resolver behaves as "every rule alerts, no override".
+type RuleModeResolver interface {
+	// Mode returns the resolved mode for (ruleID, hostID), most-specific-wins (a host-group setting overrides global). Returns
+	// DetectionRuleModeAlert when no setting applies.
+	Mode(ruleID, hostID string) DetectionRuleMode
+	// SeverityOverride returns the resolved severity override for (ruleID, hostID), or "" when none applies.
+	SeverityOverride(ruleID, hostID string) string
+}

--- a/server/rules/api/detectionconfig_test.go
+++ b/server/rules/api/detectionconfig_test.go
@@ -1,0 +1,49 @@
+package api_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/fleetdm/edr/server/rules/api"
+)
+
+func TestMatchExclusionValue(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name      string
+		matchType api.ExclusionMatchType
+		entry     string
+		candidate string
+		want      bool
+	}{
+		{"path glob crosses separators", api.ExclusionMatchPathGlob, "*/claude/versions/*", "/Users/d/claude/versions/2/claude", true},
+		{"path glob literal exact", api.ExclusionMatchPathGlob, "/usr/libexec/sshd-session", "/usr/libexec/sshd-session", true},
+		{"parent path glob non-match", api.ExclusionMatchParentPathGlob, "*/lefthook_*", "/usr/bin/python3", false},
+		{"team id exact", api.ExclusionMatchTeamID, "EQHXZ8M8AV", "EQHXZ8M8AV", true},
+		{"team id mismatch", api.ExclusionMatchTeamID, "EQHXZ8M8AV", "OTHER", false},
+		{"command substring", api.ExclusionMatchCommandSubstring, "--allow-net", "node --allow-net app.js", true},
+		{"command substring empty entry never matches", api.ExclusionMatchCommandSubstring, "", "anything", false},
+		{"domain exact", api.ExclusionMatchDomain, "example.com", "example.com", true},
+		{"domain is case-insensitive", api.ExclusionMatchDomain, "example.com", "Example.COM", true},
+		{"domain ignores trailing dot", api.ExclusionMatchDomain, "example.com", "example.com.", true},
+		{"domain matches subdomain", api.ExclusionMatchDomain, "example.com", "api.example.com", true},
+		{"domain does not match suffix-only", api.ExclusionMatchDomain, "example.com", "notexample.com", false},
+		{"cdhash exact", api.ExclusionMatchCDHash, "abc123", "abc123", true},
+		{"unknown match type never matches", api.ExclusionMatchType("bogus"), "x", "x", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, api.MatchExclusionValue(tc.matchType, tc.entry, tc.candidate))
+		})
+	}
+}
+
+func TestDetectionRuleModeAndMatchTypeValidators(t *testing.T) {
+	t.Parallel()
+	assert.True(t, api.IsValidDetectionRuleMode(api.DetectionRuleModeMonitor))
+	assert.False(t, api.IsValidDetectionRuleMode("paused"))
+	assert.True(t, api.IsValidExclusionMatchType(api.ExclusionMatchTeamID))
+	assert.False(t, api.IsValidExclusionMatchType("ip"))
+}

--- a/server/rules/internal/detectionconfig/doc.go
+++ b/server/rules/internal/detectionconfig/doc.go
@@ -1,0 +1,13 @@
+// Package detectionconfig owns the DB-backed detection-configuration surface
+// (issue #459): per-rule settings (mode / severity override / JSON settings)
+// and typed false-positive exclusions, the replacement for the boot-time
+// env-CSV allowlists + disabled-rule list.
+//
+// The Store persists and reads the two tables plus a version counter. A
+// Snapshot is an immutable in-memory view loaded from the Store and handed to
+// the catalog rules (as an api.ExclusionResolver) and the engine (as an
+// api.RuleModeResolver); both resolve PER HOST. The snapshot is swapped on
+// reload when the version advances, so a config change takes effect without a
+// restart and each replica converges by re-reading MySQL (ADR-0010: the
+// snapshot is a per-replica perf cache, safe to lose).
+package detectionconfig

--- a/server/rules/internal/detectionconfig/snapshot.go
+++ b/server/rules/internal/detectionconfig/snapshot.go
@@ -1,0 +1,160 @@
+package detectionconfig
+
+import (
+	"time"
+
+	"github.com/fleetdm/edr/server/rules/api"
+)
+
+// Membership reports whether hostID belongs to the host group groupID. The snapshot calls it to decide whether a group-scoped record
+// applies to a host. A nil Membership means "only global records apply" (the safe default before editable host groups exist).
+// Bootstrap wires this to the host-group resolver; in Phase A the only group is the seeded all-hosts group, whose membership is every
+// enrolled host.
+type Membership func(hostID string, groupID int64) bool
+
+// exclKey indexes exclusions by (rule, match type) so a lookup touches only the handful of entries for that key rather than scanning
+// the whole allowlist.
+type exclKey struct {
+	ruleID    string
+	matchType api.ExclusionMatchType
+}
+
+type exclEntry struct {
+	value       string
+	hostGroupID int64
+	expiresAt   *time.Time
+}
+
+type settingEntry struct {
+	hostGroupID int64
+	mode        api.DetectionRuleMode
+	severity    string
+}
+
+// Snapshot is an immutable in-memory view of the detection configuration at a given version. It satisfies api.ExclusionResolver and
+// api.RuleModeResolver. Construct it with NewSnapshot; never mutate after construction (it is read concurrently by rule evaluation).
+type Snapshot struct {
+	version    int64
+	exclusions map[exclKey][]exclEntry
+	settings   map[string][]settingEntry
+	membership Membership
+	now        func() time.Time
+}
+
+var (
+	_ api.ExclusionResolver = (*Snapshot)(nil)
+	_ api.RuleModeResolver  = (*Snapshot)(nil)
+)
+
+// NewSnapshot builds a snapshot from already-loaded rows. The store calls it; tests call it directly to exercise resolution without a
+// database. A nil clock defaults to time.Now (used only for exclusion expiry).
+func NewSnapshot(
+	version int64, exclusions []api.DetectionExclusion, settings []api.DetectionRuleSetting,
+	membership Membership, clock func() time.Time,
+) *Snapshot {
+	if clock == nil {
+		clock = time.Now
+	}
+	s := &Snapshot{
+		version:    version,
+		exclusions: make(map[exclKey][]exclEntry, len(exclusions)),
+		settings:   make(map[string][]settingEntry),
+		membership: membership,
+		now:        clock,
+	}
+	for _, e := range exclusions {
+		if !e.Enabled {
+			continue
+		}
+		k := exclKey{ruleID: e.RuleID, matchType: e.MatchType}
+		s.exclusions[k] = append(s.exclusions[k], exclEntry{value: e.Value, hostGroupID: e.HostGroupID, expiresAt: e.ExpiresAt})
+	}
+	for _, st := range settings {
+		s.settings[st.RuleID] = append(s.settings[st.RuleID], settingEntry{
+			hostGroupID: st.HostGroupID, mode: st.Mode, severity: st.SeverityOverride,
+		})
+	}
+	return s
+}
+
+// Version returns the config version this snapshot was loaded at.
+func (s *Snapshot) Version() int64 { return s.version }
+
+// scopeApplies reports whether a record scoped to hostGroupID applies to hostID: global records always apply; a group-scoped record
+// applies only when the host is a member of that group.
+func (s *Snapshot) scopeApplies(hostGroupID int64, hostID string) bool {
+	if hostGroupID == api.GlobalScope {
+		return true
+	}
+	return s.membership != nil && s.membership(hostID, hostGroupID)
+}
+
+// Excluded implements api.ExclusionResolver. It checks rule-specific entries and shared (rule_id == "") entries for the match type,
+// returning true on the first applicable, unexpired entry whose value matches.
+func (s *Snapshot) Excluded(ruleID string, matchType api.ExclusionMatchType, value, hostID string) bool {
+	if s.matchAny(ruleID, matchType, value, hostID) {
+		return true
+	}
+	return ruleID != "" && s.matchAny("", matchType, value, hostID)
+}
+
+func (s *Snapshot) matchAny(ruleID string, matchType api.ExclusionMatchType, value, hostID string) bool {
+	now := s.now()
+	for _, e := range s.exclusions[exclKey{ruleID: ruleID, matchType: matchType}] {
+		if e.expiresAt != nil && !e.expiresAt.After(now) {
+			continue
+		}
+		if !s.scopeApplies(e.hostGroupID, hostID) {
+			continue
+		}
+		if api.MatchExclusionValue(matchType, e.value, value) {
+			return true
+		}
+	}
+	return false
+}
+
+// Mode implements api.RuleModeResolver: the resolved mode for (ruleID, hostID), most-specific-wins. Defaults to alert when no setting
+// applies.
+func (s *Snapshot) Mode(ruleID, hostID string) api.DetectionRuleMode {
+	if w, ok := s.winning(ruleID, hostID); ok && api.IsValidDetectionRuleMode(w.mode) {
+		return w.mode
+	}
+	return api.DetectionRuleModeAlert
+}
+
+// SeverityOverride implements api.RuleModeResolver: the override severity for (ruleID, hostID), or "" when none applies.
+func (s *Snapshot) SeverityOverride(ruleID, hostID string) string {
+	if w, ok := s.winning(ruleID, hostID); ok {
+		return w.severity
+	}
+	return ""
+}
+
+// winning returns the most-specific setting entry that applies to hostID: a group-scoped entry beats the global entry. When several
+// group entries apply (a host in multiple groups, not possible in Phase A) the smallest group id wins, for determinism.
+func (s *Snapshot) winning(ruleID, hostID string) (settingEntry, bool) {
+	var best settingEntry
+	found := false
+	for _, e := range s.settings[ruleID] {
+		if !s.scopeApplies(e.hostGroupID, hostID) {
+			continue
+		}
+		if !found || moreSpecific(e, best) {
+			best = e
+			found = true
+		}
+	}
+	return best, found
+}
+
+// moreSpecific reports whether candidate outranks current: any group scope beats global; between two group scopes the smaller id wins.
+func moreSpecific(candidate, current settingEntry) bool {
+	if current.hostGroupID == api.GlobalScope {
+		return candidate.hostGroupID != api.GlobalScope
+	}
+	if candidate.hostGroupID == api.GlobalScope {
+		return false
+	}
+	return candidate.hostGroupID < current.hostGroupID
+}

--- a/server/rules/internal/detectionconfig/snapshot_test.go
+++ b/server/rules/internal/detectionconfig/snapshot_test.go
@@ -1,0 +1,100 @@
+package detectionconfig_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/fleetdm/edr/server/rules/api"
+	"github.com/fleetdm/edr/server/rules/internal/detectionconfig"
+)
+
+// fixedClock pins "now" so exclusion-expiry resolution is deterministic.
+func fixedClock(sec int64) func() time.Time {
+	return func() time.Time { return time.Unix(sec, 0) }
+}
+
+func ptrTime(sec int64) *time.Time {
+	t := time.Unix(sec, 0)
+	return &t
+}
+
+func TestSnapshotExcluded(t *testing.T) {
+	t.Parallel()
+	// host-a is a member of group 7; host-z is not.
+	membership := func(hostID string, groupID int64) bool { return hostID == "host-a" && groupID == 7 }
+	excl := []api.DetectionExclusion{
+		{RuleID: "suspicious_exec", MatchType: api.ExclusionMatchParentPathGlob, Value: "*/claude/versions/*", HostGroupID: api.GlobalScope, Enabled: true},
+		{RuleID: "privilege_launchd_plist_write", MatchType: api.ExclusionMatchTeamID, Value: "EQHXZ8M8AV", HostGroupID: api.GlobalScope, Enabled: true},
+		{RuleID: "suspicious_exec", MatchType: api.ExclusionMatchParentPathGlob, Value: "/opt/grp/tool", HostGroupID: 7, Enabled: true},
+		{RuleID: "suspicious_exec", MatchType: api.ExclusionMatchParentPathGlob, Value: "/opt/expired/tool", HostGroupID: api.GlobalScope, Enabled: true, ExpiresAt: ptrTime(500)},
+		{RuleID: "suspicious_exec", MatchType: api.ExclusionMatchParentPathGlob, Value: "/opt/disabled/tool", HostGroupID: api.GlobalScope, Enabled: false},
+		{RuleID: "", MatchType: api.ExclusionMatchPathGlob, Value: "*/shared/ok", HostGroupID: api.GlobalScope, Enabled: true},
+	}
+	s := detectionconfig.NewSnapshot(1, excl, nil, membership, fixedClock(1000))
+
+	cases := []struct {
+		name      string
+		ruleID    string
+		matchType api.ExclusionMatchType
+		value     string
+		hostID    string
+		want      bool
+	}{
+		{"global glob matches version-stamped path", "suspicious_exec", api.ExclusionMatchParentPathGlob, "/Users/dev/.local/share/claude/versions/2.1.178/claude", "host-z", true},
+		{"global team id exact match", "privilege_launchd_plist_write", api.ExclusionMatchTeamID, "EQHXZ8M8AV", "host-z", true},
+		{"team id non-match", "privilege_launchd_plist_write", api.ExclusionMatchTeamID, "OTHERTEAM", "host-z", false},
+		{"group entry applies to member host", "suspicious_exec", api.ExclusionMatchParentPathGlob, "/opt/grp/tool", "host-a", true},
+		{"group entry does not apply to non-member host", "suspicious_exec", api.ExclusionMatchParentPathGlob, "/opt/grp/tool", "host-z", false},
+		{"expired entry does not apply", "suspicious_exec", api.ExclusionMatchParentPathGlob, "/opt/expired/tool", "host-z", false},
+		{"disabled entry is absent from the snapshot", "suspicious_exec", api.ExclusionMatchParentPathGlob, "/opt/disabled/tool", "host-z", false},
+		{"shared (rule_id empty) entry applies to any rule", "sudoers_tamper", api.ExclusionMatchPathGlob, "/a/shared/ok", "host-z", true},
+		{"no match for unrelated value", "suspicious_exec", api.ExclusionMatchParentPathGlob, "/usr/bin/python3", "host-z", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, s.Excluded(tc.ruleID, tc.matchType, tc.value, tc.hostID))
+		})
+	}
+}
+
+func TestSnapshotModeAndSeverityResolution(t *testing.T) {
+	t.Parallel()
+	membership := func(hostID string, groupID int64) bool { return hostID == "host-a" && groupID == 7 }
+	settings := []api.DetectionRuleSetting{
+		{RuleID: "suspicious_exec", HostGroupID: api.GlobalScope, Mode: api.DetectionRuleModeDisabled},
+		{RuleID: "suspicious_exec", HostGroupID: 7, Mode: api.DetectionRuleModeAlert, SeverityOverride: "critical"},
+		{RuleID: "dyld_insert", HostGroupID: api.GlobalScope, Mode: api.DetectionRuleModeMonitor},
+	}
+	s := detectionconfig.NewSnapshot(1, nil, settings, membership, fixedClock(1000))
+
+	t.Run("group setting overrides global most-specific-wins", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, api.DetectionRuleModeAlert, s.Mode("suspicious_exec", "host-a"))
+		assert.Equal(t, "critical", s.SeverityOverride("suspicious_exec", "host-a"))
+	})
+	t.Run("non-member host gets the global setting", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, api.DetectionRuleModeDisabled, s.Mode("suspicious_exec", "host-z"))
+		assert.Empty(t, s.SeverityOverride("suspicious_exec", "host-z"))
+	})
+	t.Run("monitor mode resolves at global scope", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, api.DetectionRuleModeMonitor, s.Mode("dyld_insert", "host-z"))
+	})
+	t.Run("rule with no setting defaults to alert", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, api.DetectionRuleModeAlert, s.Mode("credential_keychain_dump", "host-z"))
+	})
+}
+
+func TestNilResolverDefaults(t *testing.T) {
+	t.Parallel()
+	// A nil membership means only global entries apply; an empty snapshot excludes nothing and alerts everything.
+	s := detectionconfig.NewSnapshot(0, nil, nil, nil, fixedClock(1000))
+	assert.False(t, s.Excluded("suspicious_exec", api.ExclusionMatchParentPathGlob, "/anything", "host-a"))
+	assert.Equal(t, api.DetectionRuleModeAlert, s.Mode("suspicious_exec", "host-a"))
+	assert.Empty(t, s.SeverityOverride("suspicious_exec", "host-a"))
+}

--- a/server/rules/internal/detectionconfig/store.go
+++ b/server/rules/internal/detectionconfig/store.go
@@ -54,28 +54,69 @@ type UpsertSettingInput struct {
 	Actor            string
 }
 
-// Version returns the current detection-config version. A reader compares it against the version its cached Snapshot was loaded at to
-// decide whether to reload.
-func (s *Store) Version(ctx context.Context) (int64, error) {
+// SQL shared by the *Store (whole-DB) read methods and the read transaction LoadSnapshot uses, so a query change lands once and the
+// duplicate-literal linter stays quiet. The exclusion select takes an optional `WHERE enabled = 1` suffix.
+const (
+	sqlSelectVersion    = `SELECT version FROM detection_config_meta WHERE id = 1`
+	sqlSelectExclusions = `SELECT id, rule_id, match_type, value, host_group_id, reason, enabled, expires_at, created_by, created_at
+		FROM detection_exclusions`
+	sqlSelectSettings = `SELECT id, rule_id, host_group_id, mode, COALESCE(severity_override, '') AS severity_override,
+		settings, updated_by, updated_at FROM detection_rule_settings ORDER BY rule_id, host_group_id`
+)
+
+// readVersion / readExclusions / readSettings run against any sqlx querier (the whole *Store DB or a read transaction), so a
+// consistent snapshot can read all three under one transaction.
+func readVersion(ctx context.Context, q sqlx.QueryerContext) (int64, error) {
 	var v int64
-	if err := s.db.GetContext(ctx, &v, `SELECT version FROM detection_config_meta WHERE id = 1`); err != nil {
+	if err := sqlx.GetContext(ctx, q, &v, sqlSelectVersion); err != nil {
 		return 0, fmt.Errorf("detectionconfig version: %w", err)
 	}
 	return v, nil
 }
 
-// LoadSnapshot reads the enabled exclusions + all rule settings at the current version and returns an immutable Snapshot. membership
-// and clock are passed through to the snapshot (nil clock defaults to time.Now).
+func readExclusions(ctx context.Context, q sqlx.QueryerContext, enabledOnly bool) ([]api.DetectionExclusion, error) {
+	query := sqlSelectExclusions
+	if enabledOnly {
+		query += ` WHERE enabled = 1`
+	}
+	query += ` ORDER BY id DESC`
+	var out []api.DetectionExclusion
+	if err := sqlx.SelectContext(ctx, q, &out, query); err != nil {
+		return nil, fmt.Errorf("detectionconfig list exclusions: %w", err)
+	}
+	return out, nil
+}
+
+func readSettings(ctx context.Context, q sqlx.QueryerContext) ([]api.DetectionRuleSetting, error) {
+	var out []api.DetectionRuleSetting
+	if err := sqlx.SelectContext(ctx, q, &out, sqlSelectSettings); err != nil {
+		return nil, fmt.Errorf("detectionconfig list settings: %w", err)
+	}
+	return out, nil
+}
+
+// Version returns the current detection-config version. A reader compares it against the version its cached Snapshot was loaded at to
+// decide whether to reload.
+func (s *Store) Version(ctx context.Context) (int64, error) { return readVersion(ctx, s.db) }
+
+// LoadSnapshot reads the enabled exclusions + all rule settings + the version under a single read transaction so the snapshot is a
+// consistent point-in-time view: a concurrent mutation that bumps the version cannot interleave between the three reads and yield a
+// version that disagrees with the rows. membership and clock are passed through to the snapshot (nil clock defaults to time.Now).
 func (s *Store) LoadSnapshot(ctx context.Context, membership Membership, clock func() time.Time) (*Snapshot, error) {
-	version, err := s.Version(ctx)
+	tx, err := s.db.BeginTxx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return nil, fmt.Errorf("detectionconfig begin read tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	version, err := readVersion(ctx, tx)
 	if err != nil {
 		return nil, err
 	}
-	exclusions, err := s.listExclusions(ctx, true)
+	exclusions, err := readExclusions(ctx, tx, true)
 	if err != nil {
 		return nil, err
 	}
-	settings, err := s.ListRuleSettings(ctx)
+	settings, err := readSettings(ctx, tx)
 	if err != nil {
 		return nil, err
 	}
@@ -84,34 +125,12 @@ func (s *Store) LoadSnapshot(ctx context.Context, membership Membership, clock f
 
 // ListExclusions returns every exclusion row (enabled and disabled) for the operator surface, newest first.
 func (s *Store) ListExclusions(ctx context.Context) ([]api.DetectionExclusion, error) {
-	return s.listExclusions(ctx, false)
-}
-
-func (s *Store) listExclusions(ctx context.Context, enabledOnly bool) ([]api.DetectionExclusion, error) {
-	q := `SELECT id, rule_id, match_type, value, host_group_id,
-		reason, enabled, expires_at, created_by, created_at
-		FROM detection_exclusions`
-	if enabledOnly {
-		q += ` WHERE enabled = 1`
-	}
-	q += ` ORDER BY id DESC`
-	var out []api.DetectionExclusion
-	if err := s.db.SelectContext(ctx, &out, q); err != nil {
-		return nil, fmt.Errorf("detectionconfig list exclusions: %w", err)
-	}
-	return out, nil
+	return readExclusions(ctx, s.db, false)
 }
 
 // ListRuleSettings returns every per-rule setting row.
 func (s *Store) ListRuleSettings(ctx context.Context) ([]api.DetectionRuleSetting, error) {
-	const q = `SELECT id, rule_id, host_group_id, mode,
-		COALESCE(severity_override, '') AS severity_override, settings, updated_by, updated_at
-		FROM detection_rule_settings ORDER BY rule_id, host_group_id`
-	var out []api.DetectionRuleSetting
-	if err := s.db.SelectContext(ctx, &out, q); err != nil {
-		return nil, fmt.Errorf("detectionconfig list settings: %w", err)
-	}
-	return out, nil
+	return readSettings(ctx, s.db)
 }
 
 // CreateExclusion inserts an exclusion and bumps the config version atomically.
@@ -176,8 +195,13 @@ func (s *Store) UpsertRuleSetting(ctx context.Context, in UpsertSettingInput) (a
 	if in.Actor == "" {
 		return api.DetectionRuleSetting{}, fmt.Errorf("%w: actor is required", ErrInvalidRequest)
 	}
+	// Validate the optional severity override in Go: the column is an ENUM, so an unrecognised value would otherwise surface as an
+	// opaque SQL error (HTTP 500) rather than a clean ErrInvalidRequest (HTTP 400).
 	var severity any
 	if in.SeverityOverride != "" {
+		if !api.IsValidSeverity(api.Severity(in.SeverityOverride)) {
+			return api.DetectionRuleSetting{}, fmt.Errorf("%w: severity_override %q", ErrInvalidRequest, in.SeverityOverride)
+		}
 		severity = in.SeverityOverride
 	}
 	err := s.inTx(ctx, func(tx *sqlx.Tx) error {
@@ -221,26 +245,37 @@ func (s *Store) getRuleSetting(ctx context.Context, ruleID string, hostGroupID i
 	return st, nil
 }
 
-// inTx runs fn in a transaction, committing on success and rolling back on error.
-func (s *Store) inTx(ctx context.Context, fn func(tx *sqlx.Tx) error) error {
+// inTx runs fn in a transaction, committing on success and rolling back otherwise. The deferred rollback guarantees cleanup even if
+// fn panics or returns early; after a successful Commit the rollback is a no-op (ErrTxDone), which is ignored.
+func (s *Store) inTx(ctx context.Context, fn func(tx *sqlx.Tx) error) (err error) {
 	tx, err := s.db.BeginTxx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("detectionconfig begin tx: %w", err)
 	}
-	if err := fn(tx); err != nil {
-		_ = tx.Rollback()
+	defer func() { _ = tx.Rollback() }()
+	if err = fn(tx); err != nil {
 		return err
 	}
-	if err := tx.Commit(); err != nil {
+	if err = tx.Commit(); err != nil {
 		return fmt.Errorf("detectionconfig commit tx: %w", err)
 	}
 	return nil
 }
 
-// bumpVersion increments the single-row version counter inside the caller's tx.
+// bumpVersion increments the single-row version counter inside the caller's tx. A zero-rows-affected update means the seeded
+// detection_config_meta row (id=1) is missing, which would silently break the cache-invalidation contract (readers would never see a
+// version change), so it is treated as an error that rolls the mutation back rather than committing an un-versioned write.
 func bumpVersion(ctx context.Context, tx *sqlx.Tx) error {
-	if _, err := tx.ExecContext(ctx, `UPDATE detection_config_meta SET version = version + 1 WHERE id = 1`); err != nil {
+	res, err := tx.ExecContext(ctx, `UPDATE detection_config_meta SET version = version + 1 WHERE id = 1`)
+	if err != nil {
 		return fmt.Errorf("bump detection-config version: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("bump detection-config version rows: %w", err)
+	}
+	if n == 0 {
+		return errors.New("detectionconfig: meta version row (id=1) missing; cannot bump version")
 	}
 	return nil
 }

--- a/server/rules/internal/detectionconfig/store.go
+++ b/server/rules/internal/detectionconfig/store.go
@@ -1,0 +1,246 @@
+package detectionconfig
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+
+	"github.com/fleetdm/edr/server/rules/api"
+)
+
+// ErrInvalidRequest is returned when a mutation carries an invalid match type, mode, or a missing required field. REST handlers map
+// it to HTTP 400.
+var ErrInvalidRequest = errors.New("detectionconfig: invalid request")
+
+// Store persists and reads the detection-config tables (detection_rule_settings, detection_exclusions) plus the detection_config_meta
+// version counter. Every mutation bumps the version in the same transaction so a reader can detect a change and reload the in-memory
+// Snapshot. The rules bootstrap constructs it and shares it with the REST handler + the snapshot-reload path.
+type Store struct {
+	db *sqlx.DB
+}
+
+// NewStore builds a Store. Panics on a nil db: cmd/main is the only production caller and a nil handle is a wiring bug, not a
+// recoverable state.
+func NewStore(db *sqlx.DB) *Store {
+	if db == nil {
+		panic("detectionconfig.NewStore: db must not be nil")
+	}
+	return &Store{db: db}
+}
+
+// CreateExclusionInput is the create-exclusion contract. HostGroupID is api.GlobalScope for a global entry. Actor is recorded as
+// created_by.
+type CreateExclusionInput struct {
+	RuleID      string
+	MatchType   api.ExclusionMatchType
+	Value       string
+	HostGroupID int64
+	Reason      string
+	ExpiresAt   *time.Time
+	Actor       string
+}
+
+// UpsertSettingInput is the upsert-per-(rule, scope)-setting contract.
+type UpsertSettingInput struct {
+	RuleID           string
+	HostGroupID      int64
+	Mode             api.DetectionRuleMode
+	SeverityOverride string
+	Settings         api.NullRawJSON
+	Actor            string
+}
+
+// Version returns the current detection-config version. A reader compares it against the version its cached Snapshot was loaded at to
+// decide whether to reload.
+func (s *Store) Version(ctx context.Context) (int64, error) {
+	var v int64
+	if err := s.db.GetContext(ctx, &v, `SELECT version FROM detection_config_meta WHERE id = 1`); err != nil {
+		return 0, fmt.Errorf("detectionconfig version: %w", err)
+	}
+	return v, nil
+}
+
+// LoadSnapshot reads the enabled exclusions + all rule settings at the current version and returns an immutable Snapshot. membership
+// and clock are passed through to the snapshot (nil clock defaults to time.Now).
+func (s *Store) LoadSnapshot(ctx context.Context, membership Membership, clock func() time.Time) (*Snapshot, error) {
+	version, err := s.Version(ctx)
+	if err != nil {
+		return nil, err
+	}
+	exclusions, err := s.listExclusions(ctx, true)
+	if err != nil {
+		return nil, err
+	}
+	settings, err := s.ListRuleSettings(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return NewSnapshot(version, exclusions, settings, membership, clock), nil
+}
+
+// ListExclusions returns every exclusion row (enabled and disabled) for the operator surface, newest first.
+func (s *Store) ListExclusions(ctx context.Context) ([]api.DetectionExclusion, error) {
+	return s.listExclusions(ctx, false)
+}
+
+func (s *Store) listExclusions(ctx context.Context, enabledOnly bool) ([]api.DetectionExclusion, error) {
+	q := `SELECT id, rule_id, match_type, value, host_group_id,
+		reason, enabled, expires_at, created_by, created_at
+		FROM detection_exclusions`
+	if enabledOnly {
+		q += ` WHERE enabled = 1`
+	}
+	q += ` ORDER BY id DESC`
+	var out []api.DetectionExclusion
+	if err := s.db.SelectContext(ctx, &out, q); err != nil {
+		return nil, fmt.Errorf("detectionconfig list exclusions: %w", err)
+	}
+	return out, nil
+}
+
+// ListRuleSettings returns every per-rule setting row.
+func (s *Store) ListRuleSettings(ctx context.Context) ([]api.DetectionRuleSetting, error) {
+	const q = `SELECT id, rule_id, host_group_id, mode,
+		COALESCE(severity_override, '') AS severity_override, settings, updated_by, updated_at
+		FROM detection_rule_settings ORDER BY rule_id, host_group_id`
+	var out []api.DetectionRuleSetting
+	if err := s.db.SelectContext(ctx, &out, q); err != nil {
+		return nil, fmt.Errorf("detectionconfig list settings: %w", err)
+	}
+	return out, nil
+}
+
+// CreateExclusion inserts an exclusion and bumps the config version atomically.
+func (s *Store) CreateExclusion(ctx context.Context, in CreateExclusionInput) (api.DetectionExclusion, error) {
+	if !api.IsValidExclusionMatchType(in.MatchType) {
+		return api.DetectionExclusion{}, fmt.Errorf("%w: match_type %q", ErrInvalidRequest, in.MatchType)
+	}
+	if in.Value == "" {
+		return api.DetectionExclusion{}, fmt.Errorf("%w: value is required", ErrInvalidRequest)
+	}
+	if in.Actor == "" {
+		return api.DetectionExclusion{}, fmt.Errorf("%w: actor is required", ErrInvalidRequest)
+	}
+	var id int64
+	err := s.inTx(ctx, func(tx *sqlx.Tx) error {
+		res, err := tx.ExecContext(ctx,
+			`INSERT INTO detection_exclusions (rule_id, match_type, value, host_group_id, reason, expires_at, created_by)
+			 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+			in.RuleID, in.MatchType, in.Value, in.HostGroupID, in.Reason, in.ExpiresAt, in.Actor)
+		if err != nil {
+			return fmt.Errorf("insert exclusion: %w", err)
+		}
+		id, err = res.LastInsertId()
+		if err != nil {
+			return fmt.Errorf("exclusion last insert id: %w", err)
+		}
+		return bumpVersion(ctx, tx)
+	})
+	if err != nil {
+		return api.DetectionExclusion{}, err
+	}
+	return s.getExclusion(ctx, id)
+}
+
+// DeleteExclusion removes an exclusion and bumps the version. Returns sql.ErrNoRows when the id does not exist.
+func (s *Store) DeleteExclusion(ctx context.Context, id int64) error {
+	return s.inTx(ctx, func(tx *sqlx.Tx) error {
+		res, err := tx.ExecContext(ctx, `DELETE FROM detection_exclusions WHERE id = ?`, id)
+		if err != nil {
+			return fmt.Errorf("delete exclusion: %w", err)
+		}
+		n, err := res.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("delete exclusion rows: %w", err)
+		}
+		if n == 0 {
+			return sql.ErrNoRows
+		}
+		return bumpVersion(ctx, tx)
+	})
+}
+
+// UpsertRuleSetting inserts or updates the setting for (rule, scope) and bumps the version. The unique key (rule_id, host_group_id)
+// drives the upsert, so re-setting the same scope flips the row in place rather than creating a duplicate.
+func (s *Store) UpsertRuleSetting(ctx context.Context, in UpsertSettingInput) (api.DetectionRuleSetting, error) {
+	if !api.IsValidDetectionRuleMode(in.Mode) {
+		return api.DetectionRuleSetting{}, fmt.Errorf("%w: mode %q", ErrInvalidRequest, in.Mode)
+	}
+	if in.RuleID == "" {
+		return api.DetectionRuleSetting{}, fmt.Errorf("%w: rule_id is required", ErrInvalidRequest)
+	}
+	if in.Actor == "" {
+		return api.DetectionRuleSetting{}, fmt.Errorf("%w: actor is required", ErrInvalidRequest)
+	}
+	var severity any
+	if in.SeverityOverride != "" {
+		severity = in.SeverityOverride
+	}
+	err := s.inTx(ctx, func(tx *sqlx.Tx) error {
+		_, err := tx.ExecContext(ctx,
+			`INSERT INTO detection_rule_settings (rule_id, host_group_id, mode, severity_override, settings, updated_by)
+			 VALUES (?, ?, ?, ?, ?, ?)
+			 ON DUPLICATE KEY UPDATE mode = VALUES(mode), severity_override = VALUES(severity_override),
+			 settings = VALUES(settings), updated_by = VALUES(updated_by)`,
+			in.RuleID, in.HostGroupID, in.Mode, severity, in.Settings, in.Actor)
+		if err != nil {
+			return fmt.Errorf("upsert rule setting: %w", err)
+		}
+		return bumpVersion(ctx, tx)
+	})
+	if err != nil {
+		return api.DetectionRuleSetting{}, err
+	}
+	return s.getRuleSetting(ctx, in.RuleID, in.HostGroupID)
+}
+
+func (s *Store) getExclusion(ctx context.Context, id int64) (api.DetectionExclusion, error) {
+	var e api.DetectionExclusion
+	err := s.db.GetContext(ctx, &e,
+		`SELECT id, rule_id, match_type, value, host_group_id,
+		 reason, enabled, expires_at, created_by, created_at FROM detection_exclusions WHERE id = ?`, id)
+	if err != nil {
+		return api.DetectionExclusion{}, fmt.Errorf("detectionconfig get exclusion: %w", err)
+	}
+	return e, nil
+}
+
+func (s *Store) getRuleSetting(ctx context.Context, ruleID string, hostGroupID int64) (api.DetectionRuleSetting, error) {
+	var st api.DetectionRuleSetting
+	err := s.db.GetContext(ctx, &st,
+		`SELECT id, rule_id, host_group_id, mode,
+		 COALESCE(severity_override, '') AS severity_override, settings, updated_by, updated_at
+		 FROM detection_rule_settings WHERE rule_id = ? AND host_group_id = ?`, ruleID, hostGroupID)
+	if err != nil {
+		return api.DetectionRuleSetting{}, fmt.Errorf("detectionconfig get setting: %w", err)
+	}
+	return st, nil
+}
+
+// inTx runs fn in a transaction, committing on success and rolling back on error.
+func (s *Store) inTx(ctx context.Context, fn func(tx *sqlx.Tx) error) error {
+	tx, err := s.db.BeginTxx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("detectionconfig begin tx: %w", err)
+	}
+	if err := fn(tx); err != nil {
+		_ = tx.Rollback()
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("detectionconfig commit tx: %w", err)
+	}
+	return nil
+}
+
+// bumpVersion increments the single-row version counter inside the caller's tx.
+func bumpVersion(ctx context.Context, tx *sqlx.Tx) error {
+	if _, err := tx.ExecContext(ctx, `UPDATE detection_config_meta SET version = version + 1 WHERE id = 1`); err != nil {
+		return fmt.Errorf("bump detection-config version: %w", err)
+	}
+	return nil
+}

--- a/server/rules/internal/detectionconfig/store_test.go
+++ b/server/rules/internal/detectionconfig/store_test.go
@@ -130,4 +130,9 @@ func TestStoreRejectsInvalidInput(t *testing.T) {
 		RuleID: "suspicious_exec", Mode: "bogus", Actor: "alice",
 	})
 	require.ErrorIs(t, err, detectionconfig.ErrInvalidRequest, "invalid mode is rejected")
+
+	_, err = s.UpsertRuleSetting(ctx, detectionconfig.UpsertSettingInput{
+		RuleID: "suspicious_exec", Mode: api.DetectionRuleModeAlert, SeverityOverride: "catastrophic", Actor: "alice",
+	})
+	require.ErrorIs(t, err, detectionconfig.ErrInvalidRequest, "invalid severity override is rejected before the SQL ENUM")
 }

--- a/server/rules/internal/detectionconfig/store_test.go
+++ b/server/rules/internal/detectionconfig/store_test.go
@@ -1,0 +1,133 @@
+package detectionconfig_test
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fleetdm/edr/server/migrations/runner"
+	"github.com/fleetdm/edr/server/rules/api"
+	"github.com/fleetdm/edr/server/rules/internal/detectionconfig"
+	rulesmigrations "github.com/fleetdm/edr/server/rules/migrations"
+	"github.com/fleetdm/edr/server/testdb"
+)
+
+// openStore opens an isolated test DB, applies the rules migration corpus
+// (which includes the detection-config tables), and returns a Store.
+func openStore(t *testing.T) (*detectionconfig.Store, *sqlx.DB) {
+	t.Helper()
+	db := testdb.Open(t)
+	require.NoError(t, runner.Up(t.Context(), db, rulesmigrations.FS, runner.Options{
+		Context:   "rules",
+		TableName: "rules_goose_db_version",
+	}))
+	return detectionconfig.NewStore(db), db
+}
+
+func TestStoreCreateExclusionBumpsVersionAndResolves(t *testing.T) {
+	t.Parallel()
+	s, _ := openStore(t)
+	ctx := context.Background()
+
+	v0, err := s.Version(ctx)
+	require.NoError(t, err)
+
+	_, err = s.CreateExclusion(ctx, detectionconfig.CreateExclusionInput{
+		RuleID:      "suspicious_exec",
+		MatchType:   api.ExclusionMatchParentPathGlob,
+		Value:       "*/claude/versions/*",
+		HostGroupID: api.GlobalScope,
+		Reason:      "Claude Code CLI, version-stamped path",
+		Actor:       "alice",
+	})
+	require.NoError(t, err)
+
+	v1, err := s.Version(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, v0+1, v1, "a mutation must bump the config version")
+
+	snap, err := s.LoadSnapshot(ctx, nil, nil)
+	require.NoError(t, err)
+	assert.Equal(t, v1, snap.Version())
+	assert.True(t, snap.Excluded("suspicious_exec", api.ExclusionMatchParentPathGlob,
+		"/Users/dev/.local/share/claude/versions/2.1.178/claude", "host-a"),
+		"the version-stamped parent must be excluded by the glob")
+	assert.False(t, snap.Excluded("suspicious_exec", api.ExclusionMatchParentPathGlob, "/usr/bin/python3", "host-a"))
+}
+
+func TestStoreUpsertRuleSettingResolves(t *testing.T) {
+	t.Parallel()
+	s, _ := openStore(t)
+	ctx := context.Background()
+
+	_, err := s.UpsertRuleSetting(ctx, detectionconfig.UpsertSettingInput{
+		RuleID:      "suspicious_exec",
+		HostGroupID: api.GlobalScope,
+		Mode:        api.DetectionRuleModeDisabled,
+		Actor:       "alice",
+	})
+	require.NoError(t, err)
+
+	snap, err := s.LoadSnapshot(ctx, nil, nil)
+	require.NoError(t, err)
+	assert.Equal(t, api.DetectionRuleModeDisabled, snap.Mode("suspicious_exec", "host-a"))
+
+	// Upsert again on the same (rule, scope) flips the mode in place (no duplicate row).
+	_, err = s.UpsertRuleSetting(ctx, detectionconfig.UpsertSettingInput{
+		RuleID:           "suspicious_exec",
+		HostGroupID:      api.GlobalScope,
+		Mode:             api.DetectionRuleModeAlert,
+		SeverityOverride: "critical",
+		Actor:            "bob",
+	})
+	require.NoError(t, err)
+
+	all, err := s.ListRuleSettings(ctx)
+	require.NoError(t, err)
+	require.Len(t, all, 1, "upsert on the same (rule, scope) must not create a duplicate row")
+
+	snap, err = s.LoadSnapshot(ctx, nil, nil)
+	require.NoError(t, err)
+	assert.Equal(t, api.DetectionRuleModeAlert, snap.Mode("suspicious_exec", "host-a"))
+	assert.Equal(t, "critical", snap.SeverityOverride("suspicious_exec", "host-a"))
+}
+
+func TestStoreDeleteExclusion(t *testing.T) {
+	t.Parallel()
+	s, _ := openStore(t)
+	ctx := context.Background()
+
+	created, err := s.CreateExclusion(ctx, detectionconfig.CreateExclusionInput{
+		RuleID: "sudoers_tamper", MatchType: api.ExclusionMatchPathGlob,
+		Value: "/usr/local/bin/munki", HostGroupID: api.GlobalScope, Actor: "alice",
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, s.DeleteExclusion(ctx, created.ID))
+
+	snap, err := s.LoadSnapshot(ctx, nil, nil)
+	require.NoError(t, err)
+	assert.False(t, snap.Excluded("sudoers_tamper", api.ExclusionMatchPathGlob, "/usr/local/bin/munki", "host-a"))
+
+	assert.ErrorIs(t, s.DeleteExclusion(ctx, created.ID), sql.ErrNoRows, "deleting a missing row returns sql.ErrNoRows")
+}
+
+func TestStoreRejectsInvalidInput(t *testing.T) {
+	t.Parallel()
+	s, _ := openStore(t)
+	ctx := context.Background()
+
+	_, err := s.CreateExclusion(ctx, detectionconfig.CreateExclusionInput{
+		RuleID: "suspicious_exec", MatchType: "bogus", Value: "x", Actor: "alice",
+	})
+	require.ErrorIs(t, err, detectionconfig.ErrInvalidRequest, "invalid match type is rejected")
+
+	_, err = s.UpsertRuleSetting(ctx, detectionconfig.UpsertSettingInput{
+		RuleID: "suspicious_exec", Mode: "bogus", Actor: "alice",
+	})
+	require.ErrorIs(t, err, detectionconfig.ErrInvalidRequest, "invalid mode is rejected")
+}

--- a/server/rules/migrations/00002_detection_config.sql
+++ b/server/rules/migrations/00002_detection_config.sql
@@ -1,0 +1,52 @@
+-- +goose Up
+-- Detection configuration surface (issue #459): the DB-backed replacement for the boot-time env-CSV allowlists + disabled-rule
+-- list. Two layers: per-rule settings (mode / severity override / JSON settings) and typed false-positive exclusions. Both carry a
+-- host_group_id where 0 = global scope (the api.GlobalScope sentinel); a real group id scopes the record to that host group. The
+-- sentinel (rather than a nullable column) keeps the (rule_id, host_group_id) uniqueness honest for the global row AND avoids
+-- InnoDB's restriction against ON DELETE referential actions on a column that backs a stored generated column. host_group_id is NOT
+-- FK-constrained here: group editing is Phase A immutable (only the seeded all-hosts group exists), so existence is validated at the
+-- app layer; the FK + cascade cleanup land with the editable-host-groups (Phase B) change. detection_config_meta holds a single
+-- version counter the store bumps on every mutation so each replica can detect a change and reload its in-memory snapshot.
+
+-- +goose StatementBegin
+CREATE TABLE IF NOT EXISTS detection_rule_settings (
+	id                BIGINT AUTO_INCREMENT PRIMARY KEY,
+	rule_id           VARCHAR(64) NOT NULL,
+	host_group_id     BIGINT      NOT NULL DEFAULT 0,
+	mode              ENUM('alert','monitor','disabled') NOT NULL DEFAULT 'alert',
+	severity_override ENUM('low','medium','high','critical') NULL,
+	settings          JSON         NULL,
+	created_at        TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+	updated_at        TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+	updated_by        VARCHAR(255) NOT NULL DEFAULT 'system',
+	UNIQUE KEY uk_detection_rule_settings_rule_scope (rule_id, host_group_id),
+	INDEX idx_detection_rule_settings_rule (rule_id)
+);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TABLE IF NOT EXISTS detection_exclusions (
+	id            BIGINT AUTO_INCREMENT PRIMARY KEY,
+	rule_id       VARCHAR(64)  NOT NULL DEFAULT '',
+	match_type    ENUM('path_glob','parent_path_glob','team_id','signing_id','cdhash','sha256','command_substring','domain') NOT NULL,
+	value         VARCHAR(1024) NOT NULL,
+	host_group_id BIGINT       NOT NULL DEFAULT 0,
+	reason        VARCHAR(500) NOT NULL DEFAULT '',
+	enabled       TINYINT(1)   NOT NULL DEFAULT 1,
+	expires_at    TIMESTAMP(6) NULL,
+	created_at    TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+	created_by    VARCHAR(255) NOT NULL DEFAULT 'system',
+	INDEX idx_detection_exclusions_rule_type (rule_id, match_type)
+);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TABLE IF NOT EXISTS detection_config_meta (
+	id      TINYINT NOT NULL PRIMARY KEY,
+	version BIGINT  NOT NULL DEFAULT 0
+);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+INSERT IGNORE INTO detection_config_meta (id, version) VALUES (1, 0);
+-- +goose StatementEnd

--- a/server/rules/migrations/00002_detection_config.sql
+++ b/server/rules/migrations/00002_detection_config.sql
@@ -19,8 +19,8 @@ CREATE TABLE IF NOT EXISTS detection_rule_settings (
 	created_at        TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
 	updated_at        TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
 	updated_by        VARCHAR(255) NOT NULL DEFAULT 'system',
-	UNIQUE KEY uk_detection_rule_settings_rule_scope (rule_id, host_group_id),
-	INDEX idx_detection_rule_settings_rule (rule_id)
+	-- The unique key's leftmost prefix (rule_id) already serves rule_id-only lookups, so no separate single-column index is needed.
+	UNIQUE KEY uk_detection_rule_settings_rule_scope (rule_id, host_group_id)
 );
 -- +goose StatementEnd
 
@@ -33,7 +33,8 @@ CREATE TABLE IF NOT EXISTS detection_exclusions (
 	host_group_id BIGINT       NOT NULL DEFAULT 0,
 	reason        VARCHAR(500) NOT NULL DEFAULT '',
 	enabled       TINYINT(1)   NOT NULL DEFAULT 1,
-	expires_at    TIMESTAMP(6) NULL,
+	-- DATETIME (not TIMESTAMP) so a far-future expiry is not capped at the TIMESTAMP Year-2038 ceiling.
+	expires_at    DATETIME(6)  NULL,
 	created_at    TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
 	created_by    VARCHAR(255) NOT NULL DEFAULT 'system',
 	INDEX idx_detection_exclusions_rule_type (rule_id, match_type)


### PR DESCRIPTION
…(#459)

Stage 1 of the detection-configuration surface: the data model, the shared rules.api contract, and the store + in-memory resolver, fully tested. No existing wiring is touched yet (the catalog/engine rewire, REST, env deletion, and UI follow in later stages), so the tree stays green.

- rules/api: DetectionRuleMode (alert/monitor/disabled), ExclusionMatchType, the per-host ExclusionResolver + RuleModeResolver interfaces, and the canonical GlobMatch (suspicious_exec's private copy is removed in the catalog-rewire stage). MatchExclusionValue centralises per-type semantics.
- migrations 00002: detection_rule_settings (per-(rule, scope) mode + severity override + JSON settings), detection_exclusions (typed match rows with reason/expiry/scope), and a detection_config_meta version counter. host_group_id uses a 0=global sentinel (FK + cascade to host_groups arrive with editable host groups in Phase B; existence is app-validated now).
- detectionconfig: Store (CRUD + LoadSnapshot + version bump per mutation, all in one tx) and Snapshot (immutable, indexed by (rule, match_type), resolves exclusions + mode/severity per host, most-specific-wins, honouring expiry). Store integration tests + pure snapshot tests.

openspec: detection-config-surface (proposal + tasks + deltas), refined with the three-value mode and the (rule, match_type)-indexed resolver.

<!-- Keep this short. Delete sections that do not apply. -->

## What & why



## Checklist

- [ ] **OpenSpec updated for behavior changes.** If this PR changes observable behavior (a detection rule, the event
      wire schema, persistence semantics, an API/wire shape, or an emitted event), `openspec/specs/**` is updated (and
      an `openspec/changes/` proposal added), with a `spec:<id>` test marker for any new/renamed scenario. Only if this
      PR changes NO observable behavior (a comment / refactor / gofmt / dep bump that happens to touch a scoped path)
      may you assert `no-behavior-change` (label or `[no-behavior-change]` in the title) to clear the OpenSpec-sync gate.
      That is an assertion a reviewer will check, not a way to skip the spec for a real behavior change.
- [ ] Tests added/updated for the change (unit / integration / efficacy / UI as applicable).
- [ ] Agent/extension change touching ESF, XPC, or the event wire format: exercised on a live macOS VM before RC
      (flagged below).

## VM / RC notes (if applicable)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced database-backed detection configuration replacing environment variables, enabling operators to configure rules and exclusions without restarting the server.
  * Added per-rule operating modes (alert, monitor, disabled) configurable via admin UI with audit tracking.
  * Implemented typed false-positive exclusions with optional auto-expiration and per-host-group scoping.
  * Introduced monitor mode to evaluate rules while emitting observability signals without raising alerts.
  * Disabled rules remain visible in the rules API with mode indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->