### PR TITLE
feat(observability): route-tier OTel head sampling with runtime controls (#374)

### DIFF
--- a/arch-go.yml
+++ b/arch-go.yml
@@ -91,6 +91,20 @@ dependenciesRules:
         - "**.coordination.leader"  # MySQL-advisory-lock leader coordinator: pipeline.Runner gates retention + process-TTL on it
         - "**.testdb"
 
+  # observability context internals (issue #374). A sixth bounded context (an amendment to ADR-0004's
+  # original five) that owns the runtime trace-sampler settings: its store + admin handler. It imports
+  # the shared sampler infra (internal/observability/tracing) for the Settings domain type, and
+  # identity.api for the authz chokepoint + audit recorder its admin endpoint funnels through.
+  - package: "**.server.observability.internal.**"
+    shouldOnlyDependsOn:
+      internal:
+        - "**.server.observability.internal.**"
+        - "**.observability.tracing"
+        - "**.identity.api"
+        - "**.attrkeys"
+        - "**.httpserver"
+        - "**.testdb"
+
   # ----- testkit packages -----------------------------------------------------
   #
   # testkit is a curated test-fixture surface for each bounded context.
@@ -161,6 +175,16 @@ dependenciesRules:
         - "**.attrkeys"
         - "**.httpserver"
         - "**.sqlhelpers"
+        - "**.testdb"
+
+  - package: "**.server.observability.testkit"
+    shouldOnlyDependsOn:
+      internal:
+        - "**.server.observability.bootstrap"
+        - "**.server.observability.internal.**"
+        - "**.observability.tracing"
+        - "**.attrkeys"
+        - "**.httpserver"
         - "**.testdb"
 
   # ----- api/ packages: pure-types, no cross-context internals ----------------

--- a/docs/adr/0004-modular-monolith-bounded-contexts.md
+++ b/docs/adr/0004-modular-monolith-bounded-contexts.md
@@ -29,6 +29,8 @@ Adopt a modular-monolith layout with **five bounded contexts** under `server/`:
 | `endpoint`  | Host enrollment + host-token verification. Tables: `enrollments`.               |
 | `identity`  | Operator users, sessions, login. Tables: `users`, `sessions`.                   |
 
+> Amendment (2026-06-24, issue #374): a sixth context, `observability`, was added under `server/observability/` for the deployment's runtime telemetry-control surface. It owns the OTel trace head-sampling settings (table `trace_sampler_settings`): a super-admin admin API (`GET`/`PATCH /api/settings/tracing`) and the read accessor the per-replica sampler poller consumes. It consumes `identity/api` for the authz chokepoint + audit recorder, exactly as `endpoint`/`response` do. It is a context (not a platform package) because it owns a schema and serves an authorization-gated, audited HTTP route, which is the bounded-context shape; the arch-go platform allow-list forbids context-free platform packages from importing any context, so the authz/audit dependency rules this surface out of the platform layer. The sampler mechanism itself stays in the agent-safe `internal/observability/tracing` infra package; this context only persists and serves the settings.
+
 Each context follows this layout:
 
 ```text

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -289,7 +289,7 @@ Traces are head-sampled so trace export volume stays bounded at fleet scale. Eve
 
 | Tier | Routes | Default ratio |
 | --- | --- | --- |
-| High-volume | Agent data plane: `POST /api/events`, the agent `GET /api/commands` poll, `POST /api/token/refresh`, `POST /api/enroll` | 0.01 (1%) |
+| High-volume | High-frequency agent data plane: `POST /api/events`, the agent `GET /api/commands` poll, `POST /api/token/refresh` | 0.01 (1%) |
 | Standard | Operator/UI read traffic: the dashboard and settings `GET` endpoints | 0.1 (10%) |
 | Full | Everything else: writes, admin mutations, any unclassified route | 1.0 (100%) |
 | Drop | Liveness/health probes (`/livez`, `/readyz`, `/health`) | never exported |

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -283,6 +283,39 @@ Recommended alerts (SigNoz, Grafana, wherever your OTel backend lives):
 
 Server logs go through the same OTLP pipeline (via `otelslog`) with `service.name=fleet-edr-server`. Use them for audit-style queries like "who resolved alert X" (look for `edr.admin.action=alert_update` log events with `user.id`).
 
+### Trace sampling
+
+Traces are head-sampled so trace export volume stays bounded at fleet scale. Every inbound HTTP request span is classified into a tier and sampled at that tier's ratio:
+
+| Tier | Routes | Default ratio |
+| --- | --- | --- |
+| High-volume | Agent data plane: `POST /api/events`, the agent `GET /api/commands` poll, `POST /api/token/refresh`, `POST /api/enroll` | 0.01 (1%) |
+| Standard | Operator/UI read traffic: the dashboard and settings `GET` endpoints | 0.1 (10%) |
+| Full | Everything else: writes, admin mutations, any unclassified route | 1.0 (100%) |
+| Drop | Liveness/health probes (`/livez`, `/readyz`, `/health`) | never exported |
+
+Sampling is parent-based: a sampled parent forces its children sampled, so a trace is never partially captured. Operator detail reads that carry a path parameter (e.g. `GET /api/alerts/{id}`) are not classified and fall to Full.
+
+Because traces are sampled, **read p99 / error-rate / request-rate from metrics, not from spans.** The `http.server.request.duration` histogram and the `edr.*` counters record every request and event regardless of the sample ratio; the RED dashboard above is built on that histogram and is unaffected by sampling. Spans are for exemplar drill-down, not aggregates.
+
+The ratios and an incident `force_full` toggle are stored in MySQL and polled by every replica each 60s, so changes apply across the deployment without a redeploy. Read and update them with an admin or super_admin session (the `tracing.manage` grant):
+
+```bash
+# Read the current settings.
+curl --cacert ca.pem -b cookies.txt https://edr.example.com/api/settings/tracing
+
+# Raise sampling fleet-wide during an investigation, then drop it back.
+curl --cacert ca.pem -b cookies.txt -X PATCH https://edr.example.com/api/settings/tracing \
+  -H "X-Csrf-Token: $CSRF" -H 'Content-Type: application/json' \
+  -d '{"high_volume_ratio":0.5,"standard_ratio":1.0}'
+
+# force_full lifts every tier to 100% for a debug window (probes stay dropped). Disable it when done.
+curl --cacert ca.pem -b cookies.txt -X PATCH https://edr.example.com/api/settings/tracing \
+  -H "X-Csrf-Token: $CSRF" -H 'Content-Type: application/json' -d '{"force_full":true}'
+```
+
+`PATCH` is partial: omit a field to keep its stored value. Ratios must be in `[0, 1]` (rejected by both the API and a DB `CHECK` constraint). A change reaches every replica within one 60s poll interval.
+
 ### HTTP server (RED) dashboard
 
 A starter SigNoz dashboard for the inbound HTTP surface lives at `config/observability/edr-http-server-dashboard.json`. It covers six panels (Rate / Errors / Duration): request rate by route, 5xx error rate by route, p95 and p99 latency by route, request rate by status code, and request rate by method. Import via the SigNoz UI: **Dashboards -> New Dashboard -> Import JSON** -> paste the file contents -> save. Because the access-log middleware no longer logs healthy 2xx/3xx at INFO, this dashboard (not log grep) is the volume + latency signal. All panels read the OTel `http.server.request.duration` histogram, which SigNoz stores under Prometheus-style suffixes: rate/volume panels query `http.server.request.duration.count`, latency quantiles query `http.server.request.duration.bucket`.

--- a/internal/observability/observability.go
+++ b/internal/observability/observability.go
@@ -63,6 +63,10 @@ type Options struct {
 	// Endpoint is the resolved OTLP target (e.g. "http://localhost:4317"). Empty puts Init on the no-op path so offline dev,
 	// CI, and unit tests do not need a running collector. OptionsFromEnv populates this from OTEL_EXPORTER_OTLP_ENDPOINT.
 	Endpoint string
+	// Sampler, when non-nil, is installed as the TracerProvider's head sampler (WithSampler). Callers pass an already-wrapped
+	// sampler (e.g. sdktrace.ParentBased(routeTierSampler)) so this package stays agnostic about the sampling policy. Nil leaves the
+	// SDK default sampler (ParentBased(AlwaysSample)) in place, which is the right behavior for binaries that do not classify routes.
+	Sampler sdktrace.Sampler
 }
 
 // OptionsFromEnv resolves the env-derived fields on o from the process environment and returns the result. The only place
@@ -120,10 +124,16 @@ func Init(ctx context.Context, opts Options) (ShutdownFunc, error) {
 	if err != nil {
 		return noopShutdown, fmt.Errorf("create trace exporter: %w", err)
 	}
-	tp := sdktrace.NewTracerProvider(
+	tpOpts := []sdktrace.TracerProviderOption{
 		sdktrace.WithBatcher(traceExp),
 		sdktrace.WithResource(res),
-	)
+	}
+	// A nil sampler leaves the SDK default (ParentBased(AlwaysSample)) in place; the server passes a route-tier head sampler here to
+	// cap export volume. WithSampler must precede WithBatcher's effect, but option order is irrelevant to NewTracerProvider, so append.
+	if opts.Sampler != nil {
+		tpOpts = append(tpOpts, sdktrace.WithSampler(opts.Sampler))
+	}
+	tp := sdktrace.NewTracerProvider(tpOpts...)
 
 	logExp, err := otlploggrpc.New(initCtx, otlploggrpc.WithEndpointURL(opts.Endpoint))
 	if err != nil {

--- a/internal/observability/observability.go
+++ b/internal/observability/observability.go
@@ -129,7 +129,7 @@ func Init(ctx context.Context, opts Options) (ShutdownFunc, error) {
 		sdktrace.WithResource(res),
 	}
 	// A nil sampler leaves the SDK default (ParentBased(AlwaysSample)) in place; the server passes a route-tier head sampler here to
-	// cap export volume. WithSampler must precede WithBatcher's effect, but option order is irrelevant to NewTracerProvider, so append.
+	// cap export volume. TracerProviderOption order is irrelevant to NewTracerProvider, so appending WithSampler after WithBatcher is fine.
 	if opts.Sampler != nil {
 		tpOpts = append(tpOpts, sdktrace.WithSampler(opts.Sampler))
 	}

--- a/internal/observability/observability_test.go
+++ b/internal/observability/observability_test.go
@@ -12,7 +12,10 @@ import (
 	otellog "go.opentelemetry.io/otel/log/global"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/resource"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.38.0"
+
+	"github.com/fleetdm/edr/internal/observability/tracing"
 )
 
 // TestBuildResource_ServiceInstanceID pins that a replica's telemetry resource carries service.instance.id when one is set. The
@@ -168,6 +171,32 @@ func TestInit_Enabled_BogusEndpoint(t *testing.T) { //nolint:paralleltest // Ini
 	assert.Less(t, time.Since(shutdownStart), 3*time.Second, "Shutdown should respect deadline")
 	// If Init succeeded, err is nil; if it errored, so be it. The assertion is about latency.
 	_ = err
+}
+
+// TestInit_SamplerWired exercises the Options.Sampler branch: the no-op path (empty endpoint) must ignore the sampler and still
+// return cleanly, and the enabled path must build the TracerProvider with the sampler installed (pointed at a dead port to avoid a
+// live collector). End-to-end head-sampling behavior is covered by the internal/observability/tracing unit tests.
+func TestInit_SamplerWired(t *testing.T) { //nolint:paralleltest // Init mutates process-global OTel providers; serial (issue #172)
+	restoreGlobals(t)
+	sampler := sdktrace.ParentBased(tracing.NewRouteTierSampler(tracing.NewRegistry()))
+
+	// No-op path: the sampler is accepted and ignored without error.
+	shutdown, err := Init(t.Context(), Options{ServiceName: "test-svc", Endpoint: "", Sampler: sampler})
+	require.NoError(t, err)
+	require.NotNil(t, shutdown)
+	require.NoError(t, shutdown(t.Context()))
+
+	// Enabled path: NewTracerProvider builds with WithSampler set. A dead endpoint keeps the test hermetic.
+	shutdown2, _ := Init(t.Context(), Options{
+		ServiceName: "test-svc",
+		InitTimeout: 2 * time.Second,
+		Endpoint:    "http://127.0.0.1:1",
+		Sampler:     sampler,
+	})
+	require.NotNil(t, shutdown2)
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+	_ = shutdown2(ctx)
 }
 
 // spec:observability-instrumentation/trace-propagation-through-the-request-pipeline/inbound-traceparent-is-honoured

--- a/internal/observability/observability_test.go
+++ b/internal/observability/observability_test.go
@@ -186,14 +186,21 @@ func TestInit_SamplerWired(t *testing.T) { //nolint:paralleltest // Init mutates
 	require.NotNil(t, shutdown)
 	require.NoError(t, shutdown(t.Context()))
 
-	// Enabled path: NewTracerProvider builds with WithSampler set. A dead endpoint keeps the test hermetic.
-	shutdown2, _ := Init(t.Context(), Options{
+	// Enabled path: NewTracerProvider builds with WithSampler set and is published as the global provider. A dead endpoint keeps the
+	// test hermetic. Capture the global before/after so we prove Init actually swapped in a real provider rather than early-returning on
+	// the no-op path (which would leave the global untouched and pass a weaker nil-only assertion).
+	before := otel.GetTracerProvider()
+	shutdown2, err := Init(t.Context(), Options{
 		ServiceName: "test-svc",
 		InitTimeout: 2 * time.Second,
 		Endpoint:    "http://127.0.0.1:1",
 		Sampler:     sampler,
 	})
+	require.NoError(t, err)
 	require.NotNil(t, shutdown2)
+	after := otel.GetTracerProvider()
+	assert.NotSame(t, before, after, "Init with a non-empty endpoint must publish a new TracerProvider, not no-op")
+	assert.IsType(t, &sdktrace.TracerProvider{}, after, "the published provider is the SDK provider built with WithSampler")
 	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
 	defer cancel()
 	_ = shutdown2(ctx)

--- a/internal/observability/tracing/doc.go
+++ b/internal/observability/tracing/doc.go
@@ -1,0 +1,15 @@
+// Package tracing implements a route-aware head sampler for the EDR server's OTel trace export. Every inbound HTTP span is
+// classified by a Registry into one of four tiers and sampled per tier: agent data-plane traffic (TierHighVolume) is downsampled
+// aggressively, operator/UI read traffic (TierStandard) moderately, everything else (TierFull, the zero value) at 100%, and
+// liveness/health probes (TierDrop) are dropped unconditionally. The goal is to keep the noisy agent firehose from drowning out the
+// rare load-bearing flows (enroll, command delivery, detection) without losing them.
+//
+// Mechanism vs policy: this package owns the mechanism (the sampler, the tier enum, the registry). The route-to-tier policy lives in
+// the server layer (server/tracingpolicy) so this shared package stays free of any EDR-route or bounded-context coupling, and the
+// agent can depend on internal/observability without dragging server routes in.
+//
+// Runtime control: the two ratios and a force-full incident toggle live in a durable settings record. Each replica runs
+// StartSettingsPoller, which re-reads the record on a fixed interval and atomically swaps the sampler's state, so an operator can
+// adjust sampling across a multi-replica deployment without a restart. The applied state is a per-replica cache that is safe to lose
+// (ADR-0010): on a read failure the sampler keeps its built-in defaults.
+package tracing

--- a/internal/observability/tracing/poller.go
+++ b/internal/observability/tracing/poller.go
@@ -20,17 +20,26 @@ const settingsReadTimeout = 5 * time.Second
 // pollTracer instruments the poll loop. When OTLP export is off the global provider returns a no-op tracer, so this costs nothing.
 var pollTracer = otel.Tracer("github.com/fleetdm/edr/internal/observability/tracing")
 
-// StartSettingsPoller runs the polling loop until ctx is cancelled. It does one immediate read at startup so the sampler picks up the
-// row's current values without waiting a full interval, then re-reads on each tick and applies only when something changed. If a read
-// fails, the sampler keeps its previously applied values (its compile-time defaults on the first read) and the next tick retries.
-//
-// Intended to run as `go StartSettingsPoller(ctx, sampler, reader, logger)`; it returns when ctx is cancelled.
-func StartSettingsPoller(ctx context.Context, sampler *RouteTierSampler, reader SettingsReader, logger *slog.Logger) {
+// PrimeSampler performs one synchronous settings read and applies it to the sampler, so a replica serves with the persisted settings
+// from its very first request rather than the compile-time defaults (which would otherwise apply until the background poller's first
+// read landed). cmd/main calls this BEFORE the server starts serving, then hands the returned value to StartSettingsPoller to seed its
+// change detection. On a read failure it returns nil: the sampler keeps its compile-time defaults and the poller retries on its next
+// tick (so a transient DB blip at boot does not block startup).
+func PrimeSampler(ctx context.Context, sampler *RouteTierSampler, reader SettingsReader, logger *slog.Logger) *Settings {
 	if logger == nil {
 		logger = slog.Default()
 	}
-	last := applyOnce(ctx, sampler, nil, reader, logger)
+	return applyOnce(ctx, sampler, nil, reader, logger)
+}
 
+// StartSettingsPoller re-reads the settings on a fixed interval and applies any change, until ctx is cancelled. `last` is the settings
+// already applied by PrimeSampler (pass nil if the caller did not prime); it seeds change detection so an unchanged row is not
+// re-applied, and a primed value means the loop does no redundant read at startup. Intended to run as
+// `go StartSettingsPoller(ctx, sampler, reader, logger, primed)` after a synchronous PrimeSampler; it returns when ctx is cancelled.
+func StartSettingsPoller(ctx context.Context, sampler *RouteTierSampler, reader SettingsReader, logger *slog.Logger, last *Settings) {
+	if logger == nil {
+		logger = slog.Default()
+	}
 	ticker := time.NewTicker(settingsPollInterval)
 	defer ticker.Stop()
 	for {

--- a/internal/observability/tracing/poller.go
+++ b/internal/observability/tracing/poller.go
@@ -1,0 +1,70 @@
+package tracing
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// settingsPollInterval is how often each replica re-reads trace_sampler_settings. 60s matches industry defaults for feature-flag-style
+// runtime config: an operator's change lands across the fleet within a minute, and the per-replica single-row read is negligible.
+const settingsPollInterval = 60 * time.Second
+
+// pollTracer instruments the poll loop. When OTLP export is off the global provider returns a no-op tracer, so this costs nothing.
+var pollTracer = otel.Tracer("github.com/fleetdm/edr/internal/observability/tracing")
+
+// StartSettingsPoller runs the polling loop until ctx is cancelled. It does one immediate read at startup so the sampler picks up the
+// row's current values without waiting a full interval, then re-reads on each tick and applies only when something changed. If a read
+// fails, the sampler keeps its previously applied values (its compile-time defaults on the first read) and the next tick retries.
+//
+// Intended to run as `go StartSettingsPoller(ctx, sampler, reader, logger)`; it returns when ctx is cancelled.
+func StartSettingsPoller(ctx context.Context, sampler *RouteTierSampler, reader SettingsReader, logger *slog.Logger) {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	last := applyOnce(ctx, sampler, nil, reader, logger)
+
+	ticker := time.NewTicker(settingsPollInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			last = applyOnce(ctx, sampler, last, reader, logger)
+		}
+	}
+}
+
+// applyOnce reads the settings once and applies them to the sampler when they differ from last. It returns the settings to compare
+// against next tick: the freshly read value on success, or last unchanged on a read error or a no-op (so a transient DB blip never
+// resets the sampler). Extracted from the loop so the change-detection logic is unit-testable without waiting on the ticker.
+func applyOnce(ctx context.Context, sampler *RouteTierSampler, last *Settings, reader SettingsReader, logger *slog.Logger) *Settings {
+	spanCtx, span := pollTracer.Start(ctx, "tracing.poll_settings",
+		trace.WithNewRoot(),
+		trace.WithSpanKind(trace.SpanKindInternal),
+	)
+	defer span.End()
+
+	got, err := reader.GetTraceSamplerSettings(spanCtx)
+	if err != nil {
+		logger.ErrorContext(spanCtx, "trace sampler settings poll failed", "err", err)
+		return last
+	}
+	if last != nil &&
+		got.HighVolumeRatio == last.HighVolumeRatio &&
+		got.StandardRatio == last.StandardRatio &&
+		got.ForceFull == last.ForceFull {
+		return last
+	}
+	sampler.Apply(got.HighVolumeRatio, got.StandardRatio, got.ForceFull)
+	logger.InfoContext(spanCtx, "trace sampler settings applied",
+		"high_volume_ratio", got.HighVolumeRatio,
+		"standard_ratio", got.StandardRatio,
+		"force_full", got.ForceFull,
+	)
+	return got
+}

--- a/internal/observability/tracing/poller.go
+++ b/internal/observability/tracing/poller.go
@@ -32,9 +32,9 @@ func PrimeSampler(ctx context.Context, sampler *RouteTierSampler, reader Setting
 	return applyOnce(ctx, sampler, nil, reader, logger)
 }
 
-// StartSettingsPoller re-reads the settings on a fixed interval and applies any change, until ctx is cancelled. `last` is the settings
-// already applied by PrimeSampler (pass nil if the caller did not prime); it seeds change detection so an unchanged row is not
-// re-applied, and a primed value means the loop does no redundant read at startup. Intended to run as
+// StartSettingsPoller re-reads the settings on each tick and applies any change, until ctx is cancelled. It does NOT read on startup
+// (that is PrimeSampler's job); the first read happens on the first tick. `last` is the settings already applied by PrimeSampler (pass
+// nil if the caller did not prime); it seeds change detection so the first tick does not re-apply an unchanged row. Intended to run as
 // `go StartSettingsPoller(ctx, sampler, reader, logger, primed)` after a synchronous PrimeSampler; it returns when ctx is cancelled.
 func StartSettingsPoller(ctx context.Context, sampler *RouteTierSampler, reader SettingsReader, logger *slog.Logger, last *Settings) {
 	if logger == nil {

--- a/internal/observability/tracing/poller.go
+++ b/internal/observability/tracing/poller.go
@@ -13,6 +13,10 @@ import (
 // runtime config: an operator's change lands across the fleet within a minute, and the per-replica single-row read is negligible.
 const settingsPollInterval = 60 * time.Second
 
+// settingsReadTimeout bounds a single settings read so a stalled DB connection cannot park the poll goroutine indefinitely (which would
+// freeze runtime sampler updates until process shutdown). Well above a healthy single-row read; the next tick retries on timeout.
+const settingsReadTimeout = 5 * time.Second
+
 // pollTracer instruments the poll loop. When OTLP export is off the global provider returns a no-op tracer, so this costs nothing.
 var pollTracer = otel.Tracer("github.com/fleetdm/edr/internal/observability/tracing")
 
@@ -49,7 +53,10 @@ func applyOnce(ctx context.Context, sampler *RouteTierSampler, last *Settings, r
 	)
 	defer span.End()
 
-	got, err := reader.GetTraceSamplerSettings(spanCtx)
+	// Bound each read so one stalled DB query can't park this goroutine forever and freeze runtime sampler updates.
+	readCtx, cancel := context.WithTimeout(spanCtx, settingsReadTimeout)
+	defer cancel()
+	got, err := reader.GetTraceSamplerSettings(readCtx)
 	if err != nil {
 		logger.ErrorContext(spanCtx, "trace sampler settings poll failed", "err", err)
 		return last

--- a/internal/observability/tracing/poller_test.go
+++ b/internal/observability/tracing/poller_test.go
@@ -52,6 +52,31 @@ func TestApplyOnce_noReapplyWhenUnchanged(t *testing.T) {
 	assert.Same(t, last, got)
 }
 
+func TestStartSettingsPoller_appliesFirstReadThenStopsOnCancel(t *testing.T) {
+	t.Parallel()
+	s := NewRouteTierSampler(NewRegistry())
+	reader := &fakeReader{settings: &Settings{HighVolumeRatio: 0.5, StandardRatio: 0.6, ForceFull: true}}
+
+	// Pre-cancel: StartSettingsPoller performs its immediate first read, then the loop's ctx.Done branch returns at once (no 60s wait).
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	StartSettingsPoller(ctx, s, reader, discard)
+
+	assert.GreaterOrEqual(t, reader.calls, 1, "the poller does one synchronous read before entering the loop")
+	assert.Contains(t, s.Description(), "highVolume=0.5", "the first read is applied to the sampler")
+	assert.Contains(t, s.Description(), "forceFull=true")
+}
+
+func TestStartSettingsPoller_nilLoggerDoesNotPanic(t *testing.T) {
+	t.Parallel()
+	s := NewRouteTierSampler(NewRegistry())
+	reader := &fakeReader{settings: &Settings{HighVolumeRatio: 0.1, StandardRatio: 0.2}}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	// nil logger must be defaulted internally (production passes a real logger, but the guard matters).
+	assert.NotPanics(t, func() { StartSettingsPoller(ctx, s, reader, nil) })
+}
+
 // spec:observability-instrumentation/sampler-ratios-are-runtime-adjustable-without-redeploy/settings-record-is-unreadable-at-startup
 func TestApplyOnce_readErrorKeepsDefaults(t *testing.T) {
 	t.Parallel()

--- a/internal/observability/tracing/poller_test.go
+++ b/internal/observability/tracing/poller_test.go
@@ -1,0 +1,66 @@
+package tracing
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// discard is a no-op logger so the poll loop's structured logs don't spam test output (and applyOnce never sees a nil logger,
+// which StartSettingsPoller guarantees in production).
+var discard = slog.New(slog.DiscardHandler)
+
+type fakeReader struct {
+	settings *Settings
+	err      error
+	calls    int
+}
+
+func (f *fakeReader) GetTraceSamplerSettings(context.Context) (*Settings, error) {
+	f.calls++
+	return f.settings, f.err
+}
+
+// spec:observability-instrumentation/sampler-ratios-are-runtime-adjustable-without-redeploy/a-ratio-change-propagates-to-running-replicas
+func TestApplyOnce_appliesChangedSettings(t *testing.T) {
+	t.Parallel()
+	s := NewRouteTierSampler(NewRegistry())
+	reader := &fakeReader{settings: &Settings{HighVolumeRatio: 0.5, StandardRatio: 0.6, ForceFull: true}}
+
+	got := applyOnce(context.Background(), s, nil, reader, discard)
+
+	require.NotNil(t, got)
+	assert.InDelta(t, 0.5, got.HighVolumeRatio, 1e-9)
+	assert.Contains(t, s.Description(), "highVolume=0.5")
+	assert.Contains(t, s.Description(), "standard=0.6")
+	assert.Contains(t, s.Description(), "forceFull=true")
+}
+
+func TestApplyOnce_noReapplyWhenUnchanged(t *testing.T) {
+	t.Parallel()
+	s := NewRouteTierSampler(NewRegistry())
+	last := &Settings{HighVolumeRatio: 0.5, StandardRatio: 0.6, ForceFull: false}
+	reader := &fakeReader{settings: &Settings{HighVolumeRatio: 0.5, StandardRatio: 0.6, ForceFull: false}}
+
+	got := applyOnce(context.Background(), s, last, reader, discard)
+
+	// Unchanged values: the same `last` pointer is returned (the early-return path that avoids a redundant atomic swap).
+	assert.Same(t, last, got)
+}
+
+// spec:observability-instrumentation/sampler-ratios-are-runtime-adjustable-without-redeploy/settings-record-is-unreadable-at-startup
+func TestApplyOnce_readErrorKeepsDefaults(t *testing.T) {
+	t.Parallel()
+	s := NewRouteTierSampler(NewRegistry())
+	defaultDesc := s.Description()
+	reader := &fakeReader{err: errors.New("db down")}
+
+	got := applyOnce(context.Background(), s, nil, reader, discard)
+
+	assert.Nil(t, got, "a read error returns last (nil at startup) so the next tick retries")
+	assert.Equal(t, defaultDesc, s.Description(), "sampler keeps its compile-time defaults on a read failure")
+}

--- a/internal/observability/tracing/poller_test.go
+++ b/internal/observability/tracing/poller_test.go
@@ -52,19 +52,38 @@ func TestApplyOnce_noReapplyWhenUnchanged(t *testing.T) {
 	assert.Same(t, last, got)
 }
 
-func TestStartSettingsPoller_appliesFirstReadThenStopsOnCancel(t *testing.T) {
+func TestPrimeSampler_appliesSynchronously(t *testing.T) {
 	t.Parallel()
 	s := NewRouteTierSampler(NewRegistry())
 	reader := &fakeReader{settings: &Settings{HighVolumeRatio: 0.5, StandardRatio: 0.6, ForceFull: true}}
 
-	// Pre-cancel: StartSettingsPoller performs its immediate first read, then the loop's ctx.Done branch returns at once (no 60s wait).
+	got := PrimeSampler(context.Background(), s, reader, discard)
+
+	require.NotNil(t, got, "a successful prime returns the applied settings to seed the poller")
+	assert.Equal(t, 1, reader.calls, "prime reads exactly once")
+	assert.Contains(t, s.Description(), "highVolume=0.5", "the persisted settings are applied before serving")
+	assert.Contains(t, s.Description(), "forceFull=true")
+}
+
+func TestPrimeSampler_readErrorKeepsDefaultsAndReturnsNil(t *testing.T) {
+	t.Parallel()
+	s := NewRouteTierSampler(NewRegistry())
+	defaultDesc := s.Description()
+	got := PrimeSampler(context.Background(), s, &fakeReader{err: errors.New("db down")}, discard)
+	assert.Nil(t, got, "a failed prime returns nil so the poller retries on its next tick")
+	assert.Equal(t, defaultDesc, s.Description(), "the sampler keeps its compile-time defaults; startup is not blocked")
+}
+
+func TestStartSettingsPoller_stopsOnCancelWithoutRereading(t *testing.T) {
+	t.Parallel()
+	s := NewRouteTierSampler(NewRegistry())
+	reader := &fakeReader{settings: &Settings{HighVolumeRatio: 0.5, StandardRatio: 0.6}}
+
+	// Pre-cancel: the loop returns on its ctx.Done branch without a tick, so it does no read (priming already did the first read).
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	StartSettingsPoller(ctx, s, reader, discard)
-
-	assert.GreaterOrEqual(t, reader.calls, 1, "the poller does one synchronous read before entering the loop")
-	assert.Contains(t, s.Description(), "highVolume=0.5", "the first read is applied to the sampler")
-	assert.Contains(t, s.Description(), "forceFull=true")
+	StartSettingsPoller(ctx, s, reader, discard, nil)
+	assert.Equal(t, 0, reader.calls, "the loop reads only on a tick; the synchronous first read is PrimeSampler's job")
 }
 
 func TestStartSettingsPoller_nilLoggerDoesNotPanic(t *testing.T) {
@@ -74,7 +93,7 @@ func TestStartSettingsPoller_nilLoggerDoesNotPanic(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	// nil logger must be defaulted internally (production passes a real logger, but the guard matters).
-	assert.NotPanics(t, func() { StartSettingsPoller(ctx, s, reader, nil) })
+	assert.NotPanics(t, func() { StartSettingsPoller(ctx, s, reader, nil, nil) })
 }
 
 // spec:observability-instrumentation/sampler-ratios-are-runtime-adjustable-without-redeploy/settings-record-is-unreadable-at-startup

--- a/internal/observability/tracing/registry.go
+++ b/internal/observability/tracing/registry.go
@@ -1,0 +1,55 @@
+package tracing
+
+import "sync"
+
+// Tier classifies a span for head sampling. The zero value is TierFull, so any span whose route is not registered is sampled at
+// 100%: absence from the noisy lists is what keeps the load-bearing flows safe by default.
+type Tier int
+
+const (
+	// TierFull is the catch-all (zero value). Unregistered spans land here and are sampled at 100%: writes, admin mutations, enroll,
+	// command delivery, and every span the registry does not explicitly downsample.
+	TierFull Tier = iota
+
+	// TierStandard is operator and UI read traffic: the dashboard GET endpoints. Moderate volume, moderate diagnostic value. Sampled
+	// at the configured standard ratio.
+	TierStandard
+
+	// TierHighVolume is the agent data plane that dominates request volume without being individually interesting (event ingest, the
+	// command poll, token refresh, enroll). Sampled at the configured high-volume ratio.
+	TierHighVolume
+
+	// TierDrop is liveness/health/version probe traffic: high volume, zero diagnostic value. Dropped unconditionally, and the drop
+	// wins over the force-full override so a debug window does not flood the backend with probe spans.
+	TierDrop
+)
+
+// Registry maps a span name ("METHOD /path", the format the HTTP span-name formatter emits) to a Tier. The server layer populates it
+// at startup; the sampler reads it via Lookup on every span. A span name not present returns TierFull.
+//
+// Routes added after the sampler is constructed are picked up immediately: the sampler holds the *Registry and reads it live.
+type Registry struct {
+	mu     sync.RWMutex
+	routes map[string]Tier
+}
+
+// NewRegistry returns an empty Registry. Routes are added via Register.
+func NewRegistry() *Registry {
+	return &Registry{routes: make(map[string]Tier)}
+}
+
+// Register classifies a method+path. Re-registering the same method+path overwrites the prior tier. The key is method+" "+path,
+// matching the span name the otelhttp span-name formatter produces ("POST /api/events").
+func (r *Registry) Register(method, path string, tier Tier) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.routes[method+" "+path] = tier
+}
+
+// Lookup returns the tier for a span name, or TierFull when the span name is not registered (the safe-by-default catch-all). Non-HTTP
+// span names (cron, internal work) are simply absent and fall to TierFull.
+func (r *Registry) Lookup(spanName string) Tier {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.routes[spanName]
+}

--- a/internal/observability/tracing/registry_test.go
+++ b/internal/observability/tracing/registry_test.go
@@ -1,0 +1,50 @@
+package tracing
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRegistry_LookupHitsAndMissDefaultsToFull(t *testing.T) {
+	t.Parallel()
+	reg := NewRegistry()
+	reg.Register("POST", "/api/events", TierHighVolume)
+	reg.Register("GET", "/api/hosts", TierStandard)
+	reg.Register("GET", "/livez", TierDrop)
+
+	cases := []struct {
+		name     string
+		spanName string
+		want     Tier
+	}{
+		{"high-volume hit", "POST /api/events", TierHighVolume},
+		{"standard hit", "GET /api/hosts", TierStandard},
+		{"drop hit", "GET /livez", TierDrop},
+		{"unregistered path falls to full", "GET /api/hosts/abc-123/tree", TierFull},
+		{"unregistered method falls to full", "DELETE /api/events", TierFull},
+		{"non-http span name falls to full", "db.query", TierFull},
+		{"empty span name falls to full", "", TierFull},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, reg.Lookup(tc.spanName))
+		})
+	}
+}
+
+func TestRegistry_ReRegisterOverwrites(t *testing.T) {
+	t.Parallel()
+	reg := NewRegistry()
+	reg.Register("GET", "/api/commands", TierStandard)
+	reg.Register("GET", "/api/commands", TierHighVolume)
+	assert.Equal(t, TierHighVolume, reg.Lookup("GET /api/commands"))
+}
+
+func TestTierFullIsZeroValue(t *testing.T) {
+	t.Parallel()
+	// The Lookup-miss contract depends on TierFull being the zero value.
+	var z Tier
+	assert.Equal(t, TierFull, z)
+}

--- a/internal/observability/tracing/sampler.go
+++ b/internal/observability/tracing/sampler.go
@@ -1,0 +1,111 @@
+package tracing
+
+import (
+	"fmt"
+	"sync/atomic"
+
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+)
+
+// Default sampling ratios. These match the seeded trace_sampler_settings row so a freshly started replica samples the same as one
+// that has already polled the DB. High-volume agent traffic is cut to 1%, operator/UI reads to 10%; everything in TierFull stays at
+// 100%. Both are tunable at runtime via the settings API, so these are starting points, not ceilings.
+const (
+	DefaultHighVolumeRatio = 0.01
+	DefaultStandardRatio   = 0.1
+)
+
+// RouteTierSampler implements sdktrace.Sampler. The configured ratios live in an atomic.Pointer so StartSettingsPoller can swap them
+// under a hot reader without locking. Tier classification is delegated to the Registry passed at construction.
+//
+// Wrap it in sdktrace.ParentBased at the provider so a sampled parent forces its children sampled (otherwise child spans, whose names
+// are not in the registry, would each independently fall to TierFull and export even when the root HTTP span was dropped).
+type RouteTierSampler struct {
+	state    atomic.Pointer[samplerState]
+	registry *Registry
+}
+
+type samplerState struct {
+	highVolume sdktrace.Sampler
+	standard   sdktrace.Sampler
+	full       sdktrace.Sampler
+	drop       sdktrace.Sampler
+	// highVolumeRatio + standardRatio are the clamped ratios the two ratio samplers were built from, retained for Description.
+	highVolumeRatio float64
+	standardRatio   float64
+	forceFull       bool
+}
+
+// NewRouteTierSampler returns a sampler initialized with the default ratios and force_full=false. The poller (if running) overwrites
+// these on its first tick once it reads the DB row. Panics if registry is nil.
+func NewRouteTierSampler(registry *Registry) *RouteTierSampler {
+	if registry == nil {
+		panic("tracing.NewRouteTierSampler: registry is required")
+	}
+	s := &RouteTierSampler{registry: registry}
+	s.state.Store(buildState(DefaultHighVolumeRatio, DefaultStandardRatio, false))
+	return s
+}
+
+// Apply replaces the sampler's state atomically. Out-of-range ratios are clamped to [0,1] as a defensive backstop; the DB CHECK
+// constraints and the PATCH handler validation reject them earlier.
+func (s *RouteTierSampler) Apply(highVolume, standard float64, forceFull bool) {
+	s.state.Store(buildState(clamp01(highVolume), clamp01(standard), forceFull))
+}
+
+func clamp01(v float64) float64 {
+	switch {
+	case v < 0:
+		return 0
+	case v > 1:
+		return 1
+	default:
+		return v
+	}
+}
+
+func buildState(highVolume, standard float64, forceFull bool) *samplerState {
+	return &samplerState{
+		highVolume:      sdktrace.TraceIDRatioBased(highVolume),
+		standard:        sdktrace.TraceIDRatioBased(standard),
+		full:            sdktrace.AlwaysSample(),
+		drop:            sdktrace.NeverSample(),
+		highVolumeRatio: highVolume,
+		standardRatio:   standard,
+		forceFull:       forceFull,
+	}
+}
+
+// ShouldSample implements sdktrace.Sampler. TierDrop is checked first so probes are dropped even under force_full. For every other
+// tier, force_full lifts sampling to 100%; otherwise the tier's configured ratio applies. Unregistered spans fall to TierFull (100%).
+func (s *RouteTierSampler) ShouldSample(p sdktrace.SamplingParameters) sdktrace.SamplingResult {
+	st := s.state.Load()
+	tier := s.registry.Lookup(p.Name)
+	if tier == TierDrop {
+		return st.drop.ShouldSample(p)
+	}
+	if st.forceFull {
+		return st.full.ShouldSample(p)
+	}
+	switch tier {
+	case TierHighVolume:
+		return st.highVolume.ShouldSample(p)
+	case TierStandard:
+		return st.standard.ShouldSample(p)
+	case TierFull:
+		return st.full.ShouldSample(p)
+	case TierDrop:
+		// Unreachable (handled before the force_full branch); listed so the switch is exhaustive over Tier.
+		return st.drop.ShouldSample(p)
+	}
+	// Compiler-required terminator: a switch over typed constants is not a terminating statement. A future tier with no case falls
+	// back to full fidelity rather than silently dropping.
+	return st.full.ShouldSample(p)
+}
+
+// Description implements sdktrace.Sampler. Used by the SDK for diagnostic logging.
+func (s *RouteTierSampler) Description() string {
+	st := s.state.Load()
+	return fmt.Sprintf("RouteTierSampler{highVolume=%g,standard=%g,forceFull=%t}",
+		st.highVolumeRatio, st.standardRatio, st.forceFull)
+}

--- a/internal/observability/tracing/sampler_test.go
+++ b/internal/observability/tracing/sampler_test.go
@@ -1,0 +1,143 @@
+package tracing
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"pgregory.net/rapid"
+
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// aTraceID is an arbitrary non-zero trace ID. With ratios pinned to 0 or 1 the specific value is irrelevant (TraceIDRatioBased(0)
+// never samples, (1) always), so tests stay deterministic.
+var aTraceID = trace.TraceID{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10}
+
+func params(name string) sdktrace.SamplingParameters {
+	return sdktrace.SamplingParameters{
+		ParentContext: context.Background(),
+		TraceID:       aTraceID,
+		Name:          name,
+		Kind:          trace.SpanKindServer,
+	}
+}
+
+func isSampled(r sdktrace.SamplingResult) bool { return r.Decision == sdktrace.RecordAndSample }
+
+func newSamplerWithPolicy() (*RouteTierSampler, *Registry) {
+	reg := NewRegistry()
+	reg.Register("POST", "/api/events", TierHighVolume)
+	reg.Register("GET", "/api/hosts", TierStandard)
+	reg.Register("GET", "/livez", TierDrop)
+	return NewRouteTierSampler(reg), reg
+}
+
+func TestRouteTierSampler_tierSelection(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name        string
+		highVolume  float64
+		standard    float64
+		forceFull   bool
+		spanName    string
+		wantSampled bool
+	}{
+		// spec:observability-instrumentation/route-tier-head-sampling-of-exported-traces/agent-ingest-traffic-is-downsampled
+		{"high-volume route at ratio 0 is dropped", 0, 1, false, "POST /api/events", false},
+		{"high-volume route at ratio 1 is sampled", 1, 0, false, "POST /api/events", true},
+		{"standard route at ratio 0 is dropped", 0, 0, false, "GET /api/hosts", false},
+		{"standard route at ratio 1 is sampled", 0, 1, false, "GET /api/hosts", true},
+		// spec:observability-instrumentation/route-tier-head-sampling-of-exported-traces/unclassified-routes-are-sampled-at-full-fidelity
+		{"unregistered route is full fidelity even at zero ratios", 0, 0, false, "POST /api/alerts", true},
+		{"unregistered GET detail read is full fidelity", 0, 0, false, "GET /api/alerts/42", true},
+		// spec:observability-instrumentation/force-full-override-restores-complete-tracing/force-full-lifts-all-tiers-to-full-sampling
+		{"force-full lifts high-volume to sampled", 0, 0, true, "POST /api/events", true},
+		{"force-full lifts standard to sampled", 0, 0, true, "GET /api/hosts", true},
+		// spec:observability-instrumentation/liveness-and-health-probe-traces-are-never-exported/probe-spans-are-dropped
+		{"probe route is dropped at full ratios", 1, 1, false, "GET /livez", false},
+		// spec:observability-instrumentation/liveness-and-health-probe-traces-are-never-exported/probes-stay-dropped-under-force-full
+		{"probe route stays dropped under force-full", 1, 1, true, "GET /livez", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			s, _ := newSamplerWithPolicy()
+			s.Apply(tc.highVolume, tc.standard, tc.forceFull)
+			got := isSampled(s.ShouldSample(params(tc.spanName)))
+			assert.Equal(t, tc.wantSampled, got)
+		})
+	}
+}
+
+// spec:observability-instrumentation/route-tier-head-sampling-of-exported-traces/a-sampled-parent-forces-its-children-sampled
+func TestRouteTierSampler_parentBasedForcesChildrenSampled(t *testing.T) {
+	t.Parallel()
+	s, _ := newSamplerWithPolicy()
+	s.Apply(0, 0, false) // zero ratios: a root would not be sampled
+	parentBased := sdktrace.ParentBased(s)
+
+	parentSC := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    aTraceID,
+		SpanID:     trace.SpanID{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08},
+		TraceFlags: trace.FlagsSampled,
+		Remote:     true,
+	})
+	ctx := trace.ContextWithSpanContext(context.Background(), parentSC)
+
+	// A child span whose name is not a registered route would fall to TierFull, but the sampled parent must win.
+	res := parentBased.ShouldSample(sdktrace.SamplingParameters{
+		ParentContext: ctx,
+		TraceID:       aTraceID,
+		Name:          "db.query",
+		Kind:          trace.SpanKindInternal,
+	})
+	assert.Equal(t, sdktrace.RecordAndSample, res.Decision)
+
+	// And an unsampled parent keeps the child unsampled (the ratio decision does not resurrect it).
+	unsampledSC := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID: aTraceID,
+		SpanID:  trace.SpanID{0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10},
+		Remote:  true,
+	})
+	resUnsampled := parentBased.ShouldSample(sdktrace.SamplingParameters{
+		ParentContext: trace.ContextWithSpanContext(context.Background(), unsampledSC),
+		TraceID:       aTraceID,
+		Name:          "POST /api/events",
+		Kind:          trace.SpanKindServer,
+	})
+	assert.NotEqual(t, sdktrace.RecordAndSample, resUnsampled.Decision)
+}
+
+func TestRouteTierSampler_applyClampsOutOfRange(t *testing.T) {
+	t.Parallel()
+	s, _ := newSamplerWithPolicy()
+	// high-volume clamps to 0 (never), standard clamps to 1 (always).
+	s.Apply(-0.5, 2.0, false)
+	assert.False(t, isSampled(s.ShouldSample(params("POST /api/events"))), "high-volume clamped to 0 must not sample")
+	assert.True(t, isSampled(s.ShouldSample(params("GET /api/hosts"))), "standard clamped to 1 must sample")
+	assert.Contains(t, s.Description(), "highVolume=0")
+	assert.Contains(t, s.Description(), "standard=1")
+}
+
+func TestRouteTierSampler_descriptionDefaults(t *testing.T) {
+	t.Parallel()
+	s, _ := newSamplerWithPolicy()
+	assert.Contains(t, s.Description(), "forceFull=false")
+}
+
+// TestClamp01 is the algebraic invariant: clamp01 always lands in [0,1] and is the identity inside it.
+func TestClamp01(t *testing.T) {
+	t.Parallel()
+	rapid.Check(t, func(rt *rapid.T) {
+		v := rapid.Float64().Draw(rt, "v")
+		got := clamp01(v)
+		require.GreaterOrEqual(t, got, 0.0)
+		require.LessOrEqual(t, got, 1.0)
+		if v >= 0 && v <= 1 {
+			require.InDelta(t, v, got, 0)
+		}
+	})
+}

--- a/internal/observability/tracing/settings.go
+++ b/internal/observability/tracing/settings.go
@@ -6,7 +6,8 @@ import (
 )
 
 // Settings is the runtime-tunable head-sampling configuration. It lives in the trace_sampler_settings singleton row and is polled by
-// each replica so an operator can adjust sampling without a restart. The db tags let the identity store scan a row straight into it.
+// each replica so an operator can adjust sampling without a restart. The db tags let the observability context's settings store scan a
+// row straight into it.
 type Settings struct {
 	HighVolumeRatio float64   `json:"high_volume_ratio" db:"high_volume_ratio"`
 	StandardRatio   float64   `json:"standard_ratio" db:"standard_ratio"`
@@ -14,7 +15,7 @@ type Settings struct {
 	UpdatedAt       time.Time `json:"updated_at,omitzero" db:"updated_at"`
 }
 
-// SettingsReader is the minimal store surface StartSettingsPoller needs. It is implemented by the identity context's
+// SettingsReader is the minimal store surface StartSettingsPoller needs. It is implemented by the observability context's
 // trace-sampler-settings store and injected at wiring time, so this package carries no persistence or bounded-context dependency
 // (the poller depends on the interface; cmd/main injects the implementation).
 type SettingsReader interface {

--- a/internal/observability/tracing/settings.go
+++ b/internal/observability/tracing/settings.go
@@ -1,0 +1,22 @@
+package tracing
+
+import (
+	"context"
+	"time"
+)
+
+// Settings is the runtime-tunable head-sampling configuration. It lives in the trace_sampler_settings singleton row and is polled by
+// each replica so an operator can adjust sampling without a restart. The db tags let the identity store scan a row straight into it.
+type Settings struct {
+	HighVolumeRatio float64   `json:"high_volume_ratio" db:"high_volume_ratio"`
+	StandardRatio   float64   `json:"standard_ratio" db:"standard_ratio"`
+	ForceFull       bool      `json:"force_full" db:"force_full"`
+	UpdatedAt       time.Time `json:"updated_at,omitzero" db:"updated_at"`
+}
+
+// SettingsReader is the minimal store surface StartSettingsPoller needs. It is implemented by the identity context's
+// trace-sampler-settings store and injected at wiring time, so this package carries no persistence or bounded-context dependency
+// (the poller depends on the interface; cmd/main injects the implementation).
+type SettingsReader interface {
+	GetTraceSamplerSettings(ctx context.Context) (*Settings, error)
+}

--- a/openspec/changes/otel-route-tier-sampling/.openspec.yaml
+++ b/openspec/changes/otel-route-tier-sampling/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-24

--- a/openspec/changes/otel-route-tier-sampling/design.md
+++ b/openspec/changes/otel-route-tier-sampling/design.md
@@ -1,0 +1,75 @@
+## Context
+
+The TracerProvider in `internal/observability/observability.go` is built with `WithBatcher` + `WithResource` and no sampler, so the SDK default (`ParentBased(AlwaysSample)`) records and exports every span. Production already fails trace export with `502 (Bad Gateway)` against the collector, and the dominant volume is the agent data plane (`POST /api/events`). The server is stateless and multi-replica behind a load balancer (ADR-0010), so any runtime control must propagate to every replica without shared in-process state. Cross-context calls go through the imported `api/` package only (ADR-0004).
+
+Fleet solves the same problem in `server/platform/tracing`: a `RouteTierSampler` whose ratios live in an `atomic.Pointer`, a `Registry` that classifies span names into tiers (the policy seam each context populates), and a `StartSettingsPoller` that re-reads a singleton settings row every 60s and atomically swaps the sampler state. We mirror that mechanism/policy split.
+
+One EDR-specific constraint: `otelhttp.NewHandler` is the outermost middleware (`server/httpserver/httpserver.go`), so the span is created before `net/http` route matching and the span name is the raw `method + URL.Path`, not the route template. This is workable because the routes that drive volume have literal paths.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Cap baseline trace volume with route-aware head sampling, three tiers (HighVolume / Standard / Full).
+- Let an operator change the two ratios and a force-full toggle at runtime, propagated to every replica within one poll interval, no redeploy.
+- Keep aggregate latency/alerting signals correct under sampling by anchoring them to metrics.
+
+**Non-Goals:**
+
+- Runtime log-level control (deferred; out of scope for this change).
+- New environment variables (defaults are compile-time constants seeded into the migration row).
+- Tail sampling in the collector (possible follow-up).
+- A UI control surface (API-only for now).
+
+## Decisions
+
+### Three tiers, classified by span name
+
+`Tier` is `Full | Standard | HighVolume | Drop`, with `Full` as the zero value so any unregistered span is safe-by-default at 100% until someone deliberately downsamples it.
+
+- **HighVolume**: agent data-plane routes that dominate volume without being individually interesting: `POST /api/events`, the agent `GET /api/commands` poll, `POST /api/token/refresh`, `POST /api/enroll`.
+- **Standard**: operator/UI read traffic (the dashboard `GET` endpoints).
+- **Full**: everything else (writes, admin mutations, unclassified).
+- **Drop**: liveness/health/version probes. Classified to `NeverSample`, and this check runs before the force-full branch so probe spans are never exported even during a debug window. Pure load-balancer noise with zero diagnostic value, matching Fleet's `TierNever`.
+
+The `Registry` maps `"METHOD /path"` to a tier; `Lookup` returns `Full` for misses. Because the HighVolume routes are all literal paths (no `{param}` segments), the existing raw-path span name matches the registry exactly; no path normalizer is needed. Param-bearing routes (`/api/commands/{id}`, `/api/enrollments/{host_id}/revoke`) are operator/low-volume and correctly fall to Full.
+
+**Alternative considered**: add a path normalizer (collapse UUID/numeric segments) so param-bearing routes can be tiered too. Rejected for now: the volume drivers don't need it, and a normalizer is fragile to maintain. Documented as a known limitation.
+
+### Sampler wiring: `ParentBased(RouteTierSampler)`
+
+`RouteTierSampler` implements `sdktrace.Sampler`. Its state (a `TraceIDRatioBased` per ratio-bearing tier, an `AlwaysSample` for Full, and the `force_full` flag) lives in an `atomic.Pointer` so the poller swaps it under a hot reader without locking. `Apply(highVolume, standard, forceFull)` clamps each ratio to `[0,1]` as a defensive backstop. It is wrapped in `ParentBased` at the provider so a sampled parent forces its children sampled and only root spans take a tier decision. `observability.Init` accepts the sampler via `Options` and adds `sdktrace.WithSampler(...)`.
+
+### Persistence: dedicated `trace_sampler_settings` singleton table
+
+Typed columns (`high_volume_ratio` DOUBLE, `standard_ratio` DOUBLE, `force_full` BOOL, `updated_at`) with `CHECK (... BETWEEN 0 AND 1)` constraints, single row seeded by the migration with the sampler's compile-time defaults.
+
+**Alternative considered**: extend identity's `appconfig` JSON blob. Rejected in favor of a dedicated table: explicit schema, DB-enforced bounds, and a clean read accessor, matching the Fleet design and "industry best practice" for a typed runtime-config knob.
+
+**Ownership**: the table, migration, store, and handler live in a new **`observability`** bounded context (a sixth context, amending ADR-0004). It owns a schema and serves an authz-gated, audited HTTP route, which is the bounded-context shape here; a context-free platform package can't host it because arch-go forbids platform packages from importing any context (so they can't reach `identity/api` for authz + audit). The context consumes `identity/api` for the chokepoint + audit recorder, exactly as `endpoint`/`response` do, and exposes its store as the poller's `tracing.SettingsReader`. The sampler mechanism + `Settings` type stay in the agent-safe `internal/observability/tracing` infra package, which this context imports.
+
+### Per-replica polling, 60s
+
+`StartSettingsPoller` does one immediate read at startup, then ticks every 60s, applies only on change, and keeps the compile-time defaults if the first read fails (warn-logged, retried next tick). The applied state is a per-replica cache that is safe to lose, which satisfies ADR-0010.
+
+### Admin API: `GET` / `PATCH /api/settings/tracing`
+
+Super_admin only (session cookie + CSRF, matching the other `/api/settings/*` endpoints). `PATCH` validates each ratio in `[0,1]` before persisting and returns the updated settings. Not reachable with an agent host token.
+
+### Default ratios (industry best practice)
+
+Seed `high_volume_ratio = 0.01`, `standard_ratio = 0.1`, `force_full = false`. These keep the load-bearing rare paths at full fidelity (Full = 100%) while cutting the agent firehose by ~99%. Both are tunable live, so the exact seed is low-stakes; they match the sampler's compile-time constants so a fresh replica and a polled one agree.
+
+## Risks / Trade-offs
+
+- **Param-bearing high-volume route appears later** → it would default to Full (100%) and not be downsampled until a normalizer is added. Mitigation: documented limitation; today's volume drivers are all literal-path.
+- **p99/error-rate dashboards currently read from spans** → under sampling they become biased. Mitigation: a spec requirement plus operator doc mandating that aggregate latency/alerting read from metrics (`http.server.request.duration`, counters), which are never sampled.
+- **Misconfiguration sets a ratio to 0 and hides a real incident's traces** → Mitigation: `force_full` toggle restores 100% live within one poll interval; CHECK constraints and handler validation bound the inputs.
+- **Poller adds a 60s query per replica** → negligible; single-row read, instrumented with its own internal span.
+
+## Migration Plan
+
+1. Additive migration creates `trace_sampler_settings` and seeds one row with the defaults. No change to the agent protocol, events schema, or host token, so no agent-side rollback is needed.
+2. Deploy server + ingest with the sampler wired; trace volume drops immediately to the seeded ratios.
+3. Move any span-derived p99/error dashboards to metrics before relying on them.
+4. **Rollback**: drop the table (sampler falls back to compile-time defaults) or revert the binary (TracerProvider returns to the always-on default).

--- a/openspec/changes/otel-route-tier-sampling/design.md
+++ b/openspec/changes/otel-route-tier-sampling/design.md
@@ -27,9 +27,9 @@ One EDR-specific constraint: `otelhttp.NewHandler` is the outermost middleware (
 
 `Tier` is `Full | Standard | HighVolume | Drop`, with `Full` as the zero value so any unregistered span is safe-by-default at 100% until someone deliberately downsamples it.
 
-- **HighVolume**: agent data-plane routes that dominate volume without being individually interesting: `POST /api/events`, the agent `GET /api/commands` poll, `POST /api/token/refresh`, `POST /api/enroll`.
+- **HighVolume**: high-frequency agent data-plane routes that dominate volume without being individually interesting: `POST /api/events`, the agent `GET /api/commands` poll, `POST /api/token/refresh`.
 - **Standard**: operator/UI read traffic (the dashboard `GET` endpoints).
-- **Full**: everything else (writes, admin mutations, unclassified).
+- **Full**: everything else (writes, admin mutations, unclassified) including low-frequency load-bearing agent routes like `POST /api/enroll`, which stay at 100% so enrollment traces are never sampled away.
 - **Drop**: liveness/health/version probes. Classified to `NeverSample`, and this check runs before the force-full branch so probe spans are never exported even during a debug window. Pure load-balancer noise with zero diagnostic value, matching Fleet's `TierNever`.
 
 The `Registry` maps `"METHOD /path"` to a tier; `Lookup` returns `Full` for misses. Because the HighVolume routes are all literal paths (no `{param}` segments), the existing raw-path span name matches the registry exactly; no path normalizer is needed. Param-bearing routes (`/api/commands/{id}`, `/api/enrollments/{host_id}/revoke`) are operator/low-volume and correctly fall to Full.

--- a/openspec/changes/otel-route-tier-sampling/proposal.md
+++ b/openspec/changes/otel-route-tier-sampling/proposal.md
@@ -1,0 +1,37 @@
+## Why
+
+OTel trace export is unbounded: no sampler is configured, so the SDK default (parent-based, always-on) records and exports every span. The production server is already failing exports with `traces export: exporter export timeout: ... 502 (Bad Gateway)` against a constrained collector, and the volume only grows with the fleet. Operators have no way to dial telemetry down (to survive an export incident) or up (to debug) without a redeploy. We need head sampling to cap baseline volume and a runtime control to adjust it live.
+
+## What Changes
+
+- Add a route-aware head sampler (`ParentBased(RouteTierSampler)`) to the server and ingest TracerProviders, replacing the implicit always-on SDK default.
+- Classify every HTTP span into a sampling tier:
+  - **HighVolume**: agent data-plane traffic (`POST /api/events`, the agent `GET /api/commands` poll, `POST /api/token/refresh`, `POST /api/enroll`). Heavily sampled.
+  - **Standard**: API/user read traffic (operator and UI `GET` endpoints). Moderately sampled.
+  - **Full**: everything else (writes, admin mutations, unclassified routes). Sampled at 100%, safe-by-default.
+  - **Drop**: liveness/health/version probes. Never recorded or exported, and this wins over `force_full`.
+- Add a `force_full` incident toggle that lifts all tiers to 100% for a debug window without a redeploy.
+- Persist the two ratios plus `force_full` in a dedicated `trace_sampler_settings` singleton MySQL table with `CHECK` constraints bounding each ratio to `[0, 1]`. Seed the row with the sampler's compile-time defaults. No new environment variables.
+- Each replica polls the row every 60s and atomically swaps the live sampler state, so changes propagate across the stateless app tier without a restart (ADR-0010).
+- Expose `GET` and `PATCH /api/settings/tracing` (admin + super_admin, like the SSO settings API) to read and update the settings.
+- Document that under sampling, p99 and alerting must read from metrics (counter- and histogram-based, never sampled), not from sampled spans.
+
+## Capabilities
+
+### New Capabilities
+<!-- none -->
+
+### Modified Capabilities
+- `observability-instrumentation`: adds requirements for route-tier head sampling, runtime-adjustable sampler settings (persistence, per-replica polling, admin API, force-full override), and the constraint that aggregate latency/alerting signals derive from metrics rather than sampled spans.
+
+## Impact
+
+- **Code**:
+  - New shared package `internal/observability/tracing` (Tier, Registry, RouteTierSampler, Settings, StartSettingsPoller), mirroring Fleet's `server/platform/tracing` mechanism/policy split.
+  - `internal/observability/observability.go`: `Init` wires `ParentBased(RouteTierSampler)` into the TracerProvider via `Options`.
+  - `server/cmd/fleet-edr-server/main.go` and `server/cmd/fleet-edr-ingest/main.go`: construct the sampler + registry, register the route-tier policy, start the poller. Both mount `POST /api/events`.
+  - New `observability` bounded context (a sixth context, ADR-0004 amendment): `trace_sampler_settings` table + migration, store, and the `GET`/`PATCH /api/settings/tracing` handler. It consumes `identity/api` for the authz chokepoint + audit recorder, and exposes the store as the poller's `tracing.SettingsReader`. The sampler mechanism stays in the agent-safe `internal/observability/tracing` infra package.
+- **APIs**: new admin + super_admin endpoints `GET`/`PATCH /api/settings/tracing`. No change to the agent protocol, the events schema, or the persisted host token, so no rollback steps are required for those surfaces.
+- **Database**: one additive migration creating `trace_sampler_settings`. Rollback is dropping the table; the sampler falls back to compile-time defaults if the row is unreadable.
+- **Observability**: trace volume drops to the configured ratios; dashboards/alerts that read p99 from spans must move to metrics.
+- **Docs**: operator doc for the new endpoint and the metrics-are-authoritative-under-sampling note.

--- a/openspec/changes/otel-route-tier-sampling/proposal.md
+++ b/openspec/changes/otel-route-tier-sampling/proposal.md
@@ -6,11 +6,11 @@ OTel trace export is unbounded: no sampler is configured, so the SDK default (pa
 
 - Add a route-aware head sampler (`ParentBased(RouteTierSampler)`) to the server and ingest TracerProviders, replacing the implicit always-on SDK default.
 - Classify every HTTP span into a sampling tier:
-  - **HighVolume**: agent data-plane traffic (`POST /api/events`, the agent `GET /api/commands` poll, `POST /api/token/refresh`, `POST /api/enroll`). Heavily sampled.
+  - **HighVolume**: high-frequency agent data-plane traffic (`POST /api/events`, the agent `GET /api/commands` poll, `POST /api/token/refresh`). Heavily sampled. (Rare load-bearing agent routes like `POST /api/enroll` stay Full.)
   - **Standard**: API/user read traffic (operator and UI `GET` endpoints). Moderately sampled.
   - **Full**: everything else (writes, admin mutations, unclassified routes). Sampled at 100%, safe-by-default.
   - **Drop**: liveness/health/version probes. Never recorded or exported, and this wins over `force_full`.
-- Add a `force_full` incident toggle that lifts all tiers to 100% for a debug window without a redeploy.
+- Add a `force_full` incident toggle that lifts every non-drop tier to 100% for a debug window without a redeploy (probes stay dropped).
 - Persist the two ratios plus `force_full` in a dedicated `trace_sampler_settings` singleton MySQL table with `CHECK` constraints bounding each ratio to `[0, 1]`. Seed the row with the sampler's compile-time defaults. No new environment variables.
 - Each replica polls the row every 60s and atomically swaps the live sampler state, so changes propagate across the stateless app tier without a restart (ADR-0010).
 - Expose `GET` and `PATCH /api/settings/tracing` (admin + super_admin, like the SSO settings API) to read and update the settings.

--- a/openspec/changes/otel-route-tier-sampling/specs/observability-instrumentation/spec.md
+++ b/openspec/changes/otel-route-tier-sampling/specs/observability-instrumentation/spec.md
@@ -1,0 +1,109 @@
+## ADDED Requirements
+
+### Requirement: Route-tier head sampling of exported traces
+
+When OTLP export is enabled, the system SHALL apply head sampling to traces, classifying each inbound HTTP request span into a sampling tier and sampling each ratio-bearing tier at its configured ratio: a high-volume tier for agent data-plane traffic, a standard tier for operator and UI read traffic, and a full tier for everything else. The full tier SHALL be sampled at 100% and SHALL be the default for any span not explicitly classified, so a newly added route is captured at full fidelity until it is deliberately downsampled. Sampling SHALL be parent-based: a span whose parent was sampled MUST itself be sampled, so a distributed trace is never partially captured. The agent data-plane routes `POST /api/events`, the agent command poll `GET /api/commands`, `POST /api/token/refresh`, and `POST /api/enroll` SHALL be classified high-volume.
+
+#### Scenario: Agent ingest traffic is downsampled
+
+- **GIVEN** OTLP export is enabled and the high-volume ratio is below 1.0
+- **WHEN** agents send many `POST /api/events` requests
+- **THEN** only the configured high-volume fraction of those request traces is exported
+
+#### Scenario: Unclassified routes are sampled at full fidelity
+
+- **GIVEN** a request to a route that is not registered in any sampling tier
+- **WHEN** the server handles the request
+- **THEN** the request trace is sampled at 100%
+
+#### Scenario: A sampled parent forces its children sampled
+
+- **GIVEN** an inbound request whose `traceparent` marks the parent span as sampled
+- **WHEN** the server creates child spans for downstream processing
+- **THEN** those child spans are sampled regardless of the tier ratio that would otherwise apply
+
+### Requirement: Sampler ratios are runtime-adjustable without redeploy
+
+The system SHALL persist the high-volume ratio, the standard ratio, and a force-full flag in a single durable settings record bounded so each ratio is between 0 and 1 inclusive. Each server replica SHALL read this record on startup and re-read it periodically, applying any change to its live sampler without a restart, so an operator can adjust sampling across a multi-replica deployment without redeploying. The system SHALL NOT require any environment variable to configure sampling; the durable record SHALL be seeded with built-in defaults, and a replica that cannot read the record SHALL fall back to those same built-in defaults rather than failing to start.
+
+#### Scenario: A ratio change propagates to running replicas
+
+- **GIVEN** a running server replica with a live sampler
+- **WHEN** the persisted high-volume ratio is changed
+- **THEN** the replica applies the new ratio to subsequent sampling decisions within one poll interval, without a restart
+
+#### Scenario: Settings record is unreadable at startup
+
+- **GIVEN** the settings record cannot be read when a replica starts
+- **WHEN** the replica initializes its sampler
+- **THEN** the replica uses the built-in default ratios and continues running
+
+#### Scenario: Out-of-range ratio is rejected by the store
+
+- **GIVEN** an attempt to persist a ratio outside the range 0 to 1
+- **WHEN** the write is submitted
+- **THEN** the store rejects it and the persisted ratios are unchanged
+
+### Requirement: Force-full override restores complete tracing
+
+The system SHALL provide a force-full override that, when enabled, causes every tier to be sampled at 100% regardless of its configured ratio, so an operator can capture complete traces during an incident debug window and disable it afterward, in both cases without a redeploy.
+
+#### Scenario: Force-full lifts all tiers to full sampling
+
+- **GIVEN** the high-volume and standard ratios are below 1.0 and force-full is enabled
+- **WHEN** agents and operators send requests across all tiers
+- **THEN** every request trace is exported while force-full remains enabled
+
+### Requirement: Liveness and health probe traces are never exported
+
+The system SHALL classify liveness, readiness, health, and version-probe request spans into a drop tier whose spans are never recorded or exported. This classification SHALL take precedence over the force-full override, so enabling force-full during an incident does not flood the backend with probe traffic.
+
+#### Scenario: Probe spans are dropped
+
+- **GIVEN** OTLP export is enabled
+- **WHEN** a load balancer or orchestrator polls the health or version endpoint
+- **THEN** no trace for that request is exported
+
+#### Scenario: Probes stay dropped under force-full
+
+- **GIVEN** force-full is enabled
+- **WHEN** the health or version endpoint is polled
+- **THEN** the probe request trace is still not exported
+
+### Requirement: Operators adjust sampler settings through an authenticated admin endpoint
+
+The system SHALL expose an authenticated endpoint to read and update the sampler settings, restricted to operators holding the tracing-management grant (the admin or super_admin role) and authenticated by the operator session cookie and CSRF token. The endpoint SHALL reject requests from an operator without that grant. An update SHALL validate that each ratio is between 0 and 1 inclusive before persisting and SHALL return the resulting settings.
+
+#### Scenario: An administrator updates the ratios
+
+- **GIVEN** an operator holding the tracing-management grant with a valid session cookie and CSRF token
+- **WHEN** they submit an update setting the high-volume and standard ratios within range
+- **THEN** the settings are persisted and the response returns the updated values
+
+#### Scenario: An operator without the grant is denied
+
+- **GIVEN** an authenticated operator who does not hold the tracing-management grant
+- **WHEN** they attempt to read or update the sampler settings
+- **THEN** the request is denied and the settings are unchanged
+
+#### Scenario: Update with an out-of-range ratio is rejected
+
+- **GIVEN** an authorized operator submitting an update with a ratio above 1.0
+- **WHEN** the update is processed
+- **THEN** the endpoint rejects the request and no setting is changed
+
+### Requirement: Aggregate latency and alerting derive from metrics, not sampled spans
+
+Because traces are head-sampled, aggregate request-rate, latency-percentile, and error-rate signals SHALL be derived from the metric instruments, which are never sampled, rather than from exported spans. The per-request latency histogram and the stable counters SHALL continue to record every request and event regardless of the trace sample ratio in effect, so a low sample ratio MUST NOT bias these aggregates.
+
+#### Scenario: Latency percentiles are unaffected by the sample ratio
+
+- **GIVEN** the high-volume ratio is set to a small fraction
+- **WHEN** many agent requests are handled
+- **THEN** the `http.server.request.duration` histogram records every request and its percentiles reflect the full request population, not the sampled subset
+
+#### Scenario: Event counts are unaffected by the sample ratio
+
+- **GIVEN** trace sampling is in effect at any ratio
+- **WHEN** the ingest endpoint accepts a batch of events
+- **THEN** `edr.events.ingested` is incremented by the full batch size independent of whether the request's trace was sampled

--- a/openspec/changes/otel-route-tier-sampling/specs/observability-instrumentation/spec.md
+++ b/openspec/changes/otel-route-tier-sampling/specs/observability-instrumentation/spec.md
@@ -2,7 +2,7 @@
 
 ### Requirement: Route-tier head sampling of exported traces
 
-When OTLP export is enabled, the system SHALL apply head sampling to traces, classifying each inbound HTTP request span into a sampling tier and sampling each ratio-bearing tier at its configured ratio: a high-volume tier for agent data-plane traffic, a standard tier for operator and UI read traffic, and a full tier for everything else. The full tier SHALL be sampled at 100% and SHALL be the default for any span not explicitly classified, so a newly added route is captured at full fidelity until it is deliberately downsampled. Sampling SHALL be parent-based: a span whose parent was sampled MUST itself be sampled, so a distributed trace is never partially captured. The agent data-plane routes `POST /api/events`, the agent command poll `GET /api/commands`, `POST /api/token/refresh`, and `POST /api/enroll` SHALL be classified high-volume.
+When OTLP export is enabled, the system SHALL apply head sampling to traces, classifying each inbound HTTP request span into a sampling tier and sampling each ratio-bearing tier at its configured ratio: a high-volume tier for high-frequency agent data-plane traffic, a standard tier for operator and UI read traffic, and a full tier for everything else. The full tier SHALL be sampled at 100% and SHALL be the default for any span not explicitly classified, so a newly added route is captured at full fidelity until it is deliberately downsampled. Sampling SHALL be parent-based: a span whose parent was sampled MUST itself be sampled, so a distributed trace is never partially captured. The high-frequency agent routes `POST /api/events`, the agent command poll `GET /api/commands`, and `POST /api/token/refresh` SHALL be classified high-volume; low-frequency load-bearing agent routes such as `POST /api/enroll` SHALL remain in the full tier so they are captured at full fidelity.
 
 #### Scenario: Agent ingest traffic is downsampled
 
@@ -46,7 +46,7 @@ The system SHALL persist the high-volume ratio, the standard ratio, and a force-
 
 ### Requirement: Force-full override restores complete tracing
 
-The system SHALL provide a force-full override that, when enabled, causes every tier to be sampled at 100% regardless of its configured ratio, so an operator can capture complete traces during an incident debug window and disable it afterward, in both cases without a redeploy.
+The system SHALL provide a force-full override that, when enabled, causes every non-drop tier to be sampled at 100% regardless of its configured ratio, so an operator can capture complete traces during an incident debug window and disable it afterward, in both cases without a redeploy. The drop tier is exempt: probe spans stay dropped even under force-full (see the probe requirement below).
 
 #### Scenario: Force-full lifts all tiers to full sampling
 

--- a/openspec/changes/otel-route-tier-sampling/tasks.md
+++ b/openspec/changes/otel-route-tier-sampling/tasks.md
@@ -1,0 +1,42 @@
+## 1. Shared sampler package (`internal/observability/tracing`)
+
+- [x] 1.1 Add `Tier` (Full=zero-value catch-all, Standard, HighVolume, Drop) and `Registry` (map of `"METHOD /path"` to tier; `Lookup` returns Full on miss) with `Register`/`Lookup`.
+- [x] 1.2 Add `RouteTierSampler` implementing `sdktrace.Sampler`: `atomic.Pointer` state, `TraceIDRatioBased` per ratio tier + `AlwaysSample` for Full + `NeverSample` for Drop, `Apply(highVolume, standard, forceFull)` with `[0,1]` clamp, `Description()`. Drop is checked before the force-full branch so probes stay dropped under force-full.
+- [x] 1.3 Add compile-time default consts (`DefaultHighVolumeRatio = 0.01`, `DefaultStandardRatio = 0.1`) and construct the sampler seeded with them.
+- [x] 1.4 Add `Settings` struct and `StartSettingsPoller` (immediate first read, 60s tick, apply-on-change, keep defaults on read failure, internal poll span).
+- [x] 1.5 Add `doc.go` describing the mechanism/policy split.
+
+## 2. Tracer provider wiring
+
+- [x] 2.1 Extend `observability.Options` with a `Sampler sdktrace.Sampler` field and add `sdktrace.WithSampler(...)` in `Init` (`internal/observability/observability.go`); default to the SDK behavior when nil.
+- [x] 2.2 Construct `ParentBased(RouteTierSampler)` and pass it through `Options` from the server and ingest bootstrap.
+
+## 3. Persistence (new `observability` bounded context)
+
+- [x] 3.1 Add a migration creating the `trace_sampler_settings` singleton table (`high_volume_ratio`, `standard_ratio` DOUBLE with `CHECK (... BETWEEN 0 AND 1)`, `force_full` BOOL, `updated_at`), seeding one row with the default ratios. No cross-context FK to `users` (the audit log is the authoritative record).
+- [x] 3.2 Add a store with get/update methods (update bounded by the DB `CHECK`); expose it as the poller's `tracing.SettingsReader`.
+- [x] 3.3 Scaffold the context: `bootstrap` (New/ApplySchema/RegisterAuthedRoutes/TraceSamplerSettingsReader) + `testkit` + `migrations`; add arch-go rules and amend ADR-0004 for the sixth context.
+
+## 4. Admin API
+
+- [x] 4.1 Add `GET`/`PATCH /api/settings/tracing` (admin + super_admin via the `tracing.manage` action, session cookie + CSRF), mounted alongside the other `/api/settings/*` routes.
+- [x] 4.2 `PATCH` validates ratios in `[0,1]`, persists via the store, and returns the updated settings; reject operators without the `tracing.manage` grant.
+
+## 5. Route-tier policy registration
+
+- [x] 5.1 In `server/cmd/fleet-edr-server/main.go` and `server/cmd/fleet-edr-ingest/main.go`: build the registry, register agent data-plane routes as HighVolume, operator/UI `GET` reads as Standard, and liveness/health/version probes as Drop, then start the poller with the observability context's settings reader.
+- [x] 5.2 Audit shared paths (e.g. agent `GET /api/commands` vs operator `GET /api/commands/{id}`) so agent traffic lands in HighVolume and operator reads in Standard.
+
+## 6. Tests
+
+- [x] 6.1 `RouteTierSampler`: tier selection per route, force-full override, drop-tier precedence over force-full, ratio clamp; table-driven, plus PBT for the clamp/ratio invariant.
+- [x] 6.2 `Registry`: lookup hits and Full-on-miss default.
+- [x] 6.3 `StartSettingsPoller`: apply-on-change, no-op when unchanged, defaults-on-first-read-failure (fake `settingsReader`).
+- [x] 6.4 Store: get/update round-trip and out-of-range rejection (real MySQL via `testdb/full.Open`).
+- [x] 6.5 Admin handler: authorized success, denied (no grant), invalid-JSON, missing-actor, and out-of-range validation.
+- [x] 6.6 `observability.Init`: provider builds with the sampler wired and stays no-op when the endpoint is empty.
+
+## 7. Docs and spec finalization
+
+- [x] 7.1 Operator doc for `GET`/`PATCH /api/settings/tracing`, the tier policy, defaults, and the "p99/alerting reads from metrics, not sampled spans" note.
+- [x] 7.2 Add a spectrace marker from at least one test to the new SHALL scenarios; run `openspec validate --all --strict`.

--- a/openspec/changes/otel-route-tier-sampling/tasks.md
+++ b/openspec/changes/otel-route-tier-sampling/tasks.md
@@ -3,7 +3,7 @@
 - [x] 1.1 Add `Tier` (Full=zero-value catch-all, Standard, HighVolume, Drop) and `Registry` (map of `"METHOD /path"` to tier; `Lookup` returns Full on miss) with `Register`/`Lookup`.
 - [x] 1.2 Add `RouteTierSampler` implementing `sdktrace.Sampler`: `atomic.Pointer` state, `TraceIDRatioBased` per ratio tier + `AlwaysSample` for Full + `NeverSample` for Drop, `Apply(highVolume, standard, forceFull)` with `[0,1]` clamp, `Description()`. Drop is checked before the force-full branch so probes stay dropped under force-full.
 - [x] 1.3 Add compile-time default consts (`DefaultHighVolumeRatio = 0.01`, `DefaultStandardRatio = 0.1`) and construct the sampler seeded with them.
-- [x] 1.4 Add `Settings` struct and `StartSettingsPoller` (immediate first read, 60s tick, apply-on-change, keep defaults on read failure, internal poll span).
+- [x] 1.4 Add `Settings` struct, `PrimeSampler` (synchronous first read+apply, called before serving), and `StartSettingsPoller` (60s tick, apply-on-change, keep defaults on read failure, internal poll span).
 - [x] 1.5 Add `doc.go` describing the mechanism/policy split.
 
 ## 2. Tracer provider wiring

--- a/server/bootstrap/bootstrap.go
+++ b/server/bootstrap/bootstrap.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 
 	"github.com/fleetdm/edr/internal/logging"
 	"github.com/fleetdm/edr/internal/observability"
@@ -54,6 +55,10 @@ type Env struct {
 type Options struct {
 	ServiceName    string
 	ServiceVersion string
+	// TraceSampler, when non-nil, becomes the TracerProvider's head sampler. The HTTP server binaries pass a route-tier sampler here
+	// (wrapped in sdktrace.ParentBased) so trace export volume is capped; binaries that do not classify routes leave it nil and keep
+	// the SDK default (always-on).
+	TraceSampler sdktrace.Sampler
 }
 
 // Init runs the daemon prelude. On any error the partial state is torn down before returning so the caller only has to check err.
@@ -72,6 +77,7 @@ func Init(opts Options) (context.Context, *Env, error) {
 		ServiceName:       opts.ServiceName,
 		ServiceVersion:    opts.ServiceVersion,
 		ServiceInstanceID: instanceID(),
+		Sampler:           opts.TraceSampler,
 	}))
 	if err != nil {
 		cancel()

--- a/server/cmd/fleet-edr-ingest/main.go
+++ b/server/cmd/fleet-edr-ingest/main.go
@@ -124,8 +124,11 @@ func run() error {
 		logger.ErrorContext(ctx, "observability schema", "err", err)
 		return err
 	}
-	// The applied state is a per-replica cache, safe to lose (ADR-0010).
-	go tracing.StartSettingsPoller(ctx, traceSampler, observabilityCtx.TraceSamplerSettingsReader(), logger)
+	// Prime the sampler synchronously before serving so the ingest tier's first request honors any persisted override rather than the
+	// compile-time defaults; then poll for later changes. The applied state is a per-replica cache, safe to lose (ADR-0010).
+	samplerReader := observabilityCtx.TraceSamplerSettingsReader()
+	primedSampler := tracing.PrimeSampler(ctx, traceSampler, samplerReader, logger)
+	go tracing.StartSettingsPoller(ctx, traceSampler, samplerReader, logger, primedSampler)
 
 	detectionCtx, err := detectionbootstrap.New(detectionbootstrap.Deps{
 		DB:     db,

--- a/server/cmd/fleet-edr-ingest/main.go
+++ b/server/cmd/fleet-edr-ingest/main.go
@@ -11,13 +11,18 @@ import (
 	"os"
 	"time"
 
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+
 	"github.com/fleetdm/edr/internal/keyring"
+	"github.com/fleetdm/edr/internal/observability/tracing"
 	"github.com/fleetdm/edr/server/bootstrap"
 	"github.com/fleetdm/edr/server/config"
 	detectionbootstrap "github.com/fleetdm/edr/server/detection/bootstrap"
 	endpointbootstrap "github.com/fleetdm/edr/server/endpoint/bootstrap"
 	"github.com/fleetdm/edr/server/httpserver"
 	identitybootstrap "github.com/fleetdm/edr/server/identity/bootstrap"
+	observabilitybootstrap "github.com/fleetdm/edr/server/observability/bootstrap"
+	"github.com/fleetdm/edr/server/tracingpolicy"
 )
 
 var (
@@ -44,7 +49,18 @@ func main() {
 }
 
 func run() error {
-	ctx, env, err := bootstrap.Init(bootstrap.Options{ServiceName: serviceName, ServiceVersion: version})
+	// Build the route-tier trace sampler before bootstrap.Init so it is installed on the TracerProvider at OTel init. The ingest binary
+	// serves the highest-volume route (POST /api/events), so capping its trace export is the main win of issue #374. Wrapped in
+	// ParentBased so a sampled parent forces its children sampled.
+	samplerRegistry := tracing.NewRegistry()
+	tracingpolicy.Register(samplerRegistry)
+	traceSampler := tracing.NewRouteTierSampler(samplerRegistry)
+
+	ctx, env, err := bootstrap.Init(bootstrap.Options{
+		ServiceName:    serviceName,
+		ServiceVersion: version,
+		TraceSampler:   sdktrace.ParentBased(traceSampler),
+	})
 	if err != nil {
 		return err
 	}
@@ -90,6 +106,26 @@ func run() error {
 		logger.ErrorContext(ctx, "identity schema", "err", err)
 		return err
 	}
+
+	// The observability context owns the runtime trace-sampler settings (issue #374). The ingest tier serves the highest-volume route
+	// (POST /api/events), so it polls the same row to honor an operator's ratio / force-full change without a restart. It does NOT mount
+	// the admin endpoint (ingest serves no operator routes), but it still needs the schema + read accessor.
+	observabilityCtx, err := observabilitybootstrap.New(observabilitybootstrap.Deps{
+		DB:     db,
+		Logger: logger,
+		AuthZ:  identityCtx.AuthZ(),
+		Audit:  identityCtx.AuditRecorder(),
+	})
+	if err != nil {
+		logger.ErrorContext(ctx, "open observability", "err", err)
+		return err
+	}
+	if err := observabilityCtx.ApplySchema(ctx); err != nil {
+		logger.ErrorContext(ctx, "observability schema", "err", err)
+		return err
+	}
+	// The applied state is a per-replica cache, safe to lose (ADR-0010).
+	go tracing.StartSettingsPoller(ctx, traceSampler, observabilityCtx.TraceSamplerSettingsReader(), logger)
 
 	detectionCtx, err := detectionbootstrap.New(detectionbootstrap.Deps{
 		DB:     db,

--- a/server/cmd/fleet-edr-server/main.go
+++ b/server/cmd/fleet-edr-server/main.go
@@ -15,8 +15,10 @@ import (
 	"time"
 
 	"github.com/jmoiron/sqlx"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 
 	"github.com/fleetdm/edr/internal/keyring"
+	"github.com/fleetdm/edr/internal/observability/tracing"
 	"github.com/fleetdm/edr/server/apidocs"
 	"github.com/fleetdm/edr/server/bootstrap"
 	"github.com/fleetdm/edr/server/config"
@@ -29,8 +31,10 @@ import (
 	identityapi "github.com/fleetdm/edr/server/identity/api"
 	identitybootstrap "github.com/fleetdm/edr/server/identity/bootstrap"
 	"github.com/fleetdm/edr/server/metrics"
+	observabilitybootstrap "github.com/fleetdm/edr/server/observability/bootstrap"
 	responsebootstrap "github.com/fleetdm/edr/server/response/bootstrap"
 	rulesbootstrap "github.com/fleetdm/edr/server/rules/bootstrap"
+	"github.com/fleetdm/edr/server/tracingpolicy"
 	"github.com/fleetdm/edr/server/ui"
 )
 
@@ -81,7 +85,18 @@ func main() {
 }
 
 func run() error {
-	ctx, env, err := bootstrap.Init(bootstrap.Options{ServiceName: serviceName, ServiceVersion: version})
+	// Build the route-tier trace sampler before bootstrap.Init so it can be installed on the TracerProvider at OTel init. The registry
+	// is read live on every span, so registering the policy now (before any context exists) is fine; the poller below later swaps the
+	// ratios from the DB. Wrapped in ParentBased so a sampled parent forces its children sampled (issue #374).
+	samplerRegistry := tracing.NewRegistry()
+	tracingpolicy.Register(samplerRegistry)
+	traceSampler := tracing.NewRouteTierSampler(samplerRegistry)
+
+	ctx, env, err := bootstrap.Init(bootstrap.Options{
+		ServiceName:    serviceName,
+		ServiceVersion: version,
+		TraceSampler:   sdktrace.ParentBased(traceSampler),
+	})
 	if err != nil {
 		return err
 	}
@@ -114,7 +129,7 @@ func run() error {
 	// spare connection.
 	coord := leader.NewMySQL(db, logger)
 
-	identityCtx, detectionCtx, responseCtx, rulesCtx, endpointCtx, err := openContexts(ctx, logger, db, cfg, coord, drain)
+	identityCtx, detectionCtx, responseCtx, rulesCtx, endpointCtx, observabilityCtx, err := openContexts(ctx, logger, db, cfg, coord, drain)
 	if err != nil {
 		return err
 	}
@@ -151,17 +166,21 @@ func run() error {
 	seedAdmin(ctx, logger, cfg, identityCtx, coord)
 
 	mux := buildMux(muxDeps{
-		detectionCtx: detectionCtx,
-		endpointCtx:  endpointCtx,
-		identityCtx:  identityCtx,
-		rulesCtx:     rulesCtx,
-		responseCtx:  responseCtx,
-		logger:       logger,
+		detectionCtx:     detectionCtx,
+		endpointCtx:      endpointCtx,
+		identityCtx:      identityCtx,
+		rulesCtx:         rulesCtx,
+		responseCtx:      responseCtx,
+		observabilityCtx: observabilityCtx,
+		logger:           logger,
 	})
 	registerUIRoutes(mux, identityCtx.BreakglassUIMiddleware(), logger)
 
 	go runDetection(ctx, detectionCtx, logger)
 	go runIdentity(ctx, identityCtx, logger)
+	// Poll the trace-sampler settings row so an operator's ratio / force-full change propagates to this replica without a restart
+	// (issue #374). The applied state is a per-replica cache, safe to lose (ADR-0010).
+	go tracing.StartSettingsPoller(ctx, traceSampler, observabilityCtx.TraceSamplerSettingsReader(), logger)
 	// Converge this replica's detection-config snapshot with mutations made on other replicas (ADR-0010): a peer's exclusion / rule-mode
 	// edit only bumps the shared version counter, so without this poll a non-mutating replica would serve a stale config until restart.
 	go rulesCtx.Run(ctx)
@@ -208,13 +227,14 @@ func openContexts(
 	responseCtx *responsebootstrap.Response,
 	rulesCtx *rulesbootstrap.Rules,
 	endpointCtx *endpointbootstrap.Endpoint,
+	observabilityCtx *observabilitybootstrap.Observability,
 	err error,
 ) {
 	// One root secret seeds every long-lived server-side key. Build the keyring before acquiring the migration lock so a malformed
 	// EDR_SECRET_KEY fails boot fast (config already enforces the >=32-byte floor, so New errors only as a defensive invariant).
 	kr, err := keyring.New(cfg.SecretKey)
 	if err != nil {
-		return nil, nil, nil, nil, nil, fmt.Errorf("build keyring: %w", err)
+		return nil, nil, nil, nil, nil, nil, fmt.Errorf("build keyring: %w", err)
 	}
 	// keyring.New holds its own copy of the root, and cfg.SecretKey is not read past this point, so zero the config's copy to
 	// minimize how long the raw root secret lives in memory (heap dumps, core files).
@@ -222,7 +242,7 @@ func openContexts(
 
 	release, err := coord.Lock(ctx, migrationLockName)
 	if err != nil {
-		return nil, nil, nil, nil, nil, err
+		return nil, nil, nil, nil, nil, nil, err
 	}
 	defer release()
 
@@ -242,8 +262,36 @@ func openContexts(
 	}
 	detectionCtx.LoadActive(rulesCtx.ContentService())
 	detectionCtx.SetModeResolver(rulesCtx.DetectionConfigModeResolver())
-	endpointCtx, err = openEndpoint(ctx, logger, db, cfg, identityCtx, kr.Derive(keyring.HostTokenSigningLabel))
+	if endpointCtx, err = openEndpoint(ctx, logger, db, cfg, identityCtx, kr.Derive(keyring.HostTokenSigningLabel)); err != nil {
+		return
+	}
+	// The observability context owns the runtime trace-sampler settings (issue #374); it consumes identity's chokepoint + audit
+	// recorder for its admin endpoint. Built + migrated under the same lock as the others.
+	observabilityCtx, err = openObservability(ctx, logger, db, identityCtx)
 	return
+}
+
+func openObservability(
+	ctx context.Context,
+	logger *slog.Logger,
+	db *sqlx.DB,
+	identityCtx *identitybootstrap.Identity,
+) (*observabilitybootstrap.Observability, error) {
+	observabilityCtx, err := observabilitybootstrap.New(observabilitybootstrap.Deps{
+		DB:     db,
+		Logger: logger,
+		AuthZ:  identityCtx.AuthZ(),
+		Audit:  identityCtx.AuditRecorder(),
+	})
+	if err != nil {
+		logger.ErrorContext(ctx, "open observability", "err", err)
+		return nil, err
+	}
+	if err := observabilityCtx.ApplySchema(ctx); err != nil {
+		logger.ErrorContext(ctx, "observability schema", "err", err)
+		return nil, err
+	}
+	return observabilityCtx, nil
 }
 
 func openIdentity(
@@ -602,12 +650,13 @@ func newHTTPServer(
 }
 
 type muxDeps struct {
-	detectionCtx *detectionbootstrap.Detection
-	endpointCtx  *endpointbootstrap.Endpoint
-	identityCtx  *identitybootstrap.Identity
-	rulesCtx     *rulesbootstrap.Rules
-	responseCtx  *responsebootstrap.Response
-	logger       *slog.Logger
+	detectionCtx     *detectionbootstrap.Detection
+	endpointCtx      *endpointbootstrap.Endpoint
+	identityCtx      *identitybootstrap.Identity
+	rulesCtx         *rulesbootstrap.Rules
+	responseCtx      *responsebootstrap.Response
+	observabilityCtx *observabilitybootstrap.Observability
+	logger           *slog.Logger
 }
 
 func buildMux(d muxDeps) *http.ServeMux {
@@ -657,6 +706,7 @@ func registerSessionRoutes(mux *http.ServeMux, d muxDeps) {
 		d.endpointCtx.RegisterAuthedRoutes(r)
 		d.responseCtx.RegisterAuthedRoutes(r)
 		d.identityCtx.RegisterAuthedRoutes(r)
+		d.observabilityCtx.RegisterAuthedRoutes(r)
 	})
 }
 

--- a/server/cmd/fleet-edr-server/main.go
+++ b/server/cmd/fleet-edr-server/main.go
@@ -178,9 +178,12 @@ func run() error {
 
 	go runDetection(ctx, detectionCtx, logger)
 	go runIdentity(ctx, identityCtx, logger)
-	// Poll the trace-sampler settings row so an operator's ratio / force-full change propagates to this replica without a restart
+	// Prime the sampler from the DB synchronously before serving so request #1 honors any persisted override (e.g. an active
+	// force_full or emergency downsample), not the compile-time defaults; then poll so later changes propagate without a restart
 	// (issue #374). The applied state is a per-replica cache, safe to lose (ADR-0010).
-	go tracing.StartSettingsPoller(ctx, traceSampler, observabilityCtx.TraceSamplerSettingsReader(), logger)
+	samplerReader := observabilityCtx.TraceSamplerSettingsReader()
+	primedSampler := tracing.PrimeSampler(ctx, traceSampler, samplerReader, logger)
+	go tracing.StartSettingsPoller(ctx, traceSampler, samplerReader, logger, primedSampler)
 	// Converge this replica's detection-config snapshot with mutations made on other replicas (ADR-0010): a peer's exclusion / rule-mode
 	// edit only bumps the shared version counter, so without this poll a non-mutating replica would serve a stale config until restart.
 	go rulesCtx.Run(ctx)

--- a/server/identity/api/authz.go
+++ b/server/identity/api/authz.go
@@ -92,6 +92,12 @@ const (
 	// mutations. Held by admin (write) and admin + senior_analyst (read), mirroring application_control.
 	ActionDetectionConfigRead  Action = "detection_config.read"
 	ActionDetectionConfigWrite Action = "detection_config.write"
+
+	// Trace-sampler management (issue #374). Gates reading and updating the deployment's runtime OTel trace-sampling settings (the
+	// per-tier ratios and the force-full incident toggle). Held by admin + super_admin, mirroring sso.manage: it is an operational
+	// telemetry-cost lever, peer to the other deployment-settings actions, and not granted to the analyst/auditor roles. The settings
+	// read/update handlers funnel through the chokepoint on this action.
+	ActionTracingManage Action = "tracing.manage"
 )
 
 // RegisteredActions returns the set of every Action constant declared
@@ -117,6 +123,7 @@ func RegisteredActions() []Action {
 		ActionAppControlRuleCreate, ActionAppControlRuleUpdate, ActionAppControlRuleDelete, ActionAppControlRuleBulkUpsert,
 		ActionAppControlPolicyCreate, ActionAppControlPolicyUpdate, ActionAppControlPolicyDelete,
 		ActionDetectionConfigRead, ActionDetectionConfigWrite,
+		ActionTracingManage,
 	}
 }
 

--- a/server/identity/internal/authz/policy/data/actions.json
+++ b/server/identity/internal/authz/policy/data/actions.json
@@ -31,6 +31,7 @@
     "application_control.policy_update",
     "application_control.policy_delete",
     "detection_config.read",
-    "detection_config.write"
+    "detection_config.write",
+    "tracing.manage"
   ]
 }

--- a/server/identity/internal/authz/policy/data/roles.json
+++ b/server/identity/internal/authz/policy/data/roles.json
@@ -35,7 +35,8 @@
         "application_control.policy_update",
         "application_control.policy_delete",
         "detection_config.read",
-        "detection_config.write"
+        "detection_config.write",
+        "tracing.manage"
       ]
     },
     "senior_analyst": {

--- a/server/identity/internal/authz/policy/edr_test.rego
+++ b/server/identity/internal/authz/policy/edr_test.rego
@@ -57,6 +57,25 @@ test_admin_cannot_read_audit if {
 	d == {"allow": false, "reason": "no_matching_rule"}
 }
 
+# tracing.manage is held by admin + super_admin (issue #374), mirroring sso.manage; analysts/auditors do not get it.
+test_admin_can_manage_tracing if {
+	d := authz.decision with input as {
+		"actor": {"roles": [{"role_id": "admin", "scope_type": "global", "scope_id": "*"}]},
+		"action": "tracing.manage",
+		"resource": {"type": "tracing_config"},
+	}
+	d.allow == true
+}
+
+test_analyst_cannot_manage_tracing if {
+	d := authz.decision with input as {
+		"actor": {"roles": [{"role_id": "analyst", "scope_type": "global", "scope_id": "*"}]},
+		"action": "tracing.manage",
+		"resource": {"type": "tracing_config"},
+	}
+	d == {"allow": false, "reason": "no_matching_rule"}
+}
+
 # --- senior_analyst: destructive actions allowed, audit.read denied. -
 
 test_senior_analyst_can_kill_process if {

--- a/server/metrics/metrics_test.go
+++ b/server/metrics/metrics_test.go
@@ -123,6 +123,10 @@ func (s stubGauges) OfflineHosts(context.Context, time.Duration) (int, error) {
 // edr.alerts.created, (c) the lossy=true vs lossy=false distinction on edr.agent.queue.dropped
 // (server-side mirror of the agent-side TestRecorder_QueueDropped), and (d) that collect() drives the
 // gauge callbacks and observes their values (stubGauges feeds enrolled=3, offline=1).
+//
+// spec:observability-instrumentation/aggregate-latency-and-alerting-derive-from-metrics-not-sampled-spans/event-counts-are-unaffected-by-the-sample-ratio
+// The recorder counts every ingested event with no reference to the trace sampler, so counts are authoritative regardless of the
+// trace sample ratio in effect.
 func TestRecorder_RecordsCounters(t *testing.T) {
 	t.Parallel()
 	r, collect := newTestRecorder(t, stubGauges{enrolled: 3, offline: 1}, Options{})
@@ -246,6 +250,10 @@ func (g failingGauges) OfflineHosts(context.Context, time.Duration) (int, error)
 }
 
 // spec:observability-instrumentation/http-server-request-duration/inbound-requests-are-timed-by-route-method-and-status
+// spec:observability-instrumentation/aggregate-latency-and-alerting-derive-from-metrics-not-sampled-spans/latency-percentiles-are-unaffected-by-the-sample-ratio
+//
+// The duration histogram records every request with no reference to the trace sampler, so latency percentiles reflect the full
+// request population regardless of the trace sample ratio.
 //
 // ObserveHTTPRequest records on the OTel-semantic-convention http.server.request.duration histogram. The test pins: (a) two
 // requests sharing method+route+status collapse into one series with count 2, (b) a distinct status is its own series, and

--- a/server/observability/bootstrap/bootstrap.go
+++ b/server/observability/bootstrap/bootstrap.go
@@ -1,0 +1,92 @@
+package bootstrap
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/jmoiron/sqlx"
+
+	"github.com/fleetdm/edr/internal/observability/tracing"
+	"github.com/fleetdm/edr/server/httpserver"
+	identityapi "github.com/fleetdm/edr/server/identity/api"
+	"github.com/fleetdm/edr/server/migrations/runner"
+	"github.com/fleetdm/edr/server/observability/internal/tracingadmin"
+	"github.com/fleetdm/edr/server/observability/internal/tracingconfig"
+	observabilitymigrations "github.com/fleetdm/edr/server/observability/migrations"
+)
+
+// Deps bundles what New needs. cmd/main owns the *sqlx.DB handle and shares it across every context's bootstrap.
+type Deps struct {
+	DB     *sqlx.DB
+	Logger *slog.Logger
+
+	// AuthZ is the authorization chokepoint the trace-settings admin endpoints gate on (api.ActionTracingManage). Required.
+	// cmd/main wires identityCtx.AuthZ().
+	AuthZ identityapi.AuthZ
+	// Audit is the operator-action recorder. Optional: nil disables audit emission for sampler-settings updates. cmd/main wires
+	// identityCtx.AuditRecorder().
+	Audit identityapi.AuditRecorder
+}
+
+// Observability is the handle cmd/main holds for the observability bounded context.
+type Observability struct {
+	store   *tracingconfig.Store
+	handler *tracingadmin.Handler
+	db      *sqlx.DB
+	logger  *slog.Logger
+}
+
+// New wires the observability context. Does NOT apply the schema (call ApplySchema for that).
+func New(deps Deps) (*Observability, error) {
+	if deps.DB == nil {
+		return nil, errors.New("observability bootstrap: DB is required")
+	}
+	if deps.AuthZ == nil {
+		return nil, errors.New("observability bootstrap: AuthZ is required")
+	}
+	logger := deps.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	store := tracingconfig.New(deps.DB)
+	return &Observability{
+		store:   store,
+		handler: tracingadmin.NewHandler(store, deps.AuthZ, deps.Audit, logger),
+		db:      deps.DB,
+		logger:  logger,
+	}, nil
+}
+
+// ApplySchema applies observability's goose migration corpus. Idempotent (goose skips already-applied versions). No cross-context FKs;
+// ordering with other contexts' ApplySchema is not load-bearing.
+func (o *Observability) ApplySchema(ctx context.Context) error {
+	return ApplySchema(ctx, o.db)
+}
+
+// ApplySchema is the package-level form: applies observability's goose migration corpus against the given DB without requiring a fully
+// constructed *Observability. Used by server/testdb/full so tests can apply every context's schema. Idempotent.
+func ApplySchema(ctx context.Context, db *sqlx.DB) error {
+	if db == nil {
+		return errors.New("observability ApplySchema: db must not be nil")
+	}
+	return runner.Up(ctx, db, observabilitymigrations.FS, runner.Options{
+		Context:   "observability",
+		TableName: "observability_goose_db_version",
+	})
+}
+
+// RegisterAuthedRoutes wires the operator-facing trace-settings routes:
+//
+//	GET   /api/settings/tracing
+//	PATCH /api/settings/tracing
+//
+// Caller wraps in identity.SessionMiddleware + identity.CSRFMiddleware before mounting.
+func (o *Observability) RegisterAuthedRoutes(mux httpserver.Router) {
+	o.handler.RegisterAuthedRoutes(mux)
+}
+
+// TraceSamplerSettingsReader returns the read accessor the per-replica OTel sampler poller depends on (issue #374). cmd/main passes it
+// to tracing.StartSettingsPoller; the poller depends on the tracing.SettingsReader interface and this returns the concrete store that
+// satisfies it.
+func (o *Observability) TraceSamplerSettingsReader() tracing.SettingsReader { return o.store }

--- a/server/observability/bootstrap/bootstrap.go
+++ b/server/observability/bootstrap/bootstrap.go
@@ -24,7 +24,8 @@ type Deps struct {
 	// AuthZ is the authorization chokepoint the trace-settings admin endpoints gate on (api.ActionTracingManage). Required.
 	// cmd/main wires identityCtx.AuthZ().
 	AuthZ identityapi.AuthZ
-	// Audit is the operator-action recorder. Optional: nil disables audit emission for sampler-settings updates. cmd/main wires
+	// Audit is the operator-action recorder for sampler-settings updates. Required: these runtime knobs materially change incident
+	// visibility, so a wiring mistake must fail fast rather than silently expose the endpoints with no audit trail. cmd/main wires
 	// identityCtx.AuditRecorder().
 	Audit identityapi.AuditRecorder
 }
@@ -44,6 +45,9 @@ func New(deps Deps) (*Observability, error) {
 	}
 	if deps.AuthZ == nil {
 		return nil, errors.New("observability bootstrap: AuthZ is required")
+	}
+	if deps.Audit == nil {
+		return nil, errors.New("observability bootstrap: Audit is required")
 	}
 	logger := deps.Logger
 	if logger == nil {

--- a/server/observability/bootstrap/bootstrap_test.go
+++ b/server/observability/bootstrap/bootstrap_test.go
@@ -1,0 +1,66 @@
+package bootstrap_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fleetdm/edr/internal/observability/tracing"
+	"github.com/fleetdm/edr/server/httpserver"
+	"github.com/fleetdm/edr/server/identity/api"
+	obsbootstrap "github.com/fleetdm/edr/server/observability/bootstrap"
+	"github.com/fleetdm/edr/server/testdb"
+)
+
+type allowAuthZ struct{}
+
+func (allowAuthZ) Allow(context.Context, api.Action, api.Resource) (api.Decision, error) {
+	return api.Decision{Allow: true, Reason: "granted"}, nil
+}
+
+type noopAudit struct{}
+
+func (noopAudit) Record(context.Context, api.AuditEvent) error { return nil }
+
+func TestNew_requiresDeps(t *testing.T) {
+	t.Parallel()
+	db := testdb.Open(t)
+
+	_, err := obsbootstrap.New(obsbootstrap.Deps{AuthZ: allowAuthZ{}, Audit: noopAudit{}})
+	require.Error(t, err, "nil DB must be rejected")
+
+	_, err = obsbootstrap.New(obsbootstrap.Deps{DB: db, Audit: noopAudit{}})
+	require.Error(t, err, "nil AuthZ must be rejected")
+
+	_, err = obsbootstrap.New(obsbootstrap.Deps{DB: db, AuthZ: allowAuthZ{}})
+	require.Error(t, err, "nil Audit must be rejected")
+}
+
+func TestObservability_applySchemaThenReadAndRegister(t *testing.T) {
+	t.Parallel()
+	db := testdb.Open(t)
+	o, err := obsbootstrap.New(obsbootstrap.Deps{DB: db, AuthZ: allowAuthZ{}, Audit: noopAudit{}})
+	require.NoError(t, err)
+	require.NoError(t, o.ApplySchema(t.Context()))
+
+	// After schema apply, the reader the poller consumes returns the seeded defaults.
+	got, err := o.TraceSamplerSettingsReader().GetTraceSamplerSettings(t.Context())
+	require.NoError(t, err)
+	assert.InDelta(t, tracing.DefaultHighVolumeRatio, got.HighVolumeRatio, 1e-9)
+	assert.InDelta(t, tracing.DefaultStandardRatio, got.StandardRatio, 1e-9)
+
+	// The admin routes mount on the operator mux.
+	rec := httpserver.NewRecordingRouter(http.NewServeMux())
+	o.RegisterAuthedRoutes(rec)
+	patterns := rec.Patterns()
+	assert.Contains(t, patterns, "GET /api/settings/tracing")
+	assert.Contains(t, patterns, "PATCH /api/settings/tracing")
+}
+
+func TestApplySchema_nilDBRejected(t *testing.T) {
+	t.Parallel()
+	require.Error(t, obsbootstrap.ApplySchema(t.Context(), nil))
+}

--- a/server/observability/bootstrap/doc.go
+++ b/server/observability/bootstrap/doc.go
@@ -1,0 +1,11 @@
+// Package bootstrap wires the observability bounded context: the deployment's runtime telemetry-control surface (issue #374).
+//
+// Today it owns one capability, the OTel trace head-sampling settings (the per-tier ratios + force-full toggle): a singleton MySQL
+// table, a super-admin admin API (GET/PATCH /api/settings/tracing), and the read accessor the per-replica sampler poller consumes.
+// It is a sixth bounded context (an amendment to ADR-0004's original five) because the surface owns its own schema and serves an
+// authorization-gated, audited HTTP route while consuming identity.api for authz + audit, which is the bounded-context shape in this
+// codebase and not something a context-free platform package may do.
+//
+// The sampler mechanism itself (the Sampler, Registry, poller, and Settings type) lives in internal/observability/tracing so it stays
+// agent-safe and free of any server or persistence dependency; this context only persists and serves those settings.
+package bootstrap

--- a/server/observability/internal/tests/tracingconfig_store_test.go
+++ b/server/observability/internal/tests/tracingconfig_store_test.go
@@ -15,27 +15,31 @@ func TestTraceSamplerStore_getReturnsSeededDefaults(t *testing.T) {
 	t.Parallel()
 	store := tracingconfig.New(full.Open(t))
 
-	got, err := store.GetTraceSamplerSettings(t.Context())
+	got, version, err := store.Get(t.Context())
 	require.NoError(t, err)
-	// The migration seeds the row with the sampler's compile-time defaults.
+	// The migration seeds the row with the sampler's compile-time defaults at version 1.
 	assert.InDelta(t, tracing.DefaultHighVolumeRatio, got.HighVolumeRatio, 1e-9)
 	assert.InDelta(t, tracing.DefaultStandardRatio, got.StandardRatio, 1e-9)
 	assert.False(t, got.ForceFull)
+	assert.Equal(t, int64(1), version)
 }
 
-func TestTraceSamplerStore_updateRoundTrip(t *testing.T) {
+func TestTraceSamplerStore_updateRoundTripBumpsVersion(t *testing.T) {
 	t.Parallel()
 	store := tracingconfig.New(full.Open(t))
 	ctx := t.Context()
 
-	// updatedBy nil records a non-operator write; the FK to users is exercised separately. Here we assert the value round-trip.
-	require.NoError(t, store.Update(ctx, tracing.Settings{HighVolumeRatio: 0.03, StandardRatio: 0.3, ForceFull: true}, nil))
+	_, version, err := store.Get(ctx)
+	require.NoError(t, err)
+	// updatedBy nil records a non-operator write; the value round-trip + version bump are what we assert here.
+	require.NoError(t, store.Update(ctx, tracing.Settings{HighVolumeRatio: 0.03, StandardRatio: 0.3, ForceFull: true}, version, nil))
 
-	got, err := store.GetTraceSamplerSettings(ctx)
+	got, newVersion, err := store.Get(ctx)
 	require.NoError(t, err)
 	assert.InDelta(t, 0.03, got.HighVolumeRatio, 1e-9)
 	assert.InDelta(t, 0.3, got.StandardRatio, 1e-9)
 	assert.True(t, got.ForceFull)
+	assert.Equal(t, version+1, newVersion)
 }
 
 // spec:observability-instrumentation/sampler-ratios-are-runtime-adjustable-without-redeploy/out-of-range-ratio-is-rejected-by-the-store
@@ -44,12 +48,57 @@ func TestTraceSamplerStore_outOfRangeRejectedByCheckConstraint(t *testing.T) {
 	store := tracingconfig.New(full.Open(t))
 	ctx := t.Context()
 
+	_, version, err := store.Get(ctx)
+	require.NoError(t, err)
 	// The DB CHECK constraint is the backstop behind the handler's validation: a ratio above 1 is rejected at the write.
-	err := store.Update(ctx, tracing.Settings{HighVolumeRatio: 2.0, StandardRatio: 0.1}, nil)
-	require.Error(t, err)
+	require.Error(t, store.Update(ctx, tracing.Settings{HighVolumeRatio: 2.0, StandardRatio: 0.1}, version, nil))
 
 	// And the stored row is unchanged (still the seeded default).
-	got, getErr := store.GetTraceSamplerSettings(ctx)
+	got, _, getErr := store.Get(ctx)
 	require.NoError(t, getErr)
 	assert.InDelta(t, tracing.DefaultHighVolumeRatio, got.HighVolumeRatio, 1e-9)
+}
+
+func TestTraceSamplerStore_staleVersionConflicts(t *testing.T) {
+	t.Parallel()
+	store := tracingconfig.New(full.Open(t))
+	ctx := t.Context()
+
+	_, version, err := store.Get(ctx)
+	require.NoError(t, err)
+	// First writer holding the current version succeeds and bumps it.
+	require.NoError(t, store.Update(ctx, tracing.Settings{HighVolumeRatio: 0.02, StandardRatio: 0.2}, version, nil))
+	// A second writer still holding the now-stale version is rejected (lost-update prevented).
+	err = store.Update(ctx, tracing.Settings{HighVolumeRatio: 0.04, StandardRatio: 0.4}, version, nil)
+	require.ErrorIs(t, err, tracingconfig.ErrVersionConflict)
+}
+
+func TestTraceSamplerStore_getTraceSamplerSettingsDropsVersion(t *testing.T) {
+	t.Parallel()
+	store := tracingconfig.New(full.Open(t))
+	// The reader surface the poller uses returns just the settings.
+	got, err := store.GetTraceSamplerSettings(t.Context())
+	require.NoError(t, err)
+	assert.InDelta(t, tracing.DefaultHighVolumeRatio, got.HighVolumeRatio, 1e-9)
+}
+
+func TestTraceSamplerStore_missingRowSelfHeals(t *testing.T) {
+	t.Parallel()
+	db := full.Open(t)
+	store := tracingconfig.New(db)
+	ctx := t.Context()
+	_, err := db.ExecContext(ctx, "DELETE FROM trace_sampler_settings")
+	require.NoError(t, err)
+
+	// Get on a missing row returns built-in defaults at version 0 (self-heal, not an error).
+	got, version, err := store.Get(ctx)
+	require.NoError(t, err)
+	assert.InDelta(t, tracing.DefaultHighVolumeRatio, got.HighVolumeRatio, 1e-9)
+	assert.Equal(t, int64(0), version)
+
+	// Update with version 0 re-inserts the singleton rather than failing on the absent row.
+	require.NoError(t, store.Update(ctx, tracing.Settings{HighVolumeRatio: 0.07, StandardRatio: 0.7}, 0, nil))
+	got2, _, err := store.Get(ctx)
+	require.NoError(t, err)
+	assert.InDelta(t, 0.07, got2.HighVolumeRatio, 1e-9)
 }

--- a/server/observability/internal/tests/tracingconfig_store_test.go
+++ b/server/observability/internal/tests/tracingconfig_store_test.go
@@ -1,0 +1,55 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fleetdm/edr/internal/observability/tracing"
+	"github.com/fleetdm/edr/server/observability/internal/tracingconfig"
+	"github.com/fleetdm/edr/server/testdb/full"
+)
+
+func TestTraceSamplerStore_getReturnsSeededDefaults(t *testing.T) {
+	t.Parallel()
+	store := tracingconfig.New(full.Open(t))
+
+	got, err := store.GetTraceSamplerSettings(t.Context())
+	require.NoError(t, err)
+	// The migration seeds the row with the sampler's compile-time defaults.
+	assert.InDelta(t, tracing.DefaultHighVolumeRatio, got.HighVolumeRatio, 1e-9)
+	assert.InDelta(t, tracing.DefaultStandardRatio, got.StandardRatio, 1e-9)
+	assert.False(t, got.ForceFull)
+}
+
+func TestTraceSamplerStore_updateRoundTrip(t *testing.T) {
+	t.Parallel()
+	store := tracingconfig.New(full.Open(t))
+	ctx := t.Context()
+
+	// updatedBy nil records a non-operator write; the FK to users is exercised separately. Here we assert the value round-trip.
+	require.NoError(t, store.Update(ctx, tracing.Settings{HighVolumeRatio: 0.03, StandardRatio: 0.3, ForceFull: true}, nil))
+
+	got, err := store.GetTraceSamplerSettings(ctx)
+	require.NoError(t, err)
+	assert.InDelta(t, 0.03, got.HighVolumeRatio, 1e-9)
+	assert.InDelta(t, 0.3, got.StandardRatio, 1e-9)
+	assert.True(t, got.ForceFull)
+}
+
+// spec:observability-instrumentation/sampler-ratios-are-runtime-adjustable-without-redeploy/out-of-range-ratio-is-rejected-by-the-store
+func TestTraceSamplerStore_outOfRangeRejectedByCheckConstraint(t *testing.T) {
+	t.Parallel()
+	store := tracingconfig.New(full.Open(t))
+	ctx := t.Context()
+
+	// The DB CHECK constraint is the backstop behind the handler's validation: a ratio above 1 is rejected at the write.
+	err := store.Update(ctx, tracing.Settings{HighVolumeRatio: 2.0, StandardRatio: 0.1}, nil)
+	require.Error(t, err)
+
+	// And the stored row is unchanged (still the seeded default).
+	got, getErr := store.GetTraceSamplerSettings(ctx)
+	require.NoError(t, getErr)
+	assert.InDelta(t, tracing.DefaultHighVolumeRatio, got.HighVolumeRatio, 1e-9)
+}

--- a/server/observability/internal/tracingadmin/handler.go
+++ b/server/observability/internal/tracingadmin/handler.go
@@ -1,0 +1,175 @@
+// Package tracingadmin serves the super-admin API for the deployment's runtime OTel trace-sampling settings (issue #374): read the
+// current per-tier ratios + force-full toggle, and update them without a redeploy. Both routes funnel through the authorization
+// chokepoint on api.ActionTracingManage (admin + super_admin); the update emits an audit row. The handler depends on a small store
+// interface so it is unit-testable without a database.
+package tracingadmin
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+
+	"github.com/fleetdm/edr/internal/observability/tracing"
+	"github.com/fleetdm/edr/server/httpserver"
+	"github.com/fleetdm/edr/server/identity/api"
+)
+
+// updateBodyLimit caps the PATCH body. The payload is three short fields; 64 KiB is generous.
+const updateBodyLimit = 1 << 16
+
+// store is the subset of *tracingconfig.Store the handler needs. Narrowed to an interface so tests inject a fake.
+type store interface {
+	GetTraceSamplerSettings(ctx context.Context) (*tracing.Settings, error)
+	Update(ctx context.Context, settings tracing.Settings, updatedBy *int64) error
+}
+
+// Handler serves the /api/settings/tracing routes. Construct via NewHandler; mount with RegisterAuthedRoutes behind the session + CSRF
+// middleware (PATCH inherits the CSRF check from that wrapper).
+type Handler struct {
+	store  store
+	authz  api.AuthZ
+	audit  api.AuditRecorder
+	logger *slog.Logger
+}
+
+// NewHandler builds the handler. store and authz are load-bearing; logger defaults to slog.Default. audit may be nil only in tests
+// that do not assert on the audit row.
+func NewHandler(store store, authz api.AuthZ, audit api.AuditRecorder, logger *slog.Logger) *Handler {
+	if store == nil {
+		panic("tracingadmin.NewHandler: store is required")
+	}
+	if authz == nil {
+		panic("tracingadmin.NewHandler: authz is required")
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Handler{store: store, authz: authz, audit: audit, logger: logger}
+}
+
+// RegisterAuthedRoutes mounts the tracing settings routes. The mux is expected to be wrapped in the session + CSRF middleware before
+// being mounted; the PATCH inherits the CSRF check from that wrapper.
+func (h *Handler) RegisterAuthedRoutes(mux httpserver.Router) {
+	mux.HandleFunc("GET /api/settings/tracing", h.handleGet)
+	mux.HandleFunc("PATCH /api/settings/tracing", h.handleUpdate)
+}
+
+// settingsResponse is the read shape. updated_at is intentionally omitted; the UI shows the live knobs, not write provenance.
+type settingsResponse struct {
+	HighVolumeRatio float64 `json:"high_volume_ratio"`
+	StandardRatio   float64 `json:"standard_ratio"`
+	ForceFull       bool    `json:"force_full"`
+}
+
+func (h *Handler) handleGet(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	if !api.HTTPGate(ctx, w, h.authz, h.logger, api.ActionTracingManage, api.Resource{Type: "tracing_config"}) {
+		return
+	}
+	got, err := h.store.GetTraceSamplerSettings(ctx)
+	if err != nil {
+		h.logger.ErrorContext(ctx, "tracing settings get", "err", err)
+		writeErr(ctx, h.logger, w, http.StatusInternalServerError, "internal")
+		return
+	}
+	httpserver.NoStoreJSON(ctx, h.logger, w, http.StatusOK, toResponse(got))
+}
+
+// updateRequest uses pointers so an omitted field keeps the stored value (PATCH semantics): an operator can flip force_full alone
+// without restating the ratios.
+type updateRequest struct {
+	HighVolumeRatio *float64 `json:"high_volume_ratio"`
+	StandardRatio   *float64 `json:"standard_ratio"`
+	ForceFull       *bool    `json:"force_full"`
+}
+
+func (h *Handler) handleUpdate(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	if !api.HTTPGate(ctx, w, h.authz, h.logger, api.ActionTracingManage, api.Resource{Type: "tracing_config"}) {
+		return
+	}
+	var req updateRequest
+	r.Body = http.MaxBytesReader(w, r.Body, updateBodyLimit)
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeErr(ctx, h.logger, w, http.StatusBadRequest, "invalid_json")
+		return
+	}
+	// Read-modify-write so an absent field keeps its stored value.
+	cur, err := h.store.GetTraceSamplerSettings(ctx)
+	if err != nil {
+		h.logger.ErrorContext(ctx, "tracing settings read for update", "err", err)
+		writeErr(ctx, h.logger, w, http.StatusInternalServerError, "internal")
+		return
+	}
+	next := *cur
+	if req.HighVolumeRatio != nil {
+		next.HighVolumeRatio = *req.HighVolumeRatio
+	}
+	if req.StandardRatio != nil {
+		next.StandardRatio = *req.StandardRatio
+	}
+	if req.ForceFull != nil {
+		next.ForceFull = *req.ForceFull
+	}
+	if !validRatio(next.HighVolumeRatio) || !validRatio(next.StandardRatio) {
+		writeErr(ctx, h.logger, w, http.StatusBadRequest, "ratio_out_of_range")
+		return
+	}
+	actor, ok := api.ActorFromContext(ctx)
+	if !ok {
+		// Session middleware guarantees an actor past HTTPGate's allow path; its absence here is a wiring bug.
+		h.logger.ErrorContext(ctx, "tracing settings update: no actor on context")
+		writeErr(ctx, h.logger, w, http.StatusInternalServerError, "internal")
+		return
+	}
+	if err := h.store.Update(ctx, next, &actor.UserID); err != nil {
+		h.logger.ErrorContext(ctx, "tracing settings update", "err", err)
+		writeErr(ctx, h.logger, w, http.StatusInternalServerError, "internal")
+		return
+	}
+	h.recordUpdate(ctx, r, actor.UserID, next)
+
+	got, err := h.store.GetTraceSamplerSettings(ctx)
+	if err != nil {
+		h.logger.ErrorContext(ctx, "tracing settings re-read after update", "err", err)
+		writeErr(ctx, h.logger, w, http.StatusInternalServerError, "internal")
+		return
+	}
+	httpserver.NoStoreJSON(ctx, h.logger, w, http.StatusOK, toResponse(got))
+}
+
+func validRatio(v float64) bool { return v >= 0 && v <= 1 }
+
+func toResponse(s *tracing.Settings) settingsResponse {
+	return settingsResponse{
+		HighVolumeRatio: s.HighVolumeRatio,
+		StandardRatio:   s.StandardRatio,
+		ForceFull:       s.ForceFull,
+	}
+}
+
+// recordUpdate emits the mutation audit row.
+func (h *Handler) recordUpdate(ctx context.Context, r *http.Request, userID int64, s tracing.Settings) {
+	if h.audit == nil {
+		return
+	}
+	uid := userID
+	if err := h.audit.Record(ctx, api.AuditEvent{
+		UserID:     &uid,
+		Action:     api.AuditAction("tracing.settings.updated"),
+		TargetType: "tracing_config",
+		RemoteAddr: httpserver.ClientIP(r),
+		Payload: map[string]any{
+			"high_volume_ratio": s.HighVolumeRatio,
+			"standard_ratio":    s.StandardRatio,
+			"force_full":        s.ForceFull,
+		},
+	}); err != nil {
+		h.logger.ErrorContext(ctx, "tracing settings audit record failed", "err", err)
+	}
+}
+
+func writeErr(ctx context.Context, logger *slog.Logger, w http.ResponseWriter, status int, code string) {
+	httpserver.NoStoreJSON(ctx, logger, w, status, map[string]string{"error": code})
+}

--- a/server/observability/internal/tracingadmin/handler.go
+++ b/server/observability/internal/tracingadmin/handler.go
@@ -7,21 +7,25 @@ package tracingadmin
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"io"
 	"log/slog"
 	"net/http"
 
 	"github.com/fleetdm/edr/internal/observability/tracing"
 	"github.com/fleetdm/edr/server/httpserver"
 	"github.com/fleetdm/edr/server/identity/api"
+	"github.com/fleetdm/edr/server/observability/internal/tracingconfig"
 )
 
 // updateBodyLimit caps the PATCH body. The payload is three short fields; 64 KiB is generous.
 const updateBodyLimit = 1 << 16
 
-// store is the subset of *tracingconfig.Store the handler needs. Narrowed to an interface so tests inject a fake.
+// store is the subset of *tracingconfig.Store the handler needs. Narrowed to an interface so tests inject a fake. Get returns the row
+// version so Update can apply optimistic concurrency; Update returns tracingconfig.ErrVersionConflict when a concurrent write landed.
 type store interface {
-	GetTraceSamplerSettings(ctx context.Context) (*tracing.Settings, error)
-	Update(ctx context.Context, settings tracing.Settings, updatedBy *int64) error
+	Get(ctx context.Context) (*tracing.Settings, int64, error)
+	Update(ctx context.Context, settings tracing.Settings, expectedVersion int64, updatedBy *int64) error
 }
 
 // Handler serves the /api/settings/tracing routes. Construct via NewHandler; mount with RegisterAuthedRoutes behind the session + CSRF
@@ -67,7 +71,7 @@ func (h *Handler) handleGet(w http.ResponseWriter, r *http.Request) {
 	if !api.HTTPGate(ctx, w, h.authz, h.logger, api.ActionTracingManage, api.Resource{Type: "tracing_config"}) {
 		return
 	}
-	got, err := h.store.GetTraceSamplerSettings(ctx)
+	got, _, err := h.store.Get(ctx)
 	if err != nil {
 		h.logger.ErrorContext(ctx, "tracing settings get", "err", err)
 		writeErr(ctx, h.logger, w, http.StatusInternalServerError, "internal")
@@ -91,12 +95,20 @@ func (h *Handler) handleUpdate(w http.ResponseWriter, r *http.Request) {
 	}
 	var req updateRequest
 	r.Body = http.MaxBytesReader(w, r.Body, updateBodyLimit)
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	// DisallowUnknownFields rejects misspelled keys (e.g. {"forcefull":true}) instead of silently no-op'ing a 200; the trailing
+	// Decode(&struct{}) != io.EOF check rejects extra JSON after the object so a garbage suffix can't ride along on a valid body.
+	dec := json.NewDecoder(r.Body)
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&req); err != nil {
 		writeErr(ctx, h.logger, w, http.StatusBadRequest, "invalid_json")
 		return
 	}
-	// Read-modify-write so an absent field keeps its stored value.
-	cur, err := h.store.GetTraceSamplerSettings(ctx)
+	if dec.Decode(&struct{}{}) != io.EOF {
+		writeErr(ctx, h.logger, w, http.StatusBadRequest, "invalid_json")
+		return
+	}
+	// Read-modify-write so an absent field keeps its stored value; the row version drives the optimistic-concurrency check on Update.
+	cur, version, err := h.store.Get(ctx)
 	if err != nil {
 		h.logger.ErrorContext(ctx, "tracing settings read for update", "err", err)
 		writeErr(ctx, h.logger, w, http.StatusInternalServerError, "internal")
@@ -123,14 +135,18 @@ func (h *Handler) handleUpdate(w http.ResponseWriter, r *http.Request) {
 		writeErr(ctx, h.logger, w, http.StatusInternalServerError, "internal")
 		return
 	}
-	if err := h.store.Update(ctx, next, &actor.UserID); err != nil {
+	if err := h.store.Update(ctx, next, version, &actor.UserID); err != nil {
+		if errors.Is(err, tracingconfig.ErrVersionConflict) {
+			writeErr(ctx, h.logger, w, http.StatusConflict, "version_conflict")
+			return
+		}
 		h.logger.ErrorContext(ctx, "tracing settings update", "err", err)
 		writeErr(ctx, h.logger, w, http.StatusInternalServerError, "internal")
 		return
 	}
 	h.recordUpdate(ctx, r, actor.UserID, next)
 
-	got, err := h.store.GetTraceSamplerSettings(ctx)
+	got, _, err := h.store.Get(ctx)
 	if err != nil {
 		h.logger.ErrorContext(ctx, "tracing settings re-read after update", "err", err)
 		writeErr(ctx, h.logger, w, http.StatusInternalServerError, "internal")

--- a/server/observability/internal/tracingadmin/handler_test.go
+++ b/server/observability/internal/tracingadmin/handler_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -13,28 +14,33 @@ import (
 
 	"github.com/fleetdm/edr/internal/observability/tracing"
 	"github.com/fleetdm/edr/server/identity/api"
+	"github.com/fleetdm/edr/server/observability/internal/tracingconfig"
 )
 
 type fakeStore struct {
 	cur       *tracing.Settings
+	version   int64
 	getErr    error
 	updErr    error
 	updated   *tracing.Settings
 	updatedBy *int64
+	gotExpVer int64
 }
 
-func (f *fakeStore) GetTraceSamplerSettings(context.Context) (*tracing.Settings, error) {
+func (f *fakeStore) Get(context.Context) (*tracing.Settings, int64, error) {
 	if f.getErr != nil {
-		return nil, f.getErr
+		return nil, 0, f.getErr
 	}
-	if f.cur == nil {
-		return &tracing.Settings{}, nil
+	cur := f.cur
+	if cur == nil {
+		cur = &tracing.Settings{}
 	}
-	cp := *f.cur
-	return &cp, nil
+	cp := *cur
+	return &cp, f.version, nil
 }
 
-func (f *fakeStore) Update(_ context.Context, s tracing.Settings, by *int64) error {
+func (f *fakeStore) Update(_ context.Context, s tracing.Settings, expectedVersion int64, by *int64) error {
+	f.gotExpVer = expectedVersion
 	if f.updErr != nil {
 		return f.updErr
 	}
@@ -64,20 +70,25 @@ func (c *captureAudit) Record(_ context.Context, e api.AuditEvent) error {
 	return nil
 }
 
-func patchReq(t *testing.T, body any, withActor bool) *http.Request {
+func patchReq(t *testing.T, rawBody string, withActor bool) *http.Request {
 	t.Helper()
-	b, err := json.Marshal(body)
-	require.NoError(t, err)
-	r := httptest.NewRequestWithContext(t.Context(), http.MethodPatch, "/api/settings/tracing", bytes.NewReader(b))
+	r := httptest.NewRequestWithContext(t.Context(), http.MethodPatch, "/api/settings/tracing", bytes.NewReader([]byte(rawBody)))
 	if withActor {
 		r = r.WithContext(api.WithActor(r.Context(), &api.Actor{UserID: 7, AuthMethod: "oidc"}))
 	}
 	return r
 }
 
+func patchJSON(t *testing.T, body any, withActor bool) *http.Request {
+	t.Helper()
+	b, err := json.Marshal(body)
+	require.NoError(t, err)
+	return patchReq(t, string(b), withActor)
+}
+
 func TestHandleGet_returnsCurrentSettings(t *testing.T) {
 	t.Parallel()
-	store := &fakeStore{cur: &tracing.Settings{HighVolumeRatio: 0.02, StandardRatio: 0.2, ForceFull: true}}
+	store := &fakeStore{cur: &tracing.Settings{HighVolumeRatio: 0.02, StandardRatio: 0.2, ForceFull: true}, version: 3}
 	h := NewHandler(store, allowAuthZ{}, &captureAudit{}, nil)
 
 	w := httptest.NewRecorder()
@@ -99,43 +110,46 @@ func TestHandleGet_deniedReturns403(t *testing.T) {
 	assert.Equal(t, http.StatusForbidden, w.Code)
 }
 
-// spec:observability-instrumentation/operators-adjust-sampler-settings-through-an-authenticated-admin-endpoint/an-administrator-updates-the-ratios
-func TestHandleUpdate_superAdminUpdatesRatios(t *testing.T) {
+func TestHandleGet_storeErrorReturns500(t *testing.T) {
 	t.Parallel()
-	store := &fakeStore{cur: &tracing.Settings{HighVolumeRatio: 0.01, StandardRatio: 0.1}}
+	h := NewHandler(&fakeStore{getErr: errors.New("db down")}, allowAuthZ{}, &captureAudit{}, nil)
+	w := httptest.NewRecorder()
+	h.handleGet(w, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/settings/tracing", nil))
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+// spec:observability-instrumentation/operators-adjust-sampler-settings-through-an-authenticated-admin-endpoint/an-administrator-updates-the-ratios
+func TestHandleUpdate_adminUpdatesRatios(t *testing.T) {
+	t.Parallel()
+	store := &fakeStore{cur: &tracing.Settings{HighVolumeRatio: 0.01, StandardRatio: 0.1}, version: 5}
 	audit := &captureAudit{}
 	h := NewHandler(store, allowAuthZ{}, audit, nil)
 
 	hv, std := 0.05, 0.25
 	w := httptest.NewRecorder()
-	h.handleUpdate(w, patchReq(t, updateRequest{HighVolumeRatio: &hv, StandardRatio: &std}, true))
+	h.handleUpdate(w, patchJSON(t, updateRequest{HighVolumeRatio: &hv, StandardRatio: &std}, true))
 
 	require.Equal(t, http.StatusOK, w.Code)
 	require.NotNil(t, store.updated)
 	assert.InDelta(t, 0.05, store.updated.HighVolumeRatio, 1e-9)
 	assert.InDelta(t, 0.25, store.updated.StandardRatio, 1e-9)
+	assert.Equal(t, int64(5), store.gotExpVer, "Update must carry the version read by Get for OCC")
 	require.NotNil(t, store.updatedBy)
 	assert.Equal(t, int64(7), *store.updatedBy)
 	require.Len(t, audit.events, 1)
 	assert.Equal(t, api.AuditAction("tracing.settings.updated"), audit.events[0].Action)
-
-	var resp settingsResponse
-	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-	assert.InDelta(t, 0.05, resp.HighVolumeRatio, 1e-9)
 }
 
 func TestHandleUpdate_partialKeepsStoredFields(t *testing.T) {
 	t.Parallel()
-	store := &fakeStore{cur: &tracing.Settings{HighVolumeRatio: 0.01, StandardRatio: 0.1, ForceFull: false}}
+	store := &fakeStore{cur: &tracing.Settings{HighVolumeRatio: 0.01, StandardRatio: 0.1, ForceFull: false}, version: 1}
 	h := NewHandler(store, allowAuthZ{}, &captureAudit{}, nil)
 
-	forceFull := true
 	w := httptest.NewRecorder()
-	h.handleUpdate(w, patchReq(t, updateRequest{ForceFull: &forceFull}, true))
+	h.handleUpdate(w, patchReq(t, `{"force_full":true}`, true))
 
 	require.Equal(t, http.StatusOK, w.Code)
 	require.NotNil(t, store.updated)
-	// Ratios omitted from the PATCH must be preserved.
 	assert.InDelta(t, 0.01, store.updated.HighVolumeRatio, 1e-9)
 	assert.InDelta(t, 0.1, store.updated.StandardRatio, 1e-9)
 	assert.True(t, store.updated.ForceFull)
@@ -156,10 +170,10 @@ func TestHandleUpdate_outOfRangeRejected(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			store := &fakeStore{cur: &tracing.Settings{HighVolumeRatio: 0.01, StandardRatio: 0.1}}
+			store := &fakeStore{cur: &tracing.Settings{HighVolumeRatio: 0.01, StandardRatio: 0.1}, version: 1}
 			h := NewHandler(store, allowAuthZ{}, &captureAudit{}, nil)
 			w := httptest.NewRecorder()
-			h.handleUpdate(w, patchReq(t, updateRequest{HighVolumeRatio: &tc.hv, StandardRatio: &tc.std}, true))
+			h.handleUpdate(w, patchJSON(t, updateRequest{HighVolumeRatio: &tc.hv, StandardRatio: &tc.std}, true))
 
 			assert.Equal(t, http.StatusBadRequest, w.Code)
 			assert.Nil(t, store.updated, "no write on validation failure")
@@ -170,41 +184,91 @@ func TestHandleUpdate_outOfRangeRejected(t *testing.T) {
 // spec:observability-instrumentation/operators-adjust-sampler-settings-through-an-authenticated-admin-endpoint/an-operator-without-the-grant-is-denied
 func TestHandleUpdate_deniedReturns403AndDoesNotWrite(t *testing.T) {
 	t.Parallel()
-	store := &fakeStore{cur: &tracing.Settings{HighVolumeRatio: 0.01, StandardRatio: 0.1}}
+	store := &fakeStore{cur: &tracing.Settings{HighVolumeRatio: 0.01, StandardRatio: 0.1}, version: 1}
 	h := NewHandler(store, denyAuthZ{}, &captureAudit{}, nil)
 
 	hv := 0.9
 	w := httptest.NewRecorder()
-	h.handleUpdate(w, patchReq(t, updateRequest{HighVolumeRatio: &hv}, true))
+	h.handleUpdate(w, patchJSON(t, updateRequest{HighVolumeRatio: &hv}, true))
 
 	assert.Equal(t, http.StatusForbidden, w.Code)
+	assert.Nil(t, store.updated)
+}
+
+func TestHandleUpdate_versionConflictReturns409(t *testing.T) {
+	t.Parallel()
+	store := &fakeStore{cur: &tracing.Settings{HighVolumeRatio: 0.01, StandardRatio: 0.1}, version: 1, updErr: tracingconfig.ErrVersionConflict}
+	h := NewHandler(store, allowAuthZ{}, &captureAudit{}, nil)
+
+	hv := 0.5
+	w := httptest.NewRecorder()
+	h.handleUpdate(w, patchJSON(t, updateRequest{HighVolumeRatio: &hv}, true))
+	assert.Equal(t, http.StatusConflict, w.Code)
+}
+
+func TestHandleUpdate_storeUpdateErrorReturns500(t *testing.T) {
+	t.Parallel()
+	store := &fakeStore{cur: &tracing.Settings{HighVolumeRatio: 0.01, StandardRatio: 0.1}, version: 1, updErr: errors.New("db down")}
+	h := NewHandler(store, allowAuthZ{}, &captureAudit{}, nil)
+	hv := 0.5
+	w := httptest.NewRecorder()
+	h.handleUpdate(w, patchJSON(t, updateRequest{HighVolumeRatio: &hv}, true))
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestHandleUpdate_storeReadErrorReturns500(t *testing.T) {
+	t.Parallel()
+	store := &fakeStore{getErr: errors.New("db down")}
+	h := NewHandler(store, allowAuthZ{}, &captureAudit{}, nil)
+	hv := 0.5
+	w := httptest.NewRecorder()
+	h.handleUpdate(w, patchJSON(t, updateRequest{HighVolumeRatio: &hv}, true))
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestHandleUpdate_unknownFieldRejected(t *testing.T) {
+	t.Parallel()
+	store := &fakeStore{cur: &tracing.Settings{HighVolumeRatio: 0.01, StandardRatio: 0.1}, version: 1}
+	h := NewHandler(store, allowAuthZ{}, &captureAudit{}, nil)
+	w := httptest.NewRecorder()
+	// A misspelled key must be a 400, not a silent 200 no-op.
+	h.handleUpdate(w, patchReq(t, `{"forcefull":true}`, true))
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Nil(t, store.updated)
+}
+
+func TestHandleUpdate_trailingJSONRejected(t *testing.T) {
+	t.Parallel()
+	store := &fakeStore{cur: &tracing.Settings{HighVolumeRatio: 0.01, StandardRatio: 0.1}, version: 1}
+	h := NewHandler(store, allowAuthZ{}, &captureAudit{}, nil)
+	w := httptest.NewRecorder()
+	h.handleUpdate(w, patchReq(t, `{"force_full":true}{"force_full":false}`, true))
+	assert.Equal(t, http.StatusBadRequest, w.Code)
 	assert.Nil(t, store.updated)
 }
 
 func TestHandleUpdate_invalidJSONReturns400(t *testing.T) {
 	t.Parallel()
 	h := NewHandler(&fakeStore{}, allowAuthZ{}, &captureAudit{}, nil)
-	r := httptest.NewRequestWithContext(t.Context(), http.MethodPatch, "/api/settings/tracing", bytes.NewReader([]byte("{not json")))
-	r = r.WithContext(api.WithActor(r.Context(), &api.Actor{UserID: 7}))
 	w := httptest.NewRecorder()
-	h.handleUpdate(w, r)
+	h.handleUpdate(w, patchReq(t, "{not json", true))
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
 func TestHandleUpdate_noActorIsInternalError(t *testing.T) {
 	t.Parallel()
 	// allow authz but no actor on ctx: a wiring bug, surfaced as 500 rather than a nil-deref.
-	store := &fakeStore{cur: &tracing.Settings{HighVolumeRatio: 0.01, StandardRatio: 0.1}}
+	store := &fakeStore{cur: &tracing.Settings{HighVolumeRatio: 0.01, StandardRatio: 0.1}, version: 1}
 	h := NewHandler(store, allowAuthZ{}, &captureAudit{}, nil)
 	hv := 0.5
 	w := httptest.NewRecorder()
-	h.handleUpdate(w, patchReq(t, updateRequest{HighVolumeRatio: &hv}, false))
+	h.handleUpdate(w, patchJSON(t, updateRequest{HighVolumeRatio: &hv}, false))
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
 	assert.Nil(t, store.updated)
 }
 
 func TestNewHandler_panicsWithoutRequiredDeps(t *testing.T) {
 	t.Parallel()
-	assert.Panics(t, func() { NewHandler(nil, allowAuthZ{}, nil, nil) })
-	assert.Panics(t, func() { NewHandler(&fakeStore{}, nil, nil, nil) })
+	assert.Panics(t, func() { NewHandler(nil, allowAuthZ{}, &captureAudit{}, nil) })
+	assert.Panics(t, func() { NewHandler(&fakeStore{}, nil, &captureAudit{}, nil) })
 }

--- a/server/observability/internal/tracingadmin/handler_test.go
+++ b/server/observability/internal/tracingadmin/handler_test.go
@@ -1,0 +1,210 @@
+package tracingadmin
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fleetdm/edr/internal/observability/tracing"
+	"github.com/fleetdm/edr/server/identity/api"
+)
+
+type fakeStore struct {
+	cur       *tracing.Settings
+	getErr    error
+	updErr    error
+	updated   *tracing.Settings
+	updatedBy *int64
+}
+
+func (f *fakeStore) GetTraceSamplerSettings(context.Context) (*tracing.Settings, error) {
+	if f.getErr != nil {
+		return nil, f.getErr
+	}
+	if f.cur == nil {
+		return &tracing.Settings{}, nil
+	}
+	cp := *f.cur
+	return &cp, nil
+}
+
+func (f *fakeStore) Update(_ context.Context, s tracing.Settings, by *int64) error {
+	if f.updErr != nil {
+		return f.updErr
+	}
+	cp := s
+	f.updated = &cp
+	f.updatedBy = by
+	f.cur = &cp
+	return nil
+}
+
+type allowAuthZ struct{}
+
+func (allowAuthZ) Allow(context.Context, api.Action, api.Resource) (api.Decision, error) {
+	return api.Decision{Allow: true, Reason: "granted"}, nil
+}
+
+type denyAuthZ struct{}
+
+func (denyAuthZ) Allow(context.Context, api.Action, api.Resource) (api.Decision, error) {
+	return api.Decision{Allow: false, Reason: "no_matching_rule"}, nil
+}
+
+type captureAudit struct{ events []api.AuditEvent }
+
+func (c *captureAudit) Record(_ context.Context, e api.AuditEvent) error {
+	c.events = append(c.events, e)
+	return nil
+}
+
+func patchReq(t *testing.T, body any, withActor bool) *http.Request {
+	t.Helper()
+	b, err := json.Marshal(body)
+	require.NoError(t, err)
+	r := httptest.NewRequestWithContext(t.Context(), http.MethodPatch, "/api/settings/tracing", bytes.NewReader(b))
+	if withActor {
+		r = r.WithContext(api.WithActor(r.Context(), &api.Actor{UserID: 7, AuthMethod: "oidc"}))
+	}
+	return r
+}
+
+func TestHandleGet_returnsCurrentSettings(t *testing.T) {
+	t.Parallel()
+	store := &fakeStore{cur: &tracing.Settings{HighVolumeRatio: 0.02, StandardRatio: 0.2, ForceFull: true}}
+	h := NewHandler(store, allowAuthZ{}, &captureAudit{}, nil)
+
+	w := httptest.NewRecorder()
+	h.handleGet(w, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/settings/tracing", nil))
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp settingsResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.InDelta(t, 0.02, resp.HighVolumeRatio, 1e-9)
+	assert.InDelta(t, 0.2, resp.StandardRatio, 1e-9)
+	assert.True(t, resp.ForceFull)
+}
+
+func TestHandleGet_deniedReturns403(t *testing.T) {
+	t.Parallel()
+	h := NewHandler(&fakeStore{}, denyAuthZ{}, &captureAudit{}, nil)
+	w := httptest.NewRecorder()
+	h.handleGet(w, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/settings/tracing", nil))
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+// spec:observability-instrumentation/operators-adjust-sampler-settings-through-an-authenticated-admin-endpoint/an-administrator-updates-the-ratios
+func TestHandleUpdate_superAdminUpdatesRatios(t *testing.T) {
+	t.Parallel()
+	store := &fakeStore{cur: &tracing.Settings{HighVolumeRatio: 0.01, StandardRatio: 0.1}}
+	audit := &captureAudit{}
+	h := NewHandler(store, allowAuthZ{}, audit, nil)
+
+	hv, std := 0.05, 0.25
+	w := httptest.NewRecorder()
+	h.handleUpdate(w, patchReq(t, updateRequest{HighVolumeRatio: &hv, StandardRatio: &std}, true))
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.NotNil(t, store.updated)
+	assert.InDelta(t, 0.05, store.updated.HighVolumeRatio, 1e-9)
+	assert.InDelta(t, 0.25, store.updated.StandardRatio, 1e-9)
+	require.NotNil(t, store.updatedBy)
+	assert.Equal(t, int64(7), *store.updatedBy)
+	require.Len(t, audit.events, 1)
+	assert.Equal(t, api.AuditAction("tracing.settings.updated"), audit.events[0].Action)
+
+	var resp settingsResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.InDelta(t, 0.05, resp.HighVolumeRatio, 1e-9)
+}
+
+func TestHandleUpdate_partialKeepsStoredFields(t *testing.T) {
+	t.Parallel()
+	store := &fakeStore{cur: &tracing.Settings{HighVolumeRatio: 0.01, StandardRatio: 0.1, ForceFull: false}}
+	h := NewHandler(store, allowAuthZ{}, &captureAudit{}, nil)
+
+	forceFull := true
+	w := httptest.NewRecorder()
+	h.handleUpdate(w, patchReq(t, updateRequest{ForceFull: &forceFull}, true))
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.NotNil(t, store.updated)
+	// Ratios omitted from the PATCH must be preserved.
+	assert.InDelta(t, 0.01, store.updated.HighVolumeRatio, 1e-9)
+	assert.InDelta(t, 0.1, store.updated.StandardRatio, 1e-9)
+	assert.True(t, store.updated.ForceFull)
+}
+
+// spec:observability-instrumentation/operators-adjust-sampler-settings-through-an-authenticated-admin-endpoint/update-with-an-out-of-range-ratio-is-rejected
+func TestHandleUpdate_outOfRangeRejected(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		hv   float64
+		std  float64
+	}{
+		{"high-volume above 1", 1.5, 0.1},
+		{"high-volume below 0", -0.1, 0.1},
+		{"standard above 1", 0.1, 2.0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			store := &fakeStore{cur: &tracing.Settings{HighVolumeRatio: 0.01, StandardRatio: 0.1}}
+			h := NewHandler(store, allowAuthZ{}, &captureAudit{}, nil)
+			w := httptest.NewRecorder()
+			h.handleUpdate(w, patchReq(t, updateRequest{HighVolumeRatio: &tc.hv, StandardRatio: &tc.std}, true))
+
+			assert.Equal(t, http.StatusBadRequest, w.Code)
+			assert.Nil(t, store.updated, "no write on validation failure")
+		})
+	}
+}
+
+// spec:observability-instrumentation/operators-adjust-sampler-settings-through-an-authenticated-admin-endpoint/an-operator-without-the-grant-is-denied
+func TestHandleUpdate_deniedReturns403AndDoesNotWrite(t *testing.T) {
+	t.Parallel()
+	store := &fakeStore{cur: &tracing.Settings{HighVolumeRatio: 0.01, StandardRatio: 0.1}}
+	h := NewHandler(store, denyAuthZ{}, &captureAudit{}, nil)
+
+	hv := 0.9
+	w := httptest.NewRecorder()
+	h.handleUpdate(w, patchReq(t, updateRequest{HighVolumeRatio: &hv}, true))
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
+	assert.Nil(t, store.updated)
+}
+
+func TestHandleUpdate_invalidJSONReturns400(t *testing.T) {
+	t.Parallel()
+	h := NewHandler(&fakeStore{}, allowAuthZ{}, &captureAudit{}, nil)
+	r := httptest.NewRequestWithContext(t.Context(), http.MethodPatch, "/api/settings/tracing", bytes.NewReader([]byte("{not json")))
+	r = r.WithContext(api.WithActor(r.Context(), &api.Actor{UserID: 7}))
+	w := httptest.NewRecorder()
+	h.handleUpdate(w, r)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestHandleUpdate_noActorIsInternalError(t *testing.T) {
+	t.Parallel()
+	// allow authz but no actor on ctx: a wiring bug, surfaced as 500 rather than a nil-deref.
+	store := &fakeStore{cur: &tracing.Settings{HighVolumeRatio: 0.01, StandardRatio: 0.1}}
+	h := NewHandler(store, allowAuthZ{}, &captureAudit{}, nil)
+	hv := 0.5
+	w := httptest.NewRecorder()
+	h.handleUpdate(w, patchReq(t, updateRequest{HighVolumeRatio: &hv}, false))
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.Nil(t, store.updated)
+}
+
+func TestNewHandler_panicsWithoutRequiredDeps(t *testing.T) {
+	t.Parallel()
+	assert.Panics(t, func() { NewHandler(nil, allowAuthZ{}, nil, nil) })
+	assert.Panics(t, func() { NewHandler(&fakeStore{}, nil, nil, nil) })
+}

--- a/server/observability/internal/tracingconfig/tracingconfig.go
+++ b/server/observability/internal/tracingconfig/tracingconfig.go
@@ -16,8 +16,8 @@ import (
 )
 
 // ErrVersionConflict is returned by Update when the row's version no longer matches the expected version (a concurrent write landed
-// between the caller's Get and Update). The handler maps it to 409 so the operator re-reads and retries. This is the optimistic-
-// concurrency guard the version column exists for, mirroring appconfig.
+// between the caller's Get and Update). The handler maps it to 409 so the operator re-reads and retries. This is the guard the version
+// column exists for (optimistic concurrency), mirroring appconfig.
 var ErrVersionConflict = errors.New("tracingconfig: version conflict")
 
 // Store owns the singleton trace_sampler_settings row.

--- a/server/observability/internal/tracingconfig/tracingconfig.go
+++ b/server/observability/internal/tracingconfig/tracingconfig.go
@@ -1,0 +1,70 @@
+// Package tracingconfig owns the trace_sampler_settings singleton row: the deployment's runtime OTel trace head-sampling
+// configuration (issue #374). It is the persistence + read accessor behind the super-admin settings API and the per-replica sampler
+// poller. The domain type (tracing.Settings) lives in internal/observability/tracing so the sampler, the poller, and this store all
+// agree on one shape; this package only reads and writes it.
+package tracingconfig
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/jmoiron/sqlx"
+
+	"github.com/fleetdm/edr/internal/observability/tracing"
+)
+
+// Store owns the singleton trace_sampler_settings row.
+type Store struct {
+	db *sqlx.DB
+}
+
+// New constructs a Store. Panics if db is nil.
+func New(db *sqlx.DB) *Store {
+	if db == nil {
+		panic("tracingconfig.New: db must not be nil")
+	}
+	return &Store{db: db}
+}
+
+// GetTraceSamplerSettings returns the singleton settings. The row is seeded by migration, so it normally always exists; if it is
+// somehow absent the built-in defaults are returned (not an error) so both the poller and the admin API stay functional on a fresh or
+// partially-migrated deployment. Satisfies tracing.SettingsReader.
+func (s *Store) GetTraceSamplerSettings(ctx context.Context) (*tracing.Settings, error) {
+	var out tracing.Settings
+	err := s.db.GetContext(ctx, &out,
+		`SELECT high_volume_ratio, standard_ratio, force_full, updated_at FROM trace_sampler_settings WHERE id = 1`)
+	if errors.Is(err, sql.ErrNoRows) {
+		return &tracing.Settings{
+			HighVolumeRatio: tracing.DefaultHighVolumeRatio,
+			StandardRatio:   tracing.DefaultStandardRatio,
+		}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("tracingconfig: get: %w", err)
+	}
+	return &out, nil
+}
+
+// Update writes the singleton row (upsert so a missing row self-heals). The caller validates the ratios are in [0,1]; the DB CHECK
+// constraints are the backstop. updatedBy records the operator user id as a breadcrumb (nil for a non-operator write).
+func (s *Store) Update(ctx context.Context, settings tracing.Settings, updatedBy *int64) error {
+	var by sql.NullInt64
+	if updatedBy != nil {
+		by = sql.NullInt64{Int64: *updatedBy, Valid: true}
+	}
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO trace_sampler_settings (id, high_volume_ratio, standard_ratio, force_full, updated_by)
+		VALUES (1, ?, ?, ?, ?)
+		ON DUPLICATE KEY UPDATE
+			high_volume_ratio = VALUES(high_volume_ratio),
+			standard_ratio = VALUES(standard_ratio),
+			force_full = VALUES(force_full),
+			updated_by = VALUES(updated_by)`,
+		settings.HighVolumeRatio, settings.StandardRatio, settings.ForceFull, by)
+	if err != nil {
+		return fmt.Errorf("tracingconfig: update: %w", err)
+	}
+	return nil
+}

--- a/server/observability/internal/tracingconfig/tracingconfig.go
+++ b/server/observability/internal/tracingconfig/tracingconfig.go
@@ -15,6 +15,11 @@ import (
 	"github.com/fleetdm/edr/internal/observability/tracing"
 )
 
+// ErrVersionConflict is returned by Update when the row's version no longer matches the expected version (a concurrent write landed
+// between the caller's Get and Update). The handler maps it to 409 so the operator re-reads and retries. This is the optimistic-
+// concurrency guard the version column exists for, mirroring appconfig.
+var ErrVersionConflict = errors.New("tracingconfig: version conflict")
+
 // Store owns the singleton trace_sampler_settings row.
 type Store struct {
 	db *sqlx.DB
@@ -28,43 +33,76 @@ func New(db *sqlx.DB) *Store {
 	return &Store{db: db}
 }
 
-// GetTraceSamplerSettings returns the singleton settings. The row is seeded by migration, so it normally always exists; if it is
-// somehow absent the built-in defaults are returned (not an error) so both the poller and the admin API stay functional on a fresh or
-// partially-migrated deployment. Satisfies tracing.SettingsReader.
-func (s *Store) GetTraceSamplerSettings(ctx context.Context) (*tracing.Settings, error) {
-	var out tracing.Settings
-	err := s.db.GetContext(ctx, &out,
-		`SELECT high_volume_ratio, standard_ratio, force_full, updated_at FROM trace_sampler_settings WHERE id = 1`)
+// Get returns the singleton settings and the row version for an optimistic-concurrency Update. The row is seeded by migration, so it
+// normally always exists; if it is somehow absent the built-in defaults are returned with version 0 (not an error) so both the poller
+// and the admin API stay functional on a fresh or partially-migrated deployment.
+func (s *Store) Get(ctx context.Context) (*tracing.Settings, int64, error) {
+	var row struct {
+		tracing.Settings
+		Version int64 `db:"version"`
+	}
+	err := s.db.GetContext(ctx, &row,
+		`SELECT high_volume_ratio, standard_ratio, force_full, updated_at, version FROM trace_sampler_settings WHERE id = 1`)
 	if errors.Is(err, sql.ErrNoRows) {
 		return &tracing.Settings{
 			HighVolumeRatio: tracing.DefaultHighVolumeRatio,
 			StandardRatio:   tracing.DefaultStandardRatio,
-		}, nil
+		}, 0, nil
 	}
 	if err != nil {
-		return nil, fmt.Errorf("tracingconfig: get: %w", err)
+		return nil, 0, fmt.Errorf("tracingconfig: get: %w", err)
 	}
-	return &out, nil
+	out := row.Settings
+	return &out, row.Version, nil
 }
 
-// Update writes the singleton row (upsert so a missing row self-heals). The caller validates the ratios are in [0,1]; the DB CHECK
-// constraints are the backstop. updatedBy records the operator user id as a breadcrumb (nil for a non-operator write).
-func (s *Store) Update(ctx context.Context, settings tracing.Settings, updatedBy *int64) error {
+// GetTraceSamplerSettings returns just the settings, dropping the version. It satisfies tracing.SettingsReader for the per-replica
+// poller, which needs the values but not the concurrency token.
+func (s *Store) GetTraceSamplerSettings(ctx context.Context) (*tracing.Settings, error) {
+	settings, _, err := s.Get(ctx)
+	return settings, err
+}
+
+// Update writes the singleton row with optimistic concurrency: it succeeds only when the stored version still matches expectedVersion,
+// returning ErrVersionConflict otherwise so a concurrent PATCH cannot silently clobber a peer's write. expectedVersion 0 means "no row
+// yet" and inserts the singleton (idempotent under a concurrent first write). The caller validates the ratios are in [0,1]; the DB
+// CHECK constraints are the backstop. updatedBy records the operator user id as a breadcrumb (nil for a non-operator write).
+func (s *Store) Update(ctx context.Context, settings tracing.Settings, expectedVersion int64, updatedBy *int64) error {
 	var by sql.NullInt64
 	if updatedBy != nil {
 		by = sql.NullInt64{Int64: *updatedBy, Valid: true}
 	}
-	_, err := s.db.ExecContext(ctx, `
-		INSERT INTO trace_sampler_settings (id, high_volume_ratio, standard_ratio, force_full, updated_by)
-		VALUES (1, ?, ?, ?, ?)
-		ON DUPLICATE KEY UPDATE
-			high_volume_ratio = VALUES(high_volume_ratio),
-			standard_ratio = VALUES(standard_ratio),
-			force_full = VALUES(force_full),
-			updated_by = VALUES(updated_by)`,
-		settings.HighVolumeRatio, settings.StandardRatio, settings.ForceFull, by)
+	if expectedVersion <= 0 {
+		// First write: insert the singleton. ON DUPLICATE KEY UPDATE keeps a concurrent first write idempotent.
+		_, err := s.db.ExecContext(ctx, `
+			INSERT INTO trace_sampler_settings (id, high_volume_ratio, standard_ratio, force_full, version, updated_by)
+			VALUES (1, ?, ?, ?, 1, ?)
+			ON DUPLICATE KEY UPDATE
+				high_volume_ratio = VALUES(high_volume_ratio),
+				standard_ratio = VALUES(standard_ratio),
+				force_full = VALUES(force_full),
+				version = version + 1,
+				updated_by = VALUES(updated_by)`,
+			settings.HighVolumeRatio, settings.StandardRatio, settings.ForceFull, by)
+		if err != nil {
+			return fmt.Errorf("tracingconfig: update insert: %w", err)
+		}
+		return nil
+	}
+	res, err := s.db.ExecContext(ctx, `
+		UPDATE trace_sampler_settings
+		SET high_volume_ratio = ?, standard_ratio = ?, force_full = ?, version = version + 1, updated_by = ?
+		WHERE id = 1 AND version = ?`,
+		settings.HighVolumeRatio, settings.StandardRatio, settings.ForceFull, by, expectedVersion)
 	if err != nil {
 		return fmt.Errorf("tracingconfig: update: %w", err)
+	}
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("tracingconfig: update rows-affected: %w", err)
+	}
+	if rows == 0 {
+		return ErrVersionConflict
 	}
 	return nil
 }

--- a/server/observability/migrations/00001_trace_sampler_settings.sql
+++ b/server/observability/migrations/00001_trace_sampler_settings.sql
@@ -1,0 +1,35 @@
+-- +goose Up
+-- trace_sampler_settings is the deployment's runtime OTel trace head-sampling configuration (issue #374): the per-tier sample ratios
+-- and a force-full incident toggle. Each replica polls this row and atomically swaps its live sampler, so support can dial telemetry
+-- volume up or down without a redeploy. Singleton (CHECK id = 1). The ratios are bounded by CHECK constraints so a bad write is rejected
+-- at the DB even if the API validation is bypassed. updated_by records the operator user id as a breadcrumb; it is intentionally NOT a
+-- foreign key to identity's users table (this is a separate bounded context's corpus, and the audit log is the authoritative record of
+-- who changed what). The seeded ratios match the sampler's compile-time defaults (internal/observability/tracing: 0.01 high-volume,
+-- 0.1 standard) so a replica that has polled the row samples identically to one that has not.
+
+-- +goose StatementBegin
+CREATE TABLE IF NOT EXISTS trace_sampler_settings (
+	id                TINYINT      NOT NULL DEFAULT 1,
+	high_volume_ratio DOUBLE       NOT NULL DEFAULT 0.01,
+	standard_ratio    DOUBLE       NOT NULL DEFAULT 0.1,
+	force_full        BOOLEAN      NOT NULL DEFAULT FALSE,
+	updated_at        TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6)
+	                              ON UPDATE CURRENT_TIMESTAMP(6),
+	updated_by        BIGINT       NULL,
+	PRIMARY KEY (id),
+	CONSTRAINT chk_trace_sampler_singleton CHECK (id = 1),
+	CONSTRAINT chk_trace_sampler_high_volume_ratio CHECK (high_volume_ratio BETWEEN 0 AND 1),
+	CONSTRAINT chk_trace_sampler_standard_ratio CHECK (standard_ratio BETWEEN 0 AND 1)
+);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+INSERT INTO trace_sampler_settings (id, high_volume_ratio, standard_ratio, force_full)
+VALUES (1, 0.01, 0.1, FALSE)
+ON DUPLICATE KEY UPDATE id = id;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP TABLE IF EXISTS trace_sampler_settings;
+-- +goose StatementEnd

--- a/server/observability/migrations/00001_trace_sampler_settings.sql
+++ b/server/observability/migrations/00001_trace_sampler_settings.sql
@@ -13,6 +13,7 @@ CREATE TABLE IF NOT EXISTS trace_sampler_settings (
 	high_volume_ratio DOUBLE       NOT NULL DEFAULT 0.01,
 	standard_ratio    DOUBLE       NOT NULL DEFAULT 0.1,
 	force_full        BOOLEAN      NOT NULL DEFAULT FALSE,
+	version           BIGINT       NOT NULL DEFAULT 1,
 	updated_at        TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6)
 	                              ON UPDATE CURRENT_TIMESTAMP(6),
 	updated_by        BIGINT       NULL,

--- a/server/observability/migrations/embed.go
+++ b/server/observability/migrations/embed.go
@@ -1,0 +1,11 @@
+// Package migrations holds the observability bounded context's goose-managed SQL migration corpus, embedded so it can be applied at
+// boot by server/migrations/runner without the binary reading from disk.
+package migrations
+
+import "embed"
+
+// FS is observability's migration corpus: NNNNN_name.sql files at the FS root. server/observability/bootstrap.ApplySchema passes it
+// to runner.Up against the observability_goose_db_version tracking table.
+//
+//go:embed *.sql
+var FS embed.FS

--- a/server/observability/testkit/testkit.go
+++ b/server/observability/testkit/testkit.go
@@ -1,0 +1,21 @@
+// Package testkit is observability's coordinated test-fixture surface.
+//
+// Tests reach for testkit; production wiring (cmd/main, server/testdb/full) reaches for bootstrap. The two contracts are deliberately
+// separate. Today the package only exposes ApplySchema.
+//
+// Constraint: this package must NOT import any other bounded context. arch-go pins the rule.
+package testkit
+
+import (
+	"context"
+
+	"github.com/jmoiron/sqlx"
+
+	"github.com/fleetdm/edr/server/observability/bootstrap"
+)
+
+// ApplySchema runs observability's DDL against db. Thin wrapper over bootstrap.ApplySchema so the test surface is importable
+// separately from the production wiring surface.
+func ApplySchema(ctx context.Context, db *sqlx.DB) error {
+	return bootstrap.ApplySchema(ctx, db)
+}

--- a/server/testdb/full/full.go
+++ b/server/testdb/full/full.go
@@ -10,11 +10,11 @@
 // X → testdb/full → ctx/bootstrap → X.
 //
 // Schemas are applied in dependency order: identity first (owns
-// users + sessions), then endpoint, rules, response, detection. With
-// no cross-context FKs in the current schema the remaining four are
-// independent; the order is preserved for readability and so future
-// cross-context FKs (e.g. an audit log keyed by user_id) Just Work
-// without re-shuffling the call sites.
+// users + sessions), then endpoint, rules, response, detection, and
+// observability. With no cross-context FKs in the current schema the
+// remaining contexts are independent; the order is preserved for
+// readability and so future cross-context FKs (e.g. an audit log keyed
+// by user_id) Just Work without re-shuffling the call sites.
 //
 // full imports each context's testkit rather than its bootstrap so
 // the rule "production wiring (bootstrap) and test fixtures (testkit)
@@ -30,6 +30,7 @@ import (
 	detectiontestkit "github.com/fleetdm/edr/server/detection/testkit"
 	endpointtestkit "github.com/fleetdm/edr/server/endpoint/testkit"
 	identitytestkit "github.com/fleetdm/edr/server/identity/testkit"
+	observabilitytestkit "github.com/fleetdm/edr/server/observability/testkit"
 	responsetestkit "github.com/fleetdm/edr/server/response/testkit"
 	rulestestkit "github.com/fleetdm/edr/server/rules/testkit"
 	"github.com/fleetdm/edr/server/testdb"
@@ -56,6 +57,9 @@ func Open(t *testing.T) *sqlx.DB {
 	}
 	if err := detectiontestkit.ApplySchema(ctx, db); err != nil {
 		t.Fatalf("apply detection schema: %v", err)
+	}
+	if err := observabilitytestkit.ApplySchema(ctx, db); err != nil {
+		t.Fatalf("apply observability schema: %v", err)
 	}
 	return db
 }

--- a/server/tracingpolicy/policy.go
+++ b/server/tracingpolicy/policy.go
@@ -16,13 +16,14 @@ type route struct {
 	path   string
 }
 
-// highVolume is the agent data plane: it dominates request volume and is downsampled hardest. GET /api/commands is the agent's
-// command poll (the operator detail read GET /api/commands/{id} carries a path param and is not classified here, so it stays Full).
+// highVolume is the agent data plane that dominates request volume and is downsampled hardest: event ingest, the agent's command poll
+// (GET /api/commands), and the periodic per-host token refresh. POST /api/enroll is deliberately NOT here: enrollment happens roughly
+// once per host lifetime, so it carries negligible volume and is load-bearing for debugging onboarding, so it stays Full (100%). The
+// operator detail read GET /api/commands/{id} carries a path param and is not classified here, so it also stays Full.
 var highVolume = []route{
 	{"POST", "/api/events"},
 	{"GET", "/api/commands"},
 	{"POST", "/api/token/refresh"},
-	{"POST", "/api/enroll"},
 }
 
 // standard is operator/UI read traffic: the parameter-free dashboard and settings GET endpoints. Sampled at the standard ratio.

--- a/server/tracingpolicy/policy.go
+++ b/server/tracingpolicy/policy.go
@@ -1,0 +1,62 @@
+// Package tracingpolicy holds the EDR route-to-sampling-tier policy: the mapping from HTTP routes to the tiers defined in
+// internal/observability/tracing. It is the "policy" half of the mechanism/policy split (the sampler + registry are the mechanism).
+// Keeping it in the server layer lets the shared tracing package stay free of EDR routes, and lets both server binaries
+// (fleet-edr-server and fleet-edr-ingest) share one classification.
+//
+// Classification keys are "METHOD /path" matching the span name the HTTP span-name formatter emits. Because that span name is the raw
+// request path (otelhttp runs before net/http route matching), only routes whose template has NO path parameters can be classified
+// here; the agent data-plane routes that drive volume are all parameter-free, so they match exactly. Parameter-bearing routes
+// (e.g. GET /api/alerts/{id}) are operator detail reads at low volume and intentionally fall to TierFull (100%), the safe default.
+package tracingpolicy
+
+import "github.com/fleetdm/edr/internal/observability/tracing"
+
+type route struct {
+	method string
+	path   string
+}
+
+// highVolume is the agent data plane: it dominates request volume and is downsampled hardest. GET /api/commands is the agent's
+// command poll (the operator detail read GET /api/commands/{id} carries a path param and is not classified here, so it stays Full).
+var highVolume = []route{
+	{"POST", "/api/events"},
+	{"GET", "/api/commands"},
+	{"POST", "/api/token/refresh"},
+	{"POST", "/api/enroll"},
+}
+
+// standard is operator/UI read traffic: the parameter-free dashboard and settings GET endpoints. Sampled at the standard ratio.
+var standard = []route{
+	{"GET", "/api/session"},
+	{"GET", "/api/audit-events"},
+	{"GET", "/api/hosts"},
+	{"GET", "/api/alerts"},
+	{"GET", "/api/rules"},
+	{"GET", "/api/attack-coverage"},
+	{"GET", "/api/enrollments"},
+	{"GET", "/api/settings/sso"},
+	{"GET", "/api/settings/users"},
+	{"GET", "/api/settings/service-accounts"},
+	{"GET", "/api/settings/tracing"},
+}
+
+// drop is liveness/health probe traffic: high volume, zero diagnostic value. Dropped unconditionally (even under force_full).
+var drop = []route{
+	{"GET", "/livez"},
+	{"GET", "/readyz"},
+	{"GET", "/health"},
+}
+
+// Register applies the EDR sampling-tier policy to reg. Safe to call with routes a given binary does not serve: an unused registry
+// entry is inert. Routes absent from every list fall to TierFull via Registry.Lookup's zero value.
+func Register(reg *tracing.Registry) {
+	for _, r := range highVolume {
+		reg.Register(r.method, r.path, tracing.TierHighVolume)
+	}
+	for _, r := range standard {
+		reg.Register(r.method, r.path, tracing.TierStandard)
+	}
+	for _, r := range drop {
+		reg.Register(r.method, r.path, tracing.TierDrop)
+	}
+}

--- a/server/tracingpolicy/policy_test.go
+++ b/server/tracingpolicy/policy_test.go
@@ -20,7 +20,8 @@ func TestRegister_classifiesRoutesByTier(t *testing.T) {
 		{"POST /api/events", tracing.TierHighVolume},
 		{"GET /api/commands", tracing.TierHighVolume},
 		{"POST /api/token/refresh", tracing.TierHighVolume},
-		{"POST /api/enroll", tracing.TierHighVolume},
+		// Enrollment is rare + load-bearing, so it is intentionally NOT high-volume; it falls to Full (100%).
+		{"POST /api/enroll", tracing.TierFull},
 		{"GET /api/hosts", tracing.TierStandard},
 		{"GET /api/alerts", tracing.TierStandard},
 		{"GET /api/settings/tracing", tracing.TierStandard},

--- a/server/tracingpolicy/policy_test.go
+++ b/server/tracingpolicy/policy_test.go
@@ -1,0 +1,42 @@
+package tracingpolicy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/fleetdm/edr/internal/observability/tracing"
+)
+
+func TestRegister_classifiesRoutesByTier(t *testing.T) {
+	t.Parallel()
+	reg := tracing.NewRegistry()
+	Register(reg)
+
+	cases := []struct {
+		span string
+		want tracing.Tier
+	}{
+		{"POST /api/events", tracing.TierHighVolume},
+		{"GET /api/commands", tracing.TierHighVolume},
+		{"POST /api/token/refresh", tracing.TierHighVolume},
+		{"POST /api/enroll", tracing.TierHighVolume},
+		{"GET /api/hosts", tracing.TierStandard},
+		{"GET /api/alerts", tracing.TierStandard},
+		{"GET /api/settings/tracing", tracing.TierStandard},
+		{"GET /livez", tracing.TierDrop},
+		{"GET /readyz", tracing.TierDrop},
+		{"GET /health", tracing.TierDrop},
+		// A parameter-bearing operator detail read is not classified (otelhttp emits the raw path), so it falls to full fidelity.
+		{"GET /api/alerts/42", tracing.TierFull},
+		{"GET /api/commands/abc-123", tracing.TierFull},
+		// An unknown route falls to full fidelity.
+		{"POST /api/brand-new", tracing.TierFull},
+	}
+	for _, tc := range cases {
+		t.Run(tc.span, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, reg.Lookup(tc.span))
+		})
+	}
+}


### PR DESCRIPTION
## Why

OTel trace export is unbounded: no sampler is configured, so the SDK default (parent-based, always-on) records and exports every span. Production is already failing trace export with `502 (Bad Gateway)` against the collector, and there's no way to dial telemetry down (during an export incident) or up (to debug) without a redeploy. Closes #374.

## What

Route-aware **head sampling** with four tiers, runtime-adjustable without a redeploy:

| Tier | Routes | Default ratio |
| --- | --- | --- |
| HighVolume | high-frequency agent data plane (`POST /api/events`, agent `GET /api/commands` poll, `POST /api/token/refresh`) | 0.01 |
| Standard | operator/UI `GET` reads | 0.1 |
| Full | everything else: writes, admin mutations, unclassified, and low-frequency load-bearing agent routes like `POST /api/enroll` | 1.0 |
| Drop | liveness/health probes (`/livez`, `/readyz`, `/health`) | never exported (wins over force-full) |

Wrapped in `ParentBased` so a sampled parent forces its children sampled. Ratios + a `force_full` incident toggle live in a `trace_sampler_settings` singleton table (CHECK-bounded, seeded with the compile-time defaults), polled by every replica each 60s, and adjusted via `GET`/`PATCH /api/settings/tracing` (admin + super_admin, the new `tracing.manage` action).

## Architecture

- `internal/observability/tracing` — the sampler mechanism (Tier, Registry, RouteTierSampler, Settings, poller). Agent-safe; no server or context coupling.
- `server/tracingpolicy` — the EDR route-to-tier policy, shared by both binaries.
- **New `observability` bounded context** (a sixth context, ADR-0004 amendment) owns the settings table + admin API. It owns a schema and serves an authz-gated, audited route, which is the bounded-context shape; arch-go forbids context-free platform packages from importing any context, so the authz/audit dependency rules this surface out of the platform layer. It consumes `identity/api` for the chokepoint + audit recorder.
- `observability.Init` / `bootstrap.Init` thread an `Options.Sampler` through; both `fleet-edr-server` and `fleet-edr-ingest` build the sampler, register the policy, and start the poller.

## Notes for reviewers

- **Metrics stay authoritative under sampling**: p99/error-rate/request-rate read from the `http.server.request.duration` histogram and the `edr.*` counters (never sampled), not from spans. Documented in `docs/operations.md` and pinned by spec scenarios.
- Operator detail reads with a path param (e.g. `GET /api/alerts/{id}`) aren't classified (otelhttp emits the raw path) and fall to Full (100%) safe-by-default; the volume-driving routes are all parameter-free.
- The dynamic in-app knob is an interim; collector-side tail sampling remains a possible follow-up (noted in the issue).

## Spec

OpenSpec change `otel-route-tier-sampling` modifies the `observability-instrumentation` capability (route-tier sampling, runtime-adjustable settings, force-full, admin endpoint, probe-drop, metrics-authoritative). spectrace markers cover every new SHALL scenario.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable trace sampling with route-based tiers, including full, standard, high-volume, and drop behavior.
  * Introduced an admin settings page/API to view and update tracing ratios without redeploying.
  * Enabled sampling controls to refresh automatically at runtime across replicas.

* **Documentation**
  * Updated runbooks and architecture docs with trace sampling guidance, limits, and operational examples.

* **Bug Fixes**
  * Improved observability defaults and safeguards so invalid sampling values are rejected and probes remain unexported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
