### PR TITLE
Agent control client

### DIFF
--- a/agent/cmd/fleet-edr-agent/main.go
+++ b/agent/cmd/fleet-edr-agent/main.go
@@ -9,16 +9,21 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"sync/atomic"
 	"syscall"
 	"time"
 
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"golang.org/x/net/http2"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/keepalive"
 
 	"github.com/fleetdm/edr/agent/coalesce"
 	"github.com/fleetdm/edr/agent/codesign"
 	"github.com/fleetdm/edr/agent/commander"
 	"github.com/fleetdm/edr/agent/config"
+	"github.com/fleetdm/edr/agent/controlclient"
 	"github.com/fleetdm/edr/agent/enrich"
 	"github.com/fleetdm/edr/agent/enrollment"
 	"github.com/fleetdm/edr/agent/hostid"
@@ -28,6 +33,7 @@ import (
 	"github.com/fleetdm/edr/agent/receiver"
 	"github.com/fleetdm/edr/agent/reconcile"
 	"github.com/fleetdm/edr/agent/uploader"
+	"github.com/fleetdm/edr/internal/control"
 	"github.com/fleetdm/edr/internal/logging"
 	"github.com/fleetdm/edr/internal/observability"
 )
@@ -199,7 +205,13 @@ func run() error {
 	}
 	go runUploader(ctx, up, logger)
 
-	startCommander(ctx, hostID, cfg.ServerURL, tokenProvider, esfDispatcher, agentTransport, logger)
+	// streamConnected is the shared flag the control channel raises while its stream is up so the commander suspends polling. Per-replica
+	// ephemeral state, lost on restart; the commander reads it, the control client sets it.
+	var streamConnected atomic.Bool
+	startCommander(ctx, hostID, cfg.ServerURL, tokenProvider, esfDispatcher, agentTransport, &streamConnected, logger)
+	if err := startControlClient(ctx, cfg, hostID, tokenProvider, esfDispatcher, &streamConnected, logger); err != nil {
+		return err
+	}
 	go pruneLoop(ctx, q, config.DefaultPruneAge, logger)
 	startProcessReconciler(ctx, cfg, pidTable, q, tokenProvider, logger)
 
