### PR TITLE
feat(visibility): MySQL event_queue work queue (EventLog impl) (#427)

### DIFF
--- a/arch-go.yml
+++ b/arch-go.yml
@@ -105,6 +105,18 @@ dependenciesRules:
         - "**.httpserver"
         - "**.testdb"
 
+  # visibility context internals (ADR-0015): ingestion + the event store. The
+  # MySQL event_queue (EventLog) store depends only on visibility.api; the
+  # ClickHouse EventArchive lands later and will add httpserver (TimeRange).
+  - package: "**.visibility.internal.**"
+    shouldOnlyDependsOn:
+      internal:
+        - "**.visibility.api"
+        - "**.visibility.api.**"
+        - "**.visibility.internal.**"
+        - "**.visibility.testkit"
+        - "**.testdb"
+
   # ----- testkit packages -----------------------------------------------------
   #
   # testkit is a curated test-fixture surface for each bounded context.
@@ -185,6 +197,15 @@ dependenciesRules:
         - "**.observability.tracing"
         - "**.attrkeys"
         - "**.httpserver"
+        - "**.testdb"
+
+  - package: "**.visibility.testkit"
+    shouldOnlyDependsOn:
+      internal:
+        - "**.visibility.api"
+        - "**.visibility.api.**"
+        - "**.visibility.bootstrap"
+        - "**.visibility.internal.**"
         - "**.testdb"
 
   # ----- api/ packages: pure-types, no cross-context internals ----------------

--- a/arch-go.yml
+++ b/arch-go.yml
@@ -115,6 +115,7 @@ dependenciesRules:
         - "**.visibility.api.**"
         - "**.visibility.internal.**"
         - "**.visibility.testkit"
+        - "**.sqlhelpers"
         - "**.testdb"
 
   # ----- testkit packages -----------------------------------------------------

--- a/server/detection/internal/mysql/internal_test.go
+++ b/server/detection/internal/mysql/internal_test.go
@@ -1,116 +1,13 @@
 package mysql
 
 import (
-	"context"
-	"errors"
-	"fmt"
 	"testing"
-	"time"
 
-	"github.com/go-sql-driver/mysql"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
-// isDeadlockErr is the gatekeeper for the insert-retry loop; if it misclassifies, the retry either fires on the wrong error class
-// (potentially looping on a non-transient failure) or never fires when the deadlock shows up wrapped (the production path wraps
-// with fmt.Errorf("insert %s: %w", ...)).
-func TestIsDeadlockErr(t *testing.T) {
-	t.Parallel()
-	cases := []struct {
-		name string
-		err  error
-		want bool
-	}{
-		{"nil is not a deadlock", nil, false},
-		{"plain error is not a deadlock", errors.New("connection refused"), false},
-		{"different mysql error (1062 dup key)", &mysql.MySQLError{Number: 1062, Message: "duplicate"}, false},
-		{"bare deadlock error", &mysql.MySQLError{Number: 1213, Message: "Deadlock found"}, true},
-		{"wrapped deadlock error", fmt.Errorf("insert evt-1: %w",
-			&mysql.MySQLError{Number: 1213, Message: "Deadlock found"}), true},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			assert.Equal(t, tc.want, isDeadlockErr(tc.err))
-		})
-	}
-}
-
-// TestWithDeadlockRetry pins the retry-loop contract: succeed-first-attempt, return-non-deadlock-immediately, retry-on-deadlock-then-
-// succeed, exhaust-attempts-and-return-last-deadlock, honor-context-cancel-during-backoff. The wall-clock cost of each subtest is
-// bounded by step (1ms here) times the number of retries, so the whole test stays well under 100ms.
-func TestWithDeadlockRetry(t *testing.T) {
-	t.Parallel()
-	deadlockErr := &mysql.MySQLError{Number: 1213, Message: "Deadlock found"}
-	const step = 1 * time.Millisecond
-
-	t.Run("success on first attempt", func(t *testing.T) {
-		t.Parallel()
-		calls := 0
-		err := withDeadlockRetry(t.Context(), 5, step, func() error {
-			calls++
-			return nil
-		})
-		require.NoError(t, err)
-		assert.Equal(t, 1, calls, "fn must be invoked exactly once on a clean success")
-	})
-
-	t.Run("non-deadlock error returns immediately without retry", func(t *testing.T) {
-		t.Parallel()
-		boom := errors.New("boom")
-		calls := 0
-		err := withDeadlockRetry(t.Context(), 5, step, func() error {
-			calls++
-			return boom
-		})
-		require.ErrorIs(t, err, boom)
-		assert.Equal(t, 1, calls, "non-deadlock errors must short-circuit the loop")
-	})
-
-	t.Run("retries on deadlock then succeeds", func(t *testing.T) {
-		t.Parallel()
-		calls := 0
-		err := withDeadlockRetry(t.Context(), 5, step, func() error {
-			calls++
-			if calls < 3 {
-				return fmt.Errorf("insert evt-1: %w", deadlockErr)
-			}
-			return nil
-		})
-		require.NoError(t, err)
-		assert.Equal(t, 3, calls, "fn must be retried until it stops returning deadlock")
-	})
-
-	t.Run("exhausts attempts and returns last deadlock error", func(t *testing.T) {
-		t.Parallel()
-		calls := 0
-		err := withDeadlockRetry(t.Context(), 3, step, func() error {
-			calls++
-			return deadlockErr
-		})
-		require.ErrorIs(t, err, deadlockErr)
-		assert.Equal(t, 3, calls, "fn must be invoked maxAttempts times when every attempt deadlocks")
-	})
-
-	t.Run("context cancel during backoff returns ctx.Err", func(t *testing.T) {
-		t.Parallel()
-		ctx, cancel := context.WithCancel(context.Background())
-		calls := 0
-		err := withDeadlockRetry(ctx, 5, 50*time.Millisecond, func() error {
-			calls++
-			if calls == 1 {
-				// Cancel after the first deadlock so the backoff select picks up ctx.Done() before the timer fires.
-				cancel()
-			}
-			return deadlockErr
-		})
-		require.ErrorIs(t, err, context.Canceled)
-		assert.Equal(t, 1, calls, "context cancel during backoff must stop the loop before the next fn invocation")
-	})
-}
-
-// White-box tests for package-private helpers. The other test file (store_test.go, package mysql_test) covers the public Store API
+// White-box tests for package-private helpers. The deadlock-retry helper moved to server/sqlhelpers (and is tested there); this file
+// covers the remaining detection-private helpers. The other test file (store_test.go, package mysql_test) covers the public Store API
 // against a real MySQL via testdb.
 func TestDeduplicateStrings(t *testing.T) {
 	t.Parallel()

--- a/server/detection/internal/mysql/store.go
+++ b/server/detection/internal/mysql/store.go
@@ -8,26 +8,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/go-sql-driver/mysql"
 	"github.com/jmoiron/sqlx"
 
 	"github.com/fleetdm/edr/server/detection/api"
+	"github.com/fleetdm/edr/server/sqlhelpers"
 )
