### PR TITLE
Add workflow for demo nightly

### DIFF
--- a/.github/workflows/demo-nightly.yml
+++ b/.github/workflows/demo-nightly.yml
@@ -120,13 +120,18 @@ jobs:
           fi
 
       - name: Probe unauthenticated API + UI endpoints
-        # -k: the demo serves the self-signed localhost cert minted by cert-init.
+        # Validate against the demo's self-signed localhost cert (minted by the
+        # cert-init service into the shared tls volume) rather than disabling
+        # cert validation with `curl -k`: copy the cert off the running server
+        # container and pass it as the CA. The cert's SAN covers localhost, so
+        # the chain verifies and a broken/expired cert is itself caught.
         run: |
           set -euo pipefail
+          docker compose cp server:/tls/dev.crt ./demo-ca.crt
           check() {
             local path="$1" expected="$2"
             local code
-            code="$(curl -k -s -o /dev/null -w '%{http_code}' "${BASE_URL}${path}")"
+            code="$(curl --cacert ./demo-ca.crt -s -o /dev/null -w '%{http_code}' "${BASE_URL}${path}")"
             if [ "${code}" != "${expected}" ]; then
               echo "::error::GET ${path} returned ${code}, expected ${expected}"
               return 1
@@ -140,7 +145,7 @@ jobs:
           # The operator API must reject an unauthenticated caller (auth enforced).
           check /api/hosts 401
           # The UI shell is served and embedded (the SPA index.html).
-          body="$(curl -k -s "${BASE_URL}/ui/")"
+          body="$(curl --cacert ./demo-ca.crt -s "${BASE_URL}/ui/")"
           if ! printf '%s' "${body}" | grep -q '<div id="root">'; then
             echo "::error::/ui/ did not return the SPA shell (#root missing)"
             exit 1

--- a/.github/workflows/demo-nightly.yml
+++ b/.github/workflows/demo-nightly.yml
@@ -1,0 +1,189 @@
+name: Demo nightly
+
+# Nightly health check for the README's one-command, Mac-free demo
+# (docker-compose.demo.yml). On any failure it pings ntfy.sh with a link to the
+# run.
+#
+# It runs the demo in TWO modes (matrix), because they verify different things:
+#
+#   - released: `docker compose -f docker-compose.demo.yml up`, exactly what a
+#     reviewer following the README runs today. It pulls the PUBLISHED images
+#     (ghcr fleet-edr-server / fleet-edr-demo-seed at the compose default tag,
+#     `latest`, which release.yml points at the newest non-prerelease release),
+#     so this leg catches the published demo breaking (a bad image pull, infra
+#     drift, an expired dependency) independent of main, and always tracks the
+#     newest release without a workflow edit.
+#
+#   - source: layers docker-compose.demo.build.yml to build the server + seeder
+#     images FROM THE CURRENT CHECKOUT. This leg catches a change on main that
+#     breaks the demo (a failing migration, a detection rule that stops firing,
+#     an ingest wire-format change, a UI/SSO regression) BEFORE it ships in the
+#     next release.
+#
+# Both modes use `up --build`: in released mode no service declares a build
+# section, so --build is a no-op and the pinned images are pulled; in source
+# mode the override adds build sections and --build compiles them.
+#
+# Layers of verification per leg, cheapest first:
+#   1. the compose seeder exits 0 only after it enrolls hosts, replays the
+#      curated corpus through the real ingest + detection pipeline, and verifies
+#      processes + detection alerts + an app-control alert materialised;
+#   2. unauthenticated API/UI probes (/readyz, /livez, /api/openapi.yaml, /ui/);
+#   3. a Playwright smoke that signs in as the demo SSO user and asserts the
+#      seeded hosts + alerts surface through the UI and the operator API.
+
+on:
+  schedule:
+    # 08:27 UTC daily. Off the top of the hour to dodge the cron stampede.
+    - cron: "27 8 * * *"
+  workflow_dispatch:
+
+# Top-level token has no permissions; the job grants only what it needs
+# (satisfies Scorecard Token-Permissions / zizmor excessive-permissions).
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  demo-smoke:
+    name: Smoke-test the ${{ matrix.mode }} demo stack
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    strategy:
+      # Don't cancel the released leg when source fails (or vice versa); each is
+      # an independent signal we want to see.
+      fail-fast: false
+      matrix:
+        include:
+          - mode: released
+            # README's exact command: base file only. Empty EDR_VERSION falls
+            # through to the compose default tag (`${EDR_VERSION:-latest}`).
+            compose_file: "docker-compose.demo.yml"
+            edr_version: ""
+          - mode: source
+            # Layer the build override to compile the images from the checkout.
+            compose_file: "docker-compose.demo.yml:docker-compose.demo.build.yml"
+            edr_version: demo-nightly
+    env:
+      # COMPOSE_FILE (colon-delimited on Linux) is read by every `docker compose`
+      # below, so no -f flags are needed.
+      COMPOSE_FILE: ${{ matrix.compose_file }}
+      COMPOSE_PROJECT_NAME: fleet-edr-demo
+      EDR_VERSION: ${{ matrix.edr_version }}
+      # Used only by the build override (source mode) to stamp the built image.
+      EDR_COMMIT: ${{ github.sha }}
+      BASE_URL: https://localhost:8088
+      MODE: ${{ matrix.mode }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Pull released images fresh
+        # --ignore-buildable: in released mode no service is buildable, so this
+        # pulls the current registry `latest` for the EDR images (never a stale
+        # local layer); in source mode the EDR images ARE buildable and are
+        # skipped here, leaving only the digest-pinned mysql/dex to pull. Belt
+        # and suspenders on a hosted runner (clean cache), correct-by-design if a
+        # future runner reuses a layer cache.
+        run: docker compose pull --ignore-buildable
+
+      - name: Start the demo stack
+        # Detached: the seeder is a one-shot (restart: "no") that exits when done;
+        # the rest stay up for the probes below. --build is a no-op in released
+        # mode (no build sections) and compiles from source in source mode.
+        run: docker compose up -d --build
+
+      - name: Wait for the seeder to finish and assert it succeeded
+        # The seeder is the strongest end-to-end gate: it enrolls hosts, replays
+        # the corpus through the real pipeline, and exits non-zero if the process
+        # graph, detection alerts, or app-control alert fail to materialise.
+        # `docker wait` blocks until the one-shot container stops and prints its
+        # exit code (the job timeout bounds a hung seeder).
+        run: |
+          set -euo pipefail
+          seeder_cid="$(docker compose ps -aq seeder)"
+          if [ -z "${seeder_cid}" ]; then
+            echo "::error::seeder container was never created"
+            exit 1
+          fi
+          code="$(docker wait "${seeder_cid}")"
+          echo "seeder exited with code ${code}"
+          if [ "${code}" != "0" ]; then
+            echo "::error::demo seeder failed (exit ${code}); the demo pipeline did not materialise"
+            docker compose logs --no-color seeder || true
+            exit 1
+          fi
+
+      - name: Probe unauthenticated API + UI endpoints
+        # -k: the demo serves the self-signed localhost cert minted by cert-init.
+        run: |
+          set -euo pipefail
+          check() {
+            local path="$1" expected="$2"
+            local code
+            code="$(curl -k -s -o /dev/null -w '%{http_code}' "${BASE_URL}${path}")"
+            if [ "${code}" != "${expected}" ]; then
+              echo "::error::GET ${path} returned ${code}, expected ${expected}"
+              return 1
+            fi
+            echo "GET ${path} -> ${code} (ok)"
+          }
+          check /readyz 200
+          check /livez 200
+          check /api/openapi.yaml 200
+          check /ui/ 200
+          # The operator API must reject an unauthenticated caller (auth enforced).
+          check /api/hosts 401
+          # The UI shell is served and embedded (the SPA index.html).
+          body="$(curl -k -s "${BASE_URL}/ui/")"
+          if ! printf '%s' "${body}" | grep -q '<div id="root">'; then
+            echo "::error::/ui/ did not return the SPA shell (#root missing)"
+            exit 1
+          fi
+          echo "/ui/ served the SPA shell (ok)"
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: test/e2e/package-lock.json
+
+      - name: Install e2e dependencies
+        working-directory: test/e2e
+        run: npm ci --ignore-scripts
+
+      - name: Install Playwright Chromium
+        working-directory: test/e2e
+        run: npx playwright install --with-deps chromium
+
+      - name: Run the demo UI + API smoke test
+        working-directory: test/e2e
+        run: npm run demo
+
+      - name: Notify ntfy.sh on failure
+        if: failure()
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          printf '%s demo failed: %s\n' "${MODE}" "${RUN_URL}" \
+            | curl -s -H "Title: EDR demo failed (${MODE})" -d @- https://ntfy.sh/fleet-edr-demo
+
+      - name: Collect compose logs
+        if: always()
+        run: docker compose logs --no-color > demo-compose-logs.txt 2>&1 || true
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: always()
+        with:
+          name: demo-compose-logs-${{ matrix.mode }}
+          path: demo-compose-logs.txt
+          retention-days: 14
+
+      - name: Tear down the demo stack
+        if: always()
+        run: docker compose down -v || true

--- a/.github/workflows/demo-nightly.yml
+++ b/.github/workflows/demo-nightly.yml
@@ -153,17 +153,27 @@ jobs:
           cache: npm
           cache-dependency-path: test/e2e/package-lock.json
 
+      - uses: go-task/setup-task@01a4adf9db2d14c1de7a560f09170b6e0df736aa # v2.1.0
+        with:
+          version: 3.50.0
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Install e2e dependencies
         working-directory: test/e2e
         run: npm ci --ignore-scripts
 
       - name: Install Playwright Chromium
         working-directory: test/e2e
-        run: npx playwright install --with-deps chromium
+        # Invoke the locally installed Playwright binary, not `npx` (which can
+        # implicitly fetch executables from the registry and is flagged as a
+        # supply-chain surface, Sonar S6505). Mirrors the e2e job in test.yml.
+        run: ./node_modules/.bin/playwright install --with-deps chromium
 
       - name: Run the demo UI + API smoke test
-        working-directory: test/e2e
-        run: npm run demo
+        # Through the Taskfile entrypoint so the canonical command is the source
+        # of truth (matches the repo's task-centric convention), rather than
+        # invoking Playwright ad-hoc.
+        run: task test:e2e:demo
 
       - name: Notify ntfy.sh on failure
         if: failure()
@@ -174,11 +184,20 @@ jobs:
             | curl -s -H "Title: EDR demo failed (${MODE})" -d @- https://ntfy.sh/fleet-edr-demo
 
       - name: Collect compose logs
-        if: always()
-        run: docker compose logs --no-color > demo-compose-logs.txt 2>&1 || true
+        # Only on failure: the logs are a debugging aid for a broken run, and on
+        # first boot the server prints a break-glass bootstrap banner whose
+        # redemption URL carries a one-shot plaintext setup token. Uploading on
+        # every (mostly green) run would persist that credential in CI artifacts
+        # for no reason. The sed also redacts the token from the failure-case
+        # log so it never lands in the artifact even when we do collect it.
+        if: failure()
+        run: |
+          docker compose logs --no-color 2>&1 \
+            | sed -E 's#(/admin/break-glass/setup\?token=)[^[:space:]]+#\1REDACTED#g' \
+            > demo-compose-logs.txt || true
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        if: always()
+        if: failure()
         with:
           name: demo-compose-logs-${{ matrix.mode }}
           path: demo-compose-logs.txt

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -385,6 +385,18 @@ tasks:
     cmds:
       - npm test
 
+  test:e2e:demo:
+    desc: |
+      Run the Playwright demo smoke test (test/e2e/tests/demo/) against an
+      already-running demo stack. Unlike test:e2e it does NOT auto-start a
+      server or touch the qa dex: it drives the live, seeded demo at
+      https://localhost:8088 via playwright.demo.config.ts. Used by the
+      demo-nightly workflow. Pre-reqs: `docker compose -f docker-compose.demo.yml
+      up` (seeder finished) and a one-time `task test:e2e:install`.
+    dir: test/e2e
+    cmds:
+      - npm run demo
+
   test:e2e:coverage:
     desc: |
       Run the Playwright default-env suite (auth + qa: C/D/F.4 + A.5)

--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -9,8 +9,10 @@
 # pipeline so the UI shows a process graph, fired ATT&CK alerts, and an
 # application-control block. No Mac, MDM, or Apple entitlement required.
 #
-# Images are pinned to a released tag. To run from a local source build instead
-# (no published tag needed), layer the build override:
+# Images default to the `latest` released tag so the demo always shows the
+# newest published product; pin a specific release with EDR_VERSION=vX.Y.Z. To
+# run from a local source build instead (no published tag needed), layer the
+# build override:
 #
 #   docker compose -f docker-compose.demo.yml -f docker-compose.demo.build.yml up --build
 #
@@ -81,7 +83,7 @@ services:
       - tls:/tls
 
   server:
-    image: ghcr.io/getvictor/fleet-edr-server:${EDR_VERSION:-v0.2.1}
+    image: ghcr.io/getvictor/fleet-edr-server:${EDR_VERSION:-latest}
     restart: unless-stopped
     depends_on:
       mysql:
@@ -115,7 +117,7 @@ services:
       - tls:/tls:ro
 
   seeder:
-    image: ghcr.io/getvictor/fleet-edr-demo-seed:${EDR_VERSION:-v0.2.1}
+    image: ghcr.io/getvictor/fleet-edr-demo-seed:${EDR_VERSION:-latest}
     # One-shot: enrolls hosts, replays the corpus, verifies, then exits 0.
     restart: "no"
     depends_on:

--- a/docs/install-server.md
+++ b/docs/install-server.md
@@ -122,7 +122,7 @@ EDR_TLS_KEY_FILE=/tls/privkey.pem
 
 ```sh
 cat > .env <<'EOF'
-EDR_VERSION=v0.2.0
+EDR_VERSION=v0.2.1
 OTEL_EXPORTER_OTLP_ENDPOINT=
 EOF
 ```

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -25,12 +25,13 @@ On a release-prep branch off `main`:
 On the same release-prep branch, alongside the archive from step 1:
 
 1. Draft the changelog: move the `CHANGELOG.md` `[Unreleased]` items into a new versioned section (`## [X.Y.Z] (YYYY-MM-DD)`), grouped under Added / Changed / Fixed / Removed, and write the release-notes highlights.
-2. Pass the automated gates locally (they mirror CI; a local run avoids a failed release build):
+2. Bump the pinned `EDR_VERSION` references in the operator docs to the new tag so the copy-paste deploy snippets stay current: `README.md`, `docs/quickstart-vm.md`, `docs/install-server.md`, and the example in `bootstrap.sh`. These are intentionally pinned (a pilot must deploy a known signed tag), so they do not float and must be hand-bumped here. The demo (`docker-compose.demo.yml`) deliberately defaults to `latest` and is NOT bumped.
+3. Pass the automated gates locally (they mirror CI; a local run avoids a failed release build):
    - `task lint:go`, `task lint:nilaway`, `task lint:dashes` clean.
    - `task test:go:server` and `task test:go:agent` green.
    - The cross-context integration and browser-with-fake-agent suites green.
-3. Open the release-prep PR and get it reviewed. The archive is where editing `openspec/specs/**` is expected and legitimate, unlike on a feature branch, so this is the diff a reviewer scrutinizes.
-4. Merge to `main`. Everything downstream tags off the merged commit.
+4. Open the release-prep PR and get it reviewed. The archive is where editing `openspec/specs/**` is expected and legitimate, unlike on a feature branch, so this is the diff a reviewer scrutinizes.
+5. Merge to `main`. Everything downstream tags off the merged commit.
 
 ## 3. Cut a release candidate
 

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -13,6 +13,7 @@
     "qa:allowlist": "playwright test tests/qa/breakglass-ip-allowlist.spec.ts --workers=1",
     "qa:jit-off": "playwright test tests/qa/oidc-jit-disabled.spec.ts --workers=1",
     "qa:lifecycle": "playwright test tests/qa/session-lifecycle.spec.ts --workers=1",
+    "demo": "playwright test --config playwright.demo.config.ts",
     "coverage:lcov": "node scripts/coverage-to-lcov.mjs",
     "install:browsers": "playwright install --with-deps chromium",
     "report": "playwright show-report"

--- a/test/e2e/playwright.demo.config.ts
+++ b/test/e2e/playwright.demo.config.ts
@@ -1,0 +1,42 @@
+import { defineConfig, devices } from "@playwright/test";
+
+// Playwright config for the demo smoke test (tests/demo/). Unlike the main
+// playwright.config.ts, it does NOT manage a webServer: the demo stack is
+// already running via `docker compose -f docker-compose.demo.yml -f
+// docker-compose.demo.build.yml up`, so this config just points the browser at
+// the published https://localhost:8088 and runs one read-only journey against
+// the live, seeded stack. Used by the nightly demo workflow (demo-nightly.yml)
+// to catch main breaking the README's one-command demo.
+//
+// It deliberately shares nothing with the qa fixtures (fixtures/db.ts resets
+// the DB; the demo smoke must NOT touch the seeded data). Keep it self-contained.
+
+const PORT = 8088;
+
+export default defineConfig({
+  testDir: "./tests/demo",
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  // The demo stack is shared and seeded once; a retry re-runs the read-only
+  // journey, which is safe (it mutates nothing).
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  reporter: process.env.CI ? "github" : "list",
+  use: {
+    baseURL: `https://localhost:${PORT}`,
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+    // The demo stack's cert is the self-signed localhost cert minted by the
+    // compose cert-init service, so the browser must tolerate it (same dev-only
+    // relaxation as the main config; the demo README tells humans to click
+    // through the same warning).
+    ignoreHTTPSErrors: true,
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});

--- a/test/e2e/playwright.demo.config.ts
+++ b/test/e2e/playwright.demo.config.ts
@@ -1,42 +1,22 @@
-import { defineConfig, devices } from "@playwright/test";
+import { defineConfig } from "@playwright/test";
+import baseConfig from "./playwright.config";
 
-// Playwright config for the demo smoke test (tests/demo/). Unlike the main
-// playwright.config.ts, it does NOT manage a webServer: the demo stack is
-// already running via `docker compose -f docker-compose.demo.yml -f
-// docker-compose.demo.build.yml up`, so this config just points the browser at
-// the published https://localhost:8088 and runs one read-only journey against
-// the live, seeded stack. Used by the nightly demo workflow (demo-nightly.yml)
-// to catch main breaking the README's one-command demo.
+// Playwright config for the demo smoke test (tests/demo/). It reuses the main
+// playwright.config.ts wholesale (same baseURL https://localhost:8088, Chromium
+// project, single worker, CI-aware retry/reporter, ignoreHTTPSErrors for the
+// self-signed demo cert) and overrides only the two things that differ:
 //
-// It deliberately shares nothing with the qa fixtures (fixtures/db.ts resets
-// the DB; the demo smoke must NOT touch the seeded data). Keep it self-contained.
-
-const PORT = 8088;
-
+//   - testDir points at tests/demo/ instead of the full suite.
+//   - webServer is dropped: the demo stack is already running via
+//     `docker compose -f docker-compose.demo.yml up`, so this config must NOT
+//     auto-start `task dev:server:qa-oidc` (which would race the demo on :8088
+//     and point at the qa dex, not the demo dex).
+//
+// Used by the nightly demo workflow (demo-nightly.yml) to catch main breaking
+// the README's one-command demo. Spreading the base config keeps the two in
+// lockstep (and avoids duplicating the shared block, Sonar new-code duplication).
 export default defineConfig({
+  ...baseConfig,
   testDir: "./tests/demo",
-  fullyParallel: false,
-  forbidOnly: !!process.env.CI,
-  // The demo stack is shared and seeded once; a retry re-runs the read-only
-  // journey, which is safe (it mutates nothing).
-  retries: process.env.CI ? 1 : 0,
-  workers: 1,
-  reporter: process.env.CI ? "github" : "list",
-  use: {
-    baseURL: `https://localhost:${PORT}`,
-    trace: "retain-on-failure",
-    screenshot: "only-on-failure",
-    video: "retain-on-failure",
-    // The demo stack's cert is the self-signed localhost cert minted by the
-    // compose cert-init service, so the browser must tolerate it (same dev-only
-    // relaxation as the main config; the demo README tells humans to click
-    // through the same warning).
-    ignoreHTTPSErrors: true,
-  },
-  projects: [
-    {
-      name: "chromium",
-      use: { ...devices["Desktop Chrome"] },
-    },
-  ],
+  webServer: undefined,
 });

--- a/test/e2e/tests/demo/demo-smoke.spec.ts
+++ b/test/e2e/tests/demo/demo-smoke.spec.ts
@@ -1,0 +1,79 @@
+import { Page, test, expect } from "@playwright/test";
+
+// Demo smoke test for the README's one-command, Mac-free demo
+// (docker-compose.demo.yml). Run by the nightly demo workflow against a stack
+// built from the current source so a change on main that breaks the demo is
+// caught before a reviewer hits it.
+//
+// It does NOT reset or seed the database: the compose seeder already replayed
+// the curated corpus through the real ingest + detection pipeline before this
+// runs. This spec only signs in as the bundled demo SSO user and asserts the
+// seeded data surfaces through both the UI and the operator API.
+//
+// The expected shape is fixed by server/cmd/fleet-edr-demo-seed/hosts.go:
+//   - two hosts: alex-mbp.local, ci-builder.local
+//   - four detection-source alerts: credential_keychain_dump, dns_c2_beacon,
+//     sudoers_tamper, persistence_launchagent
+//   - one application_control-source alert (the app-control block)
+
+const DEMO_EMAIL = "demo@fleet-edr.local";
+const DEMO_PASSWORD = "demo"; // NOSONAR(typescript:S2068): checked-in demo credential, not a secret
+const DEMO_HOSTNAMES = ["alex-mbp.local", "ci-builder.local"];
+const DETECTION_RULE_IDS = ["credential_keychain_dump", "dns_c2_beacon", "sudoers_tamper", "persistence_launchagent"];
+
+// signInViaDex runs the dex SSO ceremony for the single demo account. Mirrors
+// the qa oidc-login helper but with the demo credentials and the demo issuer
+// host (dex.demo.localhost, which the browser resolves to loopback per RFC
+// 6761 and reaches via the published :5556 port).
+async function signInViaDex(page: Page): Promise<void> {
+  await page.goto("/ui/login");
+  await page.getByRole("button", { name: /continue with single sign-on/i }).click();
+  await page.waitForURL(/:5556\/dex/);
+
+  // Dex's login form labels aren't <label for="...">-associated, so address the
+  // inputs by name. On a match dex 302s back to /api/auth/callback?code=...
+  await page.locator('input[name="login"]').fill(DEMO_EMAIL);
+  await page.locator('input[name="password"]').fill(DEMO_PASSWORD);
+  await page.getByRole("button", { name: /login/i }).click();
+
+  // The EDR exchanges the code, mints a session, and redirects to /ui/.
+  await page.waitForURL(
+    (url) => url.host === "localhost:8088" && !url.pathname.includes("login") && !url.pathname.includes("break-glass"),
+    { timeout: 30_000 },
+  );
+}
+
+test.describe("demo stack smoke", () => {
+  test("demo SSO user signs in and sees the seeded hosts + alerts", async ({ page }) => {
+    await signInViaDex(page);
+
+    // UI check: the home view (HostList) renders both seeded hosts.
+    for (const hostname of DEMO_HOSTNAMES) {
+      await expect(page.getByText(hostname, { exact: false })).toBeVisible({ timeout: 15_000 });
+    }
+
+    // API check: the authenticated session (page.request shares the cookie jar)
+    // returns the seeded hosts.
+    const hostsResp = await page.request.get("/api/hosts");
+    expect(hostsResp.status()).toBe(200);
+    const hosts = (await hostsResp.json()) as Array<{ host_id: string; hostname: string }>;
+    expect(hosts).toHaveLength(2);
+    const hostnames = hosts.map((h) => h.hostname).sort();
+    expect(hostnames).toEqual([...DEMO_HOSTNAMES].sort());
+
+    // API check: alerts carry both a detection-source set (the four woven
+    // ATT&CK detections) and the application_control block.
+    const alertsResp = await page.request.get("/api/alerts");
+    expect(alertsResp.status()).toBe(200);
+    const alerts = (await alertsResp.json()) as Array<{ source: string; rule_id: string }>;
+
+    const sources = new Set(alerts.map((a) => a.source));
+    expect(sources).toContain("detection");
+    expect(sources).toContain("application_control");
+
+    const ruleIDs = new Set(alerts.map((a) => a.rule_id));
+    for (const ruleID of DETECTION_RULE_IDS) {
+      expect(ruleIDs, `expected a fired alert for rule ${ruleID}`).toContain(ruleID);
+    }
+  });
+});

--- a/test/e2e/tests/demo/demo-smoke.spec.ts
+++ b/test/e2e/tests/demo/demo-smoke.spec.ts
@@ -58,8 +58,8 @@ test.describe("demo stack smoke", () => {
     expect(hostsResp.status()).toBe(200);
     const hosts = (await hostsResp.json()) as Array<{ host_id: string; hostname: string }>;
     expect(hosts).toHaveLength(2);
-    const hostnames = hosts.map((h) => h.hostname).sort();
-    expect(hostnames).toEqual([...DEMO_HOSTNAMES].sort());
+    const hostnames = hosts.map((h) => h.hostname).sort((a, b) => a.localeCompare(b));
+    expect(hostnames).toEqual([...DEMO_HOSTNAMES].sort((a, b) => a.localeCompare(b)));
 
     // API check: alerts carry both a detection-source set (the four woven
     // ATT&CK detections) and the application_control block.

--- a/test/e2e/tests/demo/demo-smoke.spec.ts
+++ b/test/e2e/tests/demo/demo-smoke.spec.ts
@@ -49,7 +49,7 @@ test.describe("demo stack smoke", () => {
 
     // UI check: the home view (HostList) renders both seeded hosts.
     for (const hostname of DEMO_HOSTNAMES) {
-      await expect(page.getByText(hostname, { exact: false })).toBeVisible({ timeout: 15_000 });
+      await expect(page.getByText(hostname, { exact: true })).toBeVisible({ timeout: 15_000 });
     }
 
     // API check: the authenticated session (page.request shares the cookie jar)


### PR DESCRIPTION
<!-- Keep this short. Delete sections that do not apply. -->

## What & why



## Checklist

- [ ] **OpenSpec updated for behavior changes.** If this PR changes observable behavior (a detection rule, the event
      wire schema, persistence semantics, an API/wire shape, or an emitted event), `openspec/specs/**` is updated (and
      an `openspec/changes/` proposal added), with a `spec:<id>` test marker for any new/renamed scenario. Only if this
      PR changes NO observable behavior (a comment / refactor / gofmt / dep bump that happens to touch a scoped path)
      may you assert `no-behavior-change` (label or `[no-behavior-change]` in the title) to clear the OpenSpec-sync gate.
      That is an assertion a reviewer will check, not a way to skip the spec for a real behavior change.
- [ ] Tests added/updated for the change (unit / integration / efficacy / UI as applicable).
- [ ] Agent/extension change touching ESF, XPC, or the event wire format: exercised on a live macOS VM before RC
      (flagged below).

## VM / RC notes (if applicable)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automated nightly smoke tests for the demo environment, validating core functionality including authentication, host discovery, and alert sources.

* **Documentation**
  * Updated installation and release processes with refined version management guidance.

* **Tests**
  * Added end-to-end smoke test suite for demo stack validation with Dex SSO login flow verification and API endpoint checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->