### PR TITLE
perf(rules): batch app-control fan-out inserts (#84)

### DIFF
--- a/openspec/changes/move-fanout-batch-insert/proposal.md
+++ b/openspec/changes/move-fanout-batch-insert/proposal.md
@@ -1,0 +1,23 @@
+# Move policy fan-out off the request hot path with batched inserts
+
+## Why
+
+When an operator mutates an application-control policy (`CreateRule` / `UpdateRule` / `DeleteRule` / `BulkUpsertRules`), the rules context fans the new snapshot out to every assigned host by enqueuing one `set_application_control` command per host. Today that fan-out runs a serial loop inside the request handler, doing one `INSERT INTO commands` round trip per host. Gemini Code Assist flagged this HIGH on PR #83: a fleet of N enrolled hosts means N serial inserts inside one synchronous HTTP request. At the post-MVP long-tail target of ~10k endpoints (ADR-0002) that is a multi-second-to-tens-of-seconds blocking mutation that can hit the server's 30s `WriteTimeout`, so the policy commits but the operator gets a 5xx and a hung UI.
+
+The synchronous, in-request shape is otherwise desirable: the operator learns the per-host fan-out result (`fanout_hosts` / `fanout_failed`) in the same audit event, there is no cross-context transaction, and a missed host self-heals on its next poll. The only problem is the per-host round-trip count.
+
+## What changes
+
+- **The per-host insert loop becomes one bounded-size multi-row insert.** A new `response.Service.InsertBatch` enqueues one command row per host across a set of host IDs using chunked multi-row `INSERT` statements (chunk size 256), the same idiom detection already uses for `bulkInsertAlertEvents`. The application-control fan-out collects the resolved unique host set and calls it once instead of looping. 500 hosts go from 500 round trips to 2; 10k hosts from 10k round trips to ~40 (~400ms), comfortably inside the request budget. The fan-out stays synchronous and in-request: the operator still gets accurate counts in the same response and audit event.
+- **`fanout_failed` accounting moves from per-host to per-batch.** A multi-row insert is atomic per statement, so a chunk either lands entirely or not at all. `fanout_failed` is now the count of unique hosts whose command did not land (`attempted - inserted`); when a chunk fails, every host in that chunk is counted as failed. The policy row is still authoritative and the missed hosts re-sync on their next poll, so the HTTP mutation still succeeds. `fanout_hosts` (total unique assigned hosts) is unchanged.
+
+### Not in this change
+
+- **The async / detached-goroutine fan-out path (issue #84 scope items 1-4).** Batched inserts complete the full enrolled fleet within one synchronous request across the entire roadmap scale (10-500 MVP, 10k long-tail), so the `FanoutAsync` detached goroutine, the `policy_fanout_jobs` table, the `GET /api/policy/fanout-jobs` endpoint, and the UI polling are unnecessary complexity here. They also change the operator-facing contract (202 + later results) and introduce in-process work that a replica restart would drop, which ADR-0010 (stateless server) discourages. Tripwire: revisit the async path if fan-out p99 latency ever approaches the `WriteTimeout`.
+- **The `commands` table schema, the command wire payload, the at-most-once delivery contract, and the policy-epoch resync (#322).** This change is confined to the insert mechanism and the failure-count granularity; the rows produced are byte-identical to the per-host path.
+
+## Impact
+
+- Affected specs: `server-application-control` (the "Command fan-out on policy mutation" requirement).
+- Affected code: `server/response/internal/mysql` (new `InsertBatch`), `server/response/internal/service` + `server/response/api` (new `InsertBatch` method on the response surface), `server/rules/internal/appcontrol` (fan-out switches to the batch closure), `server/rules/bootstrap` + `server/cmd/fleet-edr-server` (wire `InsertBatch` through instead of `Insert`).
+- Operator-visible: none on the happy path. Under a fan-out failure the `fanout_failed` count now reflects the failed batch rather than individual hosts.

--- a/openspec/changes/move-fanout-batch-insert/specs/server-application-control/spec.md
+++ b/openspec/changes/move-fanout-batch-insert/specs/server-application-control/spec.md
@@ -1,0 +1,43 @@
+# Server application control: batched fan-out delta
+
+## MODIFIED Requirements
+
+### Requirement: Command fan-out on policy mutation
+
+The system SHALL enqueue at most one `set_application_control` command per unique host that belongs to any host group assigned to a mutated policy; hosts that match through multiple groups SHALL NOT receive duplicate commands. The command payload SHALL carry `{policy_id, policy_version, policy_epoch, rules: [...]}` where each rule entry includes `{rule_type, identifier, action, enforcement, custom_msg, custom_url, severity}`. `policy_epoch` SHALL be the policy's server-assigned `updated_at` timestamp expressed in Unix microseconds (or `0` when the policy carries no timestamp), composed from the same post-mutation policy read that supplies `policy_version`; it is the restore-surviving recency marker the extension uses to re-sync after a database restore regresses `policy_version`. Disabled rules and expired rules SHALL be omitted from the payload.
+
+The enqueue SHALL be performed in bulk, as a bounded-size multi-row insert rather than one database round trip per host, so that fan-out to the full enrolled fleet completes within a single synchronous operator request even at the deployment's host-count ceiling. The system SHALL record on the mutation's audit event the total count of unique hosts the command was enqueued for (`fanout_hosts`) and the count of those unique hosts whose command did not land (`fanout_failed`). Because a multi-row insert is atomic per statement, when a bulk insert of a set of hosts fails, every unique host in that set SHALL be counted in `fanout_failed`. A fan-out failure SHALL NOT fail the operator's mutation: the policy row is authoritative and any host whose command did not land re-syncs on its next poll.
+
+#### Scenario: A new rule fans out only to assigned hosts
+
+- **GIVEN** a policy assigned to a host group whose criteria matches three of the deployment's five hosts
+- **WHEN** the operator creates a rule on that policy
+- **THEN** exactly three `set_application_control` commands are enqueued
+- **AND** the audit event records `fanout_hosts=3`, `fanout_failed=0`
+
+#### Scenario: A host that matches multiple assigned groups receives one command
+
+- **GIVEN** a policy assigned to two host groups whose criteria both match the same host
+- **WHEN** the system fans out the policy
+- **THEN** exactly one `set_application_control` command is enqueued for that host
+- **AND** the audit event's `fanout_hosts` counts that host once
+
+#### Scenario: Disabled rules are not pushed
+
+- **GIVEN** a policy with two rules, one of which is `enabled=false`
+- **WHEN** the system fans out the policy
+- **THEN** the command payload contains only the enabled rule
+
+#### Scenario: The payload carries the policy epoch
+
+- **GIVEN** a policy whose `updated_at` advances on every mutation
+- **WHEN** the system composes the `set_application_control` payload after a mutation
+- **THEN** the payload's `policy_epoch` equals the policy's post-mutation `updated_at` in Unix microseconds
+- **AND** a later mutation produces a payload whose `policy_epoch` is greater, even across a database restore that regressed `policy_version`
+
+#### Scenario: A failed enqueue batch counts every host in it as failed
+
+- **GIVEN** a policy assigned to a host group matching two hosts
+- **WHEN** the operator mutates the policy and the bulk command enqueue for that batch fails
+- **THEN** the HTTP mutation still succeeds
+- **AND** the audit event records `fanout_failed` equal to the number of hosts in the failed batch

--- a/openspec/changes/move-fanout-batch-insert/tasks.md
+++ b/openspec/changes/move-fanout-batch-insert/tasks.md
@@ -1,0 +1,25 @@
+# Tasks
+
+## 1. Response context: batched insert
+
+- [ ] 1.1 Add `Store.InsertBatch(ctx, hostIDs, commandType, payload) (int, error)` to `server/response/internal/mysql/store.go`, chunked multi-row `INSERT` (chunk size 256), mirroring `bulkInsertAlertEvents`. Returns the count of rows that landed; on a chunk error returns the count so far plus the error.
+- [ ] 1.2 Add `Service.InsertBatch` validation wrapper to `server/response/internal/service/service.go` (empty `commandType` / `payload` / `hostIDs` wrap `ErrInvalidInsertRequest`).
+- [ ] 1.3 Add `InsertBatch` to the `response/api.Service` interface with doc.
+
+## 2. Rules application-control fan-out
+
+- [ ] 2.1 Replace `appcontrol.CommandInserter` with `CommandBatchInserter` (batch signature) on the `Service`, `ServiceDeps`, and `NewService` nil-guard.
+- [ ] 2.2 Rewrite `Service.fanout` to collect the resolved unique host set and call the batch inserter once; `failed = attempted - inserted`.
+- [ ] 2.3 Thread the batch closure through `server/rules/bootstrap` (`Deps.CommandBatchInserter`) and `server/cmd/fleet-edr-server/main.go` (`responseCtx.Service().InsertBatch`).
+
+## 3. Tests
+
+- [ ] 3.1 Store: `InsertBatch` lands N rows, crosses the chunk boundary (> 256), payloads byte-identical, status pending, correct count.
+- [ ] 3.2 Service: validation branches for empty `commandType` / `payload` / `hostIDs`.
+- [ ] 3.3 appcontrol: fan-out issues a single batch call with the full unique host set; `fanout_hosts` counts uniques; a failed batch records `fanout_failed` for every host in it (new scenario marker).
+
+## 4. Gates
+
+- [ ] 4.1 `openspec validate move-fanout-batch-insert --strict`.
+- [ ] 4.2 `go build ./...`, integration tests, `task lint:go`, `task lint:dashes`.
+- [ ] 4.3 Manual: create a rule against dev:server with multiple enrolled hosts; confirm batched rows in `commands` and accurate audit counts.

--- a/server/cmd/fleet-edr-server/main.go
+++ b/server/cmd/fleet-edr-server/main.go
@@ -371,13 +371,13 @@ func openRules(
 	responseCtx *responsebootstrap.Response,
 ) (*rulesbootstrap.Rules, error) {
 	rulesCtx, err := rulesbootstrap.New(rulesbootstrap.Deps{
-		DB:              db,
-		Logger:          logger,
-		Audit:           identityCtx.AuditRecorder(),
-		AuthZ:           identityCtx.AuthZ(),
-		UserEmailByID:   userEmailByIDFromIdentity(identityCtx.Service()),
-		CommandInserter: responseCtx.Service().Insert,
-		HostLister:      hostListerFromDetection(detectionCtx.Service()),
+		DB:                   db,
+		Logger:               logger,
+		Audit:                identityCtx.AuditRecorder(),
+		AuthZ:                identityCtx.AuthZ(),
+		UserEmailByID:        userEmailByIDFromIdentity(identityCtx.Service()),
+		CommandBatchInserter: responseCtx.Service().InsertBatch,
+		HostLister:           hostListerFromDetection(detectionCtx.Service()),
 	})
 	if err != nil {
 		logger.ErrorContext(ctx, "open rules", "err", err)

--- a/server/response/api/service.go
+++ b/server/response/api/service.go
@@ -10,18 +10,24 @@ import "context"
 //     GET /api/commands/{id};
 //   - endpoint/internal/service: Insert at enroll-fan-out time,
 //     via a method-value closure;
-//   - rules/internal/appcontrol: Insert at app-control policy
+//   - rules/internal/appcontrol: InsertBatch at app-control policy
 //     fan-out time, via a method-value closure;
 //   - cmd/main metrics adapter: CountPending for the
 //     PendingCommands gauge.
 //
-// Endpoint and rules consume the Insert method as a method value
-// satisfying their existing CommandInserter closure types; neither
-// imports response/api directly.
+// Endpoint consumes the single-row Insert and rules consumes the
+// batched InsertBatch as method values satisfying their closure
+// types; neither imports response/api directly.
 type Service interface {
 	// Insert appends a command row. Returns the new id. Validation errors (empty hostID/commandType, empty payload) wrap
 	// ErrInvalidInsertRequest.
 	Insert(ctx context.Context, hostID, commandType string, payload []byte) (int64, error)
+
+	// InsertBatch appends one command row per host_id, all sharing commandType + payload, via a chunked multi-row INSERT.
+	// Returns the number of rows that landed. The application-control fan-out consumes this as a method value so a policy
+	// mutation enqueues the whole assigned host set in a couple of round trips rather than one per host. Validation errors
+	// (empty hostIDs, commandType, or payload) wrap ErrInvalidInsertRequest.
+	InsertBatch(ctx context.Context, hostIDs []string, commandType string, payload []byte) (int, error)
 
 	// Get returns a single command by id. Operator-only path: agents should use ListForHost. Returns ErrCommandNotFound for an unknown
 	// id.

--- a/server/response/bootstrap/bootstrap.go
+++ b/server/response/bootstrap/bootstrap.go
@@ -98,8 +98,9 @@ func ApplySchema(ctx context.Context, db *sqlx.DB) error {
 	})
 }
 
-// Service exposes the public api.Service for cross-context callers. endpoint and rules consume Service.Insert as a method value
-// satisfying their CommandInserter closure types; cmd/main's metrics adapter consumes Service.CountPending.
+// Service exposes the public api.Service for cross-context callers. endpoint consumes Service.Insert and rules consumes
+// Service.InsertBatch as method values satisfying their command-inserter closure types; cmd/main's metrics adapter consumes
+// Service.CountPending.
 func (r *Response) Service() api.Service { return r.svc }
 
 // RegisterAgentRoutes wires the host-token-gated agent routes:

--- a/server/response/internal/agent/handler_test.go
+++ b/server/response/internal/agent/handler_test.go
@@ -35,6 +35,10 @@ func (f fakeService) Insert(ctx context.Context, hostID, commandType string, pay
 	return f.insert(ctx, hostID, commandType, payload)
 }
 
+func (f fakeService) InsertBatch(_ context.Context, _ []string, _ string, _ []byte) (int, error) {
+	panic("fakeService.InsertBatch not set") // agent handlers never fan out; batch insert is the rules-context fan-out path
+}
+
 func (f fakeService) Get(ctx context.Context, id int64) (api.Command, error) {
 	if f.get == nil {
 		panic("fakeService.Get not set")

--- a/server/response/internal/mysql/store.go
+++ b/server/response/internal/mysql/store.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/jmoiron/sqlx"
@@ -13,6 +14,11 @@ import (
 	"github.com/fleetdm/edr/server/response/api"
 	"github.com/fleetdm/edr/server/sqlhelpers"
 )
+
+// insertBatchChunkSize caps the number of command rows per multi-row INSERT. The fan-out repeats the SAME payload across every
+// host in the batch, so a chunk's wire size is roughly chunkSize * len(payload); 256 keeps a chunk well under MySQL's default
+// max_allowed_packet even for a large set_application_control snapshot, while collapsing a 500-host fan-out into two round trips.
+const insertBatchChunkSize = 256
 
 // Store owns the commands table. All public methods take the row's fields directly (rather than a pre-constructed struct) so callers
 // don't need to import a row type.
@@ -76,6 +82,35 @@ func (s *Store) Insert(ctx context.Context, hostID, commandType string, payload 
 		return 0, fmt.Errorf("insert command last id: %w", err)
 	}
 	return id, nil
+}
+
+// InsertBatch appends one command row per host_id, all sharing commandType + payload, using chunked multi-row INSERTs
+// (insertBatchChunkSize rows per round trip) instead of one INSERT per host. It is the application-control fan-out's enqueue
+// path: a policy mutation fans the same snapshot out to the whole assigned host set in a couple of round trips rather than N.
+//
+// Returns the number of rows that landed. A multi-row INSERT is atomic per statement, so a chunk lands entirely or not at all;
+// on the first chunk that fails, InsertBatch returns the count from the chunks that already committed plus the error. The caller
+// treats the shortfall (len(hostIDs) minus inserted) as the failed-host count, preserving the fan-out's best-effort contract: the
+// policy row is authoritative and a host whose command did not land catches up on its next poll. host_ids are inserted in the
+// order given. An empty hostIDs slice is a no-op that returns (0, nil).
+func (s *Store) InsertBatch(ctx context.Context, hostIDs []string, commandType string, payload []byte) (int, error) {
+	inserted := 0
+	for start := 0; start < len(hostIDs); start += insertBatchChunkSize {
+		end := min(start+insertBatchChunkSize, len(hostIDs))
+		chunk := hostIDs[start:end]
+		placeholders := make([]string, len(chunk))
+		args := make([]any, 0, len(chunk)*3)
+		for i, hostID := range chunk {
+			placeholders[i] = "(?, ?, ?)"
+			args = append(args, hostID, commandType, payload)
+		}
+		stmt := "INSERT INTO commands (host_id, command_type, payload) VALUES " + strings.Join(placeholders, ", ")
+		if _, err := s.db.ExecContext(ctx, stmt, args...); err != nil {
+			return inserted, fmt.Errorf("insert command batch (chunk of %d): %w", len(chunk), err)
+		}
+		inserted += len(chunk)
+	}
+	return inserted, nil
 }
 
 // ListForHost returns commands for a host, optionally filtered by status (empty string returns every status). Order: created_at DESC

--- a/server/response/internal/mysql/store.go
+++ b/server/response/internal/mysql/store.go
@@ -88,13 +88,15 @@ func (s *Store) Insert(ctx context.Context, hostID, commandType string, payload 
 // (insertBatchChunkSize rows per round trip) instead of one INSERT per host. It is the application-control fan-out's enqueue
 // path: a policy mutation fans the same snapshot out to the whole assigned host set in a couple of round trips rather than N.
 //
-// Returns the number of rows that landed. A multi-row INSERT is atomic per statement, so a chunk lands entirely or not at all;
-// on the first chunk that fails, InsertBatch returns the count from the chunks that already committed plus the error. The caller
-// treats the shortfall (len(hostIDs) minus inserted) as the failed-host count, preserving the fan-out's best-effort contract: the
-// policy row is authoritative and a host whose command did not land catches up on its next poll. host_ids are inserted in the
-// order given. An empty hostIDs slice is a no-op that returns (0, nil).
+// Returns the number of rows that landed. A multi-row INSERT is atomic per statement, so a chunk lands entirely or not at all.
+// A failed chunk does NOT abort the remaining chunks: InsertBatch keeps going so one transient chunk failure can't strand every
+// host after it, matching the best-effort posture of the per-host loop this replaced. It returns the total rows that committed
+// plus the first chunk error encountered (nil when every chunk succeeded). The caller treats the shortfall (len(hostIDs) minus
+// inserted) as the failed-host count: the policy row is authoritative and a host whose command did not land catches up on its
+// next poll. host_ids are inserted in the order given; the caller orders them deterministically so chunk membership is stable.
 func (s *Store) InsertBatch(ctx context.Context, hostIDs []string, commandType string, payload []byte) (int, error) {
 	inserted := 0
+	var firstErr error
 	for start := 0; start < len(hostIDs); start += insertBatchChunkSize {
 		end := min(start+insertBatchChunkSize, len(hostIDs))
 		chunk := hostIDs[start:end]
@@ -106,11 +108,14 @@ func (s *Store) InsertBatch(ctx context.Context, hostIDs []string, commandType s
 		}
 		stmt := "INSERT INTO commands (host_id, command_type, payload) VALUES " + strings.Join(placeholders, ", ")
 		if _, err := s.db.ExecContext(ctx, stmt, args...); err != nil {
-			return inserted, fmt.Errorf("insert command batch (chunk of %d): %w", len(chunk), err)
+			if firstErr == nil {
+				firstErr = fmt.Errorf("insert command batch (chunk of %d): %w", len(chunk), err)
+			}
+			continue
 		}
 		inserted += len(chunk)
 	}
-	return inserted, nil
+	return inserted, firstErr
 }
 
 // ListForHost returns commands for a host, optionally filtered by status (empty string returns every status). Order: created_at DESC

--- a/server/response/internal/mysql/store.go
+++ b/server/response/internal/mysql/store.go
@@ -111,9 +111,10 @@ func (s *Store) InsertBatch(ctx context.Context, hostIDs []string, commandType s
 			if firstErr == nil {
 				firstErr = fmt.Errorf("insert command batch (chunk of %d): %w", len(chunk), err)
 			}
-			// Continue past an isolated chunk failure (best-effort), but stop once the request context is canceled or past its
-			// deadline: every remaining chunk would fail the same way and only delay the synchronous handler during a timeout
-			// or DB outage.
+			// Continue past an isolated chunk failure (best-effort: one bad chunk must not strand the hosts after it), but stop
+			// once the request context is canceled or past its deadline. On the synchronous mutation path a sustained DB outage
+			// surfaces as the handler's WriteTimeout firing on ctx, which lands here; an isolated failure leaves ctx live and the
+			// loop keeps enqueuing the rest.
 			if ctx.Err() != nil {
 				break
 			}

--- a/server/response/internal/mysql/store.go
+++ b/server/response/internal/mysql/store.go
@@ -111,6 +111,12 @@ func (s *Store) InsertBatch(ctx context.Context, hostIDs []string, commandType s
 			if firstErr == nil {
 				firstErr = fmt.Errorf("insert command batch (chunk of %d): %w", len(chunk), err)
 			}
+			// Continue past an isolated chunk failure (best-effort), but stop once the request context is canceled or past its
+			// deadline: every remaining chunk would fail the same way and only delay the synchronous handler during a timeout
+			// or DB outage.
+			if ctx.Err() != nil {
+				break
+			}
 			continue
 		}
 		inserted += len(chunk)

--- a/server/response/internal/mysql/store_test.go
+++ b/server/response/internal/mysql/store_test.go
@@ -2,6 +2,7 @@ package mysql_test
 
 import (
 	"encoding/json"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -205,4 +206,55 @@ func TestCountPending(t *testing.T) {
 	count, err = s.CountPending(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, 3, count)
+}
+
+// TestInsertBatch covers the application-control fan-out's enqueue path: one command row per host_id in a chunked multi-row
+// INSERT. The batch crosses the 256-row chunk boundary so the chunk loop itself is exercised, and every row must carry the
+// byte-identical shared payload + command_type the fan-out passes once.
+func TestInsertBatch(t *testing.T) {
+	t.Parallel()
+	s := newTestStore(t)
+	ctx := t.Context()
+
+	// 600 hosts forces three chunks (256 + 256 + 88) so the chunk boundary is crossed, not just the single-statement path.
+	const hostCount = 600
+	hostIDs := make([]string, hostCount)
+	for i := range hostIDs {
+		hostIDs[i] = "host-" + strconv.Itoa(i)
+	}
+	payload := json.RawMessage(`{"policy_id":1,"policy_version":2,"rules":[{"rule_type":"binary","identifier":"deadbeef"}]}`)
+
+	inserted, err := s.InsertBatch(ctx, hostIDs, "set_application_control", payload)
+	require.NoError(t, err)
+	assert.Equal(t, hostCount, inserted, "every host in the batch must land")
+
+	count, err := s.CountPending(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, hostCount, count, "every batched row is enqueued pending")
+
+	// Spot-check the first + last host: same command_type, byte-identical payload, pending status.
+	for _, hostID := range []string{"host-0", "host-599"} {
+		cmds, err := s.ListForHost(ctx, hostID, "")
+		require.NoError(t, err)
+		require.Len(t, cmds, 1, "each host gets exactly one command")
+		assert.Equal(t, "set_application_control", cmds[0].CommandType)
+		assert.Equal(t, api.StatusPending, cmds[0].Status)
+		assert.JSONEq(t, string(payload), string(cmds[0].Payload), "every row carries the shared fan-out payload byte-for-byte")
+	}
+}
+
+// TestInsertBatch_Empty: an empty host set is a no-op that enqueues nothing and returns (0, nil). The fan-out reaches this when a
+// policy resolves to zero hosts (the no_hosts_resolved skip path guards it upstream, but the store must be safe regardless).
+func TestInsertBatch_Empty(t *testing.T) {
+	t.Parallel()
+	s := newTestStore(t)
+	ctx := t.Context()
+
+	inserted, err := s.InsertBatch(ctx, nil, "set_application_control", json.RawMessage(`{}`))
+	require.NoError(t, err)
+	assert.Equal(t, 0, inserted)
+
+	count, err := s.CountPending(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0, count)
 }

--- a/server/response/internal/mysql/store_test.go
+++ b/server/response/internal/mysql/store_test.go
@@ -209,8 +209,8 @@ func TestCountPending(t *testing.T) {
 }
 
 // TestInsertBatch covers the application-control fan-out's enqueue path: one command row per host_id in a chunked multi-row
-// INSERT. The batch crosses the 256-row chunk boundary so the chunk loop itself is exercised, and every row must carry the
-// byte-identical shared payload + command_type the fan-out passes once.
+// INSERT. The batch crosses the 256-row chunk boundary so the chunk loop itself is exercised, and every host must receive the
+// same command_type + payload the fan-out passes once.
 func TestInsertBatch(t *testing.T) {
 	t.Parallel()
 	s := newTestStore(t)
@@ -232,29 +232,20 @@ func TestInsertBatch(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, hostCount, count, "every batched row is enqueued pending")
 
-	// Spot-check the first + last host: same command_type, byte-identical payload, pending status.
+	// Spot-check the first + last host (across the chunk boundary): same command_type, pending status, and a payload that
+	// semantically matches the input. The commands.payload column is MySQL JSON, which normalizes key order + whitespace on
+	// storage, so compare against the input with JSONEq (a raw byte compare would be testing MySQL's serializer, not us) and
+	// separately assert the two hosts' stored bytes are identical to each other: that IS the fan-out guarantee every host gets
+	// the same snapshot.
+	var stored [][]byte
 	for _, hostID := range []string{"host-0", "host-599"} {
 		cmds, err := s.ListForHost(ctx, hostID, "")
 		require.NoError(t, err)
 		require.Len(t, cmds, 1, "each host gets exactly one command")
 		assert.Equal(t, "set_application_control", cmds[0].CommandType)
 		assert.Equal(t, api.StatusPending, cmds[0].Status)
-		assert.JSONEq(t, string(payload), string(cmds[0].Payload), "every row carries the shared fan-out payload byte-for-byte")
+		assert.JSONEq(t, string(payload), string(cmds[0].Payload), "every row carries the shared fan-out payload")
+		stored = append(stored, cmds[0].Payload)
 	}
-}
-
-// TestInsertBatch_Empty: an empty host set is a no-op that enqueues nothing and returns (0, nil). The fan-out reaches this when a
-// policy resolves to zero hosts (the no_hosts_resolved skip path guards it upstream, but the store must be safe regardless).
-func TestInsertBatch_Empty(t *testing.T) {
-	t.Parallel()
-	s := newTestStore(t)
-	ctx := t.Context()
-
-	inserted, err := s.InsertBatch(ctx, nil, "set_application_control", json.RawMessage(`{}`))
-	require.NoError(t, err)
-	assert.Equal(t, 0, inserted)
-
-	count, err := s.CountPending(ctx)
-	require.NoError(t, err)
-	assert.Equal(t, 0, count)
+	assert.Equal(t, stored[0], stored[1], "every host in one fan-out receives byte-identical payload bytes")
 }

--- a/server/response/internal/mysql/store_test.go
+++ b/server/response/internal/mysql/store_test.go
@@ -235,17 +235,22 @@ func TestInsertBatch(t *testing.T) {
 	// Spot-check the first + last host (across the chunk boundary): same command_type, pending status, and a payload that
 	// semantically matches the input. The commands.payload column is MySQL JSON, which normalizes key order + whitespace on
 	// storage, so compare against the input with JSONEq (a raw byte compare would be testing MySQL's serializer, not us) and
-	// separately assert the two hosts' stored bytes are identical to each other: that IS the fan-out guarantee every host gets
-	// the same snapshot.
-	var stored [][]byte
-	for _, hostID := range []string{"host-0", "host-599"} {
+	// separately assert each host's stored bytes match the first host's: that IS the fan-out guarantee every host gets the same
+	// snapshot. firstStored is captured from host-0 and every later host is compared against it.
+	var firstStored []byte
+	for i, hostID := range []string{"host-0", "host-599"} {
 		cmds, err := s.ListForHost(ctx, hostID, "")
 		require.NoError(t, err)
 		require.Len(t, cmds, 1, "each host gets exactly one command")
 		assert.Equal(t, "set_application_control", cmds[0].CommandType)
 		assert.Equal(t, api.StatusPending, cmds[0].Status)
 		assert.JSONEq(t, string(payload), string(cmds[0].Payload), "every row carries the shared fan-out payload")
-		stored = append(stored, cmds[0].Payload)
+		if i == 0 {
+			firstStored = cmds[0].Payload
+			continue
+		}
+		// Compare as []byte on both sides: cmds[0].Payload is a json.RawMessage, and assert.Equal treats []byte and
+		// json.RawMessage as unequal on the dynamic type even when the bytes match.
+		assert.Equal(t, firstStored, []byte(cmds[0].Payload), "every host in one fan-out receives byte-identical payload bytes")
 	}
-	assert.Equal(t, stored[0], stored[1], "every host in one fan-out receives byte-identical payload bytes")
 }

--- a/server/response/internal/operator/handler_test.go
+++ b/server/response/internal/operator/handler_test.go
@@ -43,6 +43,10 @@ func (f fakeService) Insert(ctx context.Context, hostID, commandType string, pay
 	return f.insert(ctx, hostID, commandType, payload)
 }
 
+func (f fakeService) InsertBatch(_ context.Context, _ []string, _ string, _ []byte) (int, error) {
+	panic("fakeService.InsertBatch not set") // operator handlers never fan out; batch insert is the rules-context fan-out path
+}
+
 func (f fakeService) Get(ctx context.Context, id int64) (api.Command, error) {
 	if f.get == nil {
 		panic("fakeService.Get not set")

--- a/server/response/internal/service/service.go
+++ b/server/response/internal/service/service.go
@@ -59,6 +59,28 @@ func (s *Service) Insert(ctx context.Context, hostID, commandType string, payloa
 	return s.store.Insert(ctx, hostID, commandType, payload)
 }
 
+// InsertBatch validates the shared commandType + payload once, then enqueues one command row per host via the store's chunked
+// multi-row INSERT. It is the application-control fan-out's enqueue path; returns the number of rows that landed.
+//
+// An empty hostIDs slice, an empty commandType, or an empty payload all wrap ErrInvalidInsertRequest so callers can errors.Is +
+// map to 400. commandType is trimmed once at the boundary, matching Insert. Unlike Insert, the individual host_ids are NOT
+// trimmed: the only caller sources them from the host store's primary keys (already clean), so trimming each would be dead
+// defensive work; a malformed entry surfaces as a store error rather than being silently dropped, which would understate the
+// fan-out count.
+func (s *Service) InsertBatch(ctx context.Context, hostIDs []string, commandType string, payload []byte) (int, error) {
+	if len(hostIDs) == 0 {
+		return 0, fmt.Errorf("%w: at least one host_id is required", api.ErrInvalidInsertRequest)
+	}
+	commandType = strings.TrimSpace(commandType)
+	if commandType == "" {
+		return 0, fmt.Errorf("%w: command_type is required", api.ErrInvalidInsertRequest)
+	}
+	if len(payload) == 0 {
+		return 0, fmt.Errorf("%w: payload is required", api.ErrInvalidInsertRequest)
+	}
+	return s.store.InsertBatch(ctx, hostIDs, commandType, payload)
+}
+
 // Get returns a single command by id.
 func (s *Service) Get(ctx context.Context, id int64) (api.Command, error) {
 	return s.store.Get(ctx, id)

--- a/server/response/internal/service/service_insertbatch_test.go
+++ b/server/response/internal/service/service_insertbatch_test.go
@@ -1,0 +1,60 @@
+package service_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fleetdm/edr/server/response/api"
+	"github.com/fleetdm/edr/server/response/internal/mysql"
+	"github.com/fleetdm/edr/server/response/internal/service"
+	"github.com/fleetdm/edr/server/response/testkit"
+	"github.com/fleetdm/edr/server/testdb"
+)
+
+// newBatchService wires a Service over an isolated test DB. External test package so the testdb -> bootstrap -> mysql cycle
+// doesn't bite, matching the mysql store tests' posture.
+func newBatchService(t *testing.T) *service.Service {
+	t.Helper()
+	db := testdb.Open(t)
+	require.NoError(t, testkit.ApplySchema(t.Context(), db))
+	return service.New(mysql.NewStore(db), nil, nil)
+}
+
+// TestInsertBatch_Validation pins the boundary guards the fan-out relies on: an empty host set, command type, or payload all wrap
+// ErrInvalidInsertRequest so a caller can errors.Is + map to 400 rather than emit a malformed multi-row INSERT. The happy path
+// is exercised end-to-end by the mysql store tests; here we assert the validation branches and that a valid batch lands.
+func TestInsertBatch_Validation(t *testing.T) {
+	t.Parallel()
+	svc := newBatchService(t)
+	ctx := t.Context()
+	payload := json.RawMessage(`{"policy_id":1}`)
+
+	cases := []struct {
+		name        string
+		hostIDs     []string
+		commandType string
+		payload     []byte
+	}{
+		{name: "empty host set", hostIDs: nil, commandType: "set_application_control", payload: payload},
+		{name: "blank command type", hostIDs: []string{"host-a"}, commandType: "   ", payload: payload},
+		{name: "empty payload", hostIDs: []string{"host-a"}, commandType: "set_application_control", payload: nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			inserted, err := svc.InsertBatch(ctx, tc.hostIDs, tc.commandType, tc.payload)
+			require.ErrorIs(t, err, api.ErrInvalidInsertRequest)
+			assert.Zero(t, inserted)
+		})
+	}
+
+	t.Run("valid batch lands", func(t *testing.T) {
+		t.Parallel()
+		inserted, err := svc.InsertBatch(ctx, []string{"host-x", "host-y"}, "set_application_control", payload)
+		require.NoError(t, err)
+		assert.Equal(t, 2, inserted)
+	})
+}

--- a/server/rules/bootstrap/bootstrap.go
+++ b/server/rules/bootstrap/bootstrap.go
@@ -40,14 +40,14 @@ type Deps struct {
 	// rules context free of an identity-internal import (ADR-0004), same posture as detection's UserExists dep.
 	UserEmailByID func(ctx context.Context, userID int64) (string, error)
 
-	// CommandInserter is the closure that enqueues a response.Command to a host. The application-control fan-out path consults it on
-	// every rule-create so every enrolled host in the deployment receives one `set_application_control` command per mutation. Optional:
-	// when nil, the application-control REST routes are not mounted (the rules context still constructs cleanly so non-REST consumers like
-	// tools/gen-rule-docs keep working).
-	CommandInserter appcontrol.CommandInserter
+	// CommandBatchInserter is the closure that enqueues `set_application_control` commands to a set of hosts in one batched
+	// multi-row INSERT. The application-control fan-out path consults it on every rule mutation so every assigned host receives one
+	// command per mutation in a couple of round trips rather than one per host. Optional: when nil, the application-control REST
+	// routes are not mounted (the rules context still constructs cleanly so non-REST consumers like tools/gen-rule-docs keep working).
+	CommandBatchInserter appcontrol.CommandBatchInserter
 	// HostLister enumerates the deployment's enrolled hosts for the fan-out. cmd/main passes a wrapper over
 	// detection.api.Service.ListHosts that projects each HostSummary down to its host_id. Same optional-when-nil contract as
-	// CommandInserter; nil disables the REST surface.
+	// CommandBatchInserter; nil disables the REST surface.
 	HostLister appcontrol.HostLister
 }
 
@@ -99,10 +99,10 @@ func New(deps Deps) (*Rules, error) {
 	appControlStore := appcontrol.NewStore(deps.DB)
 	var appControlSvc *appcontrol.Service
 	var appControlH *operator.AppControlHandler
-	if deps.CommandInserter != nil && deps.HostLister != nil {
+	if deps.CommandBatchInserter != nil && deps.HostLister != nil {
 		appControlSvc = appcontrol.NewService(appcontrol.ServiceDeps{
 			Store:    appControlStore,
-			Commands: deps.CommandInserter,
+			Commands: deps.CommandBatchInserter,
 			Hosts:    deps.HostLister,
 			Audit:    deps.Audit,
 			Logger:   logger,
@@ -188,9 +188,9 @@ func (r *Rules) ApplicationControlStore() api.ApplicationControlStore { return r
 //
 //	GET  /api/rules
 //	GET  /api/attack-coverage
-//	GET  /api/v1/app-control/policies                    (when CommandInserter + HostLister are wired)
-//	GET  /api/v1/app-control/policies/{id}               (when CommandInserter + HostLister are wired)
-//	POST /api/v1/app-control/policies/{id}/rules         (when CommandInserter + HostLister are wired)
+//	GET  /api/v1/app-control/policies                    (when CommandBatchInserter + HostLister are wired)
+//	GET  /api/v1/app-control/policies/{id}               (when CommandBatchInserter + HostLister are wired)
+//	POST /api/v1/app-control/policies/{id}/rules         (when CommandBatchInserter + HostLister are wired)
 //
 // Caller wraps in identity Session + CSRF middleware before mounting.
 // rules has no public agent-facing routes, so RegisterPublicRoutes

--- a/server/rules/bootstrap/doc.go
+++ b/server/rules/bootstrap/doc.go
@@ -7,7 +7,7 @@
 // descriptive (caller-facing) while the interface names follow Effective
 // Go's "method-name + er" convention internally.
 //
-// HostLister and CommandInserter are closure types Deps takes so cmd/main
+// HostLister and CommandBatchInserter are closure types Deps takes so cmd/main
 // can supply late-bound implementations of the app-control fan-out without
 // rules taking a hard dependency on detection or response.
 package bootstrap

--- a/server/rules/internal/appcontrol/service.go
+++ b/server/rules/internal/appcontrol/service.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"sort"
 	"strconv"
 	"time"
 
@@ -293,13 +294,16 @@ func (s *Service) fanout(ctx context.Context, policyID int64, payload []byte) (a
 	for h := range seen {
 		hostIDs = append(hostIDs, h)
 	}
+	// Sort so the batch chunk boundaries are deterministic: map iteration order is randomized, which would otherwise make
+	// "which hosts share a failing chunk" vary run-to-run and harder to reproduce.
+	sort.Strings(hostIDs)
 	attempted = len(hostIDs)
-	// One batched multi-row INSERT for the whole host set instead of N round trips. A multi-row INSERT is atomic per chunk, so
-	// the inserter returns the count that landed; the shortfall is the failed-host count. A failure does NOT abort the mutation:
-	// the policy row is authoritative and a host whose command did not land catches up on its next poll.
+	// One batched multi-row INSERT for the whole host set instead of N round trips. The inserter returns the count that landed;
+	// failed is the shortfall whether or not it surfaced an error, so a partial insert is always accounted for. A failure does
+	// NOT abort the mutation: the policy row is authoritative and a host whose command did not land catches up on its next poll.
 	inserted, insErr := s.commands(ctx, hostIDs, api.CommandTypeSetApplicationControl, payload)
+	failed = attempted - inserted
 	if insErr != nil {
-		failed = attempted - inserted
 		s.logger.WarnContext(ctx, "appcontrol: batch command insert failed; missed hosts re-sync on next poll",
 			"policy_id", policyID, "attempted", attempted, "inserted", inserted, "failed", failed, "err", insErr)
 	}

--- a/server/rules/internal/appcontrol/service.go
+++ b/server/rules/internal/appcontrol/service.go
@@ -20,10 +20,12 @@ const (
 	errSvcSnapshotComposeFmt = "appcontrol snapshot compose: %w"
 )
 
-// CommandInserter is the closure cmd/main supplies so the application-control fan-out can enqueue `set_application_control` commands
-// per host. Method-value shape matches response.Service.Insert so cmd/main passes `responseCtx.Service().Insert` directly without an
-// adapter.
-type CommandInserter func(ctx context.Context, hostID, commandType string, payload []byte) (int64, error)
+// CommandBatchInserter is the closure cmd/main supplies so the application-control fan-out can enqueue one
+// `set_application_control` command per host across the whole assigned host set in a couple of round trips rather than one INSERT
+// per host. Method-value shape matches response.Service.InsertBatch so cmd/main passes `responseCtx.Service().InsertBatch`
+// directly without an adapter. Returns the number of rows that landed; the fan-out treats the shortfall against the host count as
+// the failed-host total.
+type CommandBatchInserter func(ctx context.Context, hostIDs []string, commandType string, payload []byte) (int, error)
 
 // HostLister returns the set of host_ids to fan a rule mutation out to. In the demo cut this is every enrolled host in the deployment
 // (host-groups + assignments are post-demo); cmd/main passes a thin wrapper over detection.api.Service.ListHosts that projects
@@ -42,7 +44,7 @@ type HostLister func(ctx context.Context) ([]string, error)
 // constructor takes are wired to goroutine-safe services in cmd/main.
 type Service struct {
 	store    *Store
-	commands CommandInserter
+	commands CommandBatchInserter
 	hosts    HostLister
 	audit    identityapi.AuditRecorder
 	clock    func() time.Time
@@ -54,7 +56,7 @@ type Service struct {
 // wiring readable).
 type ServiceDeps struct {
 	Store    *Store
-	Commands CommandInserter
+	Commands CommandBatchInserter
 	Hosts    HostLister
 	Audit    identityapi.AuditRecorder
 	// Clock is optional. Defaults to time.Now. Tests pin a deterministic value so MarshalSetApplicationControlPayload's expires_at filter
@@ -235,13 +237,14 @@ const (
 	fanoutSkipReasonNoHosts        = "no_hosts_resolved"
 )
 
-// fanout enqueues exactly one set_application_control command per unique host the policy's assigned host groups cover. Phase A's
-// only host-group criteria is `{"type":"all"}` (the seed `all-hosts` group) which resolves to every enrolled host via the
-// HostLister; Phase B grows the resolver to honor tag / hostname / OS predicates without changing this loop's shape.
+// fanout enqueues exactly one set_application_control command per unique host the policy's assigned host groups cover, in a single
+// batched multi-row INSERT rather than one round trip per host. Phase A's only host-group criteria is `{"type":"all"}` (the seed
+// `all-hosts` group) which resolves to every enrolled host via the HostLister; Phase B grows the resolver to honor tag / hostname
+// / OS predicates without changing this shape.
 //
-// Returns (hosts_attempted, hosts_failed, skip_reason). Per-host failures are logged but do NOT abort the loop; the policy is
-// already on disk and a missed host will catch up on its next agent poll (the version-monotonic apply in the extension is
-// idempotent).
+// Returns (hosts_attempted, hosts_failed, skip_reason). The batch insert is atomic per chunk, so hosts_failed is the count that
+// did not land (attempted minus inserted); a failure does NOT abort the mutation: the policy is already on disk and a missed host
+// catches up on its next agent poll (the version-monotonic apply in the extension is idempotent).
 //
 // A non-empty skip_reason distinguishes failure modes that would all otherwise audit as fanout_hosts=0:
 //   - `host_lister_error`: at least one assigned host group's resolver returned an error (e.g. the HostLister itself failed).
@@ -286,12 +289,19 @@ func (s *Service) fanout(ctx context.Context, policyID int64, payload []byte) (a
 		}
 		return 0, 0, fanoutSkipReasonNoHosts
 	}
+	hostIDs := make([]string, 0, len(seen))
 	for h := range seen {
-		attempted++
-		if _, err := s.commands(ctx, h, api.CommandTypeSetApplicationControl, payload); err != nil {
-			failed++
-			s.logger.WarnContext(ctx, "appcontrol: command insert failed", "host_id", h, "err", err)
-		}
+		hostIDs = append(hostIDs, h)
+	}
+	attempted = len(hostIDs)
+	// One batched multi-row INSERT for the whole host set instead of N round trips. A multi-row INSERT is atomic per chunk, so
+	// the inserter returns the count that landed; the shortfall is the failed-host count. A failure does NOT abort the mutation:
+	// the policy row is authoritative and a host whose command did not land catches up on its next poll.
+	inserted, insErr := s.commands(ctx, hostIDs, api.CommandTypeSetApplicationControl, payload)
+	if insErr != nil {
+		failed = attempted - inserted
+		s.logger.WarnContext(ctx, "appcontrol: batch command insert failed; missed hosts re-sync on next poll",
+			"policy_id", policyID, "attempted", attempted, "inserted", inserted, "failed", failed, "err", insErr)
 	}
 	// Partial-failure surfacing: even when some hosts were enqueued, signal host_lister_error if any group's resolver failed.
 	// Otherwise an operator scanning the audit log sees a "successful" fan-out while one of the policy's assigned groups

--- a/server/rules/internal/appcontrol/service_test.go
+++ b/server/rules/internal/appcontrol/service_test.go
@@ -24,16 +24,19 @@ import (
 // nil-actor/empty-tenant validation guards, and the host-lister skip-reason on the audit row. These exercise the orchestrator directly
 // so the REST tests can stay focused on HTTP behaviour.
 
+// captureInserter is a batch CommandBatchInserter stub. calls counts how many times the fan-out invoked the batch insert (one
+// per mutation, not one per host). Returns the chunk's host count as the inserted total so the service computes fanout_failed=0
+// on the happy path.
 type captureInserter struct {
 	mu    sync.Mutex
 	calls int
 }
 
-func (c *captureInserter) Insert(_ context.Context, _, _ string, _ []byte) (int64, error) {
+func (c *captureInserter) InsertBatch(_ context.Context, hostIDs []string, _ string, _ []byte) (int, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.calls++
-	return int64(c.calls), nil
+	return len(hostIDs), nil
 }
 
 type captureAudit struct {
@@ -72,7 +75,7 @@ func newService(t *testing.T) (*appcontrol.Service, *appcontrol.Store, *captureI
 	audit := &captureAudit{}
 	svc := appcontrol.NewService(appcontrol.ServiceDeps{
 		Store:    store,
-		Commands: inserter.Insert,
+		Commands: inserter.InsertBatch,
 		Hosts:    func(_ context.Context) ([]string, error) { return []string{"host-a"}, nil },
 		Audit:    audit,
 		Logger:   slog.Default(),
@@ -134,7 +137,7 @@ func TestService_NilDeps_Panics(t *testing.T) {
 		{
 			name: "nil store",
 			deps: appcontrol.ServiceDeps{
-				Commands: func(context.Context, string, string, []byte) (int64, error) { return 0, nil },
+				Commands: func(context.Context, []string, string, []byte) (int, error) { return 0, nil },
 				Hosts:    func(context.Context) ([]string, error) { return nil, nil },
 			},
 		},
@@ -149,7 +152,7 @@ func TestService_NilDeps_Panics(t *testing.T) {
 			name: "nil hosts",
 			deps: appcontrol.ServiceDeps{
 				Store:    &appcontrol.Store{},
-				Commands: func(context.Context, string, string, []byte) (int64, error) { return 0, nil },
+				Commands: func(context.Context, []string, string, []byte) (int, error) { return 0, nil },
 			},
 		},
 	}
@@ -170,7 +173,7 @@ func TestService_NilAudit_RuleStillCreates(t *testing.T) {
 	inserter := &captureInserter{}
 	svc := appcontrol.NewService(appcontrol.ServiceDeps{
 		Store:    store,
-		Commands: inserter.Insert,
+		Commands: inserter.InsertBatch,
 		Hosts:    func(_ context.Context) ([]string, error) { return []string{"host-a"}, nil },
 		Logger:   slog.Default(),
 	})
@@ -233,7 +236,7 @@ func newServiceWithHostsAndAudit(t *testing.T, hosts func(context.Context) ([]st
 	audit := &captureAudit{}
 	svc := appcontrol.NewService(appcontrol.ServiceDeps{
 		Store:    store,
-		Commands: inserter.Insert,
+		Commands: inserter.InsertBatch,
 		Hosts:    hosts,
 		Audit:    audit,
 		Logger:   slog.Default(),

--- a/server/rules/internal/tests/appcontrol_rest_test.go
+++ b/server/rules/internal/tests/appcontrol_rest_test.go
@@ -13,7 +13,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"testing"
 
 	"github.com/jmoiron/sqlx"
@@ -35,36 +34,47 @@ type capturedCommand struct {
 	Payload []byte
 }
 
-// recordingInserter is a goroutine-safe CommandInserter stub. The fan-out runs through it instead of response.Service.Insert so the
-// test can assert on the enqueued set without standing up the response context. Failures are returned for the host_ids listed in
-// FailHost so the audit-row fanout_failed accounting can be exercised.
+// recordingInserter is a goroutine-safe CommandBatchInserter stub. The fan-out runs through it instead of
+// response.Service.InsertBatch so the test can assert on the enqueued set without standing up the response context. It records
+// one capturedCommand per host in the batch (so snapshot() stays per-host) and counts batch invocations. failBatch makes the
+// next InsertBatch fail whole, modelling a multi-row INSERT's per-statement atomicity, so the audit-row fanout_failed accounting
+// can be exercised.
 type recordingInserter struct {
-	mu        sync.Mutex
-	calls     []capturedCommand
-	nextID    atomic.Int64
-	failHosts map[string]error
+	mu         sync.Mutex
+	calls      []capturedCommand
+	batchCalls int
+	failErr    error
 }
 
 func newRecordingInserter() *recordingInserter {
-	return &recordingInserter{failHosts: map[string]error{}}
+	return &recordingInserter{}
 }
 
-func (r *recordingInserter) failFor(hostID string, err error) {
+func (r *recordingInserter) failBatch(err error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	r.failHosts[hostID] = err
+	r.failErr = err
 }
 
-func (r *recordingInserter) Insert(_ context.Context, hostID, commandType string, payload []byte) (int64, error) {
+func (r *recordingInserter) InsertBatch(_ context.Context, hostIDs []string, commandType string, payload []byte) (int, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	if err, ok := r.failHosts[hostID]; ok {
-		return 0, err
+	r.batchCalls++
+	if r.failErr != nil {
+		return 0, r.failErr
 	}
-	copyPayload := make([]byte, len(payload))
-	copy(copyPayload, payload)
-	r.calls = append(r.calls, capturedCommand{HostID: hostID, Type: commandType, Payload: copyPayload})
-	return r.nextID.Add(1), nil
+	for _, hostID := range hostIDs {
+		copyPayload := make([]byte, len(payload))
+		copy(copyPayload, payload)
+		r.calls = append(r.calls, capturedCommand{HostID: hostID, Type: commandType, Payload: copyPayload})
+	}
+	return len(hostIDs), nil
+}
+
+func (r *recordingInserter) batchCallCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.batchCalls
 }
 
 func (r *recordingInserter) snapshot() []capturedCommand {
@@ -117,11 +127,11 @@ func newAppControlRig(t *testing.T, hosts []string) *appControlRig {
 	audit := &recordingAudit{}
 	hostList := append([]string(nil), hosts...)
 	rules, err := rulesbootstrap.New(rulesbootstrap.Deps{
-		DB:              db,
-		Logger:          slog.Default(),
-		AuthZ:           allowAllAuthZ{},
-		Audit:           audit,
-		CommandInserter: inserter.Insert,
+		DB:                   db,
+		Logger:               slog.Default(),
+		AuthZ:                allowAllAuthZ{},
+		Audit:                audit,
+		CommandBatchInserter: inserter.InsertBatch,
 		HostLister: func(_ context.Context) ([]string, error) {
 			return append([]string(nil), hostList...), nil
 		},
@@ -263,6 +273,7 @@ func TestAppControlREST_CreateRule_FansOutToEveryHost(t *testing.T) {
 
 	calls := r.inserter.snapshot()
 	require.Len(t, calls, 3, "fan-out must dedup duplicate host_ids")
+	assert.Equal(t, 1, r.inserter.batchCallCount(), "the whole host set enqueues in a single batched insert, not one call per host")
 	seen := map[string]struct{}{}
 	for _, c := range calls {
 		seen[c.HostID] = struct{}{}
@@ -359,12 +370,14 @@ func TestAppControlREST_CreateRule_FanOutDedupsAcrossOverlappingAssignments(t *t
 	assert.Equal(t, 2, fetched.AssignmentCount, "two assignment rows must show as count=2")
 }
 
-// TestAppControl_CreateRule_RecordsFanoutFailures: a per-host CommandInserter failure must not abort the loop AND must surface on the
-// audit row as fanout_failed > 0.
+// spec:server-application-control/command-fan-out-on-policy-mutation/a-failed-enqueue-batch-counts-every-host-in-it-as-failed
+//
+// TestAppControlREST_CreateRule_RecordsFanoutFailures: a fan-out batch-insert failure must not fail the HTTP create AND must
+// surface on the audit row. Because the enqueue is one atomic multi-row INSERT, a failed batch counts every host in it as failed.
 func TestAppControlREST_CreateRule_RecordsFanoutFailures(t *testing.T) {
 	t.Parallel()
-	r := newAppControlRig(t, []string{"host-a", "host-bad"})
-	r.inserter.failFor("host-bad", errors.New("synthetic insert failure"))
+	r := newAppControlRig(t, []string{"host-a", "host-b"})
+	r.inserter.failBatch(errors.New("synthetic batch insert failure"))
 	policyID := r.defaultPolicyID(t)
 
 	resp := r.do(t, http.MethodPost,
@@ -377,12 +390,13 @@ func TestAppControlREST_CreateRule_RecordsFanoutFailures(t *testing.T) {
 		})
 	defer resp.Body.Close()
 	require.Equal(t, http.StatusCreated, resp.StatusCode,
-		"per-host fan-out failure must NOT fail the HTTP create")
+		"fan-out failure must NOT fail the HTTP create")
 
 	events := r.audit.snapshot()
 	require.Len(t, events, 1)
-	assert.Equal(t, 2, events[0].Payload["fanout_hosts"])
-	assert.Equal(t, 1, events[0].Payload["fanout_failed"], "host-bad's failure must show in fanout_failed")
+	assert.Equal(t, 2, events[0].Payload["fanout_hosts"], "fanout_hosts is the total unique assigned-host count")
+	assert.Equal(t, 2, events[0].Payload["fanout_failed"], "a failed batch counts every host in it as failed")
+	assert.Empty(t, r.inserter.snapshot(), "a failed batch enqueues nothing")
 }
 
 // spec:server-application-control/rule-lifecycle-audit-events/creating-a-rule-emits-an-audit-event
@@ -559,11 +573,11 @@ func TestAppControlREST_CreateRule_NoActorOnContextIs500(t *testing.T) {
 	inserter := newRecordingInserter()
 	audit := &recordingAudit{}
 	rules, err := rulesbootstrap.New(rulesbootstrap.Deps{
-		DB:              db,
-		Logger:          slog.Default(),
-		AuthZ:           allowAllAuthZ{},
-		Audit:           audit,
-		CommandInserter: inserter.Insert,
+		DB:                   db,
+		Logger:               slog.Default(),
+		AuthZ:                allowAllAuthZ{},
+		Audit:                audit,
+		CommandBatchInserter: inserter.InsertBatch,
 		HostLister: func(_ context.Context) ([]string, error) {
 			return []string{"host-a"}, nil
 		},
@@ -612,11 +626,11 @@ func TestAppControlREST_CreateRule_HostListerFailureRecorded(t *testing.T) {
 	inserter := newRecordingInserter()
 	audit := &recordingAudit{}
 	rules, err := rulesbootstrap.New(rulesbootstrap.Deps{
-		DB:              db,
-		Logger:          slog.Default(),
-		AuthZ:           allowAllAuthZ{},
-		Audit:           audit,
-		CommandInserter: inserter.Insert,
+		DB:                   db,
+		Logger:               slog.Default(),
+		AuthZ:                allowAllAuthZ{},
+		Audit:                audit,
+		CommandBatchInserter: inserter.InsertBatch,
 		HostLister: func(_ context.Context) ([]string, error) {
 			return nil, errors.New("synthetic host lister failure")
 		},

--- a/server/rules/internal/tests/appcontrol_rest_test.go
+++ b/server/rules/internal/tests/appcontrol_rest_test.go
@@ -36,9 +36,9 @@ type capturedCommand struct {
 
 // recordingInserter is a goroutine-safe CommandBatchInserter stub. The fan-out runs through it instead of
 // response.Service.InsertBatch so the test can assert on the enqueued set without standing up the response context. It records
-// one capturedCommand per host in the batch (so snapshot() stays per-host) and counts batch invocations. failBatch makes the
-// next InsertBatch fail whole, modelling a multi-row INSERT's per-statement atomicity, so the audit-row fanout_failed accounting
-// can be exercised.
+// one capturedCommand per host in the batch (so snapshot() stays per-host) and counts batch invocations. failBatch makes every
+// InsertBatch call fail whole (the flag is sticky, not one-shot), modelling a multi-row INSERT's per-statement atomicity, so the
+// audit-row fanout_failed accounting can be exercised.
 type recordingInserter struct {
 	mu         sync.Mutex
 	calls      []capturedCommand

--- a/test/integration/setup.go
+++ b/test/integration/setup.go
@@ -129,11 +129,11 @@ func setupReplica(t *testing.T, db *sqlx.DB) *Stack {
 	require.NoError(t, err, "open response")
 
 	rulesCtx, err := rulesbootstrap.New(rulesbootstrap.Deps{
-		DB:              db,
-		Logger:          logger,
-		AuthZ:           identityCtx.AuthZ(),
-		Audit:           identityCtx.AuditRecorder(),
-		CommandInserter: responseCtx.Service().Insert,
+		DB:                   db,
+		Logger:               logger,
+		AuthZ:                identityCtx.AuthZ(),
+		Audit:                identityCtx.AuditRecorder(),
+		CommandBatchInserter: responseCtx.Service().InsertBatch,
 		HostLister: func(ctx context.Context) ([]string, error) {
 			hosts, err := detectionCtx.Service().ListHosts(ctx)
 			if err != nil {


### PR DESCRIPTION
The app-control fan-out enqueued one set_application_control command per host with a serial INSERT loop inside the request handler (Gemini HIGH on PR #83): N enrolled hosts meant N round trips in one synchronous mutation, risking the 30s WriteTimeout at fleet scale.

Replace the loop with a bounded-size multi-row INSERT (chunk 256, mirroring detection's bulkInsertAlertEvents). Fan-out stays synchronous and in-request with accurate fanout_hosts/fanout_failed counts; 500 hosts go from 500 round trips to 2, 10k to ~40 (~400ms), comfortably inside the request budget. No new table/endpoint/UI and no in-process state, so ADR-0010 holds. The async job-table path (issue scope 1-4) is deferred with a tripwire.

- response: Store.InsertBatch + Service.InsertBatch, added to api.Service.
- rules: CommandInserter -> CommandBatchInserter; fanout collects the unique host set and calls the batch inserter once (failed = attempted - inserted).
- wiring: rules/bootstrap + cmd/main pass responseCtx.Service().InsertBatch.
- fanout_failed now counts per failed batch rather than per host, since a multi-row INSERT is atomic per statement.

OpenSpec: move-fanout-batch-insert modifies the "Command fan-out on policy mutation" requirement and adds a per-batch-failure scenario.

Verified live against dev:server: a rule create fanned out 10 byte-identical commands across 10 hosts in one 25ms request, audit fanout_hosts=10, fanout_failed=0.

<!-- Keep this short. Delete sections that do not apply. -->

## What & why



## Checklist

- [ ] **OpenSpec updated for behavior changes.** If this PR changes observable behavior (a detection rule, the event
      wire schema, persistence semantics, an API/wire shape, or an emitted event), `openspec/specs/**` is updated (and
      an `openspec/changes/` proposal added), with a `spec:<id>` test marker for any new/renamed scenario. Only if this
      PR changes NO observable behavior (a comment / refactor / gofmt / dep bump that happens to touch a scoped path)
      may you assert `no-behavior-change` (label or `[no-behavior-change]` in the title) to clear the OpenSpec-sync gate.
      That is an assertion a reviewer will check, not a way to skip the spec for a real behavior change.
- [ ] Tests added/updated for the change (unit / integration / efficacy / UI as applicable).
- [ ] Agent/extension change touching ESF, XPC, or the event wire format: exercised on a live macOS VM before RC
      (flagged below).
- [ ] **Docs updated for user-facing changes.** If this PR changes a user-facing surface (the React UI, an HTTP
      handler, or a detection rule), `docs/` or `CHANGELOG.md` is updated in the same PR. Only if nothing a user sees
      changed (an internal refactor, a non-visible UI tweak) may you assert `no-docs-change` (label or
      `[no-docs-change]` in the title) to clear the Docs-sync gate. The model is in `docs/doc-versioning.md`.

## VM / RC notes (if applicable)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Policy changes now fan out to hosts in a single batched operation, improving large-scale command delivery.
  * Duplicate host matches are deduplicated so each host receives at most one command.

* **Bug Fixes**
  * Failed fan-out batches now count all hosts in the failed chunk consistently.
  * Host command payloads now include the correct policy version and timestamp-based epoch information.
  * Disabled or expired rules are no longer included in outgoing commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->