### PR TITLE
feat(detection-config): path-alias exclusions + cross-replica snapshot refresh (#482)

### DIFF
--- a/openspec/changes/detection-config-hardening/proposal.md
+++ b/openspec/changes/detection-config-hardening/proposal.md
@@ -1,0 +1,20 @@
+# Detection-config hardening (follow-ups to #459)
+
+## Why
+
+Issue #459 shipped the DB-backed detection-config surface (typed exclusions + per-rule modes). Issue #482 tracks the deferred follow-ups. This change delivers the two that are concrete and self-contained:
+
+- **Path canonicalization.** `path_glob` / `parent_path_glob` exclusions did not account for the macOS `/private` firmlink: an exclusion written as `/etc/...` silently failed to match an event ESF reported as `/private/etc/...` (and vice versa), so an operator's allowlist could appear to do nothing. The matcher now tests the operator's glob against both macOS forms of the concrete candidate path.
+- **Cross-replica convergence.** The in-memory detection-config snapshot reloaded only on a local mutation, so under the multi-replica topology (ADR-0010) a replica that did not handle the mutating request served a stale config until its next local mutation or a restart. A periodic version-poll now converges every replica.
+
+The remaining #482 items (typed per-rule settings schema, host-group-scoped config + exclusion editing) stay deferred: the schema is speculative until a rule needs a tunable knob, and host-group scope is blocked on editable host groups.
+
+## What changes
+
+- `api.MatchExclusionValue` aliases the concrete candidate path across `/etc`|`/var`|`/tmp` <-> `/private/...` at match time for the two path match types. The glob entry is never rewritten (globs cannot be canonicalized cleanly), so a non-aliasable path costs at most one extra match.
+- `detectionconfig.Service` gains a `RefreshLoop(ctx, interval)` that polls `detection_config_meta.version` (a single indexed-row read) and reloads only when the version advanced past the loaded snapshot's. The rules context exposes `Run(ctx)`; `cmd/main` starts it alongside the other contexts' background loops.
+
+## Impact
+
+- Behavior: exclusions match regardless of firmlink form; replicas converge within the refresh interval (default 5s). No wire-format or schema change.
+- Tests: unit (matcher aliasing), rule-layer regression (sudoers_tamper), integration (two-replica convergence over a real database).

--- a/openspec/changes/detection-config-hardening/specs/server-detection-rules-engine/spec.md
+++ b/openspec/changes/detection-config-hardening/specs/server-detection-rules-engine/spec.md
@@ -1,0 +1,25 @@
+# Server detection rules engine specification
+
+## ADDED Requirements
+
+### Requirement: Path exclusions match across the macOS /private firmlink boundary
+
+A detection exclusion of match type `path_glob` or `parent_path_glob` SHALL suppress a matching finding regardless of whether the candidate path is expressed in the public form (`/etc`, `/var`, `/tmp`) or the `/private`-prefixed firmlink form, because macOS resolves the two as the same file and ESF may report either. The operator-entered glob is matched against both macOS forms of the concrete candidate path; the glob itself MUST NOT be rewritten (a glob such as `*/claude/versions/*` cannot be canonicalized), and a candidate path under none of the aliasable prefixes is matched once with no extra cost.
+
+#### Scenario: An exclusion matches the aliased form of the candidate path
+
+- **GIVEN** a `path_glob` exclusion an operator wrote as `/etc/sudoers`
+- **WHEN** a rule evaluates a candidate path that ESF reported as `/private/etc/sudoers`
+- **THEN** the exclusion suppresses the finding
+- **AND** the reverse holds: an exclusion written as `/private/etc/*` suppresses a candidate reported as `/etc/sudoers`
+
+### Requirement: Detection configuration converges across replicas
+
+Each server replica SHALL converge its in-memory detection-config snapshot with mutations made on other replicas without a restart. A mutation bumps a shared monotonic version counter; every replica periodically polls that counter and reloads its snapshot when the stored version has advanced past the loaded snapshot's, so an exclusion or rule-mode change made through one replica takes effect on every replica within the refresh interval. The poll reads only the single-row version counter, so a steady state with no configuration churn costs one indexed read per interval per replica.
+
+#### Scenario: A replica adopts a configuration change made on another replica
+
+- **GIVEN** two replicas sharing one database, each holding a loaded detection-config snapshot that excludes nothing
+- **WHEN** an operator creates an exclusion through one replica
+- **THEN** the other replica reloads its snapshot on a subsequent refresh tick
+- **AND** begins suppressing the matching finding without a restart and without a mutation of its own

--- a/openspec/changes/detection-config-hardening/tasks.md
+++ b/openspec/changes/detection-config-hardening/tasks.md
@@ -1,0 +1,10 @@
+# Tasks
+
+- [x] Alias the candidate path across the `/private` firmlink in `api.MatchExclusionValue` for `path_glob` / `parent_path_glob` (no glob rewrite).
+- [x] Unit table cases for the aliasing (both directions, all three prefixes, non-aliasable path unaffected).
+- [x] Rule-layer regression test (`sudoers_tamper`): suppressed when the exclusion and the event path differ only in firmlink form.
+- [x] `detectionconfig.Service.RefreshLoop(ctx, interval)` + rules-context `Run(ctx)` + `cmd/fleet-edr-server` wiring; poll `detection_config_meta.version`, reload on change.
+- [x] Two-replica convergence integration test (separate Service+Store on one DB).
+- [x] OpenSpec delta + spectrace markers for the two new scenarios.
+- [ ] Gates: `go build`, `go test`, `task lint:go`, `task lint:dashes`, `tools/spectrace check --strict`, `openspec validate detection-config-hardening --strict`.
+- [ ] Archive at release (batched), not per-merge.

--- a/openspec/changes/detection-config-hardening/tasks.md
+++ b/openspec/changes/detection-config-hardening/tasks.md
@@ -6,5 +6,5 @@
 - [x] `detectionconfig.Service.RefreshLoop(ctx, interval)` + rules-context `Run(ctx)` + `cmd/fleet-edr-server` wiring; poll `detection_config_meta.version`, reload on change.
 - [x] Two-replica convergence integration test (separate Service+Store on one DB).
 - [x] OpenSpec delta + spectrace markers for the two new scenarios.
-- [ ] Gates: `go build`, `go test`, `task lint:go`, `task lint:dashes`, `tools/spectrace check --strict`, `openspec validate detection-config-hardening --strict`.
+- [x] Gates: `go build`, `go test`, `task lint:go`, `task lint:dashes`, `tools/spectrace check --strict`, `openspec validate detection-config-hardening --strict`.
 - [ ] Archive at release (batched), not per-merge.

--- a/server/cmd/fleet-edr-server/main.go
+++ b/server/cmd/fleet-edr-server/main.go
@@ -162,6 +162,9 @@ func run() error {
 
 	go runDetection(ctx, detectionCtx, logger)
 	go runIdentity(ctx, identityCtx, logger)
+	// Converge this replica's detection-config snapshot with mutations made on other replicas (ADR-0010): a peer's exclusion / rule-mode
+	// edit only bumps the shared version counter, so without this poll a non-mutating replica would serve a stale config until restart.
+	go rulesCtx.Run(ctx)
 
 	// Only construct the resolver when EDR_TRUSTED_PROXIES is non-empty. httpserver.Build skips installing the middleware on a nil
 	// resolver, and httpserver.ClientIP's fallback returns the same peer IP the resolver's empty-list path would return, so this saves

--- a/server/rules/api/detectionconfig.go
+++ b/server/rules/api/detectionconfig.go
@@ -144,13 +144,16 @@ func GlobMatch(pattern, name string) bool {
 // carried. Only the leading segment is rewritten (a deeper `/private` is left alone), and a path under none of the three prefixes
 // returns "" so the caller skips the extra match.
 func macOSPathAlias(p string) string {
-	for _, prefix := range []string{"/etc", "/var", "/tmp"} {
-		if p == prefix || strings.HasPrefix(p, prefix+"/") {
+	// Two passes with static literals so the no-match path allocates nothing (the previous single loop computed "/private"+prefix
+	// every iteration). Public -> private form first, then private -> public (slicing off the constant-length "/private" prefix).
+	for _, public := range []string{"/etc", "/var", "/tmp"} {
+		if p == public || strings.HasPrefix(p, public+"/") {
 			return "/private" + p
 		}
-		private := "/private" + prefix
+	}
+	for _, private := range []string{"/private/etc", "/private/var", "/private/tmp"} {
 		if p == private || strings.HasPrefix(p, private+"/") {
-			return strings.TrimPrefix(p, "/private")
+			return p[len("/private"):]
 		}
 	}
 	return ""

--- a/server/rules/api/detectionconfig.go
+++ b/server/rules/api/detectionconfig.go
@@ -81,7 +81,18 @@ func IsValidExclusionMatchType(mt ExclusionMatchType) bool {
 func MatchExclusionValue(mt ExclusionMatchType, entry, candidate string) bool {
 	switch mt {
 	case ExclusionMatchPathGlob, ExclusionMatchParentPathGlob:
-		return GlobMatch(entry, candidate)
+		// macOS /etc, /var, /tmp are symlinks into /private, and ESF reports a path in either form depending on how it was
+		// resolved, so an operator who excludes `/etc/...` must still match an event reported as `/private/etc/...` (and vice
+		// versa). The exclusion `entry` is a glob (`*/claude/versions/*`), which can't be canonicalized cleanly, so instead of
+		// rewriting the glob we test it against BOTH macOS forms of the concrete candidate path. macOSPathAlias yields the
+		// counterpart form (or "" when the path has no aliasable prefix), so a non-/private path costs one extra GlobMatch at most.
+		if GlobMatch(entry, candidate) {
+			return true
+		}
+		if alias := macOSPathAlias(candidate); alias != "" {
+			return GlobMatch(entry, alias)
+		}
+		return false
 	case ExclusionMatchCommandSubstring:
 		return entry != "" && strings.Contains(candidate, entry)
 	case ExclusionMatchDomain:
@@ -125,6 +136,24 @@ func GlobMatch(pattern, name string) bool {
 		px++
 	}
 	return px == len(pattern)
+}
+
+// macOSPathAlias returns the counterpart macOS form of an absolute path across the /private firmlink boundary, or "" when the path
+// has no aliasable prefix. /etc, /var, /tmp are symlinks into /private, so `/etc/sudoers` and `/private/etc/sudoers` name the same
+// file; ESF may report either. Used by MatchExclusionValue so a path-glob exclusion matches regardless of which form the event
+// carried. Only the leading segment is rewritten (a deeper `/private` is left alone), and a path under none of the three prefixes
+// returns "" so the caller skips the extra match.
+func macOSPathAlias(p string) string {
+	for _, prefix := range []string{"/etc", "/var", "/tmp"} {
+		if p == prefix || strings.HasPrefix(p, prefix+"/") {
+			return "/private" + p
+		}
+		private := "/private" + prefix
+		if p == private || strings.HasPrefix(p, private+"/") {
+			return strings.TrimPrefix(p, "/private")
+		}
+	}
+	return ""
 }
 
 // GlobalScope is the sentinel host-group id meaning "applies to every host" for a detection-config record whose scope is global. The

--- a/server/rules/api/detectionconfig_test.go
+++ b/server/rules/api/detectionconfig_test.go
@@ -31,6 +31,16 @@ func TestMatchExclusionValue(t *testing.T) {
 		{"domain does not match suffix-only", api.ExclusionMatchDomain, "example.com", "notexample.com", false},
 		{"cdhash exact", api.ExclusionMatchCDHash, "abc123", "abc123", true},
 		{"unknown match type never matches", api.ExclusionMatchType("bogus"), "x", "x", false},
+
+		// macOS /private firmlink aliasing: a path-glob exclusion must match regardless of which form (/etc vs /private/etc) the
+		// event carried. Covers both directions and all three aliasable prefixes, plus a non-aliasable path (no false match).
+		{"etc entry matches private candidate", api.ExclusionMatchPathGlob, "/etc/sudoers", "/private/etc/sudoers", true},
+		{"private entry matches etc candidate", api.ExclusionMatchPathGlob, "/private/etc/sudoers", "/etc/sudoers", true},
+		{"etc glob matches private candidate", api.ExclusionMatchPathGlob, "/etc/*", "/private/etc/sudoers", true},
+		{"var alias", api.ExclusionMatchPathGlob, "/var/db/foo", "/private/var/db/foo", true},
+		{"tmp alias parent path glob", api.ExclusionMatchParentPathGlob, "/private/tmp/build/*", "/tmp/build/run.sh", true},
+		{"alias does not over-match a different path", api.ExclusionMatchPathGlob, "/etc/sudoers", "/private/etc/passwd", false},
+		{"non-aliasable usr path unaffected", api.ExclusionMatchPathGlob, "/usr/bin/python3", "/private/usr/bin/python3", false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/server/rules/bootstrap/bootstrap.go
+++ b/server/rules/bootstrap/bootstrap.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/jmoiron/sqlx"
 
@@ -111,6 +112,18 @@ func New(deps Deps) (*Rules, error) {
 		db:                 deps.DB,
 		logger:             logger,
 	}, nil
+}
+
+// DefaultDetectionConfigRefreshInterval is how often a replica polls the detection-config version counter to pick up a config edit
+// made on another replica. Matches the revocation-snapshot cadence: edits are infrequent + operator-driven and the poll is a single
+// indexed-row read, so a tight interval is cheap and keeps cross-replica convergence far under the alert-evaluation timescale.
+const DefaultDetectionConfigRefreshInterval = 5 * time.Second
+
+// Run drives the rules context's background workers until ctx is cancelled. Today that is just the detection-config snapshot refresh,
+// which converges this replica with config mutations made on other replicas (ADR-0010 stateless server; mutations elsewhere only bump
+// the shared version counter). cmd/main starts this in a goroutine alongside the other contexts' background loops.
+func (r *Rules) Run(ctx context.Context) {
+	r.detectionConfigSvc.RefreshLoop(ctx, DefaultDetectionConfigRefreshInterval)
 }
 
 // ApplySchema applies the rules context's goose migration corpus and seeds the `Default` application control policy. Idempotent

--- a/server/rules/internal/catalog/sudoers_tamper_test.go
+++ b/server/rules/internal/catalog/sudoers_tamper_test.go
@@ -46,6 +46,27 @@ func TestSudoersTamper_ExcludedEdgeCases(t *testing.T) {
 		"empty path must not match a non-empty entry")
 }
 
+// TestSudoersTamper_ExcludedCanonicalizesPrivatePaths pins the #482 path-alias fix at the rule layer: /etc, /var, /tmp are macOS
+// symlinks into /private and ESF may report either form, so an exclusion written in one form must suppress an event reported in the
+// other. Exercised through the rule's own excluded() so a future regression in the matcher is caught where operators feel it.
+// spec:server-detection-rules-engine/path-exclusions-match-across-the-macos-private-firmlink-boundary/an-exclusion-matches-the-aliased-form-of-the-candidate-path
+func TestSudoersTamper_ExcludedCanonicalizesPrivatePaths(t *testing.T) {
+	t.Parallel()
+	// Operator excluded the bare /etc form; the rule sees the /private/etc form.
+	rEtc := &SudoersTamper{Exclusions: &fakeExclusions{entries: []fakeExcl{
+		{ruleID: "sudoers_tamper", matchType: api.ExclusionMatchPathGlob, value: "/etc/sudoers"},
+	}}}
+	assert.True(t, rEtc.excluded("/private/etc/sudoers", "host-a"),
+		"a /etc exclusion must suppress the /private/etc form ESF can report")
+
+	// And the reverse: operator excluded the /private form; the rule sees the bare form.
+	rPrivate := &SudoersTamper{Exclusions: &fakeExclusions{entries: []fakeExcl{
+		{ruleID: "sudoers_tamper", matchType: api.ExclusionMatchPathGlob, value: "/private/etc/*"},
+	}}}
+	assert.True(t, rPrivate.excluded("/etc/sudoers", "host-a"),
+		"a /private/etc glob must suppress the bare /etc form")
+}
+
 // TestSudoersTamper_MalformedPayload exercises the unmarshal-failure path: the fast-path bytes.Contains lets it through (the magic
 // substring is present), then unmarshal trips and the rule drops the event silently.
 func TestSudoersTamper_MalformedPayload(t *testing.T) {

--- a/server/rules/internal/catalog/sudoers_tamper_test.go
+++ b/server/rules/internal/catalog/sudoers_tamper_test.go
@@ -46,25 +46,26 @@ func TestSudoersTamper_ExcludedEdgeCases(t *testing.T) {
 		"empty path must not match a non-empty entry")
 }
 
-// TestSudoersTamper_ExcludedCanonicalizesPrivatePaths pins the #482 path-alias fix at the rule layer: /etc, /var, /tmp are macOS
-// symlinks into /private and ESF may report either form, so an exclusion written in one form must suppress an event reported in the
-// other. Exercised through the rule's own excluded() so a future regression in the matcher is caught where operators feel it.
+// TestSudoersTamper_ExcludedCanonicalizesPrivatePaths pins the #482 path-alias fix at the rule layer. sudoers_tamper matches the
+// WRITER process path (proc.Path), not the sudoers file, so the exclusion value is an aliasable writer (a staged installer under /var
+// or /tmp): /var and /tmp are macOS symlinks into /private and ESF may report either form, so an exclusion written in one form must
+// suppress a writer reported in the other. Exercised through the rule's own excluded() so a matcher regression is caught in real shape.
 // spec:server-detection-rules-engine/path-exclusions-match-across-the-macos-private-firmlink-boundary/an-exclusion-matches-the-aliased-form-of-the-candidate-path
 func TestSudoersTamper_ExcludedCanonicalizesPrivatePaths(t *testing.T) {
 	t.Parallel()
-	// Operator excluded the bare /etc form; the rule sees the /private/etc form.
-	rEtc := &SudoersTamper{Exclusions: &fakeExclusions{entries: []fakeExcl{
-		{ruleID: "sudoers_tamper", matchType: api.ExclusionMatchPathGlob, value: "/etc/sudoers"},
+	// Operator excluded the bare /var writer form; the rule sees the /private/var form ESF reports.
+	rVar := &SudoersTamper{Exclusions: &fakeExclusions{entries: []fakeExcl{
+		{ruleID: "sudoers_tamper", matchType: api.ExclusionMatchPathGlob, value: "/var/db/munki/installer"},
 	}}}
-	assert.True(t, rEtc.excluded("/private/etc/sudoers", "host-a"),
-		"a /etc exclusion must suppress the /private/etc form ESF can report")
+	assert.True(t, rVar.excluded("/private/var/db/munki/installer", "host-a"),
+		"a /var writer exclusion must suppress the /private/var form ESF can report")
 
 	// And the reverse: operator excluded the /private form; the rule sees the bare form.
 	rPrivate := &SudoersTamper{Exclusions: &fakeExclusions{entries: []fakeExcl{
-		{ruleID: "sudoers_tamper", matchType: api.ExclusionMatchPathGlob, value: "/private/etc/*"},
+		{ruleID: "sudoers_tamper", matchType: api.ExclusionMatchPathGlob, value: "/private/tmp/*"},
 	}}}
-	assert.True(t, rPrivate.excluded("/etc/sudoers", "host-a"),
-		"a /private/etc glob must suppress the bare /etc form")
+	assert.True(t, rPrivate.excluded("/tmp/installer", "host-a"),
+		"a /private/tmp writer glob must suppress the bare /tmp form")
 }
 
 // TestSudoersTamper_MalformedPayload exercises the unmarshal-failure path: the fast-path bytes.Contains lets it through (the magic

--- a/server/rules/internal/detectionconfig/refresh_internal_test.go
+++ b/server/rules/internal/detectionconfig/refresh_internal_test.go
@@ -1,0 +1,58 @@
+package detectionconfig
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fleetdm/edr/server/migrations/runner"
+	rulesmigrations "github.com/fleetdm/edr/server/rules/migrations"
+	"github.com/fleetdm/edr/server/testdb"
+)
+
+// White-box tests for the refresh loop's error/cancellation branches, which the black-box RefreshLoop convergence test cannot drive
+// deterministically (the select catches ctx.Done() between ticks, so an in-tick cancellation is unreachable from outside).
+
+func newInternalStore(t *testing.T) (*Store, *sqlx.DB) {
+	t.Helper()
+	db := testdb.Open(t)
+	require.NoError(t, runner.Up(t.Context(), db, rulesmigrations.FS, runner.Options{
+		Context:   "rules",
+		TableName: "rules_goose_db_version",
+	}))
+	return NewStore(db), db
+}
+
+func TestHandleRefreshErr(t *testing.T) {
+	t.Parallel()
+	svc := NewService(NewStore(testdb.Open(t)), nil, nil, nil) // store is unused by handleRefreshErr; just satisfies the nil-store guard
+
+	// Live context: the error is transient, so log + continue (stop=false).
+	assert.False(t, svc.handleRefreshErr(context.Background(), "version poll", errors.New("boom")),
+		"a transient error under a live context must not stop the loop")
+
+	// Cancelled context: shutdown raced the poll, so stop silently (stop=true, no WARN).
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	assert.True(t, svc.handleRefreshErr(ctx, "reload", context.Canceled),
+		"a cancelled context must stop the loop")
+}
+
+func TestRefreshTick(t *testing.T) {
+	t.Parallel()
+	store, _ := newInternalStore(t)
+	svc := NewService(store, nil, nil, nil)
+	require.NoError(t, svc.Reload(t.Context()))
+
+	// Stored version matches the loaded snapshot: nothing to do, keep looping.
+	assert.False(t, svc.refreshTick(t.Context()), "an unchanged version must not stop the loop")
+
+	// Cancelled context makes store.Version(ctx) return a cancellation error, so the tick stops the loop.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	assert.True(t, svc.refreshTick(ctx), "a cancelled context during the poll must stop the loop")
+}

--- a/server/rules/internal/detectionconfig/refresh_internal_test.go
+++ b/server/rules/internal/detectionconfig/refresh_internal_test.go
@@ -1,8 +1,11 @@
 package detectionconfig
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"log/slog"
+	"strings"
 	"testing"
 
 	"github.com/jmoiron/sqlx"
@@ -29,18 +32,22 @@ func newInternalStore(t *testing.T) (*Store, *sqlx.DB) {
 
 func TestHandleRefreshErr(t *testing.T) {
 	t.Parallel()
-	svc := NewService(NewStore(testdb.Open(t)), nil, nil, nil) // store is unused by handleRefreshErr; just satisfies the nil-store guard
 	cases := []struct {
 		name     string
 		cancel   bool // cancel the context before the call
 		wantStop bool
+		wantLog  bool // a WARN is emitted only for a transient (non-cancelled) error
 	}{
-		{"live context logs and continues", false, false},
-		{"cancelled context stops silently", true, true},
+		{"live context logs and continues", false, false, true},
+		{"cancelled context stops silently", true, true, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
+			// A buffered logger keeps the expected WARN out of CI output (the service otherwise defaults to slog.Default ->
+			// stderr) and lets us assert the log-vs-silent contract directly.
+			var buf bytes.Buffer
+			svc := NewService(NewStore(testdb.Open(t)), nil, nil, slog.New(slog.NewTextHandler(&buf, nil)))
 			ctx := context.Background()
 			if tc.cancel {
 				var cancel context.CancelFunc
@@ -48,6 +55,7 @@ func TestHandleRefreshErr(t *testing.T) {
 				cancel()
 			}
 			assert.Equal(t, tc.wantStop, svc.handleRefreshErr(ctx, "version poll", errors.New("boom")))
+			assert.Equal(t, tc.wantLog, strings.Contains(buf.String(), "version poll failed"))
 		})
 	}
 }

--- a/server/rules/internal/detectionconfig/refresh_internal_test.go
+++ b/server/rules/internal/detectionconfig/refresh_internal_test.go
@@ -30,16 +30,26 @@ func newInternalStore(t *testing.T) (*Store, *sqlx.DB) {
 func TestHandleRefreshErr(t *testing.T) {
 	t.Parallel()
 	svc := NewService(NewStore(testdb.Open(t)), nil, nil, nil) // store is unused by handleRefreshErr; just satisfies the nil-store guard
-
-	// Live context: the error is transient, so log + continue (stop=false).
-	assert.False(t, svc.handleRefreshErr(context.Background(), "version poll", errors.New("boom")),
-		"a transient error under a live context must not stop the loop")
-
-	// Cancelled context: shutdown raced the poll, so stop silently (stop=true, no WARN).
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-	assert.True(t, svc.handleRefreshErr(ctx, "reload", context.Canceled),
-		"a cancelled context must stop the loop")
+	cases := []struct {
+		name     string
+		cancel   bool // cancel the context before the call
+		wantStop bool
+	}{
+		{"live context logs and continues", false, false},
+		{"cancelled context stops silently", true, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			if tc.cancel {
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithCancel(ctx)
+				cancel()
+			}
+			assert.Equal(t, tc.wantStop, svc.handleRefreshErr(ctx, "version poll", errors.New("boom")))
+		})
+	}
 }
 
 func TestRefreshTick(t *testing.T) {
@@ -47,12 +57,24 @@ func TestRefreshTick(t *testing.T) {
 	store, _ := newInternalStore(t)
 	svc := NewService(store, nil, nil, nil)
 	require.NoError(t, svc.Reload(t.Context()))
-
-	// Stored version matches the loaded snapshot: nothing to do, keep looping.
-	assert.False(t, svc.refreshTick(t.Context()), "an unchanged version must not stop the loop")
-
-	// Cancelled context makes store.Version(ctx) return a cancellation error, so the tick stops the loop.
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-	assert.True(t, svc.refreshTick(ctx), "a cancelled context during the poll must stop the loop")
+	cases := []struct {
+		name     string
+		cancel   bool // cancel the context, making store.Version(ctx) return a cancellation error
+		wantStop bool
+	}{
+		{"unchanged version keeps looping", false, false},
+		{"cancelled context during poll stops", true, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := t.Context()
+			if tc.cancel {
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithCancel(context.Background())
+				cancel()
+			}
+			assert.Equal(t, tc.wantStop, svc.refreshTick(ctx))
+		})
+	}
 }

--- a/server/rules/internal/detectionconfig/service.go
+++ b/server/rules/internal/detectionconfig/service.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"strconv"
 	"sync/atomic"
+	"time"
 
 	identityapi "github.com/fleetdm/edr/server/identity/api"
 	"github.com/fleetdm/edr/server/rules/api"
@@ -159,6 +160,33 @@ func (s *Service) Reload(ctx context.Context) error {
 	}
 	s.snap.Store(snap)
 	return nil
+}
+
+// RefreshLoop periodically converges this replica's snapshot with mutations made on OTHER replicas, which only bump the version +
+// reload their own snapshot (ADR-0010: the snapshot is a per-replica cache, so a peer's mutation is invisible here until we re-read).
+// Each tick reads only the cheap single-row version counter; a full LoadSnapshot runs only when the stored version differs from the
+// loaded snapshot's, so a steady state with no config churn is one indexed read per interval. Blocks until ctx is cancelled.
+func (s *Service) RefreshLoop(ctx context.Context, interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			current, err := s.store.Version(ctx)
+			if err != nil {
+				s.logger.WarnContext(ctx, "detectionconfig: version poll failed; retrying next tick", "err", err)
+				continue
+			}
+			if current == s.snap.Load().Version() {
+				continue
+			}
+			if err := s.Reload(ctx); err != nil {
+				s.logger.WarnContext(ctx, "detectionconfig: periodic reload failed; retrying next tick", "err", err)
+			}
+		}
+	}
 }
 
 // Excluded implements api.ExclusionResolver against the current snapshot.

--- a/server/rules/internal/detectionconfig/service.go
+++ b/server/rules/internal/detectionconfig/service.go
@@ -181,8 +181,8 @@ func (s *Service) RefreshLoop(ctx context.Context, interval time.Duration) {
 	}
 }
 
-// refreshTick performs one convergence poll: it reads the cheap version counter and reloads the snapshot only when the stored
-// version has advanced past the loaded one. It returns true when the loop should stop (the context was cancelled).
+// refreshTick performs one convergence poll: it reads the cheap version counter and reloads the snapshot when the stored version
+// differs from the loaded one (versions are monotonic, so a difference means a peer advanced it). Returns true to stop (ctx cancelled).
 func (s *Service) refreshTick(ctx context.Context) (stop bool) {
 	current, err := s.store.Version(ctx)
 	if err != nil {

--- a/server/rules/internal/detectionconfig/service.go
+++ b/server/rules/internal/detectionconfig/service.go
@@ -162,7 +162,7 @@ func (s *Service) Reload(ctx context.Context) error {
 	return nil
 }
 
-// RefreshLoop periodically converges this replica's snapshot with mutations made on OTHER replicas, which only bump the version +
+// RefreshLoop periodically converges this replica's snapshot with mutations made on OTHER replicas, which only bump the version and
 // reload their own snapshot (ADR-0010: the snapshot is a per-replica cache, so a peer's mutation is invisible here until we re-read).
 // Each tick reads only the cheap single-row version counter; a full LoadSnapshot runs only when the stored version differs from the
 // loaded snapshot's, so a steady state with no config churn is one indexed read per interval. Blocks until ctx is cancelled.
@@ -176,6 +176,9 @@ func (s *Service) RefreshLoop(ctx context.Context, interval time.Duration) {
 		case <-ticker.C:
 			current, err := s.store.Version(ctx)
 			if err != nil {
+				if ctx.Err() != nil {
+					return // shutdown raced the poll; the cancellation error is expected, not worth a WARN.
+				}
 				s.logger.WarnContext(ctx, "detectionconfig: version poll failed; retrying next tick", "err", err)
 				continue
 			}
@@ -183,6 +186,9 @@ func (s *Service) RefreshLoop(ctx context.Context, interval time.Duration) {
 				continue
 			}
 			if err := s.Reload(ctx); err != nil {
+				if ctx.Err() != nil {
+					return
+				}
 				s.logger.WarnContext(ctx, "detectionconfig: periodic reload failed; retrying next tick", "err", err)
 			}
 		}

--- a/server/rules/internal/detectionconfig/service.go
+++ b/server/rules/internal/detectionconfig/service.go
@@ -174,25 +174,37 @@ func (s *Service) RefreshLoop(ctx context.Context, interval time.Duration) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			current, err := s.store.Version(ctx)
-			if err != nil {
-				if ctx.Err() != nil {
-					return // shutdown raced the poll; the cancellation error is expected, not worth a WARN.
-				}
-				s.logger.WarnContext(ctx, "detectionconfig: version poll failed; retrying next tick", "err", err)
-				continue
-			}
-			if current == s.snap.Load().Version() {
-				continue
-			}
-			if err := s.Reload(ctx); err != nil {
-				if ctx.Err() != nil {
-					return
-				}
-				s.logger.WarnContext(ctx, "detectionconfig: periodic reload failed; retrying next tick", "err", err)
+			if s.refreshTick(ctx) {
+				return
 			}
 		}
 	}
+}
+
+// refreshTick performs one convergence poll: it reads the cheap version counter and reloads the snapshot only when the stored
+// version has advanced past the loaded one. It returns true when the loop should stop (the context was cancelled).
+func (s *Service) refreshTick(ctx context.Context) (stop bool) {
+	current, err := s.store.Version(ctx)
+	if err != nil {
+		return s.handleRefreshErr(ctx, "version poll", err)
+	}
+	if current == s.snap.Load().Version() {
+		return false
+	}
+	if err := s.Reload(ctx); err != nil {
+		return s.handleRefreshErr(ctx, "reload", err)
+	}
+	return false
+}
+
+// handleRefreshErr decides what a refresh error means: a cancelled context is shutdown racing the poll, so the error is expected and
+// the loop stops silently; otherwise it is transient (the next tick retries), so log a WARN and continue.
+func (s *Service) handleRefreshErr(ctx context.Context, op string, err error) (stop bool) {
+	if ctx.Err() != nil {
+		return true
+	}
+	s.logger.WarnContext(ctx, "detectionconfig: "+op+" failed; retrying next tick", "err", err)
+	return false
 }
 
 // Excluded implements api.ExclusionResolver against the current snapshot.

--- a/server/rules/internal/detectionconfig/service_test.go
+++ b/server/rules/internal/detectionconfig/service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -125,4 +126,35 @@ func TestService_NilAuditDropsRowWithoutPanic(t *testing.T) {
 func TestService_NewServicePanicsOnNilStore(t *testing.T) {
 	t.Parallel()
 	assert.Panics(t, func() { detectionconfig.NewService(nil, nil, nil, nil) })
+}
+
+// TestService_RefreshLoop_ConvergesAcrossReplicas models two replicas (separate Service+Store on one MySQL). A mutation on replica A
+// bumps the shared version counter but only reloads A's own snapshot; B must converge via its periodic RefreshLoop without a restart
+// or a mutation of its own. The exclusion is written as `/etc/sudoers` and checked against `/private/etc/sudoers`, so this also
+// exercises the macOS /private path aliasing end-to-end through the snapshot.
+// spec:server-detection-rules-engine/detection-configuration-converges-across-replicas/a-replica-adopts-a-configuration-change-made-on-another-replica
+func TestService_RefreshLoop_ConvergesAcrossReplicas(t *testing.T) {
+	t.Parallel()
+	storeA, db := openStore(t)
+	svcA := detectionconfig.NewService(storeA, nil, nil, nil)
+	require.NoError(t, svcA.Reload(t.Context()))
+
+	// Replica B: its own Service + Store over the same database, started from an empty (boot) snapshot.
+	svcB := detectionconfig.NewService(detectionconfig.NewStore(db), nil, nil, nil)
+	require.NoError(t, svcB.Reload(t.Context()))
+	require.False(t, svcB.Excluded("sudoers_tamper", api.ExclusionMatchPathGlob, "/private/etc/sudoers", "host-a"),
+		"baseline: B excludes nothing")
+
+	// t.Context() is cancelled at test cleanup, which stops the refresh-loop goroutine; no manual cancel needed.
+	go svcB.RefreshLoop(t.Context(), 20*time.Millisecond)
+
+	// Replica A creates the exclusion. This bumps detection_config_meta.version; B never sees the mutation directly.
+	_, err := svcA.CreateExclusion(t.Context(), &identityapi.Actor{UserID: 1}, "munki writes sudoers", detectionconfig.CreateExclusionInput{
+		RuleID: "sudoers_tamper", MatchType: api.ExclusionMatchPathGlob, Value: "/etc/sudoers",
+	})
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		return svcB.Excluded("sudoers_tamper", api.ExclusionMatchPathGlob, "/private/etc/sudoers", "host-a")
+	}, 3*time.Second, 20*time.Millisecond, "replica B should converge to the exclusion created on replica A via its refresh loop")
 }

--- a/server/rules/internal/detectionconfig/service_test.go
+++ b/server/rules/internal/detectionconfig/service_test.go
@@ -130,8 +130,8 @@ func TestService_NewServicePanicsOnNilStore(t *testing.T) {
 
 // TestService_RefreshLoop_ConvergesAcrossReplicas models two replicas (separate Service+Store on one MySQL). A mutation on replica A
 // bumps the shared version counter but only reloads A's own snapshot; B must converge via its periodic RefreshLoop without a restart
-// or a mutation of its own. The exclusion is written as `/etc/sudoers` and checked against `/private/etc/sudoers`, so this also
-// exercises the macOS /private path aliasing end-to-end through the snapshot.
+// or a mutation of its own. sudoers_tamper matches the WRITER process path, so the exclusion is a staged-installer writer under
+// `/var`; it is written in the bare form and checked against the `/private/var` form, exercising the macOS firmlink aliasing end-to-end.
 // spec:server-detection-rules-engine/detection-configuration-converges-across-replicas/a-replica-adopts-a-configuration-change-made-on-another-replica
 func TestService_RefreshLoop_ConvergesAcrossReplicas(t *testing.T) {
 	t.Parallel()
@@ -142,19 +142,19 @@ func TestService_RefreshLoop_ConvergesAcrossReplicas(t *testing.T) {
 	// Replica B: its own Service + Store over the same database, started from an empty (boot) snapshot.
 	svcB := detectionconfig.NewService(detectionconfig.NewStore(db), nil, nil, nil)
 	require.NoError(t, svcB.Reload(t.Context()))
-	require.False(t, svcB.Excluded("sudoers_tamper", api.ExclusionMatchPathGlob, "/private/etc/sudoers", "host-a"),
+	require.False(t, svcB.Excluded("sudoers_tamper", api.ExclusionMatchPathGlob, "/private/var/db/munki/installer", "host-a"),
 		"baseline: B excludes nothing")
 
 	// t.Context() is cancelled at test cleanup, which stops the refresh-loop goroutine; no manual cancel needed.
 	go svcB.RefreshLoop(t.Context(), 20*time.Millisecond)
 
 	// Replica A creates the exclusion. This bumps detection_config_meta.version; B never sees the mutation directly.
-	_, err := svcA.CreateExclusion(t.Context(), &identityapi.Actor{UserID: 1}, "munki writes sudoers", detectionconfig.CreateExclusionInput{
-		RuleID: "sudoers_tamper", MatchType: api.ExclusionMatchPathGlob, Value: "/etc/sudoers",
+	_, err := svcA.CreateExclusion(t.Context(), &identityapi.Actor{UserID: 1}, "munki staged installer writes sudoers", detectionconfig.CreateExclusionInput{
+		RuleID: "sudoers_tamper", MatchType: api.ExclusionMatchPathGlob, Value: "/var/db/munki/installer",
 	})
 	require.NoError(t, err)
 
 	require.Eventually(t, func() bool {
-		return svcB.Excluded("sudoers_tamper", api.ExclusionMatchPathGlob, "/private/etc/sudoers", "host-a")
+		return svcB.Excluded("sudoers_tamper", api.ExclusionMatchPathGlob, "/private/var/db/munki/installer", "host-a")
 	}, 3*time.Second, 20*time.Millisecond, "replica B should converge to the exclusion created on replica A via its refresh loop")
 }

--- a/server/rules/internal/detectionconfig/service_test.go
+++ b/server/rules/internal/detectionconfig/service_test.go
@@ -149,9 +149,11 @@ func TestService_RefreshLoop_ConvergesAcrossReplicas(t *testing.T) {
 	go svcB.RefreshLoop(t.Context(), 20*time.Millisecond)
 
 	// Replica A creates the exclusion. This bumps detection_config_meta.version; B never sees the mutation directly.
-	_, err := svcA.CreateExclusion(t.Context(), &identityapi.Actor{UserID: 1}, "munki staged installer writes sudoers", detectionconfig.CreateExclusionInput{
-		RuleID: "sudoers_tamper", MatchType: api.ExclusionMatchPathGlob, Value: "/var/db/munki/installer",
-	})
+	_, err := svcA.CreateExclusion(
+		t.Context(), &identityapi.Actor{UserID: 1}, "munki staged installer writes sudoers",
+		detectionconfig.CreateExclusionInput{
+			RuleID: "sudoers_tamper", MatchType: api.ExclusionMatchPathGlob, Value: "/var/db/munki/installer",
+		})
 	require.NoError(t, err)
 
 	require.Eventually(t, func() bool {


### PR DESCRIPTION
## What

Two self-contained follow-ups to the #459 detection-config surface, bundled into one PR (per the minimize-PRs ask; ~190 lines). **Closes #482.**

### 1. Path canonicalization for path-glob exclusions
`/etc`, `/var`, `/tmp` are macOS symlinks into `/private`, and ESF reports either form, so an exclusion written as `/etc/sudoers` silently failed to match an event reported as `/private/etc/sudoers` (and vice versa) — an operator's allowlist could appear to do nothing. The exclusion value is a glob (`*/claude/versions/*`) and can't be canonicalized, so `MatchExclusionValue` instead aliases the **concrete candidate** path across the firmlink boundary and tests the glob against both forms. A non-aliasable path costs one extra match at most. Centralized, so all four exclusion-aware rules get it.

### 2. Cross-replica snapshot refresh
The in-memory detection-config snapshot reloaded only on a local mutation, so under the multi-replica topology (ADR-0010) a replica that didn't handle the mutating request served stale config until its next local mutation or a restart. `detectionconfig.Service.RefreshLoop` polls the single-row `detection_config_meta.version` counter and reloads only when it has advanced; the `rules` context exposes `Run(ctx)`, started from `cmd/main` alongside the other contexts' background loops.

## Testing

- Matcher aliasing table cases (both directions, all three prefixes, non-aliasable path unaffected).
- A `sudoers_tamper` rule-layer regression pinning the aliasing where operators feel it.
- A two-replica convergence integration test (separate `Service`+`Store` over one DB) that also exercises the aliasing end-to-end through the snapshot.
- Per-rule suppression + disabled/monitor routing were already covered by the #476 rewire; not duplicated.
- OpenSpec delta (`detection-config-hardening`) + spectrace markers for the two new scenarios.

Verified locally: `go build ./...`, rules tests incl `-tags=integration`, `golangci-lint` (0 issues), `spectrace --strict` (100%), `openspec validate --strict`, dash/markdown lint.

## Scope notes

Moved out so #482 could close: the typed per-rule settings schema is now #484 (v0.6.0); host-group-scoped config folds into the editable-host-groups work (#320).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbyJ6gd2Af8KgrKzPkKsR8


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detection configuration now refreshes automatically across server replicas without restart, improving convergence over time.
  * File and directory exclusion matching now handles macOS `/private` symlink boundary aliases so excluded paths match reliably.
* **Documentation**
  * Updated server detection rules and detection-config hardening specs to define required `/private` behavior and replica convergence expectations.
* **Tests**
  * Added unit and integration coverage for `/private` aliasing and multi-replica convergence, plus refresh-loop error/cancellation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->