### PR TITLE
Fixing usability issues with detection tuning

### DIFF
--- a/openspec/changes/detection-tuning-author-and-modes/proposal.md
+++ b/openspec/changes/detection-tuning-author-and-modes/proposal.md
@@ -1,0 +1,21 @@
+# Detection tuning: resolve exclusion author to an email, drop operator-selectable monitor mode
+
+## Why
+
+Manual QA of the Detection tuning admin surface surfaced two rough edges:
+
+- The exclusions table showed the raw principal identifier (`user:8`) in the "Created by" column. For a security-relevant suppression, an operator needs to see who created it; an opaque numeric id fails that accountability goal. The audit log already resolves a user id to an email at read time, so the pattern exists in the codebase.
+- The per-rule mode offered three choices (alert / monitor / disabled). `monitor` is implemented in the engine (it suppresses the alert and emits a structured log signal), but there is no UI or dashboard to review what fired in monitor mode, so it has no operator-facing value today. Offering it invites confusion. We drop it from the operator surface while keeping the engine's handling of any persisted `monitor` row intact, so this is reversible and needs no migration.
+
+## What changes
+
+- The detection-config exclusions list resolves each entry's `created_by` (`user:<id>`) to a display email at read time and returns it as a new `created_by_email` response field. Resolution goes through identity's `Service.GetUser` via a cross-context closure (same posture as detection's `UserExists` dep), is memoized per request, and degrades to an empty value (UI falls back to the raw identifier) when the user cannot be resolved.
+- The Detection tuning UI renders the resolved email in the Created by column, falling back to the raw identifier.
+- `monitor` is removed from the operator-selectable per-rule modes (alert / disabled only). A legacy persisted `monitor` row is still displayed so an operator can migrate it to alert or disabled, but monitor cannot be chosen anew. The `mode` ENUM, the server's acceptance of a `monitor` value, and the engine's monitor handling are unchanged, so existing rows keep working.
+- The rule-modes table also shows each rule's declared (default) severity next to the optional override, so the override's effect is legible.
+
+## Impact
+
+- Affected specs: `web-ui` (Detection configuration admin views).
+- Affected code: `server/rules/api` (new `CreatedByEmail` field), `server/rules/internal/operator` (resolver + list wiring), `server/rules/bootstrap` + `server/cmd/fleet-edr-server` (dep wiring), `ui/src/api.ts`, `ui/src/components/DetectionConfig/*`.
+- No database migration. No engine behavior change. The `created_by_email` field is additive and omitted when empty, so existing API consumers are unaffected.

--- a/openspec/changes/detection-tuning-author-and-modes/specs/web-ui/spec.md
+++ b/openspec/changes/detection-tuning-author-and-modes/specs/web-ui/spec.md
@@ -1,0 +1,42 @@
+# Web UI Specification (delta)
+
+## MODIFIED Requirements
+
+### Requirement: Detection configuration admin views
+
+The web UI SHALL provide an authenticated admin surface to view and edit detection configuration: per-rule mode (alert / disabled), an optional severity override, and false-positive exclusions. Monitor is NOT an operator-selectable mode; the detection engine still honors a legacy `monitor` value persisted on a rule setting, so the UI MUST display such a row (and let the operator migrate it to alert or disabled) but MUST NOT offer monitor as a new choice. The per-rule mode and severity controls MUST render uniformly for every registered rule (driven from the rule catalog), so a newly added rule appears without bespoke UI, and the table MUST show each rule's declared (default) severity alongside the optional override. The exclusion editor MUST let an operator create and delete global-scope exclusions with a typed match type, a value, a reason, and an optional expiration, and MUST surface the existing entries with their creation time and their author resolved to a display email when the author is a known user, falling back to the raw principal identifier when the user cannot be resolved. When an operator disables a rule, the UI MUST capture an operator-supplied reason before the change is submitted, because that reason is recorded in the audit trail; restoring a rule to alert and severity-only edits MAY use a system-generated reason. Mutations MUST go through the authenticated admin API and are subject to the same RBAC the API enforces. Per-rule schema-driven settings beyond mode + severity, exclusion editing, and host-group-scoped configuration are deferred to a later change (they land with the editable host groups and per-rule config-schema work).
+
+#### Scenario: An operator adds an exclusion from the UI
+
+- **GIVEN** an authenticated operator with detection-config write access
+- **WHEN** they add an exclusion with a match type, value, and reason
+- **THEN** the exclusion is created through the admin API
+- **AND** it appears in the exclusion list with its creation time and its author shown as a resolved email when the author is a known user
+
+#### Scenario: Per-rule mode and severity controls render for every rule
+
+- **GIVEN** the rule catalog registers a set of rules
+- **WHEN** an operator opens the detection-configuration admin view
+- **THEN** every registered rule shows mode and severity-override controls without UI changes specific to that rule
+- **AND** each rule's declared default severity is shown alongside its optional override
+
+#### Scenario: Disabling or monitoring a rule requires an operator reason
+
+- **GIVEN** an authenticated operator with detection-config write access
+- **WHEN** they reduce a rule's alerting (set its mode to disabled, or keep an existing monitor row reduced)
+- **THEN** the UI captures an operator-supplied reason before submitting the change
+- **AND** restoring the rule to alert or editing only its severity override does not prompt for a reason
+
+#### Scenario: Monitor is not an operator-selectable mode
+
+- **GIVEN** an authenticated operator viewing the rule-modes table
+- **WHEN** a rule has no persisted monitor setting
+- **THEN** its mode control offers only alert and disabled
+- **AND** a rule with a legacy persisted monitor value still displays monitor so the operator can migrate it to alert or disabled
+
+#### Scenario: Exclusion author is shown as a resolved email
+
+- **GIVEN** an exclusion whose author is a known user
+- **WHEN** the operator views the exclusions list
+- **THEN** the Created by column shows that user's email
+- **AND** an exclusion whose author cannot be resolved falls back to the raw principal identifier

--- a/openspec/changes/detection-tuning-author-and-modes/tasks.md
+++ b/openspec/changes/detection-tuning-author-and-modes/tasks.md
@@ -1,0 +1,31 @@
+# Tasks
+
+## Server: resolve exclusion author to an email
+
+- [x] Add `CreatedByEmail string` (json `created_by_email,omitempty`, `db:"-"`) to `api.DetectionExclusion`.
+- [x] Add an optional `userEmailResolver` to the detection-config operator handler with a `SetUserEmailResolver` setter; resolve `created_by` (`user:<id>`) per request with memoization in `handleListExclusions`.
+- [x] Wire `UserEmailByID` through `rules/bootstrap` Deps and `cmd/main` (`userEmailByIDFromIdentity` over `identityapi.Service.GetUser`).
+- [x] Handler test: email filled + memoized per id, blank on resolver error and non-user actor, blank with a nil resolver.
+
+## UI: show the resolved email
+
+- [x] Add `created_by_email?: string` to `DetectionExclusion` in `ui/src/api.ts`.
+- [x] Render `created_by_email || created_by` in the exclusions table.
+- [x] Test: email shown when present, raw identifier otherwise.
+
+## Drop operator-selectable monitor mode
+
+- [x] `MODES = [alert, disabled]`; add `modeOptions` so a legacy `monitor` row still renders and can be migrated.
+- [x] Simplify the reason modal to the disabled-only path.
+- [x] Tests: monitor not offered for a normal rule; legacy monitor row still displays.
+- [x] Keep the `mode` ENUM, server acceptance, and engine monitor handling unchanged (no migration).
+
+## Default severity column
+
+- [x] Show each rule's declared severity in the rule-modes table next to the override, ordered critical-first.
+
+## Verification
+
+- [x] `go build ./server/...`, `go test ./server/rules/internal/operator/`.
+- [x] `vitest`, `tsc --noEmit`, `eslint` for the UI.
+- [x] `task lint:dashes`.

--- a/server/cmd/fleet-edr-server/main.go
+++ b/server/cmd/fleet-edr-server/main.go
@@ -375,6 +375,7 @@ func openRules(
 		Logger:          logger,
 		Audit:           identityCtx.AuditRecorder(),
 		AuthZ:           identityCtx.AuthZ(),
+		UserEmailByID:   userEmailByIDFromIdentity(identityCtx.Service()),
 		CommandInserter: responseCtx.Service().Insert,
 		HostLister:      hostListerFromDetection(detectionCtx.Service()),
 	})
