### PR TITLE
feat(visibility): batch-prune acked rows from the event work queue (#427)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Notable changes to Fleet EDR, newest first. This project follows [Semantic Versi
 
 ### Changed
 
-- **Events move to a ClickHouse archive + a MySQL work queue.** Ingestion durably writes each accepted event to the ClickHouse archive and enqueues it on the MySQL queue, returning success only after both; the detection processor claims from the queue. Per-process network/DNS correlation and alert evidence read the archive. Event retention is now ClickHouse-native time-based expiry rather than a periodic MySQL delete (process-record pruning is unchanged).
+- **Events move to a ClickHouse archive + a MySQL work queue.** Ingestion durably writes each accepted event to the ClickHouse archive and enqueues it on the MySQL queue, returning success only after both; the detection processor claims from the queue. Per-process network/DNS correlation and alert evidence read the archive. Event retention is now ClickHouse-native time-based expiry rather than a periodic MySQL delete (process-record pruning is unchanged). A leader-gated sweep prunes acknowledged events from the work queue in batches so it keeps to its in-flight working set; the `edr.event_queue.rows_pruned` metric reports its throughput.
 
 ## [0.3.0] (2026-06-26)
 

--- a/openspec/changes/clickhouse-event-store/specs/server-event-ingestion/spec.md
+++ b/openspec/changes/clickhouse-event-store/specs/server-event-ingestion/spec.md
@@ -19,6 +19,14 @@ The system SHALL, on accepting a batch, durably store every retained event in th
 - **AND** every retained event is enqueued on the work queue marked not yet processed
 - **AND** the system responds with HTTP 200 only after both writes succeed
 
+#### Scenario: Acknowledged work is pruned from the queue
+
+- **GIVEN** events that have been claimed and acknowledged (fully processed) alongside others still unprocessed or in-flight
+- **WHEN** the queue-prune sweep runs
+- **THEN** the acknowledged events are removed from the work queue in bounded batches
+- **AND** the unprocessed and in-flight events remain claimable
+- **AND** the durable history in the event archive is unaffected
+
 ### Requirement: Horizontally scalable ingestion service
 
 The system SHALL support running the ingestion endpoint as a standalone service that shares only its backing stores (the event archive and the work queue) with the processing service. Multiple replicas of the ingestion service MUST be able to accept agent traffic concurrently against the same backing stores without coordinating with each other.

--- a/server/cmd/fleet-edr-server/main.go
+++ b/server/cmd/fleet-edr-server/main.go
@@ -407,6 +407,7 @@ func openDetection(
 		StaleProcessInterval: config.DefaultStaleProcessInterval,
 		RetentionDays:        cfg.RetentionDays,
 		RetentionInterval:    config.DefaultRetentionInterval,
+		QueuePruneInterval:   config.DefaultQueuePruneInterval,
 		UserExists:           w.identity.Service().UserExists,
 		Audit:                w.identity.AuditRecorder(),
 		AuthZ:                w.identity.AuthZ(),

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -29,6 +29,9 @@ const (
 	defaultRetentionDays = 30
 	// DefaultRetentionInterval is how often the retention runner wakes up. Wired into the retention runner at boot (no longer an env knob).
 	DefaultRetentionInterval = time.Hour
+	// DefaultQueuePruneInterval is how often the event-queue sweep removes acked rows (ADR-0015). Far shorter than the retention
+	// interval: the queue grows at the ingest rate, not the retention window, so a frequent cheap sweep keeps it to its working set.
+	DefaultQueuePruneInterval = time.Minute
 	// DefaultStaleProcessTTL is the fork-time age past which a still-running process row is force-exited by the freshness reconciler.
 	// Long enough to cover an analyst's working window; short enough that overnight greens are gone by morning.
 	DefaultStaleProcessTTL = 6 * time.Hour

--- a/server/detection/api/service.go
+++ b/server/detection/api/service.go
@@ -99,4 +99,7 @@ type MetricsRecorder interface {
 	// ProcessRetentionRowsDeleted is called by the pipeline's retention runner on every pass with the count of completed process rows
 	// pruned past the retention window (counted separately from event rows).
 	ProcessRetentionRowsDeleted(ctx context.Context, n int64)
+	// QueueRowsPruned is called by the pipeline's queue-prune sweep on every pass with the number of acked rows removed from the event
+	// work queue (the visibility EventLog), so operators can watch the sweep keep pace with ingest (ADR-0015).
+	QueueRowsPruned(ctx context.Context, n int64)
 }

--- a/server/detection/bootstrap/bootstrap.go
+++ b/server/detection/bootstrap/bootstrap.go
@@ -66,6 +66,9 @@ type Deps struct {
 	StaleProcessInterval time.Duration
 	RetentionDays        int
 	RetentionInterval    time.Duration
+	// QueuePruneInterval is the cadence of the visibility event-queue sweep that removes acked rows (ADR-0015). Zero uses the
+	// pipeline default (1 minute). Independent of RetentionDays: the queue is swept even when age-based retention is disabled.
+	QueuePruneInterval time.Duration
 
 	// Cross-context inputs (Full mode only).
 	UserExists UserExists
@@ -177,10 +180,15 @@ func New(deps Deps) (*Detection, error) {
 			Interval:      deps.RetentionInterval,
 			Logger:        logger,
 		})
+		queuePrune := pipeline.NewQueuePrune(deps.EventLog, pipeline.QueuePruneOptions{
+			Interval: deps.QueuePruneInterval,
+			Logger:   logger,
+		})
 		det.pipe = pipeline.NewRunner(pipeline.RunnerOptions{
 			Processor:   processor,
 			ProcessTTL:  processTTL,
 			Retention:   retention,
+			QueuePrune:  queuePrune,
 			DB:          deps.DB,
 			Coordinator: deps.Coordinator,
 		})

--- a/server/detection/internal/intake/fanout_test.go
+++ b/server/detection/internal/intake/fanout_test.go
@@ -47,10 +47,11 @@ func (f *fakeEventLog) Append(_ context.Context, events []api.Event) error {
 	f.appended = append(f.appended, events)
 	return f.appendErr
 }
-func (f *fakeEventLog) Claim(context.Context, int) ([]api.Event, error) { return nil, nil }
-func (f *fakeEventLog) Ack(context.Context, []string) error             { return nil }
-func (f *fakeEventLog) Nack(context.Context, []string) error            { return nil }
-func (f *fakeEventLog) CountPending(context.Context) (int64, error)     { return 0, nil }
+func (f *fakeEventLog) Claim(context.Context, int) ([]api.Event, error)    { return nil, nil }
+func (f *fakeEventLog) Ack(context.Context, []string) error                { return nil }
+func (f *fakeEventLog) Nack(context.Context, []string) error               { return nil }
+func (f *fakeEventLog) CountPending(context.Context) (int64, error)        { return 0, nil }
+func (f *fakeEventLog) PruneProcessed(context.Context, int) (int64, error) { return 0, nil }
 
 // postBatch drives handleIngest directly with host_id pinned the way the HostToken middleware does, so these tests need no DB: the
 // store (host-summary + snapshot-freshness writes) is only reached after a successful fan-out, which the error-path cases never hit.

--- a/server/detection/internal/pipeline/periodic.go
+++ b/server/detection/internal/pipeline/periodic.go
@@ -1,0 +1,31 @@
+package pipeline
+
+import (
+	"context"
+	"log/slog"
+	"time"
+)
+
+// runPeriodic runs fn once immediately and then every interval until ctx is cancelled, logging a warning when a run returns an error.
+// The retention, process-TTL, and queue-prune sweeps share this driver: each is a "do one pass, sleep, repeat" loop whose only
+// differences are the interval, the log label, and the pass itself, so the ticker plumbing lives here once rather than copied per
+// runner. The pass returns a count the driver ignores (the runner records it); only the error reaches the log. A run that fails
+// because ctx was cancelled (a graceful shutdown mid-pass) is not logged: that error is expected, not a fault, so we suppress it to
+// keep shutdown quiet.
+func runPeriodic(ctx context.Context, interval time.Duration, logger *slog.Logger, name string, fn func(context.Context) (int64, error)) {
+	t := time.NewTicker(interval)
+	defer t.Stop()
+	if _, err := fn(ctx); err != nil && ctx.Err() == nil {
+		logger.WarnContext(ctx, name+" initial run failed", "err", err)
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			if _, err := fn(ctx); err != nil && ctx.Err() == nil {
+				logger.WarnContext(ctx, name+" run failed", "err", err)
+			}
+		}
+	}
+}

--- a/server/detection/internal/pipeline/periodic_test.go
+++ b/server/detection/internal/pipeline/periodic_test.go
@@ -1,0 +1,61 @@
+package pipeline
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestRunPeriodic pins the shared sweep driver: it runs the pass once immediately, again on each tick, returns when ctx is cancelled,
+// logs a live-context error, and suppresses an error caused by the cancellation itself (so a graceful shutdown stays quiet).
+func TestRunPeriodic(t *testing.T) {
+	t.Parallel()
+
+	t.Run("runs immediately, on each tick, and stops when ctx is cancelled", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancel := context.WithCancel(context.Background())
+		var calls atomic.Int32
+		done := make(chan struct{})
+		go func() {
+			runPeriodic(ctx, time.Millisecond, slog.Default(), "test", func(context.Context) (int64, error) {
+				// Return an error on the first pass (ctx still live) to exercise the warn branch, then cancel after a few ticks.
+				if n := calls.Add(1); n == 1 {
+					return 0, errors.New("transient")
+				} else if n >= 3 {
+					cancel()
+				}
+				return 0, nil
+			})
+			close(done)
+		}()
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Fatal("runPeriodic did not return after ctx cancellation")
+		}
+		assert.GreaterOrEqual(t, calls.Load(), int32(3), "runs the initial pass plus ticks until cancelled")
+	})
+
+	t.Run("a pass that fails because ctx was cancelled returns without hanging", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // pre-cancelled: the initial pass errors, the error is ctx-induced and suppressed, then the loop returns.
+		done := make(chan struct{})
+		go func() {
+			runPeriodic(ctx, time.Hour, slog.Default(), "test", func(context.Context) (int64, error) {
+				return 0, errors.New("ctx cancelled")
+			})
+			close(done)
+		}()
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Fatal("runPeriodic did not return on a pre-cancelled context")
+		}
+	})
+}

