### PR TITLE
docs(release): restructure checklist around RC loop + add verify-release skill

### DIFF
--- a/.claude/skills/verify-release/SKILL.md
+++ b/.claude/skills/verify-release/SKILL.md
@@ -64,10 +64,16 @@ cosign verify-blob \
   SHA256SUMS
 
 # 2. Only now use the trusted SHA256SUMS to checksum every other artifact.
-shasum -a 256 -c SHA256SUMS --ignore-missing
+#    No --ignore-missing: we downloaded the whole release, so every file listed
+#    in SHA256SUMS (pkg, both profiles, both SBOMs) MUST be present. Omitting
+#    the flag turns a not-downloaded or misnamed artifact into a hard FAILED
+#    instead of a silently skipped line. The extra files on disk (the
+#    .sigstore.json bundles and SHA256SUMS itself) are not listed in
+#    SHA256SUMS, so `-c` simply does not check them.
+shasum -a 256 -c SHA256SUMS
 ```
 
-Expect `Verified OK` for the bundle, then every `shasum` line `OK`. Any `FAILED` is a corrupted or tampered artifact: stop and report.
+Expect `Verified OK` for the bundle, then every `shasum` line `OK`. Any `FAILED` (bad hash) or a `No such file` / missing line is a corrupted, tampered, or absent artifact: stop and report.
 
 ## Step 3: verify the Sigstore bundle for each remaining blob artifact
 

--- a/.claude/skills/verify-release/SKILL.md
+++ b/.claude/skills/verify-release/SKILL.md
@@ -20,13 +20,15 @@ The final step of the release checklist: confirm a published GitHub Release (`vX
 - `cosign` v3+ (`brew install cosign`).
 - `shasum` and `pkgutil` / `xcrun` / `spctl` (stock macOS) for the pkg checks.
 
-Set the constants used throughout:
+Set the constants used throughout. `TAG` must already be set (see Inputs); the signing identity is pinned to THIS tag's `release.yml` run, not any `v*` tag, so an artifact signed for a different release cannot pass even if assets were swapped between releases:
 
 ```sh
 REPO=getvictor/fleet-edr
 IMAGE=ghcr.io/getvictor/fleet-edr-server
-IDENTITY='^https://github\.com/getvictor/fleet-edr/\.github/workflows/release\.yml@refs/tags/v'
 ISSUER='https://token.actions.githubusercontent.com'
+# Escape regex metacharacters in the tag (the dots), then pin the identity to exactly this tag.
+TAG_RE=$(printf '%s' "$TAG" | sed 's/[.[\*^$()+?{|]/\\&/g')
+IDENTITY="^https://github\.com/getvictor/fleet-edr/\.github/workflows/release\.yml@refs/tags/${TAG_RE}\$"
 ```
 
 ## Step 1: confirm every expected asset is present
@@ -46,27 +48,37 @@ gh release view "$TAG" --repo "$REPO" --json assets --jq '.assets[].name' | sort
 
 Flag any missing or unexpected asset. A missing `.sigstore.json` for any artifact, or a missing SBOM, is a release defect: stop and report it.
 
-## Step 2: download and verify checksums
+## Step 2: download, then establish trust in SHA256SUMS before using it
+
+Order matters: verify the signature on `SHA256SUMS` itself BEFORE trusting it to validate the other downloads, otherwise a tampered `SHA256SUMS` could report a false `OK`.
 
 ```sh
 workdir=$(mktemp -d) && cd "$workdir"
 gh release download "$TAG" --repo "$REPO"
+
+# 1. Trust SHA256SUMS via its own Sigstore bundle FIRST.
+cosign verify-blob \
+  --bundle SHA256SUMS.sigstore.json \
+  --certificate-identity-regexp "$IDENTITY" \
+  --certificate-oidc-issuer "$ISSUER" \
+  SHA256SUMS
+
+# 2. Only now use the trusted SHA256SUMS to checksum every other artifact.
 shasum -a 256 -c SHA256SUMS --ignore-missing
 ```
 
-Expect every line to print `OK`. Any `FAILED` is a corrupted or tampered artifact: stop and report.
+Expect `Verified OK` for the bundle, then every `shasum` line `OK`. Any `FAILED` is a corrupted or tampered artifact: stop and report.
 
-## Step 3: verify the Sigstore bundle for each blob artifact
+## Step 3: verify the Sigstore bundle for each remaining blob artifact
 
