### PR TITLE
openspec: remove-sso-jit-toggle delta for the merged SSO page change

### DIFF
--- a/openspec/changes/remove-sso-jit-toggle/proposal.md
+++ b/openspec/changes/remove-sso-jit-toggle/proposal.md
@@ -1,0 +1,18 @@
+# Remove the JIT provisioning toggle from the SSO settings page
+
+## Why
+
+The Single sign-on settings page shows a just-in-time (JIT) provisioning on/off toggle whose help text reads: "When on, anyone who signs in through the provider is auto-created and given the default role. When off, an operator must be invited first." The "off" path depends on an operator invite flow that is not built yet, so turning JIT off leaves no way to provision operators at all: SSO logins would be rejected with no recourse from the UI. Offering a control whose disabled state is a dead end is a footgun, and the help text references an invite flow that does not exist.
+
+## What changes
+
+- The SSO settings page no longer renders the JIT provisioning toggle. JIT is always on: anyone who signs in through the provider is auto-created with the default role.
+- The page's help text no longer references inviting operators. It now states only that signed-in users are auto-created with the default role.
+- On save, the page always sends `jit_enabled: true`. The persisted flag and the server-side login flow are unchanged; the UI simply stops exposing a way to set it to false.
+- The default-role selector (Analyst / Auditor) stays, since auto-created users still need a default role.
+- The client-secret field opts out of password-manager capture. It is `type="password"` only to mask the value, but it holds an OIDC client secret (deployment config), not an account credential. Password managers classify any form with a password field as a login and pop a "Save login" prompt on save; the field now carries the per-manager opt-out attributes (`data-1p-ignore` and `data-form-type="other"` for 1Password / Dashlane, `data-lpignore` for LastPass, `data-bwignore` for Bitwarden) and `autocomplete="off"` for the browser's built-in manager.
+
+### Not in this change
+
+- The invite flow itself. When it lands, the toggle (and the "off" path) can be reintroduced.
+- The server-side `jit_enabled` persistence and login behavior: the column, the config record, and the login flow are untouched.

--- a/openspec/changes/remove-sso-jit-toggle/specs/sso-configuration/spec.md
+++ b/openspec/changes/remove-sso-jit-toggle/specs/sso-configuration/spec.md
@@ -29,4 +29,4 @@ The system SHALL present a Single sign-on settings page within the Admin setting
 
 - **GIVEN** an admin on the Single sign-on page
 - **WHEN** the client-secret field renders
