### PR TITLE
chore: add reuse + simplicity controls for the AI-generated codebase

### DIFF
--- a/.claude/skills/find-prior-art/SKILL.md
+++ b/.claude/skills/find-prior-art/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: find-prior-art
+description: Search the codebase for an existing helper, type, validator, constant, SQL query, or HTTP route before writing a new one, so AI-generated code extends what already exists instead of cloning it. Use BEFORE generating any non-trivial new code, and when the user asks to "check for prior art", "is there an existing X", or "avoid duplication".
+metadata:
+  author: fleet-edr
+  version: "1.0"
+---
+
+# Find prior art
+
+Before writing a new helper, type, validator, constant, SQL query, or HTTP route, search for one that already exists and extend it instead of adding a parallel implementation. Semantic duplication (the same logic under a different name) is the dominant defect in AI-generated code, and it is invisible to the SonarCloud duplication gate, which matches only lexical tokens.
+
+## When to run
+
+Run this before generating any non-trivial new code: a function or method beyond a one-line wrapper, a struct or interface, a named constant or sentinel error, a SQL statement, or an HTTP handler. Skip it for test bodies and for edits confined to an existing function.
+
+## Where to look
+
+The server is five bounded contexts under `server/`: `identity`, `endpoint`, `rules`, `response`, `detection` (ADR-0004). Cross-context code lives in the imported `api/` package; code shared by server and agent lives in `internal/`. The agent is under `agent/`, the extension under `extension/edr/`.
+
+Search in this order:
+
+1. The owning bounded context (or `agent/` package) for a local equivalent.
+2. `internal/` and `api/` for a shared equivalent the new code should call instead.
+3. The whole tree, to catch a third copy that should become the shared one.
+
+## How to search
+
+Search the concept, not the exact name you were about to type. Look for the verb and the domain noun separately, because the existing helper was probably named differently.
+
+```bash
+# Functions by concept: adjust the verb stem and domain noun to your case
+rg -n --type go -i 'func .*(normaliz|sanitiz|validat).*host' server internal api
+
+# Existing type or interface for the shape you need
+rg -n --type go 'type .*(HostID|Enrollment|Session)' server internal
+
+# Existing HTTP route before registering a new one
+rg -n --type go '(Handle|HandleFunc|\.(Get|Post|Put|Delete))\(' server | rg -i 'enroll'
+
+# Existing SQL for the same table and operation
+rg -n --type go -i 'INSERT INTO audit_events|SELECT .* FROM sessions' server
+```
+
+## What to report
+
+Return exactly one verdict:
+
+- Reuse: name the existing symbol (`pkg.Func` at `path:line`) and state how the new requirement should call or extend it.
+- Promote to shared: an equivalent exists in a sibling context; it should move to `internal/` or `api/` and both call sites use the one copy. Never copy logic sideways between contexts.
+- None found: state that the search ran, list the terms tried, and name the package the new code should live in (the owning context, or `internal/` if more than one context needs it).
+
+Do not report "none found" without showing the search terms. A shallow search that misses the existing helper is the exact failure mode this skill exists to prevent.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -150,6 +150,23 @@ reviews:
         in Playwright, and mocks where an integration test should
         hit the real component.
 
+    - path: "**/*.{go,swift,ts,tsx}"
+      instructions: |
+        Reuse and simplicity. This tree is largely AI-generated, so
+        the two defects below recur and neither the linters nor the
+        lexical SonarCloud duplication gate catch them:
+          - Semantic duplication: a new helper, type, validator, or
+            endpoint that re-implements logic already present in the
+            same bounded context or in shared internal/ or api/
+            packages. Flag it and name the existing symbol to reuse.
+            Renamed-identical logic counts even when the tokens differ.
+          - Speculative edge cases: a defensive branch or error path
+            for a state no caller can produce, or that an upstream
+            validator or the type system already rules out. Ask for
+            the input that reaches the branch; if none exists,
+            recommend deleting it. Validate at the boundary, trust
+            types inward.
+
   # ---- pre-merge checks ----------------------------------------------------
   # All advisory (mode: warning): branch protection + the CI workflow
   # checks own the actual merge decision.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -19,3 +19,10 @@ The `OpenSpec sync` CI gate has a `no-behavior-change` opt-out (label or `[no-be
 
 - Endpoint Security callback threads must never block on the network: any `SecStaticCodeCheckValidity` / code-signing evaluation on the ES path must pass `.noNetworkAccess`.
 - C pointers imported from the ESF SDK that are `_Nonnull` (e.g. `es_event_btm_launch_item_add_t.item`) are non-optional in Swift; an `x?.pointee` guard on them does not compile. `_Nullable` ones (e.g. `instigator`, `app`) do need a guard.
