### PR TITLE
test(scale): per-RC single-replica scale gate (closes #203)

### DIFF
--- a/.github/workflows/scale.yml
+++ b/.github/workflows/scale.yml
@@ -1,0 +1,76 @@
+name: Scale gate
+
+# UAT plan #203 (Larger scale leg): re-runs the single-replica scale lane per RC and gates the RC on a bounded
+# event_queue processing backlog. Mirrors the L6 efficacy workflow's "nightly + RC" gate shape: a standalone heavy
+# workflow, not a per-PR job (the lane is ~2 min) and not coupled into release.yml's signing jobs.
+#
+# Triggers:
+#   - push of a v*-rc.* tag: the gate runs automatically when an RC is cut. A red check here means the RC must not be
+#     promoted (enforced via docs/release-checklist.md, the same way the efficacy gate is).
+#   - weekly schedule on the default branch: catches a processor-throughput regression that merged between RCs.
+#   - workflow_dispatch: manual re-run.
+#
+# The full 500-host proof is the committed baseline (test/scale/baselines/post-535-500host.json); this gate runs a
+# CI-runner-feasible 200-host lane in-process (integration.Setup, EnrollRatePerMinute=1000, MemArchive so no ClickHouse)
+# and asserts the backlog stays bounded. See test/scale/scalegate_test.go.
+
+on:
+  push:
+    tags:
+      - "v*-rc.*"
+  schedule:
+    # 06:00 UTC Monday. Weekly drift check on the throughput path between RCs.
+    - cron: "0 6 * * 1"
+  workflow_dispatch: {}
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  scale-gate:
+    name: Single-replica scale gate (200 hosts)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    # The lane is ~2 min (90s load + setup). 15 is a generous ceiling that fails a wedged MySQL container without
+    # burning runner minutes, matching the efficacy gate.
+    timeout-minutes: 15
+    env:
+      EDR_TEST_DSN: "root:@tcp(127.0.0.1:3306)/edr_test?parseTime=true"
+    services:
+      mysql:
+        image: mysql:8.4.9@sha256:c36050afdca850f23cef85703f84c7531a5ae155a11b5ee1c60acb09937c4084
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+          MYSQL_DATABASE: edr_test
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping --silent"
+          --health-interval=5s
+          --health-timeout=3s
+          --health-retries=10
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+
+      # The in-process stack runs the server + 200 simulated hosts against one MySQL; raise the connection ceiling above
+      # the 151 default, matching the efficacy + server-test jobs.
+      - name: Raise MySQL max_connections
+        run: |
+          mysql -h 127.0.0.1 -P 3306 -u root -e "SET GLOBAL max_connections = 500"
+
+      - name: Run scale gate
+        # CGO_ENABLED=0 keeps the build off the receiver cgo path (belt-and-braces; ubuntu already takes the !darwin branch).
+        env:
+          CGO_ENABLED: "0"
+        run: |
+          go test -tags "integration scalegate" -v -count=1 -timeout=10m -run TestScaleGate_BacklogBounded ./test/scale/...

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -334,6 +334,14 @@ tasks:
     cmds:
       - go run ./test/scale/scaledriver {{.CLI_ARGS}}
 
+  uat:scale:gate:
+    desc: |
+      Run the per-RC scale gate (#203): a 200-host in-process lane (integration.Setup, production processor fan-out)
+      that asserts the event_queue backlog stays bounded. This is what .github/workflows/scale.yml runs on RC tags +
+      weekly; run it locally before promoting an RC. Needs a test MySQL (EDR_TEST_DSN); ~2 min wall.
+    cmds:
+      - go test -tags "integration scalegate" -v -count=1 -timeout=10m -run TestScaleGate_BacklogBounded ./test/scale/...
+
   test:go:server:coverage:
     desc: |
       Server + shared coverage flavor of test:go:server. Emits coverage-server.out

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -45,6 +45,7 @@ These layers do not run per-PR (`docs/testing-strategy.md`); the RC is where the
 
 - The macOS VM end-to-end run: real Swift extensions + real agent + real server on a SIP-enabled, Gatekeeper-enabled VM. Any agent/extension change touching ESF, XPC, or the event wire format MUST be exercised here since the last release.
 - The detection-efficacy run: the MITRE-aligned attack corpus, asserting each shipped rule fires within its SLA (detection rate gate) and the noise corpus stays clean (false-positive gate).
+- The single-replica scale gate (#203): `scale.yml` runs automatically on the `v*-rc.*` tag push and asserts the `event_queue` processing backlog stays bounded under a 200-host lane with the production processor fan-out. Confirm that check is green on the RC before promoting (or run `task uat:scale:gate` locally). The full 500-host reference is the committed baseline (`test/scale/baselines/post-535-500host.json`); re-capture it on a dev box with `task uat:scale -- --hosts=500 ...` if the throughput path changed materially.
 
 ## 5. Manual UI review
 

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -102,6 +102,8 @@ A first scale baseline ships with the rest of the plan: 100 simulated agents aga
 
 UAT plan milestone **M12** ships the first cut of the scale lane: `test/scale/` exposes a `scale.Run(ctx, Options)` runner plus a `scaledriver` binary invoked via `task uat:scale`. Each simulated host enrols via `/api/enroll`, then loops `fakeagent.PostDirect` against `/api/events` for the configured duration; the runner records client-observed p50/p95/p99 latency and asserts the documented gate (`p99 < 250ms`, zero errors). A per-PR smoke (5 hosts x 5s) at `test/scale/scale_test.go` runs on every push via the `./test/scale/...` glob in the server-test job (`task test:go:server:coverage`) and proves the harness itself does not rot. The 30-minute baseline is captured manually and committed to `test/scale/baselines/`. Queue-depth probes and SigNoz cross-checks (see the M12 row in `ai/uat/plan.md`) are explicitly deferred to a follow-up.
 
+The per-RC scale gate (#203) sits above the smoke: `test/scale/scalegate_test.go` (build tag `scalegate`, so it stays out of the per-PR run) fans out a CI-feasible 200-host lane against an in-process `integration.Setup` stack with the production processor fan-out (`ProcessConcurrency = 4`) and asserts the `event_queue` processing backlog stays bounded. The `scale.yml` workflow runs it on every `v*-rc.*` tag push plus weekly and on manual dispatch, mirroring the L6 efficacy gate's "nightly + RC" shape (standalone, not coupled into `release.yml`); a red check blocks RC promotion per `docs/release-checklist.md`. It is the regression gate for the #535 throughput work and the #544 deadlock-resilient claim. The full 500-host proof remains the committed baseline `test/scale/baselines/post-535-500host.json`.
+
 ## Reusable artefacts
 
 ### Fake agent and headless agent binary
@@ -255,12 +257,12 @@ These are the rules a contributor follows when adding code. They are enforced pa
 
 ## CI tiering
 
-| Trigger               | Layers run                                                            | Wall-time budget              |
-| --------------------- | --------------------------------------------------------------------- | ----------------------------- |
-| Every PR              | Unit through browser E2E (L0 to L4) + `spectrace` advisory            | < 20 min total (parallelised) |
-| Nightly on `main`     | + detection efficacy (L6) + small soak                                | < 90 min                      |
-| Release-candidate tag | + system / VM (L5) + detection efficacy full corpus + 100-agent scale | < 4 hours                     |
-| Manual pre-pilot      | System / VM (L5) with the pilot's specific environment knobs          | as needed                     |
+| Trigger | Layers run | Wall-time budget |
+| --- | --- | --- |
+| Every PR | Unit through browser E2E (L0 to L4) + `spectrace` advisory | < 20 min total (parallelised) |
+| Nightly on `main` | + detection efficacy (L6) + small soak | < 90 min |
+| Release-candidate tag | + system / VM (L5) + detection efficacy full corpus + the 200-host scale gate (`scale.yml`) | < 4 hours |
+| Manual pre-pilot | System / VM (L5) with the pilot's specific environment knobs | as needed |
 
 The `changes` gate-then-analyze pattern in `.github/workflows/test.yml` is preserved; jobs only fire when their relevant inputs change.
 

--- a/test/integration/setup.go
+++ b/test/integration/setup.go
@@ -112,6 +112,9 @@ func setupReplica(t *testing.T, db *sqlx.DB, opts ...Option) *Stack {
 
 	var cfg setupConfig
 	for _, opt := range opts {
+		if opt == nil { // tolerate a nil from the conditional-option idiom (var o Option; if cond { o = WithX() }; Setup(t, o))
+			continue
+		}
 		opt(&cfg)
 	}
 

--- a/test/integration/setup.go
+++ b/test/integration/setup.go
@@ -83,17 +83,37 @@ func (s *Stack) DetectionService() detectionapi.Service { return s.Detection.Ser
 //     would invent exit events for fixture processes).
 //   - RetentionDays = 0 (disabled; tests are short-lived; nothing to GC).
 //   - CookieSecure = false because httptest is plain HTTP.
-func Setup(t *testing.T) *Stack {
+func Setup(t *testing.T, opts ...Option) *Stack {
 	t.Helper()
-	return setupReplica(t, full.Open(t))
+	return setupReplica(t, full.Open(t), opts...)
+}
+
+// Option customises the stack Setup builds. Defaults reproduce the historical Setup behaviour (a single processor worker, the
+// detection bootstrap default), so existing callers are unaffected; the scale gate passes WithProcessConcurrency to exercise the
+// production multi-worker processor (issue #535 / #544).
+type Option func(*setupConfig)
+
+type setupConfig struct {
+	processConcurrency int
+}
+
+// WithProcessConcurrency runs the detection processor with n in-process workers, matching the production fan-out. Zero (the default
+// when the option is omitted) leaves the bootstrap default, which clamps to a single worker.
+func WithProcessConcurrency(n int) Option {
+	return func(c *setupConfig) { c.processConcurrency = n }
 }
 
 // setupReplica wires one full stack against an already-open database. Setup calls it with a fresh per-test DB; the multi-replica
 // test calls it twice with the SAME *sqlx.DB so two independent stacks (two sets of bootstrap contexts, two muxes, two httptest
 // servers) share one MySQL. That models two replicas: separate in-process state, one shared store. The signing key is identical
 // across calls, which is what lets a session minted against one stack validate on the other.
-func setupReplica(t *testing.T, db *sqlx.DB) *Stack {
+func setupReplica(t *testing.T, db *sqlx.DB, opts ...Option) *Stack {
 	t.Helper()
+
+	var cfg setupConfig
+	for _, opt := range opts {
+		opt(&cfg)
+	}
 
 	logger := slog.Default()
 	ctx, cancel := context.WithCancel(context.Background())
@@ -118,15 +138,16 @@ func setupReplica(t *testing.T, db *sqlx.DB) *Stack {
 	require.NoError(t, err, "open visibility")
 
 	detectionCtx, err := detectionbootstrap.New(detectionbootstrap.Deps{
-		DB:              db,
-		Logger:          logger,
-		Mode:            detectionbootstrap.ModeFull,
-		ProcessInterval: 20 * time.Millisecond,
-		ProcessBatch:    100,
-		UserExists:      identityCtx.Service().UserExists,
-		AuthZ:           identityCtx.AuthZ(),
-		EventLog:        visibilityCtx.EventLog(),
-		EventArchive:    detectiontestkit.NewMemArchive(),
+		DB:                 db,
+		Logger:             logger,
+		Mode:               detectionbootstrap.ModeFull,
+		ProcessInterval:    20 * time.Millisecond,
+		ProcessBatch:       100,
+		ProcessConcurrency: cfg.processConcurrency,
+		UserExists:         identityCtx.Service().UserExists,
+		AuthZ:              identityCtx.AuthZ(),
+		EventLog:           visibilityCtx.EventLog(),
+		EventArchive:       detectiontestkit.NewMemArchive(),
 	})
 	require.NoError(t, err, "open detection")
 

--- a/test/scale/scalegate_test.go
+++ b/test/scale/scalegate_test.go
@@ -43,6 +43,9 @@ const (
 	scaleGateMaxBacklog = 5000
 	// scaleGateBacklogPoll is how often the gate samples the queue depth during the run.
 	scaleGateBacklogPoll = 1 * time.Second
+	// scaleGateQueryTimeout bounds a single backlog COUNT so a stuck query cannot stall sampling for the rest of the lane (mirrors
+	// the scale runner's backlogQueryTimeout, which is unexported to this external test package).
+	scaleGateQueryTimeout = 5 * time.Second
 )
 
 // TestScaleGate_BacklogBounded is the per-RC gate: 200 hosts, production processor fan-out, backlog must stay bounded.
@@ -56,8 +59,10 @@ func TestScaleGate_BacklogBounded(t *testing.T) {
 
 	// Sample the server-side processing backlog (not-yet-acked rows) for the life of the run and keep the max. integration.Setup is
 	// in-process against a per-test DB whose DSN the scale runner's BacklogDSN sampler can't reach, so the gate polls the stack's own
-	// DB handle directly with the same query the runner's sampler uses.
-	maxBacklog := pollMaxBacklog(ctx, t, stack)
+	// DB handle directly with the same query the runner's sampler uses. The probe is stopped and joined after the run, and the gate
+	// requires at least one successful sample so a broken COUNT / unusable DB fails the gate closed rather than passing vacuously.
+	probeCtx, stopProbe := context.WithCancel(ctx)
+	probe := startBacklogProbe(probeCtx, stack)
 
 	opts := scale.Options{
 		HostCount:         scaleGateHosts,
@@ -79,27 +84,39 @@ func TestScaleGate_BacklogBounded(t *testing.T) {
 
 	rep, err := scale.Run(ctx, opts)
 	require.NoError(t, err, "scale.Run gate lane")
-	cancel() // stop the backlog sampler before reading its result
 
-	got := maxBacklog()
-	t.Logf("scale gate: %d hosts, %d observations, errors=%d, p99=%s, max_backlog=%d (ceiling %d)",
-		rep.HostCount, rep.ObservationCount, rep.ErrorCount, rep.LatencyP99, got, scaleGateMaxBacklog)
+	stopProbe()  // stop sampling now the lane is done
+	probe.wait() // join the sampler goroutine so no query races the test teardown
+	maxDepth, samples := probe.result()
+
+	t.Logf("scale gate: %d hosts, %d observations, errors=%d, p99=%s, max_backlog=%d over %d samples (ceiling %d)",
+		rep.HostCount, rep.ObservationCount, rep.ErrorCount, rep.LatencyP99, maxDepth, samples, scaleGateMaxBacklog)
+
+	// Fail closed: if the COUNT query / DB handle was unusable the whole run, maxDepth stays 0 and the ceiling check would pass
+	// vacuously, silently disabling the gate. Require that sampling actually happened.
+	require.Positive(t, samples, "backlog sampler took no successful samples; the gate cannot vouch for the backlog (fail closed)")
 
 	assert.Zero(t, rep.ErrorCount, "no ingest errors at the gate fan-out (enroll cap is 1000/min in-process); last error per host is in PerHost")
-	assert.Greater(t, rep.ObservationCount, scaleGateHosts, "every host posts at least once over the lane")
-	assert.Lessf(t, got, int64(scaleGateMaxBacklog),
-		"event_queue backlog must stay bounded (got max %d, ceiling %d): a processor-throughput regression makes this diverge", got, scaleGateMaxBacklog)
+	assert.GreaterOrEqual(t, rep.ObservationCount, scaleGateHosts, "every host posts at least once over the lane")
+	assert.LessOrEqualf(t, maxDepth, int64(scaleGateMaxBacklog),
+		"event_queue backlog must not exceed the ceiling (got max %d, ceiling %d): a processor-throughput regression makes this diverge", maxDepth, scaleGateMaxBacklog)
 }
 
-// pollMaxBacklog starts a goroutine that samples the event_queue processing backlog every scaleGateBacklogPoll until ctx is done,
-// and returns a getter for the maximum observed depth. Mirrors backlogSampler's query without needing a separate DSN.
-func pollMaxBacklog(ctx context.Context, t *testing.T, stack *integration.Stack) func() int64 {
-	t.Helper()
-	var (
-		mu       sync.Mutex
-		maxDepth int64
-	)
+// backlogProbe samples the event_queue processing backlog on an interval for the life of a run, tracking the maximum observed depth
+// and the count of successful samples. Mirrors the scale runner's backlogSampler query without a separate DSN, and fails closed: the
+// caller requires samples > 0 so a broken query cannot leave maxDepth at 0 and pass the gate vacuously.
+type backlogProbe struct {
+	done     chan struct{}
+	mu       sync.Mutex
+	maxDepth int64
+	samples  int
+}
+
+// startBacklogProbe launches the sampler bound to ctx; cancel ctx to stop it, then wait() to join.
+func startBacklogProbe(ctx context.Context, stack *integration.Stack) *backlogProbe {
+	p := &backlogProbe{done: make(chan struct{})}
 	go func() {
+		defer close(p.done)
 		ticker := time.NewTicker(scaleGateBacklogPoll)
 		defer ticker.Stop()
 		for {
@@ -107,21 +124,29 @@ func pollMaxBacklog(ctx context.Context, t *testing.T, stack *integration.Stack)
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
+				qctx, cancel := context.WithTimeout(ctx, scaleGateQueryTimeout)
 				var depth int64
-				if err := stack.DB.GetContext(ctx, &depth, "SELECT COUNT(*) FROM event_queue WHERE processed != 1"); err != nil {
-					continue // a transient read error during a sample is not the gate's concern; the next tick re-samples
+				err := stack.DB.GetContext(qctx, &depth, "SELECT COUNT(*) FROM event_queue WHERE processed != 1")
+				cancel()
+				if err != nil {
+					continue // a transient read error on one tick is recovered by the next; require(samples > 0) guards a total failure
 				}
-				mu.Lock()
-				if depth > maxDepth {
-					maxDepth = depth
+				p.mu.Lock()
+				p.samples++
+				if depth > p.maxDepth {
+					p.maxDepth = depth
 				}
-				mu.Unlock()
+				p.mu.Unlock()
 			}
 		}
 	}()
-	return func() int64 {
-		mu.Lock()
-		defer mu.Unlock()
-		return maxDepth
-	}
+	return p
+}
+
+func (p *backlogProbe) wait() { <-p.done }
+
+func (p *backlogProbe) result() (maxDepth int64, samples int) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.maxDepth, p.samples
 }

--- a/test/scale/scalegate_test.go
+++ b/test/scale/scalegate_test.go
@@ -1,0 +1,127 @@
+//go:build integration && scalegate
+
+// Per-RC scale gate (UAT plan #203). Unlike the per-PR M12 smoke (scale_test.go, a 5-host harness-rot check), this fans out a
+// CI-feasible 200-host lane against an in-process integration.Setup stack configured with the production processor fan-out
+// (ProcessConcurrency = 4) and asserts the server-side event_queue backlog stays bounded. It is the regression gate for the #535
+// throughput work + the #544 deadlock-resilient claim: a reverted batching or concurrency change makes the backlog diverge here.
+//
+// Build tag `scalegate` keeps it out of the per-PR `-tags integration` server-test job (it runs ~2 min); the dedicated
+// scale.yml workflow runs it with `-tags "integration scalegate"` on RC tags + weekly + manual dispatch. The full 500-host
+// proof lives in the committed baseline (test/scale/baselines/post-535-500host.json); 200 hosts is the CI-runner-feasible count
+// that still catches a processor-throughput regression via the backlog ceiling.
+//
+// In-process is deliberate: integration.Setup wires EnrollRatePerMinute = 1000, so 200 hosts enroll from the single CI source IP
+// without tripping the production 30/min per-IP limit (the enroll-rate artifact a dev:server lane would hit). The archive is the
+// in-memory MemArchive, so the gate needs only MySQL, no ClickHouse.
+
+package scale_test
+
+import (
+	"context"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fleetdm/edr/test/integration"
+	"github.com/fleetdm/edr/test/scale"
+)
+
+const (
+	// scaleGateHosts is the CI-runner-feasible fan-out. Large enough that a processor-throughput regression (e.g. reverting the
+	// batched graph builder or the intra-replica workers) makes the backlog diverge; small enough to run on a 2-4 vCPU runner in
+	// ~2 minutes alongside the in-process server.
+	scaleGateHosts = 200
+	// scaleGateDuration is the load-lane wall time. Long enough that the backlog trend is meaningful past the enroll ramp.
+	scaleGateDuration = 90 * time.Second
+	// scaleGateMaxBacklog is the event_queue processing-backlog ceiling. The post-#535 single-replica 500-host baseline held the
+	// backlog at max 17; at 200 hosts with the production fan-out it should stay in the low tens. 5000 leaves generous headroom for
+	// CI-runner noise while still failing decisively on the pre-#535 unbounded-growth class (that run climbed to ~37k).
+	scaleGateMaxBacklog = 5000
+	// scaleGateBacklogPoll is how often the gate samples the queue depth during the run.
+	scaleGateBacklogPoll = 1 * time.Second
+)
+
+// TestScaleGate_BacklogBounded is the per-RC gate: 200 hosts, production processor fan-out, backlog must stay bounded.
+func TestScaleGate_BacklogBounded(t *testing.T) {
+	t.Parallel()
+	repoRoot := filepath.Join("..", "..")
+	stack := integration.Setup(t, integration.WithProcessConcurrency(4))
+
+	ctx, cancel := context.WithTimeout(t.Context(), scaleGateDuration+60*time.Second)
+	defer cancel()
+
+	// Sample the server-side processing backlog (not-yet-acked rows) for the life of the run and keep the max. integration.Setup is
+	// in-process against a per-test DB whose DSN the scale runner's BacklogDSN sampler can't reach, so the gate polls the stack's own
+	// DB handle directly with the same query the runner's sampler uses.
+	maxBacklog := pollMaxBacklog(ctx, t, stack)
+
+	opts := scale.Options{
+		HostCount:         scaleGateHosts,
+		QuietRatio:        0.8,
+		Duration:          scaleGateDuration,
+		ServerURL:         stack.Server.URL,
+		EnrollSecret:      integration.EnrollSecret,
+		QuietScenarioPath: filepath.Join(repoRoot, "test", "fakeagent", "scenarios", "quiet-host.yaml"),
+		ActiveScenarioPaths: []string{
+			filepath.Join(repoRoot, "test", "efficacy", "corpus", "T1059-suspicious-exec", "scenario.yaml"),
+			filepath.Join(repoRoot, "test", "efficacy", "corpus", "T1543.001-launchagent-persistence", "scenario.yaml"),
+		},
+		QuietIterationGap:  500 * time.Millisecond,
+		ActiveIterationGap: 200 * time.Millisecond,
+		// Co-locating 200 clients + the server in one process inflates client latency, so the p99 gate is generous: the backlog
+		// ceiling, not ingest latency, is this gate's signal (the dev-box baseline owns the real latency numbers).
+		PassP99: 10 * time.Second,
+	}
+
+	rep, err := scale.Run(ctx, opts)
+	require.NoError(t, err, "scale.Run gate lane")
+	cancel() // stop the backlog sampler before reading its result
+
+	got := maxBacklog()
+	t.Logf("scale gate: %d hosts, %d observations, errors=%d, p99=%s, max_backlog=%d (ceiling %d)",
+		rep.HostCount, rep.ObservationCount, rep.ErrorCount, rep.LatencyP99, got, scaleGateMaxBacklog)
+
+	assert.Zero(t, rep.ErrorCount, "no ingest errors at the gate fan-out (enroll cap is 1000/min in-process); last error per host is in PerHost")
+	assert.Greater(t, rep.ObservationCount, scaleGateHosts, "every host posts at least once over the lane")
+	assert.Lessf(t, got, int64(scaleGateMaxBacklog),
+		"event_queue backlog must stay bounded (got max %d, ceiling %d): a processor-throughput regression makes this diverge", got, scaleGateMaxBacklog)
+}
+
+// pollMaxBacklog starts a goroutine that samples the event_queue processing backlog every scaleGateBacklogPoll until ctx is done,
+// and returns a getter for the maximum observed depth. Mirrors backlogSampler's query without needing a separate DSN.
+func pollMaxBacklog(ctx context.Context, t *testing.T, stack *integration.Stack) func() int64 {
+	t.Helper()
+	var (
+		mu       sync.Mutex
+		maxDepth int64
+	)
+	go func() {
+		ticker := time.NewTicker(scaleGateBacklogPoll)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				var depth int64
+				if err := stack.DB.GetContext(ctx, &depth, "SELECT COUNT(*) FROM event_queue WHERE processed != 1"); err != nil {
+					continue // a transient read error during a sample is not the gate's concern; the next tick re-samples
+				}
+				mu.Lock()
+				if depth > maxDepth {
+					maxDepth = depth
+				}
+				mu.Unlock()
+			}
+		}
+	}()
+	return func() int64 {
+		mu.Lock()
+		defer mu.Unlock()
+		return maxDepth
+	}
+}


### PR DESCRIPTION
## Summary

Closes the **scale leg of #203**. The 500-host baseline is already recorded on main (`test/scale/baselines/post-535-500host.json`, via #545); this adds the **per-RC re-run + RC-promotion gate** that the DoD requires. Soak and chaos are split to #542 / #543.

## What this adds

- **`test/scale/scalegate_test.go`** (build tag `scalegate`, so it stays out of the per-PR `-tags integration` run): a CI-feasible **200-host** lane against an in-process `integration.Setup` stack configured with the **production processor fan-out** (`ProcessConcurrency = 4`), asserting the `event_queue` processing backlog stays **bounded** (ceiling 5000). The post-#535 500-host baseline held the backlog at max 17; the pre-#535 path diverged to ~37k. Verified green locally in ~90s. It is the regression gate for #535 (batched graph builder + intra-replica concurrency) and #544 (deadlock-resilient claim).
- **`integration.Setup` gains `WithProcessConcurrency(n)`** — default unchanged (single worker), so existing callers are unaffected.
- **`.github/workflows/scale.yml`** — standalone gate on `v*-rc.*` tags + weekly + manual dispatch, mirroring the L6 efficacy "nightly + RC" shape (not coupled into `release.yml`).
- **`docs/release-checklist.md`** makes a red gate block RC promotion; **`docs/testing-strategy.md`** documents the tier; **`task uat:scale:gate`** runs it locally.

## Why in-process / 200 hosts

`integration.Setup` wires `EnrollRatePerMinute = 1000`, so 200 hosts enroll from the single CI source IP without tripping the production 30/min per-IP limit (the `enroll: context deadline exceeded` artifact a `dev:server` lane hits). The archive is the in-memory `MemArchive`, so the gate needs only MySQL, no ClickHouse. 200 hosts is the runner-feasible count that still makes a processor-throughput regression diverge the backlog; the full 500-host proof stays in the committed baseline.

Closes #203.

🤖 Generated with [Claude Code](https://claude.com/claude-code)