--- a/server/detection/internal/pipeline/processttl.go
+++ b/server/detection/internal/pipeline/processttl.go
@@ -91,21 +91,7 @@ func (r *ProcessTTLRunner) Loop(ctx context.Context) {
 		r.logger.InfoContext(ctx, "process-ttl reconciliation disabled", "edr.process.ttl_seconds", 0)
 		return
 	}
-	t := time.NewTicker(r.interval)
-	defer t.Stop()
-	if _, err := r.Run(ctx); err != nil {
-		r.logger.WarnContext(ctx, "process-ttl initial run failed", "err", err)
-	}
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-t.C:
-			if _, err := r.Run(ctx); err != nil {
-				r.logger.WarnContext(ctx, "process-ttl run failed", "err", err)
-			}
-		}
-	}
+	runPeriodic(ctx, r.interval, r.logger, "process-ttl", r.Run)
 }
 
 // Run executes one reconciliation pass and returns rows reconciled.

--- a/server/detection/internal/pipeline/queueprune.go
+++ b/server/detection/internal/pipeline/queueprune.go
@@ -31,7 +31,8 @@ type QueuePruneOptions struct {
 	// Interval between sweeps. Default 1 minute: frequent enough to keep the queue small at a high ingest rate, cheap because the
 	// DELETE is index-driven (the claim index leads with processed) and a no-op when nothing is acked.
 	Interval time.Duration
-	// BatchSize is the per-statement DELETE cap. Default 10_000, matching the process-retention sweep.
+	// BatchSize is the per-statement DELETE cap. Zero lets the EventLog apply its own default, keeping that default in one place
+	// (eventlog.Store owns it) rather than restating it here where the two could drift.
 	BatchSize int
 	Logger    *slog.Logger
 	Metrics   api.MetricsRecorder
@@ -41,9 +42,6 @@ type QueuePruneOptions struct {
 func NewQueuePrune(eventLog visibilityapi.EventLog, opts QueuePruneOptions) *QueuePruneRunner {
 	if opts.Interval <= 0 {
 		opts.Interval = time.Minute
-	}
-	if opts.BatchSize <= 0 {
-		opts.BatchSize = 10_000
 	}
 	if opts.Logger == nil {
 		opts.Logger = slog.Default()
@@ -63,28 +61,14 @@ func (r *QueuePruneRunner) SetMetrics(m api.MetricsRecorder) { r.metrics = m }
 // Loop runs a sweep immediately and then every interval until ctx is cancelled. A failed sweep logs and is retried on the next tick;
 // nothing is lost because the rows stay acked (processed = 1) until a later sweep removes them.
 func (r *QueuePruneRunner) Loop(ctx context.Context) {
-	t := time.NewTicker(r.interval)
-	defer t.Stop()
-	if _, err := r.Run(ctx); err != nil {
-		r.logger.WarnContext(ctx, "queue-prune initial run failed", "err", err)
-	}
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-t.C:
-			if _, err := r.Run(ctx); err != nil {
-				r.logger.WarnContext(ctx, "queue-prune run failed", "err", err)
-			}
-		}
-	}
+	runPeriodic(ctx, r.interval, r.logger, "queue-prune", r.Run)
 }
 
 // Run executes one sweep and returns the number of rows pruned. PruneProcessed batches the DELETEs internally; this records the total.
 func (r *QueuePruneRunner) Run(ctx context.Context) (int64, error) {
 	pruned, err := r.eventLog.PruneProcessed(ctx, r.batchSize)
 	// Record what was removed before checking the error: a mid-batch failure still removed `pruned` rows, and reporting them keeps the
-	// gauge honest (the same emit-then-check discipline the retention sweep uses).
+	// rows_pruned counter honest (the same emit-then-check discipline the retention sweep uses).
 	trace.SpanFromContext(ctx).SetAttributes(attribute.Int64("edr.event_queue.rows_pruned", pruned))
 	if r.metrics != nil {
 		r.metrics.QueueRowsPruned(ctx, pruned)

--- a/server/detection/internal/pipeline/queueprune.go
+++ b/server/detection/internal/pipeline/queueprune.go
@@ -1,0 +1,99 @@
+package pipeline
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/fleetdm/edr/server/detection/api"
+	visibilityapi "github.com/fleetdm/edr/server/visibility/api"
+)
+
+// QueuePruneRunner periodically removes acked rows from the visibility event work queue (ADR-0015). Ack only marks a row processed (a
+// cheap index UPDATE on the per-replica hot path); this leader-gated sweep does the batched DELETEs off that path so the queue keeps to
+// its in-flight working set rather than accumulating every processed event. Independent of event/process retention: the queue must be
+// swept even when age-based retention is disabled, and on a shorter cadence (the queue grows at the ingest rate, not the retention
+// window), so it is its own runner rather than folded into RetentionRunner. The durable history lives in the archive, so a pruned row
+// is never needed again.
+type QueuePruneRunner struct {
+	eventLog  visibilityapi.EventLog
+	interval  time.Duration
+	batchSize int
+	logger    *slog.Logger
+	metrics   api.MetricsRecorder
+}
+
+// QueuePruneOptions tune the queue-prune sweep.
+type QueuePruneOptions struct {
+	// Interval between sweeps. Default 1 minute: frequent enough to keep the queue small at a high ingest rate, cheap because the
+	// DELETE is index-driven (the claim index leads with processed) and a no-op when nothing is acked.
+	Interval time.Duration
+	// BatchSize is the per-statement DELETE cap. Default 10_000, matching the process-retention sweep.
+	BatchSize int
+	Logger    *slog.Logger
+	Metrics   api.MetricsRecorder
+}
+
+// NewQueuePrune builds a QueuePruneRunner over the given EventLog.
+func NewQueuePrune(eventLog visibilityapi.EventLog, opts QueuePruneOptions) *QueuePruneRunner {
+	if opts.Interval <= 0 {
+		opts.Interval = time.Minute
+	}
+	if opts.BatchSize <= 0 {
+		opts.BatchSize = 10_000
+	}
+	if opts.Logger == nil {
+		opts.Logger = slog.Default()
+	}
+	return &QueuePruneRunner{
+		eventLog:  eventLog,
+		interval:  opts.Interval,
+		batchSize: opts.BatchSize,
+		logger:    opts.Logger,
+		metrics:   opts.Metrics,
+	}
+}
+
+// SetMetrics installs the metrics recorder after construction (cmd/main two-phase setup, see RetentionRunner.SetMetrics).
+func (r *QueuePruneRunner) SetMetrics(m api.MetricsRecorder) { r.metrics = m }
+
+// Loop runs a sweep immediately and then every interval until ctx is cancelled. A failed sweep logs and is retried on the next tick;
+// nothing is lost because the rows stay acked (processed = 1) until a later sweep removes them.
+func (r *QueuePruneRunner) Loop(ctx context.Context) {
+	t := time.NewTicker(r.interval)
+	defer t.Stop()
+	if _, err := r.Run(ctx); err != nil {
+		r.logger.WarnContext(ctx, "queue-prune initial run failed", "err", err)
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			if _, err := r.Run(ctx); err != nil {
+				r.logger.WarnContext(ctx, "queue-prune run failed", "err", err)
+			}
+		}
+	}
+}
+
+// Run executes one sweep and returns the number of rows pruned. PruneProcessed batches the DELETEs internally; this records the total.
+func (r *QueuePruneRunner) Run(ctx context.Context) (int64, error) {
+	pruned, err := r.eventLog.PruneProcessed(ctx, r.batchSize)
+	// Record what was removed before checking the error: a mid-batch failure still removed `pruned` rows, and reporting them keeps the
+	// gauge honest (the same emit-then-check discipline the retention sweep uses).
+	trace.SpanFromContext(ctx).SetAttributes(attribute.Int64("edr.event_queue.rows_pruned", pruned))
+	if r.metrics != nil {
+		r.metrics.QueueRowsPruned(ctx, pruned)
+	}
+	if err != nil {
+		return pruned, err
+	}
+	if pruned > 0 {
+		r.logger.InfoContext(ctx, "pruned acked events from the queue", "rows", pruned)
+	}
+	return pruned, nil
+}

--- a/server/detection/internal/pipeline/queueprune_test.go
+++ b/server/detection/internal/pipeline/queueprune_test.go
@@ -1,0 +1,78 @@
+package pipeline
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	visibilityapi "github.com/fleetdm/edr/server/visibility/api"
+)
+
+// fakeEventLog records the batchSize PruneProcessed was called with and returns a scripted (count, err). The other EventLog methods are
+// unused by QueuePruneRunner, so they are inert.
+type fakeEventLog struct {
+	pruneN      int64
+	pruneErr    error
+	gotBatch    int
+	pruneCalled int
+}
+
+func (f *fakeEventLog) Append(context.Context, []visibilityapi.Event) error       { return nil }
+func (f *fakeEventLog) Claim(context.Context, int) ([]visibilityapi.Event, error) { return nil, nil }
+func (f *fakeEventLog) Ack(context.Context, []string) error                       { return nil }
+func (f *fakeEventLog) Nack(context.Context, []string) error                      { return nil }
+func (f *fakeEventLog) CountPending(context.Context) (int64, error)               { return 0, nil }
+func (f *fakeEventLog) PruneProcessed(_ context.Context, batchSize int) (int64, error) {
+	f.pruneCalled++
+	f.gotBatch = batchSize
+	return f.pruneN, f.pruneErr
+}
+
+func TestQueuePruneRunner_Run(t *testing.T) {
+	t.Parallel()
+
+	t.Run("prunes and reports the count", func(t *testing.T) {
+		t.Parallel()
+		log := &fakeEventLog{pruneN: 7}
+		r := NewQueuePrune(log, QueuePruneOptions{BatchSize: 500}) // metrics nil: Run must stay nil-safe
+		n, err := r.Run(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, int64(7), n, "Run returns the pruned count")
+		assert.Equal(t, 1, log.pruneCalled, "the sweep calls PruneProcessed once")
+		assert.Equal(t, 500, log.gotBatch, "the configured batch size is passed through")
+	})
+
+	t.Run("propagates a prune error", func(t *testing.T) {
+		t.Parallel()
+		log := &fakeEventLog{pruneN: 3, pruneErr: errors.New("db down")}
+		r := NewQueuePrune(log, QueuePruneOptions{})
+		n, err := r.Run(context.Background())
+		require.Error(t, err)
+		assert.Equal(t, int64(3), n, "rows removed before the failure are still reported")
+	})
+}
+
+// TestQueuePruneRunner_RecordsMetric pins that the configured recorder receives the pruned count.
+func TestQueuePruneRunner_RecordsMetric(t *testing.T) {
+	t.Parallel()
+	log := &fakeEventLog{pruneN: 5}
+	rec := &capturingRecorder{}
+	r := NewQueuePrune(log, QueuePruneOptions{Metrics: rec})
+	_, err := r.Run(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, int64(5), rec.queuePruned, "the pruned count is recorded to the metrics recorder")
+}
+
+// capturingRecorder is a MetricsRecorder that only captures the queue-prune count; the rest are inert.
+type capturingRecorder struct{ queuePruned int64 }
+
+func (c *capturingRecorder) EventsIngested(context.Context, string, int)         {}
+func (c *capturingRecorder) EventsHeartbeatDropped(context.Context, string, int) {}
+func (c *capturingRecorder) AlertCreated(context.Context, string, string)        {}
+func (c *capturingRecorder) ProcessesTTLReconciled(context.Context, int64)       {}
+func (c *capturingRecorder) RetentionRowsDeleted(context.Context, int64)         {}
+func (c *capturingRecorder) ProcessRetentionRowsDeleted(context.Context, int64)  {}
+func (c *capturingRecorder) QueueRowsPruned(_ context.Context, n int64)          { c.queuePruned += n }

--- a/server/detection/internal/pipeline/retention.go
+++ b/server/detection/internal/pipeline/retention.go
@@ -99,21 +99,7 @@ func (r *RetentionRunner) Loop(ctx context.Context) {
 		r.logger.InfoContext(ctx, "retention disabled", attrRetentionDays, 0)
 		return
 	}
-	t := time.NewTicker(r.interval)
-	defer t.Stop()
-	if _, err := r.Run(ctx); err != nil {
-		r.logger.WarnContext(ctx, "retention initial run failed", "err", err)
-	}
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-t.C:
-			if _, err := r.Run(ctx); err != nil {
-				r.logger.WarnContext(ctx, "retention run failed", "err", err)
-			}
-		}
-	}
+	runPeriodic(ctx, r.interval, r.logger, "retention", r.Run)
 }
 
 // Run executes one retention pass and returns the number of process records pruned. Event retention is ClickHouse-native TTL now