-The same identity/issuer constraints apply to every blob. Loop over the six artifacts:
+`SHA256SUMS` was already verified in step 2. The same identity/issuer constraints apply to every other blob; loop over the remaining five artifacts:
 
 ```sh
 for f in fleet-edr-"$TAG".pkg \
          edr-system-extension.mobileconfig \
          edr-tcc-fda.mobileconfig \
          fleet-edr-"$TAG"-sbom.spdx.json \
-         fleet-edr-"$TAG"-sbom.cdx.json \
-         SHA256SUMS; do
+         fleet-edr-"$TAG"-sbom.cdx.json; do
   echo "== $f =="
   cosign verify-blob \
     --bundle "${f}.sigstore.json" \
@@ -76,7 +88,7 @@ for f in fleet-edr-"$TAG".pkg \
 done
 ```
 
-Expect `Verified OK` for each. The certificate-identity binds the signature to the `release.yml` workflow run on a `refs/tags/v*` ref, so a stolen Developer ID cert alone cannot forge a passing artifact.
+Expect `Verified OK` for each. The certificate-identity binds the signature to this tag's `release.yml` workflow run, so a stolen Developer ID cert alone cannot forge a passing artifact.
 
 ## Step 4: verify the server image signature
 
@@ -88,13 +100,19 @@ cosign verify "$IMAGE:$TAG" \
   --certificate-oidc-issuer "$ISSUER"
 ```
 
-For a stable (non-`-rc`) tag, also confirm `$IMAGE:latest` resolves to the same digest as `$IMAGE:$TAG` (the workflow only advances `:latest` on stable tags):
+For a stable (non-`-rc`) tag, also confirm `$IMAGE:latest` resolves to the SAME digest as `$IMAGE:$TAG` (the workflow only advances `:latest` on stable tags). Capture both digests and compare them; do not just print them (`brew install crane` if needed):
 
 ```sh
