### PR TITLE
test(e2e): make demo-nightly released leg version-tolerant on hostnames

### DIFF
--- a/test/e2e/tests/demo/demo-smoke.spec.ts
+++ b/test/e2e/tests/demo/demo-smoke.spec.ts
@@ -1,9 +1,10 @@
 import { Page, test, expect } from "@playwright/test";
 
 // Demo smoke test for the README's one-command, Mac-free demo
-// (docker-compose.demo.yml). Run by the nightly demo workflow against a stack
-// built from the current source so a change on main that breaks the demo is
-// caught before a reviewer hits it.
+// (docker-compose.demo.yml). The nightly demo workflow runs it in two modes:
+// `source` (images built from the checkout, so a change on main that breaks the
+// demo is caught before it ships) and `released` (the published `latest` images
+// a reviewer actually pulls, which can lag main by a release).
 //
 // It does NOT reset or seed the database: the compose seeder already replayed
 // the curated corpus through the real ingest + detection pipeline before this
@@ -15,11 +16,22 @@ import { Page, test, expect } from "@playwright/test";
 //   - four detection-source alerts: credential_keychain_dump, dns_c2_beacon,
 //     sudoers_tamper, persistence_launchagent
 //   - one application_control-source alert (the app-control block)
+//
+// The host list grew a hostname column after v0.2.1, so the released leg may run
+// against an image whose /api/hosts omits hostname and whose UI lists hosts by
+// host_id. The hostname assertions are therefore capability-detected: required
+// for the source build, skipped (with a host_id fallback) when an older released
+// image doesn't expose them. The check auto-tightens once `latest` catches up.
 
 const DEMO_EMAIL = "demo@fleet-edr.local";
 const DEMO_PASSWORD = "demo"; // NOSONAR(typescript:S2068): checked-in demo credential, not a secret
 const DEMO_HOSTNAMES = ["alex-mbp.local", "ci-builder.local"];
 const DETECTION_RULE_IDS = ["credential_keychain_dump", "dns_c2_beacon", "sudoers_tamper", "persistence_launchagent"];
+
+// STRICT_BUILD gates assertions that only hold against the current source tree.
+// demo-nightly.yml sets MODE per matrix leg; it is unset for local runs, which
+// build from source, so the default is strict.
+const STRICT_BUILD = process.env.MODE !== "released";
 
 // signInViaDex runs the dex SSO ceremony for the single demo account. Mirrors
 // the qa oidc-login helper but with the demo credentials and the demo issuer
