### PR TITLE
scale (#203): server-backlog gate for the M12 harness + ADR-0016 event-delivery substrate

### DIFF
--- a/docs/adr/0016-event-delivery-substrate.md
+++ b/docs/adr/0016-event-delivery-substrate.md
@@ -1,0 +1,57 @@
+# 0016. Event delivery: database-backed work queue now, streaming substrate at scale
+
+- Status: Accepted
+- Date: 2026-06-28
+- Deciders: getvictor
+
+## Context
+
+After the ClickHouse cutover (ADR-0015), ingestion fans out each batch to the ClickHouse event archive plus a MySQL `event_queue` work queue. The detection processor claims from that queue with `SELECT ... FOR UPDATE SKIP LOCKED` (ADR-0011), processes the batch (process-graph materialization plus rule evaluation), acks it (`processed = 1`), and a leader-gated sweep prunes acked rows. This is the "database as a work queue" pattern: no message broker, all delivery state lives in MySQL.
+
+A scale test (#203) on one server replica against an isolated stack characterized the ceiling. Ingest itself scaled cleanly to 500 simulated hosts (p99 136ms, zero errors, server RSS flat). The detection processor did not keep pace: the `event_queue` backlog grew linearly (0 to ~37k pending) at 500 hosts on one replica, while 200 hosts stayed bounded, so the single-replica breakeven is roughly 300 hosts at a deliberately detection-heavy synthetic mix (20% of hosts running attack scenarios continuously). Running the same 500-host load across three replicas behind a balancer kept the backlog bounded under ~500: the processor is not leader-gated and scales out linearly via SKIP LOCKED.
+
+A pprof pass on a saturated single replica showed the processor is I/O-round-trip bound, not compute bound: only 25% CPU utilization over the sample window, ~74% of on-CPU time in syscalls and netpoll (waiting on the DB), and the wall-time concentrated in the graph builder doing per-event `SELECT` then `UPDATE`/`INSERT` round-trips (`GetProcessByPID` then `UpdateProcessExec`), one event at a time on a single goroutine. A 500-event batch is ~1000 to 1500 sequential DB round-trips.
+
+The forward question this raises: a high-scale EDR ultimately wants servers to consume from a streaming log (Kafka, Redpanda, NATS JetStream) rather than poll a database. Do we adopt a streaming backbone now, and is the throughput work worth doing on the DB-queue model if streaming replaces it later?
+
+## Decision
+
+Keep the database-backed work queue (`event_queue` plus the ADR-0011 SKIP LOCKED claim) as the event-delivery substrate for the current pilot envelope (10 to 500 endpoints, single-VM and quickstart deployment). Invest in detection-processor throughput now (batch the per-event DB round-trips in the graph builder and rule evaluation; add intra-replica processing concurrency) rather than introducing a streaming backbone. Adopt a streaming substrate only when we outgrow DB-as-queue (thousands or more endpoints, or multi-tenant SaaS), and when we do, favor a single-binary substrate (Redpanda or NATS JetStream) over a full Kafka plus ZooKeeper deployment so the self-hosted deployment story survives.
+
+The throughput work is the right near-term spend because the dominant cost (per-event processing in the graph builder and rule evaluator) is independent of how events are delivered, so it lands in the part that a streaming migration keeps. The lever transfer:
+
+| Lever (today) | Under a streaming substrate | Survives the migration? |
+| --- | --- | --- |
+| Batch the per-event DB round-trips (set-based `GetProcessByPID`, batched writes, one transaction per batch) | Unchanged: the processor still builds the graph and evaluates rules per event regardless of delivery | Yes, and it becomes the dominant lever once queue overhead is gone |
+| Intra-replica processing concurrency (N worker goroutines) | Becomes partition-parallelism: one consumer goroutine per assigned partition; partition count is the scaling knob | Yes, reframed and cleaner (no SKIP LOCKED contention) |
+| Horizontal replicas | Add consumers to the consumer group, bounded by partition count | Yes, same idea, different mechanism |
+| `event_queue` plus `Claim`/`Ack`/`Nack`/`PruneProcessed` plus the `claimed_at_ns` lease | Replaced by the log's offsets, retention, and consumer-group rebalance | No: superseded by the substrate |
+| Server-backlog gate (sampled `event_queue` pending depth, #203) | Becomes consumer lag; same gate, the broker reports the number | Yes (concept transfers; only the metric source changes) |
+
+## Consequences
+
+Easier or cheaper now: no new operational dependency; the quickstart stays a single compose file (relevant to #534); the processor improvements pay off in both architectures because they target the delivery-independent processing path; the per-host ordering the builder already tolerates (concurrent, arrival-order-resolved by parent ID) means intra-replica concurrency is no more dangerous than the cross-replica concurrency the design already runs in production.
+
+Harder or accepted as debt: MySQL does work-queue duty it is not ideal at (the claim, ack, and prune round-trips, plus the `PruneProcessed` sweep and its backlog gate, are overhead a log would not need); per-host ordering relies on `Claim ... ORDER BY host_id, timestamp_ns` plus builder tolerance rather than partition-native ordering; the eventual streaming migration is real work (stand up the substrate, re-key events by host to a partition, move the archive sink to a log consumer, swap the processor's claim loop for a consumer loop). The `event_queue` claim, ack, and prune machinery is explicitly interim and will be superseded.
+
+Backpressure today is the queue growing in MySQL (visible as the #203 backlog gate); a log would absorb spikes more gracefully and give replay for free. We accept the weaker backpressure story at the pilot scale because the queue is durable and the archive is complete, so a processing spike drains rather than loses data.
+
+## Alternatives considered
+
+Adopt Kafka now. Attractive because it is the industry-standard EDR-scale answer and would settle the delivery substrate once. Rejected: the operational weight (brokers, ZooKeeper or KRaft, partitions, a sink connector) breaks the single-VM quickstart deployment model the product is built around, and it is premature for a 10-to-500-endpoint pilot that one or two small replicas already serve.
+
+Adopt Redpanda or NATS JetStream now. Attractive because both ship as a single binary and would preserve the lightweight deployment story while giving real log semantics. Rejected for now only on timing: it is still a new dependency, and the DB-queue plus processor improvements cover the target envelope. This is the leading option for the scale move and is named here so the next maintainer starts from it rather than reaching for Kafka by reflex.
+
+ClickHouse-only, no separate work queue (poll the archive for unprocessed rows). Attractive because it removes the second store. Rejected: ClickHouse is append-and-scan optimized and is a poor work queue (no row-level claim or lease, expensive point deletes), so the claim, ack, and re-delivery semantics ADR-0011 depends on would be hard and slow to emulate.
+
+Stay on DB-as-queue indefinitely and only scale by adding replicas. Attractive for its simplicity. Rejected as the end state because DB-as-queue has a real ceiling (MySQL contention on the claim, prune cost, no native partitioned ordering or replay), but accepted as the correct choice for now: scale out with replicas plus the throughput work, and revisit when the fleet outgrows it.
+
+## References
+
+- ADR-0011 (HA architecture, SKIP LOCKED claim semantics)
+- ADR-0015 (ClickHouse visibility store)
+- ADR-0010 (stateless server, multi-replica behind a load balancer)
+- #203 (soak, chaos, and 500-agent scale testing): the measurements that motivated this decision
+- #427 (ClickHouse event-store migration) and #534 (operator ClickHouse deployment)
+- The detection-processor throughput issue filed alongside this ADR
+- pprof finding (2026-06-28): single-replica processor 25% CPU, I/O-round-trip bound in `graph.Builder.ProcessBatch` per-event `GetProcessByPID` plus `UpdateProcessExec`

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -38,6 +38,7 @@ Each ADR is immutable after it lands. When a decision changes, write a _new_ ADR
 | [0013](0013-service-account-and-api-authentication.md) | Service-account and API authentication: client-credentials with short-lived self-validating tokens | Accepted |
 | [0014](0014-inline-enforcement-failure-semantics.md) | Inline network enforcement: observation fails open, enforcement is explicit and resilient | Proposed |
 | [0015](0015-clickhouse-visibility-store.md) | ClickHouse event store in a new `visibility` bounded context | Proposed |
+| [0016](0016-event-delivery-substrate.md) | Event delivery: database-backed work queue now, streaming substrate at scale | Accepted |
 
 ## Tooling
 

--- a/test/scale/README.md
+++ b/test/scale/README.md
@@ -127,7 +127,7 @@ A large positive `client_server_delta_p99` points at network + balancer + agent-
 
 The ingest p99 gate measures the HTTP boundary; it says nothing about whether the detection processor keeps pace with ingest. After the ClickHouse cutover (ADR-0015) ingest fans out to the ClickHouse archive plus the MySQL `event_queue` work queue, and a single server replica's processor drains that queue at a finite rate. At a high enough host count the queue backlog grows during the lane (the processor falls behind) even while ingest latency stays green. A 500-host run on one replica grew the `event_queue` pending backlog to tens of thousands; the same load across three replicas kept it bounded under ~500 (the processor is not leader-gated and scales out via `FOR UPDATE SKIP LOCKED`, ADR-0011).
 
-To measure that, pass `--backlog-dsn` (the server's MySQL DSN). A background sampler polls the not-yet-acked `event_queue` depth every `--backlog-poll-interval` (default 5s) for the life of the run and records its percentiles:
+To measure that, pass `--backlog-dsn` (the server's MySQL DSN) in `direct` mode. A background sampler polls the not-yet-acked `event_queue` depth every `--backlog-poll-interval` (default 5s) for the life of the run and records its percentiles. The poll is direct-mode only (it measures the server's queue, not the agent's); passing `--backlog-dsn` in `headless` mode is rejected at startup rather than silently skipped, and `--pass-max-server-backlog` without a `--backlog-dsn` is rejected too (a ceiling with nothing to sample would be a false pass). Example output:
 
 ```json
 {

--- a/test/scale/README.md
+++ b/test/scale/README.md
@@ -123,6 +123,31 @@ Pass `--signoz-url=http://localhost:8080` to enrich the report with the SigNoz-r
 
 A large positive `client_server_delta_p99` points at network + balancer + agent-side queue time as the dominant contributor rather than server work. A failed SigNoz query is a soft error (`signoz_query_error` field), not a gate: the cross-check is a diagnostic, not a contract.
 
+## Server-backlog gate (optional, long-form lane only)
+
+The ingest p99 gate measures the HTTP boundary; it says nothing about whether the detection processor keeps pace with ingest. After the ClickHouse cutover (ADR-0015) ingest fans out to the ClickHouse archive plus the MySQL `event_queue` work queue, and a single server replica's processor drains that queue at a finite rate. At a high enough host count the queue backlog grows during the lane (the processor falls behind) even while ingest latency stays green. A 500-host run on one replica grew the `event_queue` pending backlog to tens of thousands; the same load across three replicas kept it bounded under ~500 (the processor is not leader-gated and scales out via `FOR UPDATE SKIP LOCKED`, ADR-0011).
+
+To measure that, pass `--backlog-dsn` (the server's MySQL DSN). A background sampler polls the not-yet-acked `event_queue` depth every `--backlog-poll-interval` (default 5s) for the life of the run and records its percentiles:
+
+```json
+{
+  "server_backlog_samples": 60,
+  "server_backlog_p50": 120,
+  "server_backlog_p95": 410,
+  "server_backlog_p99": 480,
+  "server_backlog_max": 512
+}
+```
+
+Set `--pass-max-server-backlog=N` to gate on it: the run fails if the sampled depth ever exceeds `N`, catching a processor-throughput regression distinct from the ingest p99 gate. The default 0 leaves the gate disabled (report-only) until an operator has captured a baseline worth gating on. This is opt-in and off by default: the per-PR smoke and the default baseline run never open a DB connection. It is the server-side counterpart to the agent-side `--pass-max-queue-depth` (headless) gate. Example baseline-with-backlog run:
+
+```bash
+task uat:scale -- --hosts=500 --duration=30m --insecure-tls=true \
+    --backlog-dsn='root:@tcp(127.0.0.1:33306)/edr?parseTime=true' \
+    --pass-max-server-backlog=5000 \
+    --output=test/scale/baselines/baseline-500.json
+```
+
 ## What this layer does NOT do
 
-- **MySQL CPU / row count growth**: the plan calls for these as observability outputs. They are not gates today; capturing them is an operator job during the baseline run (a SigNoz dashboard or `mysqladmin extended-status` snapshot). Promote to gates when a regression case justifies them.
+- **MySQL CPU / row count growth**: the plan calls for these as observability outputs. They are not gates today; capturing them is an operator job during the baseline run (a SigNoz dashboard or `mysqladmin extended-status` snapshot). Promote to gates when a regression case justifies them. (The `event_queue` processing backlog is the one DB-side metric now promoted to an opt-in gate, see "Server-backlog gate" above.)

--- a/test/scale/backlog.go
+++ b/test/scale/backlog.go
@@ -39,8 +39,9 @@ type backlogSampler struct {
 	samples []int64
 }
 
-// startBacklogSampler opens the DSN, verifies connectivity, and launches the poll goroutine bound to ctx. It returns an error if the
-// DB is unreachable so a fat-fingered DSN fails the run loudly at startup rather than silently recording zero samples.
+// startBacklogSampler opens the DSN, runs the backlog query once to prove it works, and launches the poll goroutine bound to ctx. It
+// returns an error if the query fails so a misconfigured DSN fails the run loudly at startup rather than silently recording zero
+// samples (which would bypass the PassMaxServerBacklog gate).
 func startBacklogSampler(ctx context.Context, dsn string, interval time.Duration) (*backlogSampler, error) {
 	if interval <= 0 {
 		interval = defaultBacklogPollInterval
@@ -49,9 +50,15 @@ func startBacklogSampler(ctx context.Context, dsn string, interval time.Duration
 	if err != nil {
 		return nil, err
 	}
-	if err := db.PingContext(ctx); err != nil {
+	// The sampler is a single goroutine issuing serial queries, so one connection is all it needs; cap the pool to match.
+	db.SetMaxOpenConns(1)
+	// Fail closed: run the backlog query once at startup rather than a bare Ping. A DSN can ping successfully yet be unusable for the
+	// poll (wrong schema, no SELECT on event_queue), which would otherwise drop every poll error and leave the run with zero samples,
+	// silently bypassing the PassMaxServerBacklog gate (Copilot/Gemini/CodeRabbit #536). The pre-flight query surfaces that at startup.
+	var probe int64
+	if err := db.QueryRowContext(ctx, backlogQuery).Scan(&probe); err != nil {
 		_ = db.Close()
-		return nil, err
+		return nil, fmt.Errorf("pre-flight backlog query: %w", err)
 	}
 	s := &backlogSampler{db: db, done: make(chan struct{})}
 	go func() {

--- a/test/scale/backlog.go
+++ b/test/scale/backlog.go
@@ -1,0 +1,122 @@
+package scale
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"slices"
+	"sync"
+	"time"
+
+	_ "github.com/go-sql-driver/mysql" // MySQL driver for the optional server-backlog poll; only used when --backlog-dsn is set.
+)
+
+// defaultBacklogPollInterval is the cadence at which the optional server-backlog sampler polls the MySQL event_queue depth. Five
+// seconds is frequent enough to catch a backlog that builds over a multi-minute lane without adding meaningful query load.
+const defaultBacklogPollInterval = 5 * time.Second
+
+// backlogQueryTimeout bounds a single COUNT so a stalled DB can't wedge the sampler goroutine past one poll interval.
+const backlogQueryTimeout = 5 * time.Second
+
+// backlogQuery counts not-yet-acknowledged rows in the work queue: the server-side processing backlog (waiting + in-flight). It is the
+// same predicate eventlog.Store.CountPending uses to back the processor-backlog gauge, run here from the load driver's vantage so the
+// long-form lane can gate on it without the server exposing a new endpoint.
+const backlogQuery = "SELECT COUNT(*) FROM event_queue WHERE processed != 1"
+
+// backlogSampler polls the server-side event_queue depth on an interval for the life of a run. It is started only when an operator
+// passes --backlog-dsn (the per-PR smoke and the default baseline run never open a DB connection), matching the README's stance that
+// DB-side metrics are an opt-in operator concern during a deliberate scale run.
+//
+// Why poll MySQL directly rather than scrape the OTel gauge: the driver is a black-box HTTP client with no metrics scrape path, and
+// the backlog is not exposed over HTTP. A read-only COUNT against the operator-supplied DSN is the lightest honest signal. The poll is
+// best-effort: a transient query error drops one sample rather than failing the run, the same soft-signal discipline the SigNoz
+// cross-check uses.
+type backlogSampler struct {
+	db   *sql.DB
+	done chan struct{}
+
+	mu      sync.Mutex
+	samples []int64
+}
+
+// startBacklogSampler opens the DSN, verifies connectivity, and launches the poll goroutine bound to ctx. It returns an error if the
+// DB is unreachable so a fat-fingered DSN fails the run loudly at startup rather than silently recording zero samples.
+func startBacklogSampler(ctx context.Context, dsn string, interval time.Duration) (*backlogSampler, error) {
+	if interval <= 0 {
+		interval = defaultBacklogPollInterval
+	}
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		return nil, err
+	}
+	if err := db.PingContext(ctx); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+	s := &backlogSampler{db: db, done: make(chan struct{})}
+	go func() {
+		defer close(s.done)
+		t := time.NewTicker(interval)
+		defer t.Stop()
+		s.sampleOnce(ctx) // one immediate sample so a short lane still records a baseline depth.
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+				s.sampleOnce(ctx)
+			}
+		}
+	}()
+	return s, nil
+}
+
+// sampleOnce records one backlog reading. A failed query (transient DB hiccup, ctx cancellation at the run boundary) is dropped, not
+// fatal: one missing sample never changes a percentile materially, whereas aborting the run on a blip would flake the lane.
+func (s *backlogSampler) sampleOnce(ctx context.Context) {
+	qctx, cancel := context.WithTimeout(ctx, backlogQueryTimeout)
+	defer cancel()
+	var n int64
+	if err := s.db.QueryRowContext(qctx, backlogQuery).Scan(&n); err != nil {
+		return
+	}
+	s.mu.Lock()
+	s.samples = append(s.samples, n)
+	s.mu.Unlock()
+}
+
+// stop blocks until the poll goroutine has exited (ctx cancelled at the run boundary) and closes the DB handle. Call it before reading
+// snapshot() so the sample set is final.
+func (s *backlogSampler) stop() {
+	<-s.done
+	_ = s.db.Close()
+}
+
+// snapshot returns a copy of the collected depths.
+func (s *backlogSampler) snapshot() []int64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]int64(nil), s.samples...)
+}
+
+// aggregateServerBacklog folds the sampled depths into the report and applies the optional max-backlog gate. It is pure over
+// (samples, opts) so the gate logic is unit-testable without a DB. It only ever flips Pass to false (never resets it to true), so it
+// composes after aggregate()'s ingest gates: a run can fail on ingest p99 AND backlog independently.
+func aggregateServerBacklog(rep *Report, samples []int64, opts Options) {
+	rep.PassMaxServerBacklog = opts.PassMaxServerBacklog
+	rep.ServerBacklogSamples = len(samples)
+	if len(samples) == 0 {
+		return
+	}
+	sorted := append([]int64(nil), samples...)
+	slices.Sort(sorted)
+	rep.ServerBacklogP50 = depthPercentile(sorted, percentileP50)
+	rep.ServerBacklogP95 = depthPercentile(sorted, percentileP95)
+	rep.ServerBacklogP99 = depthPercentile(sorted, percentileP99)
+	rep.ServerBacklogMax = sorted[len(sorted)-1]
+	if opts.PassMaxServerBacklog > 0 && rep.ServerBacklogMax > opts.PassMaxServerBacklog {
+		rep.Pass = false
+		rep.FailReasons = append(rep.FailReasons,
+			fmt.Sprintf("server_backlog_max %d exceeds budget %d", rep.ServerBacklogMax, opts.PassMaxServerBacklog))
+	}
+}

--- a/test/scale/backlog_test.go
+++ b/test/scale/backlog_test.go
@@ -1,0 +1,67 @@
+package scale
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestAggregateServerBacklog pins the pure aggregation + gate over a sampled-depth set, with no DB. The sampler that produces the
+// samples is exercised live by the long-form lane (it needs a real MySQL); these cases pin the percentile wiring and the gate
+// decision, including that the gate composes after the ingest gates (only ever flips Pass to false).
+func TestAggregateServerBacklog(t *testing.T) {
+	t.Parallel()
+
+	t.Run("records percentiles and leaves Pass untouched when the gate is disabled", func(t *testing.T) {
+		t.Parallel()
+		rep := &Report{Pass: true}
+		samples := []int64{10, 20, 30, 40, 50, 60, 70, 80, 90, 100}
+		aggregateServerBacklog(rep, samples, Options{PassMaxServerBacklog: 0})
+		assert.True(t, rep.Pass, "a disabled gate (0) never fails the run")
+		assert.Equal(t, 10, rep.ServerBacklogSamples)
+		assert.Equal(t, int64(100), rep.ServerBacklogMax)
+		assert.Equal(t, int64(60), rep.ServerBacklogP50, "nearest-rank p50 (rank=ceil(.5*10)+0.5 -> index 5) of 10..100 by tens")
+		assert.Equal(t, int64(100), rep.ServerBacklogP99)
+		assert.Equal(t, int64(0), rep.PassMaxServerBacklog, "echo of the disabled ceiling")
+		assert.Empty(t, rep.FailReasons)
+	})
+
+	t.Run("fails the run when max backlog exceeds the ceiling", func(t *testing.T) {
+		t.Parallel()
+		rep := &Report{Pass: true}
+		aggregateServerBacklog(rep, []int64{100, 500, 37000, 200}, Options{PassMaxServerBacklog: 1000})
+		assert.False(t, rep.Pass, "max 37000 over the 1000 ceiling fails the run")
+		assert.Equal(t, int64(37000), rep.ServerBacklogMax)
+		assert.Equal(t, int64(1000), rep.PassMaxServerBacklog)
+		if assert.Len(t, rep.FailReasons, 1) {
+			assert.Contains(t, rep.FailReasons[0], "server_backlog_max 37000 exceeds budget 1000")
+		}
+	})
+
+	t.Run("passes when max backlog stays under the ceiling", func(t *testing.T) {
+		t.Parallel()
+		rep := &Report{Pass: true}
+		aggregateServerBacklog(rep, []int64{120, 300, 415, 250}, Options{PassMaxServerBacklog: 1000})
+		assert.True(t, rep.Pass, "a bounded backlog under the ceiling passes")
+		assert.Equal(t, int64(415), rep.ServerBacklogMax)
+		assert.Empty(t, rep.FailReasons)
+	})
+
+	t.Run("no samples is a no-op beyond echoing the ceiling", func(t *testing.T) {
+		t.Parallel()
+		rep := &Report{Pass: true}
+		aggregateServerBacklog(rep, nil, Options{PassMaxServerBacklog: 1000})
+		assert.True(t, rep.Pass)
+		assert.Equal(t, 0, rep.ServerBacklogSamples)
+		assert.Equal(t, int64(0), rep.ServerBacklogMax)
+		assert.Equal(t, int64(1000), rep.PassMaxServerBacklog)
+	})
+
+	t.Run("does not resurrect an already-failed run", func(t *testing.T) {
+		t.Parallel()
+		rep := &Report{Pass: false, FailReasons: []string{"error_count > 0 (got 3)"}}
+		aggregateServerBacklog(rep, []int64{120, 250}, Options{PassMaxServerBacklog: 1000})
+		assert.False(t, rep.Pass, "a backlog under the ceiling must not flip a failed run back to pass")
+		assert.Len(t, rep.FailReasons, 1, "no spurious backlog fail-reason added")
+	})
+}

--- a/test/scale/backlog_test.go
+++ b/test/scale/backlog_test.go
@@ -4,7 +4,51 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+// TestValidateOptionsBacklogGuards pins the two server-backlog misconfiguration guards: a ceiling with no DSN to sample, and a DSN
+// passed in headless mode where the sampler does not run. Both must fail loudly rather than silently no-op the gate (#536).
+func TestValidateOptionsBacklogGuards(t *testing.T) {
+	t.Parallel()
+	// base is a minimal otherwise-valid direct-mode Options; each case overlays the field under test.
+	base := func() Options {
+		return Options{
+			ServerURL:           "https://localhost:8090",
+			EnrollSecret:        "s",
+			QuietScenarioPath:   "q.yaml",
+			ActiveScenarioPaths: []string{"a.yaml"},
+		}
+	}
+
+	t.Run("PassMaxServerBacklog without BacklogDSN is rejected", func(t *testing.T) {
+		t.Parallel()
+		o := base()
+		o.PassMaxServerBacklog = 1000
+		_, err := validateOptions(o)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "PassMaxServerBacklog requires BacklogDSN")
+	})
+
+	t.Run("BacklogDSN in headless mode is rejected", func(t *testing.T) {
+		t.Parallel()
+		o := base()
+		o.Mode = ModeHeadless
+		o.BacklogDSN = "root:@tcp(127.0.0.1:33308)/edr"
+		_, err := validateOptions(o)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "only supported in direct mode")
+	})
+
+	t.Run("a backlog ceiling with a DSN in direct mode is accepted", func(t *testing.T) {
+		t.Parallel()
+		o := base()
+		o.BacklogDSN = "root:@tcp(127.0.0.1:33308)/edr"
+		o.PassMaxServerBacklog = 1000
+		_, err := validateOptions(o)
+		require.NoError(t, err)
+	})
+}
 
 // TestAggregateServerBacklog pins the pure aggregation + gate over a sampled-depth set, with no DB. The sampler that produces the
 // samples is exercised live by the long-form lane (it needs a real MySQL); these cases pin the percentile wiring and the gate

--- a/test/scale/runner.go
+++ b/test/scale/runner.go
@@ -154,6 +154,21 @@ type Options struct {
 	// the operator has captured a baseline value worth gating on (per the M12 issue's "TBD; capture observed values
 	// first" guidance). Ignored when Mode != ModeHeadless.
 	PassMaxQueueDepth int64
+
+	// BacklogDSN is an optional MySQL DSN for the server's database. When non-empty, a background sampler polls the event_queue
+	// processing backlog (not-yet-acked rows) on BacklogPollInterval for the life of the run and records its percentiles in the
+	// Report. Empty (the default) skips the poll entirely: the per-PR smoke and the default baseline run never open a DB connection.
+	// This is the opt-in server-side counterpart to the agent-side PassMaxQueueDepth gate, for the long-form lane only.
+	BacklogDSN string
+
+	// BacklogPollInterval is the cadence of the server-backlog poll. Zero defaults to defaultBacklogPollInterval (5s). Ignored when
+	// BacklogDSN is empty.
+	BacklogPollInterval time.Duration
+
+	// PassMaxServerBacklog optionally extends the pass criteria with a server-side processing-backlog ceiling. When > 0, the run fails
+	// if the sampled event_queue depth ever crosses this value, catching a processor-throughput regression (a single replica falling
+	// behind ingest) distinct from the ingest-p99 gate. Zero (the default) leaves it disabled. Requires BacklogDSN to be set.
+	PassMaxServerBacklog int64
 }
 
 // Report is the aggregate output of a Run. Every numeric field is computed across all simulated hosts; PerHost preserves the
@@ -195,6 +210,19 @@ type Report struct {
 
 	// PassMaxQueueDepth echoes the configured ceiling. Zero (the default) means the gate was disabled.
 	PassMaxQueueDepth int64 `json:"pass_max_queue_depth,omitempty"`
+
+	// v3 fields (server-backlog poll only, populated when Options.BacklogDSN was set).
+
+	// ServerBacklogSamples is the number of event_queue depth readings aggregated into the percentile fields below. Zero when the
+	// run did not poll the server DB (the default), so a reader can tell "no backlog poll requested" from "polled, saw nothing."
+	ServerBacklogSamples int   `json:"server_backlog_samples,omitempty"`
+	ServerBacklogP50     int64 `json:"server_backlog_p50,omitempty"`
+	ServerBacklogP95     int64 `json:"server_backlog_p95,omitempty"`
+	ServerBacklogP99     int64 `json:"server_backlog_p99,omitempty"`
+	ServerBacklogMax     int64 `json:"server_backlog_max,omitempty"`
+
+	// PassMaxServerBacklog echoes the configured server-backlog ceiling. Zero (the default) means the gate was disabled.
+	PassMaxServerBacklog int64 `json:"pass_max_server_backlog,omitempty"`
 
 	// ServerLatencyP99 is the SigNoz-reported http.server.request.duration p99 over the run's time window. nil when
 	// Options.SigNozURL was empty or the query failed; SigNozQueryError captures the latter.
@@ -296,6 +324,16 @@ func Run(ctx context.Context, opts Options) (Report, error) {
 	runCtx, cancel := context.WithTimeout(ctx, opts.Duration)
 	defer cancel()
 
+	// Optional server-side backlog sampler (long-form lane only). Bound to runCtx so it stops at the run deadline alongside the hosts.
+	// A bad DSN fails the run here rather than silently recording nothing.
+	var backlog *backlogSampler
+	if opts.BacklogDSN != "" {
+		backlog, err = startBacklogSampler(runCtx, opts.BacklogDSN, opts.BacklogPollInterval)
+		if err != nil {
+			return Report{}, fmt.Errorf("start server-backlog sampler: %w", err)
+		}
+	}
+
 	g, runCtx := errgroup.WithContext(runCtx)
 	for _, h := range hosts {
 		g.Go(func() error {
@@ -308,6 +346,10 @@ func Run(ctx context.Context, opts Options) (Report, error) {
 	rep.EndTime = time.Now()
 	rep.Duration = rep.EndTime.Sub(rep.StartTime)
 	aggregate(&rep, hosts, opts)
+	if backlog != nil {
+		backlog.stop() // waits for the poll goroutine to exit (runCtx is done), then closes the DB; snapshot is final after this.
+		aggregateServerBacklog(&rep, backlog.snapshot(), opts)
+	}
 	return rep, ctx.Err()
 }
 
@@ -485,6 +527,28 @@ func percentileSorted(sorted []time.Duration, p float64) time.Duration {
 	// Nearest-rank method: rank index = ceil(p/100 * N) minus 1, clamped to [0, N-1]. Matches the convention used by Prometheus
 	// histogram_quantile for under-resolution buckets and produces stable values for small N. The 0.5 + truncation produces
 	// banker's-style rounding without pulling in math.Round.
+	const halfStep = 0.5
+	const percentageScale = 100.0
+	rank := int((p/percentageScale)*float64(len(sorted)) + halfStep)
+	if rank >= len(sorted) {
+		rank = len(sorted) - 1
+	}
+	return sorted[rank]
+}
+
+// depthPercentile is the int64 counterpart of percentileSorted, over a pre-sorted slice. Shared by the headless agent-side queue-depth
+// aggregation and the server-side backlog aggregation (backlog.go), so it lives here in the always-compiled file rather than behind
+// the headless build tag.
+func depthPercentile(sorted []int64, p float64) int64 {
+	if len(sorted) == 0 {
+		return 0
+	}
+	if p <= 0 {
+		return sorted[0]
+	}
+	if p >= 100 {
+		return sorted[len(sorted)-1]
+	}
 	const halfStep = 0.5
 	const percentageScale = 100.0
 	rank := int((p/percentageScale)*float64(len(sorted)) + halfStep)

--- a/test/scale/runner.go
+++ b/test/scale/runner.go
@@ -342,12 +342,16 @@ func Run(ctx context.Context, opts Options) (Report, error) {
 		})
 	}
 	_ = g.Wait()
+	// Cancel runCtx now that the hosts are done so the backlog sampler (bound to runCtx) exits promptly. Without this, hosts that
+	// return early (e.g. mass enroll failure) would leave the sampler running until opts.Duration, and backlog.stop() would block
+	// for the rest of the lane (Qodo #536). cancel() is idempotent with the deferred cancel above.
+	cancel()
 
 	rep.EndTime = time.Now()
 	rep.Duration = rep.EndTime.Sub(rep.StartTime)
 	aggregate(&rep, hosts, opts)
 	if backlog != nil {
-		backlog.stop() // waits for the poll goroutine to exit (runCtx is done), then closes the DB; snapshot is final after this.
+		backlog.stop() // waits for the poll goroutine to exit (runCtx is cancelled), then closes the DB; snapshot is final after this.
 		aggregateServerBacklog(&rep, backlog.snapshot(), opts)
 	}
 	return rep, ctx.Err()
@@ -684,6 +688,16 @@ func validateOptions(opts Options) (Options, error) {
 		// caller would survive that and panic in time.NewTicker (CodeRabbit #277).
 		return opts, fmt.Errorf("scale: QueueDepthPollInterval must be > 0 in headless mode, got %s",
 			opts.QueueDepthPollInterval)
+	}
+	// A server-backlog ceiling with no DSN to sample is a silent no-op: the sampler never starts, so the gate the operator
+	// asked for is never evaluated and the run reports a false pass. Reject it (Copilot/Gemini/CodeRabbit #536).
+	if opts.PassMaxServerBacklog > 0 && opts.BacklogDSN == "" {
+		return opts, errors.New("scale: PassMaxServerBacklog requires BacklogDSN to be set")
+	}
+	// The server-backlog poll is only wired into the direct-mode Run; runHeadless ignores it. Reject the flags in headless
+	// mode rather than silently skipping the poll, so --backlog-dsn in a headless run fails loudly instead of no-op'ing.
+	if opts.Mode == ModeHeadless && opts.BacklogDSN != "" {
+		return opts, errors.New("scale: BacklogDSN is only supported in direct mode, not headless")
 	}
 	return opts, nil
 }

--- a/test/scale/runner_headless.go
+++ b/test/scale/runner_headless.go
@@ -502,24 +502,3 @@ func aggregateHeadless(rep *Report, hosts []*headlessHostState, opts Options) {
 			fmt.Sprintf("queue_depth_max %d exceeds budget %d", rep.QueueDepthMax, opts.PassMaxQueueDepth))
 	}
 }
-
-// depthPercentile is the int64 analogue of percentileSorted (which operates on time.Duration). Same nearest-rank method;
-// same banker's-style rounding constant. Returns 0 for an empty input.
-func depthPercentile(sorted []int64, p float64) int64 {
-	if len(sorted) == 0 {
-		return 0
-	}
-	if p <= 0 {
-		return sorted[0]
-	}
-	if p >= 100 {
-		return sorted[len(sorted)-1]
-	}
-	const halfStep = 0.5
-	const percentageScale = 100.0
-	rank := int((p/percentageScale)*float64(len(sorted)) + halfStep)
-	if rank >= len(sorted) {
-		rank = len(sorted) - 1
-	}
-	return sorted[rank]
-}

--- a/test/scale/scaledriver/main.go
+++ b/test/scale/scaledriver/main.go
@@ -56,6 +56,9 @@ type flagSet struct {
 	queueDepthPollInterval time.Duration
 	signozURL              string
 	passMaxQueueDepth      int64
+	backlogDSN             string
+	backlogPollInterval    time.Duration
+	passMaxServerBacklog   int64
 }
 
 func main() {
@@ -103,6 +106,9 @@ func run() error {
 		QueueDepthPollInterval: fs.queueDepthPollInterval,
 		SigNozURL:              fs.signozURL,
 		PassMaxQueueDepth:      fs.passMaxQueueDepth,
+		BacklogDSN:             fs.backlogDSN,
+		BacklogPollInterval:    fs.backlogPollInterval,
+		PassMaxServerBacklog:   fs.passMaxServerBacklog,
 	})
 	if err != nil && !errors.Is(err, context.Canceled) {
 		return err
@@ -164,6 +170,12 @@ func parseFlags() flagSet {
 		"optional SigNoz base URL (e.g. http://localhost:8080); when set the report includes server-side p99 + client-vs-server delta")
 	flag.Int64Var(&fs.passMaxQueueDepth, "pass-max-queue-depth", 0,
 		"optional max-queue-depth ceiling; exit 2 if any host's max queue_depth exceeds this value (0 disables the gate)")
+	flag.StringVar(&fs.backlogDSN, "backlog-dsn", "",
+		"optional MySQL DSN for the server DB; when set, the run polls the event_queue processing backlog and reports its percentiles")
+	flag.DurationVar(&fs.backlogPollInterval, "backlog-poll-interval", 0,
+		"cadence of the server-backlog poll; 0 uses the package default of 5s (requires --backlog-dsn)")
+	flag.Int64Var(&fs.passMaxServerBacklog, "pass-max-server-backlog", 0,
+		"optional server-backlog ceiling; exit 2 if the sampled event_queue depth exceeds this value (0 disables; requires --backlog-dsn)")
 	flag.Parse()
 	return fs
 }


### PR DESCRIPTION
## What

Two related outputs from the #203 scale-testing work, post-ClickHouse-cutover:

1. **Opt-in server-backlog gate for the M12 harness** (`test/scale`). The ingest p99 gate only measures the HTTP boundary; it can't see the detection processor falling behind. A local 500-host run showed ingest staying green (p99 136ms, 0 errors) while the MySQL `event_queue` backlog grew linearly to ~37k on one replica (bounded under ~500 across three replicas). This adds `--backlog-dsn` to poll the not-yet-acked `event_queue` depth and `--pass-max-server-backlog=N` to gate on it. Off by default: the per-PR smoke and the default baseline run never open a DB connection. It is the server-side counterpart to the agent-side `--pass-max-queue-depth` gate.

2. **ADR-0016: event delivery, DB work queue now, streaming substrate at scale.** Records the decision to keep the `event_queue` + SKIP LOCKED claim (ADR-0011) for the pilot envelope and invest in detection-processor throughput rather than a streaming backbone now, adopting a single-binary substrate (Redpanda / NATS JetStream, not Kafka) only when the fleet outgrows DB-as-queue. Includes the lever-transfer analysis (the DB-I/O batching + concurrency work survives a streaming migration; the queue/claim/ack/prune machinery is superseded; the backlog gate maps to consumer lag).

## Why

A pprof pass on a saturated single replica showed the processor is I/O-round-trip bound (25% CPU; time in per-event `GetProcessByPID` + `UpdateProcessExec` in the graph builder), not compute bound. The throughput fixes are tracked in #535; this PR ships the measurement tooling (the gate) and the architecture decision (the ADR) that frame that work.

## Notes

- `depthPercentile` moved from the build-tagged `runner_headless.go` to the always-compiled `runner.go` so the untagged `backlog.go` can share it (builds verified under both tag sets).
- `aggregateServerBacklog` is pure over (samples, opts) and unit-tested; it only ever flips `Pass` to false, composing after the ingest gates.
- The poll-interval default lives in one place (`startBacklogSampler` applies it when the interval is non-positive); the flag passes 0 rather than restating it.

Related: #203 (scale testing), #535 (processor throughput), ADR-0016, ADR-0011 (claim semantics), #427 (ClickHouse cutover).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional server backlog monitoring for long-form scale runs, including configurable sampling and a pass/fail threshold.
  * Scale reports now include backlog percentiles, maximum depth, and sample counts.

* **Documentation**
  * Added guidance on the event-delivery architecture decision and updated ADR index.
  * Expanded scale-test docs with backlog gating and measurement details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->