### PR TITLE
feat(identity): unified principal model + service-account attribution (#514, #518)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Notable changes to Fleet EDR, newest first. This project follows [Semantic Versi
 
 ### Changed
 
+- **Service-account actions are now fully attributable (unified principal model).** Every operator action is recorded against a typed principal (a user or a service account), so a service-account-initiated change names the specific service account rather than appearing as an anonymous or failed write. Service accounts can now manage detection-config exclusions and rule-settings (previously rejected with `actor is required`), and SSO / app-config / app-control / trace-sampler mutations they make are attributed to them. The audit-log API response identifies the acting principal for every row. See ADR-0017.
 - **Events move to a ClickHouse archive + a MySQL work queue.** Ingestion durably writes each accepted event to the ClickHouse archive and enqueues it on the MySQL queue, returning success only after both; the detection processor claims from the queue. Per-process network/DNS correlation and alert evidence read the archive. Event retention is now ClickHouse-native time-based expiry rather than a periodic MySQL delete (process-record pruning is unchanged). A leader-gated sweep prunes acknowledged events from the work queue in batches so it keeps to its in-flight working set; the `edr.event_queue.rows_pruned` metric reports its throughput.
 
 ## [0.3.0] (2026-06-26)

--- a/server/identity/api/audit.go
+++ b/server/identity/api/audit.go
@@ -91,6 +91,10 @@ const (
 // background ctx without the original span) still attributes the row
 // to the request that triggered it.
 type AuditEvent struct {
+	// Actor is the typed acting principal (user, service account, or system). It is the forward-looking attribution field: it names a
+	// principal for every actor kind, so a service-account action is auditable rather than collapsing to a zero user. See ADR-0017. During
+	// the principal-model cutover it rides alongside UserID/ActorEmail; the recorder snapshots its label onto the row.
+	Actor PrincipalRef
 	// UserID is the authenticated user, when one exists. Nil for pre-auth events (login_failed) so the audit row records "who attempted"
 	// without claiming "who was authenticated."
 	UserID *int64

--- a/server/identity/api/audit.go
+++ b/server/identity/api/audit.go
@@ -221,9 +221,15 @@ type AuditReader interface {
 // retrieval endpoint produces actionable rows in a single query, even after a user has been deleted from the users table (UserID then
 // resolves to a nil-or-empty email).
 type AuditRow struct {
-	ID         int64          `json:"id"`
-	OccurredAt time.Time      `json:"occurred_at"`
-	UserID     *int64         `json:"user_id,omitempty"`
+	ID         int64     `json:"id"`
+	OccurredAt time.Time `json:"occurred_at"`
+	// Actor is the typed acting principal recorded on the row (user, service account, or system). It is the principal-model attribution
+	// field; UserID/UserEmail below are derived from it for backward compatibility with existing API consumers. See ADR-0017.
+	Actor PrincipalRef `json:"actor"`
+	// UserID is the numeric users.id when the actor is a user, derived from Actor for back-compat. Nil for a service-account, system, or
+	// pre-auth-failure row.
+	UserID *int64 `json:"user_id,omitempty"`
+	// UserEmail is the actor's snapshot display label (a user's email, a service account's name) for back-compat display.
 	UserEmail  string         `json:"user_email,omitempty"`
 	Action     AuditAction    `json:"action"`
 	TargetType string         `json:"target_type,omitempty"`

--- a/server/identity/api/authz.go
+++ b/server/identity/api/authz.go
@@ -192,6 +192,10 @@ const (
 // policies that gate on SessionFresh therefore default to deny, which
 // is the safe direction.
 type Actor struct {
+	// Principal is the typed identity of the acting principal (user, service account, or system). It carries a stable principal id that
+	// survives authentication for every actor kind, so a service-account request is attributable rather than collapsing to a zero user.
+	// It is the value recorded for audit and per-row attribution. See ADR-0017.
+	Principal    PrincipalRef  `json:"principal"`
 	UserID       int64         `json:"user_id"`
 	IsBreakglass bool          `json:"is_breakglass"`
 	AuthMethod   string        `json:"auth_method"`

--- a/server/identity/api/principal.go
+++ b/server/identity/api/principal.go
@@ -1,0 +1,99 @@
+package api
+
+import (
+	"strconv"
+	"strings"
+)
+
+// PrincipalType discriminates the kind of actor a PrincipalRef identifies. It is the authoritative, indexable discriminator stored on
+// the principals row; the same value is also encoded in the principal id's prefix so a bare id is self-describing on the wire and in the
+// database. The two never disagree because a single mint helper sets both. See ADR-0017.
+type PrincipalType string
+
+const (
+	// PrincipalUser is a human operator (a users row).
+	PrincipalUser PrincipalType = "user"
+	// PrincipalServiceAccount is a non-human API principal (a service_accounts row, ADR-0013).
+	PrincipalServiceAccount PrincipalType = "service_account"
+	// PrincipalSystem is the deployment itself: env-seed writes, background jobs, and migrations attribute to it rather than to a
+	// human or to a free-form literal. It is a singleton.
+	PrincipalSystem PrincipalType = "system"
+)
+
+// Principal id prefixes. The local part after the prefix is the owning subtype row's autoincrement key (usr_<users.id> /
+// svc_<service_accounts.id>), which is stable and never reused: a removed subtype row leaves a tombstoned principals row behind and the
+// autoincrement key is never reissued. Only UserID below parses the local part; everything else treats the id as opaque.
+const (
+	principalUserPrefix           = "usr_"
+	principalServiceAccountPrefix = "svc_"
+	// PrincipalSystemID is the id of the singleton system principal. Type is PrincipalSystem; it carries no numeric local part.
+	PrincipalSystemID = "sys"
+	// systemLabel is the display label of the system principal.
+	systemLabel = "system"
+)
+
+// PrincipalRef is the portable identity of an authenticated actor. ID is the type-prefixed principal id; Type is the discriminator;
+// Label is the display name (a user's email, a service account's name, or "system"). It is carried on Actor so the acting principal
+// survives authentication for every actor kind, and it is the single value recorded for audit and per-row attribution. See ADR-0017.
+type PrincipalRef struct {
+	ID    string        `json:"id"`
+	Type  PrincipalType `json:"type"`
+	Label string        `json:"label"`
+}
+
+// UserPrincipalID returns the principal id for a numeric users.id.
+func UserPrincipalID(userID int64) string {
+	return principalUserPrefix + strconv.FormatInt(userID, 10)
+}
+
+// ServiceAccountPrincipalID returns the principal id for a numeric service_accounts.id.
+func ServiceAccountPrincipalID(serviceAccountID int64) string {
+	return principalServiceAccountPrefix + strconv.FormatInt(serviceAccountID, 10)
+}
+
+// SystemPrincipal returns the singleton system principal ref, used to attribute env-seed and background writes.
+func SystemPrincipal() PrincipalRef {
+	return PrincipalRef{ID: PrincipalSystemID, Type: PrincipalSystem, Label: systemLabel}
+}
+
+// UserPrincipal builds the ref for a human operator from the user's id and display label (email).
+func UserPrincipal(userID int64, label string) PrincipalRef {
+	return PrincipalRef{ID: UserPrincipalID(userID), Type: PrincipalUser, Label: label}
+}
+
+// ServiceAccountPrincipal builds the ref for a service account from its numeric id and display name.
+func ServiceAccountPrincipal(serviceAccountID int64, label string) PrincipalRef {
+	return PrincipalRef{ID: ServiceAccountPrincipalID(serviceAccountID), Type: PrincipalServiceAccount, Label: label}
+}
+
+// UserID returns the numeric users.id when this principal is a user, parsing it back out of the usr_<n> id. Only the user-on-user paths
+// (self-edit, creator checks) call it; everything else identifies the actor by ID. It returns ok=false for any non-user id (svc_/sys),
+// a malformed local part, or a non-positive value, so callers cannot accidentally treat a service account as a user. It keys off the id
+// prefix rather than Type so it still works on a ref reconstructed from a bare attribution string with Type unset.
+func (p PrincipalRef) UserID() (int64, bool) {
+	rest, ok := strings.CutPrefix(p.ID, principalUserPrefix)
+	if !ok {
+		return 0, false
+	}
+	n, err := strconv.ParseInt(rest, 10, 64)
+	if err != nil || n <= 0 {
+		return 0, false
+	}
+	return n, true
+}
+
+// PrincipalTypeForID reports the principal type encoded in a bare id's prefix. It is the read-side inverse of the mint helpers: code
+// that loads an attribution-column string uses it to recover the type without a database lookup. ok is false for an id carrying no
+// recognized prefix (a malformed or legacy value).
+func PrincipalTypeForID(id string) (PrincipalType, bool) {
+	switch {
+	case id == PrincipalSystemID:
+		return PrincipalSystem, true
+	case strings.HasPrefix(id, principalUserPrefix):
+		return PrincipalUser, true
+	case strings.HasPrefix(id, principalServiceAccountPrefix):
+		return PrincipalServiceAccount, true
+	default:
+		return "", false
+	}
+}

--- a/server/identity/api/principal_test.go
+++ b/server/identity/api/principal_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -8,10 +9,30 @@ import (
 	"pgregory.net/rapid"
 )
 
+// TestPrincipalRefJSONRoundTrip pins that a PrincipalRef survives a JSON marshal/unmarshal unchanged: it rides on api.Actor and
+// AuditRow wire shapes, so a field-tag drift would silently break attribution serialization.
+func TestPrincipalRefJSONRoundTrip(t *testing.T) {
+	t.Parallel()
+	rapid.Check(t, func(rt *rapid.T) {
+		want := PrincipalRef{
+			ID:    rapid.StringMatching(`(usr_|svc_)[0-9]{1,18}`).Draw(rt, "id"),
+			Type:  PrincipalType(rapid.SampledFrom([]string{"user", "service_account", "system"}).Draw(rt, "type")),
+			Label: rapid.String().Draw(rt, "label"),
+		}
+		raw, err := json.Marshal(want)
+		require.NoError(rt, err)
+		var got PrincipalRef
+		require.NoError(rt, json.Unmarshal(raw, &got))
+		assert.Equal(rt, want, got)
+	})
+}
+
 // TestPrincipalIDRoundTrip is the serialization round-trip property from the testing-strategy matrix: minting a principal id from a
 // numeric key and reading it back recovers the same key and type, across the whole positive-int64 input space.
 func TestPrincipalIDRoundTrip(t *testing.T) {
+	t.Parallel()
 	t.Run("user id round-trips through UserID", func(t *testing.T) {
+		t.Parallel()
 		rapid.Check(t, func(rt *rapid.T) {
 			id := rapid.Int64Range(1, 1<<62).Draw(rt, "userID")
 			ref := UserPrincipal(id, "op@example.com")
@@ -25,6 +46,7 @@ func TestPrincipalIDRoundTrip(t *testing.T) {
 	})
 
 	t.Run("service-account id carries the service_account type", func(t *testing.T) {
+		t.Parallel()
 		rapid.Check(t, func(rt *rapid.T) {
 			id := rapid.Int64Range(1, 1<<62).Draw(rt, "saID")
 			ref := ServiceAccountPrincipal(id, "ci-bot")
@@ -40,6 +62,7 @@ func TestPrincipalIDRoundTrip(t *testing.T) {
 // TestPrincipalRefUserID pins the exact accepted and rejected shapes of the user-id accessor, the security-relevant boundary that keeps
 // a service account from ever being treated as a user.
 func TestPrincipalRefUserID(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name   string
 		id     string
@@ -58,6 +81,7 @@ func TestPrincipalRefUserID(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			got, ok := PrincipalRef{ID: tc.id}.UserID()
 			assert.Equal(t, tc.wantOK, ok)
 			assert.Equal(t, tc.wantID, got)
@@ -68,6 +92,7 @@ func TestPrincipalRefUserID(t *testing.T) {
 // TestPrincipalTypeForID covers the read-side type recovery, including the legacy/malformed values the migration backfill must not
 // produce but the parser must reject rather than misclassify.
 func TestPrincipalTypeForID(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name string
 		id   string
@@ -83,6 +108,7 @@ func TestPrincipalTypeForID(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			got, ok := PrincipalTypeForID(tc.id)
 			assert.Equal(t, tc.ok, ok)
 			assert.Equal(t, tc.want, got)
@@ -92,6 +118,7 @@ func TestPrincipalTypeForID(t *testing.T) {
 
 // TestSystemPrincipal pins the singleton system principal's shape.
 func TestSystemPrincipal(t *testing.T) {
+	t.Parallel()
 	sys := SystemPrincipal()
 	assert.Equal(t, PrincipalSystemID, sys.ID)
 	assert.Equal(t, PrincipalSystem, sys.Type)

--- a/server/identity/api/principal_test.go
+++ b/server/identity/api/principal_test.go
@@ -1,0 +1,101 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"pgregory.net/rapid"
+)
+
+// TestPrincipalIDRoundTrip is the serialization round-trip property from the testing-strategy matrix: minting a principal id from a
+// numeric key and reading it back recovers the same key and type, across the whole positive-int64 input space.
+func TestPrincipalIDRoundTrip(t *testing.T) {
+	t.Run("user id round-trips through UserID", func(t *testing.T) {
+		rapid.Check(t, func(rt *rapid.T) {
+			id := rapid.Int64Range(1, 1<<62).Draw(rt, "userID")
+			ref := UserPrincipal(id, "op@example.com")
+			got, ok := ref.UserID()
+			require.True(rt, ok, "a freshly minted user principal must parse back")
+			assert.Equal(rt, id, got)
+			typ, ok := PrincipalTypeForID(ref.ID)
+			require.True(rt, ok)
+			assert.Equal(rt, PrincipalUser, typ)
+		})
+	})
+
+	t.Run("service-account id carries the service_account type", func(t *testing.T) {
+		rapid.Check(t, func(rt *rapid.T) {
+			id := rapid.Int64Range(1, 1<<62).Draw(rt, "saID")
+			ref := ServiceAccountPrincipal(id, "ci-bot")
+			typ, ok := PrincipalTypeForID(ref.ID)
+			require.True(rt, ok)
+			assert.Equal(rt, PrincipalServiceAccount, typ)
+			_, isUser := ref.UserID()
+			assert.False(rt, isUser, "a service-account principal must never read as a user")
+		})
+	})
+}
+
+// TestPrincipalRefUserID pins the exact accepted and rejected shapes of the user-id accessor, the security-relevant boundary that keeps
+// a service account from ever being treated as a user.
+func TestPrincipalRefUserID(t *testing.T) {
+	cases := []struct {
+		name   string
+		id     string
+		wantID int64
+		wantOK bool
+	}{
+		{"well-formed user id", UserPrincipalID(42), 42, true},
+		{"service-account id rejected", ServiceAccountPrincipalID(42), 0, false},
+		{"system id rejected", PrincipalSystemID, 0, false},
+		{"empty id rejected", "", 0, false},
+		{"non-numeric local part rejected", "usr_abc", 0, false},
+		{"ULID-shaped local part rejected", "usr_01J9Z3ABCD", 0, false},
+		{"zero user id rejected", "usr_0", 0, false},
+		{"negative user id rejected", "usr_-1", 0, false},
+		{"bare prefix rejected", "usr_", 0, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := PrincipalRef{ID: tc.id}.UserID()
+			assert.Equal(t, tc.wantOK, ok)
+			assert.Equal(t, tc.wantID, got)
+		})
+	}
+}
+
+// TestPrincipalTypeForID covers the read-side type recovery, including the legacy/malformed values the migration backfill must not
+// produce but the parser must reject rather than misclassify.
+func TestPrincipalTypeForID(t *testing.T) {
+	cases := []struct {
+		name string
+		id   string
+		want PrincipalType
+		ok   bool
+	}{
+		{"user", UserPrincipalID(1), PrincipalUser, true},
+		{"service account", ServiceAccountPrincipalID(1), PrincipalServiceAccount, true},
+		{"system", PrincipalSystemID, PrincipalSystem, true},
+		{"legacy user:<id> rejected", "user:1", "", false},
+		{"legacy system literal rejected", "system", "", false},
+		{"empty rejected", "", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := PrincipalTypeForID(tc.id)
+			assert.Equal(t, tc.ok, ok)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestSystemPrincipal pins the singleton system principal's shape.
+func TestSystemPrincipal(t *testing.T) {
+	sys := SystemPrincipal()
+	assert.Equal(t, PrincipalSystemID, sys.ID)
+	assert.Equal(t, PrincipalSystem, sys.Type)
+	assert.Equal(t, "system", sys.Label)
+	_, isUser := sys.UserID()
+	assert.False(t, isUser)
+}

--- a/server/identity/bootstrap/bootstrap.go
+++ b/server/identity/bootstrap/bootstrap.go
@@ -289,7 +289,7 @@ func buildSSOAdminHandler(in ssoAdminHandlerDeps) *ssoadmin.Handler {
 		return nil
 	}
 	oidcHTTPClient := in.deps.OIDC.HTTPClient
-	apply := func(ctx context.Context, oidcIn ssoconfig.UpsertInput, appCfg appconfig.AppConfig, expectedAppVersion int64, updatedBy *int64) error {
+	apply := func(ctx context.Context, oidcIn ssoconfig.UpsertInput, appCfg appconfig.AppConfig, expectedAppVersion int64, updatedBy string) error {
 		tx, err := in.deps.DB.BeginTxx(ctx, nil)
 		if err != nil {
 			return fmt.Errorf("identity bootstrap: begin sso update tx: %w", err)
@@ -587,7 +587,7 @@ func (i *Identity) seedOIDCConfigFromEnv(ctx context.Context) error {
 		Scopes:      i.oidcSeed.Scopes,
 		JITEnabled:  i.oidcSeed.AllowJITProvisioning,
 		DefaultRole: defaultRole,
-		UpdatedBy:   nil,
+		UpdatedBy:   api.PrincipalSystemID,
 	}); err != nil {
 		return fmt.Errorf("identity bootstrap: seed OIDC config from env: %w", err)
 	}
@@ -600,7 +600,7 @@ func (i *Identity) seedOIDCConfigFromEnv(ctx context.Context) error {
 			return fmt.Errorf("identity bootstrap: read app config: %w", err)
 		} else if cur.ExternalURL == "" {
 			cur.ExternalURL = externalURL
-			if err := i.appConfigStore.Put(ctx, cur, version, nil); err != nil {
+			if err := i.appConfigStore.Put(ctx, cur, version, api.PrincipalSystemID); err != nil {
 				return fmt.Errorf("identity bootstrap: seed external URL from env: %w", err)
 			}
 		}

--- a/server/identity/internal/appconfig/appconfig.go
+++ b/server/identity/internal/appconfig/appconfig.go
@@ -13,6 +13,8 @@ import (
 	"fmt"
 
 	"github.com/jmoiron/sqlx"
+
+	"github.com/fleetdm/edr/server/identity/api"
 )
 
 // ErrVersionConflict is returned by Put when the row's version no longer matches the expected version (a concurrent write landed
@@ -64,21 +66,22 @@ func (s *Store) Get(ctx context.Context) (AppConfig, int64, error) {
 // Put writes the whole document with optimistic concurrency. Callers Get (which returns the current version), mutate, then Put with
 // that version (read-modify-write) so unrelated fields are preserved and a concurrent write is detected. expectedVersion <= 0 means
 // "first write" (no row yet) and inserts the singleton; expectedVersion > 0 updates only when the stored version still matches,
-// returning ErrVersionConflict otherwise. updatedBy nil records a non-operator write (env seed).
-func (s *Store) Put(ctx context.Context, cfg AppConfig, expectedVersion int64, updatedBy *int64) error {
+// returning ErrVersionConflict otherwise. updatedBy is the acting principal id (api.SystemPrincipal().ID for a non-operator env seed).
+func (s *Store) Put(ctx context.Context, cfg AppConfig, expectedVersion int64, updatedBy string) error {
 	return s.PutTx(ctx, s.db, cfg, expectedVersion, updatedBy)
 }
 
 // PutTx is Put against a caller-supplied executor (*sqlx.Tx or the Store's *sqlx.DB), so a write can join a transaction that also
 // updates other tables atomically (e.g. the SSO admin update that writes oidc_config and app_config together).
-func (s *Store) PutTx(ctx context.Context, ext sqlx.ExtContext, cfg AppConfig, expectedVersion int64, updatedBy *int64) error {
+func (s *Store) PutTx(ctx context.Context, ext sqlx.ExtContext, cfg AppConfig, expectedVersion int64, updatedBy string) error {
 	encoded, err := json.Marshal(cfg)
 	if err != nil {
 		return fmt.Errorf("appconfig: marshal: %w", err)
 	}
-	var by sql.NullInt64
-	if updatedBy != nil {
-		by = sql.NullInt64{Int64: *updatedBy, Valid: true}
+	// An unset updater records the system principal, matching the column's NOT NULL DEFAULT 'sys' and its FK to principals(id).
+	by := updatedBy
+	if by == "" {
+		by = api.PrincipalSystemID
 	}
 	if expectedVersion <= 0 {
 		// First write: insert the singleton. ON DUPLICATE KEY UPDATE keeps the env-seed path idempotent across a concurrent first boot.

--- a/server/identity/internal/audit/mysql.go
+++ b/server/identity/internal/audit/mysql.go
@@ -102,7 +102,7 @@ func (s *Store) Record(ctx context.Context, e api.AuditEvent) error {
 	if traceID == "" {
 		traceID = traceIDFromContext(ctx)
 	}
-	actorEmail := s.resolveActorEmail(ctx, e)
+	actor := actorOf(e)
 
 	var payloadBytes []byte
 	if len(e.Payload) > 0 {
@@ -115,12 +115,13 @@ func (s *Store) Record(ctx context.Context, e api.AuditEvent) error {
 
 	const q = `
 		INSERT INTO audit_events (
-			actor_user_id, actor_email, action, target_type, target_id,
+			actor_type, actor_principal_id, actor_label, action, target_type, target_id,
 			trace_id, remote_addr, payload
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
 	_, err := s.db.ExecContext(ctx, q,
-		nullInt64(e.UserID),
-		nullString(actorEmail),
+		nullString(string(actor.Type)),
+		nullString(actor.ID),
+		nullString(actor.Label),
 		string(e.Action),
 		nullString(e.TargetType),
 		nullString(e.TargetID),
@@ -131,7 +132,7 @@ func (s *Store) Record(ctx context.Context, e api.AuditEvent) error {
 	// Dual-emit BEFORE returning on INSERT failure so the observability pipeline always sees a record, even when the DB rejected the row.
 	// Per server-identity-audit-log spec: "The dual emit MUST happen even when the database insert fails so the observability pipeline
 	// sees a record."
-	s.emitDualEmit(ctx, e, actorEmail, traceID)
+	s.emitDualEmit(ctx, e, actor, traceID)
 	if err != nil {
 		s.logger.ErrorContext(ctx, "audit row INSERT failed",
 			"err", err,
@@ -154,16 +155,14 @@ func (s *Store) Record(ctx context.Context, e api.AuditEvent) error {
 // recovery surface is the high-privilege path). Mirrors logDropped's attribute set minus the "reason" key (drops carry queue_full /
 // writer_stopped / drain_deadline_exceeded; a successful row has none). Payload is included verbatim when non-empty so dashboards can
 // filter on payload.decision (chokepoint allow/deny) and payload.reason (OIDC + break-glass failure mode codes).
-func (s *Store) emitDualEmit(ctx context.Context, e api.AuditEvent, actorEmail, traceID string) {
-	uid := int64(0)
-	if e.UserID != nil {
-		uid = *e.UserID
-	}
+func (s *Store) emitDualEmit(ctx context.Context, e api.AuditEvent, actor api.PrincipalRef, traceID string) {
+	uid, _ := actor.UserID()
 	attrs := []any{
 		"action", string(e.Action),
 		"target_type", e.TargetType,
 		"target_id", e.TargetID,
-		"actor_email", actorEmail,
+		"actor_principal_id", actor.ID,
+		"actor_label", actor.Label,
 		attrkeys.UserID, uid,
 	}
 	if traceID != "" {
@@ -253,26 +252,23 @@ func auditReason(e api.AuditEvent) string {
 	return ""
 }
 
-// resolveActorEmail returns the email to denormalise onto the audit row. Caller-supplied ActorEmail wins (login paths know the email
-// already); otherwise look it up from users by UserID. A failed lookup is not a hard error because the audit row's user_id column
-// is still authoritative; we simply leave actor_email empty and let the LEFT JOIN on read surface the live email when the user still
-// exists.
-func (s *Store) resolveActorEmail(ctx context.Context, e api.AuditEvent) string {
-	if e.ActorEmail != "" {
-		return e.ActorEmail
+// actorOf derives the acting principal recorded on the audit row. The principal-model attribution path sets AuditEvent.Actor directly;
+// callers not yet converted still set UserID/ActorEmail, which actorOf bridges to a user principal so every row carries the principal
+// columns regardless of which caller wrote it. A pre-authentication failure (neither Actor nor UserID) yields an empty-id principal
+// whose label is the attempted identifier, so the row records "who attempted" without claiming a principal. The UserID/ActorEmail
+// bridge is removed when every caller sets Actor, in the final cutover commit (ADR-0017).
+func actorOf(e api.AuditEvent) api.PrincipalRef {
+	if e.Actor.ID != "" {
+		return e.Actor
 	}
-	if e.UserID == nil {
-		return ""
+	if e.UserID != nil {
+		return api.UserPrincipal(*e.UserID, e.ActorEmail)
 	}
-	var email sql.NullString
-	if err := s.db.QueryRowContext(ctx,
-		`SELECT email FROM users WHERE id = ?`, *e.UserID).Scan(&email); err != nil {
-		return ""
+	label := e.Actor.Label
+	if label == "" {
+		label = e.ActorEmail
 	}
-	if email.Valid {
-		return email.String
-	}
-	return ""
+	return api.PrincipalRef{Label: label}
 }
 
 // List returns audit rows matching the filter, newest first. Caller passes a non-zero Limit; the Store caps it at maxListLimit so a
@@ -286,11 +282,10 @@ func (s *Store) List(ctx context.Context, f api.AuditFilter) ([]api.AuditRow, er
 	args = append(args, limit)
 
 	q := `
-		SELECT a.id, a.occurred_at, a.actor_user_id, a.actor_email,
+		SELECT a.id, a.occurred_at, a.actor_type, a.actor_principal_id, a.actor_label,
 		       a.action, a.target_type, a.target_id, a.trace_id,
-		       a.remote_addr, a.payload, COALESCE(u.email, '')
-		FROM audit_events a
-		LEFT JOIN users u ON u.id = a.actor_user_id ` + where + `
+		       a.remote_addr, a.payload
+		FROM audit_events a ` + where + `
 		ORDER BY a.id DESC
 		LIMIT ?`
 
@@ -324,8 +319,8 @@ func buildListWhere(f api.AuditFilter) (string, []any) {
 	args := make([]any, 0, 8)
 	where := "WHERE 1=1"
 	if f.UserID != nil {
-		where += " AND a.actor_user_id = ?"
-		args = append(args, *f.UserID)
+		where += " AND a.actor_principal_id = ?"
+		args = append(args, api.UserPrincipalID(*f.UserID))
 	}
 	if f.Action != "" {
 		where += " AND a.action = ?"
@@ -360,37 +355,33 @@ func buildListWhere(f api.AuditFilter) (string, []any) {
 // round-trip assertions.
 func scanListRow(rows *sql.Rows) (api.AuditRow, error) {
 	var (
-		r            api.AuditRow
-		actorUserID  sql.NullInt64
-		actorEmail   sql.NullString
-		targetType   sql.NullString
-		targetID     sql.NullString
-		traceID      sql.NullString
-		remoteAddr   sql.NullString
-		payloadBytes []byte
-		joinedEmail  string
-		action       string
+		r                api.AuditRow
+		actorType        sql.NullString
+		actorPrincipalID sql.NullString
+		actorLabel       sql.NullString
+		targetType       sql.NullString
+		targetID         sql.NullString
+		traceID          sql.NullString
+		remoteAddr       sql.NullString
+		payloadBytes     []byte
+		action           string
 	)
 	if err := rows.Scan(
-		&r.ID, &r.OccurredAt, &actorUserID, &actorEmail,
+		&r.ID, &r.OccurredAt, &actorType, &actorPrincipalID, &actorLabel,
 		&action, &targetType, &targetID, &traceID,
-		&remoteAddr, &payloadBytes, &joinedEmail,
+		&remoteAddr, &payloadBytes,
 	); err != nil {
 		return r, fmt.Errorf("audit.List scan: %w", err)
 	}
 	r.Action = api.AuditAction(action)
-	if actorUserID.Valid {
-		id := actorUserID.Int64
-		r.UserID = &id
+	// The audit row is self-contained: the snapshot label was captured at write time, so a renamed or deleted principal does not rewrite
+	// history and no join is needed. UserID/UserEmail are derived from the principal for back-compat with existing API consumers: a user
+	// principal yields the numeric id; the label populates UserEmail for any principal kind (a service account's name surfaces there).
+	r.Actor = api.PrincipalRef{ID: actorPrincipalID.String, Type: api.PrincipalType(actorType.String), Label: actorLabel.String}
+	if uid, ok := r.Actor.UserID(); ok {
+		r.UserID = &uid
 	}
-	// Prefer the live join so the retrieval endpoint reflects current emails (e.g. an admin who renamed their email post-action sees the
-	// new value). Fall back to the denormalised actor_email when the user row no longer exists.
-	switch {
-	case joinedEmail != "":
-		r.UserEmail = joinedEmail
-	case actorEmail.Valid:
-		r.UserEmail = actorEmail.String
-	}
+	r.UserEmail = actorLabel.String
 	r.TargetType = targetType.String
 	r.TargetID = targetID.String
 	r.TraceID = traceID.String
@@ -416,13 +407,6 @@ func traceIDFromContext(ctx context.Context) string {
 		return ""
 	}
 	return sc.TraceID().String()
-}
-
-func nullInt64(p *int64) any {
-	if p == nil {
-		return nil
-	}
-	return *p
 }
 
 func nullString(s string) any {

--- a/server/identity/internal/audit/mysql.go
+++ b/server/identity/internal/audit/mysql.go
@@ -156,14 +156,16 @@ func (s *Store) Record(ctx context.Context, e api.AuditEvent) error {
 // writer_stopped / drain_deadline_exceeded; a successful row has none). Payload is included verbatim when non-empty so dashboards can
 // filter on payload.decision (chokepoint allow/deny) and payload.reason (OIDC + break-glass failure mode codes).
 func (s *Store) emitDualEmit(ctx context.Context, e api.AuditEvent, actor api.PrincipalRef, traceID string) {
-	uid, _ := actor.UserID()
 	attrs := []any{
 		"action", string(e.Action),
 		"target_type", e.TargetType,
 		"target_id", e.TargetID,
 		"actor_principal_id", actor.ID,
 		"actor_label", actor.Label,
-		attrkeys.UserID, uid,
+	}
+	// Only emit edr.user.id for a real human user; a service-account or system principal would otherwise log a misleading uid=0.
+	if uid, ok := actor.UserID(); ok {
+		attrs = append(attrs, attrkeys.UserID, uid)
 	}
 	if traceID != "" {
 		attrs = append(attrs, "trace_id", traceID)

--- a/server/identity/internal/audit/mysql_test.go
+++ b/server/identity/internal/audit/mysql_test.go
@@ -80,10 +80,10 @@ func TestRecord_RoundTrip(t *testing.T) {
 	assert.WithinDuration(t, time.Now(), r.OccurredAt, 30*time.Second)
 }
 
-// When the caller does not supply ActorEmail, the Recorder must look it up from the users table by UserID and denormalise it onto the
-// row so the audit row stays attributable after the user is later deleted. This is the key durability promise behind the cross-context
-// recordX helpers, which only have user_id from ctx (no email).
-func TestRecord_AutoResolvesActorEmailFromUserID(t *testing.T) {
+// The Recorder snapshots the acting principal (id + display label) onto the row at write time, so the row stays attributable with no
+// join and survives the user later being deleted. ADR-0017 replaced the live users-table email lookup with this snapshot. The store's
+// bridge derives the principal from a legacy UserID/ActorEmail caller until every caller sets Actor directly.
+func TestRecord_SnapshotsActorPrincipal(t *testing.T) {
 	t.Parallel()
 	store, db := newStore(t)
 	const userID = int64(99)
@@ -91,25 +91,26 @@ func TestRecord_AutoResolvesActorEmailFromUserID(t *testing.T) {
 
 	uid := userID
 	require.NoError(t, store.Record(t.Context(), api.AuditEvent{
-		UserID: &uid,
-		Action: api.AuditAlertAcknowledge,
-		// ActorEmail intentionally empty; Recorder should fill it from the users row.
+		UserID:     &uid,
+		ActorEmail: "operator-99@test",
+		Action:     api.AuditAlertAcknowledge,
 	}))
 
 	rows, err := store.List(t.Context(), api.AuditFilter{Limit: 1})
 	require.NoError(t, err)
 	require.Len(t, rows, 1)
-	assert.Equal(t, "operator-99@test", rows[0].UserEmail)
+	assert.Equal(t, "usr_99", rows[0].Actor.ID)
+	assert.Equal(t, api.PrincipalUser, rows[0].Actor.Type)
+	assert.Equal(t, "operator-99@test", rows[0].UserEmail, "snapshot label is surfaced as UserEmail for back-compat")
 
-	// And after the user is deleted, the denormalised email survives so the audit row stays attributable. Pre-deletion the LEFT JOIN
-	// returns the live email; post-deletion the join is empty and the reader falls back to the actor_email column captured at record time.
+	// The snapshot survives user deletion: no join means the label captured at write time is authoritative.
 	_, err = db.ExecContext(t.Context(), `DELETE FROM users WHERE id = ?`, userID)
 	require.NoError(t, err)
 	rowsAfter, err := store.List(t.Context(), api.AuditFilter{Limit: 1})
 	require.NoError(t, err)
 	require.Len(t, rowsAfter, 1)
 	assert.Equal(t, "operator-99@test", rowsAfter[0].UserEmail,
-		"denormalised actor_email must survive user deletion")
+		"snapshot label must survive user deletion")
 }
 
 // login_failed rows have no user_id (the email may be unknown). The retrieval endpoint must surface them with the attempted email so a
@@ -256,7 +257,8 @@ func TestRecord_EmitsInfoLogOnSuccess(t *testing.T) {
 	assert.Equal(t, "auth.login.success", entry["action"])
 	assert.Equal(t, "user", entry["target_type"])
 	assert.Equal(t, "7", entry["target_id"])
-	assert.Equal(t, "operator-7@test", entry["actor_email"])
+	assert.Equal(t, "operator-7@test", entry["actor_label"])
+	assert.Equal(t, "usr_7", entry["actor_principal_id"])
 	assert.InDelta(t, float64(userID), entry["edr.user.id"], 0)
 
 	payload, ok := entry["payload"].(map[string]any)

--- a/server/identity/internal/audit/mysql_test.go
+++ b/server/identity/internal/audit/mysql_test.go
@@ -113,6 +113,27 @@ func TestRecord_SnapshotsActorPrincipal(t *testing.T) {
 		"snapshot label must survive user deletion")
 }
 
+// TestRecord_SnapshotsServiceAccountPrincipal exercises the principal-model attribution path directly (Actor set, no legacy
+// UserID/ActorEmail bridge): a service-account action is recorded with its svc_ principal id and name, and reads back as a
+// service_account row with no user id. This is the #514 attribution guarantee for non-human actors.
+func TestRecord_SnapshotsServiceAccountPrincipal(t *testing.T) {
+	t.Parallel()
+	store, _ := newStore(t)
+
+	require.NoError(t, store.Record(t.Context(), api.AuditEvent{
+		Actor:  api.ServiceAccountPrincipal(7, "ci-bot"),
+		Action: api.AuditDetectionConfigExclusionCreate,
+	}))
+
+	rows, err := store.List(t.Context(), api.AuditFilter{Limit: 1})
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, "svc_7", rows[0].Actor.ID)
+	assert.Equal(t, api.PrincipalServiceAccount, rows[0].Actor.Type)
+	assert.Equal(t, "ci-bot", rows[0].UserEmail, "the service account's name is the snapshot label")
+	assert.Nil(t, rows[0].UserID, "a service-account row carries no numeric user id")
+}
+
 // login_failed rows have no user_id (the email may be unknown). The retrieval endpoint must surface them with the attempted email so a
 // brute-force pattern is observable in retention.
 func TestRecord_LoginFailedKeepsEmailWithoutUser(t *testing.T) {
@@ -347,7 +368,9 @@ func TestRecord_EmitsWarnLogForFailureAction(t *testing.T) {
 	assert.Equal(t, "WARN", entry["level"],
 		"server-identity-audit-log spec: error decision must emit slog at WARN")
 	assert.Equal(t, "auth.oidc.failure", entry["action"])
-	assert.InDelta(t, float64(0), entry["edr.user.id"], 0)
+	assert.Equal(t, "operator@test", entry["actor_label"], "the attempted identifier is recorded as the actor label")
+	_, hasUID := entry["edr.user.id"]
+	assert.False(t, hasUID, "a pre-auth failure has no user principal, so edr.user.id must not be emitted")
 }
 
 // Spec contract: a chokepoint deny emits slog at WARN. Pinned so the observability dashboard's "WARN threshold" alert catches

--- a/server/identity/internal/authz/engine.go
+++ b/server/identity/internal/authz/engine.go
@@ -260,11 +260,10 @@ func (e *Engine) recordDecision(
 		// ctx-extracted id.
 		TraceID: traceIDFromContext(ctx),
 	}
-	// Only stamp a user id for a real human user. A service-account actor (issue #376) has UserID==0 and no users row; setting it would
-	// persist actor_user_id=0 and make the audit writer's actor_email resolution query users for id 0 on every audited call.
-	if actor != nil && actor.UserID > 0 {
-		uid := actor.UserID
-		event.UserID = &uid
+	// Stamp the acting principal (user, service account, or system) so every chokepoint audit row names a principal with a resolvable
+	// label, not just an anonymous decision. See ADR-0017.
+	if actor != nil {
+		event.Actor = actor.Principal
 	}
 	if e.routeAsync(action, d, actor) {
 		if !audit.ShouldSampleRead(action, false, e.readSamplingRate) {

--- a/server/identity/internal/saadmin/handler.go
+++ b/server/identity/internal/saadmin/handler.go
@@ -169,10 +169,10 @@ func (h *Handler) handleCreate(w http.ResponseWriter, r *http.Request) {
 	}
 	expiresAt := h.resolveExpiry(req.ExpiresInDays)
 
-	var createdBy *int64
-	if actor, ok := api.ActorFromContext(ctx); ok && actor.UserID > 0 {
-		uid := actor.UserID
-		createdBy = &uid
+	var createdBy *string
+	if actor, ok := api.ActorFromContext(ctx); ok && actor.Principal.ID != "" {
+		pid := actor.Principal.ID
+		createdBy = &pid
 	}
 	sa, secret, err := h.store.Create(ctx, serviceaccounts.CreateInput{
 		Name: name, RoleID: role, CreatedBy: createdBy, ExpiresAt: expiresAt,

--- a/server/identity/internal/saadmin/handler_test.go
+++ b/server/identity/internal/saadmin/handler_test.go
@@ -80,7 +80,7 @@ func newHandler(store ManagementStore, az api.AuthZ, audit AuditRecorder) *Handl
 }
 
 func withActor(r *http.Request, userID int64) *http.Request {
-	return r.WithContext(api.WithActor(r.Context(), &api.Actor{UserID: userID, AuthMethod: "oidc"}))
+	return r.WithContext(api.WithActor(r.Context(), &api.Actor{Principal: api.UserPrincipal(userID, ""), AuthMethod: "oidc"}))
 }
 
 func TestHandleList(t *testing.T) {
@@ -140,7 +140,7 @@ func TestHandleCreate_success(t *testing.T) {
 	assert.Equal(t, "sa_created", resp.ClientID)
 	assert.Equal(t, "analyst", store.createInput.RoleID)
 	require.NotNil(t, store.createInput.CreatedBy)
-	assert.Equal(t, int64(42), *store.createInput.CreatedBy)
+	assert.Equal(t, "usr_42", *store.createInput.CreatedBy)
 	// Default 90-day lifetime from the injected clock.
 	assert.Equal(t, time.Unix(1_700_000_000, 0).Add(defaultLifetime).UTC(), store.createInput.ExpiresAt)
 

--- a/server/identity/internal/saadmin/token.go
+++ b/server/identity/internal/saadmin/token.go
@@ -114,7 +114,13 @@ func (h *TokenHandler) handleToken(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	now := h.now().UTC()
-	token, exp, err := h.minter.Mint(satoken.MintInput{Subject: rec.ClientID, Role: rec.RoleID, Epoch: rec.Epoch}, accessTokenTTL, now)
+	token, exp, err := h.minter.Mint(satoken.MintInput{
+		Subject:   rec.ClientID,
+		Role:      rec.RoleID,
+		Epoch:     rec.Epoch,
+		Principal: api.ServiceAccountPrincipalID(rec.ID),
+		Label:     rec.Name,
+	}, accessTokenTTL, now)
 	if err != nil {
 		h.logger.ErrorContext(ctx, "service-account token mint", "err", err)
 		httpserver.NoStoreJSON(ctx, h.logger, w, http.StatusInternalServerError, map[string]string{"error": "internal"})

--- a/server/identity/internal/satoken/satoken.go
+++ b/server/identity/internal/satoken/satoken.go
@@ -34,12 +34,14 @@ const minKeyLen = 32
 // Claims is the authenticated payload of a service-account access token. JSON tags are short because the token rides on every API
 // request the service account makes.
 type Claims struct {
-	Subject   string `json:"sub"`  // service-account client id
-	Audience  string `json:"aud"`  // the API audience this token is minted for
-	Role      string `json:"role"` // the single bound role id, evaluated by the authz chokepoint
-	Epoch     int64  `json:"ep"`   // revocation generation; checked against the per-replica snapshot
-	IssuedAt  int64  `json:"iat"`  // unix seconds
-	ExpiresAt int64  `json:"exp"`  // unix seconds
+	Subject   string `json:"sub"`           // service-account client id
+	Audience  string `json:"aud"`           // the API audience this token is minted for
+	Role      string `json:"role"`          // the single bound role id, evaluated by the authz chokepoint
+	Epoch     int64  `json:"ep"`            // revocation generation; checked against the per-replica snapshot
+	Principal string `json:"pid,omitempty"` // the service account's principal id (svc_<id>); carried so the actor survives auth with no DB read
+	Label     string `json:"nm,omitempty"`  // the service account's display name, snapshotted onto audit rows without a DB read
+	IssuedAt  int64  `json:"iat"`           // unix seconds
+	ExpiresAt int64  `json:"exp"`           // unix seconds
 	KeyID     string `json:"kid"`
 	TokenID   string `json:"jti"` // unique per mint; correlation + forward-compat with a future jti denylist
 }
@@ -81,9 +83,11 @@ func New(key []byte, kid, audience string) (*Signer, error) {
 
 // MintInput is the per-token data the caller supplies; the Signer fills in audience, timestamps, kid, and a random jti.
 type MintInput struct {
-	Subject string
-	Role    string
-	Epoch   int64
+	Subject   string
+	Role      string
+	Epoch     int64
+	Principal string // the service account's principal id (svc_<id>)
+	Label     string // the service account's display name
 }
 
 // Mint returns a token for in, valid for ttl from now, plus the absolute (second-truncated, UTC) expiry. now is injected so callers
@@ -108,6 +112,8 @@ func (s *Signer) Mint(in MintInput, ttl time.Duration, now time.Time) (string, t
 		Audience:  s.audience,
 		Role:      in.Role,
 		Epoch:     in.Epoch,
+		Principal: in.Principal,
+		Label:     in.Label,
 		IssuedAt:  now.Unix(),
 		ExpiresAt: exp.Unix(),
 		KeyID:     s.kid,

--- a/server/identity/internal/service/service.go
+++ b/server/identity/internal/service/service.go
@@ -125,6 +125,7 @@ func (s *service) LoadActor(ctx context.Context, userID int64, authMethod string
 		return nil, fmt.Errorf("load actor bindings: %w", err)
 	}
 	return &api.Actor{
+		Principal:    api.UserPrincipal(u.ID, u.Email),
 		UserID:       u.ID,
 		IsBreakglass: u.IsBreakglass,
 		AuthMethod:   authMethod,

--- a/server/identity/internal/serviceaccounts/authenticator.go
+++ b/server/identity/internal/serviceaccounts/authenticator.go
@@ -50,6 +50,14 @@ func (a *Authenticator) Authenticate(token string, now time.Time) (*api.Actor, b
 		return nil, false
 	}
 	return &api.Actor{
+		// The principal id + label ride in the token claims (stamped at the token endpoint, which already read the SA row), so the acting
+		// service account survives authentication with no DB read on the hot path. This is the root fix for #514 and #518: a service-account
+		// actor is now attributable rather than collapsing to a zero user.
+		Principal: api.PrincipalRef{
+			ID:    claims.Principal,
+			Type:  api.PrincipalServiceAccount,
+			Label: claims.Label,
+		},
 		AuthMethod:   AuthMethodServiceAccount,
 		SessionFresh: false,
 		Roles: []api.RoleBinding{{

--- a/server/identity/internal/serviceaccounts/authenticator.go
+++ b/server/identity/internal/serviceaccounts/authenticator.go
@@ -49,6 +49,12 @@ func (a *Authenticator) Authenticate(token string, now time.Time) (*api.Actor, b
 	if !a.snap.Allowed(claims.Subject, claims.Epoch) {
 		return nil, false
 	}
+	// Reject a token that carries no principal id (a pre-cutover token minted before the principal claim existed). Admitting it would
+	// produce an actor with an empty Principal.ID that then fails every attribution write; a 401 makes the client re-run the grant and
+	// get a principal-bearing token. The 15-minute TTL bounds the transition.
+	if claims.Principal == "" {
+		return nil, false
+	}
 	return &api.Actor{
 		// The principal id + label ride in the token claims (stamped at the token endpoint, which already read the SA row), so the acting
 		// service account survives authentication with no DB read on the hot path. This is the root fix for #514 and #518: a service-account

--- a/server/identity/internal/serviceaccounts/authenticator_test.go
+++ b/server/identity/internal/serviceaccounts/authenticator_test.go
@@ -26,7 +26,7 @@ func (f fakeAllow) Allowed(string, int64) bool { return f.allowed }
 func TestAuthenticator_validTokenResolvesActor(t *testing.T) {
 	t.Parallel()
 	a := NewAuthenticator(
-		fakeVerifier{claims: satoken.Claims{Subject: "sa_abc", Role: "analyst", Epoch: 3}},
+		fakeVerifier{claims: satoken.Claims{Subject: "sa_abc", Role: "analyst", Epoch: 3, Principal: "svc_7", Label: "ci-bot"}},
 		fakeAllow{allowed: true},
 	)
 	actor, ok := a.Authenticate("token", time.Now())
@@ -38,6 +38,13 @@ func TestAuthenticator_validTokenResolvesActor(t *testing.T) {
 	require.Len(t, actor.Roles, 1)
 	assert.Equal(t, "analyst", actor.Roles[0].RoleID)
 	assert.Equal(t, api.RoleBindingScopeGlobal, actor.Roles[0].ScopeType)
+	// The acting service account survives authentication as a typed principal (the root fix for #514/#518): id + label come from the
+	// token claims, with no DB read.
+	assert.Equal(t, "svc_7", actor.Principal.ID)
+	assert.Equal(t, api.PrincipalServiceAccount, actor.Principal.Type)
+	assert.Equal(t, "ci-bot", actor.Principal.Label)
+	_, isUser := actor.Principal.UserID()
+	assert.False(t, isUser, "a service-account principal must never read as a user")
 }
 
 func TestAuthenticator_invalidTokenRejected(t *testing.T) {

--- a/server/identity/internal/serviceaccounts/store.go
+++ b/server/identity/internal/serviceaccounts/store.go
@@ -21,6 +21,8 @@ import (
 	"time"
 
 	"github.com/jmoiron/sqlx"
+
+	"github.com/fleetdm/edr/server/identity/api"
 )
 
 // clientIDPrefix and secretPrefix are self-describing so a leaked secret is greppable by secret-scanners and a client id is
@@ -101,6 +103,14 @@ func (s *Store) Create(ctx context.Context, in CreateInput) (ServiceAccount, str
 	id, err := res.LastInsertId()
 	if err != nil {
 		return ServiceAccount{}, "", fmt.Errorf("serviceaccounts: last insert id: %w", err)
+	}
+	// The service account is a typed principal: insert its spine row so it is attributable and can be referenced by principal-FK
+	// attribution columns. The display label is its name, snapshotted onto audit rows. See ADR-0017.
+	if _, err := s.db.ExecContext(ctx,
+		`INSERT INTO principals (id, type, display_label) VALUES (?, 'service_account', ?)
+		 ON DUPLICATE KEY UPDATE display_label = VALUES(display_label)`,
+		api.ServiceAccountPrincipalID(id), in.Name); err != nil {
+		return ServiceAccount{}, "", fmt.Errorf("serviceaccounts: ensure principal: %w", err)
 	}
 	sa, err := s.getByID(ctx, id)
 	if err != nil {

--- a/server/identity/internal/serviceaccounts/store.go
+++ b/server/identity/internal/serviceaccounts/store.go
@@ -37,16 +37,16 @@ var ErrNotFound = errors.New("serviceaccounts: not found")
 
 // ServiceAccount is the read model returned to the admin surface. It never carries the secret or its hash.
 type ServiceAccount struct {
-	ID         int64        `db:"id"`
-	ClientID   string       `db:"client_id"`
-	Name       string       `db:"name"`
-	RoleID     string       `db:"role_id"`
-	Epoch      int64        `db:"epoch"`
-	CreatedBy  *int64       `db:"created_by"`
-	ExpiresAt  time.Time    `db:"expires_at"`
-	RevokedAt  sql.NullTime `db:"revoked_at"`
-	LastUsedAt sql.NullTime `db:"last_used_at"`
-	CreatedAt  time.Time    `db:"created_at"`
+	ID         int64          `db:"id"`
+	ClientID   string         `db:"client_id"`
+	Name       string         `db:"name"`
+	RoleID     string         `db:"role_id"`
+	Epoch      int64          `db:"epoch"`
+	CreatedBy  sql.NullString `db:"created_by"`
+	ExpiresAt  time.Time      `db:"expires_at"`
+	RevokedAt  sql.NullTime   `db:"revoked_at"`
+	LastUsedAt sql.NullTime   `db:"last_used_at"`
+	CreatedAt  time.Time      `db:"created_at"`
 }
 
 // AuthRecord is the secret-bearing lookup used only by the token endpoint to validate a presented credential. It carries the stored
@@ -77,7 +77,7 @@ func New(db *sqlx.DB) *Store {
 type CreateInput struct {
 	Name      string
 	RoleID    string
-	CreatedBy *int64
+	CreatedBy *string
 	ExpiresAt time.Time
 }
 

--- a/server/identity/internal/serviceaccounts/store.go
+++ b/server/identity/internal/serviceaccounts/store.go
@@ -93,7 +93,19 @@ func (s *Store) Create(ctx context.Context, in CreateInput) (ServiceAccount, str
 		return ServiceAccount{}, "", fmt.Errorf("serviceaccounts: generate secret: %w", err)
 	}
 	hash := hashSecret(secret)
-	res, err := s.db.ExecContext(ctx, `
+	// The service_accounts row and its principals spine row commit together: a failed principal insert must not leave an unattributable
+	// service account behind. The principal's display label is the SA name, snapshotted onto audit rows. See ADR-0017.
+	tx, err := s.db.BeginTxx(ctx, nil)
+	if err != nil {
+		return ServiceAccount{}, "", fmt.Errorf("serviceaccounts: begin create tx: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+	res, err := tx.ExecContext(ctx, `
 		INSERT INTO service_accounts (client_id, name, role_id, secret_hash, expires_at, created_by)
 		VALUES (?, ?, ?, ?, ?, ?)`,
 		clientID, in.Name, in.RoleID, hash, in.ExpiresAt.UTC(), in.CreatedBy)
@@ -104,14 +116,16 @@ func (s *Store) Create(ctx context.Context, in CreateInput) (ServiceAccount, str
 	if err != nil {
 		return ServiceAccount{}, "", fmt.Errorf("serviceaccounts: last insert id: %w", err)
 	}
-	// The service account is a typed principal: insert its spine row so it is attributable and can be referenced by principal-FK
-	// attribution columns. The display label is its name, snapshotted onto audit rows. See ADR-0017.
-	if _, err := s.db.ExecContext(ctx,
+	if _, err := tx.ExecContext(ctx,
 		`INSERT INTO principals (id, type, display_label) VALUES (?, 'service_account', ?)
 		 ON DUPLICATE KEY UPDATE display_label = VALUES(display_label)`,
 		api.ServiceAccountPrincipalID(id), in.Name); err != nil {
 		return ServiceAccount{}, "", fmt.Errorf("serviceaccounts: ensure principal: %w", err)
 	}
+	if err := tx.Commit(); err != nil {
+		return ServiceAccount{}, "", fmt.Errorf("serviceaccounts: commit create tx: %w", err)
+	}
+	committed = true
 	sa, err := s.getByID(ctx, id)
 	if err != nil {
 		return ServiceAccount{}, "", err

--- a/server/identity/internal/serviceaccounts/store.go
+++ b/server/identity/internal/serviceaccounts/store.go
@@ -50,7 +50,9 @@ type ServiceAccount struct {
 // AuthRecord is the secret-bearing lookup used only by the token endpoint to validate a presented credential. It carries the stored
 // hash (never the plaintext) plus the fields needed to mint and to decide whether minting is allowed.
 type AuthRecord struct {
+	ID         int64        `db:"id"`
 	ClientID   string       `db:"client_id"`
+	Name       string       `db:"name"`
 	RoleID     string       `db:"role_id"`
 	SecretHash []byte       `db:"secret_hash"`
 	Epoch      int64        `db:"epoch"`
@@ -122,7 +124,7 @@ func (s *Store) List(ctx context.Context) ([]ServiceAccount, error) {
 func (s *Store) AuthByClientID(ctx context.Context, clientID string) (AuthRecord, error) {
 	var rec AuthRecord
 	err := s.db.GetContext(ctx, &rec, `
-		SELECT client_id, role_id, secret_hash, epoch, expires_at, revoked_at
+		SELECT id, client_id, name, role_id, secret_hash, epoch, expires_at, revoked_at
 		FROM service_accounts WHERE client_id = ?`, clientID)
 	if errors.Is(err, sql.ErrNoRows) {
 		return AuthRecord{}, ErrNotFound

--- a/server/identity/internal/ssoadmin/handler.go
+++ b/server/identity/internal/ssoadmin/handler.go
@@ -43,7 +43,7 @@ type appConfigStore interface {
 // a new issuer/client paired with a stale derived redirect. expectedAppVersion drives the app-config optimistic-concurrency check;
 // implementations return appconfig.ErrVersionConflict on a concurrent edit. Injected so the handler stays unit-testable without a DB.
 type applyUpdate func(
-	ctx context.Context, oidcIn ssoconfig.UpsertInput, appCfg appconfig.AppConfig, expectedAppVersion int64, updatedBy *int64,
+	ctx context.Context, oidcIn ssoconfig.UpsertInput, appCfg appconfig.AppConfig, expectedAppVersion int64, updatedBy string,
 ) error
 
 // prober verifies a candidate issuer is reachable. Production wraps oidc.Probe with the deployment HTTP client; tests inject a fake.
@@ -175,12 +175,10 @@ func (h *Handler) handleUpdate(w http.ResponseWriter, r *http.Request) {
 		writeErr(ctx, h.logger, w, http.StatusInternalServerError, "internal")
 		return
 	}
-	// A service-account actor has no user id (UserID == 0), so leave UpdatedBy nil and record NULL on both writes below, the same "no
-	// operator" semantics the env-seed path uses. Binding 0 would violate the updated_by FKs (fk_oidc_config_updated_by /
-	// fk_app_config_updated_by; no users row has id 0) and fail the transaction with a 500.
-	if actor.UserID != 0 {
-		in.UpdatedBy = &actor.UserID
-	}
+	// Record the acting principal id (usr_<id> for a user, svc_<id> for a service account) as updated_by. Both are valid principals(id)
+	// FK targets, so a service-account SSO update is attributed to the service account rather than the interim NULL the #515 stopgap
+	// recorded. See ADR-0017.
+	in.UpdatedBy = actor.Principal.ID
 	// Read the app-config document (read-modify-write preserves unrelated settings) and capture its version for the optimistic-
 	// concurrency check inside the transactional apply.
 	appCfg, appVersion, err := h.appCfg.Get(ctx)

--- a/server/identity/internal/ssoadmin/handler_test.go
+++ b/server/identity/internal/ssoadmin/handler_test.go
@@ -53,11 +53,11 @@ type captureApply struct {
 	oidcIn          ssoconfig.UpsertInput
 	appCfg          appconfig.AppConfig
 	expectedVersion int64
-	updatedBy       *int64
+	updatedBy       string
 	err             error
 }
 
-func (c *captureApply) fn(_ context.Context, oidcIn ssoconfig.UpsertInput, appCfg appconfig.AppConfig, expectedVersion int64, updatedBy *int64) error {
+func (c *captureApply) fn(_ context.Context, oidcIn ssoconfig.UpsertInput, appCfg appconfig.AppConfig, expectedVersion int64, updatedBy string) error {
 	c.called = true
 	c.oidcIn = oidcIn
 	c.appCfg = appCfg
@@ -66,7 +66,7 @@ func (c *captureApply) fn(_ context.Context, oidcIn ssoconfig.UpsertInput, appCf
 	return c.err
 }
 
-func noopApply(context.Context, ssoconfig.UpsertInput, appconfig.AppConfig, int64, *int64) error {
+func noopApply(context.Context, ssoconfig.UpsertInput, appconfig.AppConfig, int64, string) error {
 	return nil
 }
 
@@ -93,7 +93,7 @@ func okProbe(context.Context, string) error { return nil }
 
 // withActor pins an actor on the request context so handleUpdate's ActorFromContext succeeds.
 func withActor(r *http.Request, userID int64) *http.Request {
-	return r.WithContext(api.WithActor(r.Context(), &api.Actor{UserID: userID, AuthMethod: "oidc"}))
+	return r.WithContext(api.WithActor(r.Context(), &api.Actor{Principal: api.UserPrincipal(userID, ""), AuthMethod: "oidc"}))
 }
 
 func putReq(t *testing.T, body any) *http.Request {
@@ -167,8 +167,7 @@ func TestHandleUpdate_validRotatesSecretAtomicallyAndAudits(t *testing.T) {
 	require.True(t, ap.called, "the transactional apply must be invoked")
 	require.NotNil(t, ap.oidcIn.NewSecret)
 	assert.Equal(t, "rotate-me", *ap.oidcIn.NewSecret)
-	require.NotNil(t, ap.updatedBy, "a human actor stamps updated_by with its user id")
-	assert.Equal(t, int64(42), *ap.updatedBy)
+	assert.Equal(t, "usr_42", ap.updatedBy, "a human actor stamps updated_by with its principal id")
 	assert.Equal(t, "https://edr.example.com", ap.appCfg.ExternalURL)
 	assert.Equal(t, int64(3), ap.expectedVersion, "the read app-config version must flow into the OCC check")
 

--- a/server/identity/internal/ssoconfig/ssoconfig.go
+++ b/server/identity/internal/ssoconfig/ssoconfig.go
@@ -10,6 +10,8 @@ import (
 	"time"
 
 	"github.com/jmoiron/sqlx"
+
+	"github.com/fleetdm/edr/server/identity/api"
 )
 
 // ErrNotFound is returned by the Get methods when no oidc_config row exists (OIDC has not been configured for the deployment).
@@ -28,7 +30,7 @@ type Config struct {
 	DefaultRole  string
 	Version      int64
 	UpdatedAt    time.Time
-	UpdatedBy    sql.NullInt64
+	UpdatedBy    sql.NullString
 }
 
 // CallbackPath is the OIDC redirect/callback route the server serves. The registered redirect URI is the deployment external URL +
@@ -59,15 +61,15 @@ func RedirectURLFor(externalURL string) string {
 
 // row is the raw DB shape; client_secret_enc stays sealed until GetDecrypted opens it.
 type row struct {
-	Issuer          string        `db:"issuer"`
-	ClientID        string        `db:"client_id"`
-	ClientSecretEnc []byte        `db:"client_secret_enc"`
-	Scopes          string        `db:"scopes"`
-	JITEnabled      bool          `db:"jit_enabled"`
-	DefaultRole     string        `db:"default_role"`
-	Version         int64         `db:"config_version"`
-	UpdatedAt       time.Time     `db:"updated_at"`
-	UpdatedBy       sql.NullInt64 `db:"updated_by"`
+	Issuer          string         `db:"issuer"`
+	ClientID        string         `db:"client_id"`
+	ClientSecretEnc []byte         `db:"client_secret_enc"`
+	Scopes          string         `db:"scopes"`
+	JITEnabled      bool           `db:"jit_enabled"`
+	DefaultRole     string         `db:"default_role"`
+	Version         int64          `db:"config_version"`
+	UpdatedAt       time.Time      `db:"updated_at"`
+	UpdatedBy       sql.NullString `db:"updated_by"`
 }
 
 // UpsertInput is the write shape. NewSecret nil leaves the stored secret unchanged (rotate-only semantics); a non-nil pointer (even to
@@ -79,7 +81,7 @@ type UpsertInput struct {
 	Scopes      []string
 	JITEnabled  bool
 	DefaultRole string
-	UpdatedBy   *int64
+	UpdatedBy   string
 }
 
 // Store owns the oidc_config table. It holds the Sealer so secret sealing/opening stays co-located with persistence.
@@ -170,9 +172,11 @@ func (s *Store) Upsert(ctx context.Context, in UpsertInput) error {
 // also updates other tables atomically (e.g. the SSO admin update that writes oidc_config and app_config together).
 func (s *Store) UpsertTx(ctx context.Context, ext sqlx.ExtContext, in UpsertInput) error {
 	scopes := strings.Join(in.Scopes, ",")
-	var updatedBy sql.NullInt64
-	if in.UpdatedBy != nil {
-		updatedBy = sql.NullInt64{Int64: *in.UpdatedBy, Valid: true}
+	// An unset updater records the system principal (env-seed / background write), matching the column's NOT NULL DEFAULT 'sys' and its
+	// FK to principals(id); an empty string would violate the FK.
+	updatedBy := in.UpdatedBy
+	if updatedBy == "" {
+		updatedBy = api.PrincipalSystemID
 	}
 
 	if in.NewSecret != nil {

--- a/server/identity/internal/tests/appconfig_store_test.go
+++ b/server/identity/internal/tests/appconfig_store_test.go
@@ -24,7 +24,7 @@ func TestAppConfigStore_putGetRoundTripAndVersionBumps(t *testing.T) {
 	ctx := t.Context()
 
 	// First write: no row yet, so expectedVersion 0 inserts the singleton.
-	require.NoError(t, store.Put(ctx, appconfig.AppConfig{ExternalURL: "https://edr.acme.com"}, 0, nil))
+	require.NoError(t, store.Put(ctx, appconfig.AppConfig{ExternalURL: "https://edr.acme.com"}, 0, "sys"))
 	cfg, version, err := store.Get(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, "https://edr.acme.com", cfg.ExternalURL)
@@ -32,7 +32,7 @@ func TestAppConfigStore_putGetRoundTripAndVersionBumps(t *testing.T) {
 
 	// Read-modify-write with the read version: the OCC update bumps the version and overwrites the document.
 	cfg.ExternalURL = "https://edr.acme.com:8443"
-	require.NoError(t, store.Put(ctx, cfg, version, nil))
+	require.NoError(t, store.Put(ctx, cfg, version, "sys"))
 	got, version, err := store.Get(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, "https://edr.acme.com:8443", got.ExternalURL)
@@ -44,13 +44,13 @@ func TestAppConfigStore_putWithStaleVersionConflicts(t *testing.T) {
 	store := appconfig.New(full.Open(t))
 	ctx := t.Context()
 
-	require.NoError(t, store.Put(ctx, appconfig.AppConfig{ExternalURL: "https://a"}, 0, nil))
+	require.NoError(t, store.Put(ctx, appconfig.AppConfig{ExternalURL: "https://a"}, 0, "sys"))
 	_, version, err := store.Get(ctx)
 	require.NoError(t, err)
 
 	// A writer holding the current version succeeds and bumps it.
-	require.NoError(t, store.Put(ctx, appconfig.AppConfig{ExternalURL: "https://b"}, version, nil))
+	require.NoError(t, store.Put(ctx, appconfig.AppConfig{ExternalURL: "https://b"}, version, "sys"))
 	// A second writer still holding the now-stale version is rejected (lost-update prevented).
-	err = store.Put(ctx, appconfig.AppConfig{ExternalURL: "https://c"}, version, nil)
+	err = store.Put(ctx, appconfig.AppConfig{ExternalURL: "https://c"}, version, "sys")
 	require.ErrorIs(t, err, appconfig.ErrVersionConflict)
 }

--- a/server/identity/internal/tests/sso_admin_integration_test.go
+++ b/server/identity/internal/tests/sso_admin_integration_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"database/sql"
 	"encoding/json"
 	"log/slog"
 	"net/http"
@@ -68,19 +67,23 @@ func newIdentityWithDiscovery(t *testing.T, idp *httptest.Server) (*bootstrap.Id
 	return id, db, ssoconfig.New(db, sealer), appconfig.New(db)
 }
 
-// seedUser inserts a users row and returns its id, for the oidc_config.updated_by FK on the admin update path.
+// seedUser inserts a users row plus its principals spine row (the oidc_config.updated_by FK targets principals(id)) and returns the
+// user id.
 func seedUser(t *testing.T, db *sqlx.DB, email string) int64 {
 	t.Helper()
 	res, err := db.ExecContext(t.Context(), "INSERT INTO users (email) VALUES (?)", email)
 	require.NoError(t, err)
 	id, err := res.LastInsertId()
 	require.NoError(t, err)
+	_, err = db.ExecContext(t.Context(),
+		"INSERT INTO principals (id, type, display_label) VALUES (?, 'user', ?)", api.UserPrincipalID(id), email)
+	require.NoError(t, err)
 	return id
 }
 
 func adminActorCtx(r *http.Request, userID int64) *http.Request {
 	actor := &api.Actor{
-		UserID:       userID,
+		Principal:    api.UserPrincipal(userID, "admin@itest.local"),
 		AuthMethod:   "oidc",
 		SessionFresh: true,
 		Roles: []api.RoleBinding{{
@@ -158,7 +161,7 @@ func TestSSOAdmin_updatePersistsAtomically(t *testing.T) {
 // "admin" (which holds sso.manage): service accounts are forbidden from binding super_admin, so admin reflects a real SA token.
 func serviceAccountActorCtx(r *http.Request) *http.Request {
 	actor := &api.Actor{
-		UserID:       0,
+		Principal:    api.ServiceAccountPrincipal(7, "ci-bot"),
 		AuthMethod:   "service_account",
 		SessionFresh: false,
 		Roles: []api.RoleBinding{{
@@ -168,13 +171,18 @@ func serviceAccountActorCtx(r *http.Request) *http.Request {
 	return r.WithContext(api.WithActor(r.Context(), actor))
 }
 
-// TestSSOAdmin_updateByServiceAccountRecordsNullUpdatedBy is a regression test: a service-account actor has no user id, so the update
-// path must record oidc_config.updated_by as NULL rather than 0. Binding 0 violates the updated_by FK to users(id) and previously
-// failed the write with a 500, blocking service-account-driven SSO configuration.
-func TestSSOAdmin_updateByServiceAccountRecordsNullUpdatedBy(t *testing.T) {
+// TestSSOAdmin_updateByServiceAccountRecordsPrincipal verifies the #514 fix: a service-account SSO update records its principal id
+// (svc_<id>) on both oidc_config.updated_by and app_config.updated_by, rather than the interim NULL the #515 stopgap recorded. The
+// columns FK principals(id), so the acting service account is attributed to the same standard as a user.
+func TestSSOAdmin_updateByServiceAccountRecordsPrincipal(t *testing.T) {
 	t.Parallel()
 	idp := oidcDiscoveryServer(t)
 	id, db, ssoStore, _ := newIdentityWithDiscovery(t, idp)
+
+	// The actor's service-account principal (svc_7) must exist for the updated_by FK to principals.
+	_, err := db.ExecContext(t.Context(),
+		"INSERT INTO principals (id, type, display_label) VALUES ('svc_7', 'service_account', 'ci-bot')")
+	require.NoError(t, err)
 
 	mux := http.NewServeMux()
 	id.RegisterAuthedRoutes(mux)
@@ -204,13 +212,12 @@ func TestSSOAdmin_updateByServiceAccountRecordsNullUpdatedBy(t *testing.T) {
 	assert.Equal(t, "edr-sa-updated", cfg.ClientID)
 	assert.Equal(t, rotated, cfg.ClientSecret)
 
-	// Both rows the transaction writes record updated_by NULL (no operator), the same semantics as env-seeding, never 0. app_config
-	// carries the same updated_by FK as oidc_config, so it would 500 the write too if a service account stamped 0.
-	var oidcUpdatedBy, appUpdatedBy sql.NullInt64
+	// Both rows the transaction writes record the acting service account's principal id, attributing the change to it (not NULL).
+	var oidcUpdatedBy, appUpdatedBy string
 	require.NoError(t, db.GetContext(t.Context(), &oidcUpdatedBy, "SELECT updated_by FROM oidc_config WHERE id = 1"))
 	require.NoError(t, db.GetContext(t.Context(), &appUpdatedBy, "SELECT updated_by FROM app_config WHERE id = 1"))
-	assert.False(t, oidcUpdatedBy.Valid, "oidc_config: service-account write must record updated_by NULL, not %d", oidcUpdatedBy.Int64)
-	assert.False(t, appUpdatedBy.Valid, "app_config: service-account write must record updated_by NULL, not %d", appUpdatedBy.Int64)
+	assert.Equal(t, "svc_7", oidcUpdatedBy, "oidc_config: service-account write records the SA principal id")
+	assert.Equal(t, "svc_7", appUpdatedBy, "app_config: service-account write records the SA principal id")
 }
 
 // TestSSOAdmin_updateDeniedWithoutGrant confirms the real chokepoint rejects an actor lacking sso.manage (analyst).

--- a/server/identity/internal/users/users.go
+++ b/server/identity/internal/users/users.go
@@ -16,6 +16,8 @@ import (
 
 	"github.com/jmoiron/sqlx"
 	"golang.org/x/crypto/argon2"
+
+	"github.com/fleetdm/edr/server/identity/api"
 )
 
 // argon2id parameters per OWASP Password Storage Cheat Sheet 2024. ~30 ms per hash on M-series Mac; the hot path (login verify) hashes
@@ -122,7 +124,24 @@ func (s *Store) Create(ctx context.Context, req CreateRequest) (*User, error) {
 	if err != nil {
 		return nil, fmt.Errorf("last insert id: %w", err)
 	}
+	if err := ensureUserPrincipal(ctx, s.db, id, email); err != nil {
+		return nil, err
+	}
 	return s.Get(ctx, id)
+}
+
+// ensureUserPrincipal inserts (idempotently) the principals spine row for a user, so the user is attributable as a typed principal and
+// can be referenced by the principal-FK attribution columns. The display label is the user's email, snapshotted onto audit rows. See
+// ADR-0017.
+func ensureUserPrincipal(ctx context.Context, ec Executor, userID int64, email string) error {
+	_, err := ec.ExecContext(ctx,
+		`INSERT INTO principals (id, type, display_label) VALUES (?, 'user', ?)
+		 ON DUPLICATE KEY UPDATE display_label = VALUES(display_label)`,
+		api.UserPrincipalID(userID), email)
+	if err != nil {
+		return fmt.Errorf("ensure user principal: %w", err)
+	}
+	return nil
 }
 
 // CreateOIDCRequest is the shape accepted by CreateOIDC. password_* columns are NULL on the resulting row: OIDC users have no
@@ -156,6 +175,10 @@ func (s *Store) CreateOIDC(ctx context.Context, ec Executor, req CreateOIDCReque
 	id, err := res.LastInsertId()
 	if err != nil {
 		return nil, fmt.Errorf("last insert id: %w", err)
+	}
+	// Same executor (the caller's tx) so the principal row commits or rolls back atomically with the user + identity + role-binding inserts.
+	if err := ensureUserPrincipal(ctx, ec, id, email); err != nil {
+		return nil, err
 	}
 	return &User{
 		ID:           id,
@@ -208,6 +231,9 @@ func (s *Store) CreateBreakglass(ctx context.Context, req CreateBreakglassReques
 	// silently flipping the row's flag and stranding the existing password.
 	if !u.IsBreakglass {
 		return &u, ErrExistingNonBreakglass
+	}
+	if err := ensureUserPrincipal(ctx, s.db, u.ID, email); err != nil {
+		return nil, err
 	}
 	return &u, nil
 }

--- a/server/identity/internal/users/users.go
+++ b/server/identity/internal/users/users.go
@@ -114,20 +114,44 @@ func (s *Store) Create(ctx context.Context, req CreateRequest) (*User, error) {
 	if err != nil {
 		return nil, err
 	}
-	res, err := s.db.ExecContext(ctx, `
-		INSERT INTO users (email, password_hash, password_salt) VALUES (?, ?, ?)
-	`, email, hash, salt)
+	// The user row and its principals spine row commit together: a failed principal insert must not leave an unattributable user behind.
+	id, err := s.txInsertUser(ctx, `INSERT INTO users (email, password_hash, password_salt) VALUES (?, ?, ?)`, email,
+		email, hash, salt)
 	if err != nil {
-		return nil, fmt.Errorf("insert user: %w", err)
-	}
-	id, err := res.LastInsertId()
-	if err != nil {
-		return nil, fmt.Errorf("last insert id: %w", err)
-	}
-	if err := ensureUserPrincipal(ctx, s.db, id, email); err != nil {
 		return nil, err
 	}
 	return s.Get(ctx, id)
+}
+
+// txInsertUser runs the user INSERT and its principals spine row in one transaction, returning the new user id. label is the principal
+// display label (the email); args are the INSERT placeholders. Keeps every user-creation path atomic in the user + principal write.
+func (s *Store) txInsertUser(ctx context.Context, insertSQL, label string, args ...any) (int64, error) {
+	tx, err := s.db.BeginTxx(ctx, nil)
+	if err != nil {
+		return 0, fmt.Errorf("begin user insert tx: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+	res, err := tx.ExecContext(ctx, insertSQL, args...)
+	if err != nil {
+		return 0, fmt.Errorf("insert user: %w", err)
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		return 0, fmt.Errorf("last insert id: %w", err)
+	}
+	if err := ensureUserPrincipal(ctx, tx, id, label); err != nil {
+		return 0, err
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, fmt.Errorf("commit user insert tx: %w", err)
+	}
+	committed = true
+	return id, nil
 }
 
 // ensureUserPrincipal inserts (idempotently) the principals spine row for a user, so the user is attributable as a typed principal and

--- a/server/identity/migrations/00005_principals.sql
+++ b/server/identity/migrations/00005_principals.sql
@@ -56,9 +56,11 @@ ALTER TABLE audit_events
 	ADD COLUMN actor_label        VARCHAR(255) NULL AFTER actor_principal_id;
 -- +goose StatementEnd
 -- +goose StatementBegin
+-- A legacy row with actor_user_id = 0 carried no real user (pre-auth failures and the old service-account 0 stopgap), so it backfills to
+-- no principal (NULL id/type) with the attempted identifier preserved in actor_label, never the bogus usr_0.
 UPDATE audit_events SET
-	actor_principal_id = CASE WHEN actor_user_id IS NULL THEN NULL ELSE CONCAT('usr_', actor_user_id) END,
-	actor_type = CASE WHEN actor_user_id IS NULL THEN NULL ELSE 'user' END,
+	actor_principal_id = CASE WHEN actor_user_id IS NULL OR actor_user_id = 0 THEN NULL ELSE CONCAT('usr_', actor_user_id) END,
+	actor_type = CASE WHEN actor_user_id IS NULL OR actor_user_id = 0 THEN NULL ELSE 'user' END,
 	actor_label = actor_email;
 -- +goose StatementEnd
 -- +goose StatementBegin

--- a/server/identity/migrations/00005_principals.sql
+++ b/server/identity/migrations/00005_principals.sql
@@ -1,0 +1,77 @@
+-- +goose Up
+-- The unified principal model (ADR-0017, issues #514 + #518). A principal is the single typed identity every authenticated actor
+-- resolves to: a human user, a service account, or the deployment itself. This migration creates the principals spine, backfills one
+-- row per existing user / service account plus the singleton system principal, and rewrites every identity-context attribution column
+-- (and the audit trail) from a user-only BIGINT to the principal id string. Hard cutover: the legacy BIGINT columns are dropped, not
+-- kept alongside (the product is pre-release, so there is no attribution history to preserve).
+
+-- +goose StatementBegin
+-- principals is the identity spine. id is a type-prefixed string (usr_<users.id> / svc_<service_accounts.id> / the singleton 'sys');
+-- type is the authoritative discriminator (also encoded in the id prefix); display_label is the snapshot-able name (user email, SA
+-- name, or 'system'); disabled_at tombstones a removed subtype row so attribution stays resolvable and the id is never reused.
+CREATE TABLE IF NOT EXISTS principals (
+	id            VARCHAR(40)  NOT NULL,
+	type          ENUM('user', 'service_account', 'system') NOT NULL,
+	display_label VARCHAR(255) NOT NULL,
+	disabled_at   TIMESTAMP(6) NULL,
+	created_at    TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+	PRIMARY KEY (id),
+	INDEX idx_principals_type (type)
+);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+-- The singleton system principal: env-seed writes, background jobs, and migrations attribute to it rather than to NULL or a free-form
+-- 'system' literal.
+INSERT INTO principals (id, type, display_label) VALUES ('sys', 'system', 'system')
+ON DUPLICATE KEY UPDATE display_label = VALUES(display_label);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+-- One principal per existing user.
+INSERT INTO principals (id, type, display_label)
+SELECT CONCAT('usr_', id), 'user', email FROM users
+ON DUPLICATE KEY UPDATE display_label = VALUES(display_label);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+-- One principal per existing service account.
+INSERT INTO principals (id, type, display_label)
+SELECT CONCAT('svc_', id), 'service_account', name FROM service_accounts
+ON DUPLICATE KEY UPDATE display_label = VALUES(display_label);
+-- +goose StatementEnd
+
+-- NOTE: the BIGINT-FK attribution columns (oidc_config.updated_by, app_config.updated_by, service_accounts.created_by) are rewritten to
+-- the principal id in the following migration (00006), paired with the store-layer threading; this migration lands the spine + the audit
+-- trail so the principal model is established first.
+
+-- audit_events: replace the user-only actor_user_id + actor_email with a typed principal triple (type, principal id, snapshot label).
+-- actor_principal_id is deliberately unconstrained (no FK): the append-only audit history must never be invalidated by a deleted
+-- principal or a later widening of the type set. A pre-auth failure row keeps a NULL principal id and records the attempted identifier
+-- in actor_label.
+-- +goose StatementBegin
+ALTER TABLE audit_events
+	ADD COLUMN actor_type         VARCHAR(32)  NULL AFTER occurred_at,
+	ADD COLUMN actor_principal_id VARCHAR(40)  NULL AFTER actor_type,
+	ADD COLUMN actor_label        VARCHAR(255) NULL AFTER actor_principal_id;
+-- +goose StatementEnd
+-- +goose StatementBegin
+UPDATE audit_events SET
+	actor_principal_id = CASE WHEN actor_user_id IS NULL THEN NULL ELSE CONCAT('usr_', actor_user_id) END,
+	actor_type = CASE WHEN actor_user_id IS NULL THEN NULL ELSE 'user' END,
+	actor_label = actor_email;
+-- +goose StatementEnd
+-- +goose StatementBegin
+ALTER TABLE audit_events DROP INDEX idx_audit_events_actor;
+-- +goose StatementEnd
+-- +goose StatementBegin
+ALTER TABLE audit_events DROP COLUMN actor_user_id, DROP COLUMN actor_email;
+-- +goose StatementEnd
+-- +goose StatementBegin
+ALTER TABLE audit_events ADD INDEX idx_audit_events_actor (actor_principal_id, occurred_at);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+SELECT 1;
+-- +goose StatementEnd

--- a/server/identity/migrations/00005_principals.sql
+++ b/server/identity/migrations/00005_principals.sql
@@ -61,7 +61,8 @@ ALTER TABLE audit_events
 UPDATE audit_events SET
 	actor_principal_id = CASE WHEN actor_user_id IS NULL OR actor_user_id = 0 THEN NULL ELSE CONCAT('usr_', actor_user_id) END,
 	actor_type = CASE WHEN actor_user_id IS NULL OR actor_user_id = 0 THEN NULL ELSE 'user' END,
-	actor_label = actor_email;
+	actor_label = actor_email
+WHERE actor_user_id IS NOT NULL OR actor_email IS NOT NULL;
 -- +goose StatementEnd
 -- +goose StatementBegin
 ALTER TABLE audit_events DROP INDEX idx_audit_events_actor;

--- a/server/identity/migrations/00006_attribution_principals.sql
+++ b/server/identity/migrations/00006_attribution_principals.sql
@@ -12,7 +12,7 @@ ALTER TABLE oidc_config DROP FOREIGN KEY fk_oidc_config_updated_by;
 ALTER TABLE oidc_config MODIFY COLUMN updated_by VARCHAR(40) NULL;
 -- +goose StatementEnd
 -- +goose StatementBegin
-UPDATE oidc_config SET updated_by = CASE WHEN updated_by IS NULL OR updated_by = '0' THEN 'sys' ELSE CONCAT('usr_', updated_by) END;
+UPDATE oidc_config SET updated_by = CASE WHEN updated_by IS NULL OR updated_by = '0' THEN 'sys' ELSE CONCAT('usr_', updated_by) END WHERE id = 1;
 -- +goose StatementEnd
 -- +goose StatementBegin
 ALTER TABLE oidc_config MODIFY COLUMN updated_by VARCHAR(40) NOT NULL DEFAULT 'sys';
@@ -29,7 +29,7 @@ ALTER TABLE app_config DROP FOREIGN KEY fk_app_config_updated_by;
 ALTER TABLE app_config MODIFY COLUMN updated_by VARCHAR(40) NULL;
 -- +goose StatementEnd
 -- +goose StatementBegin
-UPDATE app_config SET updated_by = CASE WHEN updated_by IS NULL OR updated_by = '0' THEN 'sys' ELSE CONCAT('usr_', updated_by) END;
+UPDATE app_config SET updated_by = CASE WHEN updated_by IS NULL OR updated_by = '0' THEN 'sys' ELSE CONCAT('usr_', updated_by) END WHERE id = 1;
 -- +goose StatementEnd
 -- +goose StatementBegin
 ALTER TABLE app_config MODIFY COLUMN updated_by VARCHAR(40) NOT NULL DEFAULT 'sys';

--- a/server/identity/migrations/00006_attribution_principals.sql
+++ b/server/identity/migrations/00006_attribution_principals.sql
@@ -1,0 +1,62 @@
+-- +goose Up
+-- Cut the identity-context attribution columns over from a user-only BIGINT FK to the principal id (ADR-0017, #514). Paired with the
+-- store-layer threading that writes the principal id. The principals spine + its backfill landed in 00005, so every usr_<id> / svc_<id>
+-- referenced here already exists. Hard cutover: the BIGINT columns are rewritten in place, not kept alongside.
+
+-- oidc_config.updated_by: BIGINT FK users -> VARCHAR(40) FK principals, NOT NULL DEFAULT 'sys'. A pre-existing user id becomes usr_<id>;
+-- a NULL or legacy 0 (the #514 / #515 interim stopgap) becomes the system principal, so the NULL-attribution case is gone for good.
+-- +goose StatementBegin
+ALTER TABLE oidc_config DROP FOREIGN KEY fk_oidc_config_updated_by;
+-- +goose StatementEnd
+-- +goose StatementBegin
+ALTER TABLE oidc_config MODIFY COLUMN updated_by VARCHAR(40) NULL;
+-- +goose StatementEnd
+-- +goose StatementBegin
+UPDATE oidc_config SET updated_by = CASE WHEN updated_by IS NULL OR updated_by = '0' THEN 'sys' ELSE CONCAT('usr_', updated_by) END;
+-- +goose StatementEnd
+-- +goose StatementBegin
+ALTER TABLE oidc_config MODIFY COLUMN updated_by VARCHAR(40) NOT NULL DEFAULT 'sys';
+-- +goose StatementEnd
+-- +goose StatementBegin
+ALTER TABLE oidc_config ADD CONSTRAINT fk_oidc_config_updated_by FOREIGN KEY (updated_by) REFERENCES principals(id);
+-- +goose StatementEnd
+
+-- app_config.updated_by: same rewrite as oidc_config.
+-- +goose StatementBegin
+ALTER TABLE app_config DROP FOREIGN KEY fk_app_config_updated_by;
+-- +goose StatementEnd
+-- +goose StatementBegin
+ALTER TABLE app_config MODIFY COLUMN updated_by VARCHAR(40) NULL;
+-- +goose StatementEnd
+-- +goose StatementBegin
+UPDATE app_config SET updated_by = CASE WHEN updated_by IS NULL OR updated_by = '0' THEN 'sys' ELSE CONCAT('usr_', updated_by) END;
+-- +goose StatementEnd
+-- +goose StatementBegin
+ALTER TABLE app_config MODIFY COLUMN updated_by VARCHAR(40) NOT NULL DEFAULT 'sys';
+-- +goose StatementEnd
+-- +goose StatementBegin
+ALTER TABLE app_config ADD CONSTRAINT fk_app_config_updated_by FOREIGN KEY (updated_by) REFERENCES principals(id);
+-- +goose StatementEnd
+
+-- service_accounts.created_by: BIGINT FK users -> VARCHAR(40) FK principals. Stays NULLABLE (an env-seeded first account has no creating
+-- operator); a present creator id becomes usr_<id>.
+-- +goose StatementBegin
+ALTER TABLE service_accounts DROP FOREIGN KEY fk_service_accounts_created_by;
+-- +goose StatementEnd
+-- +goose StatementBegin
+ALTER TABLE service_accounts MODIFY COLUMN created_by VARCHAR(40) NULL;
+-- +goose StatementEnd
+-- +goose StatementBegin
+UPDATE service_accounts SET created_by = CONCAT('usr_', created_by) WHERE created_by IS NOT NULL AND created_by <> '0';
+-- +goose StatementEnd
+-- +goose StatementBegin
+UPDATE service_accounts SET created_by = NULL WHERE created_by = '0';
+-- +goose StatementEnd
+-- +goose StatementBegin
+ALTER TABLE service_accounts ADD CONSTRAINT fk_service_accounts_created_by FOREIGN KEY (created_by) REFERENCES principals(id);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+SELECT 1;
+-- +goose StatementEnd

--- a/server/observability/internal/tests/tracingconfig_store_test.go
+++ b/server/observability/internal/tests/tracingconfig_store_test.go
@@ -32,7 +32,7 @@ func TestTraceSamplerStore_updateRoundTripBumpsVersion(t *testing.T) {
 	_, version, err := store.Get(ctx)
 	require.NoError(t, err)
 	// updatedBy nil records a non-operator write; the value round-trip + version bump are what we assert here.
-	require.NoError(t, store.Update(ctx, tracing.Settings{HighVolumeRatio: 0.03, StandardRatio: 0.3, ForceFull: true}, version, nil))
+	require.NoError(t, store.Update(ctx, tracing.Settings{HighVolumeRatio: 0.03, StandardRatio: 0.3, ForceFull: true}, version, ""))
 
 	got, newVersion, err := store.Get(ctx)
 	require.NoError(t, err)
@@ -51,7 +51,7 @@ func TestTraceSamplerStore_outOfRangeRejectedByCheckConstraint(t *testing.T) {
 	_, version, err := store.Get(ctx)
 	require.NoError(t, err)
 	// The DB CHECK constraint is the backstop behind the handler's validation: a ratio above 1 is rejected at the write.
-	require.Error(t, store.Update(ctx, tracing.Settings{HighVolumeRatio: 2.0, StandardRatio: 0.1}, version, nil))
+	require.Error(t, store.Update(ctx, tracing.Settings{HighVolumeRatio: 2.0, StandardRatio: 0.1}, version, ""))
 
 	// And the stored row is unchanged (still the seeded default).
 	got, _, getErr := store.Get(ctx)
@@ -67,9 +67,9 @@ func TestTraceSamplerStore_staleVersionConflicts(t *testing.T) {
 	_, version, err := store.Get(ctx)
 	require.NoError(t, err)
 	// First writer holding the current version succeeds and bumps it.
-	require.NoError(t, store.Update(ctx, tracing.Settings{HighVolumeRatio: 0.02, StandardRatio: 0.2}, version, nil))
+	require.NoError(t, store.Update(ctx, tracing.Settings{HighVolumeRatio: 0.02, StandardRatio: 0.2}, version, ""))
 	// A second writer still holding the now-stale version is rejected (lost-update prevented).
-	err = store.Update(ctx, tracing.Settings{HighVolumeRatio: 0.04, StandardRatio: 0.4}, version, nil)
+	err = store.Update(ctx, tracing.Settings{HighVolumeRatio: 0.04, StandardRatio: 0.4}, version, "")
 	require.ErrorIs(t, err, tracingconfig.ErrVersionConflict)
 }
 
@@ -97,7 +97,7 @@ func TestTraceSamplerStore_missingRowSelfHeals(t *testing.T) {
 	assert.Equal(t, int64(0), version)
 
 	// Update with version 0 re-inserts the singleton rather than failing on the absent row.
-	require.NoError(t, store.Update(ctx, tracing.Settings{HighVolumeRatio: 0.07, StandardRatio: 0.7}, 0, nil))
+	require.NoError(t, store.Update(ctx, tracing.Settings{HighVolumeRatio: 0.07, StandardRatio: 0.7}, 0, ""))
 	got2, _, err := store.Get(ctx)
 	require.NoError(t, err)
 	assert.InDelta(t, 0.07, got2.HighVolumeRatio, 1e-9)

--- a/server/observability/internal/tracingadmin/handler.go
+++ b/server/observability/internal/tracingadmin/handler.go
@@ -25,7 +25,7 @@ const updateBodyLimit = 1 << 16
 // version so Update can apply optimistic concurrency; Update returns tracingconfig.ErrVersionConflict when a concurrent write landed.
 type store interface {
 	Get(ctx context.Context) (*tracing.Settings, int64, error)
-	Update(ctx context.Context, settings tracing.Settings, expectedVersion int64, updatedBy *int64) error
+	Update(ctx context.Context, settings tracing.Settings, expectedVersion int64, updatedBy string) error
 }
 
 // Handler serves the /api/settings/tracing routes. Construct via NewHandler; mount with RegisterAuthedRoutes behind the session + CSRF
@@ -135,7 +135,7 @@ func (h *Handler) handleUpdate(w http.ResponseWriter, r *http.Request) {
 		writeErr(ctx, h.logger, w, http.StatusInternalServerError, "internal")
 		return
 	}
-	if err := h.store.Update(ctx, next, version, &actor.UserID); err != nil {
+	if err := h.store.Update(ctx, next, version, actor.Principal.ID); err != nil {
 		if errors.Is(err, tracingconfig.ErrVersionConflict) {
 			writeErr(ctx, h.logger, w, http.StatusConflict, "version_conflict")
 			return
@@ -144,7 +144,7 @@ func (h *Handler) handleUpdate(w http.ResponseWriter, r *http.Request) {
 		writeErr(ctx, h.logger, w, http.StatusInternalServerError, "internal")
 		return
 	}
-	h.recordUpdate(ctx, r, actor.UserID, next)
+	h.recordUpdate(ctx, r, actor.Principal, next)
 
 	got, _, err := h.store.Get(ctx)
 	if err != nil {
@@ -166,13 +166,12 @@ func toResponse(s *tracing.Settings) settingsResponse {
 }
 
 // recordUpdate emits the mutation audit row.
-func (h *Handler) recordUpdate(ctx context.Context, r *http.Request, userID int64, s tracing.Settings) {
+func (h *Handler) recordUpdate(ctx context.Context, r *http.Request, actor api.PrincipalRef, s tracing.Settings) {
 	if h.audit == nil {
 		return
 	}
-	uid := userID
 	if err := h.audit.Record(ctx, api.AuditEvent{
-		UserID:     &uid,
+		Actor:      actor,
 		Action:     api.AuditAction("tracing.settings.updated"),
 		TargetType: "tracing_config",
 		RemoteAddr: httpserver.ClientIP(r),

--- a/server/observability/internal/tracingadmin/handler_test.go
+++ b/server/observability/internal/tracingadmin/handler_test.go
@@ -23,7 +23,7 @@ type fakeStore struct {
 	getErr    error
 	updErr    error
 	updated   *tracing.Settings
-	updatedBy *int64
+	updatedBy string
 	gotExpVer int64
 }
 
@@ -39,7 +39,7 @@ func (f *fakeStore) Get(context.Context) (*tracing.Settings, int64, error) {
 	return &cp, f.version, nil
 }
 
-func (f *fakeStore) Update(_ context.Context, s tracing.Settings, expectedVersion int64, by *int64) error {
+func (f *fakeStore) Update(_ context.Context, s tracing.Settings, expectedVersion int64, by string) error {
 	f.gotExpVer = expectedVersion
 	if f.updErr != nil {
 		return f.updErr
@@ -74,7 +74,7 @@ func patchReq(t *testing.T, rawBody string, withActor bool) *http.Request {
 	t.Helper()
 	r := httptest.NewRequestWithContext(t.Context(), http.MethodPatch, "/api/settings/tracing", bytes.NewReader([]byte(rawBody)))
 	if withActor {
-		r = r.WithContext(api.WithActor(r.Context(), &api.Actor{UserID: 7, AuthMethod: "oidc"}))
+		r = r.WithContext(api.WithActor(r.Context(), &api.Actor{Principal: api.UserPrincipal(7, ""), AuthMethod: "oidc"}))
 	}
 	return r
 }
@@ -134,8 +134,7 @@ func TestHandleUpdate_adminUpdatesRatios(t *testing.T) {
 	assert.InDelta(t, 0.05, store.updated.HighVolumeRatio, 1e-9)
 	assert.InDelta(t, 0.25, store.updated.StandardRatio, 1e-9)
 	assert.Equal(t, int64(5), store.gotExpVer, "Update must carry the version read by Get for OCC")
-	require.NotNil(t, store.updatedBy)
-	assert.Equal(t, int64(7), *store.updatedBy)
+	assert.Equal(t, "usr_7", store.updatedBy)
 	require.Len(t, audit.events, 1)
 	assert.Equal(t, api.AuditAction("tracing.settings.updated"), audit.events[0].Action)
 }

--- a/server/observability/internal/tracingconfig/tracingconfig.go
+++ b/server/observability/internal/tracingconfig/tracingconfig.go
@@ -66,12 +66,9 @@ func (s *Store) GetTraceSamplerSettings(ctx context.Context) (*tracing.Settings,
 // Update writes the singleton row with optimistic concurrency: it succeeds only when the stored version still matches expectedVersion,
 // returning ErrVersionConflict otherwise so a concurrent PATCH cannot silently clobber a peer's write. expectedVersion 0 means "no row
 // yet" and inserts the singleton (idempotent under a concurrent first write). The caller validates the ratios are in [0,1]; the DB
-// CHECK constraints are the backstop. updatedBy records the operator user id as a breadcrumb (nil for a non-operator write).
-func (s *Store) Update(ctx context.Context, settings tracing.Settings, expectedVersion int64, updatedBy *int64) error {
-	var by sql.NullInt64
-	if updatedBy != nil {
-		by = sql.NullInt64{Int64: *updatedBy, Valid: true}
-	}
+// CHECK constraints are the backstop. updatedBy records the acting principal id as a breadcrumb ("" for a non-operator write).
+func (s *Store) Update(ctx context.Context, settings tracing.Settings, expectedVersion int64, updatedBy string) error {
+	by := sql.NullString{String: updatedBy, Valid: updatedBy != ""}
 	if expectedVersion <= 0 {
 		// First write: insert the singleton. ON DUPLICATE KEY UPDATE keeps a concurrent first write idempotent.
 		_, err := s.db.ExecContext(ctx, `

--- a/server/observability/migrations/00002_trace_sampler_principal.sql
+++ b/server/observability/migrations/00002_trace_sampler_principal.sql
@@ -1,0 +1,19 @@
+-- +goose Up
+-- Rewrite trace_sampler_settings.updated_by from a user-only BIGINT breadcrumb to the principal id (ADR-0017, #514), so a
+-- service-account update is attributable. It is intentionally NOT a foreign key (a cross-context FK into identity's principals is
+-- disallowed by ADR-0004), so this is a type change plus a value backfill only.
+
+-- +goose StatementBegin
+ALTER TABLE trace_sampler_settings MODIFY COLUMN updated_by VARCHAR(40) NULL;
+-- +goose StatementEnd
+-- +goose StatementBegin
+UPDATE trace_sampler_settings SET updated_by = CONCAT('usr_', updated_by) WHERE updated_by IS NOT NULL AND updated_by <> '0';
+-- +goose StatementEnd
+-- +goose StatementBegin
+UPDATE trace_sampler_settings SET updated_by = NULL WHERE updated_by = '0';
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+SELECT 1;
+-- +goose StatementEnd

--- a/server/rules/internal/appcontrol/service.go
+++ b/server/rules/internal/appcontrol/service.go
@@ -408,8 +408,12 @@ func (s *Service) emitAudit(
 		Payload:    payload,
 	}
 	if actor != nil {
-		userID := actor.UserID
-		event.UserID = &userID
+		event.Actor = actor.Principal
+		// Transitional: derive the legacy user id from the principal for a human actor so the audit store's UserID path stays correct
+		// until the bridge is removed. A service-account actor has no user id and is attributed via Actor alone.
+		if uid, ok := actor.Principal.UserID(); ok {
+			event.UserID = &uid
+		}
 	}
 	if err := s.audit.Record(ctx, event); err != nil {
 		s.logger.WarnContext(ctx, "appcontrol: audit record failed", "err", err, "rule_id", rule.ID)
@@ -430,11 +434,11 @@ func (s *Service) emitAudit(
 // Failed audit emission is logged but not returned; audit is best-effort relative to the mutation that already committed (same
 // posture as emitAudit's create-rule path).
 func (s *Service) recordAudit(ctx context.Context, actor *identityapi.Actor, evt identityapi.AuditEvent) {
-	if actor != nil && actor.UserID > 0 {
-		userID := actor.UserID
-		evt.UserID = &userID
-		if evt.ActorEmail == "" {
-			evt.ActorEmail = "user:" + strconv.FormatInt(actor.UserID, 10)
+	if actor != nil {
+		evt.Actor = actor.Principal
+		// Transitional: derive the legacy user id from the principal for a human actor; a service-account actor is attributed via Actor.
+		if uid, ok := actor.Principal.UserID(); ok {
+			evt.UserID = &uid
 		}
 	}
 	if s.audit == nil {

--- a/server/rules/internal/detectionconfig/service.go
+++ b/server/rules/internal/detectionconfig/service.go
@@ -133,21 +133,27 @@ func (s *Service) emitAudit(
 		Payload:    payload,
 	}
 	if actor != nil {
-		userID := actor.UserID
-		event.UserID = &userID
+		event.Actor = actor.Principal
+		// Transitional: the audit store still keys user attribution on UserID, so derive it from the principal for a human actor. A
+		// service-account actor has no user id and is attributed solely through Actor/ActorEmail (its principal id). Removed when the audit
+		// store reads Actor directly, in the final cutover commit.
+		if uid, ok := actor.Principal.UserID(); ok {
+			event.UserID = &uid
+		}
 	}
 	if err := s.audit.Record(ctx, event); err != nil {
 		s.logger.WarnContext(ctx, "detectionconfig: audit record failed", "err", err, "action", string(action))
 	}
 }
 
-// actorIdentifier renders the stable "user:<id>" identifier recorded as created_by / actor_email, matching the app-control handler's
-// convention. Empty when there is no actor on the context (a wiring bug, which the store's required-actor validation then surfaces).
+// actorIdentifier renders the acting principal id recorded as created_by / actor_email (usr_<id> for a user, svc_<id> for a service
+// account). It survives authentication for every actor kind, so a service-account write is attributed rather than rejected by the
+// store's required-actor validation (#518). Empty only when there is no actor on the context (a wiring bug). See ADR-0017.
 func actorIdentifier(actor *identityapi.Actor) string {
-	if actor == nil || actor.UserID <= 0 {
+	if actor == nil {
 		return ""
 	}
-	return "user:" + strconv.FormatInt(actor.UserID, 10)
+	return actor.Principal.ID
 }
 
 // Reload reads the current configuration from the store and atomically swaps the in-memory snapshot. Called once at boot (after the

--- a/server/rules/internal/detectionconfig/service_test.go
+++ b/server/rules/internal/detectionconfig/service_test.go
@@ -37,7 +37,7 @@ func TestService_CreateExclusion_PersistsResolvesAndAudits(t *testing.T) {
 	audit := &fakeAudit{}
 	svc := newService(t, audit)
 	ctx := context.Background()
-	actor := &identityapi.Actor{UserID: 42}
+	actor := &identityapi.Actor{Principal: identityapi.UserPrincipal(42, "ops@fleetdm.com")}
 
 	excl, err := svc.CreateExclusion(ctx, actor, "Claude Code CLI", detectionconfig.CreateExclusionInput{
 		RuleID:    "suspicious_exec",
@@ -46,7 +46,7 @@ func TestService_CreateExclusion_PersistsResolvesAndAudits(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NotZero(t, excl.ID)
-	assert.Equal(t, "user:42", excl.CreatedBy, "store records the actor identifier as created_by")
+	assert.Equal(t, "usr_42", excl.CreatedBy, "store records the acting principal id as created_by")
 
 	// The snapshot reloaded, so the resolver now suppresses the matching parent.
 	assert.True(t, svc.Excluded("suspicious_exec", api.ExclusionMatchParentPathGlob,
@@ -72,7 +72,7 @@ func TestService_UpsertRuleSetting_ResolvesAndAudits(t *testing.T) {
 	audit := &fakeAudit{}
 	svc := newService(t, audit)
 	ctx := context.Background()
-	actor := &identityapi.Actor{UserID: 7}
+	actor := &identityapi.Actor{Principal: identityapi.UserPrincipal(7, "ops@fleetdm.com")}
 
 	_, err := svc.UpsertRuleSetting(ctx, actor, "too noisy", detectionconfig.UpsertSettingInput{
 		RuleID: "suspicious_exec", Mode: api.DetectionRuleModeDisabled,
@@ -99,7 +99,7 @@ func TestService_UpsertRuleSetting_ReEnablePreviouslyDisabledRule(t *testing.T) 
 	t.Parallel()
 	svc := newService(t, &fakeAudit{})
 	ctx := context.Background()
-	actor := &identityapi.Actor{UserID: 7}
+	actor := &identityapi.Actor{Principal: identityapi.UserPrincipal(7, "ops@fleetdm.com")}
 
 	_, err := svc.UpsertRuleSetting(ctx, actor, "too noisy", detectionconfig.UpsertSettingInput{
 		RuleID: "suspicious_exec", Mode: api.DetectionRuleModeDisabled,
@@ -122,7 +122,7 @@ func TestService_DeleteExclusion(t *testing.T) {
 	audit := &fakeAudit{}
 	svc := newService(t, audit)
 	ctx := context.Background()
-	actor := &identityapi.Actor{UserID: 1}
+	actor := &identityapi.Actor{Principal: identityapi.UserPrincipal(1, "ops@fleetdm.com")}
 
 	excl, err := svc.CreateExclusion(ctx, actor, "r", detectionconfig.CreateExclusionInput{
 		RuleID: "sudoers_tamper", MatchType: api.ExclusionMatchPathGlob, Value: "/usr/local/bin/munki",
@@ -144,7 +144,7 @@ func TestService_NilAuditDropsRowWithoutPanic(t *testing.T) {
 	t.Parallel()
 	svc := newService(t, nil) // nil recorder
 	ctx := context.Background()
-	_, err := svc.CreateExclusion(ctx, &identityapi.Actor{UserID: 1}, "r", detectionconfig.CreateExclusionInput{
+	_, err := svc.CreateExclusion(ctx, &identityapi.Actor{Principal: identityapi.UserPrincipal(1, "ops@fleetdm.com")}, "r", detectionconfig.CreateExclusionInput{
 		RuleID: "dyld_insert", MatchType: api.ExclusionMatchSHA256, Value: "abc",
 	})
 	require.NoError(t, err, "a nil audit recorder must not fail the mutation")
@@ -177,7 +177,7 @@ func TestService_RefreshLoop_ConvergesAcrossReplicas(t *testing.T) {
 
 	// Replica A creates the exclusion. This bumps detection_config_meta.version; B never sees the mutation directly.
 	_, err := svcA.CreateExclusion(
-		t.Context(), &identityapi.Actor{UserID: 1}, "munki staged installer writes sudoers",
+		t.Context(), &identityapi.Actor{Principal: identityapi.UserPrincipal(1, "ops@fleetdm.com")}, "munki staged installer writes sudoers",
 		detectionconfig.CreateExclusionInput{
 			RuleID: "sudoers_tamper", MatchType: api.ExclusionMatchPathGlob, Value: "/var/db/munki/installer",
 		})

--- a/server/rules/internal/operator/appcontrol_handler.go
+++ b/server/rules/internal/operator/appcontrol_handler.go
@@ -656,10 +656,10 @@ func actorIdentifierFromContext(ctx context.Context) string {
 	if !ok {
 		return ""
 	}
-	if a.UserID > 0 {
-		return "user:" + strconv.FormatInt(a.UserID, 10)
-	}
-	return ""
+	// The acting principal id (usr_<id> for a user, svc_<id> for a service account) is recorded as created_by / updated_by. It survives
+	// authentication for every actor kind, so a service-account mutation is attributed rather than rejected by the store's required-actor
+	// validation (#518). See ADR-0017.
+	return a.Principal.ID
 }
 
 // errCodeInvalidQuery is the typed code the cross-policy list handler uses to flag a malformed query parameter (negative

--- a/server/rules/internal/operator/detectionconfig_handler.go
+++ b/server/rules/internal/operator/detectionconfig_handler.go
@@ -112,18 +112,11 @@ func (h *DetectionConfigHandler) resolveCreatedByEmails(ctx context.Context, exc
 	}
 }
 
-// parseUserActorID extracts the numeric id from the "user:<id>" actor identifier the service records as created_by. Returns false for
-// any other shape (e.g. a service-account or empty actor) so the caller leaves the email unresolved.
+// parseUserActorID extracts the numeric users.id from a usr_<id> principal identifier recorded as created_by, to resolve the author's
+// display email. Returns false for any non-user principal (a service-account svc_<id>, the system principal) or empty actor, so the
+// caller leaves the email unresolved and the UI falls back to the raw identifier. See ADR-0017.
 func parseUserActorID(actor string) (int64, bool) {
-	rest, ok := strings.CutPrefix(actor, "user:")
-	if !ok {
-		return 0, false
-	}
-	id, err := strconv.ParseInt(rest, 10, 64)
-	if err != nil || id <= 0 {
-		return 0, false
-	}
-	return id, true
+	return identityapi.PrincipalRef{ID: actor}.UserID()
 }
 
 // RegisterRoutes wires the detection-config admin routes:

--- a/server/rules/internal/operator/detectionconfig_handler_test.go
+++ b/server/rules/internal/operator/detectionconfig_handler_test.go
@@ -116,10 +116,10 @@ func TestDetectionConfigHandler_ResolvesCreatedByEmail(t *testing.T) {
 	// sharing one across the parallel subtests would let one run's resolved emails leak into the nil-resolver run.
 	newExclusions := func() []api.DetectionExclusion {
 		return []api.DetectionExclusion{
-			{ID: 1, CreatedBy: "user:8"},                 // resolves
-			{ID: 2, CreatedBy: "user:8"},                 // same author: memoized, no second lookup
-			{ID: 3, CreatedBy: "user:9"},                 // resolver errors: email stays empty
-			{ID: 4, CreatedBy: "service-account:reaper"}, // non-user actor: never looked up
+			{ID: 1, CreatedBy: "usr_8"}, // resolves
+			{ID: 2, CreatedBy: "usr_8"}, // same author: memoized, no second lookup
+			{ID: 3, CreatedBy: "usr_9"}, // resolver errors: email stays empty
+			{ID: 4, CreatedBy: "svc_5"}, // service-account principal: never looked up
 		}
 	}
 
@@ -148,7 +148,7 @@ func TestDetectionConfigHandler_ResolvesCreatedByEmail(t *testing.T) {
 		assert.Equal(t, "ops@fleetdm.com", out.Exclusions[1].CreatedByEmail)
 		assert.Empty(t, out.Exclusions[2].CreatedByEmail, "errored lookup leaves email blank")
 		assert.Empty(t, out.Exclusions[3].CreatedByEmail, "non-user actor is not looked up")
-		assert.Equal(t, 2, calls, "user:8 resolved once (memoized) + user:9 once; service-account skipped")
+		assert.Equal(t, 2, calls, "usr_8 resolved once (memoized) + usr_9 once; service-account skipped")
 	})
 
 	t.Run("nil resolver leaves created_by_email empty", func(t *testing.T) {

--- a/server/rules/internal/tests/appcontrol_rest_test.go
+++ b/server/rules/internal/tests/appcontrol_rest_test.go
@@ -142,7 +142,7 @@ func newAppControlRig(t *testing.T, hosts []string) *appControlRig {
 	mux := http.NewServeMux()
 	rules.RegisterAuthedRoutes(mux)
 	actor := &identityapi.Actor{
-		UserID: 42,
+		Principal: identityapi.UserPrincipal(42, "op@example.com"),
 		Roles: []identityapi.RoleBinding{{
 			RoleID:    "admin",
 			ScopeType: identityapi.RoleBindingScopeGlobal,
@@ -640,7 +640,7 @@ func TestAppControlREST_CreateRule_HostListerFailureRecorded(t *testing.T) {
 	mux := http.NewServeMux()
 	rules.RegisterAuthedRoutes(mux)
 	actor := &identityapi.Actor{
-		UserID: 99,
+		Principal: identityapi.UserPrincipal(99, "op@example.com"),
 		Roles: []identityapi.RoleBinding{{
 			RoleID:    "admin",
 			ScopeType: identityapi.RoleBindingScopeGlobal,

--- a/server/rules/internal/tests/integration_test.go
+++ b/server/rules/internal/tests/integration_test.go
@@ -31,7 +31,7 @@ import (
 // detection-config mutation handlers (which require an actor) can be exercised over HTTP in tests.
 func withActor(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ctx := identityapi.WithActor(r.Context(), &identityapi.Actor{UserID: 1, SessionFresh: true})
+		ctx := identityapi.WithActor(r.Context(), &identityapi.Actor{Principal: identityapi.UserPrincipal(1, "op@example.com"), SessionFresh: true})
 		h.ServeHTTP(w, r.WithContext(ctx))
 	})
 }

--- a/test/e2e/tests/qa/breakglass-login-failure-reason.spec.ts
+++ b/test/e2e/tests/qa/breakglass-login-failure-reason.spec.ts
@@ -115,7 +115,7 @@ test.describe.serial("break-glass login failure reason", () => {
         `SELECT JSON_UNQUOTE(JSON_EXTRACT(payload, '$.reason')) AS reason
            FROM audit_events
           WHERE action = 'auth.breakglass.failure'
-            AND actor_email = 'admin@fleet-edr.local'
+            AND actor_label = 'admin@fleet-edr.local'
           ORDER BY id DESC LIMIT 1`,
       )) as [Array<{ reason: string }>, unknown];
       expect(rows).toHaveLength(1);


### PR DESCRIPTION
## What & why

Implements ADR-0017 (`openspec/changes/unified-principal-model/`): every authenticated actor resolves to a typed **principal** (user, service account, or system), so service-account actions are attributable to the same standard as users. Closes the two filed bugs:

- **#518** — service-account detection-config / app-control writes were rejected at the store layer with `actor is required`. Fixed: the store gates now accept the acting principal id (`svc_<id>`).
- **#514** — service-account mutations wrote audit rows that named nobody, and the `BIGINT`-FK attribution columns could only reference `users(id)`. Fixed: audit + per-row attribution now reference the principal id.

## What's in this PR (6 commits, each green)

- `PrincipalRef` foundation type (`usr_`/`svc_`/`sys` ids, `UserID()` accessor) — PBT-tested.
- `Actor.Principal` populated for both users (from the user row) and service accounts (from token claims, no DB read; `satoken` carries the principal id + name, stamped at the token endpoint).
- **#518 fixed:** detection-config + app-control attribution and store gates use the principal id.
- **principals spine + audit cutover** (migration 00005): `principals` table + backfill; `audit_events` rewritten to `(actor_type, actor_principal_id, actor_label snapshot)`, dropping the `users` join, so a deleted user's history stays attributable.
- **#514 attribution columns** (migration 00006): `oidc_config`/`app_config`/`service_accounts.created_by` → principal FK; #515 SSO `NULL` stopgap removed.
- observability `trace_sampler_settings.updated_by` → principal (migration 00002).

All migrations validated against the test DB; `go build ./...` and the touched server test suites are green.

## In-progress (follow-up commits on this branch before merge)

This is a staged cutover. To keep every commit green, two transitional fields are **intentionally** still present and will be removed in the contract commit before merge:

- `Actor.UserID` and `AuditEvent.UserID`/`ActorEmail` remain, bridged to the principal by the audit store (`actorOf`), so emitters not yet converted keep working. **This is local commit sequencing, not a shipped expand/contract** (ADR-0017 is a hard cutover).

Remaining before this is merge-ready:
1. Detection `alerts.updated_by` → principal (removes the `UserExists` FK-replacement + `ErrInvalidUserUpdater`).
2. Endpoint + response audit emitters → set `Actor`.
3. Convert identity's remaining `AuditEvent` emitters (oidc, breakglass, login, useradmin, saadmin, authz/engine) to `Actor`.
4. Contract commit: remove `Actor.UserID` + `AuditEvent.UserID`/`ActorEmail` + the bridge.
5. Principal-label resolver replacing the email closures.
6. #518 route-sweep regression + SA-attribution integration tests; openspec `tasks.md`.

Reviewers: please don't flag the `Actor.UserID` / `AuditEvent.UserID` duality as expand/contract; it is the transitional bridge called out above, removed in step 4.

## Checklist

- [x] **OpenSpec updated** — implements the merged `unified-principal-model` change (ADR-0017); deltas already on `main`.
- [ ] Tests added/updated — per-context tests updated to the principal model; the #518 route-sweep + SA-attribution integration tests land with the contract commit (see In-progress).
- [ ] Agent/extension ESF/XPC/wire change — N/A (server identity only).
- [x] **Docs updated** — ADR-0017 + the openspec bundle (on `main`).

## VM / RC notes (if applicable)

None. Server-side only; no agent or extension change.

Closes #514, #518.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Audit records now preserve a typed actor identity, improving attribution for users, service accounts, and system actions.
  * User, service account, and system activity now uses consistent principal IDs across the product.

* **Bug Fixes**
  * Audit history now remains readable even after the original user or service account is removed.
  * SSO, tracing, and app configuration updates now correctly show who made the change, including automated/system updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->