-- **THEN** it carries the password-manager opt-out attributes so no manager offers to save it as a login: `data-1p-ignore` and `data-form-type="other"` (1Password, Dashlane), `data-lpignore` (LastPass), `data-bwignore` (Bitwarden), and `autocomplete` set to off (the browser's built-in manager)
+- **THEN** it carries the password-manager opt-out attributes so no manager offers to save it as a login: `data-1p-ignore` and `data-form-type="other"` (1Password, Dashlane), `data-lpignore` (LastPass), `data-bwignore` (Bitwarden), and `autocomplete="off"` (the browser's built-in manager)

--- a/openspec/changes/remove-sso-jit-toggle/specs/sso-configuration/spec.md
+++ b/openspec/changes/remove-sso-jit-toggle/specs/sso-configuration/spec.md
@@ -1,0 +1,32 @@
+# SSO configuration: remove the JIT provisioning toggle delta
+
+## MODIFIED Requirements
+
+### Requirement: The Single sign-on admin settings page
+
+The system SHALL present a Single sign-on settings page within the Admin settings area, reachable from the account menu and visible only to operators whose permission set includes `sso.manage`. The page SHALL render the provider configuration form (issuer, client id), an editable deployment external-URL field, a read-only redirect URL derived from the external URL (external URL + `/api/auth/callback`) with a copy affordance, the requested scopes as read-only chips, a write-only client-secret field that accepts a new value to rotate and never displays the stored secret and that opts out of password-manager capture (it holds an OIDC client secret, deployment config, not an account credential), a default-role selector restricted to Analyst and Auditor, a connection status indicator, a test-connection control, and a callout stating the break-glass account remains available if the provider is unreachable. The page SHALL NOT render a just-in-time provisioning toggle: JIT provisioning is always on, so any operator who signs in through the provider is auto-created with the default role, and the page always persists the JIT-enabled flag as true. The redirect URI registered at the IdP is the derived value; the operator maintains only the external URL. The page MUST gate its affordances on the operator's permission set returned by the session probe; the server chokepoint remains authoritative.
+
+#### Scenario: Page is hidden from operators without the grant
+
+- **GIVEN** an authenticated operator whose permission set does not include `sso.manage`
+- **WHEN** the operator opens the account menu
+- **THEN** the Admin settings entry to the Single sign-on page is not offered
+
+#### Scenario: Secret field never shows the stored secret
+
+- **GIVEN** a stored configuration with a client secret set
+- **WHEN** an admin opens the Single sign-on page
+- **THEN** the client-secret field is empty with a rotate-only affordance and the stored secret is never displayed
+
+#### Scenario: No JIT toggle and JIT is always enabled on save
+
+- **GIVEN** an admin on the Single sign-on page
+- **WHEN** the page renders and the admin saves a configuration change
+- **THEN** no just-in-time provisioning toggle is presented
+- **AND** the saved configuration carries the JIT-enabled flag set to true
+
+#### Scenario: Client-secret field opts out of password-manager capture
+
+- **GIVEN** an admin on the Single sign-on page
+- **WHEN** the client-secret field renders
+- **THEN** it carries the password-manager opt-out attributes so no manager offers to save it as a login: `data-1p-ignore` and `data-form-type="other"` (1Password, Dashlane), `data-lpignore` (LastPass), `data-bwignore` (Bitwarden), and `autocomplete` set to off (the browser's built-in manager)

--- a/openspec/changes/remove-sso-jit-toggle/tasks.md
+++ b/openspec/changes/remove-sso-jit-toggle/tasks.md
@@ -1,0 +1,22 @@
+# Remove the JIT provisioning toggle from the SSO settings page: tasks
+
+## 1. UI
+
+- [x] Remove the `<Toggle>` for JIT provisioning from `SSOSettings.tsx`, drop the now-unused `Toggle` import, `jitEnabled` form field, and the `&__jit` flex layout rule.
+- [x] Rewrite the help text to drop the invite reference: "Anyone who signs in through the provider is auto-created and given the default role."
+- [x] Always send `jit_enabled: true` on save.
+- [x] Add password-manager opt-out attributes to the client-secret field (`data-1p-ignore`, `data-form-type="other"`, `data-lpignore`, `data-bwignore`, `autocomplete="off"`) so no "Save login" prompt fires on save.
+
+## 2. Tests
+
+- [x] Update `SSOSettings.test.tsx`: assert no JIT switch is rendered and that save always sends `jit_enabled: true`.
+- [x] Assert the client-secret field carries the password-manager opt-out attributes.
+
+## 3. Spec + traceability
+
+- [x] `sso-configuration` spec: MODIFIED "The Single sign-on admin settings page" to drop the JIT toggle from the rendered controls, note the secret field opts out of password-manager capture, and add scenarios for both.
+- [x] spectrace markers for the new scenarios referenced from the UI test.
+
+## 4. Docs
+
+- [x] `docs/okta-setup.md` and `CHANGELOG.md`: drop the JIT toggle from the SSO settings-page description; state JIT is always on.

--- a/ui/src/components/SSOSettings/SSOSettings.test.tsx
+++ b/ui/src/components/SSOSettings/SSOSettings.test.tsx
@@ -71,6 +71,7 @@ describe("SSOSettings", () => {
     expect(upd.mock.calls[0][0]).toMatchObject({ client_secret: "rotated-secret" });
   });
 
+  // spec:sso-configuration/the-single-sign-on-admin-settings-page/client-secret-field-opts-out-of-password-manager-capture
   it("marks the client-secret field so password managers skip it", async () => {
     vi.spyOn(api, "getSSOConfig").mockResolvedValue(baseConfig);
     render(<SSOSettings />);
@@ -124,6 +125,7 @@ describe("SSOSettings", () => {
     expect(await screen.findByText(/discovery unreachable/)).toBeInTheDocument();
   });
 
+  // spec:sso-configuration/the-single-sign-on-admin-settings-page/no-jit-toggle-and-jit-is-always-enabled-on-save
   it("has no JIT toggle and always saves with JIT enabled", async () => {
     vi.spyOn(api, "getSSOConfig").mockResolvedValue(baseConfig);
     const upd = vi.spyOn(api, "updateSSOConfig").mockResolvedValue(baseConfig);


### PR DESCRIPTION
## What

Records the user-visible SSO settings-page change shipped in #513 as an OpenSpec delta, and re-adds the two `spec:` test markers that point at it.

#513 (UI-only) removed the just-in-time provisioning toggle, made JIT always on (`jit_enabled: true` on every save), and added password-manager opt-out attributes to the client-secret field. That left the canonical `sso-configuration` spec stale (it still described a JIT toggle), which both Copilot and Qodo flagged on #513, and which forced #513 to strip its `spec:` markers to keep spectrace green.

This PR closes that gap:

- `openspec/changes/remove-sso-jit-toggle/` — MODIFIES the "Single sign-on admin settings page" requirement to drop the JIT toggle (JIT is always on, page always persists `jit_enabled: true`) and notes the client-secret field opts out of password-manager capture. Adds two scenarios: no-JIT-toggle/JIT-always-on, and client-secret password-manager opt-out.
- `ui/src/components/SSOSettings/SSOSettings.test.tsx` — re-adds the two `spec:` markers pointing at the new scenarios.

The delta is archived into `openspec/specs/**` by the batched `openspec archive` at the next release; no separate archive PR.

## Verification

- `openspec validate remove-sso-jit-toggle --strict` — valid
- `spectrace check --strict` — clean (markers resolve to the in-flight delta)
- pre-commit hooks (dash-lint, prettier, markdownlint, eslint) — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)