+
+## Flag: duplicated logic and speculative edge cases
+
+This codebase is largely AI-generated. The two defects below recur and are caught by neither the linters nor the SonarCloud duplication gate (which sees only lexical, token-level copies).
+
+- Semantic duplication: a new helper, type, validator, or endpoint that re-implements logic already present in the same bounded context or in the shared `internal/` and `api/` packages. Flag it and name the existing symbol to reuse. Renamed-but-identical logic counts even when the tokens differ.
+- Speculative edge cases: a defensive branch or error path for a state no caller can produce, or that an upstream validator or the type system already rules out. Ask for the input that reaches the branch; if none exists, recommend deleting it. The standard is validate once at the boundary, then trust the types inward.

--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -15,6 +15,7 @@ on:
       - "**/go.mod"
       - "**/go.sum"
       - ".golangci.yml"
+      - ".golangci-strict.yml"
       - ".custom-gcl.yml"
       - "Taskfile.yml"
       - ".github/workflows/go-lint.yml"
@@ -48,7 +49,7 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
         run: |
           set -euo pipefail
-          PATTERN='\.go$|(^|/)go\.(mod|sum)$|^\.golangci\.yml$|^\.custom-gcl\.yml$|^Taskfile\.yml$|^\.github/workflows/go-lint\.yml$'
+          PATTERN='\.go$|(^|/)go\.(mod|sum)$|^\.golangci(-strict)?\.yml$|^\.custom-gcl\.yml$|^Taskfile\.yml$|^\.github/workflows/go-lint\.yml$'
           if [[ "$EVENT_NAME" != "pull_request" ]]; then
             echo "relevant=true" >> "$GITHUB_OUTPUT"
             echo "Triggered by $EVENT_NAME; running unconditionally."

--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -77,6 +77,9 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
+          # Full history so the new-code strict lint below can compute the
+          # merge base against origin/main (--new-from-merge-base).
+          fetch-depth: 0
 
       - name: Create UI dist placeholder for embed
         run: mkdir -p server/ui/dist && touch server/ui/dist/.gitkeep
@@ -163,3 +166,12 @@ jobs:
 
       - name: Run golangci-lint via Taskfile
         run: task lint:go
+
+      # New-code strict gate: cognitive complexity + dead parameters, scoped to
+      # lines changed versus the merge base so existing code is grandfathered.
+      # Populate origin/main first; the PR checkout does not create that ref.
+      # See .golangci-strict.yml and the lint:go:newcode Taskfile target.
+      - name: Run new-code strict lint (complexity + dead parameters)
+        run: |
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          task lint:go:newcode

