### PR TITLE
fix(ci): re-root vitest LCOV paths so codecov/patch sees UI coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -77,9 +77,11 @@ flag_management:
 # Path fixes. vitest's v8 provider writes the UI LCOV (ui/coverage/lcov.info) with paths relative to ui/, e.g.
 # `SF:src/components/ProcessTree.tsx`, NOT repo-relative. The `ui` flag above is scoped to `ui/src/` and PR diff paths are
 # `ui/src/...`, so without a fix codecov can't map the LCOV onto the diff and reports changed UI lines as 0% (issue #468).
-# This prefix map re-roots those `src/` paths to repo paths. Codecov path fixes are prefix-anchored, so it does NOT touch
-# the Playwright E2E LCOV (already `ui/src/`-rooted) or the Go profiles (`agent/`, `server/`). Sonar reads the same vitest
-# LCOV via sonar.javascript.lcov.reportPaths and resolves the `src/` root itself, so it needs no equivalent mapping.
+# This prefix map re-roots those `src/` paths to repo paths. Codecov anchors the prefix at the start of the path (the
+# config validator normalizes `src/` to `^src/`), so it does NOT touch the Playwright E2E LCOV (already `ui/src/`-rooted,
+# does not start with `src/`) or the Go profiles (`agent/`, `server/`). Do NOT write the `^` yourself: codecov re-anchors
+# the input, so an explicit `^src/` becomes the dead regex `^^src/` and the fix silently stops matching. Sonar reads the
+# same vitest LCOV via sonar.javascript.lcov.reportPaths and resolves the `src/` root itself, so it needs no equivalent.
 fixes:
   - "src/::ui/src/"
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -65,14 +65,23 @@ flag_management:
     - name: server
       paths:
         - server/
-    # The `ui` flag covers ui/src/**. Vitest doesn't ship UI tests
-    # today, but the Playwright E2E run captures V8 coverage of the
-    # running React bundle and emits an LCOV via monocart-coverage-
-    # reports. The same flag accumulates that LCOV; when vitest tests
-    # land they upload to the same flag and Codecov takes the union.
+    # The `ui` flag covers ui/src/**. Two LCOVs upload under it: the
+    # vitest unit-test LCOV (ui/coverage/lcov.info) and the Playwright
+    # E2E LCOV (test/e2e/coverage/lcov-e2e.info, V8 coverage of the
+    # running React bundle via monocart-coverage-reports). Codecov takes
+    # the union per flag, so a line hit by either suite counts as covered.
     - name: ui
       paths:
         - ui/src/
+
+# Path fixes. vitest's v8 provider writes the UI LCOV (ui/coverage/lcov.info) with paths relative to ui/, e.g.
+# `SF:src/components/ProcessTree.tsx`, NOT repo-relative. The `ui` flag above is scoped to `ui/src/` and PR diff paths are
+# `ui/src/...`, so without a fix codecov can't map the LCOV onto the diff and reports changed UI lines as 0% (issue #468).
+# This prefix map re-roots those `src/` paths to repo paths. Codecov path fixes are prefix-anchored, so it does NOT touch
+# the Playwright E2E LCOV (already `ui/src/`-rooted) or the Go profiles (`agent/`, `server/`). Sonar reads the same vitest
+# LCOV via sonar.javascript.lcov.reportPaths and resolves the `src/` root itself, so it needs no equivalent mapping.
+fixes:
+  - "src/::ui/src/"
 
 comment:
   layout: "header, diff, flags, components, files"


### PR DESCRIPTION
## Summary

Fixes the codecov path-root mismatch that makes `codecov/patch` and `codecov/patch/ui` report changed UI files at 0% on UI-only PRs even when they're well covered by vitest (and SonarCloud passes on the same LCOV).

**Root cause** (per the issue): vitest's v8 provider writes `ui/coverage/lcov.info` with paths relative to `ui/`, e.g. `SF:src/components/ProcessTree.tsx`, not repo-relative. The codecov `ui` flag is scoped to `ui/src/` and PR diff paths are `ui/src/...`, so codecov can't map the LCOV onto the diff and treats the changed lines as uncovered. SonarCloud reads the same LCOV correctly because `sonar-project.properties` gives it the report root; codecov had no equivalent.

## Change

A codecov `fixes:` prefix map (the issue's recommended Option 1, lowest risk):

```yaml
fixes:
  - "src/::ui/src/"
```

Plus a refresh of the now-stale `ui` flag comment that claimed vitest ships no UI tests (it does, as of the unit-test suite under `ui/src/**`).

## Why it's safe (verified)

- **Codecov auto-anchors the fix to `^src/`**: the config validator rewrote the entry to `^src/::ui/src/` and returned `Valid!`. Path fixes are prefix-anchored, so the rule matches only paths starting with `src/`.
- **Transform simulation** confirms vitest `src/...` re-roots to `ui/src/...`, while the Playwright E2E LCOV (already `ui/src/`-rooted) and the Go profiles (`agent/`, `server/`) are untouched. No regression to Go or E2E reporting.
- carryforward is already enabled (`flag_management.default_rules.carryforward: true`), so the base/head flag-count warning on partial-CI PRs stays benign once paths map correctly.

## Validation caveat

This PR changes only `codecov.yml`, so it has no `ui/src/**` diff lines and can't self-prove the UI patch gate. Final empirical confirmation comes on the next UI-only PR (the acceptance-criteria scenario); the mechanism is verified via the codecov validator + local transform sim.

Closes #468

🤖 Generated with [Claude Code](https://claude.com/claude-code)