### PR TITLE
fix(rules): one canonical name per detection across docs, catalog, and alerts (#519)

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1160,7 +1160,7 @@ components:
       properties:
         title:
           type: string
-          example: "Keychain dump (security dump-keychain)"
+          example: "Keychain credential dump"
         summary:
           type: string
           description: One-line elevator pitch shown in tooltips.

--- a/docs/detection-rules.md
+++ b/docs/detection-rules.md
@@ -15,20 +15,20 @@ Hand-edits to this file get overwritten on the next regeneration.
 
 | Rule ID | Title | Severity | ATT&CK |
 | --- | --- | --- | --- |
-| [`suspicious_exec`](#suspicious_exec) | Suspicious exec chain (non-shell → shell → temp/network) | high | T1059, T1105 |
-| [`persistence_launchagent`](#persistence_launchagent) | LaunchAgent persistence (launchctl load/bootstrap) | high | T1543.001 |
+| [`suspicious_exec`](#suspicious_exec) | Suspicious exec chain | high | T1059, T1105 |
+| [`persistence_launchagent`](#persistence_launchagent) | LaunchAgent persistence | high | T1543.001 |
 | [`dyld_insert`](#dyld_insert) | DYLD injection on exec | high | T1574.006 |
 | [`shell_from_office`](#shell_from_office) | Shell spawned by Microsoft Office | high | T1566.001, T1059.004 |
-| [`osascript_network_exec`](#osascript_network_exec) | AppleScript dropper (osascript → curl/wget → temp exec) | critical | T1059.002, T1105 |
-| [`credential_keychain_dump`](#credential_keychain_dump) | Keychain dump (security dump-keychain) | high | T1555.001 |
-| [`privilege_launchd_plist_write`](#privilege_launchd_plist_write) | LaunchDaemon persistence (BTM daemon registration) | high | T1543.004 |
-| [`sudoers_tamper`](#sudoers_tamper) | Sudoers tamper (write to /etc/sudoers or /etc/sudoers.d/*) | high | T1548.003 |
+| [`osascript_network_exec`](#osascript_network_exec) | AppleScript dropper | critical | T1059.002, T1105 |
+| [`credential_keychain_dump`](#credential_keychain_dump) | Keychain credential dump | high | T1555.001 |
+| [`privilege_launchd_plist_write`](#privilege_launchd_plist_write) | LaunchDaemon persistence | high | T1543.004 |
+| [`sudoers_tamper`](#sudoers_tamper) | Sudoers tamper | high | T1548.003 |
 | [`application_control_block`](#application_control_block) | Application control block | medium |  |
-| [`dns_c2_beacon`](#dns_c2_beacon) | DNS C2 beacon (suspicious process resolves a domain then connects to it) | high | T1071.004, T1568.002 |
+| [`dns_c2_beacon`](#dns_c2_beacon) | DNS C2 beacon | high | T1071.004, T1568.002 |
 
 ## suspicious_exec
 
-**Suspicious exec chain (non-shell → shell → temp/network)**  
+**Suspicious exec chain**  
 Flags a non-shell process that spawns a shell which, within 30 seconds, execs from /tmp or makes an outbound network connection.
 
 | | |
@@ -63,7 +63,7 @@ The rule fires on the LAST link of the chain (the temp-exec or the network_conne
 
 ## persistence_launchagent
 
-**LaunchAgent persistence (launchctl load/bootstrap)**  
+**LaunchAgent persistence**  
 Flags `launchctl load` / `launchctl bootstrap` of a plist under ~/Library/LaunchAgents or /Library/LaunchAgents.
 
 | | |
@@ -147,7 +147,7 @@ Office apps almost never need to shell out in normal use; when they do, it's an 
 
 ## osascript_network_exec
 
-**AppleScript dropper (osascript → curl/wget → temp exec)**  
+**AppleScript dropper**  
 Critical-severity catch on the canonical macOS commodity-dropper chain: osascript fetches a stage-2 over the network and runs it from /tmp.
 
 | | |
@@ -176,7 +176,7 @@ The rule requires both halves of the chain to be present, so download-only or te
 
 ## credential_keychain_dump
 
-**Keychain dump (security dump-keychain)**  
+**Keychain credential dump**  
 Flags exec of /usr/bin/security dump-keychain: the canonical macOS Keychain export command.
 
 | | |
@@ -203,7 +203,7 @@ Match shape is exact-path + exact-subcommand to keep the rule high-precision. A 
 
 ## privilege_launchd_plist_write
 
-**LaunchDaemon persistence (BTM daemon registration)**  
+**LaunchDaemon persistence**  
 Flags a system-domain LaunchDaemon whose registered executable is not an Apple platform binary and not allowlisted.
 
 | | |
@@ -235,7 +235,7 @@ Notarization is deliberately NOT a trust signal: it is an automated Apple scan, 
 
 ## sudoers_tamper
 
-**Sudoers tamper (write to /etc/sudoers or /etc/sudoers.d/*)**  
+**Sudoers tamper**  
 Flags any non-allowlisted writer that opens /etc/sudoers or /etc/sudoers.d/* in write mode.
 
 | | |
@@ -278,7 +278,7 @@ The extension's AUTH_EXEC decision walker denies execs that match an admin-defin
 
 ## dns_c2_beacon
 
-**DNS C2 beacon (suspicious process resolves a domain then connects to it)**  
+**DNS C2 beacon**  
 Flags a program that looks up a domain name and then connects to the address that lookup returned, when that program was launched from a suspicious location such as a temporary or world-writable folder. This is the classic "malware phoning home" shape, and the alert ties three normally separate signals into one finding: the program launch, the DNS lookup, and the outbound connection.
 
 | | |

--- a/openspec/changes/canonical-rule-naming/proposal.md
+++ b/openspec/changes/canonical-rule-naming/proposal.md
@@ -1,0 +1,25 @@
+# Name each detection one canonical way across docs, the rule catalog, and the alert
+
+## Why
+
+Every detection rule names itself through three independent surfaces that do not agree, so an operator sees a different string for the same detection depending on where they look (issue #519):
+
+1. **Rule ID** (`ID()`, snake_case) in `/api/rules`, `alerts.rule_id`, exclusions, and the efficacy corpus.
+2. **Doc title** (`Doc().Title`) in `/api/rules` and `docs/detection-rules.md`.
+3. **Alert title** (`Finding.Title`) in the alerts list and alert detail.
+
+For the LaunchDaemon-persistence rule the same detection is variously "LaunchDaemon persistence (BTM daemon registration)" (doc), "LaunchDaemon persistence" (alert), and `privilege_launchd_plist_write` (ID). Worse, `suspicious_exec` emitted two unrelated alert titles ("Shell spawn with outbound network connection" and "Suspicious exec from temp path"), neither matching its doc title. A user triaging an alert, reading the docs, and writing an exclusion has to mentally map several strings to one detection. Detection catalogs (Sigma, Elastic, MITRE-aligned vendor rules) instead give each detection a stable identifier plus one canonical human-readable name reused everywhere; the alert names the rule you can look up.
+
+## What changes
+
+- **Each rule exposes one canonical `DisplayName()`** on the `api.Rule` interface. Both `Doc().Title` and `Finding.Title` derive from it, so the docs, `/api/rules`, and the alert show the same name. The name is a clean human-readable label; the parenthetical implementation detail that several doc titles carried (`(security dump-keychain)`, `(launchctl load/bootstrap)`, etc.) lives in `Summary`, not the title.
+- **Observable alert titles change** for the rules whose finding title diverged from the canonical name: `suspicious_exec` (both arms now "Suspicious exec chain"; which arm fired stays in the finding Description), `persistence_launchagent`, `dyld_insert`, `shell_from_office`, `osascript_network_exec`, `credential_keychain_dump`. Documented rule titles change for the rules that carried a parenthetical.
+- **Rule IDs are unchanged.** Renaming an ID (e.g. the semantically stale `privilege_launchd_plist_write`) is a separate, migration-backed change: IDs key `alerts.rule_id`, exclusions, the efficacy corpus, and generated docs.
+- **A structural guard prevents re-drift.** A catalog test asserts `Doc().Title == DisplayName()` for every rule and that the name is a clean label; the fixture-replay harness and each rule's positive-detection test assert `Finding.Title == DisplayName()`.
+- `docs/detection-rules.md` is regenerated from the new titles.
+
+### Not in this change
+
+- No rule-ID rename (separate migration-backed change).
+- `application_control_block` keeps its per-block computed alert title (`Application blocked: <binary>`) and its per-rule `app_control:<n>` RuleID: its alerts name the blocked binary and the admin rule, not a catalog detection. `DisplayName()` ("Application control block") still backs its `Doc().Title`. It is the one rule exempt from the finding-title==DisplayName assertion.
+- No wire-shape change: `Doc().Title` stays the surfaced field, now guaranteed canonical.

--- a/openspec/changes/canonical-rule-naming/specs/server-detection-rules-engine/spec.md
+++ b/openspec/changes/canonical-rule-naming/specs/server-detection-rules-engine/spec.md
@@ -1,0 +1,24 @@
+# Server Detection Rules Engine Specification (delta)
+
+## ADDED Requirements
+
+### Requirement: Canonical rule naming
+
+The system SHALL give every detection rule one canonical human-readable name, distinct from its stable snake_case identifier, and reuse that one name across every operator-facing surface. The rule's documentation title (surfaced in `/api/rules` and `docs/detection-rules.md`) and the title of every alert the rule raises SHALL both be that canonical name, so an operator who triages an alert, reads the documentation, and writes an exclusion sees one name mapped to one rule. A rule that fires on more than one trigger arm SHALL still raise its findings under the single canonical name; the distinguishing arm detail belongs in the finding's description, not in a divergent title. The rule identifier SHALL remain unchanged by this requirement.
+
+The application-control block rule is exempt from the alert-title half: its alerts carry a per-block computed title that names the blocked binary and a per-rule identifier (`app_control:<n>`) rather than the catalog rule's identifier, because those alerts name the admin rule and binary that were blocked rather than a catalog detection. Its documentation title SHALL still be the canonical name.
+
+#### Scenario: A rule names itself the same way everywhere
+
+- **GIVEN** any registered catalog rule other than the application-control block rule
+- **WHEN** the rule's documentation title is read and the rule fires to raise an alert
+- **THEN** the documentation title equals the rule's canonical name
+- **AND** the alert's title equals that same canonical name
+- **AND** the canonical name is a clean human-readable label carrying no parenthetical implementation detail
+
+#### Scenario: A multi-arm rule raises one canonical title across arms
+
+- **GIVEN** the `suspicious_exec` rule, which fires on either a temp-path exec arm or an outbound network-connection arm
+- **WHEN** either arm fires
+- **THEN** the alert title is the one canonical name "Suspicious exec chain"
+- **AND** the finding description names which arm fired

--- a/openspec/changes/canonical-rule-naming/tasks.md
+++ b/openspec/changes/canonical-rule-naming/tasks.md
@@ -1,0 +1,23 @@
+# Tasks
+
+## 1. Interface and rules
+
+- [x] 1.1 Add `DisplayName() string` to `server/rules/api` `Rule` interface with a doc comment establishing it as the single canonical name.
+- [x] 1.2 Implement `DisplayName()` on all 10 catalog rules; set each `Doc().Title` to `r.DisplayName()`.
+- [x] 1.3 Set each rule's `Finding.Title` to `r.DisplayName()` (both `suspicious_exec` arms collapse to the one title; `application_control_block` keeps its computed per-block title).
+- [x] 1.4 Add `DisplayName()` to the test stub rules so they satisfy the interface.
+
+## 2. Guard against re-drift
+
+- [x] 2.1 Catalog test: for every rule assert `DisplayName()` non-empty, `Doc().Title == DisplayName()`, and the name carries no parenthetical.
+- [x] 2.2 Fixture-replay harness asserts `Finding.Title == DisplayName()` for every replayed rule.
+- [x] 2.3 Each non-replayed positive-detection test asserts `Finding.Title == DisplayName()`; `suspicious_exec` arm coverage re-pinned on the Description.
+
+## 3. Docs
+
+- [x] 3.1 Regenerate `docs/detection-rules.md` (`go run ./tools/gen-rule-docs`).
+
+## 4. Spec + validation
+
+- [x] 4.1 Spec delta adds the "Canonical rule naming" requirement + scenario; `registry_test.go` carries the spectrace marker.
+- [ ] 4.2 `openspec validate canonical-rule-naming --strict` and `task lint:dashes` pass.

--- a/server/detection/internal/engine/engine_test.go
+++ b/server/detection/internal/engine/engine_test.go
@@ -22,10 +22,11 @@ type stubRule struct {
 }
 
 func (r *stubRule) ID() string           { return r.id }
+func (r *stubRule) DisplayName() string  { return "Stub" }
 func (r *stubRule) Techniques() []string { return r.techniques }
 func (r *stubRule) Doc() rulesapi.Documentation {
 	return rulesapi.Documentation{
-		Title:    "Stub",
+		Title:    r.DisplayName(),
 		Severity: rulesapi.SeverityHigh,
 	}
 }

--- a/server/detection/internal/tests/integration_test.go
+++ b/server/detection/internal/tests/integration_test.go
@@ -62,10 +62,11 @@ type stubRule struct {
 }
 
 func (r *stubRule) ID() string           { return r.id }
+func (r *stubRule) DisplayName() string  { return "Stub rule" }
 func (r *stubRule) Techniques() []string { return r.techniques }
 func (r *stubRule) Doc() rulesapi.Documentation {
 	return rulesapi.Documentation{
-		Title:    "Stub rule",
+		Title:    r.DisplayName(),
 		Summary:  "test fixture",
 		Severity: rulesapi.SeverityHigh,
 	}
@@ -107,9 +108,10 @@ func (s stubProvider) ActiveRules() []rulesapi.Rule { return s.rules }
 type multiPIDStub struct{ id string }
 
 func (r *multiPIDStub) ID() string           { return r.id }
+func (r *multiPIDStub) DisplayName() string  { return "Multi-pid stub" }
 func (r *multiPIDStub) Techniques() []string { return nil }
 func (r *multiPIDStub) Doc() rulesapi.Documentation {
-	return rulesapi.Documentation{Title: "Multi-pid stub", Summary: "test fixture", Severity: rulesapi.SeverityHigh}
+	return rulesapi.Documentation{Title: r.DisplayName(), Summary: "test fixture", Severity: rulesapi.SeverityHigh}
 }
 
 func (r *multiPIDStub) Evaluate(_ context.Context, events []api.Event, _ rulesapi.GraphReader) ([]api.Finding, error) {

--- a/server/detection/internal/tests/integration_test.go
+++ b/server/detection/internal/tests/integration_test.go
@@ -155,9 +155,10 @@ type fixedPIDStub struct {
 }
 
 func (r *fixedPIDStub) ID() string           { return r.id }
+func (r *fixedPIDStub) DisplayName() string  { return "Fixed-PID stub" }
 func (r *fixedPIDStub) Techniques() []string { return nil }
 func (r *fixedPIDStub) Doc() rulesapi.Documentation {
-	return rulesapi.Documentation{Title: "Fixed-PID stub", Summary: "test fixture", Severity: rulesapi.SeverityHigh}
+	return rulesapi.Documentation{Title: r.DisplayName(), Summary: "test fixture", Severity: rulesapi.SeverityHigh}
 }
 
 func (r *fixedPIDStub) Evaluate(_ context.Context, events []api.Event, _ rulesapi.GraphReader) ([]api.Finding, error) {
@@ -185,9 +186,10 @@ func (r *fixedPIDStub) Evaluate(_ context.Context, events []api.Event, _ rulesap
 type errorStub struct{ id string }
 
 func (r *errorStub) ID() string           { return r.id }
+func (r *errorStub) DisplayName() string  { return "Erroring stub" }
 func (r *errorStub) Techniques() []string { return nil }
 func (r *errorStub) Doc() rulesapi.Documentation {
-	return rulesapi.Documentation{Title: "Erroring stub", Summary: "test fixture", Severity: rulesapi.SeverityHigh}
+	return rulesapi.Documentation{Title: r.DisplayName(), Summary: "test fixture", Severity: rulesapi.SeverityHigh}
 }
 
 func (r *errorStub) Evaluate(_ context.Context, _ []api.Event, _ rulesapi.GraphReader) ([]api.Finding, error) {
@@ -212,9 +214,10 @@ type execFiringStub struct {
 }
 
 func (r *execFiringStub) ID() string           { return r.id }
+func (r *execFiringStub) DisplayName() string  { return "Exec-firing stub" }
 func (r *execFiringStub) Techniques() []string { return nil }
 func (r *execFiringStub) Doc() rulesapi.Documentation {
-	return rulesapi.Documentation{Title: "Exec-firing stub", Summary: "test fixture", Severity: rulesapi.SeverityHigh}
+	return rulesapi.Documentation{Title: r.DisplayName(), Summary: "test fixture", Severity: rulesapi.SeverityHigh}
 }
 
 func (r *execFiringStub) Evaluate(_ context.Context, events []api.Event, _ rulesapi.GraphReader) ([]api.Finding, error) {

--- a/server/detection/testkit/replay.go
+++ b/server/detection/testkit/replay.go
@@ -147,6 +147,12 @@ func runCase(t *testing.T, rule rulesapi.Rule, path string) {
 		want := c.ExpectedFindings[i]
 		assert.Equal(t, want.RuleID, got.RuleID, "finding[%d].rule_id", i)
 		assert.Equal(t, want.Severity, got.Severity, "finding[%d].severity", i)
+		// Issue #519: a detection rule's alert title MUST be its one canonical DisplayName so the alert an operator triages names
+		// the rule they can look up in the docs and exclusions. Asserted here for every fixture-replayed rule with no per-fixture
+		// boilerplate. (application_control_block is exempt: its findings carry a per-block computed title plus an app_control:<n>
+		// RuleID, and it is table-driven, not fixture-replayed, so it is never reached here.)
+		assert.Equal(t, rule.DisplayName(), got.Title,
+			"finding[%d].title must equal the rule's canonical DisplayName (issue #519)", i)
 		if want.DescriptionContains != "" {
 			assert.Contains(t, got.Description, want.DescriptionContains,
 				"finding[%d].description must contain %q", i, want.DescriptionContains)

--- a/server/rules/api/types.go
+++ b/server/rules/api/types.go
@@ -62,6 +62,13 @@ const (
 // events. Concrete rules live in rules/internal/catalog/.
 type Rule interface {
 	ID() string
+	// DisplayName returns the single canonical human-readable name for the detection (issue #519). It is the one string a rule names
+	// itself with everywhere a human reads it: Doc().Title (docs + /api/rules + UI) and Finding.Title (the alert) both derive from it,
+	// so the operator who triages an alert, reads the docs, and writes an exclusion sees the same name mapped to one stable ID(). Unlike
+	// ID() (the snake_case machine identifier), this is prose, e.g. "Keychain credential dump". A rule with multiple trigger arms still
+	// emits this one title; which arm fired lives in the finding's Description, not in a forked title (SIEM/Sigma catalog convention:
+	// one rule, one name). The catalog guard test asserts Doc().Title == DisplayName() and that every finding carries it.
+	DisplayName() string
 	// Techniques returns the MITRE ATT&CK technique IDs the rule maps to (e.g. []string{"T1059.002", "T1105"}). Used for Navigator export
 	// + UI badging. Return an empty slice, not nil, for "no mapping".
 	Techniques() []string
@@ -87,8 +94,10 @@ type RuleMetadata struct {
 // Documentation is the structured per-rule descriptor consumed by the
 // markdown generator, /api/rules, and the UI's rule detail page.
 type Documentation struct {
-	// Title is the operator-facing display name (e.g. "Keychain dump"). Distinct from ID(): IDs are stable identifiers used in alert rows;
-	// titles are the human-readable label rendered in tables and headings.
+	// Title is the operator-facing display name (e.g. "Keychain credential dump"). It MUST equal the rule's DisplayName() (issue #519):
+	// it is set from r.DisplayName() in every Doc() so the docs, /api/rules, and the alert all show one canonical name. Distinct from
+	// ID(): IDs are stable snake_case identifiers used in alert rows; the title is the human-readable label. The catalog guard test
+	// enforces Title == DisplayName().
 	Title string `json:"title"`
 	// Summary is a one-sentence elevator pitch shown in lists / tooltips.
 	Summary string `json:"summary"`

--- a/server/rules/api/types.go
+++ b/server/rules/api/types.go
@@ -67,7 +67,8 @@ type Rule interface {
 	// so the operator who triages an alert, reads the docs, and writes an exclusion sees the same name mapped to one stable ID(). Unlike
 	// ID() (the snake_case machine identifier), this is prose, e.g. "Keychain credential dump". A rule with multiple trigger arms still
 	// emits this one title; which arm fired lives in the finding's Description, not in a forked title (SIEM/Sigma catalog convention:
-	// one rule, one name). The catalog guard test asserts Doc().Title == DisplayName() and that every finding carries it.
+	// one rule, one name). The catalog guard test (TestAll_CanonicalDisplayName) asserts Doc().Title == DisplayName(); the
+	// fixture-replay harness and each rule's positive-detection test assert that findings carry it.
 	DisplayName() string
 	// Techniques returns the MITRE ATT&CK technique IDs the rule maps to (e.g. []string{"T1059.002", "T1105"}). Used for Navigator export
 	// + UI badging. Return an empty slice, not nil, for "no mapping".

--- a/server/rules/internal/catalog/application_control_block.go
+++ b/server/rules/internal/catalog/application_control_block.go
@@ -34,8 +34,8 @@ func (r *ApplicationControlBlock) ID() string { return "application_control_bloc
 // DisplayName is the canonical name for the rule's catalog entry (Doc().Title). Unlike the other rules, the alert this rule raises
 // does NOT carry DisplayName as its title: each block event maps to a finding whose RuleID is the matched app-control rule
 // (`app_control:<n>`, not this catalog ID) and whose title is computed per block (`Application blocked: <binary>`), so the operator
-// sees which binary was blocked by which admin rule. The catalog guard test exempts this rule from the finding-title==DisplayName
-// assertion for that reason (issue #519).
+// sees which binary was blocked by which admin rule. The finding-title==DisplayName invariant is enforced by the fixture-replay
+// harness; this rule is table-driven (not fixture-replayed) and so is never subject to that assertion (issue #519).
 func (r *ApplicationControlBlock) DisplayName() string { return "Application control block" }
 
 // Techniques returns an empty slice. App-control blocks are not mapped to MITRE ATT&CK because the framework's perspective is "the

--- a/server/rules/internal/catalog/application_control_block.go
+++ b/server/rules/internal/catalog/application_control_block.go
@@ -31,6 +31,13 @@ const applicationControlBlockEventType = "application_control_block"
 
 func (r *ApplicationControlBlock) ID() string { return "application_control_block" }
 
+// DisplayName is the canonical name for the rule's catalog entry (Doc().Title). Unlike the other rules, the alert this rule raises
+// does NOT carry DisplayName as its title: each block event maps to a finding whose RuleID is the matched app-control rule
+// (`app_control:<n>`, not this catalog ID) and whose title is computed per block (`Application blocked: <binary>`), so the operator
+// sees which binary was blocked by which admin rule. The catalog guard test exempts this rule from the finding-title==DisplayName
+// assertion for that reason (issue #519).
+func (r *ApplicationControlBlock) DisplayName() string { return "Application control block" }
+
 // Techniques returns an empty slice. App-control blocks are not mapped to MITRE ATT&CK because the framework's perspective is "the
 // adversary did something": a successful block is the absence of that. Operators who want ATT&CK badging on app-control alerts can
 // tag the originating rule downstream.
@@ -38,7 +45,7 @@ func (r *ApplicationControlBlock) Techniques() []string { return []string{} }
 
 func (r *ApplicationControlBlock) Doc() api.Documentation {
 	return api.Documentation{
-		Title:   "Application control block",
+		Title:   r.DisplayName(),
 		Summary: "Surfaces every AUTH_EXEC denial from the extension as an alert in the unified view.",
 		Description: "The extension's AUTH_EXEC decision walker denies execs that match an admin-defined " +
 			"application-control rule. Every such denial emits an `application_control_block` event that this " +

--- a/server/rules/internal/catalog/credential_keychain_dump.go
+++ b/server/rules/internal/catalog/credential_keychain_dump.go
@@ -30,6 +30,9 @@ type CredentialKeychainDump struct{}
 
 func (r *CredentialKeychainDump) ID() string { return "credential_keychain_dump" }
 
+// DisplayName is the canonical human-readable name reused by Doc().Title and the finding (issue #519).
+func (r *CredentialKeychainDump) DisplayName() string { return "Keychain credential dump" }
+
 // Techniques returns the MITRE ATT&CK IDs this rule covers: T1555.001 (Credentials from Password Stores → Keychain). Apple's own docs
 // list `security dump-keychain` as the tool for enumerating Keychain items, and MITRE explicitly cites it on the technique page.
 func (r *CredentialKeychainDump) Techniques() []string { return []string{"T1555.001"} }
@@ -38,7 +41,7 @@ func (r *CredentialKeychainDump) Techniques() []string { return []string{"T1555.
 // the generated docs/detection-rules.md.
 func (r *CredentialKeychainDump) Doc() api.Documentation {
 	return api.Documentation{
-		Title:   "Keychain dump (security dump-keychain)",
+		Title:   r.DisplayName(),
 		Summary: "Flags exec of /usr/bin/security dump-keychain: the canonical macOS Keychain export command.",
 		Description: "Fires when a process invokes `/usr/bin/security` with the `dump-keychain` subcommand. " +
 			"That command exports Keychain entries (saved passwords, private keys) and is the macOS-native equivalent " +
@@ -112,7 +115,7 @@ func (r *CredentialKeychainDump) Evaluate(ctx context.Context, events []api.Even
 			HostID:      evt.HostID,
 			RuleID:      r.ID(),
 			Severity:    api.SeverityHigh,
-			Title:       "Keychain credential dump attempted",
+			Title:       r.DisplayName(),
 			Description: fmt.Sprintf("%s invoked with %q: reads all Keychain entries (Keychain credential access, MITRE T1555.001)", p.Path, sub),
 			ProcessID:   proc.ID,
 			EventIDs:    []string{evt.EventID},

--- a/server/rules/internal/catalog/dns_c2_beacon.go
+++ b/server/rules/internal/catalog/dns_c2_beacon.go
@@ -34,6 +34,9 @@ type DNSC2Beacon struct{}
 
 func (r *DNSC2Beacon) ID() string { return "dns_c2_beacon" }
 
+// DisplayName is the canonical human-readable name reused by Doc().Title and the finding (issue #519).
+func (r *DNSC2Beacon) DisplayName() string { return "DNS C2 beacon" }
+
 // Techniques is the union the rule can stamp; a given finding narrows this to the subset that actually applied (every
 // finding carries T1071.004; only DGA-domain findings add T1568.002). Procurement and ATT&CK-Navigator export read this
 // list, so it is pinned by a test.
@@ -43,7 +46,7 @@ func (r *DNSC2Beacon) Techniques() []string {
 
 func (r *DNSC2Beacon) Doc() api.Documentation {
 	return api.Documentation{
-		Title: "DNS C2 beacon (suspicious process resolves a domain then connects to it)",
+		Title: r.DisplayName(),
 		Summary: "Flags a program that looks up a domain name and then connects to the address that lookup returned, when that " +
 			"program was launched from a suspicious location such as a temporary or world-writable folder. This is the classic " +
 			"\"malware phoning home\" shape, and the alert ties three normally separate signals into one finding: the program launch, " +
@@ -193,7 +196,7 @@ func (r *DNSC2Beacon) evalEvent(
 		HostID:      evt.HostID,
 		RuleID:      r.ID(),
 		Severity:    severity,
-		Title:       "DNS C2 beacon",
+		Title:       r.DisplayName(),
 		Description: fmt.Sprintf("%s resolved %s and connected to %s", proc.Path, queryName, conn.RemoteAddress),
 		ProcessID:   proc.ID,
 		EventIDs:    []string{dnsEvt.EventID, evt.EventID},

--- a/server/rules/internal/catalog/dyld_insert.go
+++ b/server/rules/internal/catalog/dyld_insert.go
@@ -24,6 +24,9 @@ type DyldInsert struct{}
 
 func (r *DyldInsert) ID() string { return "dyld_insert" }
 
+// DisplayName is the canonical human-readable name reused by Doc().Title and the finding (issue #519).
+func (r *DyldInsert) DisplayName() string { return "DYLD injection on exec" }
+
 // Techniques returns the MITRE ATT&CK IDs this rule covers: T1574.006 (Hijack Execution Flow → Dynamic Linker Hijacking).
 // Sub-technique chosen deliberately: the rule catches DYLD_* env-var abuse specifically, not the broader "Hijack Execution Flow"
 // parent.
@@ -33,7 +36,7 @@ func (r *DyldInsert) Techniques() []string { return []string{"T1574.006"} }
 // the generated docs/detection-rules.md.
 func (r *DyldInsert) Doc() api.Documentation {
 	return api.Documentation{
-		Title:   "DYLD injection on exec",
+		Title:   r.DisplayName(),
 		Summary: "Flags exec where DYLD_INSERT_LIBRARIES or DYLD_LIBRARY_PATH is set in argv (shell-style or via env(1)).",
 		Description: "Detects the classic macOS code-injection primitive: launching a process with " +
 			"`DYLD_INSERT_LIBRARIES=…` or `DYLD_LIBRARY_PATH=…` set so dyld loads attacker-supplied dylibs into " +
@@ -95,7 +98,7 @@ func (r *DyldInsert) Evaluate(ctx context.Context, events []api.Event, s api.Gra
 			HostID:      evt.HostID,
 			RuleID:      r.ID(),
 			Severity:    api.SeverityHigh,
-			Title:       "DYLD injection env var set on exec",
+			Title:       r.DisplayName(),
 			Description: fmt.Sprintf("%s launched with %s", p.Path, matched),
 			ProcessID:   proc.ID,
 			EventIDs:    []string{evt.EventID},

--- a/server/rules/internal/catalog/dyld_insert_test.go
+++ b/server/rules/internal/catalog/dyld_insert_test.go
@@ -95,6 +95,7 @@ func TestDyldInsert_TableDriven(t *testing.T) {
 			}
 			require.Len(t, findings, 1)
 			assert.Equal(t, "dyld_insert", findings[0].RuleID)
+			assert.Equal(t, rule.DisplayName(), findings[0].Title, "alert title is the rule's canonical DisplayName (issue #519)")
 			assert.Equal(t, "high", findings[0].Severity)
 			assert.Contains(t, findings[0].Description, "<redacted>",
 				"description must not echo the raw dylib path")

--- a/server/rules/internal/catalog/osascript_network_exec.go
+++ b/server/rules/internal/catalog/osascript_network_exec.go
@@ -36,6 +36,9 @@ type OsascriptNetworkExec struct{}
 
 func (r *OsascriptNetworkExec) ID() string { return "osascript_network_exec" }
 
+// DisplayName is the canonical human-readable name reused by Doc().Title and the finding (issue #519).
+func (r *OsascriptNetworkExec) DisplayName() string { return "AppleScript dropper" }
+
 // Techniques returns the MITRE ATT&CK IDs this rule covers: T1059.002 (Command and Scripting Interpreter → AppleScript) + T1105
 // (Ingress Tool Transfer). The rule specifically flags osascript invoking a curl/wget that stages an executable to /tmp, which is the
 // exact shape of a T1105 dropper.
@@ -47,7 +50,7 @@ func (r *OsascriptNetworkExec) Techniques() []string {
 // the generated docs/detection-rules.md.
 func (r *OsascriptNetworkExec) Doc() api.Documentation {
 	return api.Documentation{
-		Title:   "AppleScript dropper (osascript → curl/wget → temp exec)",
+		Title:   r.DisplayName(),
 		Summary: "Critical-severity catch on the canonical macOS commodity-dropper chain: osascript fetches a stage-2 over the network and runs it from /tmp.",
 		Description: "Fires on the LAST link of the chain: an exec from a temp directory whose process tree has " +
 			"both an osascript ancestor and a curl/wget sibling within the osascript's 30-second descendant window. " +
@@ -194,7 +197,7 @@ func (r *OsascriptNetworkExec) evalEvent(
 		HostID:      evt.HostID,
 		RuleID:      r.ID(),
 		Severity:    api.SeverityCritical,
-		Title:       "osascript download-and-exec chain",
+		Title:       r.DisplayName(),
 		Description: fmt.Sprintf("osascript → %s → %s", downloader.Path, displayTempExec(p)),
 		ProcessID:   tempExecProc.ID,
 		EventIDs:    []string{evt.EventID},

--- a/server/rules/internal/catalog/osascript_network_exec_test.go
+++ b/server/rules/internal/catalog/osascript_network_exec_test.go
@@ -41,6 +41,7 @@ func TestOsascriptNetworkExec_DetectsChain(t *testing.T) {
 	require.Len(t, findings, 1)
 	f := findings[0]
 	assert.Equal(t, "osascript_network_exec", f.RuleID)
+	assert.Equal(t, rule.DisplayName(), f.Title, "alert title is the rule's canonical DisplayName (issue #519)")
 	assert.Equal(t, "critical", f.Severity)
 	assert.Contains(t, f.Description, "/usr/bin/curl")
 	assert.Contains(t, f.Description, "/tmp/stage2")

--- a/server/rules/internal/catalog/persistence_launchagent.go
+++ b/server/rules/internal/catalog/persistence_launchagent.go
@@ -24,6 +24,9 @@ type PersistenceLaunchAgent struct {
 
 func (r *PersistenceLaunchAgent) ID() string { return "persistence_launchagent" }
 
+// DisplayName is the canonical human-readable name reused by Doc().Title and the finding (issue #519).
+func (r *PersistenceLaunchAgent) DisplayName() string { return "LaunchAgent persistence" }
+
 // Techniques returns the MITRE ATT&CK IDs this rule covers: T1543.001 (Create or Modify System Process → Launch Agent). The rule
 // fires on `launchctl load` of user LaunchAgent plists, which is exactly this sub-technique's scope.
 func (r *PersistenceLaunchAgent) Techniques() []string { return []string{"T1543.001"} }
@@ -32,7 +35,7 @@ func (r *PersistenceLaunchAgent) Techniques() []string { return []string{"T1543.
 // the generated docs/detection-rules.md.
 func (r *PersistenceLaunchAgent) Doc() api.Documentation {
 	return api.Documentation{
-		Title:   "LaunchAgent persistence (launchctl load/bootstrap)",
+		Title:   r.DisplayName(),
 		Summary: "Flags `launchctl load` / `launchctl bootstrap` of a plist under ~/Library/LaunchAgents or /Library/LaunchAgents.",
 		Description: "Detects the canonical user-domain persistence step on macOS: an attacker drops a plist into a " +
 			"LaunchAgents directory and then activates it via `launchctl load <plist>` or `launchctl bootstrap " +
@@ -117,7 +120,7 @@ func (r *PersistenceLaunchAgent) evalEvent(ctx context.Context, evt api.Event, s
 		HostID:      evt.HostID,
 		RuleID:      r.ID(),
 		Severity:    api.SeverityHigh,
-		Title:       "LaunchAgent persistence attempt",
+		Title:       r.DisplayName(),
 		Description: fmt.Sprintf("launchctl %s %s", subcommand, plistPath),
 		ProcessID:   proc.ID,
 		EventIDs:    []string{evt.EventID},

--- a/server/rules/internal/catalog/persistence_launchagent_test.go
+++ b/server/rules/internal/catalog/persistence_launchagent_test.go
@@ -138,6 +138,7 @@ func TestPersistenceLaunchAgent_TableDriven(t *testing.T) {
 			}
 			require.Len(t, findings, 1)
 			assert.Equal(t, "persistence_launchagent", findings[0].RuleID)
+			assert.Equal(t, rule.DisplayName(), findings[0].Title, "alert title is the rule's canonical DisplayName (issue #519)")
 			assert.Equal(t, "high", findings[0].Severity)
 			assert.Contains(t, findings[0].Description, tc.wantDescHas)
 			assert.Contains(t, findings[0].EventIDs, "exec-target")

--- a/server/rules/internal/catalog/privilege_launchd_plist_write.go
+++ b/server/rules/internal/catalog/privilege_launchd_plist_write.go
@@ -44,6 +44,10 @@ type PrivilegeLaunchdPlistWrite struct {
 
 func (r *PrivilegeLaunchdPlistWrite) ID() string { return "privilege_launchd_plist_write" }
 
+// DisplayName is the canonical human-readable name reused by Doc().Title and the finding (issue #519). The ID stays the stale-but-stable
+// snake_case identifier (renaming it is a migration-backed change); the prose name reflects what the rule actually detects today.
+func (r *PrivilegeLaunchdPlistWrite) DisplayName() string { return "LaunchDaemon persistence" }
+
 // Techniques returns the MITRE ATT&CK IDs this rule covers: T1543.004
 // (Boot or Logon Autostart Execution → Launch Daemon).
 func (r *PrivilegeLaunchdPlistWrite) Techniques() []string { return []string{"T1543.004"} }
@@ -52,7 +56,7 @@ func (r *PrivilegeLaunchdPlistWrite) Techniques() []string { return []string{"T1
 // the generated docs/detection-rules.md.
 func (r *PrivilegeLaunchdPlistWrite) Doc() api.Documentation {
 	return api.Documentation{
-		Title:   "LaunchDaemon persistence (BTM daemon registration)",
+		Title:   r.DisplayName(),
 		Summary: "Flags a system-domain LaunchDaemon whose registered executable is not an Apple platform binary and not allowlisted.",
 		Description: "Detects the canonical system-domain persistence vector (T1543.004): a LaunchDaemon being registered " +
 			"with macOS Background Task Management. Once registered, the next `launchctl bootstrap system/<name>` (or a " +
@@ -149,7 +153,7 @@ func (r *PrivilegeLaunchdPlistWrite) evalEvent(
 		HostID:   evt.HostID,
 		RuleID:   r.ID(),
 		Severity: api.SeverityHigh,
-		Title:    "LaunchDaemon persistence",
+		Title:    r.DisplayName(),
 		Description: fmt.Sprintf(
 			"Untrusted executable %s registered as system LaunchDaemon %s: persistence (MITRE T1543.004)",
 			executable, p.ItemPath,

--- a/server/rules/internal/catalog/registry_test.go
+++ b/server/rules/internal/catalog/registry_test.go
@@ -1,6 +1,7 @@
 package catalog
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -79,6 +80,31 @@ func TestAll_DocStructIsPopulated(t *testing.T) {
 				// _ = is a compile-time reference, not a runtime assertion.
 				_ = c.Default
 			}
+		})
+	}
+}
+
+// spec:server-detection-rules-engine/canonical-rule-naming/a-rule-names-itself-the-same-way-everywhere
+//
+// TestAll_CanonicalDisplayName is the structural guard against the three-names-for-one-detection drift issue #519 fixed. It pins the
+// single-source-of-truth invariant for every shipped rule: Doc().Title (docs, /api/rules, UI) MUST equal DisplayName(), so the doc
+// surface can never silently diverge from the canonical name again. It also enforces that the canonical name is a clean human-readable
+// label, not the old "<name> (parenthetical implementation detail)" form whose detail belongs in Summary. The finding-title half of the
+// invariant (Finding.Title == DisplayName) is enforced for fixture-replayed rules by server/detection/testkit Replay and by each
+// rule's positive-detection test; application_control_block is the one exemption (per-block computed title + app_control:<n> RuleID).
+func TestAll_CanonicalDisplayName(t *testing.T) {
+	t.Parallel()
+	for _, r := range New(nil) {
+		t.Run(r.ID(), func(t *testing.T) {
+			t.Parallel()
+			name := r.DisplayName()
+			assert.NotEmpty(t, name, "DisplayName must be set for %s", r.ID())
+			assert.Equal(t, name, r.Doc().Title,
+				"%s: Doc().Title must equal DisplayName() so the docs and the alert name the rule one way", r.ID())
+			assert.NotContains(t, name, "(",
+				"%s DisplayName %q carries a parenthetical; the implementation detail belongs in Summary, the title stays a clean name",
+				r.ID(), name)
+			assert.Equal(t, strings.TrimSpace(name), name, "%s DisplayName must not carry leading/trailing whitespace", r.ID())
 		})
 	}
 }

--- a/server/rules/internal/catalog/shell_from_office.go
+++ b/server/rules/internal/catalog/shell_from_office.go
@@ -19,6 +19,9 @@ type ShellFromOffice struct{}
 
 func (r *ShellFromOffice) ID() string { return "shell_from_office" }
 
+// DisplayName is the canonical human-readable name reused by Doc().Title and the finding (issue #519).
+func (r *ShellFromOffice) DisplayName() string { return "Shell spawned by Microsoft Office" }
+
 // Techniques returns the MITRE ATT&CK IDs this rule covers: T1566.001 (Phishing → Spearphishing Attachment) + T1059.004 (Command and
 // Scripting Interpreter → Unix Shell). The chain "Office app → shell" is a textbook post-phish execution step.
 func (r *ShellFromOffice) Techniques() []string { return []string{"T1566.001", "T1059.004"} }
@@ -27,7 +30,7 @@ func (r *ShellFromOffice) Techniques() []string { return []string{"T1566.001", "
 // the generated docs/detection-rules.md.
 func (r *ShellFromOffice) Doc() api.Documentation {
 	return api.Documentation{
-		Title:   "Shell spawned by Microsoft Office",
+		Title:   r.DisplayName(),
 		Summary: "Flags any /bin/sh, /bin/bash, /bin/zsh (etc.) whose parent is Word, Excel, PowerPoint, or Outlook.",
 		Description: "Detects the textbook post-phishing execution step: a macro-laden Office document opens, the macro " +
 			"shells out, and the second stage takes off from there. The match is on the parent process being one of " +
@@ -111,7 +114,7 @@ func (r *ShellFromOffice) evalEvent(ctx context.Context, evt api.Event, s api.Gr
 		HostID:      evt.HostID,
 		RuleID:      r.ID(),
 		Severity:    api.SeverityHigh,
-		Title:       "Shell spawned from Office app",
+		Title:       r.DisplayName(),
 		Description: fmt.Sprintf("%s → %s", prettyOfficeParent(parent.Path), p.Path),
 		ProcessID:   proc.ID,
 		EventIDs:    []string{evt.EventID},

--- a/server/rules/internal/catalog/shell_from_office_test.go
+++ b/server/rules/internal/catalog/shell_from_office_test.go
@@ -106,6 +106,7 @@ func TestShellFromOffice_TableDriven(t *testing.T) {
 			}
 			require.Len(t, findings, 1)
 			assert.Equal(t, "shell_from_office", findings[0].RuleID)
+			assert.Equal(t, rule.DisplayName(), findings[0].Title, "alert title is the rule's canonical DisplayName (issue #519)")
 			assert.Equal(t, "high", findings[0].Severity)
 			assert.Equal(t, tc.wantDesc, findings[0].Description)
 		})

--- a/server/rules/internal/catalog/sudoers_tamper.go
+++ b/server/rules/internal/catalog/sudoers_tamper.go
@@ -52,6 +52,9 @@ type SudoersTamper struct {
 
 func (r *SudoersTamper) ID() string { return "sudoers_tamper" }
 
+// DisplayName is the canonical human-readable name reused by Doc().Title and the finding (issue #519).
+func (r *SudoersTamper) DisplayName() string { return "Sudoers tamper" }
+
 // Techniques returns the MITRE ATT&CK IDs this rule covers: T1548.003
 // (Abuse Elevation Control Mechanism: Sudo and Sudo Caching).
 func (r *SudoersTamper) Techniques() []string { return []string{"T1548.003"} }
@@ -60,7 +63,7 @@ func (r *SudoersTamper) Techniques() []string { return []string{"T1548.003"} }
 // the generated docs/detection-rules.md.
 func (r *SudoersTamper) Doc() api.Documentation {
 	return api.Documentation{
-		Title:   "Sudoers tamper (write to /etc/sudoers or /etc/sudoers.d/*)",
+		Title:   r.DisplayName(),
 		Summary: "Flags any non-allowlisted writer that opens /etc/sudoers or /etc/sudoers.d/* in write mode.",
 		Description: "Detects an instant escalation primitive: writing to `/etc/sudoers` or any direct child of " +
 			"`/etc/sudoers.d/`. A successful tamper grants future shell sessions arbitrary command execution as " +
@@ -180,7 +183,7 @@ func (r *SudoersTamper) evalEvent(
 		HostID:   evt.HostID,
 		RuleID:   r.ID(),
 		Severity: api.SeverityHigh,
-		Title:    "Sudoers tamper",
+		Title:    r.DisplayName(),
 		Description: fmt.Sprintf(
 			"%s opened %s for writing: sudo escalation surface (MITRE T1548.003)",
 			proc.Path, p.Path,

--- a/server/rules/internal/catalog/suspicious_exec.go
+++ b/server/rules/internal/catalog/suspicious_exec.go
@@ -61,6 +61,11 @@ type SuspiciousExec struct {
 
 func (r *SuspiciousExec) ID() string { return "suspicious_exec" }
 
+// DisplayName is the canonical human-readable name reused by Doc().Title and the finding (issue #519). Both trigger arms (the
+// temp-path exec and the outbound network_connect) emit this one title; which arm fired lives in the finding Description, so the
+// alert maps 1:1 to the one rule an operator can look up (SIEM/Sigma catalog convention) rather than forking into two titles.
+func (r *SuspiciousExec) DisplayName() string { return "Suspicious exec chain" }
+
 // Techniques returns the MITRE ATT&CK IDs this rule covers: T1059
 // (Command and Scripting Interpreter) + T1105 (Ingress Tool Transfer).
 func (r *SuspiciousExec) Techniques() []string {
@@ -71,7 +76,7 @@ func (r *SuspiciousExec) Techniques() []string {
 // the generated docs/detection-rules.md.
 func (r *SuspiciousExec) Doc() api.Documentation {
 	return api.Documentation{
-		Title:   "Suspicious exec chain (non-shell → shell → temp/network)",
+		Title:   r.DisplayName(),
 		Summary: "Flags a non-shell process that spawns a shell which, within 30 seconds, execs from /tmp or makes an outbound network connection.",
 		Description: "Detects two related chain shapes that share a single attribution chain:\n\n" +
 			"1. non-shell parent → shell child → temp-directory exec (e.g. `/tmp/payload`)\n" +
@@ -363,7 +368,7 @@ func (r *SuspiciousExec) evalNetwork(
 		HostID:      evt.HostID,
 		RuleID:      r.ID(),
 		Severity:    api.SeverityHigh,
-		Title:       "Shell spawn with outbound network connection",
+		Title:       r.DisplayName(),
 		Description: fmt.Sprintf("%s → %s → outbound %s:%d", parentPath, shell.Path, c.RemoteAddress, c.RemotePort),
 		ProcessID:   conn.ID,
 		EventIDs:    eventIDs,
@@ -498,7 +503,7 @@ func (r *SuspiciousExec) makeExecFinding(
 		HostID:      evt.HostID,
 		RuleID:      r.ID(),
 		Severity:    api.SeverityHigh,
-		Title:       "Suspicious exec from temp path",
+		Title:       r.DisplayName(),
 		Description: fmt.Sprintf("%s → %s → %s", parentPath, shell.Path, tempPath),
 		ProcessID:   tempProc.ID,
 		EventIDs:    eventIDs,

--- a/server/rules/internal/catalog/suspicious_exec_test.go
+++ b/server/rules/internal/catalog/suspicious_exec_test.go
@@ -52,7 +52,7 @@ func TestSuspiciousExecDetectsPayloadFromTmp(t *testing.T) {
 	f := findings[0]
 	assert.Equal(t, "suspicious_exec", f.RuleID)
 	assert.Equal(t, "high", f.Severity)
-	assert.Equal(t, "Suspicious exec from temp path", f.Title)
+	assert.Equal(t, "Suspicious exec chain", f.Title)
 	assert.Contains(t, f.Description, "/usr/bin/python3")
 	assert.Contains(t, f.Description, "/bin/sh")
 	assert.Contains(t, f.Description, "/tmp/payload")
@@ -94,7 +94,7 @@ func TestSuspiciousExecDetectsShellReExec(t *testing.T) {
 	f := findings[0]
 	assert.Equal(t, "suspicious_exec", f.RuleID)
 	assert.Equal(t, "high", f.Severity)
-	assert.Equal(t, "Suspicious exec from temp path", f.Title)
+	assert.Equal(t, "Suspicious exec chain", f.Title)
 	assert.Contains(t, f.Description, "/usr/bin/python3")
 	assert.Contains(t, f.Description, "/bin/sh")
 	assert.Contains(t, f.Description, "/private/tmp/payload")
@@ -287,7 +287,7 @@ func TestSuspiciousExecDetectsShellWithOutboundConnection(t *testing.T) {
 	f := findings[0]
 	assert.Equal(t, "suspicious_exec", f.RuleID)
 	assert.Equal(t, "high", f.Severity)
-	assert.Equal(t, "Shell spawn with outbound network connection", f.Title)
+	assert.Equal(t, "Suspicious exec chain", f.Title)
 	assert.Contains(t, f.Description, "198.51.100.42:443")
 	assert.Contains(t, f.EventIDs, "exec-sh")
 	assert.Contains(t, f.EventIDs, "net-curl")
@@ -325,8 +325,11 @@ func TestSuspiciousExecPrefersSuspiciousPathOverNetwork(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, findings, 1)
 
-	// Should be the path-based finding, not the network one.
-	assert.Equal(t, "Suspicious exec from temp path", findings[0].Title)
+	// Should be the path-based finding, not the network one. Both arms now share the canonical title (issue #519), so the
+	// discriminator is the Description: the temp arm names the /tmp path, the network arm says "outbound".
+	assert.Equal(t, "Suspicious exec chain", findings[0].Title)
+	assert.Contains(t, findings[0].Description, "/tmp/payload")
+	assert.NotContains(t, findings[0].Description, "outbound")
 }
 
 func TestIsSuspiciousPath(t *testing.T) {
@@ -382,7 +385,7 @@ func TestSuspiciousExecDetectsShebangScriptInArgs(t *testing.T) {
 	findings, err := rule.Evaluate(ctx, events, s.GraphReader())
 	require.NoError(t, err)
 	require.Len(t, findings, 1, "shebang script in argv[1] must match the temp-exec arm")
-	assert.Equal(t, "Suspicious exec from temp path", findings[0].Title)
+	assert.Equal(t, "Suspicious exec chain", findings[0].Title)
 	assert.Contains(t, findings[0].Description, "/usr/bin/python3")
 	assert.Contains(t, findings[0].Description, "/tmp/payload.sh", "description must surface the argv script path, not just /bin/sh")
 }
@@ -515,7 +518,7 @@ func TestSuspiciousExec_CrossBatchTempExec(t *testing.T) {
 	findings2, err := rule.Evaluate(ctx, batch2, s.GraphReader())
 	require.NoError(t, err)
 	require.Len(t, findings2, 1, "temp-binary exec in batch 2 must walk up to python3 → sh from batch 1")
-	assert.Equal(t, "Suspicious exec from temp path", findings2[0].Title)
+	assert.Equal(t, "Suspicious exec chain", findings2[0].Title)
 	assert.Contains(t, findings2[0].Description, "/usr/bin/python3")
 	assert.Contains(t, findings2[0].Description, "/bin/sh")
 	assert.Contains(t, findings2[0].Description, "/tmp/payload")
@@ -683,7 +686,7 @@ func TestSuspiciousExec_LocalResolverDNSDeNoising(t *testing.T) {
 		findings, err := rule.Evaluate(ctx, events, s.GraphReader())
 		require.NoError(t, err)
 		require.Len(t, findings, 1, "DNS to a public resolver must still trigger the network arm")
-		assert.Equal(t, "Shell spawn with outbound network connection", findings[0].Title)
+		assert.Equal(t, "Suspicious exec chain", findings[0].Title)
 		assert.Contains(t, findings[0].Description, "8.8.8.8:53")
 	})
 

--- a/tools/gen-rule-docs/main_test.go
+++ b/tools/gen-rule-docs/main_test.go
@@ -70,21 +70,35 @@ func TestRenderTechniqueLinks(t *testing.T) {
 	assert.Contains(t, out, "https://attack.mitre.org/techniques/T1059/")
 }
 
-// TestRenderConfigKnobsListed confirms that rules with config knobs surface
-// their env var, type, and description in the per-rule Configuration table.
+// TestRenderConfigKnobsListed confirms that a rule with config knobs surfaces their env var, type, and description in the per-rule
+// Configuration table. The shipped catalog currently declares no env-var knobs (per-host tuning moved to the durable detection-config
+// exclusion surface, issue #459), so this drives the renderer with a synthetic rule that does, pinning writeRuleConfig's output shape
+// independent of whether any live rule happens to carry a knob.
 func TestRenderConfigKnobsListed(t *testing.T) {
 	t.Parallel()
+	synthetic := []rulesapi.RuleMetadata{{
+		ID:         "synthetic_configurable_rule",
+		Techniques: []string{"T1059"},
+		Doc: rulesapi.Documentation{
+			Title:       "Synthetic configurable rule",
+			Summary:     "fixture",
+			Description: "fixture",
+			Severity:    rulesapi.SeverityHigh,
+			EventTypes:  []string{"exec"},
+			Config: []rulesapi.ConfigKnob{{
+				EnvVar:      "EDR_SYNTHETIC_ALLOWLIST",
+				Type:        "csv-paths",
+				Default:     "",
+				Description: "Absolute paths exempt from the synthetic rule.",
+			}},
+		},
+	}}
 	var buf bytes.Buffer
-	require.NoError(t, render(&buf, allRegisteredRules()))
+	require.NoError(t, render(&buf, synthetic))
 	out := buf.String()
 
-	for _, env := range []string{
-		"EDR_LAUNCHAGENT_ALLOWLIST",
-		"EDR_LAUNCHDAEMON_TEAMID_ALLOWLIST",
-		"EDR_SUDOERS_WRITER_ALLOWLIST",
-		"EDR_SUSPICIOUS_EXEC_PARENT_ALLOWLIST",
-	} {
-		assert.Contains(t, out, "`"+env+"`",
-			"expected config env var %q to appear in generated docs", env)
-	}
+	assert.Contains(t, out, "### Configuration", "a rule with config knobs must render a Configuration section")
+	assert.Contains(t, out, "`EDR_SYNTHETIC_ALLOWLIST`", "config knob env var must appear in the table")
+	assert.Contains(t, out, "`csv-paths`", "config knob type must appear in the table")
+	assert.Contains(t, out, "Absolute paths exempt from the synthetic rule.", "config knob description must appear in the table")
 }

--- a/ui/src/components/DetectionConfig/DetectionConfig.test.tsx
+++ b/ui/src/components/DetectionConfig/DetectionConfig.test.tsx
@@ -102,20 +102,19 @@ describe("DetectionConfig", () => {
     expect(screen.getByRole("cell", { name: "medium" })).toBeInTheDocument();
   });
 
-  // The rule picker shows a concise rule name: the descriptive parenthetical and the rule id are dropped from the option text,
-  // while the id still rides as the option value the form submits.
-  it("renders a concise rule name in the picker, dropping the descriptive aside and id", async () => {
-    const verbose = makeRuleEntry({
+  // The rule picker shows the rule's canonical title verbatim as the option text (titles are clean single names, issue #519),
+  // while the id rides as the option value the form submits.
+  it("renders the canonical rule title in the picker, with the id as the option value", async () => {
+    const entry = makeRuleEntry({
       id: "suspicious_exec",
-      doc: makeRuleDoc({ title: "Suspicious exec chain (non-shell → shell → temp/network)" }),
+      doc: makeRuleDoc({ title: "Suspicious exec chain" }),
     });
-    stubReads({ rules: [verbose] });
+    stubReads({ rules: [entry] });
     renderPage();
     await waitFor(() => { expect(screen.getByText(/no exclusions configured/i)).toBeInTheDocument(); });
 
     const option = screen.getByRole("option", { name: "Suspicious exec chain" });
     expect(option).toHaveValue("suspicious_exec");
-    expect(screen.queryByRole("option", { name: /\(suspicious_exec\)/ })).not.toBeInTheDocument();
   });
 
   it("orders the rule picker alphabetically by display name", async () => {

--- a/ui/src/components/DetectionConfig/DetectionConfig.tsx
+++ b/ui/src/components/DetectionConfig/DetectionConfig.tsx
@@ -66,20 +66,6 @@ function globalSetting(settings: DetectionRuleSetting[], ruleID: string): Detect
   return settings.find((s) => s.rule_id === ruleID && s.host_group_id === 0);
 }
 
-// ruleLabel is the concise rule name the picker shows. Catalog titles carry a trailing descriptive aside (e.g. "Suspicious exec
-// chain (non-shell → shell → temp/network)") which, paired with the rule id, made each option long and noisy. Top EDR consoles list
-// the short rule name only, so we drop the aside and the id; the id still rides as the option value.
-function ruleLabel(title: string): string {
-  // Drop a trailing " (...)" aside with linear string ops rather than a regex: the equivalent /\s*\([^)]*\)\s*$/ has super-linear
-  // backtracking (Sonar S8786) because .replace retries the greedy leading \s* at every start position.
-  const trimmed = title.trimEnd();
-  if (trimmed.endsWith(")")) {
-    const open = trimmed.lastIndexOf("(");
-    if (open > 0) return trimmed.slice(0, open).trim() || title;
-  }
-  return title;
-}
-
 // DetectionConfig is the admin surface for detection-rule tuning (issue #459): per-host false-positive exclusions and per-rule
 // mode/severity. It edits global scope only (host-group scoping arrives with editable host groups). Write affordances are gated on
 // detection_config.write; the server still enforces. The per-rule "settings" are mode + severity today; when a rule declares
@@ -113,9 +99,10 @@ export function DetectionConfig() {
   const [pendingMode, setPendingMode] = useState<{ ruleID: string; ruleTitle: string; mode: string; severity: string } | null>(null);
   const [modalError, setModalError] = useState<string | null>(null);
 
-  // The exclusion picker lists rules alphabetically by display name so an operator can scan to the rule they want.
+  // The exclusion picker lists rules alphabetically by their canonical title so an operator can scan to the rule they want. Titles
+  // are clean single names (issue #519), so the option shows the title verbatim.
   const rulesByName = useMemo(
-    () => [...rules].sort((a, b) => ruleLabel(a.doc.title).localeCompare(ruleLabel(b.doc.title))),
+    () => [...rules].sort((a, b) => a.doc.title.localeCompare(b.doc.title)),
     [rules],
   );
   // The rule-modes table orders by declared severity (critical first), where muting a rule is most consequential, then
@@ -260,7 +247,7 @@ export function DetectionConfig() {
                 <Select label="Rule" id="dc-rule" inline={false} value={formRuleID}
                   onChange={(e) => { setFormRuleID(e.target.value); }}>
                   <option value="">Select a rule...</option>
-                  {rulesByName.map((r) => <option key={r.id} value={r.id}>{ruleLabel(r.doc.title)}</option>)}
+                  {rulesByName.map((r) => <option key={r.id} value={r.id}>{r.doc.title}</option>)}
                 </Select>
                 <Select label="Match type" id="dc-match" inline={false} value={formMatchType}
                   onChange={(e) => { setFormMatchType(e.target.value); }}>

--- a/ui/src/components/ProcessTree.test.tsx
+++ b/ui/src/components/ProcessTree.test.tsx
@@ -126,7 +126,7 @@ describe("ProcessTreeView process-backed alert", () => {
     vi.spyOn(api, "getAlertDetail").mockResolvedValue({
       ...launchDaemonAlert,
       rule_id: "suspicious_exec",
-      title: "Shell spawn with outbound network connection",
+      title: "Suspicious exec chain",
       process_id: 99,
     });
     renderTree("?alert=7&process=99&at=1750248000000");


### PR DESCRIPTION
## What & why

Closes #519. Every detection rule named itself three independent ways (`ID()`, `Doc().Title`, `Finding.Title`) that did not agree, so an operator saw a different string for the same detection depending on where they looked. `suspicious_exec` even emitted two unrelated alert titles, one per arm. Detection catalogs (Sigma, Elastic, MITRE-aligned vendor rules) instead give each detection a stable identifier plus one canonical human-readable name reused everywhere; the alert names the rule you can look up.

### Changes

- **`DisplayName()` on the `api.Rule` interface** is the single canonical name. Both `Doc().Title` and `Finding.Title` derive from it, so the docs, `/api/rules`, and the alert show one name mapped to one stable `ID()`.
- **Observable alert titles change** for the rules whose finding title diverged: `suspicious_exec` (both arms now "Suspicious exec chain"; which arm fired stays in the finding description, SIEM/Sigma convention), `persistence_launchagent`, `dyld_insert`, `shell_from_office`, `osascript_network_exec`, `credential_keychain_dump`. Documented titles lose the parenthetical implementation detail (it lives in `Summary`).
- **Rule IDs are unchanged.** Renaming an ID (e.g. the stale `privilege_launchd_plist_write`) is a separate migration-backed change: IDs key `alerts.rule_id`, exclusions, the efficacy corpus, and generated docs.
- **`application_control_block` is the one exemption:** it keeps its per-block computed title (`Application blocked: <binary>`) and `app_control:<n>` RuleID, since those alerts name the blocked binary and admin rule, not a catalog detection.
- **Guards against re-drift:** `TestAll_CanonicalDisplayName` asserts `Doc().Title == DisplayName()` and a clean (no-parenthetical) name for every rule; the fixture-replay harness and each positive-detection test assert `Finding.Title == DisplayName()`.
- Regenerated `docs/detection-rules.md`; fixed the OpenAPI example + a UI mock.

Ships the `canonical-rule-naming` openspec delta (the new "Canonical rule naming" requirement + scenario, referenced by a `spec:` marker in `registry_test.go`).

### Follow-up cleanups in this PR (second commit)

- `gen-rule-docs` `TestRenderConfigKnobsListed` asserted four `EDR_*_ALLOWLIST` env-var knobs no shipped rule declares anymore (tuning moved to the detection-config surface, #459) and failed on `main` independent of this branch; re-pointed at a synthetic rule so it pins the renderer, not the live catalog.
- Removed the DetectionConfig picker's now-dead parenthetical-stripping (`ruleLabel`): canonical titles never carry a parenthetical, so the picker shows the title verbatim.

## Checklist

- [x] **OpenSpec updated for behavior changes.** `openspec/changes/canonical-rule-naming/` delta added; `spec:` marker in `registry_test.go`.
- [x] Tests added/updated (catalog guard + fixture-replay + per-rule finding-title asserts + UI).
- [ ] Agent/extension change touching ESF, XPC, or the event wire format: N/A (server + UI only).
- [x] **Docs updated for user-facing changes.** `docs/detection-rules.md` regenerated; OpenAPI example updated.

## VM / RC notes

None. Server + UI only; no agent/extension/wire change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BxbWcMpjYFGpHZDU2d2mfm