-gh api "/users/getvictor/packages/container/fleet-edr-server/versions" --jq \
-  '.[] | select(.metadata.container.tags[]? == "latest") | .name' # digest carrying :latest
-crane digest "$IMAGE:$TAG" 2>/dev/null || cosign triangulate "$IMAGE:$TAG"
+latest_digest=$(crane digest "$IMAGE:latest")
+tag_digest=$(crane digest "$IMAGE:$TAG")
+if [ -n "$tag_digest" ] && [ "$latest_digest" = "$tag_digest" ]; then
+  echo "PASS: :latest matches $TAG ($tag_digest)"
+else
+  echo "FAIL: :latest=$latest_digest does not match $TAG=$tag_digest"
+fi
 ```
+
+Skip this comparison for an `-rc` tag: `:latest` legitimately points at the previous stable release.
 
 ## Step 5: verify build-provenance attestations
 

--- a/.claude/skills/verify-release/SKILL.md
+++ b/.claude/skills/verify-release/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: verify-release
+description: Verify a published Fleet EDR GitHub Release carries every expected artifact and that each one's signatures check out. Use after the release workflow finishes (or when the user asks to "verify the release", "check the release artifacts", "verify the signatures for vX.Y.Z").
+metadata:
+  author: fleet-edr
+  version: "1.0"
+---
+
+# Verify a published release
+
+The final step of the release checklist: confirm a published GitHub Release (`vX.Y.Z` or `vX.Y.Z-rc.N`) carries every artifact the release workflow is supposed to produce and that each artifact verifies against its checksum, its Sigstore bundle, and its build-provenance attestation. This is read-only verification of an already-published release; it signs nothing and changes nothing.
+
+## Inputs
+
+- `TAG`: the release tag to verify (for example `v0.2.0` or `v0.2.0-rc.1`). Ask the user if it is not supplied.
+
+## Prerequisites
+
+- `gh` authenticated against `getvictor/fleet-edr`.
+- `cosign` v3+ (`brew install cosign`).
+- `shasum` and `pkgutil` / `xcrun` / `spctl` (stock macOS) for the pkg checks.
+
+Set the constants used throughout:
+
+```sh
+REPO=getvictor/fleet-edr
+IMAGE=ghcr.io/getvictor/fleet-edr-server
+IDENTITY='^https://github\.com/getvictor/fleet-edr/\.github/workflows/release\.yml@refs/tags/v'
+ISSUER='https://token.actions.githubusercontent.com'
+```
+
+## Step 1: confirm every expected asset is present
+
+Pull the asset list for the tag and check it against what the workflow uploads. For a tag `vX.Y.Z` the release must carry these 12 assets (six artifacts, each with its `.sigstore.json` bundle):
+
+- `fleet-edr-<TAG>.pkg` (+ `.sigstore.json`)
+- `edr-system-extension.mobileconfig` (+ `.sigstore.json`)
+- `edr-tcc-fda.mobileconfig` (+ `.sigstore.json`)
+- `fleet-edr-<TAG>-sbom.spdx.json` (+ `.sigstore.json`)
+- `fleet-edr-<TAG>-sbom.cdx.json` (+ `.sigstore.json`)
+- `SHA256SUMS` (+ `.sigstore.json`)
+
+```sh
+gh release view "$TAG" --repo "$REPO" --json assets --jq '.assets[].name' | sort
+```
+
+Flag any missing or unexpected asset. A missing `.sigstore.json` for any artifact, or a missing SBOM, is a release defect: stop and report it.
+
+## Step 2: download and verify checksums
+
+```sh
+workdir=$(mktemp -d) && cd "$workdir"
+gh release download "$TAG" --repo "$REPO"
+shasum -a 256 -c SHA256SUMS --ignore-missing
+```
+
+Expect every line to print `OK`. Any `FAILED` is a corrupted or tampered artifact: stop and report.
+
+## Step 3: verify the Sigstore bundle for each blob artifact
+
+The same identity/issuer constraints apply to every blob. Loop over the six artifacts:
+
+```sh
+for f in fleet-edr-"$TAG".pkg \
+         edr-system-extension.mobileconfig \
+         edr-tcc-fda.mobileconfig \
+         fleet-edr-"$TAG"-sbom.spdx.json \
+         fleet-edr-"$TAG"-sbom.cdx.json \
+         SHA256SUMS; do
+  echo "== $f =="
+  cosign verify-blob \
+    --bundle "${f}.sigstore.json" \
+    --certificate-identity-regexp "$IDENTITY" \
+    --certificate-oidc-issuer "$ISSUER" \
+    "$f"
+done
+```
+
+Expect `Verified OK` for each. The certificate-identity binds the signature to the `release.yml` workflow run on a `refs/tags/v*` ref, so a stolen Developer ID cert alone cannot forge a passing artifact.
+
+## Step 4: verify the server image signature
+
+The image signature and its SBOM attestation are stored as OCI 1.1 referring artifacts (cosign v3), not as release assets:
+
+```sh
+cosign verify "$IMAGE:$TAG" \
+  --certificate-identity-regexp "$IDENTITY" \
+  --certificate-oidc-issuer "$ISSUER"
+```
+
+For a stable (non-`-rc`) tag, also confirm `$IMAGE:latest` resolves to the same digest as `$IMAGE:$TAG` (the workflow only advances `:latest` on stable tags):
+
+```sh
+gh api "/users/getvictor/packages/container/fleet-edr-server/versions" --jq \
+  '.[] | select(.metadata.container.tags[]? == "latest") | .name' # digest carrying :latest
+crane digest "$IMAGE:$TAG" 2>/dev/null || cosign triangulate "$IMAGE:$TAG"
+```
+
+## Step 5: verify build-provenance attestations
+
+The workflow attests the pkg, both profiles, both SBOMs, `SHA256SUMS`, and the image via `actions/attest-build-provenance`. Spot-check with the GitHub attestation verifier:
+
+```sh
+gh attestation verify fleet-edr-"$TAG".pkg --owner getvictor
+gh attestation verify oci://"$IMAGE:$TAG" --owner getvictor
+```
+
+Expect a verified provenance summary tying each artifact to the workflow run.
+
+## Step 6: macOS Gatekeeper checks on the pkg (optional but recommended for stable)
+
+Confirms the pkg is Apple-signed, notarized, and stapled, independent of Sigstore:
+
+```sh
+pkgutil --check-signature fleet-edr-"$TAG".pkg   # signed by Apple-issued Developer ID + notarized
+xcrun stapler validate fleet-edr-"$TAG".pkg      # stapled ticket present (works offline)
+spctl -a -v --type install fleet-edr-"$TAG".pkg  # Gatekeeper accepts: source=Notarized Developer ID
+```
+
+## Report
+
+Summarize as a PASS/FAIL table: asset completeness, checksums, each blob's Sigstore verification, the image signature (+ `:latest` digest match for stable), provenance attestations, and the Gatekeeper checks. Any failure means the release is not safe to announce: name the specific artifact and the failing check, and do not declare the release verified. Clean up the temp dir when done.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -1,6 +1,8 @@
 # Release checklist
 
-The steps to cut a tagged release (`vX.Y.Z`). The signed/notarized pkg, the mobileconfig profiles, the SBOMs, and the cosign attestations are produced automatically by `.github/workflows/release.yml` on the `v*` tag push; this checklist covers the human-ordered work that has to happen first, plus the OpenSpec archive step that the release gate enforces.
+The steps to cut a tagged release. The signed/notarized pkg, the mobileconfig profiles, the SBOMs, and the cosign attestations are produced automatically by `.github/workflows/release.yml` on a `v*` tag push; this checklist covers the human-ordered work that has to happen first, plus the validation gates that a release candidate must clear before it is promoted to a stable tag.
+
+The flow is built around a release-candidate (RC) loop: cut `vX.Y.Z-rc.N`, run the candidate-only validation against it, and only then promote to the stable `vX.Y.Z` tag. An RC tag is signed like a stable tag but does NOT advance the `:latest` server image (`docs/README.md`), so it is safe to validate against real infrastructure. If validation surfaces a blocker, fix it on `main` and cut `rc.N+1`; repeat until an RC is clean.
 
 ## 1. Archive all completed OpenSpec changes
 
@@ -10,29 +12,58 @@ On a release-prep branch off `main`:
 
 1. List the pending changes: `ls -1 openspec/changes/ | grep -v '^archive$'`.
 2. For each completed change, run `openspec archive <name> -y` (NO `--skip-specs`). This merges the delta into `openspec/specs/**` and moves the folder to `openspec/changes/archive/<date>-<name>/`. Use `--skip-specs` ONLY for a tooling/doc-only change that shipped no spec delta.
-3. If a merged change is genuinely deferred to a later release (incomplete, intentionally held), it must not ship its delta into the canonical specs yet. Decide explicitly: either finish + archive it, or back its delta out of this release. The gate (step 4) does not let an un-archived change ride silently into a release.
+3. If a merged change is genuinely deferred to a later release (incomplete, intentionally held), it must not ship its delta into the canonical specs yet. Decide explicitly: either finish + archive it, or back its delta out of this release. The release gate (`openspec-archived` in `release.yml`) does not let an un-archived change ride silently into a release.
 4. Verify the canonical tree is well-formed and fully traced after archiving:
    - `openspec validate --all --strict`
    - `go run ./tools/spectrace check --strict`
 5. Confirm nothing un-archived remains: `ls -1 openspec/changes/ | grep -v '^archive$'` prints nothing.
 
-Open the release-prep PR, get it reviewed (the archive is where editing `openspec/specs/**` is expected and legitimate, unlike on a feature branch), and merge it to `main` before tagging.
-
 > Note on removed requirements: a change that retires a requirement (a `## REMOVED Requirements` delta) does not need to be archived early to keep CI green. `spectrace check --strict` exempts canonical scenarios whose requirement an in-flight delta marks `## REMOVED`, so the requirement's tests can be deleted on the merging PR and the gate stays honest until this archive step finalizes the removal.
 
-## 2. Pre-tag verification
+## 2. Prepare and land the release-prep PR
 
-- `task lint:go`, `task lint:nilaway`, `task lint:dashes` clean.
-- `task test:go:server` and `task test:go:agent` green (CI mirrors these; a local run avoids a failed release build).
-- Agent/extension changes touching ESF, XPC, or the event wire format have been exercised on a live macOS VM since the last release (the system/VM layer; see `docs/testing-strategy.md`).
-- `CHANGELOG` / release notes drafted.
+On the same release-prep branch, alongside the archive from step 1:
 
-## 3. Tag and let the release workflow run
+1. Draft the changelog: move the `CHANGELOG.md` `[Unreleased]` items into a new versioned section (`## [X.Y.Z] (YYYY-MM-DD)`), grouped under Added / Changed / Fixed / Removed, and write the release-notes highlights.
+2. Pass the automated gates locally (they mirror CI; a local run avoids a failed release build):
+   - `task lint:go`, `task lint:nilaway`, `task lint:dashes` clean.
+   - `task test:go:server` and `task test:go:agent` green.
+   - The cross-context integration and browser-with-fake-agent suites green.
+3. Open the release-prep PR and get it reviewed. The archive is where editing `openspec/specs/**` is expected and legitimate, unlike on a feature branch, so this is the diff a reviewer scrutinizes.
+4. Merge to `main`. Everything downstream tags off the merged commit.
 
-1. Create the annotated tag on the merged release-prep commit: `git tag -a vX.Y.Z -m "vX.Y.Z"` and push it.
-2. The `v*` push triggers `.github/workflows/release.yml`. Its `openspec-archived` job runs first; every publishing job (`macos-pkg`, `docker-server`, `docker-demo-seed`) depends on it via `needs:`, so the release fails before any signing if `openspec/changes/` still holds a non-archive folder. That is the automated backstop for the "nothing un-archived remains" check (section 1, item 5).
-3. After the workflow succeeds, verify the GitHub Release carries the signed pkg, the two mobileconfig profiles, the SBOMs, the `SHA256SUMS`, and the cosign bundles; spot-check `cosign verify-attestation` per the signing docs.
+## 3. Cut a release candidate
 
-## 4. Dry-run option
+1. Create the annotated RC tag on the merged commit: `git tag -a vX.Y.Z-rc.N -m "vX.Y.Z-rc.N"` and push it.
+2. The `v*` push triggers `release.yml`. Its `openspec-archived` job runs first; every publishing job (`macos-pkg`, `docker-server`, `docker-demo-seed`) depends on it via `needs:`, so the release fails before any signing if `openspec/changes/` still holds a non-archive folder. That is the automated backstop for the "nothing un-archived remains" check (step 1, item 5).
+3. The RC is signed and published but does not advance `:latest`. Use it for the validation in steps 4 through 6.
+
+## 4. Run candidate-only validation against the RC
+
+These layers do not run per-PR (`docs/testing-strategy.md`); the RC is where they gate.
+
+- The macOS VM end-to-end run: real Swift extensions + real agent + real server on a SIP-enabled, Gatekeeper-enabled VM. Any agent/extension change touching ESF, XPC, or the event wire format MUST be exercised here since the last release.
+- The detection-efficacy run: the MITRE-aligned attack corpus, asserting each shipped rule fires within its SLA (detection rate gate) and the noise corpus stays clean (false-positive gate).
+
+## 5. Manual UI review
+
+Drive the built UI from the RC server image and walk the core operator journeys to catch rendering and interaction regressions the automated suites do not assert: sign-in, host list, process tree, alert detail, and policy / app-control editing.
+
+## 6. Deploy the RC to the dogfood server and enroll a real device
+
+Roll the candidate server image onto the live dogfood deployment, enroll an actual Mac, and confirm on real hardware: enrollment succeeds, telemetry flows, and at least one real detection fires end to end. This is the last gate that exercises the full product the way a pilot customer would.
+
+If any of steps 4 through 6 surfaces a blocker, fix it on `main` and return to step 3 with `rc.N+1`. Only a clean RC is promoted.
+
+## 7. Promote to a stable tag
+
+1. Create the annotated stable tag on the same commit the clean RC was built from: `git tag -a vX.Y.Z -m "vX.Y.Z"` and push it.
+2. `release.yml` re-runs and, because this is a non-`-rc` tag, advances `:latest` and produces the final signed pkg, the two mobileconfig profiles, the SBOMs, the `SHA256SUMS`, and the cosign bundles.
+
+## 8. Verify the published release
+
+Run the `verify-release` skill against the stable tag. It confirms the GitHub Release carries every expected artifact and that each one verifies: asset completeness, checksums, per-artifact Sigstore bundles, the server image signature (plus the `:latest` digest match for a stable tag), the build-provenance attestations, and the macOS Gatekeeper checks on the pkg. Any failure means the release is not safe to announce.
+
+## Dry-run option
 
 To rehearse the build/sign path from a topic branch without cutting a tag, trigger `release.yml` via `workflow_dispatch`; the run sets `--dry-run` and skips signing/notarization. The `openspec-archived` gate is advisory on a dry-run (it reports but does not fail), since a topic branch legitimately carries in-flight changes.


### PR DESCRIPTION
## Summary

Restructures the release process docs around a release-candidate (RC) loop and adds a skill for the final verification step.

- **`docs/release-checklist.md`** rebuilt around an RC spine: (1) archive OpenSpec, (2) prepare + land the release-prep PR (changelog + local gates folded into one step), (3) cut `vX.Y.Z-rc.N`, (4) candidate-only validation (macOS VM end-to-end + detection efficacy), (5) manual UI review, (6) dogfood deploy with a real enrolled device, (7) promote to the stable `vX.Y.Z` tag, (8) verify the published release. The fix-and-recut loop back to step 3 and the existing `workflow_dispatch` dry-run option are both retained.
- The RC loop, manual-UI-review, and dogfood-deploy gates were previously undocumented or scattered across `docs/testing-strategy.md`; they are now explicit release steps.
- **`.claude/skills/verify-release/SKILL.md`** new skill driving step 8 end to end: asset completeness, checksums, per-artifact Sigstore bundles, the server image signature (plus `:latest` digest match for stable), build-provenance attestations, and the macOS Gatekeeper checks, ending in a PASS/FAIL report.

## Notes

Docs-only change, no behavior change. The path is not one the OpenSpec sync gate watches, so no spec delta is required.

[no-behavior-change]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbyJ6gd2Af8KgrKzPkKsR8