@@ -387,6 +388,19 @@ func openRules(
 		return nil, err
 	}
 	return rulesCtx, nil
+}
+
+// userEmailByIDFromIdentity adapts identity's Service.GetUser to the rules-context UserEmailByID closure shape used to resolve an
+// exclusion's created_by ("user:<id>") to a display email. Lives in cmd/main because, like the host-lister projection, it is part of
+// the cross-context dep wiring: rules can't import identity/bootstrap without breaking the bounded-context import rule (ADR-0004).
+func userEmailByIDFromIdentity(svc identityapi.Service) func(context.Context, int64) (string, error) {
+	return func(ctx context.Context, userID int64) (string, error) {
+		u, err := svc.GetUser(ctx, userID)
+		if err != nil {
+			return "", err
+		}
+		return u.Email, nil
+	}
 }
 
 // hostListerFromDetection projects detection's ListHosts (returns the richer HostSummary shape) down to the appcontrol.HostLister

--- a/server/rules/api/detectionconfig.go
+++ b/server/rules/api/detectionconfig.go
@@ -175,7 +175,11 @@ type DetectionExclusion struct {
 	Enabled     bool               `db:"enabled" json:"enabled"`
 	ExpiresAt   *time.Time         `db:"expires_at" json:"expires_at,omitempty"`
 	CreatedBy   string             `db:"created_by" json:"created_by"`
-	CreatedAt   time.Time          `db:"created_at" json:"created_at"`
+	// CreatedByEmail is the display email resolved from CreatedBy ("user:<id>") at read time. Not persisted (db:"-"); the operator
+	// handler fills it from the identity directory so the UI can show an email instead of the raw principal id. Empty when the user
+	// could not be resolved (e.g. deleted), in which case the UI falls back to CreatedBy.
+	CreatedByEmail string    `db:"-" json:"created_by_email,omitempty"`
+	CreatedAt      time.Time `db:"created_at" json:"created_at"`
 }
 
 // DetectionRuleSetting mirrors a row in detection_rule_settings: the per-(rule, scope) mode + optional severity override + JSON

--- a/server/rules/bootstrap/bootstrap.go
+++ b/server/rules/bootstrap/bootstrap.go
@@ -35,6 +35,11 @@ type Deps struct {
 	// route gates on. Required. cmd/main wires identityCtx.AuthZ().
 	AuthZ identityapi.AuthZ
 
+	// UserEmailByID resolves a user id to its display email for the detection-config exclusions list's created_by column. Optional:
+	// when nil the handler returns the raw "user:<id>" identifier. cmd/main wires it over identity's Service.GetUser; a func keeps the
+	// rules context free of an identity-internal import (ADR-0004), same posture as detection's UserExists dep.
+	UserEmailByID func(ctx context.Context, userID int64) (string, error)
+
 	// CommandInserter is the closure that enqueues a response.Command to a host. The application-control fan-out path consults it on
 	// every rule-create so every enrolled host in the deployment receives one `set_application_control` command per mutation. Optional:
 	// when nil, the application-control REST routes are not mounted (the rules context still constructs cleanly so non-REST consumers like
@@ -87,6 +92,9 @@ func New(deps Deps) (*Rules, error) {
 	opH.SetAudit(deps.Audit)
 
 	detectionConfigH := operator.NewDetectionConfig(detectionConfigSvc, deps.AuthZ, logger)
+	if deps.UserEmailByID != nil {
+		detectionConfigH.SetUserEmailResolver(deps.UserEmailByID)
+	}
 
 	appControlStore := appcontrol.NewStore(deps.DB)
 	var appControlSvc *appcontrol.Service

--- a/server/rules/internal/operator/detectionconfig_handler.go
+++ b/server/rules/internal/operator/detectionconfig_handler.go
@@ -45,13 +45,19 @@ type detectionConfigService interface {
 	UpsertRuleSetting(ctx context.Context, actor *identityapi.Actor, reason string, in detectionconfig.UpsertSettingInput) (api.DetectionRuleSetting, error)
 }
 
+// userEmailResolver resolves a numeric user id to its display email for the exclusions list's created_by column. Optional: a nil
+// resolver (or one that errors / returns "") leaves CreatedByEmail empty so the UI falls back to the raw "user:<id>". cmd/main wires
+// it over identity's Service.GetUser; keeping it a func avoids a cross-context import of the identity internals (ADR-0004).
+type userEmailResolver func(ctx context.Context, userID int64) (string, error)
+
 // DetectionConfigHandler serves the rules-context /api/v1/detection-config/* admin routes (issue #459): the per-host false-positive
 // exclusions and per-rule mode/severity the detection engine consults at evaluation time. Separate from the App Control handler
 // because the surface and dependencies do not overlap.
 type DetectionConfigHandler struct {
-	svc    detectionConfigService
-	authz  identityapi.AuthZ
-	logger *slog.Logger
+	svc       detectionConfigService
+	authz     identityapi.AuthZ
+	userEmail userEmailResolver
+	logger    *slog.Logger
 }
 
 // NewDetectionConfig builds the detection-config operator handler. svc + authz are required; logger defaults to slog.Default. A nil
@@ -67,6 +73,53 @@ func NewDetectionConfig(svc detectionConfigService, authz identityapi.AuthZ, log
 		logger = slog.Default()
 	}
 	return &DetectionConfigHandler{svc: svc, authz: authz, logger: logger}
+}
+
+// SetUserEmailResolver wires the optional directory lookup that resolves an exclusion's created_by ("user:<id>") to a display email.
+// Mirrors SetAudit: set post-construction so non-REST consumers and tests that don't need email resolution can skip it.
+func (h *DetectionConfigHandler) SetUserEmailResolver(r userEmailResolver) {
+	h.userEmail = r
+}
+
+// resolveCreatedByEmails fills CreatedByEmail on each exclusion by resolving its "user:<id>" created_by through the directory. A nil
+// resolver is a no-op (the UI falls back to the raw identifier). Lookups are memoized per call so N exclusions from the same author
+// cost one directory hit; a failed or empty lookup leaves that row's email blank rather than failing the list.
+func (h *DetectionConfigHandler) resolveCreatedByEmails(ctx context.Context, exclusions []api.DetectionExclusion) {
+	if h.userEmail == nil {
+		return
+	}
+	cache := make(map[int64]string)
+	for i := range exclusions {
+		id, ok := parseUserActorID(exclusions[i].CreatedBy)
+		if !ok {
+			continue
+		}
+		email, seen := cache[id]
+		if !seen {
+			resolved, err := h.userEmail(ctx, id)
+			if err != nil {
+				h.logger.WarnContext(ctx, "detectionconfig: resolve created_by email", "user_id", id, "err", err)
+				resolved = ""
+			}
+			email = resolved
+			cache[id] = email
+		}
+		exclusions[i].CreatedByEmail = email
+	}
+}
+
+// parseUserActorID extracts the numeric id from the "user:<id>" actor identifier the service records as created_by. Returns false for
+// any other shape (e.g. a service-account or empty actor) so the caller leaves the email unresolved.
+func parseUserActorID(actor string) (int64, bool) {
+	rest, ok := strings.CutPrefix(actor, "user:")
+	if !ok {
+		return 0, false
+	}
+	id, err := strconv.ParseInt(rest, 10, 64)
+	if err != nil || id <= 0 {
+		return 0, false
+	}
+	return id, true
 }
 
 // RegisterRoutes wires the detection-config admin routes:
@@ -99,6 +152,7 @@ func (h *DetectionConfigHandler) handleListExclusions(w http.ResponseWriter, r *
 		writeDetectionConfigErr(ctx, h.logger, w, http.StatusInternalServerError, errCodeDCInternal, msgDCInternal)
 		return
 	}
+	h.resolveCreatedByEmails(ctx, exclusions)
 	writeJSON(ctx, h.logger, w, http.StatusOK, map[string]any{"exclusions": exclusions})
 }
 