-
-// mysqlErrDeadlock is MySQL error 1213: "Deadlock found when trying to get lock; try restarting transaction". The server-error
-// documentation explicitly tells callers to retry, and INSERT IGNORE under concurrent batch load can trip gap locks on secondary
-// indexes even when primary keys do not collide.
-const mysqlErrDeadlock = 1213
-
-// isDeadlockErr reports whether err wraps a MySQL deadlock (error 1213). Surface-level signal only: the caller decides whether
-// retrying is safe (which depends on whether the transaction is idempotent).
-func isDeadlockErr(err error) bool {
-	var mysqlErr *mysql.MySQLError
-	if !errors.As(err, &mysqlErr) {
-		return false
-	}
-	return mysqlErr.Number == mysqlErrDeadlock
-}
 
 // Store is the persistence handle for the detection bounded context. Holds the shared *sqlx.DB pool that cmd/main opens once via
 // server/bootstrap.OpenDB and shares across every context.
@@ -96,31 +81,9 @@ func (s *Store) insertEventsAt(ctx context.Context, events []api.Event, ingested
 	// indexes (idx_events_host_id, idx_events_host_type_ingested, etc.) and unrelated concurrent inserts on different host_ids can
 	// still hit lock-order inversion. The transaction is fully idempotent (INSERT IGNORE skips duplicates and we re-stamp
 	// ingested_at_ns only on rows actually inserted), so we retry on error 1213.
-	return withDeadlockRetry(ctx, insertMaxAttempts, insertBackoffStep, func() error {
+	return sqlhelpers.WithDeadlockRetry(ctx, insertMaxAttempts, insertBackoffStep, func() error {
 		return s.insertEventsAtOnce(ctx, events, ingestedAtNs)
 	})
-}
-
-// withDeadlockRetry runs fn up to maxAttempts times, retrying on MySQL deadlock errors (1213) with a linear backoff of attempt*step.
-// Returns immediately on success or on a non-deadlock error. Respects ctx cancellation during backoff. Callers must guarantee fn is
-// idempotent (running it after a rolled-back attempt must produce the same final state); this helper does not enforce that property.
-func withDeadlockRetry(ctx context.Context, maxAttempts int, step time.Duration, fn func() error) error {
-	var lastErr error
-	for attempt := 1; attempt <= maxAttempts; attempt++ {
-		lastErr = fn()
-		if lastErr == nil {
-			return nil
-		}
-		if !isDeadlockErr(lastErr) {
-			return lastErr
-		}
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-time.After(time.Duration(attempt) * step):
-		}
-	}
-	return lastErr
 }
 
 func (s *Store) insertEventsAtOnce(ctx context.Context, events []api.Event, ingestedAtNs int64) error {

--- a/server/sqlhelpers/deadlock.go
+++ b/server/sqlhelpers/deadlock.go
@@ -1,0 +1,47 @@
+package sqlhelpers
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/go-sql-driver/mysql"
+)
+
+// mysqlErrDeadlock is MySQL error 1213: "Deadlock found when trying to get lock; try restarting transaction". Under concurrent
+// multi-replica writes, INSERT/UPDATE statements that touch overlapping secondary-index gaps can deadlock; MySQL rolls one back with
+// 1213 and a retry of the same idempotent statement clears it.
+const mysqlErrDeadlock = 1213
+
+// IsDeadlockErr reports whether err wraps a MySQL deadlock (error 1213). Surface-level signal only: the caller decides whether the
+// operation is safe to retry.
+func IsDeadlockErr(err error) bool {
+	var mysqlErr *mysql.MySQLError
+	if !errors.As(err, &mysqlErr) {
+		return false
+	}
+	return mysqlErr.Number == mysqlErrDeadlock
+}
+
+// WithDeadlockRetry runs fn up to maxAttempts times, retrying only on a MySQL deadlock (1213) with a linear backoff of attempt*step,
+// honoring ctx cancellation between attempts. Any non-deadlock error returns immediately. fn MUST be idempotent: it is re-run verbatim
+// on a deadlock. Shared by the data-plane stores whose concurrent writes can deadlock on gap locks (detection events, visibility
+// event_queue).
+func WithDeadlockRetry(ctx context.Context, maxAttempts int, step time.Duration, fn func() error) error {
+	var lastErr error
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		lastErr = fn()
+		if lastErr == nil {
+			return nil
+		}
+		if !IsDeadlockErr(lastErr) {
+			return lastErr
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(time.Duration(attempt) * step):
+		}
+	}
+	return lastErr
+}