--- a/.golangci-strict.yml
+++ b/.golangci-strict.yml
@@ -1,0 +1,44 @@
+# Strict, NEW-CODE-ONLY golangci-lint config. This is NOT the project's main
+# config (.golangci.yml owns the whole-repo correctness sweep). It is run
+# separately by `task lint:go:newcode` with `--new-from-merge-base origin/main`
+# so it reports ONLY on lines changed versus the merge base. Existing code is
+# grandfathered: the 5000+ aggregate cognitive complexity that the AI-generated
+# tree already carries is not retroactively flagged, but new functions cannot
+# add to it past the threshold.
+#
+# Division of labour (see docs/maintenance/tasks/consolidation-pass.md):
+#   * SonarCloud owns DUPLICATION (new_duplicated_lines_density gate, lexical).
+#   * This config owns COGNITIVE COMPLEXITY and DEAD PARAMETERS on new code.
+#   * Semantic duplication (renamed-identical logic) is owned by the
+#     find-prior-art skill plus the AI review bots; no linter sees it.
+#
+# Run with the custom binary so it shares the cache built by `task lint:install`
+# (the commentwrap plugin is compiled in but simply not enabled here).
+version: "2"
+
+linters:
+  default: none
+  enable:
+    - gocognit # cognitive complexity per function; mirrors Sonar's metric
+    - unparam # unused function parameters and always-same return values (speculative flexibility)
+
+  settings:
+    gocognit:
+      # 20 is a deliberate midpoint: Sonar flags functions above 15, gocyclo
+      # conventions sit near 30. Tune in lockstep if the new-code run proves
+      # too tight or too loose; raising it weakens the gate for everyone.
+      min-complexity: 20
+
+  exclusions:
+    generated: strict
+    paths:
+      - tmp
+      - ui/node_modules
+    rules:
+      # Table-driven tests legitimately carry high branching, and test helpers
+      # often take parameters a single caller does not yet use. Neither is the
+      # over-engineering this gate targets, so tests are out of scope.
+      - path: _test\.go
+        linters:
+          - gocognit
+          - unparam

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -40,6 +40,11 @@ userspace-claimed fields where a kernel-vouched value exists (use audit_token-de
 or PII in log statements, audit-log tampering (audit_events is append-only), weak crypto, and SQL injection.
 Performance on ingestion paths (ES event handling, event upload pipeline, MySQL writes on the ingest path) is a correctness
 concern: flag per-event allocations, N+1 queries, and lock contention there.
+This tree is largely AI-generated, so also flag (secondary to the security and performance findings above): a new helper, type,
+validator, or endpoint that re-implements logic already present in the same bounded context or in shared internal/ or api/
+packages (semantic duplication the lexical SonarCloud gate misses; name the existing symbol to reuse), and defensive branches or
+error paths for states no caller can produce or that the type system already rules out (validate at the boundary, then delete the
+unreachable guard). See best_practices.md "Reuse and simplicity".
 Do not flag: style or formatting that linters own (golangci-lint, SwiftLint, Prettier, dash-lint); Go 1.26 language and stdlib
 features (integer range expressions, strings.SplitSeq) as compile errors; the word "fleet"/"fleets" in docs/fleet-deployment.md
 (Fleet renamed teams to fleets in v4.82, the doc is correct); long Markdown lines (prose is never hard-wrapped, enforced by

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,3 +139,10 @@ Layered on the global guide. Project-specific:
   both Copilot and CodeRabbit caught a dispatcher reference on a function whose
   dispatcher argument no longer existed). Treat the comment delta as part of the
   deletion, not a follow-up.
+
+## Reuse and simplicity
+
+This codebase is largely AI-generated, which produces two failure modes no linter catches: code that re-implements helpers, types, or endpoints that already exist (because it was generated without searching the tree), and defensive branches for inputs no caller can produce. Two rules counter this.
+
+- Search before you add. Before writing a new helper, type, validator, constant, SQL query, or HTTP route, search the owning bounded context and the shared `internal/` and `api/` packages for an existing equivalent, and extend it rather than cloning it. The `find-prior-art` skill automates that search; run it before generating non-trivial new code. SonarCloud gates new lexical duplication, but semantic duplication (the same logic renamed) is invisible to it and is the author's and reviewer's responsibility.
+- No speculative edge cases. Every defensive branch and error path needs a real caller that reaches it. If a state is already ruled out by a type or an upstream validator, do not re-handle it: validate once at the boundary and trust the types inward. A guard you cannot produce an input for is dead code, not robustness. New-code cognitive complexity and unused parameters are gated by `task lint:go:newcode`; the existing backlog is paid down by the monthly `consolidation-pass` maintenance task.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -472,6 +472,18 @@ tasks:
     cmds:
       - tmp/golangci-lint-custom run --fix ./...
 
+  lint:go:newcode:
+    desc: |
+      NEW-CODE-ONLY strict lint: cognitive complexity (gocognit) + dead parameters
+      (unparam), scoped to lines changed versus origin/main via --new-from-merge-base.
+      Uses the separate .golangci-strict.yml so the whole-repo lint:go run is untouched.
+      Existing AI-generated complexity is grandfathered; new functions cannot add past
+      the gocognit threshold. CI fetches origin/main first; local runs need it present.
+      See docs/maintenance/tasks/consolidation-pass.md for paying down the existing stock.
+    deps: [lint:install]
+    cmds:
+      - tmp/golangci-lint-custom run --config .golangci-strict.yml --new-from-merge-base origin/main ./...
+
   lint:install:
     desc: |
       Build the custom golangci-lint binary at tmp/golangci-lint-custom by running

--- a/best_practices.md
+++ b/best_practices.md
@@ -27,3 +27,10 @@ The hot paths are the ES event handlers in the extension, the agent's event queu
 - Error handling on the agent and server: errors from the queue, uploader, and store are handled or explicitly logged with context; a swallowed error on the ingest path hides data loss.
 - Re-exec chains and process trees: code walking `previous_exec_id` or building process forests must terminate on cycles and missing parents; assume the input can be adversarial.
 - When a symbol is deleted (function, type, command, XPC message kind, config field), every comment referencing it goes in the same diff. Stale references in IPC-adjacent comments are a recurring review defect in this repo.
+
+## Reuse and simplicity
+
+This codebase is largely AI-generated; both defects below evade the linters and the SonarCloud duplication gate (which sees only lexical, token-level duplication).
+
+- Semantic duplication. A new helper, type, validator, or endpoint that re-implements logic already present in the same bounded context or in the shared `internal/` and `api/` packages is a finding even when the tokens differ. Name the existing symbol to reuse. The `find-prior-art` skill runs this search before code is written.
+- Speculative edge cases. A defensive branch or error path that no caller can reach, or that an upstream validator or the type system already rules out, is dead code, not robustness. The standard is to validate once at the boundary, then trust the types inward. A guard with no producible input is a finding. New-code cognitive complexity and unused parameters are gated by `task lint:go:newcode`.

--- a/docs/maintenance/README.md
+++ b/docs/maintenance/README.md
@@ -44,7 +44,7 @@ If a finding from a scheduled task could be moved into one of those automated ga
 
 | Cadence | Tasks |
 | --- | --- |
-| **Monthly** | [`doc-accuracy-sweep`](tasks/doc-accuracy-sweep.md), [`stale-implementation-references`](tasks/stale-implementation-references.md), [`memory-and-claudemd-audit`](tasks/memory-and-claudemd-audit.md), [`todo-fixme-sweep`](tasks/todo-fixme-sweep.md), [`observability-review`](tasks/observability-review.md) |
+| **Monthly** | [`doc-accuracy-sweep`](tasks/doc-accuracy-sweep.md), [`stale-implementation-references`](tasks/stale-implementation-references.md), [`memory-and-claudemd-audit`](tasks/memory-and-claudemd-audit.md), [`todo-fixme-sweep`](tasks/todo-fixme-sweep.md), [`observability-review`](tasks/observability-review.md), [`consolidation-pass`](tasks/consolidation-pass.md) |
 | **Quarterly** | [`adr-audit`](tasks/adr-audit.md), [`best-practices-refresh`](tasks/best-practices-refresh.md), [`architecture-drift`](tasks/architecture-drift.md), [`dead-code-sweep`](tasks/dead-code-sweep.md), [`config-surface-review`](tasks/config-surface-review.md), [`test-suite-health`](tasks/test-suite-health.md), [`claude-config-audit`](tasks/claude-config-audit.md), [`ai-review-bot-config-audit`](tasks/ai-review-bot-config-audit.md), [`threat-model-and-security-refresh`](tasks/threat-model-and-security-refresh.md) |
 
 Suggested anchor: run monthly tasks on the first Monday, quarterly tasks on the first Monday of the quarter (Jan / Apr / Jul / Oct). A "kick the can" of one week is fine; skipping a quarter twice in a row is not.
@@ -83,6 +83,7 @@ Use any existing task file as a template. Update the cadence calendar above and 
 - [`test-suite-health`](tasks/test-suite-health.md): flaky, skipped, slow, semantically thin
 - [`architecture-drift`](tasks/architecture-drift.md): semantic boundary violations beyond what `arch-go` catches
 - [`config-surface-review`](tasks/config-surface-review.md): dead knobs, wrong-layer knobs, and tuning that should be a fixed constant across server + agent config
+- [`consolidation-pass`](tasks/consolidation-pass.md): semantic duplication and cognitive-complexity hotspots in code that is live (not dead), consolidated one cluster per PR
 
 ### AI tooling hygiene (new domain)
 

--- a/docs/maintenance/tasks/consolidation-pass.md
+++ b/docs/maintenance/tasks/consolidation-pass.md
@@ -28,7 +28,7 @@ Repo-wide: duplicated lines 1.3%, 33 duplicated blocks across 21 files; aggregat
 
 ## Steps
 
-1. Pull the duplication report. Via the SonarQube MCP: `search_duplicated_files` and `get_duplications` for project `getvictor_fleet-edr`. Or the web API:
+1. Pull the duplication report from SonarCloud. If the SonarQube MCP is configured locally (optional), `search_duplicated_files` and `get_duplications` for project `getvictor_fleet-edr` are the quickest path; otherwise use the SonarCloud web API, which always works:
 
    ```bash
    curl -s -u "$SONAR_TOKEN:" \
@@ -58,8 +58,9 @@ One focused PR per consolidation candidate (do not bundle unrelated clusters). T
 Run the consolidation pass defined in docs/maintenance/tasks/consolidation-pass.md.
 
 Step 1: pull the SonarCloud duplication and cognitive-complexity reports for getvictor_fleet-edr
-(via the SonarQube MCP search_duplicated_files / get_duplications, and the component_tree measures API
-in the task file). List the top duplicated files and the top cognitive-complexity files.
+(the SonarQube MCP search_duplicated_files / get_duplications if it is configured, otherwise the
+component_tree measures API shown in the task file). List the top duplicated files and the top
+cognitive-complexity files.
 
 Step 2: for the top few, confirm the copies are live (grep the call sites) and propose a target shape:
 which implementation wins, where it lives (owning bounded context, or internal/ and api/ if shared), and

--- a/docs/maintenance/tasks/consolidation-pass.md
+++ b/docs/maintenance/tasks/consolidation-pass.md
@@ -1,0 +1,79 @@
+# Consolidation pass
+
+**Cadence:** monthly **Time budget:** 90 min **Trigger mode:** manual (schedulable)
+
+## Why this matters
+
+This codebase is largely AI-generated. AI assistants generate one function at a time without reading the rest of the tree, so they accrete two kinds of decay that the per-PR gates do not stop:
+
+- Semantic duplication: the same logic re-implemented under a different name. SonarCloud's duplication gate (`new_duplicated_lines_density > 3%`) catches only lexical, token-level copies; renamed-identical logic sails through.
+- Cognitive-complexity hotspots: over-built functions, deep nesting, and defensive branches for states no caller can produce.
+
+The new-code gates stop NEW instances: the golangci `lint:go:newcode` run gates cognitive complexity and dead parameters on changed lines, and the Sonar gate caps new lexical duplication. This pass pays down the existing stock those gates grandfather. The decision of what shape to consolidate into is a human one; the mechanical extract-and-replace is the part to delegate.
+
+## Relationship to other tasks (do not duplicate)
+
+- `dead-code-sweep` targets code that is UNUSED. This task targets code that IS used but is duplicated or over-complex.
+- `architecture-drift` targets boundary violations. This task is orthogonal: consolidation must respect context boundaries (shared logic moves to `internal/` or `api/`, never sideways between contexts).
+
+## Baseline (recorded when this task was added, 2026-06)
+
+Repo-wide: duplicated lines 1.3%, 33 duplicated blocks across 21 files; aggregate cognitive complexity 5282 over 53k ncloc. Lexical duplication is already low, so the higher-value target is usually the cognitive-complexity hotspots. Use these as the trend baseline and record the new numbers each run in the log.
+
+## Scope
+
+- Duplicated files and blocks (SonarCloud whole-repo measure, not the new-code gate).
+- The highest cognitive-complexity files (SonarCloud `cognitive_complexity` per file).
+- Semantic duplicates the review bots or a manual grep surface that Sonar's lexical matcher missed.
+
+## Steps
+
+1. Pull the duplication report. Via the SonarQube MCP: `search_duplicated_files` and `get_duplications` for project `getvictor_fleet-edr`. Or the web API:
+
+   ```bash
+   curl -s -u "$SONAR_TOKEN:" \
+     "https://sonarcloud.io/api/measures/component_tree?component=getvictor_fleet-edr&metricKeys=duplicated_blocks,duplicated_lines_density&qualifiers=FIL&s=metric&metricSort=duplicated_blocks&asc=false&ps=25" | jq .
+   ```
+
+2. Pull the cognitive-complexity hotspots:
+
+   ```bash
+   curl -s -u "$SONAR_TOKEN:" \
+     "https://sonarcloud.io/api/measures/component_tree?component=getvictor_fleet-edr&metricKeys=cognitive_complexity&qualifiers=FIL&s=metric&metricSort=cognitive_complexity&asc=false&ps=25" | jq .
+   ```
+
+3. Cluster the top findings into at most a handful of consolidation candidates. For each, confirm the copies are live (grep the call sites, the way `find-prior-art` does) and decide the target shape: which implementation wins, where it lives (owning context, or `internal/` and `api/` if shared), and what the call sites become.
+
+4. Consolidate one candidate per PR. The human decides the target; the extract-and-replace is mechanical. Keep each PR small enough to review in one sitting.
+
+5. Refuse compounded scope. If a candidate is more than a focused session of work (a cross-context redesign, a schema change), file an issue and stop. A 3-day refactor disguised as a sweep is how the sweep gets skipped.
+
+## Output
+
+One focused PR per consolidation candidate (do not bundle unrelated clusters). The PR body records the before metric (the duplicated-block count, or the file's cognitive complexity) so the reviewer can see the reduction.
+
+## Prompt template
+
+```text
+Run the consolidation pass defined in docs/maintenance/tasks/consolidation-pass.md.
+
+Step 1: pull the SonarCloud duplication and cognitive-complexity reports for getvictor_fleet-edr
+(via the SonarQube MCP search_duplicated_files / get_duplications, and the component_tree measures API
+in the task file). List the top duplicated files and the top cognitive-complexity files.
+
+Step 2: for the top few, confirm the copies are live (grep the call sites) and propose a target shape:
+which implementation wins, where it lives (owning bounded context, or internal/ and api/ if shared), and
+what the call sites become. Respect context boundaries; never consolidate sideways between contexts.
+
+Step 3: implement ONE candidate on a branch as a focused PR. Record the before metric in the PR body.
+File an issue for anything bigger than a single session and stop.
+
+Time budget 90 minutes. Skip ambiguous clusters and file an issue instead of guessing the target shape.
+```
+
+## Definition of done
+
+- [ ] Sonar duplication and cognitive-complexity reports pulled, and the top findings listed.
+- [ ] At least one consolidation PR opened, or an explicit "nothing above threshold this month" finding written down.
+- [ ] Oversized candidates filed as issues, not left half-done in the sweep.
+- [ ] Dated entry in [`docs/maintenance/log.md`](../log.md) with the current duplication % and aggregate cognitive complexity.


### PR DESCRIPTION
## Why

This codebase is largely AI-generated, which produces a predictable failure mode: locally plausible, globally incoherent. The recurring defects are semantic duplication (the same logic re-implemented under a different name), speculative edge cases (defensive branches for inputs no caller can produce), and cognitive-complexity creep. None are caught by the existing gates. This PR adds machine-enforced controls for each, plus a maintenance task to pay down the existing stock.

## What

**1. New-code complexity gate.** `.golangci-strict.yml` runs `gocognit` (>20) + `unparam`, scoped to changed lines via `--new-from-merge-base origin/main` (new `lint:go:newcode` Taskfile target, wired into `go-lint.yml`). The whole-repo `lint:go` run is untouched, so existing complexity is grandfathered; new functions cannot add past the threshold. Confirmed the linters fire on existing code (a `func New` at cognitive complexity 26, an unused `cfg` param, a `window` param that always receives the same value). SonarCloud already owns duplication (`new_duplicated_lines_density > 3%`, currently 0.5% new / 1.3% repo), so the split is clean: Sonar owns duplication, golangci owns complexity + dead parameters.

**2. `find-prior-art` skill.** `.claude/skills/find-prior-art/SKILL.md` searches the owning bounded context plus shared `internal/` and `api/` for an existing helper/type/endpoint before generating a new one. Counters the semantic duplication the lexical Sonar gate cannot see.

**3. Review discipline.** Semantic-duplication and speculative-edge-case rules added to `CLAUDE.md`, `best_practices.md`, `.coderabbit.yaml`, `.github/copilot-instructions.md`, and `.pr_agent.toml`.

**4. Consolidation pass.** `docs/maintenance/tasks/consolidation-pass.md`, slotted into the existing maintenance cadence (Monthly) and index. Pulls the Sonar duplication + cognitive-complexity reports, clusters them, and produces one focused PR per cluster, with the "human decides the target shape, refuse compounded scope" discipline.

## Verification

dash-lint, Prettier, markdownlint, actionlint, TOML/YAML parse, and the new-code gate's end-to-end run all pass locally (also green via pre-commit hooks). No gated OpenSpec paths touched, so no spec delta required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidelines for code reuse and reducing semantic duplication across the codebase.
  * Introduced a new monthly consolidation procedure to address duplication and complexity hotspots.
  * Updated contributor best practices and maintenance documentation.

* **Chores**
  * Enhanced code review automation with stricter linting for new code contributions.
  * Updated CI workflows to enforce cognitive complexity and parameter validation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->