@@ -47,19 +59,37 @@ test.describe("demo stack smoke", () => {
   test("demo SSO user signs in and sees the seeded hosts + alerts", async ({ page }) => {
     await signInViaDex(page);
 
-    // UI check: the home view (HostList) renders both seeded hosts.
-    for (const hostname of DEMO_HOSTNAMES) {
-      await expect(page.getByText(hostname, { exact: true })).toBeVisible({ timeout: 15_000 });
-    }
-
     // API check: the authenticated session (page.request shares the cookie jar)
-    // returns the seeded hosts.
+    // returns the two seeded hosts.
     const hostsResp = await page.request.get("/api/hosts");
     expect(hostsResp.status()).toBe(200);
-    const hosts = (await hostsResp.json()) as Array<{ host_id: string; hostname: string }>;
+    const hosts = (await hostsResp.json()) as Array<{ host_id: string; hostname?: string }>;
     expect(hosts).toHaveLength(2);
-    const hostnames = hosts.map((h) => h.hostname).sort((a, b) => a.localeCompare(b));
-    expect(hostnames).toEqual([...DEMO_HOSTNAMES].sort((a, b) => a.localeCompare(b)));
+    for (const host of hosts) {
+      expect(host.host_id, "every host row carries a host_id").toBeTruthy();
+    }
+
+    // Capability-detect the post-v0.2.1 hostname column (see the file header). The
+    // source build must expose it; an older released image is allowed to omit it.
+    const hasHostnames = hosts.every((host) => typeof host.hostname === "string" && host.hostname.length > 0);
+    if (STRICT_BUILD) {
+      expect(hasHostnames, "the source build must expose hostnames on /api/hosts").toBe(true);
+    }
+
+    if (hasHostnames) {
+      // API + UI: the hostnames match the seeded set and render in the host list.
+      const hostnames = hosts.map((host) => host.hostname ?? "").sort((a, b) => a.localeCompare(b));
+      expect(hostnames).toEqual([...DEMO_HOSTNAMES].sort((a, b) => a.localeCompare(b)));
+      for (const hostname of DEMO_HOSTNAMES) {
+        await expect(page.getByText(hostname, { exact: true })).toBeVisible({ timeout: 15_000 });
+      }
+    } else {
+      // Older released image: the host list renders rows by host_id. Assert both
+      // seeded rows surfaced through the authenticated UI.
+      for (const host of hosts) {
+        await expect(page.getByText(host.host_id, { exact: true })).toBeVisible({ timeout: 15_000 });
+      }
+    }
 
     // API check: alerts carry both a detection-source set (the four woven
     // ATT&CK detections) and the application_control block.

--- a/test/e2e/tests/demo/demo-smoke.spec.ts
+++ b/test/e2e/tests/demo/demo-smoke.spec.ts
@@ -69,23 +69,28 @@ test.describe("demo stack smoke", () => {
       expect(host.host_id, "every host row carries a host_id").toBeTruthy();
     }
 
-    // Capability-detect the post-v0.2.1 hostname column (see the file header). The
-    // source build must expose it; an older released image is allowed to omit it.
-    const hasHostnames = hosts.every((host) => typeof host.hostname === "string" && host.hostname.length > 0);
+    // Capability-detect the post-v0.2.1 hostname column (see the file header) by
+    // field PRESENCE, not by value: /api/hosts emits the key unconditionally once
+    // the column exists, so a present-but-empty hostname is a regression to catch,
+    // not a reason to fall back (the UI renders host_id when hostname is empty).
+    // The source build must expose it; an older released image is allowed to omit it.
+    const supportsHostnameField = hosts.every((host) => "hostname" in host);
     if (STRICT_BUILD) {
-      expect(hasHostnames, "the source build must expose hostnames on /api/hosts").toBe(true);
+      expect(supportsHostnameField, "the source build must expose hostnames on /api/hosts").toBe(true);
     }
 
-    if (hasHostnames) {
-      // API + UI: the hostnames match the seeded set and render in the host list.
+    if (supportsHostnameField) {
+      // API + UI: the hostnames are populated, match the seeded set, and render in
+      // the host list. Empty or incorrect values fail here in both legs rather
+      // than silently degrading to the host_id fallback below.
       const hostnames = hosts.map((host) => host.hostname ?? "").sort((a, b) => a.localeCompare(b));
       expect(hostnames).toEqual([...DEMO_HOSTNAMES].sort((a, b) => a.localeCompare(b)));
       for (const hostname of DEMO_HOSTNAMES) {
         await expect(page.getByText(hostname, { exact: true })).toBeVisible({ timeout: 15_000 });
       }
     } else {
-      // Older released image: the host list renders rows by host_id. Assert both
-      // seeded rows surfaced through the authenticated UI.
+      // Older released image: the field is absent and the host list renders rows
+      // by host_id. Assert both seeded rows surfaced through the authenticated UI.
       for (const host of hosts) {
         await expect(page.getByText(host.host_id, { exact: true })).toBeVisible({ timeout: 15_000 });
       }


### PR DESCRIPTION
The demo-nightly "released" leg runs main's demo smoke spec against the published `latest` images (currently v0.2.1). The host-list hostname column was added after v0.2.1, so v0.2.1's /api/hosts omits `hostname` and its UI lists hosts by host_id; the spec's `getByText('alex-mbp.local')` assertion could never pass there, even though SSO, breakglass, hosts, and alerts all work. The source leg (main's UI) passed, so only released failed nightly.

Capability-detect the hostname field instead of assuming it:
- source build (MODE != "released", the default for local runs): require hostname on /api/hosts and assert the hostname text in the UI, so a real regression on main still fails the source leg.
- released leg against an older image: fall back to asserting both seeded host IDs render in the authenticated UI. Alert assertions (source + rule_id) are compatible with both versions and run unchanged.

The check auto-tightens once `latest` reaches v0.3.0+ (which exposes the field), so no revert or workflow edit is needed. Verified against the real published v0.2.1 images: released mode passes, strict mode fails with "the source build must expose hostnames on /api/hosts".

<!-- Keep this short. Delete sections that do not apply. -->

## What & why



## Checklist

- [ ] **OpenSpec updated for behavior changes.** If this PR changes observable behavior (a detection rule, the event
      wire schema, persistence semantics, an API/wire shape, or an emitted event), `openspec/specs/**` is updated (and
      an `openspec/changes/` proposal added), with a `spec:<id>` test marker for any new/renamed scenario. Only if this
      PR changes NO observable behavior (a comment / refactor / gofmt / dep bump that happens to touch a scoped path)
      may you assert `no-behavior-change` (label or `[no-behavior-change]` in the title) to clear the OpenSpec-sync gate.
      That is an assertion a reviewer will check, not a way to skip the spec for a real behavior change.
- [ ] Tests added/updated for the change (unit / integration / efficacy / UI as applicable).
- [ ] Agent/extension change touching ESF, XPC, or the event wire format: exercised on a live macOS VM before RC
      (flagged below).
- [ ] **Docs updated for user-facing changes.** If this PR changes a user-facing surface (the React UI, an HTTP
      handler, or a detection rule), `docs/` or `CHANGELOG.md` is updated in the same PR. Only if nothing a user sees
      changed (an internal refactor, a non-visible UI tweak) may you assert `no-docs-change` (label or
      `[no-docs-change]` in the title) to clear the Docs-sync gate. The model is in `docs/doc-versioning.md`.

## VM / RC notes (if applicable)


