### PR TITLE
fix(observability): stop benign duplicate-key SQL writes raising hasE…

### DIFF
--- a/server/detection/internal/mysql/alerts.go
+++ b/server/detection/internal/mysql/alerts.go
@@ -8,7 +8,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/go-sql-driver/mysql"
 	"github.com/jmoiron/sqlx"
 
 	"github.com/fleetdm/edr/server/detection/api"
@@ -21,8 +20,9 @@ const alertEventsBatchSize = 500
 
 // InsertAlert creates an alert and links it to the given event IDs.
 // If a duplicate alert exists (same source, host_id, rule_id,
-// subject), the insert is skipped and the existing alert ID is
-// returned. Returns the alert ID and whether it was newly created.
+// subject), the existing row is matched and its ID is returned
+// without raising a driver error. Returns the alert ID and whether
+// it was newly created.
 //
 // Callers SHOULD set a.Source; a blank Source defaults to
 // AlertSourceDetection so existing catalog-rule call sites that
@@ -68,16 +68,21 @@ func (s *Store) InsertAlert(ctx context.Context, a api.Alert, eventIDs []string)
 
 	// NULLIF(process_id, 0) stores a process-less alert's link as NULL (there is no processes(id) = 0 row, so a literal 0
 	// would violate fk_alerts_process). Dedup is on `subject`, not process_id.