--- a/server/sqlhelpers/deadlock_test.go
+++ b/server/sqlhelpers/deadlock_test.go
@@ -1,0 +1,95 @@
+package sqlhelpers
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsDeadlockErr(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"deadlock", &mysql.MySQLError{Number: mysqlErrDeadlock}, true},
+		{"other mysql error", &mysql.MySQLError{Number: 1062}, false},
+		{"plain error", errors.New("boom"), false},
+		{"nil", nil, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, IsDeadlockErr(tc.err))
+		})
+	}
+}
+
+func TestWithDeadlockRetry(t *testing.T) {
+	t.Parallel()
+	deadlock := &mysql.MySQLError{Number: mysqlErrDeadlock}
+
+	t.Run("succeeds first try", func(t *testing.T) {
+		t.Parallel()
+		calls := 0
+		err := WithDeadlockRetry(context.Background(), 5, time.Millisecond, func() error {
+			calls++
+			return nil
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 1, calls)
+	})
+
+	t.Run("retries on deadlock then succeeds", func(t *testing.T) {
+		t.Parallel()
+		calls := 0
+		err := WithDeadlockRetry(context.Background(), 5, time.Millisecond, func() error {
+			calls++
+			if calls < 3 {
+				return deadlock
+			}
+			return nil
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 3, calls)
+	})
+
+	t.Run("returns non-deadlock error immediately", func(t *testing.T) {
+		t.Parallel()
+		other := errors.New("syntax error")
+		calls := 0
+		err := WithDeadlockRetry(context.Background(), 5, time.Millisecond, func() error {
+			calls++
+			return other
+		})
+		require.ErrorIs(t, err, other)
+		assert.Equal(t, 1, calls)
+	})
+
+	t.Run("gives up after maxAttempts on persistent deadlock", func(t *testing.T) {
+		t.Parallel()
+		calls := 0
+		err := WithDeadlockRetry(context.Background(), 3, time.Millisecond, func() error {
+			calls++
+			return deadlock
+		})
+		require.Error(t, err)
+		assert.Equal(t, 3, calls)
+	})
+
+	t.Run("honors context cancellation between retries", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		err := WithDeadlockRetry(ctx, 5, time.Second, func() error {
+			return deadlock
+		})
+		require.ErrorIs(t, err, context.Canceled)
+	})
+}

--- a/server/visibility/bootstrap/bootstrap.go
+++ b/server/visibility/bootstrap/bootstrap.go
@@ -1,0 +1,62 @@
+package bootstrap
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/jmoiron/sqlx"
+
+	"github.com/fleetdm/edr/server/migrations/runner"
+	"github.com/fleetdm/edr/server/visibility/api"
+	"github.com/fleetdm/edr/server/visibility/internal/eventlog"
+	visibilitymigrations "github.com/fleetdm/edr/server/visibility/migrations"
+)
+
+// Deps bundles what New needs to wire the visibility context.
+type Deps struct {
+	DB     *sqlx.DB
+	Logger *slog.Logger
+}
+
+// Visibility is the handle cmd/main holds for the visibility context.
+type Visibility struct {
+	eventLog *eventlog.Store
+	db       *sqlx.DB
+	logger   *slog.Logger
+}
+
+// New wires the visibility context. It does NOT apply the schema (call ApplySchema).
+func New(deps Deps) (*Visibility, error) {
+	if deps.DB == nil {
+		return nil, errors.New("visibility bootstrap: DB is required")
+	}
+	logger := deps.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	el, err := eventlog.New(deps.DB)
+	if err != nil {
+		return nil, fmt.Errorf("visibility bootstrap: %w", err)
+	}
+	return &Visibility{eventLog: el, db: deps.DB, logger: logger}, nil
+}
+
+// EventLog returns the durable work queue that decouples ingestion from detection processing.
+func (v *Visibility) EventLog() api.EventLog { return v.eventLog }
+
+// ApplySchema runs visibility's migrations against the context's DB. Idempotent.
+func (v *Visibility) ApplySchema(ctx context.Context) error { return ApplySchema(ctx, v.db) }
+
+// ApplySchema is the package-level form: applies visibility's goose migration corpus against db without a fully constructed
+// *Visibility. Used by the test fixture composer. Idempotent (goose skips already-applied versions).
+func ApplySchema(ctx context.Context, db *sqlx.DB) error {
+	if db == nil {
+		return errors.New("visibility ApplySchema: db must not be nil")
+	}
+	return runner.Up(ctx, db, visibilitymigrations.FS, runner.Options{
+		Context:   "visibility",
+		TableName: "visibility_goose_db_version",
+	})
+}

--- a/server/visibility/bootstrap/bootstrap_test.go
+++ b/server/visibility/bootstrap/bootstrap_test.go
@@ -1,0 +1,19 @@
+package bootstrap
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNew_NilDB(t *testing.T) {
+	t.Parallel()
+	_, err := New(Deps{DB: nil})
+	require.Error(t, err)
+}
+
+func TestApplySchema_NilDB(t *testing.T) {
+	t.Parallel()
+	require.Error(t, ApplySchema(context.Background(), nil))
+}

--- a/server/visibility/bootstrap/doc.go
+++ b/server/visibility/bootstrap/doc.go
@@ -1,0 +1,8 @@
+// Package bootstrap wires the visibility bounded context (ADR-0015): endpoint event ingestion and the event store.
+//
+// It applies the context's schema and constructs its stores, handing cmd/main a handle with accessors for the published seams. Today
+// it owns the EventLog (the MySQL `event_queue` work queue that decouples ingestion from detection processing); the EventArchive
+// (the ClickHouse event lake) and the live ingest/processor wiring land in subsequent increments.
+//
+// Production wiring (cmd/main) calls New + ApplySchema; tests reach for visibility/testkit instead. arch-go pins that split.
+package bootstrap