--- a/server/rules/internal/operator/detectionconfig_handler.go
+++ b/server/rules/internal/operator/detectionconfig_handler.go
@@ -98,7 +98,11 @@ func (h *DetectionConfigHandler) resolveCreatedByEmails(ctx context.Context, exc
 		if !seen {
 			resolved, err := h.userEmail(ctx, id)
 			if err != nil {
-				h.logger.WarnContext(ctx, "detectionconfig: resolve created_by email", "user_id", id, "err", err)
+				// A deleted user (ErrUserNotFound) is the expected fallback case: the UI shows the raw "user:<id>". Warning on it
+				// would spam the log on every list render per missing author, so only genuinely unexpected failures get a WARN.
+				if !errors.Is(err, identityapi.ErrUserNotFound) {
+					h.logger.WarnContext(ctx, "detectionconfig: resolve created_by email", "user_id", id, "err", err)
+				}
 				resolved = ""
 			}
 			email = resolved

--- a/server/rules/internal/operator/detectionconfig_handler_test.go
+++ b/server/rules/internal/operator/detectionconfig_handler_test.go
@@ -3,6 +3,7 @@ package operator
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"log/slog"
 	"net/http"
@@ -93,6 +94,74 @@ func dcDo(t *testing.T, srv *httptest.Server, method, path, body string) *http.R
 	resp, err := srv.Client().Do(req)
 	require.NoError(t, err)
 	return resp
+}
+
+// mountDC mounts the handler behind allow-all authz + an actor-injecting middleware so the list path runs with an actor on ctx.
+func mountDC(t *testing.T, h *DetectionConfigHandler) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := identityapi.WithActor(r.Context(), &identityapi.Actor{UserID: 7, SessionFresh: true})
+		mux.ServeHTTP(w, r.WithContext(ctx))
+	})
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestDetectionConfigHandler_ResolvesCreatedByEmail(t *testing.T) {
+	t.Parallel()
+	exclusions := []api.DetectionExclusion{
+		{ID: 1, CreatedBy: "user:8"},                 // resolves
+		{ID: 2, CreatedBy: "user:8"},                 // same author: memoized, no second lookup
+		{ID: 3, CreatedBy: "user:9"},                 // resolver errors: email stays empty
+		{ID: 4, CreatedBy: "service-account:reaper"}, // non-user actor: never looked up
+	}
+
+	t.Run("fills email, memoizes per id, falls back on error or non-user actor", func(t *testing.T) {
+		t.Parallel()
+		var calls int
+		h := NewDetectionConfig(&fakeDCService{exclusions: exclusions}, allowAllAuthZ{}, slog.Default())
+		h.SetUserEmailResolver(func(_ context.Context, id int64) (string, error) {
+			calls++
+			if id == 8 {
+				return "ops@fleetdm.com", nil
+			}
+			return "", errors.New("user not found")
+		})
+		srv := mountDC(t, h)
+		resp := dcDo(t, srv, http.MethodGet, "/api/v1/detection-config/exclusions", "")
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		var out struct {
+			Exclusions []api.DetectionExclusion `json:"exclusions"`
+		}
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&out))
+		resp.Body.Close()
+
+		require.Len(t, out.Exclusions, 4)
+		assert.Equal(t, "ops@fleetdm.com", out.Exclusions[0].CreatedByEmail)
+		assert.Equal(t, "ops@fleetdm.com", out.Exclusions[1].CreatedByEmail)
+		assert.Empty(t, out.Exclusions[2].CreatedByEmail, "errored lookup leaves email blank")
+		assert.Empty(t, out.Exclusions[3].CreatedByEmail, "non-user actor is not looked up")
+		assert.Equal(t, 2, calls, "user:8 resolved once (memoized) + user:9 once; service-account skipped")
+	})
+
+	t.Run("nil resolver leaves created_by_email empty", func(t *testing.T) {
+		t.Parallel()
+		h := NewDetectionConfig(&fakeDCService{exclusions: exclusions}, allowAllAuthZ{}, slog.Default())
+		srv := mountDC(t, h)
+		resp := dcDo(t, srv, http.MethodGet, "/api/v1/detection-config/exclusions", "")
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		var out struct {
+			Exclusions []api.DetectionExclusion `json:"exclusions"`
+		}
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&out))
+		resp.Body.Close()
+		for _, ex := range out.Exclusions {
+			assert.Empty(t, ex.CreatedByEmail)
+		}
+	})
 }
 
 func TestDetectionConfigHandler_Reads(t *testing.T) {

--- a/server/rules/internal/operator/detectionconfig_handler_test.go
+++ b/server/rules/internal/operator/detectionconfig_handler_test.go
@@ -112,17 +112,21 @@ func mountDC(t *testing.T, h *DetectionConfigHandler) *httptest.Server {
 
 func TestDetectionConfigHandler_ResolvesCreatedByEmail(t *testing.T) {
 	t.Parallel()
-	exclusions := []api.DetectionExclusion{
-		{ID: 1, CreatedBy: "user:8"},                 // resolves
-		{ID: 2, CreatedBy: "user:8"},                 // same author: memoized, no second lookup
-		{ID: 3, CreatedBy: "user:9"},                 // resolver errors: email stays empty
-		{ID: 4, CreatedBy: "service-account:reaper"}, // non-user actor: never looked up
+	// resolveCreatedByEmails fills CreatedByEmail in place, so each subtest needs its own slice (with its own backing array):
+	// sharing one across the parallel subtests would let one run's resolved emails leak into the nil-resolver run.
+	newExclusions := func() []api.DetectionExclusion {
+		return []api.DetectionExclusion{
+			{ID: 1, CreatedBy: "user:8"},                 // resolves
+			{ID: 2, CreatedBy: "user:8"},                 // same author: memoized, no second lookup
+			{ID: 3, CreatedBy: "user:9"},                 // resolver errors: email stays empty
+			{ID: 4, CreatedBy: "service-account:reaper"}, // non-user actor: never looked up
+		}
 	}
 
 	t.Run("fills email, memoizes per id, falls back on error or non-user actor", func(t *testing.T) {
 		t.Parallel()
 		var calls int
-		h := NewDetectionConfig(&fakeDCService{exclusions: exclusions}, allowAllAuthZ{}, slog.Default())
+		h := NewDetectionConfig(&fakeDCService{exclusions: newExclusions()}, allowAllAuthZ{}, slog.Default())
 		h.SetUserEmailResolver(func(_ context.Context, id int64) (string, error) {
 			calls++
 			if id == 8 {
@@ -149,7 +153,7 @@ func TestDetectionConfigHandler_ResolvesCreatedByEmail(t *testing.T) {
 
 	t.Run("nil resolver leaves created_by_email empty", func(t *testing.T) {
 		t.Parallel()
-		h := NewDetectionConfig(&fakeDCService{exclusions: exclusions}, allowAllAuthZ{}, slog.Default())
+		h := NewDetectionConfig(&fakeDCService{exclusions: newExclusions()}, allowAllAuthZ{}, slog.Default())
 		srv := mountDC(t, h)
 		resp := dcDo(t, srv, http.MethodGet, "/api/v1/detection-config/exclusions", "")
 		require.Equal(t, http.StatusOK, resp.StatusCode)

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -832,6 +832,9 @@ export interface DetectionExclusion {
   enabled: boolean;
   expires_at?: string;
   created_by: string;
+  // created_by_email is the display email the server resolves from created_by ("user:<id>") at read time. Absent when the user
+  // could not be resolved (e.g. deleted); the UI then falls back to created_by.
+  created_by_email?: string;
   created_at: string;
 }
 

--- a/ui/src/components/DetectionConfig/DetectionConfig.scss
+++ b/ui/src/components/DetectionConfig/DetectionConfig.scss
@@ -13,19 +13,45 @@
   margin: 0 0 $pad-medium 0;
 }
 
-// The add-exclusion form is a wrapping flex row so the rule / match-type / value / reason controls and the submit button
-// reflow onto a second line on narrow viewports instead of squeezing.
+// The add-exclusion form is a two-column grid: Rule + Match type share the top row (each exactly half), so together they span the
+// same width as the full-width Value and Reason rows below. Expires occupies one column, and the primary action sits on its own
+// full-width row aligned to the right, matching the modal action-row convention (justify-content: flex-end). The capped width keeps
+// the full-width inputs at a comfortable line length on wide viewports.
 .detection-config__form {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: flex-end;
-  gap: $pad-small;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  align-items: end;
+  gap: $pad-small $pad-medium;
   margin-bottom: $pad-medium;
+  max-width: 640px;
+
+  // Each field fills its grid cell, so the two top controls are exactly half the form (matching the full-width rows below).
+  .field,
+  .field__input {
+    width: 100%;
+  }
+}
+
+// Value and Reason span both columns.
+.detection-config__form-field--full {
+  grid-column: 1 / -1;
+}
+
+// The action row spans both columns; the primary button is right-aligned, consistent with the reason modal's action row.
+.detection-config__form-actions {
+  grid-column: 1 / -1;
+  display: flex;
+  justify-content: flex-end;
 }
 
 .detection-config__rule-id {
   font-size: $xxx-small;
   color: $ui-fleet-black-50;
+}
+
+// The catalog declares severities lowercase ("medium"); present them capitalized so the column reads as a label, not a raw value.
+.detection-config__default-severity {
+  text-transform: capitalize;
 }
 
 .dc-reason-modal {

--- a/ui/src/components/DetectionConfig/DetectionConfig.test.tsx
+++ b/ui/src/components/DetectionConfig/DetectionConfig.test.tsx
@@ -133,10 +133,12 @@ describe("DetectionConfig", () => {
     expect(options).toEqual(["Select a rule...", "Alpha rule", "Mid rule", "Zeta rule"]);
   });
 
-  // The rule-modes table sorts by declared severity (critical first), ties broken alphabetically by title.
+  // The rule-modes table sorts by declared severity (critical first), ties broken alphabetically by title; an unspecified ("")
+  // severity ranks last.
   it("orders the rule-modes table by severity, critical first, then alphabetically", async () => {
     stubReads({
       rules: [
+        makeRuleEntry({ id: "unset_a", doc: makeRuleDoc({ title: "A rule", severity: "" }) }),
         makeRuleEntry({ id: "low_b", doc: makeRuleDoc({ title: "B rule", severity: "low" }) }),
         makeRuleEntry({ id: "crit_z", doc: makeRuleDoc({ title: "Z rule", severity: "critical" }) }),
         makeRuleEntry({ id: "high_a", doc: makeRuleDoc({ title: "A rule", severity: "high" }) }),
@@ -147,7 +149,9 @@ describe("DetectionConfig", () => {
     await waitFor(() => { expect(screen.getByLabelText("mode for crit_a")).toBeInTheDocument(); });
 
     const order = screen.getAllByLabelText(/^mode for /).map((s) => s.getAttribute("aria-label"));
-    expect(order).toEqual(["mode for crit_a", "mode for crit_z", "mode for high_a", "mode for low_b"]);
+    expect(order).toEqual([
+      "mode for crit_a", "mode for crit_z", "mode for high_a", "mode for low_b", "mode for unset_a",
+    ]);
   });
 
   it("shows an empty state when there are no exclusions", async () => {

--- a/ui/src/components/DetectionConfig/DetectionConfig.test.tsx
+++ b/ui/src/components/DetectionConfig/DetectionConfig.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { DetectionConfig } from "./DetectionConfig";
 import { PermissionsProvider } from "../../permissions";
@@ -96,6 +96,58 @@ describe("DetectionConfig", () => {
     // The rule-modes table reflects the persisted setting (monitor + high).
     expect(screen.getByLabelText("mode for suspicious_exec")).toHaveValue("monitor");
     expect(screen.getByLabelText("severity override for suspicious_exec")).toHaveValue("high");
+    // The rule-modes table surfaces each rule's declared (default) severity from its catalog doc. Queried as a cell so the
+    // "medium" option in the severity-override select doesn't make the match ambiguous.
+    expect(screen.getByText("Default severity")).toBeInTheDocument();
+    expect(screen.getByRole("cell", { name: "medium" })).toBeInTheDocument();
+  });
+
+  // The rule picker shows a concise rule name: the descriptive parenthetical and the rule id are dropped from the option text,
+  // while the id still rides as the option value the form submits.
+  it("renders a concise rule name in the picker, dropping the descriptive aside and id", async () => {
+    const verbose = makeRuleEntry({
+      id: "suspicious_exec",
+      doc: makeRuleDoc({ title: "Suspicious exec chain (non-shell → shell → temp/network)" }),
+    });
+    stubReads({ rules: [verbose] });
+    renderPage();
+    await waitFor(() => { expect(screen.getByText(/no exclusions configured/i)).toBeInTheDocument(); });
+
+    const option = screen.getByRole("option", { name: "Suspicious exec chain" });
+    expect(option).toHaveValue("suspicious_exec");
+    expect(screen.queryByRole("option", { name: /\(suspicious_exec\)/ })).not.toBeInTheDocument();
+  });
+
+  it("orders the rule picker alphabetically by display name", async () => {
+    stubReads({
+      rules: [
+        makeRuleEntry({ id: "zeta", doc: makeRuleDoc({ title: "Zeta rule" }) }),
+        makeRuleEntry({ id: "alpha", doc: makeRuleDoc({ title: "Alpha rule" }) }),
+        makeRuleEntry({ id: "mid", doc: makeRuleDoc({ title: "Mid rule" }) }),
+      ],
+    });
+    renderPage();
+    await waitFor(() => { expect(screen.getByText(/no exclusions configured/i)).toBeInTheDocument(); });
+
+    const options = within(screen.getByLabelText("Rule")).getAllByRole("option").map((o) => o.textContent);
+    expect(options).toEqual(["Select a rule...", "Alpha rule", "Mid rule", "Zeta rule"]);
+  });
+
+  // The rule-modes table sorts by declared severity (critical first), ties broken alphabetically by title.
+  it("orders the rule-modes table by severity, critical first, then alphabetically", async () => {
+    stubReads({
+      rules: [
+        makeRuleEntry({ id: "low_b", doc: makeRuleDoc({ title: "B rule", severity: "low" }) }),
+        makeRuleEntry({ id: "crit_z", doc: makeRuleDoc({ title: "Z rule", severity: "critical" }) }),
+        makeRuleEntry({ id: "high_a", doc: makeRuleDoc({ title: "A rule", severity: "high" }) }),
+        makeRuleEntry({ id: "crit_a", doc: makeRuleDoc({ title: "A rule", severity: "critical" }) }),
+      ],
+    });
+    renderPage();
+    await waitFor(() => { expect(screen.getByLabelText("mode for crit_a")).toBeInTheDocument(); });
+
+    const order = screen.getAllByLabelText(/^mode for /).map((s) => s.getAttribute("aria-label"));
+    expect(order).toEqual(["mode for crit_a", "mode for crit_z", "mode for high_a", "mode for low_b"]);
   });
 
   it("shows an empty state when there are no exclusions", async () => {
@@ -174,7 +226,7 @@ describe("DetectionConfig", () => {
     });
   });
 
-  // Reducing a rule's alerting (-> disabled/monitor) opens the reason modal; the operator's reason rides the upsert for the audit row.
+  // Reducing a rule's alerting opens the reason modal; the operator's reason rides the upsert for the audit row.
   // spec:web-ui/detection-configuration-admin-views/disabling-or-monitoring-a-rule-requires-an-operator-reason
   it("requires a reason via the modal before disabling a rule", async () => {
     stubReads({ rules: [makeRuleEntry()], settings: [] });
@@ -205,11 +257,47 @@ describe("DetectionConfig", () => {
     renderPage();
     await waitFor(() => { expect(screen.getByLabelText("mode for suspicious_exec")).toBeInTheDocument(); });
 
-    fireEvent.change(screen.getByLabelText("mode for suspicious_exec"), { target: { value: "monitor" } });
-    await waitFor(() => { expect(screen.getByText(/Set "Suspicious execution" to monitor/)).toBeInTheDocument(); });
+    fireEvent.change(screen.getByLabelText("mode for suspicious_exec"), { target: { value: "disabled" } });
+    await waitFor(() => { expect(screen.getByText(/Disable "Suspicious execution"/)).toBeInTheDocument(); });
     fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
-    await waitFor(() => { expect(screen.queryByText(/to monitor/)).not.toBeInTheDocument(); });
+    await waitFor(() => { expect(screen.queryByText(/Disable "Suspicious execution"/)).not.toBeInTheDocument(); });
     expect(upsert).not.toHaveBeenCalled();
+  });
+
+  // monitor is no longer operator-selectable: a rule with no persisted setting offers only alert and disabled.
+  // spec:web-ui/detection-configuration-admin-views/monitor-is-not-an-operator-selectable-mode
+  it("does not offer monitor as a selectable mode", async () => {
+    stubReads({ rules: [makeRuleEntry()], settings: [] });
+    renderPage();
+    await waitFor(() => { expect(screen.getByLabelText("mode for suspicious_exec")).toBeInTheDocument(); });
+
+    const modes = within(screen.getByLabelText("mode for suspicious_exec")).getAllByRole("option").map((o) => o.textContent);
+    expect(modes).toEqual(["alert", "disabled"]);
+  });
+
+  // A legacy persisted `monitor` row still displays correctly (monitor is shown so the controlled select matches), letting the
+  // operator migrate it to alert/disabled.
+  it("still displays a legacy monitor setting so it can be migrated", async () => {
+    stubReads({ rules: [makeRuleEntry()], settings: [makeSetting({ mode: "monitor" })] });
+    renderPage();
+    await waitFor(() => { expect(screen.getByLabelText("mode for suspicious_exec")).toHaveValue("monitor"); });
+
+    const modes = within(screen.getByLabelText("mode for suspicious_exec")).getAllByRole("option").map((o) => o.textContent);
+    expect(modes).toEqual(["monitor", "alert", "disabled"]);
+  });
+
+  // created_by shows the server-resolved email when present, falling back to the raw "user:<id>" identifier otherwise.
+  // spec:web-ui/detection-configuration-admin-views/exclusion-author-is-shown-as-a-resolved-email
+  it("renders created_by_email when the server resolves it, else the raw identifier", async () => {
+    stubReads({
+      exclusions: [
+        makeExclusion({ id: 1, created_by: "user:8", created_by_email: "ops@fleetdm.com" }),
+        makeExclusion({ id: 2, created_by: "user:9" }),
+      ],
+    });
+    renderPage();
+    await waitFor(() => { expect(screen.getByText("ops@fleetdm.com")).toBeInTheDocument(); });
+    expect(screen.getByText("user:9")).toBeInTheDocument();
   });
 
   it("re-enabling a rule (mode -> alert) applies immediately with a generated reason and no modal", async () => {

--- a/ui/src/components/DetectionConfig/DetectionConfig.tsx
+++ b/ui/src/components/DetectionConfig/DetectionConfig.tsx
@@ -33,7 +33,7 @@ const MATCH_TYPES = [
 
 // The per-rule modes an operator can select: alert (default) and disabled (emit nothing). A legacy `monitor` value may still exist on
 // persisted rows and the engine continues to honor it, but monitor is no longer operator-selectable (it had no review surface). See
-// the drop-monitor-from-detection-tuning openspec change.
+// the detection-tuning-author-and-modes openspec change.
 const MODES = ["alert", "disabled"] as const;
 
 // modeOptions returns the modes shown for a row. It prepends the row's current mode when that mode is not operator-selectable (a
@@ -45,10 +45,14 @@ function modeOptions(current: string): readonly string[] {
 // Severity-override choices; the empty value means "no override" (keep the rule's declared severity).
 const SEVERITIES = ["", "low", "medium", "high", "critical"] as const;
 
-// severityRank orders a declared severity most-severe first for the rule-modes table; an unset or unrecognized severity returns -1
-// and sorts last. Reuses the SEVERITIES list (declared low..critical) as the single source of truth, read high-index-first.
+// SEVERITY_ORDER lists declared severities most- to least-severe; the rule-modes table sorts by it (ascending rank = critical first).
+const SEVERITY_ORDER = ["critical", "high", "medium", "low"] as const;
+
+// severityRank returns a rule's position in SEVERITY_ORDER (0 = critical). A severity that isn't one of the four (an unset "" or an
+// unrecognized value) ranks last, so "(unspecified)" rules fall to the bottom of the table.
 function severityRank(sev: string): number {
-  return SEVERITIES.indexOf(sev as (typeof SEVERITIES)[number]);
+  const i = SEVERITY_ORDER.indexOf(sev as (typeof SEVERITY_ORDER)[number]);
+  return i === -1 ? SEVERITY_ORDER.length : i;
 }
 
 // errMessage renders a typed detection-config API error's message, falling back to a generic string.
@@ -97,8 +101,8 @@ export function DetectionConfig() {
   const [formReason, setFormReason] = useState("");
   const [formExpires, setFormExpires] = useState("");
 
-  // pendingMode holds a not-yet-applied alerting-reducing rule change (mode -> monitor/disabled) while the reason modal collects an
-  // operator justification. modalError surfaces a failed confirm inside the modal so it stays open for a retry.
+  // pendingMode holds a not-yet-applied disable (the alerting-reducing change) while the reason modal collects an operator
+  // justification. modalError surfaces a failed confirm inside the modal so it stays open for a retry.
   const [pendingMode, setPendingMode] = useState<{ ruleID: string; ruleTitle: string; mode: string; severity: string } | null>(null);
   const [modalError, setModalError] = useState<string | null>(null);
 
@@ -111,7 +115,7 @@ export function DetectionConfig() {
   // alphabetically by title within a severity band.
   const rulesBySeverity = useMemo(
     () => [...rules].sort((a, b) =>
-      severityRank(b.doc.severity) - severityRank(a.doc.severity) || a.doc.title.localeCompare(b.doc.title)),
+      severityRank(a.doc.severity) - severityRank(b.doc.severity) || a.doc.title.localeCompare(b.doc.title)),
     [rules],
   );
 

--- a/ui/src/components/DetectionConfig/DetectionConfig.tsx
+++ b/ui/src/components/DetectionConfig/DetectionConfig.tsx
@@ -70,7 +70,14 @@ function globalSetting(settings: DetectionRuleSetting[], ruleID: string): Detect
 // chain (non-shell → shell → temp/network)") which, paired with the rule id, made each option long and noisy. Top EDR consoles list
 // the short rule name only, so we drop the aside and the id; the id still rides as the option value.
 function ruleLabel(title: string): string {
-  return title.replace(/\s*\([^)]*\)\s*$/, "").trim() || title;
+  // Drop a trailing " (...)" aside with linear string ops rather than a regex: the equivalent /\s*\([^)]*\)\s*$/ has super-linear
+  // backtracking (Sonar S8786) because .replace retries the greedy leading \s* at every start position.
+  const trimmed = title.trimEnd();
+  if (trimmed.endsWith(")")) {
+    const open = trimmed.lastIndexOf("(");
+    if (open > 0) return trimmed.slice(0, open).trim() || title;
+  }
+  return title;
 }
 
 // DetectionConfig is the admin surface for detection-rule tuning (issue #459): per-host false-positive exclusions and per-rule

--- a/ui/src/components/DetectionConfig/DetectionConfig.tsx
+++ b/ui/src/components/DetectionConfig/DetectionConfig.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   listDetectionExclusions,
   listDetectionRuleSettings,
@@ -31,12 +31,25 @@ const MATCH_TYPES = [
   "domain",
 ] as const;
 
-// The three per-rule modes (api.DetectionRuleMode): alert (default), monitor (evaluate but
-// emit a signal instead of an alert), disabled (emit nothing).
-const MODES = ["alert", "monitor", "disabled"] as const;
+// The per-rule modes an operator can select: alert (default) and disabled (emit nothing). A legacy `monitor` value may still exist on
+// persisted rows and the engine continues to honor it, but monitor is no longer operator-selectable (it had no review surface). See
+// the drop-monitor-from-detection-tuning openspec change.
+const MODES = ["alert", "disabled"] as const;
+
+// modeOptions returns the modes shown for a row. It prepends the row's current mode when that mode is not operator-selectable (a
+// legacy `monitor` row) so the controlled <select> renders a matching option and the operator can migrate it to alert/disabled.
+function modeOptions(current: string): readonly string[] {
+  return (MODES as readonly string[]).includes(current) ? MODES : [current, ...MODES];
+}
 
 // Severity-override choices; the empty value means "no override" (keep the rule's declared severity).
 const SEVERITIES = ["", "low", "medium", "high", "critical"] as const;
+
+// severityRank orders a declared severity most-severe first for the rule-modes table; an unset or unrecognized severity returns -1
+// and sorts last. Reuses the SEVERITIES list (declared low..critical) as the single source of truth, read high-index-first.
+function severityRank(sev: string): number {
+  return SEVERITIES.indexOf(sev as (typeof SEVERITIES)[number]);
+}
 
 // errMessage renders a typed detection-config API error's message, falling back to a generic string.
 function errMessage(err: unknown): string {
@@ -47,6 +60,13 @@ function errMessage(err: unknown): string {
 // globalSetting picks the global-scope (host_group_id 0) setting for a rule, the only scope the Phase A surface edits.
 function globalSetting(settings: DetectionRuleSetting[], ruleID: string): DetectionRuleSetting | undefined {
   return settings.find((s) => s.rule_id === ruleID && s.host_group_id === 0);
+}
+
+// ruleLabel is the concise rule name the picker shows. Catalog titles carry a trailing descriptive aside (e.g. "Suspicious exec
+// chain (non-shell → shell → temp/network)") which, paired with the rule id, made each option long and noisy. Top EDR consoles list
+// the short rule name only, so we drop the aside and the id; the id still rides as the option value.
+function ruleLabel(title: string): string {
+  return title.replace(/\s*\([^)]*\)\s*$/, "").trim() || title;
 }
 
 // DetectionConfig is the admin surface for detection-rule tuning (issue #459): per-host false-positive exclusions and per-rule
@@ -81,6 +101,19 @@ export function DetectionConfig() {
   // operator justification. modalError surfaces a failed confirm inside the modal so it stays open for a retry.
   const [pendingMode, setPendingMode] = useState<{ ruleID: string; ruleTitle: string; mode: string; severity: string } | null>(null);
   const [modalError, setModalError] = useState<string | null>(null);
+
+  // The exclusion picker lists rules alphabetically by display name so an operator can scan to the rule they want.
+  const rulesByName = useMemo(
+    () => [...rules].sort((a, b) => ruleLabel(a.doc.title).localeCompare(ruleLabel(b.doc.title))),
+    [rules],
+  );
+  // The rule-modes table orders by declared severity (critical first), where muting a rule is most consequential, then
+  // alphabetically by title within a severity band.
+  const rulesBySeverity = useMemo(
+    () => [...rules].sort((a, b) =>
+      severityRank(b.doc.severity) - severityRank(a.doc.severity) || a.doc.title.localeCompare(b.doc.title)),
+    [rules],
+  );
 
   const reload = useCallback(async (): Promise<void> => {
     const [excl, ruleDocs, ruleSettings] = await Promise.all([
@@ -148,7 +181,7 @@ export function DetectionConfig() {
   }, [runMutation]);
 
   // handleModeChange splits on whether the new mode reduces alerting. Restoring a rule to `alert` is applied immediately with a
-  // generated reason; reducing it to `monitor` / `disabled` first opens the reason modal so the operator's justification is audited.
+  // generated reason; disabling it first opens the reason modal so the operator's justification is audited.
   const handleModeChange = useCallback((ruleID: string, ruleTitle: string, mode: string, severity: string) => {
     if (mode === "alert") {
       runMutation(() => upsertDetectionRuleSetting({
@@ -213,20 +246,28 @@ export function DetectionConfig() {
             <h2 className="detection-config__heading">Exclusions</h2>
             {canWrite && (
               <div className="detection-config__form">
-                <Select label="Rule" id="dc-rule" value={formRuleID} onChange={(e) => { setFormRuleID(e.target.value); }}>
+                <Select label="Rule" id="dc-rule" inline={false} value={formRuleID}
+                  onChange={(e) => { setFormRuleID(e.target.value); }}>
                   <option value="">Select a rule...</option>
-                  {rules.map((r) => <option key={r.id} value={r.id}>{r.doc.title} ({r.id})</option>)}
+                  {rulesByName.map((r) => <option key={r.id} value={r.id}>{ruleLabel(r.doc.title)}</option>)}
                 </Select>
-                <Select label="Match type" id="dc-match" value={formMatchType} onChange={(e) => { setFormMatchType(e.target.value); }}>
+                <Select label="Match type" id="dc-match" inline={false} value={formMatchType}
+                  onChange={(e) => { setFormMatchType(e.target.value); }}>
                   {MATCH_TYPES.map((m) => <option key={m} value={m}>{m}</option>)}
                 </Select>
-                <Input label="Value" id="dc-value" value={formValue} onChange={(e) => { setFormValue(e.target.value); }}
-                  placeholder="*/claude/versions/*" />
-                <Input label="Reason" id="dc-reason" value={formReason} onChange={(e) => { setFormReason(e.target.value); }}
-                  placeholder="why this is benign" />
+                <div className="detection-config__form-field--full">
+                  <Input label="Value" id="dc-value" value={formValue} onChange={(e) => { setFormValue(e.target.value); }}
+                    placeholder="*/MyApp/versions/*" />
+                </div>
+                <div className="detection-config__form-field--full">
+                  <Input label="Reason" id="dc-reason" value={formReason} onChange={(e) => { setFormReason(e.target.value); }}
+                    placeholder="why this is benign" />
+                </div>
                 <Input label="Expires (optional)" id="dc-expires" type="date" value={formExpires}
                   onChange={(e) => { setFormExpires(e.target.value); }} />
-                <Button variant="primary" disabled={addDisabled || mutating} onClick={handleAddExclusion}>Add exclusion</Button>
+                <div className="detection-config__form-actions">
+                  <Button variant="primary" disabled={addDisabled || mutating} onClick={handleAddExclusion}>Add exclusion</Button>
+                </div>
               </div>
             )}
             {exclusions.length === 0 ? (
@@ -252,7 +293,7 @@ export function DetectionConfig() {
                       <td><code>{ex.value}</code></td>
                       <td>{ex.reason}</td>
                       <td>{ex.expires_at ? ex.expires_at.split("T")[0] : "never"}</td>
-                      <td>{ex.created_by}</td>
+                      <td>{ex.created_by_email || ex.created_by}</td>
                       {canWrite && (
                         <td>
                           <Button variant="alert" disabled={mutating} onClick={() => { handleDelete(ex.id); }}
@@ -272,23 +313,31 @@ export function DetectionConfig() {
               <thead>
                 <tr>
                   <th>Rule</th>
-                  <th>Mode</th>
-                  <th>Severity override</th>
+                  <th title="The severity each rule declares in the catalog. It applies whenever no override is set below.">
+                    Default severity
+                  </th>
+                  <th title="Alert (default) raises alerts; monitor evaluates but emits a signal instead; disabled emits nothing.">
+                    Mode
+                  </th>
+                  <th title="Replaces the rule's default severity on every alert it raises. (none) keeps the default.">
+                    Severity override
+                  </th>
                 </tr>
               </thead>
               <tbody>
-                {rules.map((r) => {
+                {rulesBySeverity.map((r) => {
                   const setting = globalSetting(settings, r.id);
                   const mode = setting?.mode ?? "alert";
                   const severity = setting?.severity_override ?? "";
                   return (
                     <tr key={r.id}>
                       <td>{r.doc.title}<br /><code className="detection-config__rule-id">{r.id}</code></td>
+                      <td className="detection-config__default-severity">{r.doc.severity || "(unspecified)"}</td>
                       <td>
                         <Select label="" id={`dc-mode-${r.id}`} value={mode} disabled={!canWrite || mutating}
                           aria-label={`mode for ${r.id}`}
                           onChange={(e) => { handleModeChange(r.id, r.doc.title, e.target.value, severity); }}>
-                          {MODES.map((m) => <option key={m} value={m}>{m}</option>)}
+                          {modeOptions(mode).map((m) => <option key={m} value={m}>{m}</option>)}
                         </Select>
                       </td>
                       <td>
@@ -309,14 +358,10 @@ export function DetectionConfig() {
 
       {pendingMode && (
         <ReasonModal
-          title={pendingMode.mode === "disabled"
-            ? `Disable "${pendingMode.ruleTitle}"?`
-            : `Set "${pendingMode.ruleTitle}" to monitor?`}
-          description={pendingMode.mode === "disabled"
-            ? "The rule stays registered but stops producing alerts. This is recorded in the audit log."
-            : "The rule keeps evaluating and emits a monitoring signal, but stops raising alerts. This is recorded in the audit log."}
-          confirmLabel={pendingMode.mode === "disabled" ? "Disable rule" : "Set to monitor"}
-          confirmVariant={pendingMode.mode === "disabled" ? "alert" : "primary"}
+          title={`Disable "${pendingMode.ruleTitle}"?`}
+          description="The rule stays registered but stops producing alerts. This is recorded in the audit log."
+          confirmLabel="Disable rule"
+          confirmVariant="alert"
           busy={mutating}
           error={modalError}
           onConfirm={confirmPendingMode}

--- a/ui/src/components/ui/AccountMenu.test.tsx
+++ b/ui/src/components/ui/AccountMenu.test.tsx
@@ -41,6 +41,26 @@ describe("AccountMenu", () => {
     expect(screen.queryByRole("link", { name: "Admin settings" })).not.toBeInTheDocument();
   });
 
+  it("shows Detection tuning when detection_config.read is granted, linking to the page", () => {
+    renderMenu([PermissionAction.DetectionConfigRead]);
+    fireEvent.click(screen.getByRole("button", { name: /mike@fleetdm.com/ }));
+    const link = screen.getByRole("link", { name: "Detection tuning" });
+    expect(link).toHaveAttribute("href", "/detection-config");
+  });
+
+  it("hides Detection tuning when detection_config.read is absent", () => {
+    renderMenu([PermissionAction.HostRead]);
+    fireEvent.click(screen.getByRole("button", { name: /mike@fleetdm.com/ }));
+    expect(screen.queryByRole("link", { name: "Detection tuning" })).not.toBeInTheDocument();
+  });
+
+  it("closes the menu when Detection tuning is clicked", () => {
+    renderMenu([PermissionAction.DetectionConfigRead]);
+    fireEvent.click(screen.getByRole("button", { name: /mike@fleetdm.com/ }));
+    fireEvent.click(screen.getByRole("link", { name: "Detection tuning" }));
+    expect(screen.queryByRole("button", { name: "Log out" })).not.toBeInTheDocument();
+  });
+
   it("calls onLogout from the menu", () => {
     const { onLogout } = renderMenu([PermissionAction.SSOManage]);
     fireEvent.click(screen.getByRole("button", { name: /mike@fleetdm.com/ }));

--- a/ui/src/components/ui/AccountMenu.tsx
+++ b/ui/src/components/ui/AccountMenu.tsx
@@ -16,7 +16,8 @@ function authMethodLabel(authMethod?: string): string | null {
 }
 
 // AccountMenu is the top-right avatar dropdown: it carries the entry point to the Admin
-// settings area (gated on sso.manage so only admins see it) plus Documentation and Log
+// settings area (gated on sso.manage so only admins see it), Detection tuning (gated on
+// detection_config.read, so admins and senior analysts see it), Documentation, and Log
 // out. The "Admin settings" link is the only way into the settings area, matching the
 // design. Closes on outside-click and Escape. Implemented as a disclosure (trigger carries
 // aria-expanded) rather than the ARIA menu pattern: the items are plain links/buttons, so
@@ -72,6 +73,15 @@ export function AccountMenu({ user, authMethod, onLogout }: AccountMenuProps) {
               onClick={() => { setOpen(false); }}
             >
               Admin settings
+            </Link>
+          )}
+          {can(PermissionAction.DetectionConfigRead) && (
+            <Link
+              to="/detection-config"
+              className="account-menu__item"
+              onClick={() => { setOpen(false); }}
+            >
+              Detection tuning
             </Link>
           )}
           <a

--- a/ui/src/components/ui/TopNav.test.tsx
+++ b/ui/src/components/ui/TopNav.test.tsx
@@ -34,14 +34,10 @@ describe("TopNav capability gating", () => {
     expect(screen.getByRole("link", { name: "Application control" })).toBeInTheDocument();
   });
 
-  it("hides the Detection tuning entry without detection_config.read", () => {
-    renderNav([PermissionAction.HostRead, PermissionAction.AlertRead]);
-    expect(screen.queryByRole("link", { name: "Detection tuning" })).not.toBeInTheDocument();
-  });
-
-  it("shows the Detection tuning entry with detection_config.read", () => {
+  it("never renders Detection tuning in the top nav (it lives in the account menu)", () => {
+    // Even with detection_config.read, Detection tuning is not a top-nav tab; it moved into the account dropdown.
     renderNav([PermissionAction.HostRead, PermissionAction.DetectionConfigRead]);
-    expect(screen.getByRole("link", { name: "Detection tuning" })).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "Detection tuning" })).not.toBeInTheDocument();
   });
 
   it("always shows the ungated Coverage entry", () => {

--- a/ui/src/components/ui/TopNav.tsx
+++ b/ui/src/components/ui/TopNav.tsx
@@ -19,7 +19,6 @@ const LINKS: NavLink[] = [
   { to: "/", label: "Hosts", action: PermissionAction.HostRead },
   { to: "/alerts", label: "Alerts", action: PermissionAction.AlertRead },
   { to: "/app-control", label: "Application control", action: PermissionAction.AppControlRead },
-  { to: "/detection-config", label: "Detection tuning", action: PermissionAction.DetectionConfigRead },
   { to: "/coverage", label: "Coverage" },
 ];
 

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -26,7 +26,9 @@ export default defineConfig(({ mode }) => ({
   },
   server: {
     proxy: {
-      "/api": "http://localhost:8088",
+      // The dev server (task dev:server) serves HTTPS on :8088 with a mkcert-signed local cert, so the proxy target is https and
+      // secure:false skips cert verification for the self-signed dev chain. Dev/preview only; vite build ignores server.proxy.
+      "/api": { target: "https://localhost:8088", secure: false, changeOrigin: true },
     },
   },
   test: {


### PR DESCRIPTION
<!-- Keep this short. Delete sections that do not apply. -->

## What & why



## Checklist

- [ ] **OpenSpec updated for behavior changes.** If this PR changes observable behavior (a detection rule, the event
      wire schema, persistence semantics, an API/wire shape, or an emitted event), `openspec/specs/**` is updated (and
      an `openspec/changes/` proposal added), with a `spec:<id>` test marker for any new/renamed scenario. Only if this
      PR changes NO observable behavior (a comment / refactor / gofmt / dep bump that happens to touch a scoped path)
      may you assert `no-behavior-change` (label or `[no-behavior-change]` in the title) to clear the OpenSpec-sync gate.
      That is an assertion a reviewer will check, not a way to skip the spec for a real behavior change.
- [ ] Tests added/updated for the change (unit / integration / efficacy / UI as applicable).
- [ ] Agent/extension change touching ESF, XPC, or the event wire format: exercised on a live macOS VM before RC
      (flagged below).

## VM / RC notes (if applicable)