@@ -329,6 +341,7 @@ func startCommander(
 	tokenProvider enrollment.TokenProvider,
 	appControlSender commander.ApplicationControlSender,
 	transport http.RoundTripper,
+	streamConnected *atomic.Bool,
 	logger *slog.Logger,
 ) {
 	if hostID == "" {
@@ -342,6 +355,8 @@ func startCommander(
 		HostID:                   hostID,
 		Interval:                 commanderPollInterval,
 		ApplicationControlSender: appControlSender,
+		// Defer to the control channel while it is connected (the gateway pushes commands in real time); the poll is the fallback floor.
+		StreamConnected: streamConnected.Load,
 	}, &http.Client{Transport: transport, Timeout: 10 * time.Second}, logger)
 	go func() {
 		if err := cmdr.Run(ctx); err != nil && ctx.Err() == nil {
@@ -349,6 +364,63 @@ func startCommander(
 		}
 	}()
 	logger.InfoContext(ctx, "commander polling", "host_id_prefix", safePrefix(hostID))
+}
+
+// startControlClient opens the persistent control-channel stream when EDR_CONTROL_ADDR is set. It dials the gateway over the same
+// pinned TLS the agent uses for HTTP, presents the host token at connect, and signals streamConnected so the commander suspends polling
+// while the stream is up. Opt-in: an empty ControlAddr leaves the agent on the short-poll path, so this changes nothing by default.
+func startControlClient(
+	ctx context.Context,
+	cfg *config.Config,
+	hostID string,
+	tokenProvider enrollment.TokenProvider,
+	appControlSender commander.ApplicationControlSender,
+	streamConnected *atomic.Bool,
+	logger *slog.Logger,
+) error {
+	if cfg.ControlAddr == "" {
+		return nil
+	}
+	if hostID == "" {
+		logger.WarnContext(ctx, "no host_id available; control channel disabled")
+		return nil
+	}
+	//nolint:contextcheck // BuildTLSConfig takes no context; its TLS-handshake callback intentionally uses context.Background (the
+	// handshake has no request context), the same call newAgentHTTPClient makes.
+	tlsCfg, err := enrollment.BuildTLSConfig(cfg.AllowInsecure, cfg.ServerFingerprint, logger)
+	if err != nil {
+		return err
+	}
+	conn, err := grpc.NewClient(cfg.ControlAddr,
+		grpc.WithTransportCredentials(credentials.NewTLS(tlsCfg)),
+		// Keep-alive PINGs detect a half-open link (laptop sleep, NAT rebind) on the long-lived stream, mirroring the HTTP/2 transport.
+		grpc.WithKeepaliveParams(keepalive.ClientParameters{
+			Time:                h2ReadIdleTimeout,
+			Timeout:             h2PingTimeout,
+			PermitWithoutStream: true,
+		}),
+	)
+	if err != nil {
+		logger.ErrorContext(ctx, "control channel dial", "addr", cfg.ControlAddr, "err", err)
+		return err
+	}
+	client := controlclient.New(controlclient.Config{
+		Client:                   control.NewControlChannelClient(conn),
+		HostID:                   hostID,
+		TokenFn:                  tokenProvider.Token,
+		OnAuthFail:               tokenProvider.OnUnauthorized,
+		ApplicationControlSender: appControlSender,
+		OnConnectedChange:        streamConnected.Store,
+		Logger:                   logger,
+	})
+	go func() {
+		if err := client.Run(ctx); err != nil && ctx.Err() == nil {
+			logger.ErrorContext(ctx, "control channel", "err", err)
+		}
+		_ = conn.Close()
+	}()
+	logger.InfoContext(ctx, "control channel enabled", "addr", cfg.ControlAddr, "host_id_prefix", safePrefix(hostID))
+	return nil
 }
 
 // startProcessReconciler runs the agent-side kill(pid,0) sweep that closes processes whose kernel exit notification went missing

--- a/agent/cmd/fleet-edr-agent/main.go
+++ b/agent/cmd/fleet-edr-agent/main.go
@@ -210,6 +210,9 @@ func run() error {
 	var streamConnected atomic.Bool
 	startCommander(ctx, hostID, cfg.ServerURL, tokenProvider, esfDispatcher, agentTransport, &streamConnected, logger)
 	if err := startControlClient(ctx, cfg, hostID, tokenProvider, esfDispatcher, &streamConnected, logger); err != nil {
+		// Cancel first so the goroutines started above (receiver loops, uploader, commander, coalescer) wind down before the
+		// deferred queue close runs; otherwise the LIFO defers would close the queue while those goroutines still write to it.
+		cancel()
 		return err
 	}
 	go pruneLoop(ctx, q, config.DefaultPruneAge, logger)

--- a/agent/commander/commander.go
+++ b/agent/commander/commander.go
@@ -10,17 +10,12 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
-	"syscall"
 	"time"
 )
 
 // defaultPollInterval is the fallback Interval when Config.Interval is zero.
 // Mirrored as commanderPollInterval in agent/cmd/fleet-edr-agent.
 const defaultPollInterval = 5 * time.Second
-
-// invalidPayloadPrefix is the reason prefix every command handler emits when json.Unmarshal of cmd.Payload fails. Centralised so the
-// wire shape stays stable across handlers.
-const invalidPayloadPrefix = "invalid payload: "
 
 // ApplicationControlSender forwards a raw application-control snapshot JSON payload to the ESF extension over XPC. The commander stays
 // decoupled from the concrete receiver so tests can supply a recording double. Nil is allowed (set_application_control commands are
@@ -41,13 +36,18 @@ type Config struct {
 	// ApplicationControlSender is the XPC bridge to the ESF extension. Used by the set_application_control command handler; nil means
 	// "commander cannot apply snapshot updates" and the handler will report the command failed with a clear reason.
 	ApplicationControlSender ApplicationControlSender
+	// StreamConnected, when set, lets the commander defer to the persistent control channel: while it returns true the poll is skipped
+	// (the gateway pushes commands in real time), and the poll resumes the moment the stream drops. Nil means "always poll" (the control
+	// channel is disabled), which is the degraded floor.
+	StreamConnected func() bool
 }
 
 // Commander polls the server for pending commands and dispatches them.
 type Commander struct {
-	cfg    Config
-	client *http.Client
-	logger *slog.Logger
+	cfg      Config
+	client   *http.Client
+	executor *Executor
+	logger   *slog.Logger
 }
 
 // New creates a Commander. The client should already be wrapped with otelhttp.NewTransport if
@@ -63,36 +63,11 @@ func New(cfg Config, client *http.Client, logger *slog.Logger) *Commander {
 		logger = slog.Default()
 	}
 	return &Commander{
-		cfg:    cfg,
-		client: client,
-		logger: logger,
+		cfg:      cfg,
+		client:   client,
+		executor: NewExecutor(cfg.ApplicationControlSender, logger),
+		logger:   logger,
 	}
-}
-
-// command mirrors the server-side Command struct (fields we need).
-type command struct {
-	ID          int64           `json:"id"`
-	HostID      string          `json:"host_id"`
-	CommandType string          `json:"command_type"`
-	Payload     json.RawMessage `json:"payload"`
-	Status      string          `json:"status"`
-}
-
-type killPayload struct {
-	PID int `json:"pid"`
-}
-
-// setApplicationControlPayload mirrors server/rules/api.SetApplicationControlPayload. Field names + json tags are load-bearing:
-// the extension parses the same JSON bytes and the byte-shape must match across all three sides. The commander's job is envelope
-// validation (policy_id present, version positive, rules is a JSON array) before handing the raw bytes off to the extension;
-// the per-rule decode happens on the extension side, which is the only consumer that actually walks the rules list. Gating on the
-// rules-is-an-array check here prevents reporting `completed` for a payload the extension will silently fail to decode.
-type setApplicationControlPayload struct {
-	PolicyID      int64 `json:"policy_id"`
-	PolicyVersion int64 `json:"policy_version"`
-	// Rules is decoded as json.RawMessage so the commander doesn't need to know the rule shape; the extension is the source of truth for
-	// the per-rule schema and the commander only forwards the bytes it received.
-	Rules json.RawMessage `json:"rules"`
 }
 
 type statusUpdate struct {
@@ -116,6 +91,11 @@ func (c *Commander) Run(ctx context.Context) error {
 }
 
 func (c *Commander) pollAndDispatch(ctx context.Context) {
+	// Defer to the persistent control channel while it is connected: it pushes commands in real time, so polling would only race it and
+	// produce invalid-transition noise on already-acked commands. The poll is the degraded floor, used while the stream is down.
+	if c.cfg.StreamConnected != nil && c.cfg.StreamConnected() {
+		return
+	}
 	commands, err := c.fetchPending(ctx)
 	if err != nil {
 		c.logger.WarnContext(ctx, "commander fetch pending", "err", err)
@@ -127,7 +107,7 @@ func (c *Commander) pollAndDispatch(ctx context.Context) {
 	}
 }
 
-func (c *Commander) fetchPending(ctx context.Context) ([]command, error) {
+func (c *Commander) fetchPending(ctx context.Context) ([]Command, error) {
 	reqURL := fmt.Sprintf("%s/api/commands?host_id=%s&status=pending", c.cfg.ServerURL, url.QueryEscape(c.cfg.HostID))
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
@@ -150,144 +130,22 @@ func (c *Commander) fetchPending(ctx context.Context) ([]command, error) {
 		return nil, fmt.Errorf("server returned %d: %s", resp.StatusCode, string(body))
 	}
 
-	var commands []command
+	var commands []Command
 	if err := json.NewDecoder(resp.Body).Decode(&commands); err != nil {
 		return nil, fmt.Errorf("decode commands: %w", err)
 	}
 	return commands, nil
 }
 
-func (c *Commander) dispatch(ctx context.Context, cmd command) {
-	if err := c.updateStatus(ctx, cmd.ID, "acked", nil); err != nil {
-		c.logger.ErrorContext(ctx, "commander ack", "cmd_id", cmd.ID, "err", err)
-		return
-	}
-
-	switch cmd.CommandType {
-	case "kill_process":
-		c.executeKill(ctx, cmd)
-	case "set_application_control":
-		c.executeSetApplicationControl(ctx, cmd)
-	default:
-		if err := c.updateStatus(ctx, cmd.ID, "failed", marshalResult("unknown command type: "+cmd.CommandType)); err != nil {
-			c.logger.ErrorContext(ctx, "commander fail", "cmd_id", cmd.ID, "err", err)
-		}
-	}
+func (c *Commander) dispatch(ctx context.Context, cmd Command) {
+	c.executor.Execute(ctx, cmd, c.report(cmd.ID))
 }
 
-// executeSetApplicationControl forwards the raw command payload to the ESF
-// extension over XPC. Result shape on success:
-// {"policy_id": P, "policy_version": V} so operators can confirm via
-// `GET /commands/{id}` that the agent applied the snapshot it was meant to.
-//
-// Envelope validation only: the per-rule shape is the extension's
-// responsibility. Forwarding the raw bytes (rather than re-marshalling)
-// keeps the wire shape byte-identical across server → agent → extension so
-// a future schema tightening that fails on one side surfaces on the same
-// commit.
-func (c *Commander) executeSetApplicationControl(ctx context.Context, cmd command) {
-	var payload setApplicationControlPayload
-	if err := json.Unmarshal(cmd.Payload, &payload); err != nil {
-		_ = c.updateStatus(ctx, cmd.ID, "failed", marshalResult(invalidPayloadPrefix+err.Error()))
-		return
+// report adapts the executor's outcome callback to the poll transport: each status transition is a PUT /api/commands/{id}.
+func (c *Commander) report(id int64) ReportFunc {
+	return func(ctx context.Context, status string, result json.RawMessage) error {
+		return c.updateStatus(ctx, id, status, result)
 	}
-	if payload.PolicyID <= 0 {
-		_ = c.updateStatus(ctx, cmd.ID, "failed", marshalResult("payload missing or invalid policy_id"))
-		return
-	}
-	if payload.PolicyVersion <= 0 {
-		// Versioning is the ordering guard for snapshot state on the extension; a zero/negative version would either mask an
-		// out-of-order delivery or reflect a hand-queued test command that shouldn't be acted on. Fail fast so the server-
-		// side audit trail attributes the error to its source rather than to the XPC layer returning opaque decode errors from
-		// the extension.
-		_ = c.updateStatus(ctx, cmd.ID, "failed", marshalResult("invalid policy_version"))
-		return
-	}
-	// Validate that rules is present AND a JSON array (empty array allowed). Without this gate, payloads with missing/null/non-array rules
-	// slip past the envelope check because the json.RawMessage decode accepts any well-formed JSON value, the extension then fails to
-	// decode silently, and the server sees `completed` for a snapshot the extension never applied.
-	if !isJSONArray(payload.Rules) {
-		_ = c.updateStatus(ctx, cmd.ID, "failed", marshalResult("payload missing or invalid rules array"))
-		return
-	}
-	if c.cfg.ApplicationControlSender == nil {
-		_ = c.updateStatus(ctx, cmd.ID, "failed", marshalResult("application control sender not configured"))
-		return
-	}
-
-	c.logger.InfoContext(ctx, "commander set_application_control",
-		"cmd_id", cmd.ID,
-		"edr.app_control.policy_id", payload.PolicyID,
-		"edr.app_control.policy_version", payload.PolicyVersion,
-	)
-
-	// Forward the raw JSON bytes so the extension parses the same shape the server wrote. Re-marshalling would introduce drift in field
-	// ordering / casing that a future schema tightening could catch on one side but not the other.
-	if err := c.cfg.ApplicationControlSender.SendApplicationControl([]byte(cmd.Payload)); err != nil {
-		_ = c.updateStatus(ctx, cmd.ID, "failed", marshalResult("xpc send: "+err.Error()))
-		return
-	}
-
-	// The send is async: completing the command here does NOT mean the extension has successfully applied the snapshot. The demo cut
-	// intentionally stops short of an extension-side ack; the audit trail of "command completed on agent" is sufficient for now. A future
-	// revision can add a round-trip ack with the actually-applied version.
-	result, _ := json.Marshal(map[string]any{
-		"policy_id":      payload.PolicyID,
-		"policy_version": payload.PolicyVersion,
-	})
-	if err := c.updateStatus(ctx, cmd.ID, "completed", result); err != nil {
-		c.logger.ErrorContext(ctx, "commander report set_application_control success", "cmd_id", cmd.ID, "err", err)
-	}
-}
-
-func (c *Commander) executeKill(ctx context.Context, cmd command) {
-	var payload killPayload
-	if err := json.Unmarshal(cmd.Payload, &payload); err != nil {
-		_ = c.updateStatus(ctx, cmd.ID, "failed", marshalResult(invalidPayloadPrefix+err.Error()))
-		return
-	}
-
-	if payload.PID <= 0 {
-		_ = c.updateStatus(ctx, cmd.ID, "failed", marshalResult("invalid pid"))
-		return
-	}
-
-	c.logger.InfoContext(ctx, "commander kill_process", "pid", payload.PID, "cmd_id", cmd.ID)
-
-	if err := syscall.Kill(payload.PID, syscall.SIGKILL); err != nil {
-		if updateErr := c.updateStatus(ctx, cmd.ID, "failed", marshalResult(err.Error())); updateErr != nil {
-			c.logger.ErrorContext(ctx, "commander report kill failure", "cmd_id", cmd.ID, "err", updateErr)
-		}
-		return
-	}
-
-	successResult, _ := json.Marshal(map[string]int{"killed_pid": payload.PID})
-	if err := c.updateStatus(ctx, cmd.ID, "completed", successResult); err != nil {
-		c.logger.ErrorContext(ctx, "commander report kill success", "cmd_id", cmd.ID, "err", err)
-	}
-}
-
-// marshalResult builds a properly-escaped JSON result with an error field.
-func marshalResult(errMsg string) json.RawMessage {
-	b, _ := json.Marshal(map[string]string{"error": errMsg})
-	return b
-}
-
-// isJSONArray reports whether raw is a JSON array (including the empty array). Used by the set_application_control envelope check to
-// reject payloads with missing or null `rules` fields, which would otherwise slip through json.Unmarshal-into-json.RawMessage and only
-// fail at extension decode time after the server has already seen `completed`.
-func isJSONArray(raw json.RawMessage) bool {
-	for _, b := range raw {
-		switch b {
-		case ' ', '\t', '\r', '\n':
-			continue
-		case '[':
-			return true
-		default:
-			return false
-		}
-	}
-	return false
 }
 
 func (c *Commander) updateStatus(ctx context.Context, cmdID int64, status string, result json.RawMessage) error {

--- a/agent/commander/commander_test.go
+++ b/agent/commander/commander_test.go
@@ -24,7 +24,7 @@ import (
 // would respond with the wrong scope and the per-host audit trail would silently merge.
 func TestFetchPending(t *testing.T) {
 	t.Parallel()
-	commands := []command{
+	commands := []Command{
 		{ID: 1, HostID: "host-a", CommandType: "kill_process", Payload: json.RawMessage(`{"pid":123}`), Status: "pending"},
 	}
 
@@ -136,12 +136,12 @@ func TestExecuteSetApplicationControl_HappyPath(t *testing.T) {
 	}, nil, nil)
 
 	rawPayload := `{"policy_id":7,"policy_version":42,"rules":[{"rule_type":"BINARY","identifier":"aaa","action":"BLOCK","enforcement":"PROTECT","severity":"medium"}]}`
-	cmd := command{
+	cmd := Command{
 		ID:          11,
 		CommandType: "set_application_control",
 		Payload:     json.RawMessage(rawPayload),
 	}
-	c.executeSetApplicationControl(t.Context(), cmd)
+	c.dispatch(t.Context(), cmd)
 
 	require.Len(t, sender.sent, 1)
 	// Byte equality, not JSONEq: the commander's contract with the extension is "forward the exact payload bytes the server sent",
@@ -176,7 +176,7 @@ func TestExecuteSetApplicationControl_InvalidPayload(t *testing.T) {
 	sender := &recordingApplicationControlSender{}
 	c := New(Config{ServerURL: srv.URL, HostID: "host-a", ApplicationControlSender: sender}, nil, nil)
 
-	c.executeSetApplicationControl(t.Context(), command{
+	c.dispatch(t.Context(), Command{
 		ID:          12,
 		CommandType: "set_application_control",
 		Payload:     json.RawMessage(`{`), // malformed
@@ -207,7 +207,7 @@ func TestExecuteSetApplicationControl_InvalidVersion(t *testing.T) {
 	sender := &recordingApplicationControlSender{}
 	c := New(Config{ServerURL: srv.URL, HostID: "host-a", ApplicationControlSender: sender}, nil, nil)
 
-	c.executeSetApplicationControl(t.Context(), command{
+	c.dispatch(t.Context(), Command{
 		ID:          13,
 		CommandType: "set_application_control",
 		Payload:     json.RawMessage(`{"policy_id":7,"policy_version":0,"rules":[]}`),
@@ -239,7 +239,7 @@ func TestExecuteSetApplicationControl_MissingPolicyID(t *testing.T) {
 	sender := &recordingApplicationControlSender{}
 	c := New(Config{ServerURL: srv.URL, HostID: "host-a", ApplicationControlSender: sender}, nil, nil)
 
-	c.executeSetApplicationControl(t.Context(), command{
+	c.dispatch(t.Context(), Command{
 		ID:          14,
 		CommandType: "set_application_control",
 		Payload:     json.RawMessage(`{"policy_id":0,"policy_version":1,"rules":[]}`),
@@ -283,7 +283,7 @@ func TestExecuteSetApplicationControl_RulesMissingOrInvalid(t *testing.T) {
 
 			sender := &recordingApplicationControlSender{}
 			c := New(Config{ServerURL: srv.URL, HostID: "host-a", ApplicationControlSender: sender}, nil, nil)
-			c.executeSetApplicationControl(t.Context(), command{
+			c.dispatch(t.Context(), Command{
 				ID:          16,
 				CommandType: "set_application_control",
 				Payload:     json.RawMessage(tc.payload),
@@ -306,7 +306,7 @@ func TestExecuteSetApplicationControl_EmptyRulesAccepted(t *testing.T) {
 
 	sender := &recordingApplicationControlSender{}
 	c := New(Config{ServerURL: srv.URL, HostID: "host-a", ApplicationControlSender: sender}, nil, nil)
-	c.executeSetApplicationControl(t.Context(), command{
+	c.dispatch(t.Context(), Command{
 		ID:          17,
 		CommandType: "set_application_control",
 		Payload:     json.RawMessage(`{"policy_id":7,"policy_version":1,"rules":[]}`),
@@ -331,7 +331,7 @@ func TestExecuteSetApplicationControl_NoSenderConfigured(t *testing.T) {
 	defer srv.Close()
 
 	c := New(Config{ServerURL: srv.URL, HostID: "host-a"}, nil, nil)
-	c.executeSetApplicationControl(t.Context(), command{
+	c.dispatch(t.Context(), Command{
 		ID:          15,
 		CommandType: "set_application_control",
 		Payload:     json.RawMessage(`{"policy_id":7,"policy_version":1,"rules":[]}`),
@@ -389,7 +389,7 @@ func TestDispatchUnknownCommand(t *testing.T) {
 	defer srv.Close()
 
 	cmdr := New(Config{ServerURL: srv.URL, HostID: "host-a"}, nil, nil)
-	cmd := command{ID: 42, CommandType: "reboot", Payload: json.RawMessage(`{}`)}
+	cmd := Command{ID: 42, CommandType: "reboot", Payload: json.RawMessage(`{}`)}
 	cmdr.dispatch(t.Context(), cmd)
 
 	mu.Lock()
@@ -424,7 +424,7 @@ func TestDispatchKillInvalidPayload(t *testing.T) {
 	defer srv.Close()
 
 	cmdr := New(Config{ServerURL: srv.URL, HostID: "host-a"}, nil, nil)
-	cmd := command{ID: 43, CommandType: "kill_process", Payload: json.RawMessage(`{"pid":0}`)}
+	cmd := Command{ID: 43, CommandType: "kill_process", Payload: json.RawMessage(`{"pid":0}`)}
 	cmdr.dispatch(t.Context(), cmd)
 
 	mu.Lock()
@@ -493,7 +493,7 @@ func TestAcknowledgementFailsDoesNotExecute(t *testing.T) {
 
 	sender := &recordingApplicationControlSender{}
 	cmdr := New(Config{ServerURL: srv.URL, HostID: "host-a", ApplicationControlSender: sender}, nil, nil)
-	cmd := command{
+	cmd := Command{
 		ID:          50,
 		CommandType: "set_application_control",
 		Payload:     json.RawMessage(`{"policy_id":7,"policy_version":1,"rules":[]}`),
@@ -530,7 +530,7 @@ func TestKillProcessAlreadyGone(t *testing.T) {
 
 	cmdr := New(Config{ServerURL: srv.URL, HostID: "host-a"}, nil, nil)
 	// math.MaxInt32 is well outside the pid range any real macOS/Linux process holds.
-	cmd := command{ID: 60, CommandType: "kill_process", Payload: json.RawMessage(`{"pid":2147483647}`)}
+	cmd := Command{ID: 60, CommandType: "kill_process", Payload: json.RawMessage(`{"pid":2147483647}`)}
 	cmdr.dispatch(t.Context(), cmd)
 
 	mu.Lock()
@@ -588,7 +588,7 @@ func TestKillProcessSuccessful(t *testing.T) {
 	cmdr := New(Config{ServerURL: srv.URL, HostID: "host-a"}, nil, nil)
 	payload, err := json.Marshal(map[string]int{"pid": pid})
 	require.NoError(t, err)
-	cmdr.dispatch(t.Context(), command{ID: 70, CommandType: "kill_process", Payload: payload})
+	cmdr.dispatch(t.Context(), Command{ID: 70, CommandType: "kill_process", Payload: payload})
 
 	mu.Lock()
 	defer mu.Unlock()

--- a/agent/commander/executor.go
+++ b/agent/commander/executor.go
@@ -1,0 +1,182 @@
+package commander
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"syscall"
+)
+
+// Command is the agent-side view of a server command to execute. The json tags decode the poll-path response body; the control-channel
+// client builds the same struct from the pushed gRPC frame. Shared so both transports run one execution path.
+type Command struct {
+	ID          int64           `json:"id"`
+	HostID      string          `json:"host_id"`
+	CommandType string          `json:"command_type"`
+	Payload     json.RawMessage `json:"payload"`
+	Status      string          `json:"status"`
+}
+
+// Status values the executor reports through ReportFunc. They mirror the server-side command lifecycle and are exported so the
+// control-channel client can recognize a terminal outcome (to cache it for idempotent re-report on re-delivery).
+const (
+	StatusAcked     = "acked"
+	StatusCompleted = "completed"
+	StatusFailed    = "failed"
+)
+
+// invalidPayloadPrefix is the reason prefix every handler emits when json.Unmarshal of cmd.Payload fails. Centralised so the wire shape
+// stays stable across handlers.
+const invalidPayloadPrefix = "invalid payload: "
+
+// ReportFunc records a status transition for a command. The command id is bound by the caller (each transport reports over its own
+// channel: the poll path PUTs /api/commands/{id}; the control channel sends an Outcome frame). A non-nil error means the report did not
+// reach the server.
+type ReportFunc func(ctx context.Context, status string, result json.RawMessage) error
+
+// Executor runs a command's local side effect and reports its outcome through a transport-supplied ReportFunc. It holds no transport
+// state, so the poll loop and the control-channel client share one instance's worth of behavior without coupling to how commands are
+// delivered or how outcomes are sent back.
+type Executor struct {
+	sender ApplicationControlSender
+	// kill is the process-termination syscall, injectable so tests exercise the kill_process path without signalling a real process.
+	kill   func(pid int, sig syscall.Signal) error
+	logger *slog.Logger
+}
+
+// NewExecutor builds an Executor. sender may be nil (set_application_control then reports failed with a clear reason); logger nil uses
+// the default.
+func NewExecutor(sender ApplicationControlSender, logger *slog.Logger) *Executor {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Executor{sender: sender, kill: syscall.Kill, logger: logger}
+}
+
+// Execute drives one command through the acknowledged-then-completed-or-failed lifecycle: it reports acked first (so an operator never
+// sees a stuck pending command after work has begun), runs the type-specific side effect, then reports the terminal outcome. If the
+// acked report fails the side effect is skipped, leaving the command eligible for re-dispatch. Unknown types fail explicitly.
+func (e *Executor) Execute(ctx context.Context, cmd Command, report ReportFunc) {
+	if err := report(ctx, StatusAcked, nil); err != nil {
+		e.logger.ErrorContext(ctx, "commander ack", "cmd_id", cmd.ID, "err", err)
+		return
+	}
+	switch cmd.CommandType {
+	case "kill_process":
+		e.executeKill(ctx, cmd, report)
+	case "set_application_control":
+		e.executeSetApplicationControl(ctx, cmd, report)
+	default:
+		if err := report(ctx, StatusFailed, marshalResult("unknown command type: "+cmd.CommandType)); err != nil {
+			e.logger.ErrorContext(ctx, "commander fail", "cmd_id", cmd.ID, "err", err)
+		}
+	}
+}
+
+func (e *Executor) executeKill(ctx context.Context, cmd Command, report ReportFunc) {
+	var payload killPayload
+	if err := json.Unmarshal(cmd.Payload, &payload); err != nil {
+		_ = report(ctx, StatusFailed, marshalResult(invalidPayloadPrefix+err.Error()))
+		return
+	}
+	if payload.PID <= 0 {
+		_ = report(ctx, StatusFailed, marshalResult("invalid pid"))
+		return
+	}
+	e.logger.InfoContext(ctx, "commander kill_process", "pid", payload.PID, "cmd_id", cmd.ID)
+	if err := e.kill(payload.PID, syscall.SIGKILL); err != nil {
+		if reportErr := report(ctx, StatusFailed, marshalResult(err.Error())); reportErr != nil {
+			e.logger.ErrorContext(ctx, "commander report kill failure", "cmd_id", cmd.ID, "err", reportErr)
+		}
+		return
+	}
+	successResult, _ := json.Marshal(map[string]int{"killed_pid": payload.PID})
+	if err := report(ctx, StatusCompleted, successResult); err != nil {
+		e.logger.ErrorContext(ctx, "commander report kill success", "cmd_id", cmd.ID, "err", err)
+	}
+}
+
+// executeSetApplicationControl forwards the raw command payload to the ESF extension over XPC. Result on success is
+// {"policy_id": P, "policy_version": V} so operators can confirm per host which snapshot the agent applied. Envelope validation only
+// (policy_id present, version positive, rules is a JSON array); the per-rule shape is the extension's responsibility, and forwarding the
+// raw bytes keeps the wire shape byte-identical across server, agent, and extension.
+func (e *Executor) executeSetApplicationControl(ctx context.Context, cmd Command, report ReportFunc) {
+	var payload setApplicationControlPayload
+	if err := json.Unmarshal(cmd.Payload, &payload); err != nil {
+		_ = report(ctx, StatusFailed, marshalResult(invalidPayloadPrefix+err.Error()))
+		return
+	}
+	if payload.PolicyID <= 0 {
+		_ = report(ctx, StatusFailed, marshalResult("payload missing or invalid policy_id"))
+		return
+	}
+	if payload.PolicyVersion <= 0 {
+		// Versioning is the ordering guard for snapshot state on the extension; a zero/negative version would either mask an
+		// out-of-order delivery or reflect a hand-queued test command that shouldn't be acted on. Fail fast so the audit trail
+		// attributes the error to its source rather than to opaque XPC decode errors from the extension.
+		_ = report(ctx, StatusFailed, marshalResult("invalid policy_version"))
+		return
+	}
+	if !isJSONArray(payload.Rules) {
+		_ = report(ctx, StatusFailed, marshalResult("payload missing or invalid rules array"))
+		return
+	}
+	if e.sender == nil {
+		_ = report(ctx, StatusFailed, marshalResult("application control sender not configured"))
+		return
+	}
+	e.logger.InfoContext(ctx, "commander set_application_control",
+		"cmd_id", cmd.ID,
+		"edr.app_control.policy_id", payload.PolicyID,
+		"edr.app_control.policy_version", payload.PolicyVersion,
+	)
+	// Forward the raw JSON bytes so the extension parses the same shape the server wrote. The send is async: completing here does NOT
+	// mean the extension has applied the snapshot; the audit trail of "command completed on agent" is sufficient for now.
+	if err := e.sender.SendApplicationControl([]byte(cmd.Payload)); err != nil {
+		_ = report(ctx, StatusFailed, marshalResult("xpc send: "+err.Error()))
+		return
+	}
+	result, _ := json.Marshal(map[string]any{
+		"policy_id":      payload.PolicyID,
+		"policy_version": payload.PolicyVersion,
+	})
+	if err := report(ctx, StatusCompleted, result); err != nil {
+		e.logger.ErrorContext(ctx, "commander report set_application_control success", "cmd_id", cmd.ID, "err", err)
+	}
+}
+
+type killPayload struct {
+	PID int `json:"pid"`
+}
+
+// setApplicationControlPayload mirrors server/rules/api.SetApplicationControlPayload. Field names + json tags are load-bearing: the
+// extension parses the same JSON bytes and the byte-shape must match across all three sides.
+type setApplicationControlPayload struct {
+	PolicyID      int64 `json:"policy_id"`
+	PolicyVersion int64 `json:"policy_version"`
+	// Rules is decoded as json.RawMessage so the agent doesn't need to know the rule shape; the extension is the source of truth.
+	Rules json.RawMessage `json:"rules"`
+}
+
+// marshalResult builds a properly-escaped JSON result with an error field.
+func marshalResult(errMsg string) json.RawMessage {
+	b, _ := json.Marshal(map[string]string{"error": errMsg})
+	return b
+}
+
+// isJSONArray reports whether raw is a JSON array (including the empty array). Used by the set_application_control envelope check to
+// reject payloads with missing or null `rules` fields, which would otherwise slip through json.Unmarshal-into-json.RawMessage and only
+// fail at extension decode time after the server has already seen `completed`.
+func isJSONArray(raw json.RawMessage) bool {
+	for _, b := range raw {
+		switch b {
+		case ' ', '\t', '\r', '\n':
+			continue
+		case '[':
+			return true
+		default:
+			return false
+		}
+	}
+	return false
+}

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -57,8 +57,9 @@ type Config struct {
 	EnrollSecret      string
 	TokenFile         string
 	ServerFingerprint string
-	// ControlAddr is the server's control-channel gRPC endpoint (host:port). Empty (default) keeps the agent on the GET /api/commands
-	// short-poll; set EDR_CONTROL_ADDR to open the persistent push stream (the poll then becomes the fallback floor). From #477.
+	// ControlAddr is the server's reachable control-channel gRPC endpoint, e.g. "edr.example.com:8090" (the server's address, not a
+	// bind literal like ":8090"). Empty (default) keeps the agent on the GET /api/commands short-poll; set EDR_CONTROL_ADDR to open the
+	// persistent push stream (the poll then becomes the fallback floor). From #477.
 	ControlAddr              string
 	HostIDOverride           string
 	QueueDBPath              string

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -53,10 +53,13 @@ const (
 
 // Config is the resolved agent configuration.
 type Config struct {
-	ServerURL                string
-	EnrollSecret             string
-	TokenFile                string
-	ServerFingerprint        string
+	ServerURL         string
+	EnrollSecret      string
+	TokenFile         string
+	ServerFingerprint string
+	// ControlAddr is the server's control-channel gRPC endpoint (host:port). Empty (default) keeps the agent on the GET /api/commands
+	// short-poll; set EDR_CONTROL_ADDR to open the persistent push stream (the poll then becomes the fallback floor). From #477.
+	ControlAddr              string
 	HostIDOverride           string
 	QueueDBPath              string
 	XPCService               string
@@ -110,6 +113,7 @@ func loadFrom(getenv func(string) string) (*Config, error) {
 	c.EnrollSecret = getenv("EDR_ENROLL_SECRET")
 	optional(&c.TokenFile, "EDR_TOKEN_FILE", getenv)
 	optional(&c.ServerFingerprint, "EDR_SERVER_FINGERPRINT", getenv)
+	optional(&c.ControlAddr, "EDR_CONTROL_ADDR", getenv)
 
 	c.AllowInsecure = getenv("EDR_ALLOW_INSECURE") == "1"
 	if c.ServerURL != "" {

--- a/agent/controlclient/backoff_internal_test.go
+++ b/agent/controlclient/backoff_internal_test.go
@@ -1,0 +1,67 @@
+package controlclient
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fleetdm/edr/internal/control"
+)
+
+// stubChannelClient is the minimal control.ControlChannelClient needed to construct a Client without a real connection. New only
+// records it; these tests never call Connect.
+type stubChannelClient struct{ control.ControlChannelClient }
+
+// TestNewBackoffBounds pins how New resolves the InitialBackoff / MaxBackoff config into the effective bounds, including the
+// misordered-config clamp that previously fell back to the 30s default instead of clamping up to InitialBackoff.
+func TestNewBackoffBounds(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name        string
+		initial     time.Duration
+		maxBackoff  time.Duration
+		wantInitial time.Duration
+		wantMax     time.Duration
+	}{
+		{"both unset take defaults", 0, 0, defaultInitialBackoff, defaultMaxBackoff},
+		{"max unset takes default cap", 2 * time.Second, 0, 2 * time.Second, defaultMaxBackoff},
+		{"misordered max clamps up to initial", 10 * time.Second, 5 * time.Second, 10 * time.Second, 10 * time.Second},
+		{"normal bounds preserved", 1 * time.Second, 20 * time.Second, 1 * time.Second, 20 * time.Second},
+		{"negative initial takes default", -1, 20 * time.Second, defaultInitialBackoff, 20 * time.Second},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			c := New(Config{Client: stubChannelClient{}, InitialBackoff: tc.initial, MaxBackoff: tc.maxBackoff})
+			assert.Equal(t, tc.wantInitial, c.initialBackoff)
+			assert.Equal(t, tc.wantMax, c.maxBackoff)
+		})
+	}
+}
+
+func TestNewPanicsWithoutClient(t *testing.T) {
+	t.Parallel()
+	require.PanicsWithValue(t, "controlclient.New: Client must not be nil", func() { New(Config{}) })
+}
+
+// TestJitter guards the reconnect jitter against rand.Int64N(0), which panics: any duration whose half rounds to zero must yield no
+// jitter rather than crashing the control-client goroutine.
+func TestJitter(t *testing.T) {
+	t.Parallel()
+	assert.Zero(t, jitter(0))
+	assert.Zero(t, jitter(1), "1ns/2 rounds to 0; must not call rand.Int64N(0)")
+	assert.Zero(t, jitter(-5), "negative duration yields no jitter")
+	for range 50 {
+		j := jitter(10 * time.Second)
+		assert.GreaterOrEqual(t, j, time.Duration(0))
+		assert.Less(t, j, 5*time.Second, "jitter is bounded by half the duration")
+	}
+}
+
+func TestMinDuration(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, 1*time.Second, minDuration(1*time.Second, 2*time.Second))
+	assert.Equal(t, 1*time.Second, minDuration(2*time.Second, 1*time.Second))
+}

--- a/agent/controlclient/controlclient.go
+++ b/agent/controlclient/controlclient.go
@@ -1,0 +1,248 @@
+// Package controlclient is the agent side of the persistent control channel (issue #477): it holds one gRPC bidirectional stream to the
+// server's control gateway, executes pushed commands in real time, and reports their outcomes back over the same stream. It reuses the
+// commander's Executor so the push path and the poll path run one execution. When the stream is up it signals the commander to suspend
+// polling; when it drops, the agent reconnects with backoff and the commander's poll resumes as the degraded floor.
+package controlclient
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"math/rand/v2"
+	"sync"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+
+	"github.com/fleetdm/edr/agent/commander"
+	"github.com/fleetdm/edr/internal/control"
+)
+
+const (
+	defaultInitialBackoff = 1 * time.Second
+	defaultMaxBackoff     = 30 * time.Second
+	// outcomeCacheCapacity bounds the remembered-outcomes map. Commands are infrequent (operator actions), so a small cache covers the
+	// re-delivery window; it is a per-agent ephemeral cache, lost on restart.
+	outcomeCacheCapacity = 256
+)
+
+// Config holds the control client's dependencies.
+type Config struct {
+	// Client is the gRPC stub over the (pinned-TLS) connection to the server's control gateway.
+	Client control.ControlChannelClient
+	HostID string
+	// TokenFn returns the current host bearer token, read at each (re)connect so a refreshed token is presented. Nil sends no token
+	// (the server then rejects the connect, which is the correct failure for an unauthenticated agent).
+	TokenFn func() string
+	// OnAuthFail is invoked when the server rejects the stream as unauthenticated, so the agent can re-enroll. Nil is allowed.
+	OnAuthFail func(ctx context.Context)
+	// ApplicationControlSender is the XPC bridge handed to the shared executor; nil means set_application_control commands fail with a
+	// clear reason, matching the poll path.
+	ApplicationControlSender commander.ApplicationControlSender
+	// OnConnectedChange reports stream up (true) / down (false) so the commander can suspend / resume polling. Nil is allowed.
+	OnConnectedChange func(bool)
+	Logger            *slog.Logger
+	// InitialBackoff / MaxBackoff override the reconnect backoff bounds; zero uses the defaults.
+	InitialBackoff time.Duration
+	MaxBackoff     time.Duration
+}
+
+// Client maintains the persistent control stream.
+type Client struct {
+	cfg            Config
+	executor       *commander.Executor
+	outcomes       *outcomeCache
+	logger         *slog.Logger
+	initialBackoff time.Duration
+	maxBackoff     time.Duration
+}
+
+// New builds a control Client. Panics if Client is nil (a programming error: there is nothing to stream over).
+func New(cfg Config) *Client {
+	if cfg.Client == nil {
+		panic("controlclient.New: Client must not be nil")
+	}
+	logger := cfg.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	initial := cfg.InitialBackoff
+	if initial <= 0 {
+		initial = defaultInitialBackoff
+	}
+	maxB := cfg.MaxBackoff
+	if maxB < initial {
+		maxB = defaultMaxBackoff
+	}
+	return &Client{
+		cfg:            cfg,
+		executor:       commander.NewExecutor(cfg.ApplicationControlSender, logger),
+		outcomes:       newOutcomeCache(outcomeCacheCapacity),
+		logger:         logger,
+		initialBackoff: initial,
+		maxBackoff:     maxB,
+	}
+}
+
+// Run holds the control stream open, reconnecting with capped exponential backoff (plus jitter, to avoid a fleet-wide reconnect
+// stampede) until ctx is cancelled. A backoff resets after any session that actually connected, so a long-lived connection that drops
+// retries immediately rather than inheriting a grown delay.
+func (c *Client) Run(ctx context.Context) error {
+	backoff := c.initialBackoff
+	for {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		connected, err := c.runStream(ctx)
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if connected {
+			backoff = c.initialBackoff
+		}
+		c.logger.WarnContext(ctx, "control channel disconnected; reconnecting", "err", err, "retry_in", backoff)
+		if !sleepCtx(ctx, backoff+jitter(backoff)) {
+			return ctx.Err()
+		}
+		backoff = minDuration(backoff*2, c.maxBackoff)
+	}
+}
+
+// runStream opens one stream and pumps it until it ends. The bool reports whether the stream actually connected (so Run can reset the
+// backoff); the error is the disconnect cause.
+func (c *Client) runStream(ctx context.Context) (bool, error) {
+	sctx := ctx
+	if c.cfg.TokenFn != nil {
+		if token := c.cfg.TokenFn(); token != "" {
+			sctx = metadata.AppendToOutgoingContext(ctx, "authorization", "Bearer "+token)
+		}
+	}
+	stream, err := c.cfg.Client.Connect(sctx)
+	if err != nil {
+		return false, err
+	}
+	c.setConnected(true)
+	defer c.setConnected(false)
+	c.logger.InfoContext(ctx, "control channel connected", "host_id_present", c.cfg.HostID != "")
+
+	for {
+		frame, err := stream.Recv()
+		if err != nil {
+			if status.Code(err) == codes.Unauthenticated && c.cfg.OnAuthFail != nil {
+				c.cfg.OnAuthFail(ctx)
+			}
+			return true, err
+		}
+		if cmd := frame.GetCommand(); cmd != nil {
+			c.handleCommand(ctx, stream, cmd)
+		}
+	}
+}
+
+// handleCommand executes a pushed command and reports its outcome over the stream. Delivery is at-least-once: if the command has
+// already been executed (its outcome is cached), the agent re-reports the recorded outcome instead of running the side effect again, so
+// a re-delivery after a lost report still drives the command to terminal and a non-idempotent command (kill_process) is never re-run.
+func (c *Client) handleCommand(ctx context.Context, stream control.ControlChannel_ConnectClient, pushed *control.Command) {
+	cmd := commander.Command{
+		ID:          pushed.GetId(),
+		HostID:      pushed.GetHostId(),
+		CommandType: pushed.GetCommandType(),
+		Payload:     pushed.GetPayload(),
+	}
+	if prior, ok := c.outcomes.get(cmd.ID); ok {
+		// Re-delivery of an already-executed command: replay ack + the recorded terminal outcome (no side effect). The ack drives the
+		// server out of pending if its earlier ack was lost; an already-acked command makes the server reject the duplicate ack benignly.
+		_ = c.send(stream, cmd.ID, commander.StatusAcked, nil)
+		_ = c.send(stream, cmd.ID, prior.status, prior.result)
+		return
+	}
+	c.executor.Execute(ctx, cmd, func(_ context.Context, statusValue string, result json.RawMessage) error {
+		if statusValue == commander.StatusCompleted || statusValue == commander.StatusFailed {
+			c.outcomes.put(cmd.ID, cachedOutcome{status: statusValue, result: result})
+		}
+		return c.send(stream, cmd.ID, statusValue, result)
+	})
+}
+
+func (c *Client) send(stream control.ControlChannel_ConnectClient, id int64, statusValue string, result json.RawMessage) error {
+	return stream.Send(&control.AgentFrame{Frame: &control.AgentFrame_Outcome{Outcome: &control.Outcome{
+		Id:     id,
+		Status: statusValue,
+		Result: result,
+	}}})
+}
+
+func (c *Client) setConnected(v bool) {
+	if c.cfg.OnConnectedChange != nil {
+		c.cfg.OnConnectedChange(v)
+	}
+}
+
+// cachedOutcome is a remembered terminal outcome for idempotent re-report.
+type cachedOutcome struct {
+	status string
+	result json.RawMessage
+}
+
+// outcomeCache is a bounded most-recent map of command id to terminal outcome. Per-agent ephemeral cache, safe to lose on restart (a
+// restart's worst case is re-executing a command the server still has pending, which kill_process tolerates as a no-op "no such
+// process" and set_application_control tolerates as an idempotent snapshot re-apply).
+type outcomeCache struct {
+	mu    sync.Mutex
+	m     map[int64]cachedOutcome
+	order []int64
+	cap   int
+}
+
+func newOutcomeCache(capacity int) *outcomeCache {
+	return &outcomeCache{m: make(map[int64]cachedOutcome, capacity), cap: capacity}
+}
+
+func (o *outcomeCache) get(id int64) (cachedOutcome, bool) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	oc, ok := o.m[id]
+	return oc, ok
+}
+
+func (o *outcomeCache) put(id int64, oc cachedOutcome) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	if _, exists := o.m[id]; !exists {
+		if len(o.order) >= o.cap {
+			oldest := o.order[0]
+			o.order = o.order[1:]
+			delete(o.m, oldest)
+		}
+		o.order = append(o.order, id)
+	}
+	o.m[id] = oc
+}
+
+func sleepCtx(ctx context.Context, d time.Duration) bool {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	}
+}
+
+func jitter(d time.Duration) time.Duration {
+	if d <= 0 {
+		return 0
+	}
+	//nolint:gosec // G404: reconnect-backoff jitter is timing, not security-sensitive; a weak PRNG is correct here.
+	return time.Duration(rand.Int64N(int64(d / 2)))
+}
+
+func minDuration(a, b time.Duration) time.Duration {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/agent/controlclient/controlclient.go
+++ b/agent/controlclient/controlclient.go
@@ -73,8 +73,14 @@ func New(cfg Config) *Client {
 		initial = defaultInitialBackoff
 	}
 	maxB := cfg.MaxBackoff
-	if maxB < initial {
+	if maxB <= 0 {
+		// Unset: take the default cap.
 		maxB = defaultMaxBackoff
+	}
+	if maxB < initial {
+		// Misordered config (max below initial): clamp up to initial so the doubling step still makes forward progress, matching
+		// receiver.NewLoop. Replacing it with the 30s default would silently slow reconnects far past what the caller asked for.
+		maxB = initial
 	}
 	return &Client{
 		cfg:            cfg,
@@ -99,7 +105,11 @@ func (c *Client) Run(ctx context.Context) error {
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
-		if connected {
+		// Reset the backoff after a session that actually connected, so a long-lived stream that drops retries immediately.
+		// Exception: a stream rejected as Unauthenticated "connects" at the gRPC layer and then fails on the first frame, so
+		// resetting would spin a ~1s reconnect + re-enrollment storm against an invalid/revoked token. Let the backoff grow in
+		// that case so re-enrollment is attempted at the capped cadence instead.
+		if connected && status.Code(err) != codes.Unauthenticated {
 			backoff = c.initialBackoff
 		}
 		c.logger.WarnContext(ctx, "control channel disconnected; reconnecting", "err", err, "retry_in", backoff)
@@ -121,6 +131,11 @@ func (c *Client) runStream(ctx context.Context) (bool, error) {
 	}
 	stream, err := c.cfg.Client.Connect(sctx)
 	if err != nil {
+		// The server's auth interceptor can reject the stream during setup, not only on the first Recv; treat an
+		// Unauthenticated rejection here the same way so a revoked/expired token still drives re-enrollment.
+		if status.Code(err) == codes.Unauthenticated && c.cfg.OnAuthFail != nil {
+			c.cfg.OnAuthFail(ctx)
+		}
 		return false, err
 	}
 	c.setConnected(true)
@@ -145,6 +160,15 @@ func (c *Client) runStream(ctx context.Context) (bool, error) {
 // already been executed (its outcome is cached), the agent re-reports the recorded outcome instead of running the side effect again, so
 // a re-delivery after a lost report still drives the command to terminal and a non-idempotent command (kill_process) is never re-run.
 func (c *Client) handleCommand(ctx context.Context, stream control.ControlChannel_ConnectClient, pushed *control.Command) {
+	// Defense in depth: the gateway routes a host's commands to that host's stream, but the agent is the last boundary before a
+	// privileged side effect (kill_process). If a command's host_id doesn't match this agent's, drop it without executing and
+	// without reporting an outcome: any outcome we sent would carry this command's id, which belongs to another host, and could
+	// flip that host's command state on the server. A mismatch means a server-side routing bug, so log it loudly.
+	if c.cfg.HostID != "" && pushed.GetHostId() != "" && pushed.GetHostId() != c.cfg.HostID {
+		c.logger.ErrorContext(ctx, "control channel: dropping command addressed to a different host",
+			"cmd_id", pushed.GetId(), "command_type", pushed.GetCommandType())
+		return
+	}
 	cmd := commander.Command{
 		ID:          pushed.GetId(),
 		HostID:      pushed.GetHostId(),
@@ -186,9 +210,10 @@ type cachedOutcome struct {
 	result json.RawMessage
 }
 
-// outcomeCache is a bounded most-recent map of command id to terminal outcome. Per-agent ephemeral cache, safe to lose on restart (a
-// restart's worst case is re-executing a command the server still has pending, which kill_process tolerates as a no-op "no such
-// process" and set_application_control tolerates as an idempotent snapshot re-apply).
+// outcomeCache is a bounded map of command id to terminal outcome with FIFO (insertion-order) eviction: a get does not change an
+// entry's position, so once the cache is full the oldest-inserted id is dropped first. Per-agent ephemeral cache, safe to lose on
+// restart (a restart's worst case is re-executing a command the server still has pending, which kill_process tolerates as a no-op "no
+// such process" and set_application_control tolerates as an idempotent snapshot re-apply).
 type outcomeCache struct {
 	mu    sync.Mutex
 	m     map[int64]cachedOutcome
@@ -233,11 +258,13 @@ func sleepCtx(ctx context.Context, d time.Duration) bool {
 }
 
 func jitter(d time.Duration) time.Duration {
-	if d <= 0 {
+	half := int64(d / 2)
+	if half <= 0 {
+		// d <= 1ns: rand.Int64N(0) would panic, and there is no meaningful jitter to add at that scale anyway.
 		return 0
 	}
 	//nolint:gosec // G404: reconnect-backoff jitter is timing, not security-sensitive; a weak PRNG is correct here.
-	return time.Duration(rand.Int64N(int64(d / 2)))
+	return time.Duration(rand.Int64N(half))
 }
 
 func minDuration(a, b time.Duration) time.Duration {

--- a/agent/controlclient/controlclient.go
+++ b/agent/controlclient/controlclient.go
@@ -151,7 +151,11 @@ func (c *Client) runStream(ctx context.Context) (bool, error) {
 			return true, err
 		}
 		if cmd := frame.GetCommand(); cmd != nil {
-			c.handleCommand(ctx, stream, cmd)
+			if err := c.handleCommand(ctx, stream, cmd); err != nil {
+				// A send failure means the stream is one-way broken (we can still Recv but can no longer report outcomes). Tear it
+				// down and reconnect rather than sit "connected" while silently dropping every outcome.
+				return true, err
+			}
 		}
 	}
 }
@@ -159,15 +163,18 @@ func (c *Client) runStream(ctx context.Context) (bool, error) {
 // handleCommand executes a pushed command and reports its outcome over the stream. Delivery is at-least-once: if the command has
 // already been executed (its outcome is cached), the agent re-reports the recorded outcome instead of running the side effect again, so
 // a re-delivery after a lost report still drives the command to terminal and a non-idempotent command (kill_process) is never re-run.
-func (c *Client) handleCommand(ctx context.Context, stream control.ControlChannel_ConnectClient, pushed *control.Command) {
+// A non-nil return is a stream-send failure: the caller must tear the stream down and reconnect, since outcomes can no longer be
+// reported on it. A dropped or misrouted command (host mismatch) is not a send failure and returns nil.
+func (c *Client) handleCommand(ctx context.Context, stream control.ControlChannel_ConnectClient, pushed *control.Command) error {
 	// Defense in depth: the gateway routes a host's commands to that host's stream, but the agent is the last boundary before a
 	// privileged side effect (kill_process). If a command's host_id doesn't match this agent's, drop it without executing and
 	// without reporting an outcome: any outcome we sent would carry this command's id, which belongs to another host, and could
-	// flip that host's command state on the server. A mismatch means a server-side routing bug, so log it loudly.
+	// flip that host's command state on the server. A mismatch means a server-side routing bug, so log it loudly. It is not a stream
+	// fault, so keep the stream up (return nil).
 	if c.cfg.HostID != "" && pushed.GetHostId() != "" && pushed.GetHostId() != c.cfg.HostID {
 		c.logger.ErrorContext(ctx, "control channel: dropping command addressed to a different host",
 			"cmd_id", pushed.GetId(), "command_type", pushed.GetCommandType())
-		return
+		return nil
 	}
 	cmd := commander.Command{
 		ID:          pushed.GetId(),
@@ -178,16 +185,24 @@ func (c *Client) handleCommand(ctx context.Context, stream control.ControlChanne
 	if prior, ok := c.outcomes.get(cmd.ID); ok {
 		// Re-delivery of an already-executed command: replay ack + the recorded terminal outcome (no side effect). The ack drives the
 		// server out of pending if its earlier ack was lost; an already-acked command makes the server reject the duplicate ack benignly.
-		_ = c.send(stream, cmd.ID, commander.StatusAcked, nil)
-		_ = c.send(stream, cmd.ID, prior.status, prior.result)
-		return
+		if err := c.send(stream, cmd.ID, commander.StatusAcked, nil); err != nil {
+			return err
+		}
+		return c.send(stream, cmd.ID, prior.status, prior.result)
 	}
+	// sendErr captures a stream-send failure from inside the executor callback (the executor itself only logs report errors). The
+	// executor stops on the first report error (it skips the side effect if the ack send fails), so sendErr holds that failure;
+	// handleCommand returns it so runStream reconnects. This also surfaces send failures on the terminal "failed" reports, whose
+	// errors the executor's validation paths otherwise discard.
+	var sendErr error
 	c.executor.Execute(ctx, cmd, func(_ context.Context, statusValue string, result json.RawMessage) error {
 		if statusValue == commander.StatusCompleted || statusValue == commander.StatusFailed {
 			c.outcomes.put(cmd.ID, cachedOutcome{status: statusValue, result: result})
 		}
-		return c.send(stream, cmd.ID, statusValue, result)
+		sendErr = c.send(stream, cmd.ID, statusValue, result)
+		return sendErr
 	})
+	return sendErr
 }
 
 func (c *Client) send(stream control.ControlChannel_ConnectClient, id int64, statusValue string, result json.RawMessage) error {
@@ -211,9 +226,11 @@ type cachedOutcome struct {
 }
 
 // outcomeCache is a bounded map of command id to terminal outcome with FIFO (insertion-order) eviction: a get does not change an
-// entry's position, so once the cache is full the oldest-inserted id is dropped first. Per-agent ephemeral cache, safe to lose on
-// restart (a restart's worst case is re-executing a command the server still has pending, which kill_process tolerates as a no-op "no
-// such process" and set_application_control tolerates as an idempotent snapshot re-apply).
+// entry's position, so once the cache is full the oldest-inserted id is dropped first. It is a per-agent in-memory cache, lost on
+// restart, so it dedupes re-deliveries only within a single agent process. It does NOT make a restart-safe guarantee: a still-pending
+// command re-delivered after a restart can be executed again. For set_application_control that is a harmless idempotent snapshot
+// re-apply, but kill_process targets a bare PID, and PIDs can be reused, so a re-execution after restart could in principle signal an
+// unrelated process. Restart-safe dedupe for non-idempotent commands is tracked separately (see issue #558).
 type outcomeCache struct {
 	mu    sync.Mutex
 	m     map[int64]cachedOutcome

--- a/agent/controlclient/controlclient_test.go
+++ b/agent/controlclient/controlclient_test.go
@@ -2,6 +2,7 @@ package controlclient_test
 
 import (
 	"context"
+	"io"
 	"net"
 	"sync"
 	"sync/atomic"
@@ -288,4 +289,81 @@ func TestControlClientAuthFailOnConnect(t *testing.T) {
 
 	require.Eventually(t, func() bool { return authFails.Load() >= 1 }, 2*time.Second, 5*time.Millisecond)
 	assert.GreaterOrEqual(t, stub.calls(), 1)
+}
+
+// scriptedStream is a client bidi stream whose Send always fails (a one-way-broken stream) and whose Recv yields a queued command
+// then blocks until ctx ends. It exercises the runStream path that reconnects when handleCommand cannot report an outcome.
+type scriptedStream struct {
+	grpc.ClientStream
+	ctx     context.Context
+	mu      sync.Mutex
+	recvQ   []*control.ServerFrame
+	sendErr error
+}
+
+func (s *scriptedStream) Send(*control.AgentFrame) error { return s.sendErr }
+
+func (s *scriptedStream) Recv() (*control.ServerFrame, error) {
+	s.mu.Lock()
+	if len(s.recvQ) > 0 {
+		f := s.recvQ[0]
+		s.recvQ = s.recvQ[1:]
+		s.mu.Unlock()
+		return f, nil
+	}
+	s.mu.Unlock()
+	<-s.ctx.Done()
+	return nil, io.EOF
+}
+
+// scriptedClient hands out a failing-Send stream on the first connect (carrying one command) and inert streams afterwards, so a
+// reconnect is observable without spinning.
+type scriptedClient struct {
+	cmd      *control.Command
+	sendErr  error
+	mu       sync.Mutex
+	connects int
+}
+
+func (c *scriptedClient) Connect(ctx context.Context, _ ...grpc.CallOption) (grpc.BidiStreamingClient[control.AgentFrame, control.ServerFrame], error) {
+	c.mu.Lock()
+	c.connects++
+	first := c.connects == 1
+	c.mu.Unlock()
+	st := &scriptedStream{ctx: ctx}
+	if first {
+		st.recvQ = []*control.ServerFrame{{Frame: &control.ServerFrame_Command{Command: c.cmd}}}
+		st.sendErr = c.sendErr
+	}
+	return st, nil
+}
+
+func (c *scriptedClient) connectCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.connects
+}
+
+func TestControlClientReconnectsOnSendFailure(t *testing.T) {
+	t.Parallel()
+	// The first stream delivers a command but every Send fails (one-way-broken stream). handleCommand must surface that error so
+	// runStream tears the stream down and reconnects, rather than sitting "connected" while silently dropping outcomes.
+	stub := &scriptedClient{
+		cmd:     &control.Command{Id: 21, HostId: "host-a", CommandType: "set_application_control", Payload: []byte(appControlPayload)},
+		sendErr: status.Error(codes.Unavailable, "broken send"),
+	}
+	client := controlclient.New(controlclient.Config{
+		Client:                   stub,
+		HostID:                   "host-a",
+		TokenFn:                  func() string { return "tok" },
+		ApplicationControlSender: &recordingSender{},
+		InitialBackoff:           5 * time.Millisecond,
+		MaxBackoff:               20 * time.Millisecond,
+	})
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+	go func() { _ = client.Run(ctx) }()
+
+	// A reconnect (connects >= 2) proves the send failure tore the stream down rather than wedging it.
+	require.Eventually(t, func() bool { return stub.connectCount() >= 2 }, 2*time.Second, 5*time.Millisecond)
 }

--- a/agent/controlclient/controlclient_test.go
+++ b/agent/controlclient/controlclient_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -23,8 +24,9 @@ import (
 // reports back.
 type fakeGateway struct {
 	control.UnimplementedControlChannelServer
-	push      []*control.Command
-	failFirst bool
+	push          []*control.Command
+	failFirst     bool
+	authFailFirst bool
 
 	mu       sync.Mutex
 	attempts int
@@ -38,6 +40,9 @@ func (g *fakeGateway) Connect(stream control.ControlChannel_ConnectServer) error
 	g.mu.Unlock()
 	if first && g.failFirst {
 		return status.Error(codes.Unavailable, "transient failure") // forces the client to back off and reconnect
+	}
+	if first && g.authFailFirst {
+		return status.Error(codes.Unauthenticated, "bad token") // forces the client to re-enroll, then reconnect
 	}
 	for _, cmd := range g.push {
 		if err := stream.Send(&control.ServerFrame{Frame: &control.ServerFrame_Command{Command: cmd}}); err != nil {
@@ -82,8 +87,9 @@ func (r *recordingSender) count() int {
 	return len(r.sent)
 }
 
-// startClient wires a fakeGateway over bufconn and runs a control client against it until the test ends.
-func startClient(t *testing.T, fake *fakeGateway, sender *recordingSender) (*fakeGateway, func() bool) {
+// startClient wires a fakeGateway over bufconn and runs a control client against it until the test ends. It returns a connected
+// predicate and an auth-failure counter so tests can observe re-enrollment without standing up a real token provider.
+func startClient(t *testing.T, fake *fakeGateway, sender *recordingSender) (isConnected func() bool, authFails func() int) {
 	t.Helper()
 	lis := bufconn.Listen(1 << 20)
 	srv := grpc.NewServer()
@@ -97,12 +103,18 @@ func startClient(t *testing.T, fake *fakeGateway, sender *recordingSender) (*fak
 	require.NoError(t, err)
 
 	var connected bool
+	var authFailCount int
 	var mu sync.Mutex
 	client := controlclient.New(controlclient.Config{
 		Client:                   control.NewControlChannelClient(cc),
 		HostID:                   "host-a",
 		TokenFn:                  func() string { return "tok" },
 		ApplicationControlSender: sender,
+		OnAuthFail: func(context.Context) {
+			mu.Lock()
+			authFailCount++
+			mu.Unlock()
+		},
 		OnConnectedChange: func(v bool) {
 			mu.Lock()
 			connected = v
@@ -119,12 +131,17 @@ func startClient(t *testing.T, fake *fakeGateway, sender *recordingSender) (*fak
 		srv.Stop()
 		_ = cc.Close()
 	})
-	isConnected := func() bool {
+	isConnected = func() bool {
 		mu.Lock()
 		defer mu.Unlock()
 		return connected
 	}
-	return fake, isConnected
+	authFails = func() int {
+		mu.Lock()
+		defer mu.Unlock()
+		return authFailCount
+	}
+	return isConnected, authFails
 }
 
 const appControlPayload = `{"policy_id":7,"policy_version":1,"rules":[]}`
@@ -138,7 +155,7 @@ func TestControlClient(t *testing.T) {
 			{Id: 7, HostId: "host-a", CommandType: "set_application_control", Payload: []byte(appControlPayload)},
 		}}
 		sender := &recordingSender{}
-		_, isConnected := startClient(t, fake, sender)
+		isConnected, _ := startClient(t, fake, sender)
 
 		require.Eventually(t, isConnected, 2*time.Second, 10*time.Millisecond)
 		require.Eventually(t, func() bool { return len(fake.recorded()) >= 2 }, 2*time.Second, 10*time.Millisecond)
@@ -193,4 +210,82 @@ func TestControlClient(t *testing.T) {
 		assert.Equal(t, "failed", outs[1].GetStatus())
 		assert.Contains(t, string(outs[1].GetResult()), "unknown command type")
 	})
+
+	t.Run("command addressed to a different host is dropped without executing", func(t *testing.T) {
+		t.Parallel()
+		// The first command targets another host (a server routing bug); it must not run and must not report any outcome, since
+		// that outcome would carry an id belonging to host-b. The second, correctly addressed, command still executes so the
+		// stream is proven live.
+		fake := &fakeGateway{push: []*control.Command{
+			{Id: 100, HostId: "host-b", CommandType: "set_application_control", Payload: []byte(appControlPayload)},
+			{Id: 101, HostId: "host-a", CommandType: "set_application_control", Payload: []byte(appControlPayload)},
+		}}
+		sender := &recordingSender{}
+		_, _ = startClient(t, fake, sender)
+
+		// Wait until the correctly addressed command has driven acked+completed.
+		require.Eventually(t, func() bool { return len(fake.recorded()) >= 2 }, 2*time.Second, 10*time.Millisecond)
+		assert.Equal(t, 1, sender.count(), "only the correctly addressed command runs its side effect")
+		for _, oc := range fake.recorded() {
+			assert.Equal(t, int64(101), oc.GetId(), "no outcome is ever reported for the misrouted command")
+		}
+	})
+
+	t.Run("auth rejection on connect drives re-enrollment then recovers", func(t *testing.T) {
+		t.Parallel()
+		// The gateway rejects the first stream as Unauthenticated. The client must invoke OnAuthFail (re-enrollment) and, crucially,
+		// must NOT reset its backoff for an auth-rejected session, then reconnect and execute the pushed command.
+		fake := &fakeGateway{
+			authFailFirst: true,
+			push:          []*control.Command{{Id: 12, HostId: "host-a", CommandType: "set_application_control", Payload: []byte(appControlPayload)}},
+		}
+		sender := &recordingSender{}
+		_, authFails := startClient(t, fake, sender)
+
+		require.Eventually(t, func() bool { return authFails() >= 1 }, 2*time.Second, 10*time.Millisecond)
+		require.Eventually(t, func() bool { return sender.count() == 1 }, 3*time.Second, 10*time.Millisecond)
+	})
+}
+
+// connectErrClient is a control.ControlChannelClient whose Connect fails before any stream exists, exercising the runStream path that
+// inspects the Connect() error (rather than the first Recv) for an Unauthenticated rejection.
+type connectErrClient struct {
+	err error
+	mu  sync.Mutex
+	n   int
+}
+
+func (c *connectErrClient) Connect(context.Context, ...grpc.CallOption) (grpc.BidiStreamingClient[control.AgentFrame, control.ServerFrame], error) {
+	c.mu.Lock()
+	c.n++
+	c.mu.Unlock()
+	return nil, c.err
+}
+
+func (c *connectErrClient) calls() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.n
+}
+
+func TestControlClientAuthFailOnConnect(t *testing.T) {
+	t.Parallel()
+	// When the gateway rejects the RPC during Connect() (the auth interceptor can deny before the stream opens), the client must
+	// still treat it as an auth failure and trigger re-enrollment, not silently retry forever.
+	stub := &connectErrClient{err: status.Error(codes.Unauthenticated, "denied at setup")}
+	var authFails atomic.Int32
+	client := controlclient.New(controlclient.Config{
+		Client:         stub,
+		HostID:         "host-a",
+		TokenFn:        func() string { return "tok" },
+		OnAuthFail:     func(context.Context) { authFails.Add(1) },
+		InitialBackoff: 10 * time.Millisecond,
+		MaxBackoff:     30 * time.Millisecond,
+	})
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+	go func() { _ = client.Run(ctx) }()
+
+	require.Eventually(t, func() bool { return authFails.Load() >= 1 }, 2*time.Second, 5*time.Millisecond)
+	assert.GreaterOrEqual(t, stub.calls(), 1)
 }

--- a/agent/controlclient/controlclient_test.go
+++ b/agent/controlclient/controlclient_test.go
@@ -1,0 +1,196 @@
+package controlclient_test
+
+import (
+	"context"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
+
+	"github.com/fleetdm/edr/agent/controlclient"
+	"github.com/fleetdm/edr/internal/control"
+)
+
+// fakeGateway is an in-memory control gateway: it pushes a fixed set of commands on connect and records every outcome the agent
+// reports back.
+type fakeGateway struct {
+	control.UnimplementedControlChannelServer
+	push      []*control.Command
+	failFirst bool
+
+	mu       sync.Mutex
+	attempts int
+	outcomes []*control.Outcome
+}
+
+func (g *fakeGateway) Connect(stream control.ControlChannel_ConnectServer) error {
+	g.mu.Lock()
+	g.attempts++
+	first := g.attempts == 1
+	g.mu.Unlock()
+	if first && g.failFirst {
+		return status.Error(codes.Unavailable, "transient failure") // forces the client to back off and reconnect
+	}
+	for _, cmd := range g.push {
+		if err := stream.Send(&control.ServerFrame{Frame: &control.ServerFrame_Command{Command: cmd}}); err != nil {
+			return err
+		}
+	}
+	for {
+		frame, err := stream.Recv()
+		if err != nil {
+			return err
+		}
+		if oc := frame.GetOutcome(); oc != nil {
+			g.mu.Lock()
+			g.outcomes = append(g.outcomes, oc)
+			g.mu.Unlock()
+		}
+	}
+}
+
+func (g *fakeGateway) recorded() []*control.Outcome {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return append([]*control.Outcome(nil), g.outcomes...)
+}
+
+// recordingSender captures application-control payloads so the test sees how many times a command's side effect ran, without cgo/XPC.
+type recordingSender struct {
+	mu   sync.Mutex
+	sent [][]byte
+}
+
+func (r *recordingSender) SendApplicationControl(payload []byte) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.sent = append(r.sent, append([]byte(nil), payload...))
+	return nil
+}
+
+func (r *recordingSender) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.sent)
+}
+
+// startClient wires a fakeGateway over bufconn and runs a control client against it until the test ends.
+func startClient(t *testing.T, fake *fakeGateway, sender *recordingSender) (*fakeGateway, func() bool) {
+	t.Helper()
+	lis := bufconn.Listen(1 << 20)
+	srv := grpc.NewServer()
+	control.RegisterControlChannelServer(srv, fake)
+	go func() { _ = srv.Serve(lis) }()
+
+	cc, err := grpc.NewClient("passthrough:///bufnet",
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) { return lis.DialContext(ctx) }),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(t, err)
+
+	var connected bool
+	var mu sync.Mutex
+	client := controlclient.New(controlclient.Config{
+		Client:                   control.NewControlChannelClient(cc),
+		HostID:                   "host-a",
+		TokenFn:                  func() string { return "tok" },
+		ApplicationControlSender: sender,
+		OnConnectedChange: func(v bool) {
+			mu.Lock()
+			connected = v
+			mu.Unlock()
+		},
+		InitialBackoff: 10 * time.Millisecond,
+		MaxBackoff:     50 * time.Millisecond,
+	})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	go func() { _ = client.Run(ctx) }()
+	t.Cleanup(func() {
+		cancel()
+		srv.Stop()
+		_ = cc.Close()
+	})
+	isConnected := func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return connected
+	}
+	return fake, isConnected
+}
+
+const appControlPayload = `{"policy_id":7,"policy_version":1,"rules":[]}`
+
+func TestControlClient(t *testing.T) {
+	t.Parallel()
+
+	t.Run("pushed command is executed and its outcome reported", func(t *testing.T) {
+		t.Parallel()
+		fake := &fakeGateway{push: []*control.Command{
+			{Id: 7, HostId: "host-a", CommandType: "set_application_control", Payload: []byte(appControlPayload)},
+		}}
+		sender := &recordingSender{}
+		_, isConnected := startClient(t, fake, sender)
+
+		require.Eventually(t, isConnected, 2*time.Second, 10*time.Millisecond)
+		require.Eventually(t, func() bool { return len(fake.recorded()) >= 2 }, 2*time.Second, 10*time.Millisecond)
+
+		assert.Equal(t, 1, sender.count(), "the command's side effect runs exactly once")
+		outs := fake.recorded()
+		require.GreaterOrEqual(t, len(outs), 2)
+		assert.Equal(t, "acked", outs[0].GetStatus())
+		assert.Equal(t, "completed", outs[1].GetStatus())
+		assert.Equal(t, int64(7), outs[0].GetId())
+	})
+
+	t.Run("re-delivered command re-reports its outcome without re-executing", func(t *testing.T) {
+		t.Parallel()
+		// The gateway pushes the same command id twice (the lost-ack / reconnect re-delivery case).
+		cmd := &control.Command{Id: 9, HostId: "host-a", CommandType: "set_application_control", Payload: []byte(appControlPayload)}
+		fake := &fakeGateway{push: []*control.Command{cmd, cmd}}
+		sender := &recordingSender{}
+		_, _ = startClient(t, fake, sender)
+
+		// Both deliveries report acked+completed (4 outcomes), but the side effect runs only once.
+		require.Eventually(t, func() bool { return len(fake.recorded()) >= 4 }, 2*time.Second, 10*time.Millisecond)
+		assert.Equal(t, 1, sender.count(), "a re-delivered command must not run its side effect again")
+		for _, oc := range fake.recorded() {
+			assert.Equal(t, int64(9), oc.GetId())
+		}
+	})
+
+	t.Run("reconnects with backoff after a dropped stream", func(t *testing.T) {
+		t.Parallel()
+		// The gateway fails the first stream; the client must back off and reconnect, then receive and execute the pushed command.
+		fake := &fakeGateway{
+			failFirst: true,
+			push:      []*control.Command{{Id: 5, HostId: "host-a", CommandType: "set_application_control", Payload: []byte(appControlPayload)}},
+		}
+		sender := &recordingSender{}
+		_, _ = startClient(t, fake, sender)
+
+		require.Eventually(t, func() bool { return len(fake.recorded()) >= 2 }, 3*time.Second, 10*time.Millisecond)
+		assert.Equal(t, 1, sender.count())
+	})
+
+	t.Run("unknown command type fails explicitly", func(t *testing.T) {
+		t.Parallel()
+		fake := &fakeGateway{push: []*control.Command{
+			{Id: 3, HostId: "host-a", CommandType: "reboot", Payload: []byte(`{}`)},
+		}}
+		_, _ = startClient(t, fake, &recordingSender{})
+		require.Eventually(t, func() bool { return len(fake.recorded()) >= 2 }, 2*time.Second, 10*time.Millisecond)
+		outs := fake.recorded()
+		assert.Equal(t, "acked", outs[0].GetStatus())
+		assert.Equal(t, "failed", outs[1].GetStatus())
+		assert.Contains(t, string(outs[1].GetResult()), "unknown command type")
+	})
+}

--- a/server/detection/internal/tests/integration_test.go
+++ b/server/detection/internal/tests/integration_test.go
@@ -1563,7 +1563,11 @@ func TestService_CountOfflineHosts(t *testing.T) {
 
 func TestService_CountUnprocessed(t *testing.T) {
 	t.Parallel()
-	d := newDetection(t, detectionOpts{mode: bootstrap.ModeFull})
+	// Intake mode, NOT Full: this asserts that freshly ingested events sit in the EventLog backlog, so the processor loop must NOT be
+	// running. Under ModeFull the 20ms processor tick can claim (SKIP LOCKED) the just-inserted events before CountUnprocessed reads,
+	// draining the backlog to 0 under parallel load and flaking the assertion. ModeIntake wires the same service + EventLog (which
+	// CountUnprocessed counts via CountPending) but starts no consumer, so the count is deterministic.
+	d := newDetection(t, detectionOpts{mode: bootstrap.ModeIntake})
 	ctx := t.Context()
 
 	insertEventsViaIngest(ctx, t, d, "host-a", []api.Event{
@@ -1574,7 +1578,7 @@ func TestService_CountUnprocessed(t *testing.T) {
 	count, err := d.Service().CountUnprocessed(ctx)
 	require.NoError(t, err)
 	assert.GreaterOrEqual(t, count, int64(2),
-		"freshly inserted events start unprocessed (state 0 or 2)")
+		"freshly inserted events sit unprocessed in the EventLog backlog")
 }
 
 // ---- Bootstrap mode tests --------------------------------------------------

--- a/server/response/internal/gateway/gateway.go
+++ b/server/response/internal/gateway/gateway.go
@@ -26,6 +26,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
@@ -44,6 +45,9 @@ const (
 	// defaultStopGrace bounds the graceful shutdown. Control streams are long-lived and never end on their own, so an unbounded
 	// GracefulStop would hang shutdown forever; after this window we force the streams closed and the agents reconnect (and poll).
 	defaultStopGrace = 5 * time.Second
+	// clientKeepaliveMinTime is the minimum spacing the server tolerates between agent keep-alive PINGs. It must be at most the agent's
+	// keep-alive interval (the agent reuses its 15s HTTP/2 ReadIdleTimeout) or the server GOAWAYs the connection with "too_many_pings".
+	clientKeepaliveMinTime = 10 * time.Second
 
 	// notifyBuffer bounds the fast-path signal queue. A full buffer is harmless: the 1s watch is the backstop, so a dropped notify just
 	// means the command waits up to one watch interval instead of arriving immediately.
@@ -127,6 +131,13 @@ func New(deps Deps) *Gateway {
 	opts := []grpc.ServerOption{
 		grpc.StatsHandler(otelgrpc.NewServerHandler()),
 		grpc.StreamInterceptor(g.authInterceptor),
+		// Permit the agent's keep-alive PINGs. The agent pings on a short cadence (matching its HTTP/2 half-open detection) to notice a
+		// dropped link fast; without this the gRPC default enforcement policy (5-minute floor) GOAWAYs the connection with
+		// "too_many_pings", so the control stream churns every minute. MinTime must be at most the agent's ping interval.
+		grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
+			MinTime:             clientKeepaliveMinTime,
+			PermitWithoutStream: true,
+		}),
 	}
 	if deps.TLSConfig != nil {
 		opts = append(opts, grpc.Creds(credentials.NewTLS(deps.TLSConfig)))


### PR DESCRIPTION
<!-- Keep this short. Delete sections that do not apply. -->

## What & why



## Checklist

- [ ] **OpenSpec updated for behavior changes.** If this PR changes observable behavior (a detection rule, the event
      wire schema, persistence semantics, an API/wire shape, or an emitted event), `openspec/specs/**` is updated (and
      an `openspec/changes/` proposal added), with a `spec:<id>` test marker for any new/renamed scenario. Only if this
      PR changes NO observable behavior (a comment / refactor / gofmt / dep bump that happens to touch a scoped path)
      may you assert `no-behavior-change` (label or `[no-behavior-change]` in the title) to clear the OpenSpec-sync gate.
      That is an assertion a reviewer will check, not a way to skip the spec for a real behavior change.
- [ ] Tests added/updated for the change (unit / integration / efficacy / UI as applicable).
- [ ] Agent/extension change touching ESF, XPC, or the event wire format: exercised on a live macOS VM before RC
      (flagged below).
- [ ] **Docs updated for user-facing changes.** If this PR changes a user-facing surface (the React UI, an HTTP
      handler, or a detection rule), `docs/` or `CHANGELOG.md` is updated in the same PR. Only if nothing a user sees
      changed (an internal refactor, a non-visible UI tweak) may you assert `no-docs-change` (label or
      `[no-docs-change]` in the title) to clear the Docs-sync gate. The model is in `docs/doc-versioning.md`.

## VM / RC notes (if applicable)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional persistent control-channel connectivity for faster real-time command delivery.
  * Introduced improved support for receiving and executing commands continuously without relying only on polling.

* **Bug Fixes**
  * Reduced command duplication by preventing the same action from running twice during reconnects or redelivery.
  * Improved connection stability with better keep-alive handling to avoid unnecessary disconnects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->