+	//
+	// ON DUPLICATE KEY UPDATE id = LAST_INSERT_ID(id) turns the expected dedup collision (a re-fired finding deliberately
+	// colliding with uk_alerts_dedup) into an idempotent single statement instead of letting the driver raise a duplicate-key
+	// error that surfaces as a benign hasError trace span on every deduplicated alert (#522). LAST_INSERT_ID(id) makes
+	// res.LastInsertId() return the existing row's id on the matched path. The no-op id=id assignment means RowsAffected is 1
+	// for a fresh insert and 0 when an existing row matched, which is how we derive `created` (the DSN does not set
+	// clientFoundRows, so a match never reports 1). This keeps the single-statement, race-safe dedup the insert-and-catch path
+	// gave us across replicas (ADR-0010) without the error span.
 	res, err := tx.ExecContext(ctx, `
 		INSERT INTO alerts (host_id, rule_id, source, severity, title, description, process_id, subject, techniques)
-		VALUES (?, ?, ?, ?, ?, ?, NULLIF(?, 0), ?, ?)`,
+		VALUES (?, ?, ?, ?, ?, ?, NULLIF(?, 0), ?, ?)
+		ON DUPLICATE KEY UPDATE id = LAST_INSERT_ID(id)`,
 		a.HostID, a.RuleID, a.Source, a.Severity, a.Title, a.Description, a.ProcessID, a.Subject, a.Techniques,
 	)
 	if err != nil {
-		if isDuplicateKeyErr(err) {
-			existingID, attachErr := s.attachEventsToExistingAlert(ctx, tx, a, eventIDs, evidence)
-			return existingID, false, attachErr // dedup branch never creates a row
-		}
 		return 0, false, fmt.Errorf("insert alert: %w", err)
 	}
 
@@ -85,8 +90,15 @@ func (s *Store) InsertAlert(ctx context.Context, a api.Alert, eventIDs []string)
 	if err != nil {
 		return 0, false, fmt.Errorf("insert alert last id: %w", err)
 	}
+	rowsAffected, err := res.RowsAffected()
+	if err != nil {
+		return 0, false, fmt.Errorf("insert alert rows affected: %w", err)
+	}
+	created := rowsAffected == 1
 
-	if err := bulkInsertAlertEvents(ctx, tx, alertID, eventIDs, false /* not dedup */); err != nil {
+	// A re-fired-finding dedup re-links any newly-triggering events to the existing alert (INSERT IGNORE absorbs the rows
+	// already linked); a fresh alert links them with a plain INSERT. Both copy the triggering-event payloads idempotently.
+	if err := bulkInsertAlertEvents(ctx, tx, alertID, eventIDs, !created /* dedup re-link uses INSERT IGNORE */); err != nil {
 		return 0, false, err
 	}
 	if err := insertEventPayloads(ctx, tx, alertID, evidence); err != nil {
@@ -96,7 +108,7 @@ func (s *Store) InsertAlert(ctx context.Context, a api.Alert, eventIDs []string)
 	if err := tx.Commit(); err != nil {
 		return 0, false, fmt.Errorf("commit insert alert: %w", err)
 	}
-	return alertID, true, nil
+	return alertID, created, nil
 }
 
 // bulkInsertAlertEvents links eventIDs to alertID with one (chunked) multi-row INSERT instead of N round-trips. dedup=true switches to
@@ -124,45 +136,6 @@ func bulkInsertAlertEvents(ctx context.Context, tx *sqlx.Tx, alertID int64, even
 		}
 	}
 	return nil
-}
-
-// mysqlErrDuplicateKey is MySQL error 1062 (duplicate primary/unique key).
-const mysqlErrDuplicateKey = 1062
-
-// isDuplicateKeyErr matches MySQL error 1062 (duplicate primary/unique key).
-func isDuplicateKeyErr(err error) bool {
-	var mysqlErr *mysql.MySQLError
-	if !errors.As(err, &mysqlErr) {
-		return false
-	}
-	return mysqlErr.Number == mysqlErrDuplicateKey
-}
-
-// attachEventsToExistingAlert handles the dedup branch when (source, host_id, rule_id, subject) already has an alert row. Extracted
-// from InsertAlert to keep the main path under the cognitive complexity limit. Returns the existing alert's id; the caller reports
-// created=false (this branch never creates a row).
-func (s *Store) attachEventsToExistingAlert(ctx context.Context, tx *sqlx.Tx, a api.Alert, eventIDs []string, evidence []api.Event) (int64, error) {
-	var existingID int64
-	// FOR UPDATE makes this a locking (current) read rather than a consistent snapshot read. We only reach here after the
-	// INSERT hit a duplicate-key error, i.e. a concurrent transaction inserted and committed this (source, host_id,
-	// rule_id, subject) row; under REPEATABLE READ a plain SELECT could miss that row against this transaction's MVCC
-	// snapshot. The locking read sees the latest committed row (Gemini).
-	if err := tx.GetContext(ctx, &existingID,
-		"SELECT id FROM alerts WHERE source = ? AND host_id = ? AND rule_id = ? AND subject = ? FOR UPDATE",
-		a.Source, a.HostID, a.RuleID, a.Subject,
-	); err != nil {
-		return 0, fmt.Errorf("lookup duplicate alert: %w", err)
-	}
-	if err := bulkInsertAlertEvents(ctx, tx, existingID, eventIDs, true /* dedup */); err != nil {
-		return 0, err
-	}
-	if err := insertEventPayloads(ctx, tx, existingID, evidence); err != nil {
-		return 0, err
-	}
-	if err := tx.Commit(); err != nil {
-		return 0, fmt.Errorf("commit duplicate alert lookup: %w", err)
-	}
-	return existingID, nil
 }
 
 // insertEventPayloads makes the alert's evidence self-contained: it copies the given triggering-event envelopes (already read from the

--- a/server/detection/internal/mysql/alerts.go
+++ b/server/detection/internal/mysql/alerts.go
@@ -69,17 +69,18 @@ func (s *Store) InsertAlert(ctx context.Context, a api.Alert, eventIDs []string)
 	// NULLIF(process_id, 0) stores a process-less alert's link as NULL (there is no processes(id) = 0 row, so a literal 0
 	// would violate fk_alerts_process). Dedup is on `subject`, not process_id.
 	//
-	// ON DUPLICATE KEY UPDATE id = LAST_INSERT_ID(id) turns the expected dedup collision (a re-fired finding deliberately
-	// colliding with uk_alerts_dedup) into an idempotent single statement instead of letting the driver raise a duplicate-key
-	// error that surfaces as a benign hasError trace span on every deduplicated alert (#522). LAST_INSERT_ID(id) makes
-	// res.LastInsertId() return the existing row's id on the matched path. The no-op id=id assignment means RowsAffected is 1
-	// for a fresh insert and 0 when an existing row matched, which is how we derive `created` (the DSN does not set
-	// clientFoundRows, so a match never reports 1). This keeps the single-statement, race-safe dedup the insert-and-catch path
-	// gave us across replicas (ADR-0010) without the error span.
+	// ON DUPLICATE KEY UPDATE turns the expected dedup collision (a re-fired finding deliberately colliding with uk_alerts_dedup)
+	// into an idempotent single statement instead of letting the driver raise a duplicate-key error that surfaces as a benign
+	// hasError trace span on every deduplicated alert (#522). LAST_INSERT_ID(id) makes res.LastInsertId() return the existing
+	// row's id on the matched path. Both assignments are no-ops (id and updated_at set to their current values), so MySQL treats
+	// the matched row as unchanged: it does not fire updated_at's ON UPDATE CURRENT_TIMESTAMP (a dedup must not churn the
+	// API-visible timestamp) and reports RowsAffected 1 only for a fresh insert, 0 for a match. created is therefore
+	// rowsAffected == 1; this holds because no DSN enables clientFoundRows (which would make a match report 1 as "found").
+	// Keeps the single-statement, race-safe dedup the insert-and-catch path gave us across replicas (ADR-0010), span-free.
 	res, err := tx.ExecContext(ctx, `
 		INSERT INTO alerts (host_id, rule_id, source, severity, title, description, process_id, subject, techniques)
 		VALUES (?, ?, ?, ?, ?, ?, NULLIF(?, 0), ?, ?)
-		ON DUPLICATE KEY UPDATE id = LAST_INSERT_ID(id)`,
+		ON DUPLICATE KEY UPDATE id = LAST_INSERT_ID(id), updated_at = updated_at`,
 		a.HostID, a.RuleID, a.Source, a.Severity, a.Title, a.Description, a.ProcessID, a.Subject, a.Techniques,
 	)
 	if err != nil {

--- a/server/detection/internal/mysql/perf_test.go
+++ b/server/detection/internal/mysql/perf_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -146,6 +147,11 @@ func TestInsertAlert_DedupBranchAlsoLinksAllEvents(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, created1)
 
+	beforeDedup, err := s.GetAlert(ctx, alertID1)
+	require.NoError(t, err)
+	// Sleep so a stray updated_at bump on the dedup path would land in a distinct microsecond and fail the assertion below.
+	time.Sleep(5 * time.Millisecond)
+
 	alertID2, created2, err := s.InsertAlert(ctx, api.Alert{
 		HostID: "h", RuleID: "r", Severity: api.SeverityHigh,
 		Title: "T", Description: "D", ProcessID: procID,
@@ -153,6 +159,12 @@ func TestInsertAlert_DedupBranchAlsoLinksAllEvents(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, created2, "duplicate (host_id,rule_id,process_id) must dedup, not create")
 	assert.Equal(t, alertID1, alertID2, "dedup returns the existing alert id")
+
+	// #522: the dedup upsert pins `updated_at = updated_at` so a routine dedup collision does not churn the API-visible
+	// timestamp (the no-op match never fires the column's ON UPDATE CURRENT_TIMESTAMP). Pins the Copilot/Qodo concern.
+	afterDedup, err := s.GetAlert(ctx, alertID1)
+	require.NoError(t, err)
+	assert.Equal(t, beforeDedup.UpdatedAt, afterDedup.UpdatedAt, "dedup must not bump updated_at")
 
 	got, err := s.GetAlertEventIDs(ctx, alertID1)
 	require.NoError(t, err)

--- a/server/identity/internal/breakglass/finishflow_test.go
+++ b/server/identity/internal/breakglass/finishflow_test.go
@@ -228,6 +228,46 @@ func TestService_FinishSetup_HappyPath(t *testing.T) {
 	assert.ErrorIs(t, err, breakglass.ErrTokenConsumed)
 }
 
+// FinishSetup must resolve (not re-insert) a local_password identity an earlier seed/migration already created: the expected-duplicate
+// path now upserts in one statement instead of insert-and-catch-the-duplicate, so it no longer raises a benign hasError trace span
+// (#522). The redemption still succeeds, resolves to the pre-existing identity id, and leaves exactly one identities row.
+func TestService_FinishSetup_PreexistingIdentityResolves(t *testing.T) {
+	t.Parallel()
+	svc, db, rec, uid, _ := newFakeService(t)
+
+	// Pre-seed the local_password identity the redemption would otherwise insert, mirroring a row left by an earlier seed.
+	res, err := db.ExecContext(t.Context(),
+		`INSERT INTO identities (user_id, provider, subject) VALUES (?, ?, ?)`,
+		uid, identities.ProviderLocalPassword, "admin@fleet-edr.local")
+	require.NoError(t, err)
+	seededID, err := res.LastInsertId()
+	require.NoError(t, err)
+
+	plaintext, _, err := svc.IssueSetupToken(t.Context(), uid, time.Hour)
+	require.NoError(t, err)
+	_, tok, user, err := svc.BeginSetup(t.Context(), plaintext)
+	require.NoError(t, err)
+
+	setup, err := svc.FinishSetup(t.Context(), breakglass.FinishSetupRequest{
+		Token:          tok,
+		User:           user,
+		Session:        webauthn.SessionData{Challenge: "fake-challenge"},
+		Password:       "long-enough-password",
+		CredentialName: "yk-test",
+		Attestation:    fakeAttestation(),
+	})
+	require.NoError(t, err, "an already-seeded identity must not fail the redemption")
+	require.NotNil(t, setup)
+
+	// Exactly one identities row survives, and the redemption resolved to the pre-seeded id (no second row).
+	var idCount int
+	require.NoError(t, db.GetContext(t.Context(), &idCount,
+		`SELECT COUNT(*) FROM identities WHERE user_id = ? AND provider = ?`, uid, identities.ProviderLocalPassword))
+	assert.Equal(t, 1, idCount, "the upsert resolves the existing row rather than inserting a duplicate")
+	require.Len(t, rec.events, 1)
+	assert.Equal(t, seededID, rec.events[0].Payload["identity_id"], "redemption resolves to the pre-existing identity id")
+}
+
 // FinishSetup with a too-short password rejects with ErrPasswordTooShort BEFORE touching the WebAuthn engine: the validator runs
 // first per the implementation contract.
 func TestService_FinishSetup_PasswordTooShort(t *testing.T) {

--- a/server/identity/internal/breakglass/service.go
+++ b/server/identity/internal/breakglass/service.go
@@ -8,7 +8,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/go-sql-driver/mysql"
 	"github.com/go-webauthn/webauthn/protocol"
 	"github.com/go-webauthn/webauthn/webauthn"
 	"github.com/jmoiron/sqlx"
@@ -249,42 +248,18 @@ func (s *Service) FinishSetup(ctx context.Context, req FinishSetupRequest) (*Fin
 	return &FinishSetupResult{Session: sess, CredentialID: credID}, nil
 }
 
-// resolveLocalPasswordIdentityID inserts the local_password identity row for the redeeming user. When the row already exists
-// from an earlier seed, it finds it instead. Distinguishes duplicate-key (the only acceptable path to "row already exists") from any other
-// DB failure: a transient outage or permission glitch must propagate so the redemption rolls back instead of silently committing a
-// partial account.
+// resolveLocalPasswordIdentityID inserts the local_password identity row for the redeeming user, or returns the id of the row an
+// earlier seed/migration already created. identities.UpsertWith does both in one statement on the redemption transaction, so the
+// expected-duplicate re-run no longer raises a driver error that surfaces as a benign hasError trace span (#522). A transient outage or
+// permission glitch still propagates so the redemption rolls back instead of silently committing a partial account.
 func (s *Service) resolveLocalPasswordIdentityID(
 	ctx context.Context, tx *sqlx.Tx, u *users.User,
 ) (int64, error) {
-	id, err := s.identities.InsertWith(ctx, tx,
-		u.ID, identities.ProviderLocalPassword, u.Email)
-	if err == nil {
-		return id, nil
+	id, err := s.identities.UpsertWith(ctx, tx, u.ID, identities.ProviderLocalPassword, u.Email)
+	if err != nil {
+		return 0, fmt.Errorf("breakglass: resolve identity: %w", err)
 	}
-	if !isMySQLDuplicateKey(err) {
-		return 0, fmt.Errorf("breakglass: insert identity: %w", err)
-	}
-	// Dup-key only: the row exists from a prior seed/migration. Look it up via the same tx so the CASCADE guarantees a consistent read.
-	existing, lookupErr := s.identities.FindByProviderSubject(ctx,
-		identities.ProviderLocalPassword, u.Email)
-	if lookupErr != nil {
-		return 0, fmt.Errorf("breakglass: lookup existing identity: %w", lookupErr)
-	}
-	return existing.ID, nil
-}
-
-// mysqlErrDupEntry is the MySQL "Duplicate entry" code we expect on the local_password identity insert when the row already exists.
-// Lifted to a const so the magic-number lint is satisfied.
-const mysqlErrDupEntry = 1062
-
-// isMySQLDuplicateKey reports whether err wraps the MySQL 1062
-// "Duplicate entry" code. Mirrors the helper in jit.go.
-func isMySQLDuplicateKey(err error) bool {
-	var mysqlErr *mysql.MySQLError
-	if !errors.As(err, &mysqlErr) {
-		return false
-	}
-	return mysqlErr.Number == mysqlErrDupEntry
+	return id, nil
 }
 
 // LoginChallenge mirrors SetupChallenge but for the assertion flow.

--- a/server/identity/internal/identities/identities.go
+++ b/server/identity/internal/identities/identities.go
@@ -83,6 +83,10 @@ type Executor interface {
 
 // InsertWith persists a new identity row using the provided executor (typically the *sqlx.Tx wrapping a JIT provision). Returns the
 // row id assigned by MySQL's auto_increment.
+//
+// JIT provisioning relies on the duplicate-key error this raises on a (provider, subject) collision: it IS the concurrency-race signal
+// that oidc.ProvisionOrFind re-resolves on. A caller whose duplicate is expected and benign (an idempotent re-resolve) wants UpsertWith
+// instead, so the expected collision never raises a hasError trace span (#522).
 func (s *Store) InsertWith(ctx context.Context, ec Executor, userID int64, provider, subject string) (int64, error) {
 	res, err := ec.ExecContext(ctx, `
 		INSERT INTO identities (user_id, provider, subject) VALUES (?, ?, ?)
@@ -93,6 +97,28 @@ func (s *Store) InsertWith(ctx context.Context, ec Executor, userID int64, provi
 	id, err := res.LastInsertId()
 	if err != nil {
 		return 0, fmt.Errorf("identities: last insert id: %w", err)
+	}
+	return id, nil
+}
+
+// UpsertWith persists a new identity row, or returns the id of the existing (provider, subject) row when one is already present, in a
+// single statement. Unlike InsertWith it never raises a duplicate-key error on the expected-duplicate path: ON DUPLICATE KEY UPDATE
+// id = LAST_INSERT_ID(id) makes res.LastInsertId() return the existing row's id on the matched path. Used by the break-glass redemption
+// to re-resolve a local_password identity that an earlier seed already created, so an idempotent re-run does not surface a benign
+// hasError trace span (#522). It runs on the caller's executor, so the read of the existing row stays inside the redemption transaction.
+//
+// JIT provisioning deliberately keeps using InsertWith: there the duplicate-key error is the concurrency-race signal that must surface.
+func (s *Store) UpsertWith(ctx context.Context, ec Executor, userID int64, provider, subject string) (int64, error) {
+	res, err := ec.ExecContext(ctx, `
+		INSERT INTO identities (user_id, provider, subject) VALUES (?, ?, ?)
+		ON DUPLICATE KEY UPDATE id = LAST_INSERT_ID(id)
+	`, userID, provider, subject)
+	if err != nil {
+		return 0, fmt.Errorf("identities: upsert %q/%q: %w", provider, subject, err)
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		return 0, fmt.Errorf("identities: upsert last insert id: %w", err)
 	}
 	return id, nil
 }

--- a/server/identity/internal/identities/identities_test.go
+++ b/server/identity/internal/identities/identities_test.go
@@ -1,0 +1,88 @@
+package identities_test
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+
+	_ "github.com/go-sql-driver/mysql" // registers the "mysql" driver so sqlx.Open builds a (lazy, never-connected) handle.
+	"github.com/jmoiron/sqlx"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fleetdm/edr/server/identity/internal/identities"
+)
+
+// fakeExec is a stub identities.Executor that returns a preset result/error, so the InsertWith / UpsertWith error-wrapping branches
+// can be exercised without a database. Pinning these paths keeps #522's UpsertWith addition honest: a DB fault must surface as a
+// wrapped error, never a bare driver error.
+type fakeExec struct {
+	res sql.Result
+	err error
+}
+
+func (f fakeExec) ExecContext(context.Context, string, ...any) (sql.Result, error) {
+	return f.res, f.err
+}
+
+// fakeResult satisfies sql.Result with a configurable LastInsertId error, so the post-exec LastInsertId() failure branch is reachable.
+type fakeResult struct {
+	id    int64
+	idErr error
+}
+
+func (r fakeResult) LastInsertId() (int64, error) { return r.id, r.idErr }
+func (r fakeResult) RowsAffected() (int64, error) { return 0, nil }
+
+func TestInsertAndUpsertWith_WrapErrors(t *testing.T) {
+	t.Parallel()
+	// New requires a non-nil handle, but InsertWith / UpsertWith run on the passed Executor, not s.db. A lazy sqlx.Open handle (no
+	// connection is made until a query runs, and none does) satisfies the guard without needing a real database.
+	db, err := sqlx.Open("mysql", "root@tcp(127.0.0.1:0)/identities_unit_test")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	s := identities.New(db)
+	ctx := context.Background()
+	execErr := errors.New("boom")
+	lastIDErr := errors.New("no last id")
+
+	t.Run("InsertWith wraps exec error", func(t *testing.T) {
+		t.Parallel()
+		_, err := s.InsertWith(ctx, fakeExec{err: execErr}, 1, "local_password", "a@b.test")
+		require.Error(t, err)
+		require.ErrorIs(t, err, execErr)
+		assert.Contains(t, err.Error(), "identities: insert")
+	})
+
+	t.Run("InsertWith wraps LastInsertId error", func(t *testing.T) {
+		t.Parallel()
+		_, err := s.InsertWith(ctx, fakeExec{res: fakeResult{idErr: lastIDErr}}, 1, "local_password", "a@b.test")
+		require.Error(t, err)
+		require.ErrorIs(t, err, lastIDErr)
+		assert.Contains(t, err.Error(), "last insert id")
+	})
+
+	t.Run("UpsertWith wraps exec error", func(t *testing.T) {
+		t.Parallel()
+		_, err := s.UpsertWith(ctx, fakeExec{err: execErr}, 1, "local_password", "a@b.test")
+		require.Error(t, err)
+		require.ErrorIs(t, err, execErr)
+		assert.Contains(t, err.Error(), "identities: upsert")
+	})
+
+	t.Run("UpsertWith wraps LastInsertId error", func(t *testing.T) {
+		t.Parallel()
+		_, err := s.UpsertWith(ctx, fakeExec{res: fakeResult{idErr: lastIDErr}}, 1, "local_password", "a@b.test")
+		require.Error(t, err)
+		require.ErrorIs(t, err, lastIDErr)
+		assert.Contains(t, err.Error(), "upsert last insert id")
+	})
+
+	t.Run("UpsertWith returns the row id on success", func(t *testing.T) {
+		t.Parallel()
+		id, err := s.UpsertWith(ctx, fakeExec{res: fakeResult{id: 42}}, 1, "local_password", "a@b.test")
+		require.NoError(t, err)
+		assert.Equal(t, int64(42), id)
+	})
+}

--- a/server/identity/internal/rbac/role_bindings.go
+++ b/server/identity/internal/rbac/role_bindings.go
@@ -86,12 +86,19 @@ type BindRoleRequest struct {
 	ExpiresAt *time.Time
 }
 
-// BindRole inserts a role_bindings row. Used by Phase-4 JIT provisioning to bind a freshly-provisioned OIDC user to the default role
-// for the deployment.
+// BindRole idempotently inserts a role_bindings row. Used by Phase-4 JIT provisioning to bind a freshly-provisioned OIDC user to the
+// default role, and by seed.Admin's idempotent bootstrap-time bind.
+//
+// ON DUPLICATE KEY UPDATE user_id = user_id makes a re-bind of an already-bound (user_id, role_id, scope_type, scope_id) a
+// single-statement no-op instead of a duplicate-key error: the break-glass admin re-seed runs on every container boot where an existing
+// binding is expected, and the old insert-and-let-the-caller-swallow path raised a benign hasError trace span on each restart (#522).
+// The no-op update leaves the existing row (including its expires_at) untouched, matching the prior swallow-the-duplicate semantics
+// exactly. Unlike INSERT IGNORE, a genuine FK violation or other DB error still surfaces.
 func (s *Store) BindRole(ctx context.Context, ec Executor, req BindRoleRequest) error {
 	_, err := ec.ExecContext(ctx, `
 		INSERT INTO role_bindings (user_id, role_id, scope_type, scope_id, expires_at)
 		VALUES (?, ?, ?, ?, ?)
+		ON DUPLICATE KEY UPDATE user_id = user_id
 	`, req.UserID, req.RoleID, req.ScopeType, req.ScopeID, req.ExpiresAt)
 	if err != nil {
 		return fmt.Errorf("bind role %q to user %d: %w", req.RoleID, req.UserID, err)

--- a/server/identity/internal/rbac/role_bindings_test.go
+++ b/server/identity/internal/rbac/role_bindings_test.go
@@ -166,6 +166,32 @@ func TestProvisionUser(t *testing.T) {
 	assert.Equal(t, 1, count)
 }
 
+// TestBindRole_IsIdempotent pins #522: re-binding an already-bound (user_id, role_id, scope_type, scope_id) must be a single-statement
+// no-op that returns no error (the break-glass re-seed on every container boot), not a duplicate-key error that the caller swallows but
+// that still surfaces as a benign hasError trace span. A second bind leaves exactly one row, and a third bind carrying a different
+// ExpiresAt leaves the original (non-expiring) binding untouched, matching the prior swallow-the-duplicate semantics.
+func TestBindRole_IsIdempotent(t *testing.T) {
+	t.Parallel()
+	db := openSchema(t)
+	uid := insertUser(t, db, "rebind@test")
+	s := rbac.New(db)
+
+	req := rbac.BindRoleRequest{UserID: uid, RoleID: "admin", ScopeType: "global", ScopeID: api.RoleBindingScopeWildcard}
+	require.NoError(t, s.BindRole(t.Context(), db, req), "first bind creates the row")
+	require.NoError(t, s.BindRole(t.Context(), db, req), "re-binding the same key must not raise a duplicate-key error")
+
+	future := time.Now().Add(time.Hour)
+	withExpiry := req
+	withExpiry.ExpiresAt = &future
+	require.NoError(t, s.BindRole(t.Context(), db, withExpiry), "re-bind with a different ExpiresAt is still a no-op")
+
+	got, err := s.ListLiveBindings(t.Context(), uid)
+	require.NoError(t, err)
+	require.Len(t, got, 1, "idempotent re-binds collapse to exactly one row")
+	assert.Equal(t, "admin", got[0].RoleID)
+	assert.Nil(t, got[0].ExpiresAt, "the no-op update leaves the original non-expiring binding untouched")
+}
+
 // openSchema returns a fresh test DB with identity's full schema + seeds applied. roles are seeded by ApplySchema so the FK-bound
 // role_bindings inserts in these tests don't trip fk_role_bindings_role.
 func openSchema(t *testing.T) *sqlx.DB {

--- a/server/identity/internal/seed/admin.go
+++ b/server/identity/internal/seed/admin.go
@@ -18,8 +18,6 @@ import (
 	"io"
 	"log/slog"
 
-	"github.com/go-sql-driver/mysql"
-
 	"github.com/fleetdm/edr/server/attrkeys"
 	"github.com/fleetdm/edr/server/identity/api"
 	"github.com/fleetdm/edr/server/identity/internal/rbac"
@@ -34,11 +32,6 @@ const DefaultAdminEmail = "admin@fleet-edr.local"
 // break-glass account lands in `super_admin` so an operator who completes the redemption flow can do every operator action without a
 // manual SQL promotion. Without this binding the user has zero grants and the chokepoint denies even host.read.
 const DefaultAdminRole = "super_admin"
-
-// mysqlErrDupEntry is the SQL state for "row already exists with the unique key you tried to insert." We rely on the role_bindings
-// unique key (user_id, role_id, scope_type, scope_id) to make the seed idempotent across container restarts; a duplicate just means
-// "already seeded, nothing to do."
-const mysqlErrDupEntry = 1062
 
 // Admin idempotently seeds the break-glass admin user AND its
 // super_admin role binding. Returns the inserted (or pre-existing)
@@ -110,25 +103,19 @@ func resolveOrCreateAdmin(ctx context.Context, us *users.Store, logger *slog.Log
 	return u, nil
 }
 
-// bindSuperAdmin inserts the role_bindings row that gives the break-glass admin its wave-1 grants. Idempotent on the rbac unique key:
-// a duplicate-entry error is swallowed (binding already exists, nothing to do); any other DB failure surfaces.
+// bindSuperAdmin inserts the role_bindings row that gives the break-glass admin its wave-1 grants. rbac.BindRole is idempotent on the
+// unique key (INSERT ... ON DUPLICATE KEY UPDATE), so a re-seed where the binding already exists is a single-statement no-op rather than
+// a swallowed duplicate-key error; any other DB failure surfaces.
 func bindSuperAdmin(ctx context.Context, rb *rbac.Store, u *users.User, logger *slog.Logger) error {
-	err := rb.BindRole(ctx, rb.DB(), rbac.BindRoleRequest{
+	if err := rb.BindRole(ctx, rb.DB(), rbac.BindRoleRequest{
 		UserID:    u.ID,
 		RoleID:    DefaultAdminRole,
 		ScopeType: string(api.RoleBindingScopeGlobal),
 		ScopeID:   api.RoleBindingScopeWildcard,
-	})
-	var mysqlErr *mysql.MySQLError
-	if errors.As(err, &mysqlErr) && mysqlErr.Number == mysqlErrDupEntry {
-		logger.DebugContext(ctx, "break-glass admin role binding already present",
-			attrkeys.UserID, u.ID, "role", DefaultAdminRole)
-		return nil
-	}
-	if err != nil {
+	}); err != nil {
 		return fmt.Errorf("bind %s to %d: %w", DefaultAdminRole, u.ID, err)
 	}
-	logger.InfoContext(ctx, "break-glass admin role binding seeded",
+	logger.InfoContext(ctx, "break-glass admin role binding ensured",
 		attrkeys.UserID, u.ID, "role", DefaultAdminRole)
 	return nil
 }


### PR DESCRIPTION
…rror trace spans (#522)

Several SQL writes that are part of normal operation deliberately collide with a unique key and swallow the resulting duplicate-key error as their control flow. The driver still raised the error first, so each routine collision surfaced as a hasError sql.stmt.exec span, making a trace error-rate alert on fleet-edr-server fire on routine activity.

Replace insert-and-catch-the-duplicate with race-safe idempotent upserts so the expected-duplicate case never reaches the error path (MySQL 8.4):

- InsertAlert: INSERT ... ON DUPLICATE KEY UPDATE id = LAST_INSERT_ID(id). LastInsertId() returns the existing row id on the dedup path; created is derived from RowsAffected (1 = inserted, 0 = matched existing, since the DSN does not set clientFoundRows). Drops attachEventsToExistingAlert, isDuplicateKeyErr, and the FOR UPDATE re-lookup: one round-trip, no span, identical dedup semantics across replicas (ADR-0010).
- rbac.BindRole: INSERT ... ON DUPLICATE KEY UPDATE user_id = user_id. The no-op update leaves the existing binding untouched, matching the prior swallow-the-duplicate semantics; unlike INSERT IGNORE a real FK/other error still surfaces. seed.bindSuperAdmin no longer branches on the dup.
- identities.UpsertWith (new) + breakglass.resolveLocalPasswordIdentityID: the redemption now upserts the local_password identity in one statement instead of insert-then-lookup-on-duplicate, so re-resolving a seeded identity no longer raises a span. InsertWith stays for JIT, where the duplicate-key error IS the concurrency-race signal ProvisionOrFind needs.

Audited the rest and left as-is, because the duplicate there is not benign routine traffic: the app-control create/rename and user-provision paths map the collision to a user-facing 409 conflict; the OIDC JIT identity-insert duplicate is a rare concurrency-race re-resolve (error+rollback is the mechanism); the detection retry classifier and the deadlock helper are not insert-and-catch (and processes has no unique key, so 1062 can't fire there).

Internal hygiene: dedup/seed/redemption behavior is unchanged, so no spec delta.

Claude-Session: https://claude.ai/code/session_01BxbWcMpjYFGpHZDU2d2mfm

<!-- Keep this short. Delete sections that do not apply. -->

## What & why



## Checklist

- [ ] **OpenSpec updated for behavior changes.** If this PR changes observable behavior (a detection rule, the event
      wire schema, persistence semantics, an API/wire shape, or an emitted event), `openspec/specs/**` is updated (and
      an `openspec/changes/` proposal added), with a `spec:<id>` test marker for any new/renamed scenario. Only if this
      PR changes NO observable behavior (a comment / refactor / gofmt / dep bump that happens to touch a scoped path)
      may you assert `no-behavior-change` (label or `[no-behavior-change]` in the title) to clear the OpenSpec-sync gate.
      That is an assertion a reviewer will check, not a way to skip the spec for a real behavior change.
- [ ] Tests added/updated for the change (unit / integration / efficacy / UI as applicable).
- [ ] Agent/extension change touching ESF, XPC, or the event wire format: exercised on a live macOS VM before RC
      (flagged below).
- [ ] **Docs updated for user-facing changes.** If this PR changes a user-facing surface (the React UI, an HTTP
      handler, or a detection rule), `docs/` or `CHANGELOG.md` is updated in the same PR. Only if nothing a user sees
      changed (an internal refactor, a non-visible UI tweak) may you assert `no-docs-change` (label or
      `[no-docs-change]` in the title) to clear the Docs-sync gate. The model is in `docs/doc-versioning.md`.

## VM / RC notes (if applicable)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved idempotency for alert creation, identity setup, and role binding so repeated operations no longer create duplicates or fail on expected collisions.
  * Pre-existing identities are now correctly reused during breakglass setup, preserving the original identity record.
  * Reapplying the same role binding now becomes a no-op, leaving existing access details unchanged.

* **Tests**
  * Added integration coverage for pre-existing identity resolution and repeated role binding behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->