### PR TITLE
chore(sonar): clear the open SonarCloud maintainability backlog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ This release retires a number of `EDR_*` environment variables in favor of in-pr
 - **Telemetry is retried, not discarded, when the edge rejects uploads.** When a proxy, WAF, edge, or unhealthy origin blanket-rejects uploads (for example with a 403), the agent keeps that telemetry queued and retries until the endpoint recovers, and emits a loud warning and metric so operators see the misconfiguration.
 - **Alerts not tied to a single live process now explain themselves.** Persistence and similar alerts no longer open into a blank process graph; they show the alert description and MITRE technique tags with a clear explanation and an opt-in to widen to surrounding host activity.
 - **More accurate exclusions and forensic attribution.** Detection exclusions now match correctly regardless of the macOS `/private` path form, so an allowlist you write takes effect; in multi-server deployments every replica picks up detection-config changes within seconds instead of serving stale config; and a network or DNS event from a process that re-launches itself is attributed to the correct generation in the alert timeline.
+- **More accessible admin UI status messages.** The single sign-on connection-test result and the account-menu authentication-method badge now meet the WCAG AA color-contrast minimum, and the SSO status banners are emitted as semantic `<output>` live regions so assistive technology announces them.
 
 ### Removed
 

--- a/agent/cmd/fleet-edr-agent/main.go
+++ b/agent/cmd/fleet-edr-agent/main.go
@@ -180,10 +180,22 @@ func run() error {
 	go coalescer.Run(ctx)
 
 	pidTable := proctable.New()
-	go startReceiverLoop(ctx, logger, cfg.XPCService, coalescer.Handle, pidTable, true, esfDispatcher, nil)
+	go startReceiverLoop(ctx, receiverLoopParams{
+		logger:      logger,
+		xpcService:  cfg.XPCService,
+		enqueue:     coalescer.Handle,
+		pt:          pidTable,
+		updateTable: true,
+		dispatcher:  esfDispatcher,
+	})
 	if cfg.NetXPCService != "" {
-		go startReceiverLoop(ctx, logger, cfg.NetXPCService, coalescer.Handle, pidTable, false, nil,
-			func() bool { return receiver.NEUpgradePending(ctx) })
+		go startReceiverLoop(ctx, receiverLoopParams{
+			logger:       logger,
+			xpcService:   cfg.NetXPCService,
+			enqueue:      coalescer.Handle,
+			pt:           pidTable,
+			upgradeProbe: func() bool { return receiver.NEUpgradePending(ctx) },
+		})
 	}
 	go runUploader(ctx, up, logger)
 
@@ -387,18 +399,21 @@ func pruneLoop(ctx context.Context, q *queue.Queue, pruneAge time.Duration, logg
 // application_control Dispatcher into OnConnected / OnDisconnected. dispatcher may be nil for non-ESF services that do not receive
 // outbound pushes. enqueue is the coalescer's Handle: network_connect / dns_query are coalesced before reaching the queue, every
 // other event passes straight through.
-func startReceiverLoop(
-	ctx context.Context,
-	logger *slog.Logger,
-	xpcService string,
-	enqueue func(context.Context, []byte) error,
-	pt *proctable.Table,
-	updateTable bool,
-	dispatcher *receiver.Dispatcher,
-	upgradeProbe func() bool,
-) {
+// receiverLoopParams configures startReceiverLoop. ctx is passed separately so the call sites read like a normal context-first
+// function; everything else is grouped here. dispatcher may be nil for non-ESF services that do not receive outbound pushes.
+type receiverLoopParams struct {
+	logger       *slog.Logger
+	xpcService   string
+	enqueue      func(context.Context, []byte) error
+	pt           *proctable.Table
+	updateTable  bool
+	dispatcher   *receiver.Dispatcher
+	upgradeProbe func() bool
+}
+
+func startReceiverLoop(ctx context.Context, p receiverLoopParams) {
 	factory := func() receiver.Connector {
-		return receiver.New(xpcService, receiverEventBuffer)
+		return receiver.New(p.xpcService, receiverEventBuffer)
 	}
 	hooks := receiver.LoopHooks{
 		OnEvent: func(ctx context.Context, evt receiver.Event) {
@@ -406,27 +421,27 @@ func startReceiverLoop(
 			// executable: the sandboxed extension cannot read it on a SIP-enabled host, so the agent (unsandboxed root,
 			// off the ES callback thread) computes it here. No-op for every other event and on the linux headless build.
 			data := enrich.BtmExecutableSigning(evt.Data, codesign.Evaluate)
-			if updateTable {
-				updateProcTable(pt, data)
+			if p.updateTable {
+				updateProcTable(p.pt, data)
 			}
-			if err := enqueue(ctx, data); err != nil {
-				logger.WarnContext(ctx, "enqueue", "err", err)
+			if err := p.enqueue(ctx, data); err != nil {
+				p.logger.WarnContext(ctx, "enqueue", "err", err)
 			}
 		},
 	}
-	if dispatcher != nil {
-		hooks.OnConnected = dispatcher.Set
-		hooks.OnDisconnected = dispatcher.Clear
+	if p.dispatcher != nil {
+		hooks.OnConnected = p.dispatcher.Set
+		hooks.OnDisconnected = p.dispatcher.Clear
 	}
 	// Only the network-extension loop wires UpgradeProbe (nil for ESF): after a staged upgrade the NE's nesessionmanager-owned
 	// Mach service stays bound to the terminated old version until reboot, so a sustained NE connect failure paired with a
 	// pending-uninstall old version means "reboot required", not "needs approval" (#399).
-	hooks.UpgradeProbe = upgradeProbe
+	hooks.UpgradeProbe = p.upgradeProbe
 	loop := receiver.NewLoop(factory, receiver.LoopConfig{
-		ServiceName:       xpcService,
+		ServiceName:       p.xpcService,
 		HeartbeatInterval: xpcHeartbeatInterval,
 		HeartbeatTimeout:  xpcHeartbeatPingTimeout,
-	}, hooks, logger)
+	}, hooks, p.logger)
 	loop.Run(ctx)
 }
 

--- a/agent/coalesce/coalesce_test.go
+++ b/agent/coalesce/coalesce_test.go
@@ -96,7 +96,7 @@ func TestCoalescer_MergesIdenticalConnections(t *testing.T) {
 	s := &sink{}
 	c := New(time.Minute, s.enqueue, nil)
 	for i, ts := range []int64{30, 10, 20} { // out of order on purpose: earliest must win
-		ev := mkConnect(t, "nc-"+string(rune('a'+i)), ts, 42, "tcp", "outbound", "1.2.3.4", 443, nil)
+		ev := mkConnect(t, "nc-"+string(rune('a'+i)), ts, 42, 443, nil)
 		require.NoError(t, c.Handle(context.Background(), ev))
 	}
 	assert.Empty(t, s.events(), "buffered, nothing enqueued until flush")
@@ -118,9 +118,9 @@ func TestCoalescer_DistinctTuplesDoNotMerge(t *testing.T) {
 	t.Parallel()
 	s := &sink{}
 	c := New(time.Minute, s.enqueue, nil)
-	require.NoError(t, c.Handle(context.Background(), mkConnect(t, "a", 1, 42, "tcp", "outbound", "1.2.3.4", 443, nil)))
-	require.NoError(t, c.Handle(context.Background(), mkConnect(t, "b", 2, 42, "tcp", "outbound", "1.2.3.4", 8080, nil))) // diff port
-	require.NoError(t, c.Handle(context.Background(), mkConnect(t, "c", 3, 99, "tcp", "outbound", "1.2.3.4", 443, nil)))  // diff pid
+	require.NoError(t, c.Handle(context.Background(), mkConnect(t, "a", 1, 42, 443, nil)))
+	require.NoError(t, c.Handle(context.Background(), mkConnect(t, "b", 2, 42, 8080, nil))) // diff port
+	require.NoError(t, c.Handle(context.Background(), mkConnect(t, "c", 3, 99, 443, nil)))  // diff pid
 	c.Flush(context.Background())
 	assert.Len(t, s.events(), 3, "different identity keys stay separate")
 }
@@ -130,8 +130,8 @@ func TestCoalescer_PIDVersionDistinguishesKeys(t *testing.T) {
 	s := &sink{}
 	c := New(time.Minute, s.enqueue, nil)
 	v1, v2 := 7, 8
-	require.NoError(t, c.Handle(context.Background(), mkConnect(t, "a", 1, 42, "tcp", "outbound", "1.2.3.4", 443, &v1)))
-	require.NoError(t, c.Handle(context.Background(), mkConnect(t, "b", 2, 42, "tcp", "outbound", "1.2.3.4", 443, &v2)))
+	require.NoError(t, c.Handle(context.Background(), mkConnect(t, "a", 1, 42, 443, &v1)))
+	require.NoError(t, c.Handle(context.Background(), mkConnect(t, "b", 2, 42, 443, &v2)))
 	c.Flush(context.Background())
 	assert.Len(t, s.events(), 2, "a recycled PID with a new generation must not merge into the prior one")
 }
@@ -182,7 +182,7 @@ func TestCoalescer_SingletonIsByteIdentical(t *testing.T) {
 	t.Parallel()
 	s := &sink{}
 	c := New(time.Minute, s.enqueue, nil)
-	ev := mkConnect(t, "solo", 5, 42, "tcp", "outbound", "1.2.3.4", 443, nil)
+	ev := mkConnect(t, "solo", 5, 42, 443, nil)
 	require.NoError(t, c.Handle(context.Background(), ev))
 	c.Flush(context.Background())
 	got := s.events()
@@ -196,7 +196,7 @@ func TestCoalescer_WindowZeroIsPassthrough(t *testing.T) {
 	s := &sink{}
 	c := New(0, s.enqueue, nil)
 	assert.False(t, c.Enabled())
-	ev := mkConnect(t, "x", 5, 42, "tcp", "outbound", "1.2.3.4", 443, nil)
+	ev := mkConnect(t, "x", 5, 42, 443, nil)
 	require.NoError(t, c.Handle(context.Background(), ev))
 	got := s.events()
 	require.Len(t, got, 1, "with coalescing disabled the event is enqueued immediately")
@@ -213,7 +213,7 @@ func TestCoalescer_FlushesOnShutdown(t *testing.T) {
 	go func() { c.Run(ctx); close(done) }()
 
 	for i, ts := range []int64{1, 2} {
-		require.NoError(t, c.Handle(ctx, mkConnect(t, "s"+string(rune('a'+i)), ts, 42, "tcp", "outbound", "1.2.3.4", 443, nil)))
+		require.NoError(t, c.Handle(ctx, mkConnect(t, "s"+string(rune('a'+i)), ts, 42, 443, nil)))
 	}
 	assert.Empty(t, s.events(), "nothing emitted before shutdown")
 
@@ -241,7 +241,7 @@ func TestCoalescer_PropertyConnectionMerge(t *testing.T) {
 			if ts > maxTS {
 				maxTS = ts
 			}
-			require.NoError(rt, c.Handle(context.Background(), mkConnect(rt, "e"+string(rune(i)), ts, 42, "tcp", "outbound", "1.2.3.4", 443, nil)))
+			require.NoError(rt, c.Handle(context.Background(), mkConnect(rt, "e"+string(rune(i)), ts, 42, 443, nil)))
 		}
 		c.Flush(context.Background())
 		got := s.events()
@@ -300,9 +300,9 @@ func TestCoalescer_BufferCapEarlyFlush(t *testing.T) {
 	c.maxEntries = 2 // white-box: shrink the cap so the test doesn't have to push 10k keys
 
 	// Three distinct 5-tuples (different ports) => three identity keys. The third trips the cap and flushes the first two.
-	require.NoError(t, c.Handle(context.Background(), mkConnect(t, "a", 1, 42, "tcp", "outbound", "1.2.3.4", 1, nil)))
-	require.NoError(t, c.Handle(context.Background(), mkConnect(t, "b", 2, 42, "tcp", "outbound", "1.2.3.4", 2, nil)))
-	require.NoError(t, c.Handle(context.Background(), mkConnect(t, "c", 3, 42, "tcp", "outbound", "1.2.3.4", 3, nil)))
+	require.NoError(t, c.Handle(context.Background(), mkConnect(t, "a", 1, 42, 1, nil)))
+	require.NoError(t, c.Handle(context.Background(), mkConnect(t, "b", 2, 42, 2, nil)))
+	require.NoError(t, c.Handle(context.Background(), mkConnect(t, "c", 3, 42, 3, nil)))
 	assert.Len(t, s.events(), 2, "reaching the cap flushes the buffered representatives early")
 
 	c.Flush(context.Background())
@@ -326,9 +326,12 @@ func FuzzCoalescer_Handle(f *testing.F) {
 	})
 }
 
-func mkConnect(t require.TestingT, id string, ts int64, pid int, proto, dir, remote string, port int, pidversion *int) []byte {
+// mkConnect builds a network_connect envelope. protocol / direction / remote_address are fixed fixtures (tcp / outbound /
+// 1.2.3.4): the coalescing tests vary only pid, port, and pidversion, so the connection tuple's constant fields stay constant.
+// Pass pidversion=nil to omit the field.
+func mkConnect(t require.TestingT, id string, ts int64, pid, port int, pidversion *int) []byte {
 	payload := map[string]any{
-		"pid": pid, "protocol": proto, "direction": dir, "remote_address": remote, "remote_port": port,
+		"pid": pid, "protocol": "tcp", "direction": "outbound", "remote_address": "1.2.3.4", "remote_port": port,
 	}
 	if pidversion != nil {
 		payload["pidversion"] = *pidversion

--- a/scripts/demo/trigger-dns-c2.sh
+++ b/scripts/demo/trigger-dns-c2.sh
@@ -23,8 +23,8 @@ case "$MODE" in
   *) echo "usage: $0 [critical|high]" >&2; exit 2 ;;
 esac
 
-say() { printf '\n\033[1;36m==> %s\033[0m\n' "$1"; }   # cyan step banner
-sub() { printf '    %s\n' "$1"; }                       # indented detail
+say() { local msg="$1"; printf '\n\033[1;36m==> %s\033[0m\n' "$msg"; }   # cyan step banner
+sub() { local msg="$1"; printf '    %s\n' "$msg"; }                       # indented detail
 
 # Stage the payload at a UNIQUE temp path and guarantee it is removed on ANY exit. mktemp gives a name we own, so two
 # concurrent runs never collide and the cleanup never clobbers a pre-existing /tmp/beacon the script did not create. The
@@ -70,7 +70,7 @@ sub "a binary running out of /tmp does. This is the 'dropped payload' shape."
 # --- Step 2: choose the command-and-control domain ----------------------------------
 say "Step 2/4  Pick the command-and-control (C2) domain"
 SINK_IP=1.1.1.1   # any routable IP; the outbound TCP SYN alone emits network_connect
-if [ "$MODE" = "critical" ]; then
+if [[ "$MODE" = "critical" ]]; then
   # high-entropy 18-char label -> looksLikeDGADomain() -> Critical + ATT&CK T1568.002.
   # Read a finite chunk of /dev/urandom and slice in bash; piping urandom into `head -c`
   # closes the pipe early and kills `tr` with SIGPIPE (exit 141) under `set -o pipefail`.
@@ -104,7 +104,7 @@ sub "filter emits network_connect). Resolve-then-connect, same PID, inside the 3
 # NO alert fires. Warn instead of the misleading "Beacon sent"; any other result still emitted the connect SYN signal.
 beacon_rc=0
 "$BEACON" -4 -s -m 5 -o /dev/null "https://${DOMAIN}/" || beacon_rc=$?
-if [ "$beacon_rc" -eq 6 ]; then
+if [[ "$beacon_rc" -eq 6 ]]; then
   echo "WARNING: DNS resolution failed for ${DOMAIN} (curl exit 6); no connection was attempted." >&2
   echo "         No dns_query/network_connect was emitted, so the EDR alert will NOT fire." >&2
   echo "         Check this host's internet/DNS connectivity and re-run." >&2
@@ -120,7 +120,7 @@ sub "Removed ${BEACON} (typical of malware covering its tracks)."
 say "Done. Now watch Fleet EDR."
 sub "Within a few seconds an alert should appear in the EDR UI:"
 sub "  Title:    DNS C2 beacon"
-if [ "$MODE" = "critical" ]; then
+if [[ "$MODE" = "critical" ]]; then
   sub "  Severity: Critical   ATT&CK: T1071.004 + T1568.002"
 else
   sub "  Severity: High       ATT&CK: T1071.004"

--- a/server/identity/bootstrap/bootstrap.go
+++ b/server/identity/bootstrap/bootstrap.go
@@ -207,60 +207,22 @@ func New(ctx context.Context, deps Deps) (*Identity, error) {
 	}
 
 	// The SSO admin API (read/update/test-connection) shares the config + app-config stores with the resolver; built only when the
-	// OIDC config store exists (i.e. keys were supplied).
-	var ssoAdminHandler *ssoadmin.Handler
-	if ssoStore != nil {
-		oidcHTTPClient := deps.OIDC.HTTPClient
-		// apply writes oidc_config and app_config in ONE transaction so a partial failure can't pair a new issuer with a stale
-		// derived redirect; app_config carries the optimistic-concurrency version check.
-		apply := func(ctx context.Context, oidcIn ssoconfig.UpsertInput, appCfg appconfig.AppConfig, expectedAppVersion int64, updatedBy int64) error {
-			tx, err := deps.DB.BeginTxx(ctx, nil)
-			if err != nil {
-				return fmt.Errorf("identity bootstrap: begin sso update tx: %w", err)
-			}
-			committed := false
-			defer func() {
-				if !committed {
-					_ = tx.Rollback()
-				}
-			}()
-			if err := ssoStore.UpsertTx(ctx, tx, oidcIn); err != nil {
-				return err
-			}
-			if err := appConfigStore.PutTx(ctx, tx, appCfg, expectedAppVersion, &updatedBy); err != nil {
-				return err
-			}
-			if err := tx.Commit(); err != nil {
-				return fmt.Errorf("identity bootstrap: commit sso update tx: %w", err)
-			}
-			committed = true
-			return nil
-		}
-		ssoAdminHandler = ssoadmin.NewHandler(ssoStore, appConfigStore, apply, authzEngine, auditStore,
-			func(ctx context.Context, issuer string) error { return oidc.Probe(ctx, issuer, oidcHTTPClient) }, logger)
-	}
+	// OIDC config store exists (i.e. keys were supplied), else nil and the surface is not mounted.
+	ssoAdminHandler := buildSSOAdminHandler(ssoAdminHandlerDeps{
+		deps:      deps,
+		logger:    logger,
+		ssoStore:  ssoStore,
+		appConfig: appConfigStore,
+		authz:     authzEngine,
+		audit:     auditStore,
+	})
 
-	// Service-account surface (issue #376, ADR-0013). Built only when a signing key was provided (omitted in minimal test wiring). The
-	// snapshot is a per-replica revocation cache (ADR-0010 safe-to-lose); cmd/main starts its refresh loop.
-	var (
-		saAdminHandler *saadmin.Handler
-		saTokenHandler *saadmin.TokenHandler
-		saSnapshot     *serviceaccounts.Snapshot
-		apiAuthMW      func(http.Handler) http.Handler
-	)
+	// Service-account surface (issue #376, ADR-0013). Built only when a signing key was provided (zero-valued in minimal test wiring).
 	sessionMW := middleware.Session(svc, logger)
 	csrfMW := middleware.CSRF(logger)
-	if len(deps.ServiceAccountTokenSigningKey) > 0 {
-		saStore := serviceaccounts.New(deps.DB)
-		saSigner, sErr := satoken.New(deps.ServiceAccountTokenSigningKey, serviceAccountTokenKeyID, serviceAccountTokenAudience)
-		if sErr != nil {
-			return nil, fmt.Errorf("identity bootstrap: service-account token signer: %w", sErr)
-		}
-		saSnapshot = serviceaccounts.NewSnapshot(saStore, logger)
-		saAuthenticator := serviceaccounts.NewAuthenticator(saSigner, saSnapshot)
-		apiAuthMW = middleware.APIAuth(saAuthenticator, sessionMW, csrfMW, logger)
-		saAdminHandler = saadmin.NewHandler(saStore, authzEngine, auditStore, logger)
-		saTokenHandler = saadmin.NewTokenHandler(saStore, saSigner, auditStore, logger)
+	saSurface, err := buildServiceAccountSurface(deps, authzEngine, auditStore, sessionMW, csrfMW, logger)
+	if err != nil {
+		return nil, err
 	}
 
 	bgService, bgHandler, err := buildBreakglass(breakglassDeps{
@@ -299,12 +261,90 @@ func New(ctx context.Context, deps Deps) (*Identity, error) {
 		ssoStore:          ssoStore,
 		appConfigStore:    appConfigStore,
 		ssoAdminHandler:   ssoAdminHandler,
-		saAdminHandler:    saAdminHandler,
-		saTokenHandler:    saTokenHandler,
-		saSnapshot:        saSnapshot,
-		apiAuthMW:         apiAuthMW,
+		saAdminHandler:    saSurface.adminHandler,
+		saTokenHandler:    saSurface.tokenHandler,
+		saSnapshot:        saSurface.snapshot,
+		apiAuthMW:         saSurface.apiAuthMW,
 		userAdminHandler:  useradmin.NewHandler(usersStore, rbacStore, authzEngine, auditStore, logger),
 		oidcSeed:          deps.OIDC,
+	}, nil
+}
+
+// ssoAdminHandlerDeps bundles the per-call inputs to buildSSOAdminHandler. Same shape pattern as oidcHandlerDeps so future field
+// additions don't widen the function signature.
+type ssoAdminHandlerDeps struct {
+	deps      Deps
+	logger    *slog.Logger
+	ssoStore  *ssoconfig.Store
+	appConfig *appconfig.Store
+	authz     *authz.Engine
+	audit     *audit.Store
+}
+
+// buildSSOAdminHandler builds the SSO admin API (read/update/test-connection). It returns nil when no OIDC config store exists (no
+// keys supplied), in which case the surface is simply not mounted. apply writes oidc_config and app_config in ONE transaction so a
+// partial failure can't pair a new issuer with a stale derived redirect; app_config carries the optimistic-concurrency version check.
+func buildSSOAdminHandler(in ssoAdminHandlerDeps) *ssoadmin.Handler {
+	if in.ssoStore == nil {
+		return nil
+	}
+	oidcHTTPClient := in.deps.OIDC.HTTPClient
+	apply := func(ctx context.Context, oidcIn ssoconfig.UpsertInput, appCfg appconfig.AppConfig, expectedAppVersion int64, updatedBy int64) error {
+		tx, err := in.deps.DB.BeginTxx(ctx, nil)
+		if err != nil {
+			return fmt.Errorf("identity bootstrap: begin sso update tx: %w", err)
+		}
+		committed := false
+		defer func() {
+			if !committed {
+				_ = tx.Rollback()
+			}
+		}()
+		if err := in.ssoStore.UpsertTx(ctx, tx, oidcIn); err != nil {
+			return err
+		}
+		if err := in.appConfig.PutTx(ctx, tx, appCfg, expectedAppVersion, &updatedBy); err != nil {
+			return err
+		}
+		if err := tx.Commit(); err != nil {
+			return fmt.Errorf("identity bootstrap: commit sso update tx: %w", err)
+		}
+		committed = true
+		return nil
+	}
+	return ssoadmin.NewHandler(in.ssoStore, in.appConfig, apply, in.authz, in.audit,
+		func(ctx context.Context, issuer string) error { return oidc.Probe(ctx, issuer, oidcHTTPClient) }, in.logger)
+}
+
+// serviceAccountSurface bundles the optional service-account handlers plus the API-auth middleware. All fields are nil/zero in
+// minimal test wiring (no signing key supplied).
+type serviceAccountSurface struct {
+	adminHandler *saadmin.Handler
+	tokenHandler *saadmin.TokenHandler
+	snapshot     *serviceaccounts.Snapshot
+	apiAuthMW    func(http.Handler) http.Handler
+}
+
+// buildServiceAccountSurface builds the service-account surface (issue #376, ADR-0013) when a token signing key was provided,
+// returning a zero surface otherwise. The snapshot is a per-replica revocation cache (ADR-0010 safe-to-lose); cmd/main starts its
+// refresh loop. apiAuthMW chains the SA authenticator ahead of the session + CSRF middleware.
+func buildServiceAccountSurface(deps Deps, authzEngine *authz.Engine, auditStore *audit.Store,
+	sessionMW, csrfMW func(http.Handler) http.Handler, logger *slog.Logger) (serviceAccountSurface, error) {
+	if len(deps.ServiceAccountTokenSigningKey) == 0 {
+		return serviceAccountSurface{}, nil
+	}
+	saStore := serviceaccounts.New(deps.DB)
+	saSigner, err := satoken.New(deps.ServiceAccountTokenSigningKey, serviceAccountTokenKeyID, serviceAccountTokenAudience)
+	if err != nil {
+		return serviceAccountSurface{}, fmt.Errorf("identity bootstrap: service-account token signer: %w", err)
+	}
+	snapshot := serviceaccounts.NewSnapshot(saStore, logger)
+	authenticator := serviceaccounts.NewAuthenticator(saSigner, snapshot)
+	return serviceAccountSurface{
+		adminHandler: saadmin.NewHandler(saStore, authzEngine, auditStore, logger),
+		tokenHandler: saadmin.NewTokenHandler(saStore, saSigner, auditStore, logger),
+		snapshot:     snapshot,
+		apiAuthMW:    middleware.APIAuth(authenticator, sessionMW, csrfMW, logger),
 	}, nil
 }
 

--- a/tools/dash-lint/main.go
+++ b/tools/dash-lint/main.go
@@ -150,41 +150,17 @@ func readPathsFromStdin() ([]string, error) {
 // " -- " (e.g. a `task ... -- scenario` end-of-options separator) commonly lives in one.
 func checkMarkdown(path string, data []byte) []string {
 	var findings []string
-	inFence := false
-	inIndentCode := false
-	prevBlank := true // start of document is set off like a blank line, so a leading indented block counts as code
+	// prevBlank starts true: the start of document is set off like a blank line, so a leading indented block counts as code.
+	state := mdCodeState{prevBlank: true}
 	sc := bufio.NewScanner(bytes.NewReader(data))
 	sc.Buffer(make([]byte, 0, 64*1024), maxLineBytes)
 	lineNo := 0
 	for sc.Scan() {
 		lineNo++
 		raw := sc.Text()
-		if fenceLine.MatchString(raw) {
-			inFence = !inFence
-			inIndentCode = false
-			prevBlank = false
-			continue
+		if state.step(raw) {
+			continue // line is inside a fenced or indented code block (or blank), not prose
 		}
-		if inFence {
-			continue
-		}
-		if strings.TrimSpace(raw) == "" {
-			prevBlank = true // a blank line does not close an indented block; interior blanks belong to it
-			continue
-		}
-		indented := strings.HasPrefix(raw, "    ") || strings.HasPrefix(raw, "\t")
-		if inIndentCode {
-			if indented {
-				prevBlank = false
-				continue // still inside the indented code block
-			}
-			inIndentCode = false // a dedented line ends the block; fall through and scan this line as prose
-		} else if prevBlank && indented {
-			inIndentCode = true // a blank line then a 4-space/tab indent opens an indented code block
-			prevBlank = false
-			continue
-		}
-		prevBlank = false
 		if strings.Contains(raw, ignoreDirective) {
 			continue
 		}
@@ -194,6 +170,44 @@ func checkMarkdown(path string, data []byte) []string {
 		}
 	}
 	return findings
+}
+
+// mdCodeState tracks Markdown fenced/indented code-block state across lines so checkMarkdown can skip code when scanning prose.
+type mdCodeState struct {
+	inFence      bool
+	inIndentCode bool
+	prevBlank    bool
+}
+
+// step advances the state for one raw line and reports whether that line is code/blank (skip it) rather than prose.
+func (s *mdCodeState) step(raw string) (skip bool) {
+	if fenceLine.MatchString(raw) {
+		s.inFence = !s.inFence
+		s.inIndentCode = false
+		s.prevBlank = false
+		return true
+	}
+	if s.inFence {
+		return true
+	}
+	if strings.TrimSpace(raw) == "" {
+		s.prevBlank = true // a blank line does not close an indented block; interior blanks belong to it
+		return true
+	}
+	indented := strings.HasPrefix(raw, "    ") || strings.HasPrefix(raw, "\t")
+	if s.inIndentCode {
+		if indented {
+			s.prevBlank = false
+			return true // still inside the indented code block
+		}
+		s.inIndentCode = false // a dedented line ends the block; fall through and scan this line as prose
+	} else if s.prevBlank && indented {
+		s.inIndentCode = true // a blank line then a 4-space/tab indent opens an indented code block
+		s.prevBlank = false
+		return true
+	}
+	s.prevBlank = false
+	return false
 }
 
 // checkGo lexes the file and flags em-dash use inside comment, string, and char tokens only (never bare code).
@@ -222,35 +236,46 @@ func goTokenFindings(path string, startLine int, tok token.Token, lit string, ig
 	// An if-ladder, not a switch on tok: token.Token has ~80 members and the exhaustive linter (configured here so a default
 	// case does not satisfy it) would demand every one be listed.
 	if tok == token.STRING || tok == token.CHAR {
-		if ignored[startLine] {
-			return nil
-		}
-		// Match on the unquoted value so an escape like "\n - x" (an embedded newline before a list-ish " - ") is not
-		// misread as an em dash; the raw literal would show `n - ` and false-positive. A multi-line raw string is reported
-		// at its start line.
-		val := lit
-		if unquoted, err := strconv.Unquote(lit); err == nil {
-			val = unquoted
-		}
-		if emDashUse.MatchString(val) {
-			return []string{fmt.Sprintf(findingFmt, path, startLine, strings.TrimSpace(firstLine(lit)))}
-		}
-		return nil
+		return goStringTokenFinding(path, startLine, lit, ignored)
 	}
 	if tok == token.COMMENT {
-		var out []string
-		for offset, line := range strings.Split(lit, "\n") {
-			lineNo := startLine + offset
-			if ignored[lineNo] {
-				continue
-			}
-			if emDashUse.MatchString(commentProse(line)) {
-				out = append(out, fmt.Sprintf(findingFmt, path, lineNo, strings.TrimSpace(line)))
-			}
-		}
-		return out
+		return goCommentTokenFindings(path, startLine, lit, ignored)
 	}
 	return nil
+}
+
+// goStringTokenFinding reports a finding for a STRING/CHAR literal whose unquoted value contains em-dash use. Matching on the
+// unquoted value keeps an escape like "\n - x" (an embedded newline before a list-ish " - ") from being misread as an em dash;
+// the raw literal would show `n - ` and false-positive. A multi-line raw string is reported at its start line.
+func goStringTokenFinding(path string, startLine int, lit string, ignored map[int]bool) []string {
+	if ignored[startLine] {
+		return nil
+	}
+	val := lit
+	if unquoted, err := strconv.Unquote(lit); err == nil {
+		val = unquoted
+	}
+	if emDashUse.MatchString(val) {
+		return []string{fmt.Sprintf(findingFmt, path, startLine, strings.TrimSpace(firstLine(lit)))}
+	}
+	return nil
+}
+
+// goCommentTokenFindings scans a COMMENT token line by line so the per-line `dash-lint:ignore` directive and the reported line
+// number match the line-based scanners exactly: a directive on line N suppresses only line N, and a violation on a later line of
+// a /* ... */ block is still reported at that line.
+func goCommentTokenFindings(path string, startLine int, lit string, ignored map[int]bool) []string {
+	var out []string
+	for offset, line := range strings.Split(lit, "\n") {
+		lineNo := startLine + offset
+		if ignored[lineNo] {
+			continue
+		}
+		if emDashUse.MatchString(commentProse(line)) {
+			out = append(out, fmt.Sprintf(findingFmt, path, lineNo, strings.TrimSpace(line)))
+		}
+	}
+	return out
 }
 
 // checkCStyleComments flags em-dash use inside // line comments and /* block comments */, ignoring code and string literals.

--- a/ui/src/components/SSOSettings/SSOSettings.scss
+++ b/ui/src/components/SSOSettings/SSOSettings.scss
@@ -77,6 +77,7 @@
   }
 
   &__test {
+    display: block;
     margin-bottom: 16px;
     padding: 10px 12px;
     border-radius: 4px;
@@ -84,7 +85,8 @@
 
     &--ok {
       background: rgba(61, 182, 123, 0.15);
-      color: #2b7f56;
+      // Darkened from #2b7f56 to clear WCAG AA (4.5:1) against the tinted-green background.
+      color: #1f6e48;
     }
 
     &--fail {
@@ -129,8 +131,9 @@
   }
 
   &__saved {
+    display: block;
     margin-bottom: 12px;
-    color: #2b7f56;
+    color: #1f6e48;
     font-size: 14px;
   }
 

--- a/ui/src/components/SSOSettings/SSOSettings.tsx
+++ b/ui/src/components/SSOSettings/SSOSettings.tsx
@@ -219,7 +219,10 @@ export function SSOSettings() {
         </div>
 
         {testResult !== null && (
-          <output className={testResult.ok ? "sso-settings__test sso-settings__test--ok" : "sso-settings__test sso-settings__test--fail"}>
+          <output
+            className={testResult.ok ? "sso-settings__test sso-settings__test--ok" : "sso-settings__test sso-settings__test--fail"}
+            aria-live="polite"
+          >
             {testResult.ok
               ? "Connection verified: discovery and token endpoint reachable."
               : `Connection failed: ${testResult.reason ?? "unreachable"}`}
@@ -360,7 +363,11 @@ export function SSOSettings() {
           {saveError}
         </div>
       )}
-      {saved && <output className="sso-settings__saved">Settings saved.</output>}
+      {saved && (
+        <output className="sso-settings__saved" aria-live="polite">
+          Settings saved.
+        </output>
+      )}
 
       <div className="sso-settings__footer">
         <Button type="submit" variant="primary" isLoading={saving}>

--- a/ui/src/components/SSOSettings/SSOSettings.tsx
+++ b/ui/src/components/SSOSettings/SSOSettings.tsx
@@ -96,7 +96,9 @@ export function SSOSettings() {
       .finally(() => {
         if (!cancelled) setLoading(false);
       });
-    return () => { cancelled = true; };
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   if (loading) return <div className="sso-settings__status">Loading...</div>;
@@ -140,7 +142,7 @@ export function SSOSettings() {
         issuer: form.issuer.trim(),
         client_id: form.clientID.trim(),
         // Omit the secret unless the operator entered a new value (write-only rotate).
-        ...(secret !== "" ? { client_secret: secret } : {}),
+        ...(secret === "" ? {} : { client_secret: secret }),
         external_url: form.externalURL.trim(),
         scopes,
         jit_enabled: form.jitEnabled,
@@ -155,7 +157,6 @@ export function SSOSettings() {
       setSaving(false);
     }
   }
-
 
   async function handleTest() {
     if (!form) return;
@@ -188,30 +189,41 @@ export function SSOSettings() {
   }
 
   return (
-    <form className="sso-settings" onSubmit={(e) => { e.preventDefault(); void handleSave(); }}>
+    <form
+      className="sso-settings"
+      onSubmit={(e) => {
+        e.preventDefault();
+        void handleSave();
+      }}
+    >
       <PageHeader
         title="Single sign-on"
         subtitle="Operators sign in through your OpenID Connect provider. One identity provider is configured per deployment."
-        actions={config.configured
-          ? <Badge variant="success">Configured</Badge>
-          : <Badge variant="neutral">Not configured</Badge>}
+        actions={config.configured ? <Badge variant="success">Configured</Badge> : <Badge variant="neutral">Not configured</Badge>}
       />
 
       <Card padding="large">
         <div className="sso-settings__card-head">
           <h2 className="sso-settings__card-title">OpenID Connect</h2>
-          <Button type="button" variant="inverse" size="small" onClick={() => { void handleTest(); }} isLoading={testing}>
+          <Button
+            type="button"
+            variant="inverse"
+            size="small"
+            onClick={() => {
+              void handleTest();
+            }}
+            isLoading={testing}
+          >
             Test connection
           </Button>
         </div>
 
         {testResult !== null && (
-          <div
-            className={testResult.ok ? "sso-settings__test sso-settings__test--ok" : "sso-settings__test sso-settings__test--fail"}
-            role="status"
-          >
-            {testResult.ok ? "Connection verified: discovery and token endpoint reachable." : `Connection failed: ${testResult.reason ?? "unreachable"}`}
-          </div>
+          <output className={testResult.ok ? "sso-settings__test sso-settings__test--ok" : "sso-settings__test sso-settings__test--fail"}>
+            {testResult.ok
+              ? "Connection verified: discovery and token endpoint reachable."
+              : `Connection failed: ${testResult.reason ?? "unreachable"}`}
+          </output>
         )}
 
         <div className="sso-settings__grid">
@@ -221,7 +233,9 @@ export function SSOSettings() {
             type="text"
             placeholder="https://acme.okta.com"
             value={form.issuer}
-            onChange={(e) => { update("issuer", e.target.value); }}
+            onChange={(e) => {
+              update("issuer", e.target.value);
+            }}
           />
           <Input
             id="sso-client-id"
@@ -229,7 +243,9 @@ export function SSOSettings() {
             type="text"
             placeholder="0oa8x2k4mWq1ZpL5d7"
             value={form.clientID}
-            onChange={(e) => { update("clientID", e.target.value); }}
+            onChange={(e) => {
+              update("clientID", e.target.value);
+            }}
           />
 
           <div className="sso-settings__field-full">
@@ -239,7 +255,9 @@ export function SSOSettings() {
               type="text"
               placeholder="https://edr.acme.com"
               value={form.externalURL}
-              onChange={(e) => { update("externalURL", e.target.value); }}
+              onChange={(e) => {
+                update("externalURL", e.target.value);
+              }}
               aria-describedby="sso-external-url-help"
             />
             <p id="sso-external-url-help" className="sso-settings__help">
@@ -250,14 +268,16 @@ export function SSOSettings() {
           <div className="sso-settings__field-full">
             <span className="field__label">Redirect URL</span>
             <div className="sso-settings__readonly-row">
-              <input
-                className="field__input sso-settings__readonly"
-                type="text"
-                readOnly
-                aria-label="Redirect URL"
-                value={redirectURL}
-              />
-              <Button type="button" variant="inverse" size="small" onClick={() => { void handleCopyRedirect(); }} disabled={redirectURL === ""}>
+              <input className="field__input sso-settings__readonly" type="text" readOnly aria-label="Redirect URL" value={redirectURL} />
+              <Button
+                type="button"
+                variant="inverse"
+                size="small"
+                onClick={() => {
+                  void handleCopyRedirect();
+                }}
+                disabled={redirectURL === ""}
+              >
                 Copy
               </Button>
             </div>
@@ -274,7 +294,9 @@ export function SSOSettings() {
               autoComplete="new-password"
               placeholder={config.secret_set ? "•••••• enter a new value to rotate" : "enter the client secret"}
               value={form.secret}
-              onChange={(e) => { update("secret", e.target.value); }}
+              onChange={(e) => {
+                update("secret", e.target.value);
+              }}
             />
             <p className="sso-settings__help">Write-only. Enter a new value to rotate; leave blank to keep the current secret.</p>
           </div>
@@ -282,7 +304,11 @@ export function SSOSettings() {
           <div className="sso-settings__field-full">
             <span className="field__label">Scopes</span>
             <div className="sso-settings__chips">
-              {scopes.map((s) => <span key={s} className="sso-settings__chip">{s}</span>)}
+              {scopes.map((s) => (
+                <span key={s} className="sso-settings__chip">
+                  {s}
+                </span>
+              ))}
             </div>
             <p className="sso-settings__help">Group-to-role mapping (the groups scope) ships in a future release.</p>
           </div>
@@ -294,14 +320,17 @@ export function SSOSettings() {
           <div>
             <h2 className="sso-settings__card-title">Just-in-time provisioning</h2>
             <p className="sso-settings__help">
-              When on, anyone who signs in through the provider is auto-created and given the default role. When off, an operator must be invited first.
+              When on, anyone who signs in through the provider is auto-created and given the default role. When off, an operator must be
+              invited first.
             </p>
           </div>
           <Toggle
             id="sso-jit"
             aria-label="Just-in-time provisioning"
             checked={form.jitEnabled}
-            onChange={(e) => { update("jitEnabled", e.target.checked); }}
+            onChange={(e) => {
+              update("jitEnabled", e.target.checked);
+            }}
           />
         </div>
         <div className="sso-settings__jit-role">
@@ -309,7 +338,9 @@ export function SSOSettings() {
             id="sso-default-role"
             label="Default role for new SSO users"
             value={form.defaultRole}
-            onChange={(e) => { update("defaultRole", e.target.value); }}
+            onChange={(e) => {
+              update("defaultRole", e.target.value);
+            }}
             inline
           >
             <option value="analyst">Analyst</option>
@@ -320,15 +351,21 @@ export function SSOSettings() {
       </Card>
 
       <div className="sso-settings__callout" role="note">
-        <strong>Break-glass account stays available.</strong> If the provider is unreachable, the break-glass admin can still sign in via the
-        Break-glass login link on the login page. The surface is IP-allowlist gated, so off-network callers never see it.
+        <strong>Break-glass account stays available.</strong> If the provider is unreachable, the break-glass admin can still sign in via
+        the Break-glass login link on the login page. The surface is IP-allowlist gated, so off-network callers never see it.
       </div>
 
-      {saveError !== null && <div className="sso-settings__save-error" role="alert">{saveError}</div>}
-      {saved && <div className="sso-settings__saved" role="status">Settings saved.</div>}
+      {saveError !== null && (
+        <div className="sso-settings__save-error" role="alert">
+          {saveError}
+        </div>
+      )}
+      {saved && <output className="sso-settings__saved">Settings saved.</output>}
 
       <div className="sso-settings__footer">
-        <Button type="submit" variant="primary" isLoading={saving}>Save changes</Button>
+        <Button type="submit" variant="primary" isLoading={saving}>
+          Save changes
+        </Button>
       </div>
     </form>
   );

--- a/ui/src/components/ServiceAccounts/ServiceAccounts.tsx
+++ b/ui/src/components/ServiceAccounts/ServiceAccounts.tsx
@@ -1,11 +1,5 @@
 import { useEffect, useState } from "react";
-import {
-  listServiceAccounts,
-  createServiceAccount,
-  rotateServiceAccount,
-  revokeServiceAccount,
-  type ServiceAccount,
-} from "../../api";
+import { listServiceAccounts, createServiceAccount, rotateServiceAccount, revokeServiceAccount, type ServiceAccount } from "../../api";
 import { PageHeader } from "../ui/PageHeader";
 import { Card } from "../ui/Card";
 import { Button } from "../ui/Button";
@@ -84,16 +78,30 @@ export function ServiceAccounts() {
   function reload(): void {
     listServiceAccounts()
       // Clear any prior error on success so the page recovers after a transient failure (the render gates on error === null).
-      .then((rows) => { setAccounts(rows); setError(null); })
-      .catch((err: unknown) => { setError(err instanceof Error ? err.message : "Failed to load service accounts"); });
+      .then((rows) => {
+        setAccounts(rows);
+        setError(null);
+      })
+      .catch((err: unknown) => {
+        setError(err instanceof Error ? err.message : "Failed to load service accounts");
+      });
   }
 
   useEffect(() => {
     let cancelled = false;
     listServiceAccounts()
-      .then((rows) => { if (!cancelled) { setAccounts(rows); setError(null); } })
-      .catch((err: unknown) => { if (!cancelled) setError(err instanceof Error ? err.message : "Failed to load service accounts"); });
-    return () => { cancelled = true; };
+      .then((rows) => {
+        if (!cancelled) {
+          setAccounts(rows);
+          setError(null);
+        }
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : "Failed to load service accounts");
+      });
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   async function handleCreate() {
@@ -119,7 +127,7 @@ export function ServiceAccounts() {
       const created = await createServiceAccount({
         name: trimmed,
         role,
-        ...(days !== undefined ? { expires_in_days: days } : {}),
+        ...(days === undefined ? {} : { expires_in_days: days }),
       });
       setIssued({ name: created.name, clientID: created.client_id, secret: created.secret });
       setName("");
@@ -168,7 +176,13 @@ export function ServiceAccounts() {
         title="Service accounts"
         subtitle="Non-human identities (CI, integrations, scripts) that authenticate to the API with a client credential and carry a role."
         actions={
-          <Button type="button" variant="primary" onClick={() => { setShowCreate((v) => !v); }}>
+          <Button
+            type="button"
+            variant="primary"
+            onClick={() => {
+              setShowCreate((v) => !v);
+            }}
+          >
             Create service account
           </Button>
         }
@@ -184,13 +198,7 @@ export function ServiceAccounts() {
           <div className="field">
             <span className="field__label">Client ID</span>
             <div className="service-accounts__credential">
-              <input
-                className="field__input service-accounts__mono"
-                type="text"
-                readOnly
-                aria-label="Client ID"
-                value={issued.clientID}
-              />
+              <input className="field__input service-accounts__mono" type="text" readOnly aria-label="Client ID" value={issued.clientID} />
               <CopyButton value={issued.clientID} label="Copy client ID" />
             </div>
           </div>
@@ -208,7 +216,14 @@ export function ServiceAccounts() {
             </div>
           </div>
           <div className="service-accounts__footer">
-            <Button type="button" variant="primary" size="small" onClick={() => { setIssued(null); }}>
+            <Button
+              type="button"
+              variant="primary"
+              size="small"
+              onClick={() => {
+                setIssued(null);
+              }}
+            >
               Done
             </Button>
           </div>
@@ -226,10 +241,24 @@ export function ServiceAccounts() {
               placeholder="ci-pipeline"
               maxLength={255}
               value={name}
-              onChange={(e) => { setName(e.target.value); }}
+              onChange={(e) => {
+                setName(e.target.value);
+              }}
             />
-            <Select id="sa-role" label="Role" value={role} onChange={(e) => { setRole(e.target.value); }} inline={false}>
-              {ROLES.map((r) => <option key={r.value} value={r.value}>{r.label}</option>)}
+            <Select
+              id="sa-role"
+              label="Role"
+              value={role}
+              onChange={(e) => {
+                setRole(e.target.value);
+              }}
+              inline={false}
+            >
+              {ROLES.map((r) => (
+                <option key={r.value} value={r.value}>
+                  {r.label}
+                </option>
+              ))}
             </Select>
             <Input
               id="sa-expires"
@@ -239,25 +268,50 @@ export function ServiceAccounts() {
               max={365}
               placeholder="90"
               value={expiresInDays}
-              onChange={(e) => { setExpiresInDays(e.target.value); }}
+              onChange={(e) => {
+                setExpiresInDays(e.target.value);
+              }}
             />
           </div>
           <p className="service-accounts__help">
             Defaults to 90 days, capped at 365. Admin grants full control (including managing service accounts); super admin is not allowed.
           </p>
-          {formError !== null && <div className="service-accounts__error" role="alert">{formError}</div>}
+          {formError !== null && (
+            <div className="service-accounts__error" role="alert">
+              {formError}
+            </div>
+          )}
           <div className="service-accounts__footer">
-            <Button type="button" variant="primary" isLoading={creating} onClick={() => { void handleCreate(); }}>
+            <Button
+              type="button"
+              variant="primary"
+              isLoading={creating}
+              onClick={() => {
+                void handleCreate();
+              }}
+            >
               Create
             </Button>
-            <Button type="button" variant="inverse" disabled={creating} onClick={() => { setShowCreate(false); setFormError(null); }}>
+            <Button
+              type="button"
+              variant="inverse"
+              disabled={creating}
+              onClick={() => {
+                setShowCreate(false);
+                setFormError(null);
+              }}
+            >
               Cancel
             </Button>
           </div>
         </Card>
       )}
 
-      {actionError !== null && <div className="service-accounts__error" role="alert">{actionError}</div>}
+      {actionError !== null && (
+        <div className="service-accounts__error" role="alert">
+          {actionError}
+        </div>
+      )}
 
       <Card padding="large">
         {error !== null && <div className="service-accounts__status service-accounts__status--error">Error: {error}</div>}
@@ -269,7 +323,12 @@ export function ServiceAccounts() {
           <table className="service-accounts__table">
             <thead>
               <tr>
-                <th>Name</th><th>Role</th><th>Status</th><th>Created</th><th>Last used</th><th aria-label="Actions" />
+                <th>Name</th>
+                <th>Role</th>
+                <th>Status</th>
+                <th>Created</th>
+                <th>Last used</th>
+                <th aria-label="Actions" />
               </tr>
             </thead>
             <tbody>
@@ -279,24 +338,37 @@ export function ServiceAccounts() {
                     <div className="service-accounts__name">{sa.name}</div>
                     <div className="service-accounts__mono service-accounts__client-id">{sa.client_id}</div>
                   </td>
-                  <td><Badge variant={roleVariant(sa.role)}>{roleLabel(sa.role)}</Badge></td>
-                  <td><Badge variant={statusVariant(sa.status)}>{sa.status}</Badge></td>
+                  <td>
+                    <Badge variant={roleVariant(sa.role)}>{roleLabel(sa.role)}</Badge>
+                  </td>
+                  <td>
+                    <Badge variant={statusVariant(sa.status)}>{sa.status}</Badge>
+                  </td>
                   <td>{formatDate(sa.created_at)}</td>
                   <td>{formatDate(sa.last_used_at)}</td>
                   <td className="service-accounts__row-actions">
                     {sa.status !== "revoked" && confirmRevokeID !== sa.id && (
                       <>
                         <Button
-                          type="button" variant="inverse" size="small"
+                          type="button"
+                          variant="inverse"
+                          size="small"
                           isLoading={busyID === sa.id}
-                          onClick={() => { void handleRotate(sa); }}
+                          onClick={() => {
+                            void handleRotate(sa);
+                          }}
                         >
                           Rotate
                         </Button>
                         <Button
-                          type="button" variant="alert" size="small"
+                          type="button"
+                          variant="alert"
+                          size="small"
                           disabled={busyID === sa.id}
-                          onClick={() => { setConfirmRevokeID(sa.id); setActionError(null); }}
+                          onClick={() => {
+                            setConfirmRevokeID(sa.id);
+                            setActionError(null);
+                          }}
                         >
                           Revoke
                         </Button>
@@ -306,13 +378,24 @@ export function ServiceAccounts() {
                       <>
                         <span className="service-accounts__confirm">Revoke {sa.name}?</span>
                         <Button
-                          type="button" variant="alert" size="small"
+                          type="button"
+                          variant="alert"
+                          size="small"
                           isLoading={busyID === sa.id}
-                          onClick={() => { void handleRevoke(sa); }}
+                          onClick={() => {
+                            void handleRevoke(sa);
+                          }}
                         >
                           Confirm
                         </Button>
-                        <Button type="button" variant="inverse" size="small" onClick={() => { setConfirmRevokeID(null); }}>
+                        <Button
+                          type="button"
+                          variant="inverse"
+                          size="small"
+                          onClick={() => {
+                            setConfirmRevokeID(null);
+                          }}
+                        >
                           Cancel
                         </Button>
                       </>

--- a/ui/src/components/ui/AccountMenu.scss
+++ b/ui/src/components/ui/AccountMenu.scss
@@ -44,7 +44,8 @@
     padding: 2px 6px;
     border-radius: 4px;
     background: rgba(235, 188, 67, 0.2);
-    color: #ebbc43;
+    // Darkened from #ebbc43 to clear WCAG AA (4.5:1) against the light-gold background; matches the amber used elsewhere.
+    color: #7a5e12;
     font-size: 11px;
   }
 


### PR DESCRIPTION
Clears the open SonarCloud backlog on `main` (the quality gate was already green; these are old-code maintainability smells, none are bugs/vulnerabilities). 16 fixed here; the other 6 are waived in SonarCloud directly (rationale below).

## Fixed

| Area | Rule | Fix |
|---|---|---|
| `agent/cmd/fleet-edr-agent/main.go` | S107 (8 params) | bundle config into `receiverLoopParams`; ctx stays first |
| `agent/coalesce/coalesce_test.go` | S107 (9 params) | drop the 3 always-constant fixture args from `mkConnect` (tcp/outbound/1.2.3.4 hardcoded), de-noising 12 call sites |
| `server/identity/bootstrap/bootstrap.go` | S3776 (cog. 26) | extract `buildSSOAdminHandler` + `buildServiceAccountSurface` from `New`, mirroring the existing `buildOIDCHandler`/`buildBreakglass` helpers |
| `tools/dash-lint/main.go` | S3776 ×2 (19, 17) | extract the Markdown code-block state machine (`mdCodeState`) and split `goTokenFindings` into per-token helpers. Behavior unchanged |
| `scripts/demo/trigger-dns-c2.sh` | S7679 ×2, S7688 ×3 | local-var the `say`/`sub` args; `[`→`[[` |
| `SSOSettings.tsx`, `ServiceAccounts.tsx` | S7735 ×2, S6819 ×2 | invert negated ternaries; swap two status `div`s to `<output>` (+`display:block`) |
| `SSOSettings.scss`, `AccountMenu.scss` | S7924 ×2 | darken low-contrast success/badge text to clear WCAG AA 4.5:1 |

## Waived in SonarCloud (not in this diff)

- `bump-doc-versions.sh` S7677 -> **false-positive**: `::error::` is a GitHub Actions annotation command and must go to stdout to render; redirecting to stderr would break it.
- `SSOSettings.tsx:24` S8786 (ReDoS) -> **false-positive**: `/\/+$/` is single-char repetition anchored at end, linear, no ambiguous/nested quantifier.
- S8196 ×4 (`Source` ×2, `configStore`, `appConfigStore`) -> **won't-fix**: the names convey the collaborator role; the `-er` rename would reduce readability.

## Verification

No behavior change. Local gates green: `go build ./...`, gofmt, golangci-lint (confirms the S3776/S107 gates now pass), `task lint:dashes` (dash-lint behavior unchanged), UI tests 36/36, full identity test suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)