--- a/server/visibility/internal/eventlog/store.go
+++ b/server/visibility/internal/eventlog/store.go
@@ -1,0 +1,207 @@
+// Package eventlog is the MySQL implementation of the visibility context's EventLog: the durable work queue that decouples ingestion
+// from detection processing (ADR-0015). It backs the `event_queue` table and preserves the multi-replica, lock-free, per-host-ordered
+// claim of ADR-0011 (FOR UPDATE SKIP LOCKED), mirroring the proven claim the detection event store used before the store split.
+package eventlog
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/go-sql-driver/mysql"
+	"github.com/jmoiron/sqlx"
+
+	"github.com/fleetdm/edr/server/visibility/api"
+)
+
+const (
+	// insertMaxAttempts / insertBackoffStep bound the deadlock-retry loop. Concurrent multi-replica appends to event_queue can deadlock
+	// on secondary-index gap locks under INSERT IGNORE (MySQL 1213); a few linear-backoff retries clear it. Mirrors the detection store.
+	insertMaxAttempts = 5
+	insertBackoffStep = 5 * time.Millisecond
+
+	// appendChunkRows caps a single multi-row INSERT at 500 events (6 placeholders each, well under MySQL's 65535-placeholder and
+	// 4 MB max_allowed_packet ceilings).
+	appendChunkRows = 500
+
+	mysqlErrDeadlock = 1213
+)
+
+// Store is the MySQL-backed EventLog. It holds the shared *sqlx.DB pool cmd/main opens once via server/bootstrap.OpenDB; closing the
+// handle is cmd/main's responsibility, not Store's.
+type Store struct {
+	db *sqlx.DB
+}
+
+// Compile-time check that Store satisfies the published EventLog contract.
+var _ api.EventLog = (*Store)(nil)
+
+// New returns a Store wrapping db. Schema is applied separately via visibility/bootstrap.ApplySchema.
+func New(db *sqlx.DB) (*Store, error) {
+	if db == nil {
+		return nil, errors.New("visibility eventlog.New: db handle must not be nil")
+	}
+	return &Store{db: db}, nil
+}
+
+// Append enqueues events as not-yet-processed (processed = 0). Idempotent by EventID: INSERT IGNORE drops a re-appended event_id so an
+// agent retry never double-enqueues. Events are persisted with the IngestedAtNs the caller already stamped; the queue does not
+// re-stamp. At-least-once safe: a partial failure surfaces as an error and the caller retries the whole batch.
+func (s *Store) Append(ctx context.Context, events []api.Event) error {
+	if len(events) == 0 {
+		return nil
+	}
+	return withDeadlockRetry(ctx, insertMaxAttempts, insertBackoffStep, func() error {
+		return s.appendOnce(ctx, events)
+	})
+}
+
+func (s *Store) appendOnce(ctx context.Context, events []api.Event) error {
+	for start := 0; start < len(events); start += appendChunkRows {
+		end := min(start+appendChunkRows, len(events))
+		chunk := events[start:end]
+		placeholders, args, err := appendArgs(chunk)
+		if err != nil {
+			return err
+		}
+		_, err = s.db.ExecContext(ctx, `INSERT IGNORE INTO event_queue (event_id, host_id, timestamp_ns, ingested_at_ns, event_type, payload) VALUES `+
+			strings.Join(placeholders, ", "), args...)
+		if err != nil {
+			return fmt.Errorf("append events chunk [%d:%d]: %w", start, end, err)
+		}
+	}
+	return nil
+}
+
+func appendArgs(chunk []api.Event) ([]string, []any, error) {
+	placeholders := make([]string, len(chunk))
+	args := make([]any, 0, len(chunk)*6)
+	for i := range chunk {
+		payloadBytes, err := json.Marshal(chunk[i].Payload)
+		if err != nil {
+			return nil, nil, fmt.Errorf("marshal payload for %s: %w", chunk[i].EventID, err)
+		}
+		placeholders[i] = "(?, ?, ?, ?, ?, ?)"
+		args = append(args, chunk[i].EventID, chunk[i].HostID, chunk[i].TimestampNs, chunk[i].IngestedAtNs, chunk[i].EventType, payloadBytes)
+	}
+	return placeholders, args, nil
+}
+
+// Claim atomically claims up to limit not-yet-processed events for this worker, ordered per host by timestamp, without blocking
+// concurrent claimers (FOR UPDATE SKIP LOCKED, ADR-0011). Claimed rows transition 0 -> 2 in the same transaction so other claimers
+// skip them until Ack or Nack.
+func (s *Store) Claim(ctx context.Context, limit int) ([]api.Event, error) {
+	if limit <= 0 {
+		return nil, nil
+	}
+	tx, err := s.db.BeginTxx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("begin tx for claim: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	var events []api.Event
+	err = tx.SelectContext(ctx, &events, `
+		SELECT event_id, host_id, timestamp_ns, ingested_at_ns, event_type, payload
+		FROM event_queue
+		WHERE processed = 0
+		ORDER BY host_id, timestamp_ns
+		LIMIT ?
+		FOR UPDATE SKIP LOCKED`, limit)
+	if err != nil {
+		return nil, fmt.Errorf("claim select: %w", err)
+	}
+	if len(events) == 0 {
+		return events, tx.Commit()
+	}
+
+	ids := make([]string, len(events))
+	for i, e := range events {
+		ids[i] = e.EventID
+	}
+	query, args, err := sqlx.In("UPDATE event_queue SET processed = 2 WHERE event_id IN (?)", ids)
+	if err != nil {
+		return nil, fmt.Errorf("claim build update: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, query, args...); err != nil {
+		return nil, fmt.Errorf("claim update: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit claim tx: %w", err)
+	}
+	return events, nil
+}
+
+// Ack marks claimed events fully processed (2 -> 1); they will not be claimed again. A separate retention sweep removes acknowledged
+// rows so the queue stays small (the archive holds the retained history).
+func (s *Store) Ack(ctx context.Context, eventIDs []string) error {
+	if len(eventIDs) == 0 {
+		return nil
+	}
+	query, args, err := sqlx.In("UPDATE event_queue SET processed = 1 WHERE event_id IN (?)", eventIDs)
+	if err != nil {
+		return fmt.Errorf("ack build query: %w", err)
+	}
+	if _, err := s.db.ExecContext(ctx, query, args...); err != nil {
+		return fmt.Errorf("ack: %w", err)
+	}
+	return nil
+}
+
+// Nack returns claimed events to the not-yet-processed state for a later Claim. Scoped to processed = 2 so it only reverts in-flight
+// rows and never resurrects an already-acknowledged event.
+func (s *Store) Nack(ctx context.Context, eventIDs []string) error {
+	if len(eventIDs) == 0 {
+		return nil
+	}
+	query, args, err := sqlx.In("UPDATE event_queue SET processed = 0 WHERE processed = 2 AND event_id IN (?)", eventIDs)
+	if err != nil {
+		return fmt.Errorf("nack build query: %w", err)
+	}
+	if _, err := s.db.ExecContext(ctx, query, args...); err != nil {
+		return fmt.Errorf("nack: %w", err)
+	}
+	return nil
+}
+
+// CountPending counts events not yet acknowledged (processed != 1): the waiting-plus-in-flight backlog. Backs the processor-backlog
+// gauge.
+func (s *Store) CountPending(ctx context.Context) (int64, error) {
+	var count int64
+	if err := s.db.GetContext(ctx, &count, "SELECT COUNT(*) FROM event_queue WHERE processed != 1"); err != nil {
+		return 0, fmt.Errorf("count pending: %w", err)
+	}
+	return count, nil
+}
+
+// withDeadlockRetry retries fn on a MySQL deadlock (1213) up to maxAttempts with linear backoff, honoring ctx cancellation. Any
+// non-deadlock error returns immediately.
+func withDeadlockRetry(ctx context.Context, maxAttempts int, step time.Duration, fn func() error) error {
+	var lastErr error
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		lastErr = fn()
+		if lastErr == nil {
+			return nil
+		}
+		if !isDeadlockErr(lastErr) {
+			return lastErr
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(time.Duration(attempt) * step):
+		}
+	}
+	return lastErr
+}
+
+func isDeadlockErr(err error) bool {
+	var mysqlErr *mysql.MySQLError
+	if !errors.As(err, &mysqlErr) {
+		return false
+	}
+	return mysqlErr.Number == mysqlErrDeadlock
+}

--- a/server/visibility/internal/eventlog/store.go
+++ b/server/visibility/internal/eventlog/store.go
@@ -11,15 +11,15 @@ import (
 	"strings"
 	"time"
 
-	"github.com/go-sql-driver/mysql"
 	"github.com/jmoiron/sqlx"
 
+	"github.com/fleetdm/edr/server/sqlhelpers"
 	"github.com/fleetdm/edr/server/visibility/api"
 )
 
 const (
 	// insertMaxAttempts / insertBackoffStep bound the deadlock-retry loop. Concurrent multi-replica appends to event_queue can deadlock
-	// on secondary-index gap locks under INSERT IGNORE (MySQL 1213); a few linear-backoff retries clear it. Mirrors the detection store.
+	// on secondary-index gap locks under INSERT IGNORE (MySQL 1213); a few linear-backoff retries clear it.
 	insertMaxAttempts = 5
 	insertBackoffStep = 5 * time.Millisecond
 
@@ -27,7 +27,12 @@ const (
 	// 4 MB max_allowed_packet ceilings).
 	appendChunkRows = 500
 
-	mysqlErrDeadlock = 1213
+	// claimLeaseNs is the visibility timeout on a claim. A worker that claims events (processed = 2) but crashes before Ack/Nack leaves
+	// them in-flight; once their claim is older than the lease, a later Claim re-offers them, honoring the EventLog at-least-once
+	// contract. Set well above the longest expected per-batch processing time so a live worker is never double-served.
+	claimLeaseNs = int64(5 * time.Minute)
+
+	insertPrefix = `INSERT IGNORE INTO event_queue (event_id, host_id, timestamp_ns, ingested_at_ns, event_type, payload) VALUES `
 )
 
 // Store is the MySQL-backed EventLog. It holds the shared *sqlx.DB pool cmd/main opens once via server/bootstrap.OpenDB; closing the
@@ -54,7 +59,7 @@ func (s *Store) Append(ctx context.Context, events []api.Event) error {
 	if len(events) == 0 {
 		return nil
 	}
-	return withDeadlockRetry(ctx, insertMaxAttempts, insertBackoffStep, func() error {
+	return sqlhelpers.WithDeadlockRetry(ctx, insertMaxAttempts, insertBackoffStep, func() error {
 		return s.appendOnce(ctx, events)
 	})
 }
@@ -67,9 +72,7 @@ func (s *Store) appendOnce(ctx context.Context, events []api.Event) error {
 		if err != nil {
 			return err
 		}
-		_, err = s.db.ExecContext(ctx, `INSERT IGNORE INTO event_queue (event_id, host_id, timestamp_ns, ingested_at_ns, event_type, payload) VALUES `+
-			strings.Join(placeholders, ", "), args...)
-		if err != nil {
+		if _, err := s.db.ExecContext(ctx, insertPrefix+strings.Join(placeholders, ", "), args...); err != nil {
 			return fmt.Errorf("append events chunk [%d:%d]: %w", start, end, err)
 		}
 	}
@@ -90,9 +93,10 @@ func appendArgs(chunk []api.Event) ([]string, []any, error) {
 	return placeholders, args, nil
 }
 
-// Claim atomically claims up to limit not-yet-processed events for this worker, ordered per host by timestamp, without blocking
-// concurrent claimers (FOR UPDATE SKIP LOCKED, ADR-0011). Claimed rows transition 0 -> 2 in the same transaction so other claimers
-// skip them until Ack or Nack.
+// Claim atomically claims up to limit events for this worker, ordered per host by timestamp, without blocking concurrent claimers
+// (FOR UPDATE SKIP LOCKED, ADR-0011). It offers both never-claimed rows (processed = 0) and rows whose prior claim has expired past
+// claimLeaseNs (processed = 2 with a stale claimed_at_ns), so a worker that crashed between Claim and Ack has its events re-delivered.
+// Claimed rows are stamped processed = 2 with a fresh claimed_at_ns in the same transaction.
 func (s *Store) Claim(ctx context.Context, limit int) ([]api.Event, error) {
 	if limit <= 0 {
 		return nil, nil
@@ -103,14 +107,15 @@ func (s *Store) Claim(ctx context.Context, limit int) ([]api.Event, error) {
 	}
 	defer tx.Rollback() //nolint:errcheck
 
+	cutoff := time.Now().UnixNano() - claimLeaseNs
 	var events []api.Event
 	err = tx.SelectContext(ctx, &events, `
 		SELECT event_id, host_id, timestamp_ns, ingested_at_ns, event_type, payload
 		FROM event_queue
-		WHERE processed = 0
+		WHERE processed = 0 OR (processed = 2 AND claimed_at_ns < ?)
 		ORDER BY host_id, timestamp_ns
 		LIMIT ?
-		FOR UPDATE SKIP LOCKED`, limit)
+		FOR UPDATE SKIP LOCKED`, cutoff, limit)
 	if err != nil {
 		return nil, fmt.Errorf("claim select: %w", err)
 	}
@@ -122,7 +127,7 @@ func (s *Store) Claim(ctx context.Context, limit int) ([]api.Event, error) {
 	for i, e := range events {
 		ids[i] = e.EventID
 	}
-	query, args, err := sqlx.In("UPDATE event_queue SET processed = 2 WHERE event_id IN (?)", ids)
+	query, args, err := sqlx.In("UPDATE event_queue SET processed = 2, claimed_at_ns = ? WHERE event_id IN (?)", time.Now().UnixNano(), ids)
 	if err != nil {
 		return nil, fmt.Errorf("claim build update: %w", err)
 	}
@@ -135,7 +140,7 @@ func (s *Store) Claim(ctx context.Context, limit int) ([]api.Event, error) {
 	return events, nil
 }
 
-// Ack marks claimed events fully processed (2 -> 1); they will not be claimed again. A separate retention sweep removes acknowledged
+// Ack marks claimed events fully processed (-> 1); they will not be claimed again. A separate retention sweep removes acknowledged
 // rows so the queue stays small (the archive holds the retained history).
 func (s *Store) Ack(ctx context.Context, eventIDs []string) error {
 	if len(eventIDs) == 0 {
@@ -151,13 +156,13 @@ func (s *Store) Ack(ctx context.Context, eventIDs []string) error {
 	return nil
 }
 
-// Nack returns claimed events to the not-yet-processed state for a later Claim. Scoped to processed = 2 so it only reverts in-flight
-// rows and never resurrects an already-acknowledged event.
+// Nack returns claimed events to the not-yet-processed state for an immediate later Claim, clearing the claim timestamp. Scoped to
+// processed = 2 so it only reverts in-flight rows and never resurrects an already-acknowledged event.
 func (s *Store) Nack(ctx context.Context, eventIDs []string) error {
 	if len(eventIDs) == 0 {
 		return nil
 	}
-	query, args, err := sqlx.In("UPDATE event_queue SET processed = 0 WHERE processed = 2 AND event_id IN (?)", eventIDs)
+	query, args, err := sqlx.In("UPDATE event_queue SET processed = 0, claimed_at_ns = 0 WHERE processed = 2 AND event_id IN (?)", eventIDs)
 	if err != nil {
 		return fmt.Errorf("nack build query: %w", err)
 	}
@@ -175,33 +180,4 @@ func (s *Store) CountPending(ctx context.Context) (int64, error) {
 		return 0, fmt.Errorf("count pending: %w", err)
 	}
 	return count, nil
-}
-
-// withDeadlockRetry retries fn on a MySQL deadlock (1213) up to maxAttempts with linear backoff, honoring ctx cancellation. Any
-// non-deadlock error returns immediately.
-func withDeadlockRetry(ctx context.Context, maxAttempts int, step time.Duration, fn func() error) error {
-	var lastErr error
-	for attempt := 1; attempt <= maxAttempts; attempt++ {
-		lastErr = fn()
-		if lastErr == nil {
-			return nil
-		}
-		if !isDeadlockErr(lastErr) {
-			return lastErr
-		}
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-time.After(time.Duration(attempt) * step):
-		}
-	}
-	return lastErr
-}
-
-func isDeadlockErr(err error) bool {
-	var mysqlErr *mysql.MySQLError
-	if !errors.As(err, &mysqlErr) {
-		return false
-	}
-	return mysqlErr.Number == mysqlErrDeadlock
 }

--- a/server/visibility/internal/eventlog/store_test.go
+++ b/server/visibility/internal/eventlog/store_test.go
@@ -1,0 +1,123 @@
+package eventlog
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fleetdm/edr/server/visibility/api"
+)
+
+func TestNew_NilDB(t *testing.T) {
+	t.Parallel()
+	_, err := New(nil)
+	require.Error(t, err)
+}
+
+func TestIsDeadlockErr(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"deadlock", &mysql.MySQLError{Number: mysqlErrDeadlock}, true},
+		{"other mysql error", &mysql.MySQLError{Number: 1062}, false},
+		{"plain error", errors.New("boom"), false},
+		{"nil", nil, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, isDeadlockErr(tc.err))
+		})
+	}
+}
+
+func TestWithDeadlockRetry(t *testing.T) {
+	t.Parallel()
+	deadlock := &mysql.MySQLError{Number: mysqlErrDeadlock}
+
+	t.Run("succeeds first try", func(t *testing.T) {
+		t.Parallel()
+		calls := 0
+		err := withDeadlockRetry(context.Background(), 5, time.Millisecond, func() error {
+			calls++
+			return nil
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 1, calls)
+	})
+
+	t.Run("retries on deadlock then succeeds", func(t *testing.T) {
+		t.Parallel()
+		calls := 0
+		err := withDeadlockRetry(context.Background(), 5, time.Millisecond, func() error {
+			calls++
+			if calls < 3 {
+				return deadlock
+			}
+			return nil
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 3, calls)
+	})
+
+	t.Run("returns non-deadlock error immediately", func(t *testing.T) {
+		t.Parallel()
+		other := errors.New("syntax error")
+		calls := 0
+		err := withDeadlockRetry(context.Background(), 5, time.Millisecond, func() error {
+			calls++
+			return other
+		})
+		require.ErrorIs(t, err, other)
+		assert.Equal(t, 1, calls)
+	})
+
+	t.Run("gives up after maxAttempts on persistent deadlock", func(t *testing.T) {
+		t.Parallel()
+		calls := 0
+		err := withDeadlockRetry(context.Background(), 3, time.Millisecond, func() error {
+			calls++
+			return deadlock
+		})
+		require.Error(t, err)
+		assert.Equal(t, 3, calls)
+	})
+
+	t.Run("honors context cancellation between retries", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		err := withDeadlockRetry(ctx, 5, time.Second, func() error {
+			return deadlock
+		})
+		require.ErrorIs(t, err, context.Canceled)
+	})
+}
+
+func TestAppendArgs(t *testing.T) {
+	t.Parallel()
+	events := []api.Event{
+		{EventID: "e1", HostID: "h1", TimestampNs: 10, IngestedAtNs: 11, EventType: "exec", Payload: json.RawMessage(`{"pid":1}`)},
+		{EventID: "e2", HostID: "h1", TimestampNs: 20, IngestedAtNs: 21, EventType: "fork", Payload: json.RawMessage(`{"pid":2}`)},
+	}
+	placeholders, args, err := appendArgs(events)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"(?, ?, ?, ?, ?, ?)", "(?, ?, ?, ?, ?, ?)"}, placeholders)
+	require.Len(t, args, 12)
+	// First row's flattened args, in column order.
+	assert.Equal(t, "e1", args[0])
+	assert.Equal(t, "h1", args[1])
+	assert.Equal(t, int64(10), args[2])
+	assert.Equal(t, int64(11), args[3])
+	assert.Equal(t, "exec", args[4])
+	assert.Equal(t, []byte(`{"pid":1}`), args[5])
+}

--- a/server/visibility/internal/eventlog/store_test.go
+++ b/server/visibility/internal/eventlog/store_test.go
@@ -1,13 +1,9 @@
 package eventlog
 
 import (
-	"context"
 	"encoding/json"
-	"errors"
 	"testing"
-	"time"
 
-	"github.com/go-sql-driver/mysql"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -18,89 +14,6 @@ func TestNew_NilDB(t *testing.T) {
 	t.Parallel()
 	_, err := New(nil)
 	require.Error(t, err)
-}
-
-func TestIsDeadlockErr(t *testing.T) {
-	t.Parallel()
-	cases := []struct {
-		name string
-		err  error
-		want bool
-	}{
-		{"deadlock", &mysql.MySQLError{Number: mysqlErrDeadlock}, true},
-		{"other mysql error", &mysql.MySQLError{Number: 1062}, false},
-		{"plain error", errors.New("boom"), false},
-		{"nil", nil, false},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			assert.Equal(t, tc.want, isDeadlockErr(tc.err))
-		})
-	}
-}
-
-func TestWithDeadlockRetry(t *testing.T) {
-	t.Parallel()
-	deadlock := &mysql.MySQLError{Number: mysqlErrDeadlock}
-
-	t.Run("succeeds first try", func(t *testing.T) {
-		t.Parallel()
-		calls := 0
-		err := withDeadlockRetry(context.Background(), 5, time.Millisecond, func() error {
-			calls++
-			return nil
-		})
-		require.NoError(t, err)
-		assert.Equal(t, 1, calls)
-	})
-
-	t.Run("retries on deadlock then succeeds", func(t *testing.T) {
-		t.Parallel()
-		calls := 0
-		err := withDeadlockRetry(context.Background(), 5, time.Millisecond, func() error {
-			calls++
-			if calls < 3 {
-				return deadlock
-			}
-			return nil
-		})
-		require.NoError(t, err)
-		assert.Equal(t, 3, calls)
-	})
-
-	t.Run("returns non-deadlock error immediately", func(t *testing.T) {
-		t.Parallel()
-		other := errors.New("syntax error")
-		calls := 0
-		err := withDeadlockRetry(context.Background(), 5, time.Millisecond, func() error {
-			calls++
-			return other
-		})
-		require.ErrorIs(t, err, other)
-		assert.Equal(t, 1, calls)
-	})
-
-	t.Run("gives up after maxAttempts on persistent deadlock", func(t *testing.T) {
-		t.Parallel()
-		calls := 0
-		err := withDeadlockRetry(context.Background(), 3, time.Millisecond, func() error {
-			calls++
-			return deadlock
-		})
-		require.Error(t, err)
-		assert.Equal(t, 3, calls)
-	})
-
-	t.Run("honors context cancellation between retries", func(t *testing.T) {
-		t.Parallel()
-		ctx, cancel := context.WithCancel(context.Background())
-		cancel()
-		err := withDeadlockRetry(ctx, 5, time.Second, func() error {
-			return deadlock
-		})
-		require.ErrorIs(t, err, context.Canceled)
-	})
 }
 
 func TestAppendArgs(t *testing.T) {

--- a/server/visibility/internal/tests/eventlog_integration_test.go
+++ b/server/visibility/internal/tests/eventlog_integration_test.go
@@ -1,0 +1,140 @@
+//go:build integration
+
+// Package tests holds per-context integration tests for the visibility bounded context. They skip when EDR_TEST_DSN isn't set,
+// matching the project's other DB-using tests, and exercise the EventLog work queue via visibility/bootstrap against a real MySQL.
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fleetdm/edr/server/testdb"
+	visibilityapi "github.com/fleetdm/edr/server/visibility/api"
+	visibilitybootstrap "github.com/fleetdm/edr/server/visibility/bootstrap"
+	visibilitytestkit "github.com/fleetdm/edr/server/visibility/testkit"
+)
+
+func newEventLog(t *testing.T) visibilityapi.EventLog {
+	t.Helper()
+	db := testdb.Open(t)
+	require.NoError(t, visibilitytestkit.ApplySchema(t.Context(), db))
+	vis, err := visibilitybootstrap.New(visibilitybootstrap.Deps{DB: db})
+	require.NoError(t, err)
+	return vis.EventLog()
+}
+
+func ev(id, host string, ts int64, etype string) visibilityapi.Event {
+	return visibilityapi.Event{
+		EventID:      id,
+		HostID:       host,
+		TimestampNs:  ts,
+		IngestedAtNs: ts + 1,
+		EventType:    etype,
+		Payload:      json.RawMessage(`{"pid":1}`),
+	}
+}
+
+func ids(events []visibilityapi.Event) []string {
+	out := make([]string, len(events))
+	for i, e := range events {
+		out[i] = e.EventID
+	}
+	return out
+}
+
+func TestEventLog_AppendClaimAckNack(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	log := newEventLog(t)
+
+	require.NoError(t, log.Append(ctx, []visibilityapi.Event{
+		ev("e1", "h1", 100, "exec"),
+		ev("e2", "h1", 200, "fork"),
+	}))
+
+	pending, err := log.CountPending(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), pending, "both appended events are pending")
+
+	claimed, err := log.Claim(ctx, 10)
+	require.NoError(t, err)
+	require.Len(t, claimed, 2)
+	assert.Equal(t, []string{"e1", "e2"}, ids(claimed))
+	assert.Equal(t, int64(101), claimed[0].IngestedAtNs, "ingested_at_ns round-trips from the stored row")
+
+	// A re-claim returns nothing: the rows are in-flight (processed = 2), not re-offered.
+	again, err := log.Claim(ctx, 10)
+	require.NoError(t, err)
+	assert.Empty(t, again)
+
+	// Ack one, Nack the other.
+	require.NoError(t, log.Ack(ctx, []string{"e1"}))
+	require.NoError(t, log.Nack(ctx, []string{"e2"}))
+
+	pending, err = log.CountPending(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), pending, "acked event leaves the pending count; nacked event remains")
+
+	// The nacked event is claimable again; the acked one is not.
+	reclaimed, err := log.Claim(ctx, 10)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"e2"}, ids(reclaimed))
+}
+
+func TestEventLog_IdempotentAppend(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	log := newEventLog(t)
+
+	batch := []visibilityapi.Event{ev("dup", "h1", 100, "exec")}
+	require.NoError(t, log.Append(ctx, batch))
+	require.NoError(t, log.Append(ctx, batch), "re-appending the same event_id is a no-op, not an error")
+
+	pending, err := log.CountPending(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), pending, "the duplicate event_id is not enqueued twice")
+}
+
+func TestEventLog_ClaimOrderingAndDisjoint(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	log := newEventLog(t)
+
+	// Interleave two hosts; the claim orders host-major then timestamp, and successive claims are disjoint.
+	require.NoError(t, log.Append(ctx, []visibilityapi.Event{
+		ev("b2", "hostB", 400, "exec"),
+		ev("a1", "hostA", 100, "exec"),
+		ev("b1", "hostB", 200, "exec"),
+		ev("a2", "hostA", 300, "exec"),
+	}))
+
+	first, err := log.Claim(ctx, 2)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"a1", "a2"}, ids(first), "ordered by (host_id, timestamp_ns)")
+
+	second, err := log.Claim(ctx, 2)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"b1", "b2"}, ids(second), "second claim is disjoint from the first")
+}
+
+func TestEventLog_EmptyOps(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	log := newEventLog(t)
+
+	require.NoError(t, log.Append(ctx, nil))
+	require.NoError(t, log.Ack(ctx, nil))
+	require.NoError(t, log.Nack(ctx, nil))
+
+	claimed, err := log.Claim(ctx, 0)
+	require.NoError(t, err)
+	assert.Empty(t, claimed)
+
+	pending, err := log.CountPending(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), pending)
+}

--- a/server/visibility/internal/tests/eventlog_integration_test.go
+++ b/server/visibility/internal/tests/eventlog_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/jmoiron/sqlx"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -20,11 +21,17 @@ import (
 
 func newEventLog(t *testing.T) visibilityapi.EventLog {
 	t.Helper()
+	log, _ := newEventLogWithDB(t)
+	return log
+}
+
+func newEventLogWithDB(t *testing.T) (visibilityapi.EventLog, *sqlx.DB) {
+	t.Helper()
 	db := testdb.Open(t)
 	require.NoError(t, visibilitytestkit.ApplySchema(t.Context(), db))
 	vis, err := visibilitybootstrap.New(visibilitybootstrap.Deps{DB: db})
 	require.NoError(t, err)
-	return vis.EventLog()
+	return vis.EventLog(), db
 }
 
 func ev(id, host string, ts int64, etype string) visibilityapi.Event {
@@ -119,6 +126,32 @@ func TestEventLog_ClaimOrderingAndDisjoint(t *testing.T) {
 	second, err := log.Claim(ctx, 2)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"b1", "b2"}, ids(second), "second claim is disjoint from the first")
+}
+
+func TestEventLog_ReclaimsStaleClaim(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	log, db := newEventLogWithDB(t)
+
+	require.NoError(t, log.Append(ctx, []visibilityapi.Event{ev("e1", "h1", 100, "exec")}))
+
+	claimed, err := log.Claim(ctx, 10)
+	require.NoError(t, err)
+	require.Len(t, claimed, 1, "the event is claimed and now in-flight")
+
+	// A fresh claim does not re-offer the in-flight event (its lease has not expired).
+	again, err := log.Claim(ctx, 10)
+	require.NoError(t, err)
+	assert.Empty(t, again, "an unexpired in-flight claim is not re-offered")
+
+	// Simulate a worker that crashed between Claim and Ack: backdate the claim past the lease.
+	_, err = db.ExecContext(ctx, "UPDATE event_queue SET claimed_at_ns = 1 WHERE event_id = ?", "e1")
+	require.NoError(t, err)
+
+	// The stale claim is now re-offered, so a crashed worker's events are not lost (at-least-once).
+	reclaimed, err := log.Claim(ctx, 10)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"e1"}, ids(reclaimed), "an expired claim is re-delivered on a later Claim")
 }
 
 func TestEventLog_EmptyOps(t *testing.T) {

--- a/server/visibility/migrations/00001_event_queue.sql
+++ b/server/visibility/migrations/00001_event_queue.sql
@@ -1,0 +1,23 @@
+-- +goose Up
+-- event_queue is the visibility context's durable work queue (ADR-0015): the EventLog seam that decouples ingestion from detection
+-- processing. It carries the full event envelope (payload included) so a claimer can build the process graph and evaluate rules
+-- without a second store read. `processed` is the claim state machine: 0 unclaimed, 2 claimed/in-flight, 1 acknowledged. The
+-- (processed, host_id, timestamp_ns) index backs the FOR UPDATE SKIP LOCKED claim ordered per host (ADR-0011). Rows are append-only
+-- here; the high-volume retained archive lives in ClickHouse, so this table holds only the in-flight + recently-acked working set.
+
+-- +goose StatementBegin
+CREATE TABLE IF NOT EXISTS event_queue (
+    event_id        VARCHAR(255) PRIMARY KEY,
+    host_id         VARCHAR(255) NOT NULL,
+    timestamp_ns    BIGINT       NOT NULL,
+    ingested_at_ns  BIGINT       NOT NULL DEFAULT 0,
+    event_type      VARCHAR(64)  NOT NULL,
+    payload         JSON         NOT NULL,
+    processed       TINYINT(1)   NOT NULL DEFAULT 0,
+    created_at      TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    INDEX idx_event_queue_claim (processed, host_id, timestamp_ns)
+);
+-- +goose StatementEnd
+
+-- +goose Down
+DROP TABLE IF EXISTS event_queue;

--- a/server/visibility/migrations/00001_event_queue.sql
+++ b/server/visibility/migrations/00001_event_queue.sql
@@ -14,6 +14,7 @@ CREATE TABLE IF NOT EXISTS event_queue (
     event_type      VARCHAR(64)  NOT NULL,
     payload         JSON         NOT NULL,
     processed       TINYINT(1)   NOT NULL DEFAULT 0,
+    claimed_at_ns   BIGINT       NOT NULL DEFAULT 0,
     created_at      TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
     INDEX idx_event_queue_claim (processed, host_id, timestamp_ns)
 );

--- a/server/visibility/migrations/embed.go
+++ b/server/visibility/migrations/embed.go
@@ -1,0 +1,11 @@
+// Package migrations holds the visibility bounded context's goose-managed SQL migration corpus, embedded so it can be applied at
+// boot by server/migrations/runner without the binary reading from disk.
+package migrations
+
+import "embed"
+
+// FS is visibility's migration corpus: NNNNN_name.sql files at the FS root. server/visibility/bootstrap.ApplySchema passes it to
+// runner.Up against the visibility_goose_db_version tracking table.
+//
+//go:embed *.sql
+var FS embed.FS

--- a/server/visibility/testkit/testkit.go
+++ b/server/visibility/testkit/testkit.go
@@ -1,0 +1,17 @@
+// Package testkit is visibility's coordinated test-fixture surface. Tests reach for testkit; production wiring (cmd/main) reaches for
+// bootstrap. arch-go pins the split and pins testkit to its own context so it cannot become a transitive cross-context sneak-in path.
+package testkit
+
+import (
+	"context"
+
+	"github.com/jmoiron/sqlx"
+
+	"github.com/fleetdm/edr/server/visibility/bootstrap"
+)
+
+// ApplySchema runs visibility's DDL against db. Thin wrapper over bootstrap.ApplySchema so the test surface is importable separately
+// from the production wiring surface.
+func ApplySchema(ctx context.Context, db *sqlx.DB) error {
+	return bootstrap.ApplySchema(ctx, db)
+}


### PR DESCRIPTION
Second increment of the ClickHouse transition (ADR-0015), after #507 (the `visibility/api` scaffold). Implements the **EventLog** seam: the durable, multi-replica work queue that decouples ingestion from detection processing.

## What this is

**No behavior change** — the queue is implemented and tested but not yet wired into the live ingest/processor path (that's the cutover PR). The transition needs two stores; this builds the MySQL work-queue half first because it's the ADR-0011-critical claim, mirrors detection's proven code, and is fully testable against the existing MySQL infra (no new CI service).

- **`server/visibility/internal/eventlog`** — MySQL-backed `EventLog` over a new `event_queue` table: `Append` (idempotent `INSERT IGNORE`), `Claim` (`FOR UPDATE SKIP LOCKED`, per-host order, `processed 0→2`), `Ack` (`2→1`), `Nack` (`2→0`), `CountPending`. Mirrors the detection event store's proven claim + deadlock-retry patterns (ADR-0011); the queue carries the payload so a claimer needs no second store read.
- **`server/visibility/migrations`** — `00001_event_queue.sql` (goose MySQL), embedded.
- **`server/visibility/bootstrap` + `testkit`** — `New`/`ApplySchema` wiring + the test-fixture surface, mirroring the other contexts.
- **arch-go** — `visibility.internal` + `visibility.testkit` blocks (least-privilege: the queue store depends only on `visibility.api`).

## Why no spec delta

This realizes the "Decoupled processing pipeline" behavior already specified in the merged `clickhouse-event-store` OpenSpec change. It touches none of the OpenSpec sync-gate paths (`server/rules/internal/catalog/`, `schema/events.json`, `server/detection/migrations/`), and introduces no new spec scenarios. spectrace markers land with the cutover (which implements the ingest path those scenarios describe).

## Verification

`go build ./...`, arch-go, golangci-lint (default + `integration` tags, 0 issues), unit tests, and integration tests against real MySQL (Append/Claim/Ack/Nack lifecycle, idempotency, per-host ordering, disjoint claims). Visibility coverage 84.7%.

## Remaining transition PRs

ClickHouse archive (`EventArchive` + CI ClickHouse service), then the cutover (intake fan-out, processor on the queue, reads → ClickHouse, `alert_event_payloads`, drop `events`, retention TTL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visibility event processing support with schema setup and a durable queue for storing, claiming, acknowledging, and requeuing events.
  * Added a shared test helper for applying the visibility schema in test environments.

* **Bug Fixes**
  * Improved handling of duplicate event inserts to avoid creating extra queue entries.
  * Added safer behavior for empty operations and database-related failures.

* **Tests**
  * Added unit and integration coverage for queue behavior, retry handling, ordering, and claim/ack/nack transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->