--- a/server/detection/internal/pipeline/runner.go
+++ b/server/detection/internal/pipeline/runner.go
@@ -59,8 +59,8 @@ func NewRunner(opts RunnerOptions) *Runner {
 	}
 }
 
-// SetMetrics propagates the metrics recorder to processTTL + retention (the processor itself doesn't take a recorder directly;
-// alert metrics flow through engine.SetMetrics). Called by Detection.SetMetrics.
+// SetMetrics propagates the metrics recorder to the processTTL, retention, and queue-prune sweeps (the processor itself doesn't take a
+// recorder directly; alert metrics flow through engine.SetMetrics). Called by Detection.SetMetrics.
 func (r *Runner) SetMetrics(m api.MetricsRecorder) {
 	if r.processTTL != nil {
 		r.processTTL.SetMetrics(m)
@@ -73,8 +73,8 @@ func (r *Runner) SetMetrics(m api.MetricsRecorder) {
 	}
 }
 
-// Run launches the three loops and blocks until ctx is cancelled and every loop returns. Each loop logs its own errors; a single
-// goroutine panic recovers via slog.Default per goroutine.
+// Run launches the configured loops (processor, process-TTL, retention, queue-prune) and blocks until ctx is cancelled and every loop
+// returns. Each loop logs its own errors; a single goroutine panic recovers via slog.Default per goroutine.
 func (r *Runner) Run(ctx context.Context) error {
 	var wg sync.WaitGroup
 	if r.processor != nil {

--- a/server/detection/internal/pipeline/runner.go
+++ b/server/detection/internal/pipeline/runner.go
@@ -15,19 +15,22 @@ import (
 const (
 	lockProcessTTL = "edr_process_ttl"
 	lockRetention  = "edr_retention"
+	lockQueuePrune = "edr_queue_prune"
 )
 
-// Runner composes the three background goroutines that the detection
-// context owns: processor (event materialisation + rule evaluation),
-// processttl (stale-process janitor), and retention (event purge).
+// Runner composes the background goroutines that the detection context
+// owns: processor (event materialisation + rule evaluation), processttl
+// (stale-process janitor), retention (process-record purge), and
+// queueprune (acked-event sweep of the visibility work queue).
 //
 // One Run(ctx) call fans them out under a shared WaitGroup; each loop
-// honours ctx cancellation independently. Run returns when all three
+// honours ctx cancellation independently. Run returns when all of them
 // have returned.
 type Runner struct {
 	processor   *Processor
 	processTTL  *ProcessTTLRunner
 	retention   *RetentionRunner
+	queuePrune  *QueuePruneRunner
 	coordinator leader.Coordinator
 }
 
@@ -36,6 +39,7 @@ type RunnerOptions struct {
 	Processor  *Processor
 	ProcessTTL *ProcessTTLRunner
 	Retention  *RetentionRunner
+	QueuePrune *QueuePruneRunner
 	DB         *sqlx.DB
 	// Coordinator gates the single-replica periodic tasks (processTTL + retention) so they run on exactly one replica at a time.
 	// Nil disables coordination: the tasks run directly on this process, which is correct for a single-replica deployment and for
@@ -50,6 +54,7 @@ func NewRunner(opts RunnerOptions) *Runner {
 		processor:   opts.Processor,
 		processTTL:  opts.ProcessTTL,
 		retention:   opts.Retention,
+		queuePrune:  opts.QueuePrune,
 		coordinator: opts.Coordinator,
 	}
 }
@@ -62,6 +67,9 @@ func (r *Runner) SetMetrics(m api.MetricsRecorder) {
 	}
 	if r.retention != nil {
 		r.retention.SetMetrics(m)
+	}
+	if r.queuePrune != nil {
+		r.queuePrune.SetMetrics(m)
 	}
 }
 
@@ -88,6 +96,14 @@ func (r *Runner) Run(ctx context.Context) error {
 		wg.Go(func() {
 			r.runLeaderGated(ctx, lockRetention, func(ctx context.Context) error {
 				r.retention.Loop(ctx)
+				return nil
+			})
+		})
+	}
+	if r.queuePrune != nil {
+		wg.Go(func() {
+			r.runLeaderGated(ctx, lockQueuePrune, func(ctx context.Context) error {
+				r.queuePrune.Loop(ctx)
 				return nil
 			})
 		})

--- a/server/detection/internal/tests/integration_test.go
+++ b/server/detection/internal/tests/integration_test.go
@@ -277,6 +277,10 @@ func (m *recordingMetrics) ProcessRetentionRowsDeleted(_ context.Context, n int6
 	m.processRowsDeleted += n
 }
 
+// QueueRowsPruned satisfies the recorder interface; this suite asserts queue-prune behavior through the EventLog + runner tests, not
+// this fake, so it is a no-op here.
+func (m *recordingMetrics) QueueRowsPruned(_ context.Context, _ int64) {}
+
 func (m *recordingMetrics) snapshot() (events, alerts int, reconciled, deleted int64) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -59,6 +59,7 @@ type Recorder struct {
 	alertsCreated               metric.Int64Counter
 	retentionRowsDeleted        metric.Int64Counter
 	processRetentionRowsDeleted metric.Int64Counter
+	queueRowsPruned             metric.Int64Counter
 	processesReconciled         metric.Int64Counter
 	queueDropped                metric.Int64Counter
 	httpRequestDuration         metric.Float64Histogram
@@ -118,6 +119,11 @@ func New(gauges GaugeSource, opts Options) *Recorder {
 	r.processRetentionRowsDeleted, _ = meter.Int64Counter(
 		"edr.retention.processes.rows_deleted",
 		metric.WithDescription("Total completed process rows deleted by the retention job since server start."),
+		metric.WithUnit("{row}"),
+	)
+	r.queueRowsPruned, _ = meter.Int64Counter(
+		"edr.event_queue.rows_pruned",
+		metric.WithDescription("Total acked rows pruned from the event work queue since server start."),
 		metric.WithUnit("{row}"),
 	)
 	r.processesReconciled, _ = meter.Int64Counter(
@@ -247,6 +253,15 @@ func (r *Recorder) ProcessRetentionRowsDeleted(ctx context.Context, n int64) {
 		return
 	}
 	r.processRetentionRowsDeleted.Add(ctx, n)
+}
+
+// QueueRowsPruned satisfies api.MetricsRecorder. Counts acked rows the queue-prune sweep removed from the event work queue, so a
+// dashboard can compare prune throughput against ingest and catch a sweep falling behind.
+func (r *Recorder) QueueRowsPruned(ctx context.Context, n int64) {
+	if r == nil || r.queueRowsPruned == nil || n <= 0 {
+		return
+	}
+	r.queueRowsPruned.Add(ctx, n)
 }
 
 // ProcessesTTLReconciled satisfies processttl.MetricsRecorder. A non-zero rate of this indicates the fleet is losing exit events

--- a/server/metrics/metrics_test.go
+++ b/server/metrics/metrics_test.go
@@ -137,6 +137,7 @@ func TestRecorder_RecordsCounters(t *testing.T) {
 	r.AlertCreated(ctx, "dyld_insert", "high")
 	r.RetentionRowsDeleted(ctx, 42)
 	r.ProcessRetentionRowsDeleted(ctx, 7)
+	r.QueueRowsPruned(ctx, 9)
 	r.QueueDropped(ctx, 3, false)
 	r.QueueDropped(ctx, 5, true)
 
@@ -147,6 +148,7 @@ func TestRecorder_RecordsCounters(t *testing.T) {
 	assert.Equal(t, int64(1), findSum(t, rm, "edr.alerts.created", map[string]any{"rule_id": "dyld_insert", "severity": "high"}))
 	assert.Equal(t, int64(42), findSum(t, rm, "edr.retention.rows_deleted", nil))
 	assert.Equal(t, int64(7), findSum(t, rm, "edr.retention.processes.rows_deleted", nil))
+	assert.Equal(t, int64(9), findSum(t, rm, "edr.event_queue.rows_pruned", nil))
 	assert.Equal(t, int64(3), findSum(t, rm, "edr.agent.queue.dropped", map[string]any{"lossy": false}))
 	assert.Equal(t, int64(5), findSum(t, rm, "edr.agent.queue.dropped", map[string]any{"lossy": true}))
 	assert.Equal(t, int64(3), findGauge(t, rm, "edr.enrolled.hosts"))

--- a/server/visibility/api/eventlog.go
+++ b/server/visibility/api/eventlog.go
@@ -32,4 +32,10 @@ type EventLog interface {
 
 	// CountPending counts events that have not been fully processed. Backs the processor-backlog gauge.
 	CountPending(ctx context.Context) (int64, error)
+
+	// PruneProcessed removes fully-processed (acked) events from the queue in batches of at most batchSize, returning the total
+	// removed. It is the sweep that keeps the queue to its in-flight working set (the archive holds the durable history); a high-volume
+	// deployment runs it on a cadence off the hot path rather than deleting on each Ack. Removing only acked events never affects a
+	// not-yet-processed or in-flight claim.
+	PruneProcessed(ctx context.Context, batchSize int) (int64, error)
 }

--- a/server/visibility/api/eventlog.go
+++ b/server/visibility/api/eventlog.go
@@ -22,8 +22,9 @@ type EventLog interface {
 	// concurrent claimers. The claimed events are hidden from other claimers until Ack or Nack.
 	Claim(ctx context.Context, limit int) ([]Event, error)
 
-	// Ack marks the claimed events (identified by EventID) fully processed; they leave the queue. Acknowledgment needs only identity,
-	// so it takes IDs rather than whole events: the caller need not retain the (potentially large) payloads until ack.
+	// Ack marks the claimed events (identified by EventID) fully processed: they are excluded from future claims but stay in the queue
+	// until PruneProcessed removes them, so Ack is a cheap index update off the delete path. Acknowledgment needs only identity, so it
+	// takes IDs rather than whole events: the caller need not retain the (potentially large) payloads until ack.
 	Ack(ctx context.Context, eventIDs []string) error
 
 	// Nack returns the claimed events (identified by EventID) to the not-yet-processed state for a later Claim (retry after a
@@ -33,9 +34,10 @@ type EventLog interface {
 	// CountPending counts events that have not been fully processed. Backs the processor-backlog gauge.
 	CountPending(ctx context.Context) (int64, error)
 
-	// PruneProcessed removes fully-processed (acked) events from the queue in batches of at most batchSize, returning the total
-	// removed. It is the sweep that keeps the queue to its in-flight working set (the archive holds the durable history); a high-volume
-	// deployment runs it on a cadence off the hot path rather than deleting on each Ack. Removing only acked events never affects a
-	// not-yet-processed or in-flight claim.
+	// PruneProcessed removes fully-processed (acked) events from the queue in batches of at most batchSize (a non-positive batchSize
+	// uses the implementation's default), returning the total removed. The count is meaningful even when err != nil: a sweep that fails
+	// mid-run still removed the returned rows. It is the sweep that keeps the queue to its in-flight working set (the archive holds the
+	// durable history); a high-volume deployment runs it on a cadence off the hot path rather than deleting on each Ack. Removing only
+	// acked events never affects a not-yet-processed or in-flight claim.
 	PruneProcessed(ctx context.Context, batchSize int) (int64, error)
 }

--- a/server/visibility/internal/eventlog/store.go
+++ b/server/visibility/internal/eventlog/store.go
@@ -18,10 +18,11 @@ import (
 )
 
 const (
-	// insertMaxAttempts / insertBackoffStep bound the deadlock-retry loop. Concurrent multi-replica appends to event_queue can deadlock
-	// on secondary-index gap locks under INSERT IGNORE (MySQL 1213); a few linear-backoff retries clear it.
-	insertMaxAttempts = 5
-	insertBackoffStep = 5 * time.Millisecond
+	// deadlockMaxAttempts / deadlockBackoffStep bound the deadlock-retry loop shared by the append and prune paths. Concurrent
+	// multi-replica writes to event_queue can deadlock on secondary-index gap locks (MySQL 1213) under INSERT IGNORE or a batched
+	// DELETE; a few linear-backoff retries clear it.
+	deadlockMaxAttempts = 5
+	deadlockBackoffStep = 5 * time.Millisecond
 
 	// appendChunkRows caps a single multi-row INSERT at 500 events (6 placeholders each, well under MySQL's 65535-placeholder and
 	// 4 MB max_allowed_packet ceilings).
@@ -59,7 +60,7 @@ func (s *Store) Append(ctx context.Context, events []api.Event) error {
 	if len(events) == 0 {
 		return nil
 	}
-	return sqlhelpers.WithDeadlockRetry(ctx, insertMaxAttempts, insertBackoffStep, func() error {
+	return sqlhelpers.WithDeadlockRetry(ctx, deadlockMaxAttempts, deadlockBackoffStep, func() error {
 		return s.appendOnce(ctx, events)
 	})
 }
@@ -140,7 +141,7 @@ func (s *Store) Claim(ctx context.Context, limit int) ([]api.Event, error) {
 	return events, nil
 }
 
-// Ack marks claimed events fully processed (-> 1); they will not be claimed again. A separate retention sweep removes acknowledged
+// Ack marks claimed events fully processed (-> 1); they will not be claimed again. A separate PruneProcessed sweep removes acknowledged
 // rows so the queue stays small (the archive holds the retained history).
 func (s *Store) Ack(ctx context.Context, eventIDs []string) error {
 	if len(eventIDs) == 0 {
@@ -198,7 +199,7 @@ func (s *Store) PruneProcessed(ctx context.Context, batchSize int) (int64, error
 	var total int64
 	for {
 		var affected int64
-		if err := sqlhelpers.WithDeadlockRetry(ctx, insertMaxAttempts, insertBackoffStep, func() error {
+		if err := sqlhelpers.WithDeadlockRetry(ctx, deadlockMaxAttempts, deadlockBackoffStep, func() error {
 			res, err := s.db.ExecContext(ctx,
 				"DELETE FROM event_queue WHERE processed = 1 ORDER BY host_id, timestamp_ns LIMIT ?", batchSize)
 			if err != nil {

--- a/server/visibility/internal/eventlog/store.go
+++ b/server/visibility/internal/eventlog/store.go
@@ -181,3 +181,37 @@ func (s *Store) CountPending(ctx context.Context) (int64, error) {
 	}
 	return count, nil
 }
+
+// defaultPruneBatch caps a single prune DELETE so each statement's InnoDB row-lock + undo footprint stays bounded on a large backlog,
+// the same per-batch discipline the process-retention sweep uses.
+const defaultPruneBatch = 10_000
+
+// PruneProcessed deletes acked rows (processed = 1) in bounded batches until none remain, returning the total removed. Ack only marks a
+// row processed (a cheap index UPDATE on the hot path); this sweep does the deletes off the hot path so a high-volume queue does not
+// accumulate. The DELETE is index-driven (the claim index leads with processed) and ordered like the claim, and each batch is
+// deadlock-retried since concurrent claims take gap locks on the same index. processed = 1 is terminal (Nack only reverts processed = 2),
+// so a row selected here is never concurrently resurrected.
+func (s *Store) PruneProcessed(ctx context.Context, batchSize int) (int64, error) {
+	if batchSize <= 0 {
+		batchSize = defaultPruneBatch
+	}
+	var total int64
+	for {
+		var affected int64
+		if err := sqlhelpers.WithDeadlockRetry(ctx, insertMaxAttempts, insertBackoffStep, func() error {
+			res, err := s.db.ExecContext(ctx,
+				"DELETE FROM event_queue WHERE processed = 1 ORDER BY host_id, timestamp_ns LIMIT ?", batchSize)
+			if err != nil {
+				return err
+			}
+			affected, err = res.RowsAffected()
+			return err
+		}); err != nil {
+			return total, fmt.Errorf("prune processed event_queue: %w", err)
+		}
+		total += affected
+		if affected < int64(batchSize) {
+			return total, nil
+		}
+	}
+}

--- a/server/visibility/internal/tests/eventlog_integration_test.go
+++ b/server/visibility/internal/tests/eventlog_integration_test.go
@@ -198,6 +198,72 @@ func TestEventLog_ConcurrentReplicasShareOneQueue(t *testing.T) {
 		"each event_id is enqueued exactly once despite both replicas appending it concurrently")
 }
 
+// spec:server-event-ingestion/decoupled-processing-pipeline/acknowledged-work-is-pruned-from-the-queue
+//
+// PruneProcessed removes acked rows (processed = 1) so the queue keeps to its in-flight working set, while leaving unprocessed
+// (processed = 0) and in-flight (claimed, processed = 2) rows for a later claim.
+func TestEventLog_PruneProcessedRemovesOnlyAcked(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	log := newEventLog(t)
+
+	require.NoError(t, log.Append(ctx, []visibilityapi.Event{
+		ev("acked", "h1", 100, "exec"),
+		ev("inflight", "h1", 200, "exec"),
+		ev("waiting", "h1", 300, "exec"),
+	}))
+
+	// Claim acked+inflight, ack only "acked", leave "inflight" claimed (processed = 2), "waiting" untouched (processed = 0).
+	claimed, err := log.Claim(ctx, 2)
+	require.NoError(t, err)
+	require.Equal(t, []string{"acked", "inflight"}, ids(claimed))
+	require.NoError(t, log.Ack(ctx, []string{"acked"}))
+
+	pruned, err := log.PruneProcessed(ctx, 10)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), pruned, "only the acked row is pruned")
+
+	// The acked row is gone; the in-flight and waiting rows remain (CountPending still counts both not-fully-processed rows).
+	pending, err := log.CountPending(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), pending, "in-flight + waiting rows survive the prune")
+
+	// A second prune with nothing acked is a no-op.
+	pruned, err = log.PruneProcessed(ctx, 10)
+	require.NoError(t, err)
+	assert.Zero(t, pruned, "nothing left to prune")
+}
+
+// TestEventLog_PruneProcessedBatches drives the batched DELETE loop across more than one batch (batchSize < acked count) and confirms
+// every acked row is removed.
+func TestEventLog_PruneProcessedBatches(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	log := newEventLog(t)
+
+	const n = 25
+	batch := make([]visibilityapi.Event, n)
+	allIDs := make([]string, n)
+	for i := range batch {
+		allIDs[i] = fmt.Sprintf("e-%02d", i)
+		batch[i] = ev(allIDs[i], "h1", int64(i+1), "exec")
+	}
+	require.NoError(t, log.Append(ctx, batch))
+	claimed, err := log.Claim(ctx, n)
+	require.NoError(t, err)
+	require.Len(t, claimed, n)
+	require.NoError(t, log.Ack(ctx, allIDs))
+
+	// batchSize 10 < 25 acked, so the internal loop runs three DELETEs (10, 10, 5) and removes all of them.
+	pruned, err := log.PruneProcessed(ctx, 10)
+	require.NoError(t, err)
+	assert.Equal(t, int64(n), pruned, "every acked row is removed across batches")
+
+	pending, err := log.CountPending(ctx)
+	require.NoError(t, err)
+	assert.Zero(t, pending, "queue is empty after pruning all acked rows")
+}
+
 func TestEventLog_EmptyOps(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()


### PR DESCRIPTION
## Summary

The ClickHouse cutover (#532) wired `EventLog.Ack` to mark rows `processed = 1` but nothing removed them, so the MySQL `event_queue` grew unbounded (confirmed on the demo: 1557 rows after a full seed). `CountPending` stayed correct, so detection was unaffected, but the table would grow without bound at fleet scale. The `Ack` doc already promised "a separate retention sweep" — this adds it.

For a high-throughput EDR the delete should not sit on the per-replica hot processing path, so `Ack` stays a cheap index UPDATE and a **leader-gated sweep does batched DELETEs off that path** — the same per-batch discipline the process-retention runner uses. The claim's `WHERE processed = 0` index seek is unaffected by piled-up done rows.

## Changes

- **`EventLog.PruneProcessed(ctx, batchSize)`**: batched, deadlock-retried DELETE of `processed = 1` rows until none remain. Only acked rows are removed (Nack reverts `processed = 2`, so a selected row is never concurrently resurrected). The ClickHouse archive history is untouched.
- **`QueuePruneRunner`**: a leader-gated loop with its own advisory lock and a 1-minute default interval, independent of age-based retention (the queue must be swept even when retention is disabled, and on a shorter cadence since it grows at the ingest rate). Wired into the detection `pipeline.Runner`.
- **Metric** `edr.event_queue.rows_pruned` so operators can watch the sweep keep pace with ingest.
- **OpenSpec**: adds the "Acknowledged work is pruned from the queue" scenario to the `clickhouse-event-store` delta's Decoupled-processing-pipeline requirement.

## Tests

`EventLog.PruneProcessed` (only-acked survivorship + multi-batch loop, integration), `QueuePruneRunner.Run` (count, error propagation, metric, unit), the recorder counter, and the detection + visibility integration suites (pipeline wiring regression-free). spectrace 548/548; openspec validate clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added periodic pruning of processed events from the event queue, helping keep the queue smaller over time.
  * Introduced a new metric to track how many queue rows are removed during pruning.
  * Queue maintenance now runs with a default cadence during startup.

* **Bug Fixes**
  * Event ingestion now reports success only after the event is safely stored and queued.
  * Queue pruning preserves unprocessed and in-flight events while removing only acknowledged ones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->