### PR TITLE
feat: kernel-cached app-control ALLOW (#209) + gzip telemetry upload (#405)

### DIFF
--- a/agent/uploader/uploader.go
+++ b/agent/uploader/uploader.go
@@ -4,6 +4,7 @@ package uploader
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -466,12 +467,37 @@ func (*requestEntityTooLargeError) Error() string {
 	return "server returned 413 (request entity too large)"
 }
 
+// gzipBytes returns body compressed with gzip at the default level. Default level (not BestCompression) is the deliberate
+// pick: the batch is tiny and CPU-bound work runs on the agent's drain tick, so the marginal ratio from a slower level is not
+// worth the cycles on the endpoint. A bytes.Buffer cannot fail to write, so the only error path is the writer Close flushing
+// the trailer, which is surfaced to the caller.
+func gzipBytes(body []byte) ([]byte, error) {
+	var buf bytes.Buffer
+	zw := gzip.NewWriter(&buf)
+	if _, err := zw.Write(body); err != nil {
+		return nil, fmt.Errorf("gzip write: %w", err)
+	}
+	if err := zw.Close(); err != nil {
+		return nil, fmt.Errorf("gzip close: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
 func (u *Uploader) doUpload(ctx context.Context, url string, body []byte) error {
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	// gzip the JSON batch on the wire. Event payloads are small, repetitive JSON (shared envelope keys, enum-like fields), so
+	// compression cuts upload bandwidth several-fold on the insert-heavy ingest path (#405). The raw `body` still drives the
+	// caller's 413 split-and-retry (which bisects by event count), so that recovery path is unaffected by the wire encoding.
+	compressed, err := gzipBytes(body)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(compressed))
 	if err != nil {
 		return err
 	}
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-Encoding", "gzip")
 	if u.cfg.TokenFn != nil {
 		if tok := u.cfg.TokenFn(); tok != "" {
 			req.Header.Set("Authorization", "Bearer "+tok)

--- a/agent/uploader/uploader_test.go
+++ b/agent/uploader/uploader_test.go
@@ -2,6 +2,7 @@ package uploader
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -56,7 +57,7 @@ func TestUploadBatch(t *testing.T) {
 			return
 		}
 
-		body, _ := io.ReadAll(r.Body)
+		body := readUploadBody(t, r)
 		if err := json.Unmarshal(body, &received); err != nil {
 			t.Errorf("unmarshal: %v", err)
 		}
@@ -267,11 +268,7 @@ func TestUpload_BoundedBatchSize(t *testing.T) {
 	// against the main-goroutine read after drainOnce. int64 avoids the gosec int->int32 overflow lint.
 	var receivedCount atomic.Int64
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		body, err := io.ReadAll(r.Body)
-		if err != nil {
-			t.Errorf("read body: %v", err)
-			return
-		}
+		body := readUploadBody(t, r)
 		var events []json.RawMessage
 		if err := json.Unmarshal(body, &events); err != nil {
 			t.Errorf("unmarshal: %v", err)
@@ -316,11 +313,7 @@ func TestUpload_DrainUntilCaughtUp(t *testing.T) {
 	// atomic because the httptest handler runs on its own goroutine; int64 avoids the gosec int->int32 lint.
 	var requests, events atomic.Int64
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		body, err := io.ReadAll(r.Body)
-		if err != nil {
-			t.Errorf("read body: %v", err)
-			return
-		}
+		body := readUploadBody(t, r)
 		var batch []json.RawMessage
 		if err := json.Unmarshal(body, &batch); err != nil {
 			t.Errorf("unmarshal: %v", err)
@@ -451,6 +444,71 @@ func TestUpload_401IsNonRetryableWithinCycle(t *testing.T) {
 	}
 }
 
+// readUploadBody returns the JSON the uploader posted, transparently gunzipping it when the agent set Content-Encoding: gzip
+// (the production path as of #405). Mirrors the server's readBodyWithCap so every test handler sees the raw JSON regardless of
+// the wire encoding. Fails the test on a read or decode error rather than returning one, so call sites stay assertion-focused.
+func readUploadBody(t *testing.T, r *http.Request) []byte {
+	t.Helper()
+	if strings.EqualFold(r.Header.Get("Content-Encoding"), "gzip") {
+		zr, err := gzip.NewReader(r.Body)
+		require.NoError(t, err, "request advertised Content-Encoding: gzip but the body is not a valid gzip stream")
+		defer func() { _ = zr.Close() }()
+		body, err := io.ReadAll(zr)
+		require.NoError(t, err, "gunzip request body")
+		return body
+	}
+	body, err := io.ReadAll(r.Body)
+	require.NoError(t, err, "read request body")
+	return body
+}
+
+// TestUpload_GzipWireShape pins the #405 contract: the uploader posts the batch gzip-compressed with Content-Encoding: gzip,
+// and the bytes decompress back to exactly the JSON array it marshalled. This is the wire-shape pin the broader behavioural
+// tests (which decode via readUploadBody) do not assert directly.
+//
+// spec:agent-event-uploader/bounded-request-size/the-upload-body-is-gzip-compressed
+func TestUpload_GzipWireShape(t *testing.T) {
+	q := openTestQueue(t)
+	ctx := t.Context()
+
+	const eventJSON = `{"event_id":"aaa","event_type":"exec"}`
+	require.NoError(t, q.Enqueue(ctx, []byte(eventJSON)))
+
+	// The handler only captures the header and the raw wire bytes (atomically, since httptest serves on its own goroutine);
+	// the gzip decode + assertions run in the test goroutine after the drain, so no require() lands inside the handler.
+	var sawGzipHeader atomic.Bool
+	var rawWire atomic.Value // []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawGzipHeader.Store(strings.EqualFold(r.Header.Get("Content-Encoding"), "gzip"))
+		body, _ := io.ReadAll(r.Body)
+		rawWire.Store(body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	cfg := DefaultConfig()
+	cfg.ServerURL = srv.URL
+	cfg.BatchSize = 10
+	u := New(q, cfg, nil, nil)
+	require.NoError(t, u.drainOnce(ctx))
+
+	assert.True(t, sawGzipHeader.Load(), "uploader must set Content-Encoding: gzip")
+	wire, _ := rawWire.Load().([]byte)
+	require.NotEmpty(t, wire, "server must have received a body")
+
+	zr, err := gzip.NewReader(bytes.NewReader(wire))
+	require.NoError(t, err, "the wire body must be a valid gzip stream")
+	decompressed, err := io.ReadAll(zr)
+	require.NoError(t, err)
+	require.NoError(t, zr.Close())
+	assert.NotEqual(t, wire, decompressed, "the wire body must actually be compressed, not raw JSON")
+
+	var arr []json.RawMessage
+	require.NoError(t, json.Unmarshal(decompressed, &arr), "decompressed body must be the JSON array the uploader marshalled")
+	require.Len(t, arr, 1)
+	assert.JSONEq(t, eventJSON, string(arr[0]))
+}
+
 func openTestQueue(t *testing.T) *queue.Queue {
 	t.Helper()
 	dbPath := filepath.Join(t.TempDir(), "test.db")
@@ -493,11 +551,7 @@ func tooLarge413Server(t *testing.T, maxEventsPerRequest int) (*httptest.Server,
 	t.Helper()
 	var success, rejected atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		body, err := io.ReadAll(r.Body)
-		if err != nil {
-			http.Error(w, "read body", http.StatusInternalServerError)
-			return
-		}
+		body := readUploadBody(t, r)
 		var arr []json.RawMessage
 		if err := json.Unmarshal(body, &arr); err != nil {
 			http.Error(w, "parse body", http.StatusBadRequest)
@@ -678,7 +732,7 @@ func TestUpload_413_TooManyEventsRoutedThroughSplit(t *testing.T) {
 
 	var success, rejected atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		body, _ := io.ReadAll(r.Body)
+		body := readUploadBody(t, r)
 		var arr []json.RawMessage
 		_ = json.Unmarshal(body, &arr)
 		if len(arr) > 2 {
@@ -727,7 +781,7 @@ func TestUpload_413_ContextCancelBetweenHalves(t *testing.T) {
 
 	var posts atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		body, _ := io.ReadAll(r.Body)
+		body := readUploadBody(t, r)
 		var arr []json.RawMessage
 		_ = json.Unmarshal(body, &arr)
 		n := posts.Add(1)
@@ -923,7 +977,7 @@ func TestUpload_PoisonBatchQuarantinesWhileSiblingDelivers(t *testing.T) {
 
 	var goodDelivered atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		body, _ := io.ReadAll(r.Body)
+		body := readUploadBody(t, r)
 		if bytes.Contains(body, []byte("poison")) {
 			w.WriteHeader(http.StatusBadRequest) // genuine poison-content 400
 			return

--- a/agent/uploader/uploader_test.go
+++ b/agent/uploader/uploader_test.go
@@ -480,7 +480,12 @@ func TestUpload_GzipWireShape(t *testing.T) {
 	var rawWire atomic.Value // []byte
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		sawGzipHeader.Store(strings.EqualFold(r.Header.Get("Content-Encoding"), "gzip"))
-		body, _ := io.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			// t.Errorf (not require) is safe from this handler goroutine; surface an I/O failure directly instead of letting it
+			// masquerade as an empty-body assertion failure downstream.
+			t.Errorf("read request body: %v", err)
+		}
 		rawWire.Store(body)
 		w.WriteHeader(http.StatusOK)
 	}))

--- a/extension/edr/Tests/EDRExtensionLogicTests/ApplicationControlStoreInvalidationTests.swift
+++ b/extension/edr/Tests/EDRExtensionLogicTests/ApplicationControlStoreInvalidationTests.swift
@@ -1,0 +1,62 @@
+// ApplicationControlStoreInvalidationTests pins the onSnapshotApplied hook (#209): the store invokes it once on every
+// accepted snapshot swap and never on a rejected (stale / duplicate) apply. ESFSubscriber wires that hook to
+// es_clear_cache(client), so the cached-ALLOW optimisation cannot outlive a rule change. The flush itself needs
+// EndpointSecurity and is exercised at the system / VM layer; this layer pins the trigger contract the store owns. Split into
+// its own file so each ApplicationControlStore suite stays under SwiftLint's per-type / per-file length budgets.
+
+import Foundation
+@testable import EDRExtensionLogic
+import XCTest
+
+final class ApplicationControlStoreInvalidationTests: AppControlStoreTestCase {
+    // The spec marker ID is a single unwrappable token; the resync suite disables the same rule for the same reason.
+    // swiftlint:disable:next line_length
+    // spec:extension-application-control/decided-allow-is-cached-and-flushed-on-snapshot-replacement/replacing-the-active-snapshot-flushes-the-kernel-auth-cache
+    func testHookFiresOnEveryAcceptedSwapAndNeverOnRejection() {
+        let store = makeStore()
+        var flushes = 0
+        store.onSnapshotApplied = { flushes += 1 }
+
+        // Initial accept: empty -> version 1. The swap happened, so the cache must be flushed.
+        store.apply(rawJSON: document(
+            policyID: 1, version: 1, rules: [RuleSpec(type: "BINARY", identifier: "a", ruleID: "a")], epoch: 1_000
+        ))
+        XCTAssertEqual(flushes, 1, "an accepted apply must flush the kernel cache")
+
+        // Version advance: accepted -> flush.
+        store.apply(rawJSON: document(
+            policyID: 1, version: 2, rules: [RuleSpec(type: "BINARY", identifier: "b", ruleID: "b")], epoch: 1_000
+        ))
+        XCTAssertEqual(flushes, 2, "a version advance flushes")
+
+        // Stale replay (older on both axes, same policy): rejected by the recency gate -> NO flush. A flush here would be
+        // wasteful but harmless; asserting its absence pins that the hook tracks acceptance, not every inbound message.
+        store.apply(rawJSON: document(
+            policyID: 1, version: 1, rules: [RuleSpec(type: "BINARY", identifier: "stale", ruleID: "stale")], epoch: 500
+        ))
+        XCTAssertEqual(flushes, 2, "a rejected stale apply must not flush")
+
+        // Epoch-only re-sync (version regressed, epoch advanced: the DB-restore signature): accepted -> flush. Broader than a
+        // bare version bump, which is why the hook fires on acceptance rather than only on a version advance.
+        store.apply(rawJSON: document(
+            policyID: 1, version: 1, rules: [RuleSpec(type: "BINARY", identifier: "resync", ruleID: "resync")], epoch: 2_000
+        ))
+        XCTAssertEqual(flushes, 3, "an epoch-axis re-sync flushes")
+
+        // Policy retarget (different policy_id): always accepted -> flush. A different ruleset is now active.
+        store.apply(rawJSON: document(
+            policyID: 2, version: 1, rules: [RuleSpec(type: "BINARY", identifier: "retarget", ruleID: "retarget")], epoch: 1
+        ))
+        XCTAssertEqual(flushes, 4, "a policy retarget flushes")
+    }
+
+    // A store with no hook wired (the no-enforcement embedding and any test that doesn't care) must apply snapshots normally:
+    // the optional hook is purely additive and its absence never breaks the gate.
+    func testApplyWithoutHookIsANoOp() {
+        let store = makeStore()
+        store.apply(rawJSON: document(
+            policyID: 1, version: 1, rules: [RuleSpec(type: "BINARY", identifier: "a", ruleID: "a")], epoch: 1_000
+        ))
+        XCTAssertEqual(store.currentSnapshot().policyVersion, 1, "apply must succeed with no onSnapshotApplied wired")
+    }
+}

--- a/extension/edr/Tests/EDRExtensionLogicTests/AuthResultCacheableTests.swift
+++ b/extension/edr/Tests/EDRExtensionLogicTests/AuthResultCacheableTests.swift
@@ -1,0 +1,36 @@
+// AuthResultCacheableTests pins authResultIsCacheable: the pure mapping from an AuthDecision to the kernel-cache flag the
+// AUTH_EXEC wire side passes to es_respond_auth_result (#209). The wire call lives in ESFSubscriber.swift (excluded from this
+// target because it imports EndpointSecurity), so this is the only layer that can pin the contract below the system / VM run.
+// A decided ALLOW is cacheable (the verdict is a function of the stable identity tuple + the active snapshot, and the store
+// flushes the kernel cache on every snapshot swap); undecided ALLOWs and every DENY are not.
+
+@testable import EDRExtensionLogic
+import XCTest
+
+final class AuthResultCacheableTests: XCTestCase {
+    // spec:extension-application-control/decided-allow-is-cached-and-flushed-on-snapshot-replacement/a-decided-allow-is-cached-at-the-kernel
+    func testDecidedAllowIsCacheable() {
+        XCTAssertTrue(authResultIsCacheable(.allow), "a decided ALLOW must be pinned into the kernel AUTH cache")
+    }
+
+    // spec:extension-application-control/decided-allow-is-cached-and-flushed-on-snapshot-replacement/an-undecided-allow-is-not-cached
+    func testUndecidedAllowIsNotCacheable() {
+        XCTAssertFalse(
+            authResultIsCacheable(.allowWithUndecidedAudit(reason: .deadline)),
+            "an undecided ALLOW must not be cached: the identity is not yet known, so caching would defeat the deferred fill"
+        )
+    }
+
+    // spec:extension-application-control/decided-allow-is-cached-and-flushed-on-snapshot-replacement/a-denial-is-not-cached
+    func testDenyIsNotCacheable() {
+        let rule = makeRule(ruleType: ApplicationControlRuleType.cdhash, identifier: "c0")
+        XCTAssertFalse(
+            authResultIsCacheable(.deny(rule: rule, matchedIdentifier: "c0")),
+            "a DENY must not be cached so removing the block rule takes effect on the next exec"
+        )
+        XCTAssertFalse(
+            authResultIsCacheable(.denyWithUndecidedAudit(reason: .deadline)),
+            "an undecided DENY (fail-closed posture) must not be cached either"
+        )
+    }
+}

--- a/extension/edr/Tests/EDRExtensionLogicTests/AuthResultCacheableTests.swift
+++ b/extension/edr/Tests/EDRExtensionLogicTests/AuthResultCacheableTests.swift
@@ -1,36 +1,59 @@
-// AuthResultCacheableTests pins authResultIsCacheable: the pure mapping from an AuthDecision to the kernel-cache flag the
-// AUTH_EXEC wire side passes to es_respond_auth_result (#209). The wire call lives in ESFSubscriber.swift (excluded from this
-// target because it imports EndpointSecurity), so this is the only layer that can pin the contract below the system / VM run.
-// A decided ALLOW is cacheable (the verdict is a function of the stable identity tuple + the active snapshot, and the store
-// flushes the kernel cache on every snapshot swap); undecided ALLOWs and every DENY are not.
+// AuthResultCacheableTests pins authResultIsCacheable: the pure mapping from an AuthDecision (plus the lazily-resolved
+// identity state) to the kernel-cache flag the AUTH_EXEC wire side passes to es_respond_auth_result (#209). The wire call
+// lives in ESFSubscriber.swift (excluded from this target because it imports EndpointSecurity), so this is the only layer
+// that can pin the contract below the system / VM run. A FULLY RESOLVED decided ALLOW is cacheable; a cold-miss ALLOW (the
+// BINARY hash timed out / could not be read, or a CERTIFICATE rule silently missed a not-yet-cached leaf cert) and every
+// DENY are not, so the kernel does not short-circuit the re-exec that would warm the cache and let the block rule fire.
 
 @testable import EDRExtensionLogic
 import XCTest
 
 final class AuthResultCacheableTests: XCTestCase {
     // spec:extension-application-control/decided-allow-is-cached-and-flushed-on-snapshot-replacement/a-decided-allow-is-cached-at-the-kernel
-    func testDecidedAllowIsCacheable() {
-        XCTAssertTrue(authResultIsCacheable(.allow), "a decided ALLOW must be pinned into the kernel AUTH cache")
+    func testFullyResolvedAllowIsCacheable() {
+        // Hash computed + no certificate rules: identity fully resolved, nothing left to warm.
+        XCTAssertTrue(authResultIsCacheable(
+            .allow, hashOutcome: .computed("abc"), leafCertResolved: false, snapshotHasCertificateRules: false))
+        // No BINARY rules (hash not needed) + certificate rules present but the leaf cert was resolved.
+        XCTAssertTrue(authResultIsCacheable(
+            .allow, hashOutcome: .notNeeded, leafCertResolved: true, snapshotHasCertificateRules: true))
+    }
+
+    // spec:extension-application-control/decided-allow-is-cached-and-flushed-on-snapshot-replacement/a-cold-miss-allow-is-not-cached
+    func testColdMissAllowIsNotCacheable() {
+        // BINARY hash unresolved (deadline / read failure under a fail-open posture): a warm re-hash could match a BINARY
+        // block rule, so do not let the kernel cache short-circuit it.
+        XCTAssertFalse(authResultIsCacheable(
+            .allow, hashOutcome: .deadlineExceeded, leafCertResolved: true, snapshotHasCertificateRules: false),
+            "a deadline-exceeded allow must not be cached")
+        XCTAssertFalse(authResultIsCacheable(
+            .allow, hashOutcome: .readFailed, leafCertResolved: true, snapshotHasCertificateRules: false),
+            "a read-failure allow must not be cached")
+        // Certificate rules present but the leaf cert was cold (silent miss): a warm cert could match a CERTIFICATE block
+        // rule, so do not cache.
+        XCTAssertFalse(authResultIsCacheable(
+            .allow, hashOutcome: .computed("abc"), leafCertResolved: false, snapshotHasCertificateRules: true),
+            "an allow that silently missed a cold certificate rule must not be cached")
     }
 
     // spec:extension-application-control/decided-allow-is-cached-and-flushed-on-snapshot-replacement/an-undecided-allow-is-not-cached
     func testUndecidedAllowIsNotCacheable() {
-        XCTAssertFalse(
-            authResultIsCacheable(.allowWithUndecidedAudit(reason: .deadline)),
-            "an undecided ALLOW must not be cached: the identity is not yet known, so caching would defeat the deferred fill"
-        )
+        XCTAssertFalse(authResultIsCacheable(
+            .allowWithUndecidedAudit(reason: .deadline),
+            hashOutcome: .deadlineExceeded, leafCertResolved: true, snapshotHasCertificateRules: false),
+            "an undecided ALLOW must not be cached: the identity is not yet known")
     }
 
     // spec:extension-application-control/decided-allow-is-cached-and-flushed-on-snapshot-replacement/a-denial-is-not-cached
     func testDenyIsNotCacheable() {
         let rule = makeRule(ruleType: ApplicationControlRuleType.cdhash, identifier: "c0")
-        XCTAssertFalse(
-            authResultIsCacheable(.deny(rule: rule, matchedIdentifier: "c0")),
-            "a DENY must not be cached so removing the block rule takes effect on the next exec"
-        )
-        XCTAssertFalse(
-            authResultIsCacheable(.denyWithUndecidedAudit(reason: .deadline)),
-            "an undecided DENY (fail-closed posture) must not be cached either"
-        )
+        XCTAssertFalse(authResultIsCacheable(
+            .deny(rule: rule, matchedIdentifier: "c0"),
+            hashOutcome: .computed("c0"), leafCertResolved: true, snapshotHasCertificateRules: false),
+            "a DENY must not be cached so removing the block rule takes effect on the next exec")
+        XCTAssertFalse(authResultIsCacheable(
+            .denyWithUndecidedAudit(reason: .deadline),
+            hashOutcome: .deadlineExceeded, leafCertResolved: true, snapshotHasCertificateRules: false),
+            "an undecided DENY (fail-closed posture) must not be cached either")
     }
 }

--- a/extension/edr/extension/ApplicationControlStore.swift
+++ b/extension/edr/extension/ApplicationControlStore.swift
@@ -161,6 +161,15 @@ final class ApplicationControlStore {
     /// and any non-production embedding that doesn't emit events leave it nil; the gate behaviour does not depend on it.
     var resyncReporter: ((ApplicationControlResyncPayload) -> Void)?
 
+    /// onSnapshotApplied is invoked once after apply() accepts and swaps in a new snapshot (any acceptance: version advance,
+    /// epoch-only re-sync, or a policy_id retarget), so the AUTH_EXEC fast paths that cache ALLOW results at the kernel
+    /// (#209) can flush the stale cache. ESFSubscriber wires this to es_clear_cache(client): without it, a binary that was
+    /// ALLOW-cached under the prior ruleset would never re-consult the handler, so a newly added block rule would never fire.
+    /// Fired on every accepted swap rather than only on a version bump because epoch re-sync and retarget also mutate the
+    /// active rules. Optional so the no-EndpointSecurity test target and any non-enforcing embedding leave it nil; the gate
+    /// behaviour does not depend on it. Invoked outside the lock so the flush never extends the critical section.
+    var onSnapshotApplied: (() -> Void)?
+
     /// defaultStoragePath is the on-disk policy file the production singleton uses. Extracted from the init's default
     /// argument so Sonar S1075 (hardcoded URI in source) lands on the named constant rather than the function signature;
     /// the constant is still in one place and the doc-comment on `.shared` continues to discourage production callers
@@ -257,6 +266,10 @@ final class ApplicationControlStore {
             return
         }
         reportResyncIfRegressed(snapshot: snapshot, prior: prior)
+        // Flush the kernel AUTH cache now that the active ruleset changed: any ALLOW the AUTH_EXEC handler pinned into the
+        // kernel cache under `prior` (#209) must be re-decided against the new snapshot so an added block rule takes effect on
+        // the next exec. Fired here, on every accepted swap, outside the lock.
+        onSnapshotApplied?()
         // Same OSLogMessage / line_length pattern as in loadFromDisk above:
         // build the message as a plain String, then interpolate once.
         let summary = "applied app control snapshot: " +

--- a/extension/edr/extension/AuthExecDecider.swift
+++ b/extension/edr/extension/AuthExecDecider.swift
@@ -97,18 +97,35 @@ enum AuthDecision: Equatable, Sendable {
 
 /// authResultIsCacheable reports whether a decided AUTH_EXEC verdict may be pinned into the kernel's per-(dev,inode,mtime)
 /// AUTH cache via `es_respond_auth_result(..., cache: true)`. Pure and ES-free so the no-EndpointSecurity test target can pin
-/// the contract (#209). Only a fully decided `.allow` is cacheable: its verdict is a function of the stable identity tuple and
-/// the active snapshot, and ApplicationControlStore flushes the kernel cache on every snapshot swap (es_clear_cache via
-/// onSnapshotApplied), so a later rule change still fires on the next exec. The undecided fallbacks are uncached because the
-/// identity is not yet known (a cached ALLOW would defeat the deferred fill); DENY is uncached so removing a block rule takes
-/// effect on the next exec rather than being pinned by the kernel cache.
-func authResultIsCacheable(_ decision: AuthDecision) -> Bool {
-    switch decision {
-    case .allow:
-        return true
-    case .allowWithUndecidedAudit, .deny, .denyWithUndecidedAudit:
+/// the contract (#209). ApplicationControlStore flushes the kernel cache on every snapshot swap (es_clear_cache via
+/// onSnapshotApplied), so caching is safe against a later rule CHANGE; the remaining hazard this guards is caching a verdict
+/// that a warm re-evaluation under the SAME snapshot could flip.
+///
+/// Only a FULLY RESOLVED `.allow` is cacheable. The `.allow` verdict is returned both for a clean walk that consulted the
+/// whole identity tuple AND for a fall-through where a lazily-resolved identity component was still cold: a deadline/read
+/// failure on the BINARY hash (under a fail-open posture), or a CERTIFICATE rule that silently missed because the leaf cert
+/// was not cached yet. Caching such a cold-miss allow would let the kernel short-circuit the very re-exec that would warm the
+/// cache and let the BINARY/CERTIFICATE block rule fire, so those stay uncached (issue #209). Concretely, `.allow` is
+/// cacheable only when the BINARY hash was computed or not needed AND (the snapshot has no CERTIFICATE rules OR the leaf cert
+/// was resolved). DENY and the undecided audit variants are never cached: DENY so removing a block rule takes effect on the
+/// next exec, undecided because the identity is not yet known.
+func authResultIsCacheable(
+    _ decision: AuthDecision,
+    hashOutcome: HashOutcome,
+    leafCertResolved: Bool,
+    snapshotHasCertificateRules: Bool
+) -> Bool {
+    guard case .allow = decision else {
         return false
     }
+    let hashResolved: Bool
+    switch hashOutcome {
+    case .computed, .notNeeded:
+        hashResolved = true
+    case .deadlineExceeded, .readFailed:
+        hashResolved = false
+    }
+    return hashResolved && (!snapshotHasCertificateRules || leafCertResolved)
 }
 
 /// decideAuthExec walks the precedence ladder against the active snapshot and returns the wire-level decision. Pure: no

--- a/extension/edr/extension/AuthExecDecider.swift
+++ b/extension/edr/extension/AuthExecDecider.swift
@@ -80,9 +80,10 @@ struct AuthTuple: Equatable, Sendable {
 /// of the kernel-cached platform-binary carve-out and the unconditional self-allow failsafe (both short-circuit before the
 /// decider runs).
 enum AuthDecision: Equatable, Sendable {
-    /// Allow the exec; do NOT pin the result into the kernel AUTH cache. Used when no rule matched and the hash either was not
-    /// needed (no BINARY rules) or returned a clean miss against the BINARY map. Uncached because a later rule update could
-    /// turn this exec into a block on the next run; a kernel-cached ALLOW would skip our handler entirely.
+    /// Allow the exec; the result IS pinned into the kernel AUTH cache (see authResultIsCacheable). Used when no rule matched
+    /// and the hash either was not needed (no BINARY rules) or returned a clean miss against the BINARY map. The verdict is a
+    /// pure function of the stable identity tuple and the active snapshot, and ApplicationControlStore flushes the kernel
+    /// cache (es_clear_cache) on every snapshot swap, so a later rule update still takes effect on the next exec (#209).
     case allow
     /// Allow the exec and emit an application_control_undecided event with verdict=allow and the given reason. Fires only
     /// under auditOnly posture when the hash is unavailable.
@@ -92,6 +93,22 @@ enum AuthDecision: Equatable, Sendable {
     /// Deny the exec and emit application_control_undecided with verdict=deny. Fires only under failClosed posture when the
     /// hash is unavailable. Separate from .deny because there is no actual matched rule, only the posture's verdict.
     case denyWithUndecidedAudit(reason: UndecidedReason)
+}
+
+/// authResultIsCacheable reports whether a decided AUTH_EXEC verdict may be pinned into the kernel's per-(dev,inode,mtime)
+/// AUTH cache via `es_respond_auth_result(..., cache: true)`. Pure and ES-free so the no-EndpointSecurity test target can pin
+/// the contract (#209). Only a fully decided `.allow` is cacheable: its verdict is a function of the stable identity tuple and
+/// the active snapshot, and ApplicationControlStore flushes the kernel cache on every snapshot swap (es_clear_cache via
+/// onSnapshotApplied), so a later rule change still fires on the next exec. The undecided fallbacks are uncached because the
+/// identity is not yet known (a cached ALLOW would defeat the deferred fill); DENY is uncached so removing a block rule takes
+/// effect on the next exec rather than being pinned by the kernel cache.
+func authResultIsCacheable(_ decision: AuthDecision) -> Bool {
+    switch decision {
+    case .allow:
+        return true
+    case .allowWithUndecidedAudit, .deny, .denyWithUndecidedAudit:
+        return false
+    }
 }
 
 /// decideAuthExec walks the precedence ladder against the active snapshot and returns the wire-level decision. Pure: no

--- a/extension/edr/extension/ESFSubscriber.swift
+++ b/extension/edr/extension/ESFSubscriber.swift
@@ -82,6 +82,19 @@ final class ESFSubscriber: Sendable {
         }
 
         self.client = rawClient
+
+        // Flush the kernel AUTH result cache whenever the application-control snapshot is replaced. The AUTH_EXEC handler
+        // pins decided ALLOWs into the kernel cache (#209) so a fork-exec storm of an allowed binary does not re-enter the
+        // handler; that optimisation is only correct if an updated ruleset invalidates those cached ALLOWs. es_clear_cache is
+        // the supported flush. [weak self] avoids a needless retain of the subscriber by the process-lifetime store singleton;
+        // the captured client pointer is valid for the rest of the process.
+        ApplicationControlStore.shared.onSnapshotApplied = { [weak self] in
+            guard let self, let client = self.client else { return }
+            let clearResult = es_clear_cache(client)
+            if clearResult != ES_CLEAR_CACHE_RESULT_SUCCESS {
+                logger.warning("es_clear_cache after snapshot apply returned \(clearResult.rawValue, privacy: .public)")
+            }
+        }
     }
 
     func start() {
@@ -182,7 +195,11 @@ final class ESFSubscriber: Sendable {
         // brick the EDR itself. Match BOTH team_id and the exhaustive Fleet bundle-id set; team_id alone would exempt every binary
         // ever signed by extensionTeamID, which is broader than intended.
         if teamID == extensionTeamID, fleetSelfAllowSigningIDs.contains(signingID) {
-            es_respond_auth_result(client, message, ES_AUTH_RESULT_ALLOW, false)
+            // cache:true is safe here: the answer is a function of the binary's intrinsic identity (extensionTeamID + a Fleet
+            // signing_id), which is stable for the lifetime of the binary on disk, and the kernel keys the AUTH cache on
+            // (dev,inode,mtime) so any binary swap forces a fresh decision. Caching elides the per-exec handler cost during a
+            // fork-exec storm of our own tools (#209).
+            es_respond_auth_result(client, message, ES_AUTH_RESULT_ALLOW, true)
             return
         }
 
@@ -253,12 +270,17 @@ final class ESFSubscriber: Sendable {
     /// emissions the decision implies. Extracted from handleAuthExec so the decision logic stays testable
     /// (AuthExecDeciderTests) and the wire dispatch stays one switch.
     private func dispatchAuthDecision(_ decision: AuthDecision, context: AuthDispatchContext) {
+        // A decided ALLOW is pinned into the kernel AUTH cache so a fork-exec storm of an allowed binary does not re-enter the
+        // handler; the undecided fallbacks and every DENY stay uncached. The flag is a pure function of the decision
+        // (authResultIsCacheable, unit-tested in the no-ES target) and the cache stays correct because the store flushes it on
+        // every snapshot swap (#209).
+        let cacheResult = authResultIsCacheable(decision)
         switch decision {
         case .allow:
-            es_respond_auth_result(client, context.message, ES_AUTH_RESULT_ALLOW, false)
+            es_respond_auth_result(client, context.message, ES_AUTH_RESULT_ALLOW, cacheResult)
         case .allowWithUndecidedAudit(let reason):
             logger.warning("AUTH_EXEC ALLOW (undecided) reason=\(reason.rawValue, privacy: .public)")
-            es_respond_auth_result(client, context.message, ES_AUTH_RESULT_ALLOW, false)
+            es_respond_auth_result(client, context.message, ES_AUTH_RESULT_ALLOW, cacheResult)
             emitUndecidedEvent(
                 target: context.target, fileStat: context.fileStat, verdict: "allow", reason: reason, snapshot: context.snapshot
             )

--- a/extension/edr/extension/ESFSubscriber.swift
+++ b/extension/edr/extension/ESFSubscriber.swift
@@ -255,8 +255,17 @@ final class ESFSubscriber: Sendable {
         }
 
         let decision = decideAuthExec(tuple: tuple, snapshot: snapshot, hashOutcome: hashOutcome)
+        // Cacheability is computed here, where the lazily-resolved identity state is still in scope: a decided ALLOW is only
+        // pinned into the kernel cache when the BINARY hash was resolved and the leaf cert was warm (or no cert rules exist),
+        // so a cold-miss allow is not cached and the next exec re-evaluates once the hash/cert fill (#209).
+        let cacheable = authResultIsCacheable(
+            decision,
+            hashOutcome: hashOutcome,
+            leafCertResolved: tuple.leafCertSHA256 != nil,
+            snapshotHasCertificateRules: !snapshot.certificateRules.isEmpty
+        )
         dispatchAuthDecision(decision, context: AuthDispatchContext(
-            message: message, target: target, fileStat: fileStat, snapshot: snapshot, path: path
+            message: message, target: target, fileStat: fileStat, snapshot: snapshot, path: path, cacheable: cacheable
         ))
     }
 
@@ -269,17 +278,18 @@ final class ESFSubscriber: Sendable {
         let fileStat: stat
         let snapshot: ApplicationControlSnapshot
         let path: String
+        let cacheable: Bool
     }
 
     /// dispatchAuthDecision turns the pure-logic AuthDecision into the wire-level kernel response plus any event/notification
     /// emissions the decision implies. Extracted from handleAuthExec so the decision logic stays testable
     /// (AuthExecDeciderTests) and the wire dispatch stays one switch.
     private func dispatchAuthDecision(_ decision: AuthDecision, context: AuthDispatchContext) {
-        // A decided ALLOW is pinned into the kernel AUTH cache so a fork-exec storm of an allowed binary does not re-enter the
-        // handler; the undecided fallbacks and every DENY stay uncached. The flag is a pure function of the decision
-        // (authResultIsCacheable, unit-tested in the no-ES target) and the cache stays correct because the store flushes it on
-        // every snapshot swap (#209).
-        let cacheResult = authResultIsCacheable(decision)
+        // A fully resolved decided ALLOW is pinned into the kernel AUTH cache so a fork-exec storm of an allowed binary does
+        // not re-enter the handler; the undecided fallbacks, cold-miss allows, and every DENY stay uncached. The flag was
+        // computed in decideAndRespond (authResultIsCacheable, unit-tested in the no-ES target) where the hash/cert resolution
+        // state was in scope; the cache stays correct because the store flushes it on every snapshot swap (#209).
+        let cacheResult = context.cacheable
         switch decision {
         case .allow:
             es_respond_auth_result(client, context.message, ES_AUTH_RESULT_ALLOW, cacheResult)

--- a/extension/edr/extension/ESFSubscriber.swift
+++ b/extension/edr/extension/ESFSubscriber.swift
@@ -87,7 +87,8 @@ final class ESFSubscriber: Sendable {
         // pins decided ALLOWs into the kernel cache (#209) so a fork-exec storm of an allowed binary does not re-enter the
         // handler; that optimisation is only correct if an updated ruleset invalidates those cached ALLOWs. es_clear_cache is
         // the supported flush. [weak self] avoids a needless retain of the subscriber by the process-lifetime store singleton;
-        // the captured client pointer is valid for the rest of the process.
+        // the closure reads self.client under a guard, and stop() clears this hook before es_delete_client, so it never runs
+        // against a freed or nil client.
         ApplicationControlStore.shared.onSnapshotApplied = { [weak self] in
             guard let self, let client = self.client else { return }
             let clearResult = es_clear_cache(client)

--- a/extension/edr/extension/ESFSubscriber.swift
+++ b/extension/edr/extension/ESFSubscriber.swift
@@ -138,12 +138,17 @@ final class ESFSubscriber: Sendable {
     }
 
     func stop() {
+        // Clear the snapshot-applied hook before tearing down the client: the closure calls es_clear_cache(client), so a
+        // snapshot apply arriving after es_delete_client would dereference a freed client (use-after-free). Clearing it first,
+        // and nil-ing client below, closes that window for tests and any future pre-exit shutdown.
+        ApplicationControlStore.shared.onSnapshotApplied = nil
         es_unsubscribe_all(client)
         // Drain in-flight AUTH decisions before deleting the client: each holds a retained message it must still respond to
         // and release, and es_respond on a deleted client is undefined. Operations are deadline-bounded, so this returns
         // promptly (#298).
         authDecisionQueue.waitUntilAllOperationsAreFinished()
         es_delete_client(client)
+        client = nil
     }
 
     private func handleMessage(_ message: UnsafePointer<es_message_t>) {

--- a/openspec/changes/exec-auth-cache-and-ingest-gzip/proposal.md
+++ b/openspec/changes/exec-auth-cache-and-ingest-gzip/proposal.md
@@ -1,0 +1,27 @@
+# Exec-auth result caching and gzip telemetry upload
+
+## Why
+
+Two independent efficiency wins that share a single macOS VM QA session, shipped together:
+
+- **#209**: the AUTH_EXEC handler answers every ALLOW with `cache: false`, so a fork-exec storm of an already-allowed binary (a compiler, linker, or interpreter re-execed in a tight loop) re-enters the handler every time: lock acquisition, snapshot read, and an optional hash lookup the kernel cache exists to elide. Santa caches ALLOW for stable identities. We do not.
+- **#405 (compression slice)**: the agent posts raw, uncompressed JSON batches to `POST /api/events`. Event payloads are highly compressible (~1.3 KB JSON each, repetitive keys), so gzip cuts upload bandwidth several-fold on the insert-heavy ingest path at pilot and fleet scale. This is the compression slice only; persistent-connection and transport modernization stay in #405.
+
+## What changes
+
+### #209 Kernel-cached ALLOW with snapshot-driven invalidation
+
+- A fully decided ALLOW (`AuthDecision.allow`) and the self-allow failsafe respond with `cache: true`; the result is a function of the binary's stable identity tuple and the active snapshot.
+- Undecided ALLOWs (cold cache / deadline / read failure) and every DENY stay `cache: false`.
+- The load-bearing piece: `ApplicationControlStore` flushes the kernel AUTH cache (`es_clear_cache`) on every accepted snapshot swap, so a cached ALLOW cannot outlive a rule change. Fired on acceptance (version advance, epoch re-sync, or policy retarget), not only on a version bump, because all three mutate the active ruleset.
+
+### #405 gzip request compression for `POST /api/events`
+
+- Agent gzips the request body and sets `Content-Encoding: gzip`. The raw JSON still flows through the 413 split-and-retry path (which splits by event count), so that recovery is unaffected.
+- Server decompresses when `Content-Encoding: gzip` is present and caps the DECOMPRESSED stream at the existing per-request byte cap, so a gzip bomb cannot expand past the limit. A corrupt gzip stream is rejected distinctly from an oversize body. The uncompressed path stays supported (the demo-seed tool and any non-gzip caller keep working); no agent/server version lockstep is required.
+
+## Impact
+
+- Affected specs: `extension-application-control` (ADDED requirement), `agent-event-uploader` (MODIFIED), `server-event-ingestion` (MODIFIED).
+- Affected code: `extension/edr/extension/{ESFSubscriber,ApplicationControlStore,AuthExecDecider}.swift`; `agent/uploader/uploader.go`; `server/detection/internal/intake/handler.go`.
+- No wire-struct or event-field change; no new struct, so no PBT round-trip obligation. Behavior verified by unit tests plus a macOS VM QA run (ESF cache behavior must be exercised live before RC).

--- a/openspec/changes/exec-auth-cache-and-ingest-gzip/specs/agent-event-uploader/spec.md
+++ b/openspec/changes/exec-auth-cache-and-ingest-gzip/specs/agent-event-uploader/spec.md
@@ -1,0 +1,20 @@
+# Agent Event Uploader Specification
+
+## MODIFIED Requirements
+
+### Requirement: Bounded request size
+
+The system MUST cap the size of each upload request and split larger queue contents across multiple requests so that any single HTTP request stays within the server's accepted body size and the network's practical MTU for streaming bodies. The system SHALL gzip-compress the request body and set `Content-Encoding: gzip`, because event batches are small, repetitive JSON that compress several-fold and the ingest path is bandwidth-bound; the uncompressed batch still drives the over-cap split-and-retry recovery, which bisects by event count and is unaffected by the wire encoding.
+
+#### Scenario: Queue holds more events than fit in one request
+
+- **GIVEN** the queue contains more events than the per-request batch limit
+- **WHEN** the uploader runs an upload cycle
+- **THEN** the uploader emits one or more requests of bounded size
+- **AND** events that did not fit in the first request remain queued for subsequent requests
+
+#### Scenario: The upload body is gzip-compressed
+
+- **GIVEN** the uploader has a batch to send
+- **WHEN** it posts the batch to the server
+- **THEN** the request carries `Content-Encoding: gzip` and the body is a gzip stream that decompresses to exactly the JSON array of events the uploader marshalled

--- a/openspec/changes/exec-auth-cache-and-ingest-gzip/specs/extension-application-control/spec.md
+++ b/openspec/changes/exec-auth-cache-and-ingest-gzip/specs/extension-application-control/spec.md
@@ -1,0 +1,32 @@
+# Extension Application Control Specification
+
+## ADDED Requirements
+
+### Requirement: Decided ALLOW is cached and flushed on snapshot replacement
+
+The extension SHALL respond to a fully decided ALLOW (the precedence walk returned no block and the verdict is allow) and to the self-allow failsafe with `es_respond_auth_result(..., cache: true)`, pinning the result into the kernel's per-`(dev, inode, mtime)` AUTH cache so subsequent execs of the same binary do not re-enter the handler. The extension SHALL respond to an undecided ALLOW (cold-cache, deadline-exceeded, or read-failure fallback) and to every DENY with `cache: false`, because an undecided ALLOW does not yet know the identity and a cached DENY would survive a block-rule removal. Whenever the active application-control snapshot is replaced (any accepted apply: a version advance, an epoch-axis re-sync, or a policy retarget), the extension SHALL flush the kernel AUTH cache via `es_clear_cache` so a cached ALLOW cannot outlive a rule change; a snapshot apply rejected by the recency gate SHALL NOT trigger a flush.
+
+#### Scenario: A decided allow is cached at the kernel
+
+- **GIVEN** the precedence walk against the active snapshot returns a decided allow
+- **WHEN** the extension forms the AUTH_EXEC response
+- **THEN** the cacheable flag for that response is true
+
+#### Scenario: An undecided allow is not cached
+
+- **GIVEN** the decision is an undecided allow (cold cache, deadline exceeded, or read failure under an allow-leaning posture)
+- **WHEN** the extension forms the AUTH_EXEC response
+- **THEN** the cacheable flag for that response is false
+
+#### Scenario: A denial is not cached
+
+- **GIVEN** the decision is a denial (a matched block rule or an undecided deny under fail-closed posture)
+- **WHEN** the extension forms the AUTH_EXEC response
+- **THEN** the cacheable flag for that response is false
+
+#### Scenario: Replacing the active snapshot flushes the kernel auth cache
+
+- **GIVEN** an active application-control snapshot and a wired cache-flush hook
+- **WHEN** a newer snapshot is accepted by the recency gate (version advance, epoch re-sync, or policy retarget)
+- **THEN** the kernel AUTH cache flush fires once per accepted swap
+- **AND** a stale snapshot rejected by the recency gate does not fire the flush

--- a/openspec/changes/exec-auth-cache-and-ingest-gzip/specs/extension-application-control/spec.md
+++ b/openspec/changes/exec-auth-cache-and-ingest-gzip/specs/extension-application-control/spec.md
@@ -4,13 +4,19 @@
 
 ### Requirement: Decided ALLOW is cached and flushed on snapshot replacement
 
-The extension SHALL respond to a fully decided ALLOW (the precedence walk returned no block and the verdict is allow) and to the self-allow failsafe with `es_respond_auth_result(..., cache: true)`, pinning the result into the kernel's per-`(dev, inode, mtime)` AUTH cache so subsequent execs of the same binary do not re-enter the handler. The extension SHALL respond to an undecided ALLOW (cold-cache, deadline-exceeded, or read-failure fallback) and to every DENY with `cache: false`, because an undecided ALLOW does not yet know the identity and a cached DENY would survive a block-rule removal. Whenever the active application-control snapshot is replaced (any accepted apply: a version advance, an epoch-axis re-sync, or a policy retarget), the extension SHALL flush the kernel AUTH cache via `es_clear_cache` so a cached ALLOW cannot outlive a rule change; a snapshot apply rejected by the recency gate SHALL NOT trigger a flush.
+The extension SHALL respond to a FULLY RESOLVED decided ALLOW and to the self-allow failsafe with `es_respond_auth_result(..., cache: true)`, pinning the result into the kernel's per-`(dev, inode, mtime)` AUTH cache so subsequent execs of the same binary do not re-enter the handler. An allow is fully resolved only when every lazily-resolved identity component the active snapshot could consult was available at decision time: the BINARY hash was computed (or not needed because the snapshot has no BINARY rules), AND either the snapshot has no CERTIFICATE rules or the leaf certificate was resolved. The extension SHALL respond with `cache: false` to a cold-miss ALLOW (a BINARY hash that timed out or could not be read under a fail-open posture, or a CERTIFICATE rule that silently missed a not-yet-cached leaf certificate), to an undecided ALLOW, and to every DENY: a cold-miss ALLOW must let the next exec re-evaluate once the hash or certificate warms so a block rule can still fire, an undecided ALLOW does not yet know the identity, and a cached DENY would survive a block-rule removal. Whenever the active application-control snapshot is replaced (any accepted apply: a version advance, an epoch-axis re-sync, or a policy retarget), the extension SHALL flush the kernel AUTH cache via `es_clear_cache` so a cached ALLOW cannot outlive a rule change; a snapshot apply rejected by the recency gate SHALL NOT trigger a flush.
 
 #### Scenario: A decided allow is cached at the kernel
 
-- **GIVEN** the precedence walk against the active snapshot returns a decided allow
+- **GIVEN** a decided allow whose identity was fully resolved (BINARY hash computed or not needed, and the leaf certificate resolved or no CERTIFICATE rules present)
 - **WHEN** the extension forms the AUTH_EXEC response
 - **THEN** the cacheable flag for that response is true
+
+#### Scenario: A cold-miss allow is not cached
+
+- **GIVEN** an allow reached while a lazily-resolved identity component was still cold (the BINARY hash timed out or could not be read, or a CERTIFICATE rule silently missed a not-yet-cached leaf certificate)
+- **WHEN** the extension forms the AUTH_EXEC response
+- **THEN** the cacheable flag for that response is false, so the next exec re-evaluates once the hash or certificate warms
 
 #### Scenario: An undecided allow is not cached
 

--- a/openspec/changes/exec-auth-cache-and-ingest-gzip/specs/server-event-ingestion/spec.md
+++ b/openspec/changes/exec-auth-cache-and-ingest-gzip/specs/server-event-ingestion/spec.md
@@ -1,0 +1,61 @@
+# Server Event Ingestion Specification
+
+## MODIFIED Requirements
+
+### Requirement: Authenticated batch event submission
+
+The system SHALL expose `POST /api/events` that accepts a JSON array of event envelopes from an enrolled agent. The caller MUST present a per-host bearer token in the `Authorization` header; the system MUST reject requests whose token does not resolve to an enrolled host. When the request carries `Content-Encoding: gzip` the system SHALL decompress the body before parsing; a request without that header is read as-is, so an uncompressed caller stays supported and no agent/server version lockstep is required.
+
+#### Scenario: A valid agent posts a batch
+
+- **GIVEN** an enrolled host with a valid bearer token
+- **WHEN** the agent submits a JSON array of well-formed event envelopes to `POST /api/events`
+- **THEN** the system responds with HTTP 200 and a JSON body reporting the number of events accepted
+- **AND** every submitted event is persisted before the response is returned
+
+#### Scenario: A request without a host token is rejected
+
+- **GIVEN** a client that omits or supplies an unrecognized bearer token
+- **WHEN** the client submits any payload to `POST /api/events`
+- **THEN** the system responds with HTTP 401 and does not persist any of the events
+
+#### Scenario: A gzip-encoded batch is accepted and persisted
+
+- **GIVEN** an enrolled host with a valid bearer token
+- **WHEN** the agent submits a well-formed batch gzip-compressed with `Content-Encoding: gzip`
+- **THEN** the system decompresses the body, responds with HTTP 200, and persists every event identically to the uncompressed path
+
+### Requirement: Body size limit
+
+The system SHALL cap the bytes it reads from the request body of `POST /api/events` at 10 MB. Bodies that exceed the cap MUST result in HTTP 413 with a typed `body_too_large` diagnostic, and no events from that batch are persisted. The 413 status (RFC 9110 §15.5.14) is the canonical "your body exceeded the limit" signal and matches the shape Elastic Fleet, Datadog, Splunk HEC, and CrowdStrike's ingestion endpoints all use; an agent that sees 413 SHOULD split larger telemetry into multiple batches under the cap rather than retry the same body.
+
+The system MUST enforce the cap before allocating a buffer for the body so a malicious or misconfigured caller cannot trigger an arbitrary-size allocation. When the request advertises `Content-Length` greater than 10 MB the system MUST respond with 413 without reading any of the body; when the request uses chunked transfer-encoding the system MUST enforce the cap via a streaming reader and respond with 413 as soon as the cap is crossed.
+
+When the request is `Content-Encoding: gzip`, the 10 MB cap SHALL apply to the DECOMPRESSED bytes: the system MUST bound the compressed input AND the decompressed output independently, so a small compressed body that expands past 10 MB (a decompression bomb) is rejected with HTTP 413 `body_too_large` rather than allocated in full. A request whose body is not a valid gzip stream (bad header, truncated, or corrupt) MUST be rejected with HTTP 400 and a typed `invalid_gzip` diagnostic, distinct from the 413 oversize signal, so the size-versus-malformed split stays honest.
+
+#### Scenario: An oversized request body is rejected
+
+- **GIVEN** an authenticated agent
+- **WHEN** the request body exceeds 10 MB
+- **THEN** the system responds with HTTP 413 and the body is `{"error":"body_too_large"}`
+- **AND** no events from that batch are persisted
+
+#### Scenario: A right-at-cap body is accepted
+
+- **GIVEN** an authenticated agent submitting a JSON array whose serialized length is at or below 10 MB
+- **WHEN** the batch is otherwise well-formed
+- **THEN** the system reads the entire body, validates and persists every event, and returns HTTP 200
+
+#### Scenario: A gzip decompression bomb is rejected
+
+- **GIVEN** an authenticated agent sending `Content-Encoding: gzip`
+- **WHEN** the compressed body is itself under the cap but decompresses to more than 10 MB
+- **THEN** the system responds with HTTP 413 `body_too_large` without allocating the full decompressed payload
+- **AND** no events from that batch are persisted
+
+#### Scenario: A malformed gzip body is rejected
+
+- **GIVEN** an authenticated agent sending `Content-Encoding: gzip`
+- **WHEN** the request body is not a valid gzip stream
+- **THEN** the system responds with HTTP 400 and a typed `invalid_gzip` diagnostic
+- **AND** no events from that body are persisted

--- a/openspec/changes/exec-auth-cache-and-ingest-gzip/tasks.md
+++ b/openspec/changes/exec-auth-cache-and-ingest-gzip/tasks.md
@@ -11,13 +11,13 @@
 
 ## #405 gzip request compression
 
-- [ ] Agent gzips the body + sets `Content-Encoding: gzip` in `uploader.doUpload`.
-- [ ] Server decompresses on `Content-Encoding: gzip`, caps the decompressed stream, rejects corrupt gzip distinctly; plaintext path preserved.
-- [ ] Unit tests: gzip accepted, plaintext accepted, decompression bomb -> 413, corrupt gzip -> error.
-- [ ] VM QA: agent uploads are gzip on the wire and ingest succeeds.
+- [x] Agent gzips the body + sets `Content-Encoding: gzip` in `uploader.doUpload`.
+- [x] Server decompresses on `Content-Encoding: gzip`, caps the decompressed stream, rejects corrupt gzip distinctly; plaintext path preserved.
+- [x] Unit tests: gzip accepted, plaintext accepted, decompression bomb -> 413, corrupt gzip -> error.
+- [x] VM QA: agent uploads are gzip on the wire and ingest succeeds (edr-dev, 2026-06-22: real agent end-to-end + curl A/B).
 
 ## Gates
 
-- [ ] `go test ./agent/uploader/... ./server/detection/...`
-- [ ] Swift logic tests (EDRExtensionLogicTests).
-- [ ] `task lint:go`, `task lint:dashes`, `openspec validate --all --strict`.
+- [x] `go test ./agent/uploader/... ./server/detection/...`
+- [x] Swift logic tests (EDRExtensionLogicTests).
+- [x] `task lint:go`, `task lint:dashes`, `openspec validate --all --strict`.

--- a/openspec/changes/exec-auth-cache-and-ingest-gzip/tasks.md
+++ b/openspec/changes/exec-auth-cache-and-ingest-gzip/tasks.md
@@ -1,0 +1,23 @@
+# Tasks
+
+## #209 Exec-auth result caching
+
+- [x] Add pure `authResultIsCacheable(AuthDecision) -> Bool` (decided ALLOW cacheable; undecided + DENY not).
+- [x] `dispatchAuthDecision` responds with the computed cache flag; self-allow failsafe responds `cache: true`.
+- [x] `ApplicationControlStore.onSnapshotApplied` hook fired on every accepted apply; wired to `es_clear_cache` in ESFSubscriber.
+- [x] Scrub the stale `.allow` doc comment that said the result is not cached.
+- [x] Unit tests: cacheability mapping + store flush-on-accept / no-flush-on-reject.
+- [ ] VM QA: tight-loop exec of an allowed binary shows far fewer handler entries; a policy push flushes the cache.
+
+## #405 gzip request compression
+
+- [ ] Agent gzips the body + sets `Content-Encoding: gzip` in `uploader.doUpload`.
+- [ ] Server decompresses on `Content-Encoding: gzip`, caps the decompressed stream, rejects corrupt gzip distinctly; plaintext path preserved.
+- [ ] Unit tests: gzip accepted, plaintext accepted, decompression bomb -> 413, corrupt gzip -> error.
+- [ ] VM QA: agent uploads are gzip on the wire and ingest succeeds.
+
+## Gates
+
+- [ ] `go test ./agent/uploader/... ./server/detection/...`
+- [ ] Swift logic tests (EDRExtensionLogicTests).
+- [ ] `task lint:go`, `task lint:dashes`, `openspec validate --all --strict`.

--- a/server/detection/internal/intake/handler.go
+++ b/server/detection/internal/intake/handler.go
@@ -2,6 +2,7 @@ package intake
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -9,6 +10,7 @@ import (
 	"log/slog"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/fleetdm/edr/server/detection/api"
@@ -292,24 +294,66 @@ func partitionHeartbeats(events []api.Event) (toStore []api.Event, heartbeats []
 //     json.Unmarshal and surface as `invalid_json`, hiding the real cause. MaxBytesReader's distinguished error is
 //     what makes the 413-vs-400 split honest.
 //
-// HTTP 413 (RFC 9110 §15.5.14) is the canonical status; matches Elastic Fleet, Datadog, Splunk HEC, CrowdStrike.
+// When the agent sends `Content-Encoding: gzip` (#405) the MaxBytesReader cap above bounds the COMPRESSED bytes, which a
+// decompression bomb can still expand past the cap; readGzipBodyWithCap therefore caps the DECOMPRESSED stream as a second,
+// independent stage. The uncompressed path is kept for non-gzip callers (the demo-seed tool, any client that does not
+// compress), so no agent/server version lockstep is required. HTTP 413 (RFC 9110 §15.5.14) is the canonical over-cap status;
+// matches Elastic Fleet, Datadog, Splunk HEC, CrowdStrike.
 func (h *Handler) readBodyWithCap(w http.ResponseWriter, r *http.Request) ([]byte, bool) {
 	ctx := r.Context()
 	if r.ContentLength > MaxIngestBodyBytes {
 		writeErr(ctx, h.logger, w, http.StatusRequestEntityTooLarge, "body_too_large")
 		return nil, false
 	}
+	// Cap the bytes off the wire first. For a gzip body this is the bomb's first line of defence; readGzipBodyWithCap adds
+	// the decompressed cap as the second.
 	r.Body = http.MaxBytesReader(w, r.Body, MaxIngestBodyBytes)
+
+	if strings.EqualFold(r.Header.Get("Content-Encoding"), "gzip") {
+		return h.readGzipBodyWithCap(w, r)
+	}
+
 	body, err := io.ReadAll(r.Body)
 	if err == nil {
 		return body, true
 	}
+	return h.writeBodyReadFailure(ctx, w, err, "read_body")
+}
+
+// readGzipBodyWithCap decodes a gzip-encoded request body and enforces the per-request cap on the DECOMPRESSED bytes. The
+// caller has already wrapped r.Body in a MaxBytesReader so the compressed input is bounded too; this guards the expansion a
+// small compressed body can produce (a decompression bomb). A malformed gzip stream (bad header or a truncated/corrupt body)
+// is reported as 400 invalid_gzip, distinct from 413 body_too_large, so the 413-vs-400 split stays honest.
+func (h *Handler) readGzipBodyWithCap(w http.ResponseWriter, r *http.Request) ([]byte, bool) {
+	ctx := r.Context()
+	zr, err := gzip.NewReader(r.Body)
+	if err != nil {
+		return h.writeBodyReadFailure(ctx, w, err, "invalid_gzip")
+	}
+	defer func() { _ = zr.Close() }()
+	// Read one byte past the cap: an exactly-at-cap decompressed body still succeeds, while an over-cap body is detected
+	// without allocating the whole oversize payload.
+	body, err := io.ReadAll(io.LimitReader(zr, MaxIngestBodyBytes+1))
+	if err != nil {
+		return h.writeBodyReadFailure(ctx, w, err, "invalid_gzip")
+	}
+	if len(body) > MaxIngestBodyBytes {
+		writeErr(ctx, h.logger, w, http.StatusRequestEntityTooLarge, "body_too_large")
+		return nil, false
+	}
+	return body, true
+}
+
+// writeBodyReadFailure maps a body-read error to the wire response and returns the (nil, false) the caller propagates. A
+// *http.MaxBytesError (the compressed-input cap was crossed mid-stream) is 413 body_too_large regardless of encoding; any
+// other error is the supplied 4xx errCode (`read_body` for a raw body, `invalid_gzip` for a malformed gzip stream).
+func (h *Handler) writeBodyReadFailure(ctx context.Context, w http.ResponseWriter, err error, malformedCode string) ([]byte, bool) {
 	var maxErr *http.MaxBytesError
 	if errors.As(err, &maxErr) {
 		writeErr(ctx, h.logger, w, http.StatusRequestEntityTooLarge, "body_too_large")
 		return nil, false
 	}
-	writeErr(ctx, h.logger, w, http.StatusBadRequest, "read_body")
+	writeErr(ctx, h.logger, w, http.StatusBadRequest, malformedCode)
 	return nil, false
 }
 

--- a/server/detection/internal/intake/handler_test.go
+++ b/server/detection/internal/intake/handler_test.go
@@ -1,12 +1,15 @@
 package intake
 
 import (
+	"bytes"
+	"compress/gzip"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/fleetdm/edr/server/detection/api"
+	endpointapi "github.com/fleetdm/edr/server/endpoint/api"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -158,5 +161,57 @@ func TestHandleReadyz_Draining(t *testing.T) {
 		}
 		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
 		assert.Equal(t, "draining", body.Status, "drain must take precedence over the DB check")
+	})
+}
+
+// gzipBytesForTest compresses b so the gzip ingest-decode paths can be exercised with a real gzip stream.
+func gzipBytesForTest(t *testing.T, b []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := gzip.NewWriter(&buf)
+	_, err := zw.Write(b)
+	require.NoError(t, err)
+	require.NoError(t, zw.Close())
+	return buf.Bytes()
+}
+
+// postGzipToIngest drives the ingest handler with a host_id already pinned on the context (as endpoint.HostToken would) and a
+// Content-Encoding: gzip request whose body is the supplied raw wire bytes. The store is nil: every case here is rejected by
+// readBodyWithCap before the handler reaches the store, so no MySQL is needed. Returns the recorder for status/code asserts.
+func postGzipToIngest(t *testing.T, wire []byte) *httptest.ResponseRecorder {
+	t.Helper()
+	h := New(nil, nil, BuildInfo{})
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/events", bytes.NewReader(wire))
+	req.Header.Set("Content-Encoding", "gzip")
+	req = req.WithContext(endpointapi.WithHostIDForTest(req.Context(), "host-a"))
+	rec := httptest.NewRecorder()
+	h.IngestHandler().ServeHTTP(rec, req)
+	return rec
+}
+
+// TestIngest_GzipDecodeRejections pins the two failure modes the gzip ingest path adds (#405): a decompression bomb (a small
+// compressed body that expands past the per-request cap) must be 413 body_too_large, and a body that is not a valid gzip
+// stream must be 400 invalid_gzip. Both are rejected before any event is parsed or stored.
+func TestIngest_GzipDecodeRejections(t *testing.T) {
+	t.Parallel()
+
+	// spec:server-event-ingestion/body-size-limit/a-gzip-decompression-bomb-is-rejected
+	t.Run("decompression bomb exceeds the decompressed cap", func(t *testing.T) {
+		t.Parallel()
+		// Over-cap payload of a single repeated byte compresses to a few KB: it slips past the Content-Length and wire-byte
+		// caps, so only the decompressed-stream cap can catch it.
+		bomb := gzipBytesForTest(t, bytes.Repeat([]byte("A"), MaxIngestBodyBytes+1024))
+		require.Less(t, len(bomb), MaxIngestBodyBytes, "the compressed bomb must itself be under the wire cap to test the decompressed cap")
+		rec := postGzipToIngest(t, bomb)
+		assert.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
+		assert.Contains(t, rec.Body.String(), "body_too_large")
+	})
+
+	// spec:server-event-ingestion/body-size-limit/a-malformed-gzip-body-is-rejected
+	t.Run("a body that is not a valid gzip stream is invalid_gzip", func(t *testing.T) {
+		t.Parallel()
+		rec := postGzipToIngest(t, []byte("this is plainly not a gzip stream"))
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+		assert.Contains(t, rec.Body.String(), "invalid_gzip")
 	})
 }

--- a/server/detection/internal/tests/integration_test.go
+++ b/server/detection/internal/tests/integration_test.go
@@ -10,6 +10,8 @@
 package tests
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -380,6 +382,42 @@ func TestIngest_PersistsEvents(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, hosts, 1)
 	assert.Equal(t, "host-a", hosts[0].HostID)
+	assert.Equal(t, int64(1), hosts[0].EventCount)
+}
+
+// spec:server-event-ingestion/authenticated-batch-event-submission/a-gzip-encoded-batch-is-accepted-and-persisted
+//
+// The agent gzips the batch with Content-Encoding: gzip (#405). The handler must decompress, accept, and persist it
+// identically to the uncompressed path (TestIngest_PersistsEvents above pins the plaintext side, which stays supported). End
+// to end through the real bootstrap + MySQL so the decompress -> parse -> store path is exercised whole.
+func TestIngest_GzipEncodedBatchPersists(t *testing.T) {
+	t.Parallel()
+	d := newDetection(t, detectionOpts{mode: bootstrap.ModeFull})
+	ctx := t.Context()
+
+	srv := httptest.NewServer(withHostID(d.Service().IngestHandler(), "host-b"))
+	t.Cleanup(srv.Close)
+
+	body := `[{"event_id":"g1","host_id":"host-b","timestamp_ns":2000,"event_type":"fork","payload":{"child_pid":7,"parent_pid":1}}]`
+	var buf bytes.Buffer
+	zw := gzip.NewWriter(&buf)
+	_, err := zw.Write([]byte(body))
+	require.NoError(t, err)
+	require.NoError(t, zw.Close())
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, srv.URL, bytes.NewReader(buf.Bytes()))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-Encoding", "gzip")
+	resp, err := srv.Client().Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	hosts, err := d.Service().ListHosts(ctx)
+	require.NoError(t, err)
+	require.Len(t, hosts, 1)
+	assert.Equal(t, "host-b", hosts[0].HostID)
 	assert.Equal(t, int64(1), hosts[0].EventCount)
 }
 


### PR DESCRIPTION
## Summary

Two independent efficiency wins that share one macOS VM QA session, shipped together (closes #209, closes #405).

### #209 Kernel-cached ALLOW with snapshot-driven invalidation (extension, Swift)

The AUTH_EXEC handler answered every ALLOW with `cache: false`, so a fork-exec storm of an already-allowed binary (a compiler/linker/interpreter re-execed in a tight loop) re-entered the handler every time: lock acquisition, snapshot read, optional hash lookup the kernel cache exists to elide. Santa caches ALLOW for stable identities; we did not.

- A fully decided `.allow` and the self-allow failsafe now respond `cache: true`; undecided ALLOWs (cold-cache / deadline / read-failure) and every DENY stay `cache: false`.
- The cache flag is a pure, ES-free `authResultIsCacheable(AuthDecision)` so the no-EndpointSecurity test target can pin it.
- Load-bearing correctness: `ApplicationControlStore` flushes the kernel AUTH cache (`es_clear_cache`) on **every accepted snapshot swap** via the new `onSnapshotApplied` hook, so a cached ALLOW cannot outlive a rule change. Fired on acceptance (version advance, epoch re-sync, or policy retarget), broader than the issue's "version advance" because all three mutate the active ruleset.

### #405 gzip request compression for `POST /api/events` (agent + server, Go)

Compression slice of #405. Persistent-connection / transport modernization stay in #405.

- Agent gzips each batch and sets `Content-Encoding: gzip`. Event JSON is small and repetitive, so this cuts upload bandwidth several-fold on the insert-heavy ingest path. The raw JSON still drives the agent's 413 split-and-retry (which bisects by event count), so that recovery is unaffected.
- Server decompresses when `Content-Encoding: gzip` is present and caps the **decompressed** stream at `MaxIngestBodyBytes`, so a small compressed body cannot expand past the cap (decompression bomb → 413 `body_too_large`). A malformed gzip stream is rejected as 400 `invalid_gzip`, distinct from the oversize signal.
- The plaintext path is preserved (the demo-seed tool and any non-gzip caller keep working), so no agent/server version lockstep is required.

## Spec

Three OpenSpec deltas under `openspec/changes/exec-auth-cache-and-ingest-gzip/`: `extension-application-control` (ADDED), `agent-event-uploader` (MODIFIED), `server-event-ingestion` (MODIFIED). New SHALL/MUST scenarios carry test markers (spectrace 100%).

## Testing

- `go test` (uploader wire-shape + intake bomb/corrupt rejections); the gzip batch persists end-to-end against real MySQL (integration).
- `swift test` (cacheability mapping + store flush-on-accept / no-flush-on-reject); extension target compiles via xcodebuild (the `es_clear_cache` wire path is real-typed).
- `task lint:go`, `lint:go:newcode`, `lint:dashes`, `swiftlint`, `openspec validate --all --strict`, `spectrace check` all green.

### Live VM QA (edr-dev, 2026-06-22)

**#405 passed end-to-end.** A real agent (fresh seeded queue, bypassing the broken edr-dev XPC) gzip-uploaded to a from-branch server; events persisted in MySQL. curl A/B on the wire:

| Case | Result |
|---|---|
| gzip + `Content-Encoding: gzip` | 200 `{"accepted":1}` |
| same gzip bytes, no header | 400 `invalid_json` (proves the body is genuinely compressed) |
| 11 MB → 10,720-byte bomb + header | 413 `body_too_large` |
| corrupt gzip + header | 400 `invalid_gzip` |

**#209 ESF cache QA is deferred to a live ES client** (edr-dev's agent↔extension XPC is broken). Tracked as section 7 of the v0.3.0 edr-qa QA issue (#450): reduced AUTH_EXEC handler entries under a fork-exec storm, self-allow/platform binaries still run, and the `es_clear_cache`-on-policy-push invalidation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Event telemetry uploads now use gzip compression for reduced bandwidth consumption
  * Fully decided allow authorization decisions are now cached in the kernel to improve performance
  * Kernel authorization cache is automatically flushed whenever application control policies are updated, ensuring stale cached decisions do not persist across ruleset changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->