### PR TITLE
Control channel single port

### DIFF
--- a/agent/cmd/fleet-edr-agent/main.go
+++ b/agent/cmd/fleet-edr-agent/main.go
@@ -5,8 +5,11 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"os/signal"
 	"sync/atomic"
@@ -17,6 +20,7 @@ import (
 	"golang.org/x/net/http2"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/keepalive"
 
 	"github.com/fleetdm/edr/agent/coalesce"
@@ -369,9 +373,11 @@ func startCommander(
 	logger.InfoContext(ctx, "commander polling", "host_id_prefix", safePrefix(hostID))
 }
 
-// startControlClient opens the persistent control-channel stream when EDR_CONTROL_ADDR is set. It dials the gateway over the same
-// pinned TLS the agent uses for HTTP, presents the host token at connect, and signals streamConnected so the commander suspends polling
-// while the stream is up. Opt-in: an empty ControlAddr leaves the agent on the short-poll path, so this changes nothing by default.
+// startControlClient opens the persistent control-channel stream to the server. The endpoint is derived from EDR_SERVER_URL (issue
+// #477): the push channel shares the server's address and port with the REST path, so there is nothing extra to configure. It dials
+// over the same pinned TLS the agent uses for HTTP, presents the host token at connect, and signals streamConnected so the commander
+// suspends polling while the stream is up. If the stream can't connect or won't stay up, the commander's GET /api/commands short-poll
+// remains the floor; the control channel is an always-on enhancement, not a separately-enabled feature.
 func startControlClient(
 	ctx context.Context,
 	cfg *config.Config,
@@ -381,21 +387,18 @@ func startControlClient(
 	streamConnected *atomic.Bool,
 	logger *slog.Logger,
 ) error {
-	if cfg.ControlAddr == "" {
-		return nil
-	}
 	if hostID == "" {
 		logger.WarnContext(ctx, "no host_id available; control channel disabled")
 		return nil
 	}
-	//nolint:contextcheck // BuildTLSConfig takes no context; its TLS-handshake callback intentionally uses context.Background (the
-	// handshake has no request context), the same call newAgentHTTPClient makes.
-	tlsCfg, err := enrollment.BuildTLSConfig(cfg.AllowInsecure, cfg.ServerFingerprint, logger)
+	//nolint:contextcheck // controlDialTarget only reaches enrollment.BuildTLSConfig, whose handshake callback intentionally uses
+	// context.Background (the TLS handshake has no request context); see its own nolint inside controlDialTarget.
+	target, creds, err := controlDialTarget(cfg, logger)
 	if err != nil {
 		return err
 	}
-	conn, err := grpc.NewClient(cfg.ControlAddr,
-		grpc.WithTransportCredentials(credentials.NewTLS(tlsCfg)),
+	conn, err := grpc.NewClient(target,
+		grpc.WithTransportCredentials(creds),
 		// Keep-alive PINGs detect a half-open link (laptop sleep, NAT rebind) on the long-lived stream, mirroring the HTTP/2 transport.
 		grpc.WithKeepaliveParams(keepalive.ClientParameters{
 			Time:                h2ReadIdleTimeout,
@@ -404,7 +407,7 @@ func startControlClient(
 		}),
 	)
 	if err != nil {
-		logger.ErrorContext(ctx, "control channel dial", "addr", cfg.ControlAddr, "err", err)
+		logger.ErrorContext(ctx, "control channel dial", "addr", target, "err", err)
 		return err
 	}
 	client := controlclient.New(controlclient.Config{
@@ -422,8 +425,38 @@ func startControlClient(
 		}
 		_ = conn.Close()
 	}()
-	logger.InfoContext(ctx, "control channel enabled", "addr", cfg.ControlAddr, "host_id_prefix", safePrefix(hostID))
+	logger.InfoContext(ctx, "control channel enabled", "addr", target, "host_id_prefix", safePrefix(hostID))
 	return nil
+}
+
+// controlDialTarget derives the control-channel gRPC dial target and transport credentials from EDR_SERVER_URL, so the push channel
+// shares the server's host and port with the REST path (issue #477): there is no separate control endpoint to configure. An https URL
+// dials over the same pinned TLS the REST client uses; an http URL (dev, EDR_ALLOW_INSECURE) dials cleartext with insecure credentials,
+// matching the server's TLS-terminated-by-proxy / plaintext posture. A missing port defaults to the scheme's standard port.
+func controlDialTarget(cfg *config.Config, logger *slog.Logger) (string, credentials.TransportCredentials, error) {
+	u, err := url.Parse(cfg.ServerURL)
+	if err != nil {
+		return "", nil, fmt.Errorf("parse EDR_SERVER_URL %q: %w", cfg.ServerURL, err)
+	}
+	port := u.Port()
+	if port == "" {
+		if u.Scheme == "https" {
+			port = "443"
+		} else {
+			port = "80"
+		}
+	}
+	target := net.JoinHostPort(u.Hostname(), port)
+	if u.Scheme != "https" {
+		return target, insecure.NewCredentials(), nil
+	}
+	//nolint:contextcheck // BuildTLSConfig takes no context; its TLS-handshake callback intentionally uses context.Background (the
+	// handshake has no request context), the same call newAgentHTTPClient makes.
+	tlsCfg, err := enrollment.BuildTLSConfig(cfg.AllowInsecure, cfg.ServerFingerprint, logger)
+	if err != nil {
+		return "", nil, err
+	}
+	return target, credentials.NewTLS(tlsCfg), nil
 }
 
 // startProcessReconciler runs the agent-side kill(pid,0) sweep that closes processes whose kernel exit notification went missing

--- a/agent/cmd/fleet-edr-agent/main_test.go
+++ b/agent/cmd/fleet-edr-agent/main_test.go
@@ -18,3 +18,40 @@ func TestNewAgentHTTPClient(t *testing.T) {
 	require.NotNil(t, transport)
 	require.NotNil(t, client)
 }
+
+// TestControlDialTarget pins how the control-channel dial endpoint and transport credentials are derived from EDR_SERVER_URL (issue
+// #477: the push channel shares the server's address with the REST path). An https URL dials with TLS credentials; an http URL (dev,
+// EDR_ALLOW_INSECURE) dials cleartext with insecure credentials; a missing port defaults to the scheme's standard port.
+func TestControlDialTarget(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name       string
+		serverURL  string
+		allowInsec bool
+		wantTarget string
+		wantSecure bool // true => TLS transport creds; false => insecure (cleartext h2c)
+	}{
+		{"https with explicit port", "https://edr.example.com:8088", false, "edr.example.com:8088", true},
+		{"https default port", "https://edr.example.com", false, "edr.example.com:443", true},
+		{"https self-signed dev", "https://192.168.64.1:8088", true, "192.168.64.1:8088", true},
+		{"http dev insecure", "http://127.0.0.1:8088", true, "127.0.0.1:8088", false},
+		{"http default port", "http://localhost", true, "localhost:80", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			target, creds, err := controlDialTarget(&config.Config{ServerURL: tc.serverURL, AllowInsecure: tc.allowInsec}, slog.Default())
+			require.NoError(t, err)
+			require.Equal(t, tc.wantTarget, target)
+			require.NotNil(t, creds)
+			// The insecure credentials report security level "NoSecurity"; TLS credentials report "tls". This is the stable, public way
+			// to assert which transport the agent chose without dialing.
+			info := creds.Info()
+			if tc.wantSecure {
+				require.Equal(t, "tls", info.SecurityProtocol)
+			} else {
+				require.Equal(t, "insecure", info.SecurityProtocol)
+			}
+		})
+	}
+}

--- a/agent/cmd/fleet-edr-agent/main_test.go
+++ b/agent/cmd/fleet-edr-agent/main_test.go
@@ -22,6 +22,8 @@ func TestNewAgentHTTPClient(t *testing.T) {
 // TestControlDialTarget pins how the control-channel dial endpoint and transport credentials are derived from EDR_SERVER_URL (issue
 // #477: the push channel shares the server's address with the REST path). An https URL dials with TLS credentials; an http URL (dev,
 // EDR_ALLOW_INSECURE) dials cleartext with insecure credentials; a missing port defaults to the scheme's standard port.
+//
+// spec:agent-control-channel/the-agent-derives-the-control-endpoint-from-its-server-url/the-control-endpoint-is-derived-from-the-server-url
 func TestControlDialTarget(t *testing.T) {
 	t.Parallel()
 	cases := []struct {

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -53,14 +53,13 @@ const (
 
 // Config is the resolved agent configuration.
 type Config struct {
-	ServerURL         string
-	EnrollSecret      string
-	TokenFile         string
-	ServerFingerprint string
-	// ControlAddr is the server's reachable control-channel gRPC endpoint, e.g. "edr.example.com:8090" (the server's address, not a
-	// bind literal like ":8090"). Empty (default) keeps the agent on the GET /api/commands short-poll; set EDR_CONTROL_ADDR to open the
-	// persistent push stream (the poll then becomes the fallback floor). From #477.
-	ControlAddr              string
+	// ServerURL is the base URL of the server. The agent reaches the REST API, the event-upload path, AND the persistent control-channel
+	// gRPC stream (issue #477) at this one address: the control endpoint is derived from it (same host and port), so there is no separate
+	// control address to configure.
+	ServerURL                string
+	EnrollSecret             string
+	TokenFile                string
+	ServerFingerprint        string
 	HostIDOverride           string
 	QueueDBPath              string
 	XPCService               string
@@ -114,7 +113,6 @@ func loadFrom(getenv func(string) string) (*Config, error) {
 	c.EnrollSecret = getenv("EDR_ENROLL_SECRET")
 	optional(&c.TokenFile, "EDR_TOKEN_FILE", getenv)
 	optional(&c.ServerFingerprint, "EDR_SERVER_FINGERPRINT", getenv)
-	optional(&c.ControlAddr, "EDR_CONTROL_ADDR", getenv)
 
 	c.AllowInsecure = getenv("EDR_ALLOW_INSECURE") == "1"
 	if c.ServerURL != "" {

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/pressly/goose/v3 v3.27.1
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/contrib/bridges/otelslog v0.18.0
+	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.68.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.68.0
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.19.0
@@ -97,7 +98,6 @@ require (
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/yashtewari/glob-intersection v0.2.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
-	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.68.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect

--- a/openspec/changes/control-channel-single-port/design.md
+++ b/openspec/changes/control-channel-single-port/design.md
@@ -1,0 +1,21 @@
+# Design: serve the control channel on the main port
+
+This records the transport and shutdown decisions behind `control-channel-single-port`. The spec deltas state observable behavior; this document records how it is realized and the alternative that was rejected.
+
+## Multiplex by content-type on one native HTTP/2 server
+
+`server/httpserver.RunAndShutdown` wraps the REST/UI handler: when a control gateway is supplied, requests with `r.ProtoMajor == 2` and an `application/grpc` content type are dispatched to the gateway's `grpc.Server.ServeHTTP`, and all others to the original handler. Over TLS, `ListenAndServeTLS` negotiates HTTP/2 via ALPN; in the TLS-terminated-by-proxy mode the server sets `http.Server.Protocols` to enable HTTP/1.1 plus cleartext HTTP/2 (h2c) so a front proxy can forward gRPC on the same upstream. The gateway's gRPC server carries no transport credentials of its own (TLS is terminated upstream) and keeps only its stream interceptor (host-token auth) and stats handler (OTel propagation).
+
+The agent derives its dial target from `EDR_SERVER_URL`: `host:port` (defaulting the port to the scheme's standard), with `credentials.NewTLS(pinnedConfig)` for `https` and insecure credentials for `http`. This is the same host, port, and transport security as the REST client.
+
+## Rejected: a connection multiplexer (cmux)
+
+The first implementation used `cmux` to split gRPC from REST by sniffing the connection's opening HTTP/2 frames for the `application/grpc` content type. It was rejected: `cmux`'s HTTP/2 header matcher injects a SETTINGS frame while sniffing, which corrupts persistent HTTP/2 connections that do not match. In dev-server testing every real agent's REST poll connection failed with `http2: PROTOCOL_ERROR` after the first request. Dispatching inside one native HTTP/2 server avoids sniffing entirely: net/http owns the HTTP/2 framing and the handler only reads an already-parsed request header. A unit test pins multi-request reuse over a single HTTP/2 connection so this regression cannot return.
+
+## Shutdown without grpc GracefulStop
+
+Because the gateway is served via `grpc.Server.ServeHTTP` (riding net/http's HTTP/2 server), `grpc.Server.GracefulStop` is unusable: its `serverHandlerTransport` has no `Drain`, so GracefulStop panics. Shutdown is instead driven by `http.Server.Shutdown`, with the gateway cancelling its live streams so their handlers return promptly: `Gateway.Stop` marks the gateway closing (a connection accepted mid-shutdown is rejected) and cancels every registered connection's context. The control streams are long-lived and would otherwise hold `http.Server.Shutdown` open until its deadline. The agent's keep-alive PINGs need no special server policy: net/http's HTTP/2 server answers them without gRPC's strict ping-flood GOAWAY, so the previous keepalive-enforcement option is dropped.
+
+## Deployment
+
+In the quickstart / single-VM model a front proxy (Caddy) terminates the public TLS and reverse-proxies to the server's plaintext port. The proxy SHALL forward to the upstream over HTTP/2 cleartext (h2c) so the bidirectional control stream is carried, not just HTTP/1.1 REST. The server's plaintext mode accepts h2c for exactly this.

--- a/openspec/changes/control-channel-single-port/proposal.md
+++ b/openspec/changes/control-channel-single-port/proposal.md
@@ -1,0 +1,18 @@
+# Serve the agent control channel on the main port
+
+## Why
+
+The push control channel (`push-command-channel`) shipped on its own gRPC listener, gated by an `EDR_CONTROL_ADDR` bind address on the server and a matching dial address on the agent. That is more deployment surface than the pilot envelope needs and more than the established endpoint products expose: CrowdStrike, SentinelOne, Microsoft Defender for Endpoint, and Carbon Black all run a single agent-initiated outbound connection on one port, always on, with the channel sharing the address the agent already uses. A second port means a second firewall rule, a second proxy route, and a second thing an operator can misconfigure, for no capability gain.
+
+This change folds the control channel onto the server's existing HTTPS listener and derives the agent's endpoint from its server URL, so there is nothing extra to configure on either side. The channel is always on; the short-poll remains the automatic fallback. The control channel was still off by default and unreleased, so this is an internal refinement with no migration for any deployment.
+
+## What changes
+
+- **One port.** The control-channel gRPC gateway is multiplexed onto the same listener and port as the REST API and UI. A single native HTTP/2 server dispatches by content-type: `application/grpc` to the gateway (via `grpc.Server.ServeHTTP`), everything else to the REST/UI handler. TLS is terminated once at that listener (or by the front proxy), so the gateway runs without its own transport credentials.
+- **No control-channel configuration.** `EDR_CONTROL_ADDR` is removed from both the server and the agent. The server needs no separate bind address; the agent derives the control endpoint from `EDR_SERVER_URL` (same host and port, same transport security). A still-set, no-longer-recognized control-address variable is inert.
+- **Always on, poll is the floor.** The agent attempts the control channel whenever a server URL and host identity are configured, with no enabling flag and no disabling flag. If the stream cannot connect or drops, the `GET /api/commands` short-poll continues to serve commands.
+
+## Affected specs
+
+- `server-configuration`: ADDED requirement that the control channel shares the server's single listener (multiplexed by content-type, no separate bind address). The existing "an environment variable the server no longer recognizes SHALL be inert" requirement already covers a still-set `EDR_CONTROL_ADDR`.
+- `agent-control-channel`: ADDED requirement that the agent derives the control endpoint from its server URL and keeps the channel always on with the short-poll as the fallback. The persistent-connection, auth, delivery, outcome, liveness, and revocation requirements from `push-command-channel` are unchanged.

--- a/openspec/changes/control-channel-single-port/specs/agent-control-channel/spec.md
+++ b/openspec/changes/control-channel-single-port/specs/agent-control-channel/spec.md
@@ -1,0 +1,12 @@
+## ADDED Requirements
+
+### Requirement: The agent derives the control endpoint from its server URL
+
+The agent SHALL derive the control-channel endpoint from its configured server URL, dialing the same host and port it uses for the REST API, over the same transport security: the pinned-TLS configuration for an `https` server URL, and cleartext for an `http` server URL (the development / proxy-terminated posture). The agent SHALL NOT require a separate control-channel address. The agent SHALL attempt the control channel whenever a server URL and a host identity are configured, without a separate enabling flag; when the stream cannot be established or is lost, the agent SHALL continue to serve commands over the `GET /api/commands` short-poll, which remains the fallback floor.
+
+#### Scenario: The control endpoint is derived from the server URL
+
+- **GIVEN** an agent configured with a server URL and no separate control-channel address
+- **WHEN** it opens the control channel
+- **THEN** it dials the same host and port as the server URL, with the same transport security
+- **AND** an `https` URL dials with the agent's pinned-TLS configuration while an `http` URL dials cleartext

--- a/openspec/changes/control-channel-single-port/specs/server-configuration/spec.md
+++ b/openspec/changes/control-channel-single-port/specs/server-configuration/spec.md
@@ -1,0 +1,12 @@
+## ADDED Requirements
+
+### Requirement: The agent control channel shares the main server listener
+
+The server SHALL serve the agent control-channel gRPC gateway on the same listener and port as the REST API and the UI, multiplexed by request content-type: gRPC requests (HTTP/2 with an `application/grpc` content type, which gRPC requires) are dispatched to the control gateway, and all other requests to the REST/UI handler. The server SHALL NOT expose a separate bind address for the control channel; there is no control-channel address environment variable. A deployment that still sets a no-longer-recognized control-channel address variable SHALL find it inert: boot succeeds and behavior is unchanged. When the server terminates TLS itself, gRPC and REST SHALL both be served over the single TLS listener using ALPN-negotiated HTTP/2; in the TLS-terminated-by-proxy mode the server SHALL also accept cleartext HTTP/2 (h2c), so a front proxy can forward the control stream to the same upstream as REST.
+
+#### Scenario: gRPC and REST share one port
+
+- **GIVEN** a server listening on a single address, whether it terminates TLS itself or runs behind a TLS-terminating proxy
+- **WHEN** an agent opens the control-channel gRPC stream and a client issues a REST request to the same server
+- **THEN** both are served on the same host and port, separated by request content-type
+- **AND** no separate control-channel bind address is configured on the server

--- a/openspec/changes/control-channel-single-port/tasks.md
+++ b/openspec/changes/control-channel-single-port/tasks.md
@@ -1,0 +1,23 @@
+## 1. Spec delta and decision
+
+- [x] 1.1 This proposal plus spec deltas pass `openspec validate control-channel-single-port --strict`
+- [x] 1.2 Record the cmux rejection and the ServeHTTP shutdown rework in `design.md`
+
+## 2. Server: multiplex on the main listener
+
+- [x] 2.1 Dispatch `application/grpc` HTTP/2 requests to the control gateway and all others to the REST/UI handler, in one native HTTP/2 server (`httpserver.RunAndShutdown`)
+- [x] 2.2 Enable cleartext HTTP/2 (h2c) in the TLS-terminated-by-proxy mode; rely on ALPN for the TLS mode
+- [x] 2.3 Build the gateway without transport credentials and serve it via `grpc.Server.ServeHTTP`; drop the separate listener and `EDR_CONTROL_ADDR`
+- [x] 2.4 Rework `Gateway.Stop` to cancel live streams (no `grpc.GracefulStop`, which panics under `ServeHTTP`); shutdown is driven by `http.Server.Shutdown`
+- [x] 2.5 Unit test: gRPC + HTTP/1.1 + HTTP/2 (including a reused HTTP/2 connection) coexist on one listener, TLS and plaintext; bidirectional control stream over net/http's HTTP/2
+
+## 3. Agent: derive the endpoint, always on
+
+- [x] 3.1 Derive the control endpoint from `EDR_SERVER_URL` (host:port, scheme-based transport security); remove `EDR_CONTROL_ADDR`
+- [x] 3.2 Attempt the channel unconditionally (no enabling flag); keep the short-poll as the fallback
+- [x] 3.3 Unit test for the server-URL-derived dial target and credentials
+
+## 4. Deployment
+
+- [ ] 4.1 Quickstart Caddy reverse-proxies to the upstream over h2c so the control stream is forwarded
+- [ ] 4.2 Validate the proxied control stream on the notarized RC (covered by the agent/extension RC re-test, #557)

--- a/packaging/caddy/Caddyfile
+++ b/packaging/caddy/Caddyfile
@@ -7,5 +7,11 @@
 # inspection, no managed WAF, so security telemetry uploads are never flagged as
 # attacks. The server enforces its own request-body cap, so none is set here.
 {$EDR_DOMAIN} {
-	reverse_proxy http://server:8088
+	# Forward to the server over HTTP/2 cleartext (h2c). h2c is required so the agent control-channel gRPC stream (issue #477) is
+	# proxied as HTTP/2 rather than downgraded to HTTP/1.1: the server multiplexes gRPC and REST on this one port and serves cleartext
+	# HTTP/2 behind the proxy. REST and UI traffic is re-originated over the same transport. flush_interval -1 disables response
+	# buffering so the long-lived bidirectional control stream is delivered frame-by-frame instead of buffered.
+	reverse_proxy h2c://server:8088 {
+		flush_interval -1
+	}
 }

--- a/server/cmd/fleet-edr-ingest/main.go
+++ b/server/cmd/fleet-edr-ingest/main.go
@@ -224,9 +224,10 @@ func run() error {
 	}); err != nil {
 		return err
 	}
-	// The ingest binary shuts down immediately on SIGTERM (nil drain, 0 delay). Graceful-drain wiring for the ingest tier is a
+	// The ingest binary serves only the event-intake HTTP surface (no agent control channel), so it passes a nil control mux: no gRPC
+	// multiplexing. It also shuts down immediately on SIGTERM (nil drain, 0 delay); graceful-drain wiring for the ingest tier is a
 	// follow-up to the server's (server-availability arc); nil/0 preserves the prior immediate-shutdown behavior with no regression.
-	return httpserver.RunAndShutdown(ctx, srv, logger, nil, 0)
+	return httpserver.RunAndShutdown(ctx, srv, nil, logger, nil, 0)
 }
 
 // openVisibility opens the required ClickHouse event archive (ADR-0015) and builds the visibility context. The ingest tier fans every

--- a/server/cmd/fleet-edr-server/main.go
+++ b/server/cmd/fleet-edr-server/main.go
@@ -221,11 +221,29 @@ func run() error {
 	}
 	// Multiplex the agent control-channel gRPC gateway onto the same listener as the REST/UI surface (issue #477): one port, one
 	// firewall rule, no separate control address to configure. TLS is terminated once at the shared listener (or by the front proxy),
-	// so the gateway's gRPC server runs without its own transport credentials. The watch loop drives cross-replica command delivery;
-	// RunAndShutdown owns the gateway's bounded graceful stop.
+	// so the gateway's gRPC server runs without its own transport credentials.
 	gw := responseCtx.BuildControlGateway(endpointCtx.Service(), detectionCtx.Service().RecordHostSeen)
-	go gw.Run(ctx)
-	return httpserver.RunAndShutdown(ctx, srv, gw, logger, drain, cfg.ShutdownDrain)
+	// Run the gateway's delivery loop on a context that SIGTERM does NOT cancel, so queued commands keep being pushed to still-connected
+	// agents throughout the shutdown drain window. RunAndShutdown calls control.Stop() after the drain window; controlChannel.Stop then
+	// cancels this loop and tears down the live streams. Tying the loop to the process context instead would kill delivery on SIGTERM
+	// while the streams stay up and the agents keep polling suppressed, stalling command delivery for the whole drain window.
+	gwCtx, gwCancel := context.WithCancel(context.WithoutCancel(ctx))
+	defer gwCancel() // controlChannel.Stop cancels this on shutdown; the defer is a belt-and-suspenders guard against a context leak
+	go gw.Run(gwCtx)
+	return httpserver.RunAndShutdown(ctx, srv, controlChannel{ControlMux: gw, stopRun: gwCancel}, logger, drain, cfg.ShutdownDrain)
+}
+
+// controlChannel adapts the response control gateway to httpserver.ControlMux so shutdown also ends the gateway's delivery loop. The
+// gateway's ServeHTTP is promoted from the embedded interface; Stop first cancels the delivery-loop context (started with SIGTERM
+// cancellation stripped, so the loop survives the drain window) and then tears down the live streams via the gateway's own Stop.
+type controlChannel struct {
+	httpserver.ControlMux
+	stopRun context.CancelFunc
+}
+
+func (c controlChannel) Stop() {
+	c.stopRun()
+	c.ControlMux.Stop()
 }
 
 // openContexts wires every bounded context and applies each one's schema under a single MySQL advisory lock. Under a rolling

--- a/server/cmd/fleet-edr-server/main.go
+++ b/server/cmd/fleet-edr-server/main.go
@@ -4,13 +4,11 @@ package main
 
 import (
 	"context"
-	"crypto/tls"
 	"errors"
 	"fmt"
 	"io"
 	"io/fs"
 	"log/slog"
-	"net"
 	"net/http"
 	"os"
 	"strings"
@@ -221,10 +219,13 @@ func run() error {
 	if err := configureTLS(ctx, logger, srv, cfg); err != nil {
 		return err
 	}
-	if err := startControlGateway(ctx, logger, cfg, srv.TLSConfig, responseCtx, endpointCtx, detectionCtx); err != nil {
-		return err
-	}
-	return httpserver.RunAndShutdown(ctx, srv, logger, drain, cfg.ShutdownDrain)
+	// Multiplex the agent control-channel gRPC gateway onto the same listener as the REST/UI surface (issue #477): one port, one
+	// firewall rule, no separate control address to configure. TLS is terminated once at the shared listener (or by the front proxy),
+	// so the gateway's gRPC server runs without its own transport credentials. The watch loop drives cross-replica command delivery;
+	// RunAndShutdown owns the gateway's bounded graceful stop.
+	gw := responseCtx.BuildControlGateway(endpointCtx.Service(), detectionCtx.Service().RecordHostSeen)
+	go gw.Run(ctx)
+	return httpserver.RunAndShutdown(ctx, srv, gw, logger, drain, cfg.ShutdownDrain)
 }
 
 // openContexts wires every bounded context and applies each one's schema under a single MySQL advisory lock. Under a rolling
@@ -641,49 +642,6 @@ func configureTLS(ctx context.Context, logger *slog.Logger, srv *http.Server, cf
 		KeyFile:  cfg.TLSKeyFile,
 		Logger:   logger,
 	})
-}
-
-// startControlGateway mounts the agent control-channel gRPC gateway on its own listener when EDR_CONTROL_ADDR is set. It is opt-in: an
-// empty ControlAddr leaves the gateway unmounted and agents use the GET /api/commands short-poll path, so this changes nothing in the
-// default deployment. When enabled it serves on a dedicated listener (the HTTP serve path is untouched), reusing the server's TLS 1.3
-// cert so the agent reaches it on the same pinned identity; in TLS-terminated-by-proxy mode it serves plaintext gRPC behind the proxy,
-// matching the HTTP posture. The watch loop runs alongside, and a graceful stop on ctx cancellation lets agents reconnect (and fall
-// back to polling) against a peer replica.
-func startControlGateway(
-	ctx context.Context,
-	logger *slog.Logger,
-	cfg *config.Config,
-	tlsConfig *tls.Config,
-	responseCtx *responsebootstrap.Response,
-	endpointCtx *endpointbootstrap.Endpoint,
-	detectionCtx *detectionbootstrap.Detection,
-) error {
-	if cfg.ControlAddr == "" {
-		return nil
-	}
-	// Reuse the HTTP server's already-built TLS config (srv.TLSConfig) rather than loading the cert a second time: one cert holder and
-	// one SIGHUP reload watcher keeps the gateway and the HTTP listener on the same certificate through a rotation, preserving the
-	// agent's single pinned identity. It is nil in TLS-terminated-by-proxy mode, which serves the gateway plaintext behind the proxy,
-	// matching the HTTP posture.
-	gw := responseCtx.BuildControlGateway(endpointCtx.Service(), detectionCtx.Service().RecordHostSeen, tlsConfig)
-	var lc net.ListenConfig
-	lis, err := lc.Listen(ctx, "tcp", cfg.ControlAddr)
-	if err != nil {
-		logger.ErrorContext(ctx, "control gateway listen", "addr", cfg.ControlAddr, "err", err)
-		return err
-	}
-	go func() {
-		if serveErr := gw.Serve(lis); serveErr != nil {
-			logger.ErrorContext(ctx, "control gateway serve", "err", serveErr)
-		}
-	}()
-	go gw.Run(ctx)
-	go func() {
-		<-ctx.Done()
-		gw.Stop() // GracefulStop drains in-flight RPCs and closes the listener
-	}()
-	logger.InfoContext(ctx, "control gateway serving", "addr", cfg.ControlAddr, "tls", tlsConfig != nil)
-	return nil
 }
 
 func runDetection(ctx context.Context, detectionCtx *detectionbootstrap.Detection, logger *slog.Logger) {

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -65,11 +65,9 @@ func DefaultOIDCScopes() []string { return []string{"openid", "email", "profile"
 type Config struct {
 	DSN           string
 	ClickHouseDSN string
-	ListenAddr    string
-	// ControlAddr is the bind address for the agent control-channel gRPC gateway (the push replacement for GET /api/commands polling,
-	// issue #477). Deployment-shape config like ListenAddr. Empty (the default) leaves the gateway unmounted, so agents use the
-	// short-poll path; set EDR_CONTROL_ADDR (for example ":8090") to serve the control channel on its own TLS listener.
-	ControlAddr  string
+	// ListenAddr is the single bind address for the whole server: the REST API, the embedded UI, and the agent control-channel gRPC
+	// gateway are multiplexed on it (issue #477), so there is no separate control-channel address to configure.
+	ListenAddr   string
 	EnrollSecret string
 	TLSCertFile  string
 	TLSKeyFile   string
@@ -233,7 +231,6 @@ func loadCoreEnv(c *Config, getenv func(string) string, errs *[]error) {
 		*errs = append(*errs, errors.New("EDR_DSN is required (use EDR_DSN_FILE for docker-secret mounts)"))
 	}
 	optionalStr(&c.ListenAddr, "EDR_LISTEN_ADDR", getenv)
-	optionalStr(&c.ControlAddr, "EDR_CONTROL_ADDR", getenv)
 	requireStr(&c.EnrollSecret, "EDR_ENROLL_SECRET", getenv, errs, true)
 	optionalStr(&c.TLSCertFile, "EDR_TLS_CERT_FILE", getenv)
 	optionalStr(&c.TLSKeyFile, "EDR_TLS_KEY_FILE", getenv)

--- a/server/httpserver/multiplex_test.go
+++ b/server/httpserver/multiplex_test.go
@@ -1,0 +1,170 @@
+package httpserver_test
+
+import (
+	"context"
+	"crypto/tls"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/http2"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/health"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+
+	"github.com/fleetdm/edr/server/httpserver"
+)
+
+// grpcControlMux adapts a *grpc.Server to httpserver.ControlMux for the multiplex test: ServeHTTP is the gRPC-over-HTTP/2 handler and
+// Stop is a graceful stop, mirroring what the real control gateway does.
+type grpcControlMux struct{ s *grpc.Server }
+
+func (g grpcControlMux) ServeHTTP(w http.ResponseWriter, r *http.Request) { g.s.ServeHTTP(w, r) }
+
+func (g grpcControlMux) Stop() { g.s.GracefulStop() }
+
+func waitListening(t *testing.T, addr string) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel()
+		c, err := (&net.Dialer{}).DialContext(ctx, "tcp", addr)
+		if err != nil {
+			return false
+		}
+		_ = c.Close()
+		return true
+	}, 3*time.Second, 20*time.Millisecond, "server never started listening on %s", addr)
+}
+
+// TestRunAndShutdown_MultiplexesGRPCAndHTTP pins the shared-port design (issue #477): the agent control-channel gRPC gateway and the
+// REST/UI HTTP surface are served on ONE listener, separated by content-type. It asserts that a gRPC call (HTTP/2,
+// application/grpc) and HTTP requests over both HTTP/1.1 and HTTP/2 all succeed on the same address, in both the server-terminates-TLS
+// and the plaintext (proxy-terminated) modes, and that a ctx cancel still drives a clean shutdown.
+func TestRunAndShutdown_MultiplexesGRPCAndHTTP(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name   string
+		useTLS bool
+	}{
+		{"server terminates TLS", true},
+		{"plaintext (proxy-terminated)", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			addr := freeAddr(t)
+
+			mux := http.NewServeMux()
+			mux.HandleFunc("GET /ping", func(w http.ResponseWriter, r *http.Request) {
+				// Echo the protocol so the test can assert HTTP/2 REST was served (not misrouted to the gRPC server).
+				_, _ = io.WriteString(w, r.Proto) //nolint:gosec // G705: r.Proto is the negotiated protocol string, not user-controlled input
+			})
+			srv := &http.Server{Addr: addr, Handler: mux, ReadHeaderTimeout: 5 * time.Second}
+			if tc.useTLS {
+				srv.TLSConfig = &tls.Config{Certificates: []tls.Certificate{selfSignedTLS(t)}, MinVersion: tls.VersionTLS12}
+			}
+
+			grpcSrv := grpc.NewServer()
+			hs := health.NewServer()
+			hs.SetServingStatus("", healthpb.HealthCheckResponse_SERVING)
+			healthpb.RegisterHealthServer(grpcSrv, hs)
+
+			ctx, cancel := context.WithCancel(context.Background())
+			done := make(chan error, 1)
+			go func() {
+				done <- httpserver.RunAndShutdown(ctx, srv, grpcControlMux{s: grpcSrv}, slog.Default(), nil, 0)
+			}()
+			waitListening(t, addr)
+
+			scheme := "http"
+			var grpcCreds credentials.TransportCredentials
+			if tc.useTLS {
+				scheme = "https"
+				grpcCreds = credentials.NewTLS(&tls.Config{InsecureSkipVerify: true}) //nolint:gosec // in-test self-signed cert
+			} else {
+				grpcCreds = insecure.NewCredentials()
+			}
+
+			// gRPC over HTTP/2 (content-type application/grpc) must reach the gRPC server.
+			cc, err := grpc.NewClient(addr, grpc.WithTransportCredentials(grpcCreds))
+			require.NoError(t, err)
+			defer func() { _ = cc.Close() }()
+			callCtx, callCancel := context.WithTimeout(ctx, 3*time.Second)
+			defer callCancel()
+			resp, err := healthpb.NewHealthClient(cc).Check(callCtx, &healthpb.HealthCheckRequest{})
+			require.NoError(t, err, "gRPC health check on the shared port")
+			assert.Equal(t, healthpb.HealthCheckResponse_SERVING, resp.GetStatus())
+
+			// HTTP/1.1 REST on the same port must reach the HTTP server.
+			body, proto := httpGet(t, h1Client(tc.useTLS), scheme+"://"+addr+"/ping")
+			assert.Equal(t, "HTTP/1.1", body, "HTTP/1.1 request body echoes its own proto")
+			assert.Equal(t, "HTTP/1.1", proto)
+
+			// HTTP/2 REST (NOT application/grpc) must reach the HTTP server, not be swallowed by the gRPC matcher. Reuse ONE client
+			// (one pooled HTTP/2 connection) across multiple requests, the way a real Go agent does: the multiplexer must not corrupt
+			// the persistent connection after the first request.
+			restClient := h2Client(t, tc.useTLS, addr)
+			for req := range 3 {
+				h2body, proto := httpGet(t, restClient, scheme+"://"+addr+"/ping")
+				assert.Equal(t, "HTTP/2.0", h2body, "request %d: HTTP/2 REST is multiplexed to the HTTP server", req)
+				assert.Equal(t, "HTTP/2.0", proto, "request %d stays on HTTP/2 over the reused connection", req)
+			}
+
+			cancel()
+			select {
+			case err := <-done:
+				require.NoError(t, err, "graceful shutdown returns nil")
+			case <-time.After(httpserver.ShutdownTimeout + 2*time.Second):
+				t.Fatal("RunAndShutdown did not return after ctx cancel")
+			}
+		})
+	}
+}
+
+func httpGet(t *testing.T, c *http.Client, url string) (body, proto string) {
+	t.Helper()
+	resp, err := c.Get(url) //nolint:noctx // short-lived test client
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	b, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	return string(b), resp.Proto
+}
+
+// h1Client is an HTTP/1.1 client (no HTTP/2) so the HTTP/1.1 branch of the multiplexer is exercised deterministically.
+func h1Client(useTLS bool) *http.Client {
+	tr := &http.Transport{TLSNextProto: map[string]func(string, *tls.Conn) http.RoundTripper{}}
+	if useTLS {
+		tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} //nolint:gosec // in-test self-signed cert
+	}
+	return &http.Client{Transport: tr, Timeout: 3 * time.Second}
+}
+
+// h2Client forces HTTP/2: over TLS via ALPN, and over cleartext (h2c) via a plain dialer, so the multiplexer's content-type split is
+// exercised with REST traffic that rides the same HTTP/2 the gRPC channel uses.
+func h2Client(t *testing.T, useTLS bool, addr string) *http.Client {
+	t.Helper()
+	if useTLS {
+		return &http.Client{
+			Transport: &http2.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}, //nolint:gosec // in-test self-signed cert
+			Timeout:   3 * time.Second,
+		}
+	}
+	return &http.Client{
+		Transport: &http2.Transport{
+			AllowHTTP: true,
+			DialTLSContext: func(ctx context.Context, network, a string, _ *tls.Config) (net.Conn, error) {
+				return (&net.Dialer{}).DialContext(ctx, network, a)
+			},
+		},
+		Timeout: 3 * time.Second,
+	}
+}

--- a/server/httpserver/multiplex_test.go
+++ b/server/httpserver/multiplex_test.go
@@ -23,12 +23,13 @@ import (
 )
 
 // grpcControlMux adapts a *grpc.Server to httpserver.ControlMux for the multiplex test: ServeHTTP is the gRPC-over-HTTP/2 handler and
-// Stop is a graceful stop, mirroring what the real control gateway does.
+// Stop force-stops the server. GracefulStop is avoided deliberately: it panics ("Drain is not implemented") once the server has served
+// via grpc.Server.ServeHTTP, which is the production path here; the real gateway's Stop likewise ends streams rather than GracefulStop.
 type grpcControlMux struct{ s *grpc.Server }
 
 func (g grpcControlMux) ServeHTTP(w http.ResponseWriter, r *http.Request) { g.s.ServeHTTP(w, r) }
 
-func (g grpcControlMux) Stop() { g.s.GracefulStop() }
+func (g grpcControlMux) Stop() { g.s.Stop() }
 
 func waitListening(t *testing.T, addr string) {
 	t.Helper()

--- a/server/httpserver/multiplex_test.go
+++ b/server/httpserver/multiplex_test.go
@@ -48,6 +48,8 @@ func waitListening(t *testing.T, addr string) {
 // REST/UI HTTP surface are served on ONE listener, separated by content-type. It asserts that a gRPC call (HTTP/2,
 // application/grpc) and HTTP requests over both HTTP/1.1 and HTTP/2 all succeed on the same address, in both the server-terminates-TLS
 // and the plaintext (proxy-terminated) modes, and that a ctx cancel still drives a clean shutdown.
+//
+// spec:server-configuration/the-agent-control-channel-shares-the-main-server-listener/grpc-and-rest-share-one-port
 func TestRunAndShutdown_MultiplexesGRPCAndHTTP(t *testing.T) {
 	t.Parallel()
 	for _, tc := range []struct {

--- a/server/httpserver/serve.go
+++ b/server/httpserver/serve.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
+	"strings"
 	"sync/atomic"
 	"time"
 )
@@ -27,28 +28,53 @@ func (d *DrainState) BeginDrain() { d.draining.Store(true) }
 // IsDraining reports whether graceful-shutdown draining has begun.
 func (d *DrainState) IsDraining() bool { return d.draining.Load() }
 
+// ControlMux is the agent control-channel gateway as RunAndShutdown consumes it: an HTTP/2 handler (the gateway's gRPC server exposed
+// via grpc.Server.ServeHTTP) plus a bounded graceful stop. It is an interface so httpserver does not depend on the response context's
+// concrete gateway type. A nil ControlMux serves HTTP only (the ingest binary and tests).
+type ControlMux interface {
+	http.Handler
+	Stop()
+}
+
 // RunAndShutdown starts srv in a background goroutine, blocks until ctx is cancelled or the server returns a fatal error, then
 // performs a graceful shutdown. It serves TLS when srv.TLSConfig is populated (ConfigureTLS ran, the default), and plaintext HTTP
 // when it is nil. The server terminates TLS itself by default (issue #140); the nil-TLSConfig plaintext path is reached only when
 // the operator opts into EDR_TLS_TERMINATED_BY_PROXY, i.e. a TLS-terminating proxy is in front (callers skip ConfigureTLS then).
+//
+// When control is non-nil, the agent control-channel gRPC gateway shares the SAME listener and port as the REST/UI surface (issue
+// #477): one native HTTP/2 server dispatches each request by content-type, sending application/grpc to the gateway (gRPC over HTTP/2)
+// and everything else to the REST/UI handler. This keeps the whole product on one port with one firewall rule and no separate control
+// address to configure, without byte-sniffing the connection (which corrupts persistent HTTP/2). Over TLS, HTTP/2 is negotiated via
+// ALPN by ListenAndServeTLS; in the plaintext proxy-terminated mode, cleartext HTTP/2 (h2c) is enabled so the front proxy can forward
+// gRPC. A nil control serves HTTP only.
 //
 // Returns the server-side error on abnormal exit, or nil on a ctx-driven graceful shutdown (which also logs "shutdown complete"
 // on the way out).
 //
 // On ctx cancellation (SIGTERM) the server enters a drain phase before closing the listener: drain.BeginDrain() flips /readyz to
 // 503 so a load balancer stops routing new requests here, then the server stays up for drainDelay so the LB observes that and
-// removes the replica from rotation. In-flight and new requests are served throughout the drain window; only after it does
-// srv.Shutdown close the listener and wait (up to ShutdownTimeout) for in-flight requests to finish. A nil drain or a zero
-// drainDelay skips the drain phase (the single-process and test paths). The binary exits within drainDelay + ShutdownTimeout.
-func RunAndShutdown(ctx context.Context, srv *http.Server, logger *slog.Logger, drain *DrainState, drainDelay time.Duration) error {
+// removes the replica from rotation. In-flight and new requests are served throughout the drain window; only after it do the control
+// gateway's bounded graceful stop and srv.Shutdown close the listener and wait (up to ShutdownTimeout) for in-flight work to finish. A
+// nil drain or a zero drainDelay skips the drain phase (the single-process and test paths). The binary exits within drainDelay +
+// ShutdownTimeout.
+func RunAndShutdown(
+	ctx context.Context,
+	srv *http.Server,
+	control ControlMux,
+	logger *slog.Logger,
+	drain *DrainState,
+	drainDelay time.Duration,
+) error {
+	if control != nil {
+		mountControlChannel(srv, control)
+	}
+
 	serverErr := make(chan error, 1)
 	go func() {
-		// srv.TLSConfig is populated by ConfigureTLS when the server terminates TLS itself. When it's nil the operator opted into
-		// EDR_TLS_TERMINATED_BY_PROXY (a TLS-terminating proxy is in front), so we serve plaintext HTTP. Branching on TLSConfig
-		// keeps the proxy-mode plumbing out of this function's signature and its two callers.
 		var serveErr error
 		if srv.TLSConfig != nil {
-			// ConfigureTLS owns the cert source via GetCertificate; pass empty strings.
+			// ConfigureTLS owns the cert source via GetCertificate; pass empty strings. ListenAndServeTLS negotiates HTTP/2 via ALPN, so
+			// the gRPC dispatch handler sees application/grpc requests over HTTP/2.
 			serveErr = srv.ListenAndServeTLS("", "")
 		} else {
 			serveErr = srv.ListenAndServe()
@@ -84,6 +110,11 @@ func RunAndShutdown(ctx context.Context, srv *http.Server, logger *slog.Logger, 
 		}
 	}
 
+	// Stop the control gateway first: its bounded GracefulStop drains in-flight RPCs and force-closes the long-lived control streams
+	// after the grace window, so they can't hold shutdown open. Then drain HTTP.
+	if control != nil {
+		control.Stop()
+	}
 	// Derive the shutdown deadline context from ctx via WithoutCancel so it inherits ctx's values (trace-id, logger attrs) but NOT ctx's
 	// cancellation: otherwise srv.Shutdown would return immediately because ctx is already Done. http.Server.Shutdown uses its context
 	// purely to decide when to give up on in-flight connections, so a fresh, timeout-bounded, values-inherited context is the correct
@@ -95,4 +126,24 @@ func RunAndShutdown(ctx context.Context, srv *http.Server, logger *slog.Logger, 
 	}
 	logger.InfoContext(shutdownCtx, "shutdown complete")
 	return nil
+}
+
+// mountControlChannel wraps srv.Handler so application/grpc HTTP/2 requests are dispatched to the control gateway and all other
+// requests to the original REST/UI handler. In the plaintext (proxy-terminated) mode it also enables cleartext HTTP/2 so the front
+// proxy can forward gRPC; over TLS, HTTP/2 comes from ALPN.
+func mountControlChannel(srv *http.Server, control ControlMux) {
+	base := srv.Handler
+	srv.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.ProtoMajor == 2 && strings.HasPrefix(r.Header.Get("Content-Type"), "application/grpc") {
+			control.ServeHTTP(w, r)
+			return
+		}
+		base.ServeHTTP(w, r)
+	})
+	if srv.TLSConfig == nil {
+		protocols := new(http.Protocols)
+		protocols.SetHTTP1(true)
+		protocols.SetUnencryptedHTTP2(true)
+		srv.Protocols = protocols
+	}
 }

--- a/server/httpserver/serve.go
+++ b/server/httpserver/serve.go
@@ -29,8 +29,9 @@ func (d *DrainState) BeginDrain() { d.draining.Store(true) }
 func (d *DrainState) IsDraining() bool { return d.draining.Load() }
 
 // ControlMux is the agent control-channel gateway as RunAndShutdown consumes it: an HTTP/2 handler (the gateway's gRPC server exposed
-// via grpc.Server.ServeHTTP) plus a bounded graceful stop. It is an interface so httpserver does not depend on the response context's
-// concrete gateway type. A nil ControlMux serves HTTP only (the ingest binary and tests).
+// via grpc.Server.ServeHTTP) plus a Stop that returns promptly after ending the long-lived control streams, so http.Server.Shutdown
+// can then drain. It is an interface so httpserver does not depend on the response context's concrete gateway type. A nil ControlMux
+// serves HTTP only (the ingest binary and tests).
 type ControlMux interface {
 	http.Handler
 	Stop()
@@ -53,10 +54,10 @@ type ControlMux interface {
 //
 // On ctx cancellation (SIGTERM) the server enters a drain phase before closing the listener: drain.BeginDrain() flips /readyz to
 // 503 so a load balancer stops routing new requests here, then the server stays up for drainDelay so the LB observes that and
-// removes the replica from rotation. In-flight and new requests are served throughout the drain window; only after it do the control
-// gateway's bounded graceful stop and srv.Shutdown close the listener and wait (up to ShutdownTimeout) for in-flight work to finish. A
-// nil drain or a zero drainDelay skips the drain phase (the single-process and test paths). The binary exits within drainDelay +
-// ShutdownTimeout.
+// removes the replica from rotation. In-flight and new requests are served throughout the drain window; only after it does the control
+// gateway's Stop end the long-lived control streams and srv.Shutdown close the listener and wait (up to ShutdownTimeout) for in-flight
+// work to finish. A nil drain or a zero drainDelay skips the drain phase (the single-process and test paths). The binary exits within
+// drainDelay + ShutdownTimeout.
 func RunAndShutdown(
 	ctx context.Context,
 	srv *http.Server,
@@ -110,8 +111,9 @@ func RunAndShutdown(
 		}
 	}
 
-	// Stop the control gateway first: its bounded GracefulStop drains in-flight RPCs and force-closes the long-lived control streams
-	// after the grace window, so they can't hold shutdown open. Then drain HTTP.
+	// Stop the control gateway first: Stop cancels the long-lived control streams so their handlers return, otherwise they would hold
+	// http.Server.Shutdown open until its deadline. (The gateway is served via grpc.Server.ServeHTTP, where grpc's own GracefulStop is
+	// unusable, so Stop ends the streams directly.) Then drain HTTP.
 	if control != nil {
 		control.Stop()
 	}

--- a/server/httpserver/serve_test.go
+++ b/server/httpserver/serve_test.go
@@ -96,7 +96,7 @@ func TestRunAndShutdown_DrainThenGracefulShutdown(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
 	const drainDelay = 100 * time.Millisecond
-	go func() { done <- httpserver.RunAndShutdown(ctx, srv, slog.Default(), drain, drainDelay) }()
+	go func() { done <- httpserver.RunAndShutdown(ctx, srv, nil, slog.Default(), drain, drainDelay) }()
 
 	client := &http.Client{Transport: &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true, MinVersion: tls.VersionTLS12}, //nolint:gosec // test client against a self-signed test cert

--- a/server/response/bootstrap/bootstrap.go
+++ b/server/response/bootstrap/bootstrap.go
@@ -2,7 +2,6 @@ package bootstrap
 
 import (
 	"context"
-	"crypto/tls"
 	"errors"
 	"log/slog"
 	"net/http"
@@ -107,16 +106,16 @@ func (r *Response) Service() api.Service { return r.svc }
 
 // BuildControlGateway constructs the agent control-channel gateway for this context and wires the fast-path notifier so a command
 // queued on this replica is pushed to a locally-held connection immediately. cmd/main supplies the cross-context dependencies (the
-// host-token verifier from endpoint, the last-seen closure from detection) and owns serving the returned gateway's gRPC server and
-// running its watch loop. The gateway uses the concrete service (which carries the gateway-only ListPendingForHosts query), so this
-// stays inside the response context rather than widening the public api.Service.
-func (r *Response) BuildControlGateway(verifier gateway.TokenVerifier, heartbeat gateway.Heartbeat, tlsConfig *tls.Config) *gateway.Gateway {
+// host-token verifier from endpoint, the last-seen closure from detection), multiplexes the returned gateway's gRPC server onto the
+// main HTTPS listener, and runs its watch loop. TLS is terminated once at that shared listener (or by the front proxy), so the gateway
+// runs without its own transport credentials. The gateway uses the concrete service (which carries the gateway-only
+// ListPendingForHosts query), so this stays inside the response context rather than widening the public api.Service.
+func (r *Response) BuildControlGateway(verifier gateway.TokenVerifier, heartbeat gateway.Heartbeat) *gateway.Gateway {
 	gw := gateway.New(gateway.Deps{
 		Source:    r.svc,
 		Verifier:  verifier,
 		Heartbeat: heartbeat,
 		Logger:    r.logger,
-		TLSConfig: tlsConfig,
 	})
 	r.svc.SetNotifier(gw.Notify)
 	return gw

--- a/server/response/internal/gateway/gateway.go
+++ b/server/response/internal/gateway/gateway.go
@@ -14,19 +14,17 @@ package gateway
 
 import (
 	"context"
-	"crypto/tls"
 	"errors"
 	"io"
 	"log/slog"
-	"net"
+	"net/http"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/credentials"
-	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
@@ -42,12 +40,6 @@ const (
 	defaultWatchInterval      = 1 * time.Second
 	defaultLivenessInterval   = 30 * time.Second
 	defaultRevocationInterval = 5 * time.Second
-	// defaultStopGrace bounds the graceful shutdown. Control streams are long-lived and never end on their own, so an unbounded
-	// GracefulStop would hang shutdown forever; after this window we force the streams closed and the agents reconnect (and poll).
-	defaultStopGrace = 5 * time.Second
-	// clientKeepaliveMinTime is the minimum spacing the server tolerates between agent keep-alive PINGs. It must be at most the agent's
-	// keep-alive interval (the agent reuses its 15s HTTP/2 ReadIdleTimeout) or the server GOAWAYs the connection with "too_many_pings".
-	clientKeepaliveMinTime = 10 * time.Second
 
 	// notifyBuffer bounds the fast-path signal queue. A full buffer is harmless: the 1s watch is the backstop, so a dropped notify just
 	// means the command waits up to one watch interval instead of arriving immediately.
@@ -77,9 +69,6 @@ type Deps struct {
 	Verifier  TokenVerifier
 	Heartbeat Heartbeat // optional; nil disables the last-seen bump
 	Logger    *slog.Logger
-	// TLSConfig, when set, secures the gRPC server with these credentials (the server's TLS 1.3 cert, so the agent reaches the control
-	// channel on the same pinned identity as the HTTP path). Nil serves without transport credentials, used only by in-memory tests.
-	TLSConfig *tls.Config
 }
 
 // Gateway holds the agent control connections and the gRPC server that serves them.
@@ -100,7 +89,10 @@ type Gateway struct {
 	watchInterval      time.Duration
 	livenessInterval   time.Duration
 	revocationInterval time.Duration
-	stopGrace          time.Duration
+
+	// closing is set by Stop so a connection accepted during shutdown is rejected rather than stranding http.Server.Shutdown on a
+	// long-lived stream. Per-replica ephemeral flag.
+	closing atomic.Bool
 }
 
 // New builds a Gateway and its gRPC server (auth stream interceptor + OTel trace propagation over stream metadata). Panics if a
@@ -126,55 +118,38 @@ func New(deps Deps) *Gateway {
 		watchInterval:      defaultWatchInterval,
 		livenessInterval:   defaultLivenessInterval,
 		revocationInterval: defaultRevocationInterval,
-		stopGrace:          defaultStopGrace,
 	}
 	opts := []grpc.ServerOption{
 		grpc.StatsHandler(otelgrpc.NewServerHandler()),
 		grpc.StreamInterceptor(g.authInterceptor),
-		// Permit the agent's keep-alive PINGs. The agent pings on a short cadence (matching its HTTP/2 half-open detection) to notice a
-		// dropped link fast; without this the gRPC default enforcement policy (5-minute floor) GOAWAYs the connection with
-		// "too_many_pings", so the control stream churns every minute. MinTime must be at most the agent's ping interval.
-		grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
-			MinTime:             clientKeepaliveMinTime,
-			PermitWithoutStream: true,
-		}),
 	}
-	if deps.TLSConfig != nil {
-		opts = append(opts, grpc.Creds(credentials.NewTLS(deps.TLSConfig)))
-	}
+	// No grpc.Creds and no keepalive enforcement: the gateway is served via grpc.Server.ServeHTTP behind the shared HTTPS listener
+	// (cmd/main multiplexes it with the REST/UI surface), so it rides net/http's HTTP/2 server. Transport-level options do not apply
+	// there: TLS is terminated once at that listener (or the front proxy), and net/http answers the agent's keep-alive PINGs itself
+	// without gRPC's strict ping-flood GOAWAY. ServeHTTP honors the stream interceptor (host-token auth) and the stats handler (OTel),
+	// which is all the gateway needs.
 	g.grpc = grpc.NewServer(opts...)
 	control.RegisterControlChannelServer(g.grpc, g)
 	return g
 }
 
-// GRPCServer returns the configured gRPC server. Exposed for tests; production uses Serve/Stop.
+// GRPCServer returns the configured gRPC server. Exposed for tests that serve it over an in-memory listener.
 func (g *Gateway) GRPCServer() *grpc.Server { return g.grpc }
 
-// Serve accepts connections on lis until Stop is called. cmd/main supplies a TCP listener on EDR_CONTROL_ADDR; the gRPC server applies
-// the TLS credentials from Deps. grpc.ErrServerStopped is the normal shutdown signal, not an error, so it is mapped to nil; the caller
-// only logs genuine serve failures.
-func (g *Gateway) Serve(lis net.Listener) error {
-	if err := g.grpc.Serve(lis); err != nil && !errors.Is(err, grpc.ErrServerStopped) {
-		return err
-	}
-	return nil
-}
+// ServeHTTP serves the control channel as a gRPC-over-HTTP/2 handler. cmd/main mounts it on the shared HTTPS listener so the control
+// gateway and the REST/UI surface share one port (issue #477): the front handler dispatches application/grpc requests here. TLS is
+// terminated upstream, so this rides net/http's HTTP/2 server with no transport credentials of its own; auth is the per-stream
+// host-token interceptor.
+func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) { g.grpc.ServeHTTP(w, r) }
 
-// Stop drains in-flight RPCs and closes all connections, bounded by stopGrace. Long-lived control streams never end on their own, so a
-// plain GracefulStop would block shutdown indefinitely; after the grace window we force them closed. Either way agents reconnect (and
-// fall back to polling) against a peer replica rather than hanging the shutdown.
+// Stop tears down every live control stream so the shared HTTP server's shutdown can complete. Because the gateway is served via
+// grpc.Server.ServeHTTP (riding net/http's HTTP/2 server), grpc.Server.GracefulStop is unusable here (it panics: the ServeHTTP
+// transport has no Drain). Instead we mark the gateway closing (so a connection accepted mid-shutdown is rejected) and cancel every
+// registered connection's context, which makes its Connect handler return promptly; the caller's http.Server.Shutdown then drains the
+// now-finished requests. Agents reconnect (and fall back to polling) against a peer replica rather than hanging the shutdown.
 func (g *Gateway) Stop() {
-	done := make(chan struct{})
-	go func() {
-		g.grpc.GracefulStop()
-		close(done)
-	}()
-	select {
-	case <-done:
-	case <-time.After(g.stopGrace):
-		g.grpc.Stop()
-		<-done
-	}
+	g.closing.Store(true)
+	g.reg.closeAll()
 }
 
 // Run drives the cross-replica watch and the fast-path notify drain until ctx is cancelled. Both call deliverPending; the watch sweeps
@@ -254,6 +229,12 @@ func (g *Gateway) Connect(stream control.ControlChannel_ConnectServer) error {
 		g.logger.InfoContext(ctx, "control gateway replaced existing connection", attrkeys.HostID, hostID)
 	}
 	defer g.reg.remove(hostID, c)
+	// If Stop raced ahead of this registration, close immediately so a connection accepted during shutdown can't strand
+	// http.Server.Shutdown waiting on a long-lived stream. Checked after add so closeAll cannot miss us.
+	if g.closing.Load() {
+		c.close()
+		return status.Error(codes.Unavailable, "control gateway shutting down")
+	}
 
 	g.bumpLastSeen(connCtx, hostID)
 	go c.writeLoop(connCtx, stream, g.logger)

--- a/server/response/internal/gateway/gateway_test.go
+++ b/server/response/internal/gateway/gateway_test.go
@@ -315,9 +315,13 @@ func TestGatewayServeAndStop(t *testing.T) {
 	require.NoError(t, stream.Send(&control.AgentFrame{Frame: &control.AgentFrame_Outcome{
 		Outcome: &control.Outcome{Id: 5, Status: "completed"},
 	}}))
+	// The server must actually receive and apply the outcome (recvLoop -> UpdateStatus): without this assertion the test would pass even
+	// if the client->server direction were broken, since Send buffers locally.
+	require.Eventually(t, func() bool { return src.updateCount() >= 1 }, 2*time.Second, 10*time.Millisecond,
+		"server applies the outcome reported over the bidi stream")
 
-	streamCancel() // end the client stream so GracefulStop can drain promptly instead of waiting out the grace window
+	streamCancel() // end the client stream so Stop's stream-cancel completes promptly
 	g.Stop()
 	require.NoError(t, httpSrv.Shutdown(context.WithoutCancel(runCtx)))
-	<-serveDone
+	require.ErrorIs(t, <-serveDone, http.ErrServerClosed, "Serve returns ErrServerClosed after Shutdown, not an unexpected failure")
 }

--- a/server/response/internal/gateway/gateway_test.go
+++ b/server/response/internal/gateway/gateway_test.go
@@ -2,14 +2,8 @@ package gateway
 
 import (
 	"context"
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
-	"crypto/tls"
-	"crypto/x509"
-	"crypto/x509/pkix"
-	"math/big"
 	"net"
+	"net/http"
 	"sync"
 	"testing"
 	"time"
@@ -18,7 +12,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
@@ -279,60 +272,52 @@ func TestGateway(t *testing.T) {
 	})
 }
 
-// genTestCert returns a self-signed TLS 1.3-usable cert for the gateway's TLS serve path.
-func genTestCert(t *testing.T) tls.Certificate {
-	t.Helper()
-	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	require.NoError(t, err)
-	tmpl := &x509.Certificate{
-		SerialNumber: big.NewInt(1),
-		Subject:      pkix.Name{CommonName: "edr-control-test"},
-		NotBefore:    time.Now().Add(-time.Hour),
-		NotAfter:     time.Now().Add(time.Hour),
-		DNSNames:     []string{"localhost"},
-		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
-		KeyUsage:     x509.KeyUsageDigitalSignature,
-		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
-	}
-	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
-	require.NoError(t, err)
-	return tls.Certificate{Certificate: [][]byte{der}, PrivateKey: key}
-}
-
-// TestGatewayServeTLS exercises the production serve path: New with TLS credentials, Serve on a real TCP listener, a client dialing
-// over TLS with a token, command delivery, and a graceful Stop.
-func TestGatewayServeTLS(t *testing.T) {
+// TestGatewayServeAndStop exercises the production serve path: New, Serve on a real TCP listener, a client dialing with a token,
+// command delivery over a BIDIRECTIONAL stream, and a graceful Stop. This serves the gateway through its production entry point,
+// grpc.Server.ServeHTTP behind a net/http HTTP/2 server (how cmd/main multiplexes it onto the shared HTTPS listener), so it pins that
+// the long-lived bidi control stream works over net/http's HTTP/2 (the documented ServeHTTP caveat), not only over gRPC's own
+// transport. TLS is terminated upstream in production; here the server speaks cleartext HTTP/2 (h2c) and the client dials insecure.
+func TestGatewayServeAndStop(t *testing.T) {
 	t.Parallel()
 	src := newFakeSource()
 	ver := newFakeVerifier()
 	ver.add("tok-a", "host-a")
 	src.addPending(api.Command{ID: 5, HostID: "host-a", CommandType: "kill_process", Payload: []byte(`{"pid":9}`)})
 
-	g := New(Deps{Source: src, Verifier: ver, TLSConfig: &tls.Config{Certificates: []tls.Certificate{genTestCert(t)}, MinVersion: tls.VersionTLS13}})
+	g := New(Deps{Source: src, Verifier: ver})
 	g.watchInterval = 20 * time.Millisecond
-	g.stopGrace = 200 * time.Millisecond // bound the force-close path under test
 
 	lis, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp", "127.0.0.1:0")
 	require.NoError(t, err)
+	// Serve the gateway exactly as production does: a net/http server with cleartext HTTP/2 enabled, dispatching to g.ServeHTTP.
+	protocols := new(http.Protocols)
+	protocols.SetHTTP1(true)
+	protocols.SetUnencryptedHTTP2(true)
+	httpSrv := &http.Server{Handler: g, Protocols: protocols, ReadHeaderTimeout: 5 * time.Second}
 	serveDone := make(chan error, 1)
-	go func() { serveDone <- g.Serve(lis) }()
+	go func() { serveDone <- httpSrv.Serve(lis) }()
 	runCtx, runCancel := context.WithCancel(t.Context())
 	defer runCancel()
 	go g.Run(runCtx)
 
-	creds := credentials.NewTLS(&tls.Config{InsecureSkipVerify: true}) //nolint:gosec // test client against an in-test self-signed cert
-	cc, err := grpc.NewClient(lis.Addr().String(), grpc.WithTransportCredentials(creds))
+	cc, err := grpc.NewClient(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	require.NoError(t, err)
 	defer func() { _ = cc.Close() }()
 
 	streamCtx, streamCancel := context.WithCancel(connectCtx("tok-a"))
 	stream, err := control.NewControlChannelClient(cc).Connect(streamCtx)
 	require.NoError(t, err)
+	// Server -> client: the pushed command arrives over the bidi stream.
 	frame, err := stream.Recv()
 	require.NoError(t, err)
 	assert.Equal(t, int64(5), frame.GetCommand().GetId())
+	// Client -> server: report an outcome on the same stream, exercising the other direction of the full-duplex stream over ServeHTTP.
+	require.NoError(t, stream.Send(&control.AgentFrame{Frame: &control.AgentFrame_Outcome{
+		Outcome: &control.Outcome{Id: 5, Status: "completed"},
+	}}))
 
 	streamCancel() // end the client stream so GracefulStop can drain promptly instead of waiting out the grace window
 	g.Stop()
-	require.NoError(t, <-serveDone, "Serve returns nil after a graceful Stop")
+	require.NoError(t, httpSrv.Shutdown(context.WithoutCancel(runCtx)))
+	<-serveDone
 }

--- a/server/response/internal/gateway/registry.go
+++ b/server/response/internal/gateway/registry.go
@@ -125,3 +125,18 @@ func (r *registry) len() int {
 	defer r.mu.Unlock()
 	return len(r.conns)
 }
+
+// closeAll cancels every live connection so its Connect handler returns. Used on gateway shutdown: cancelling the contexts unblocks
+// the long-lived streams (which never end on their own) so the shared HTTP server's graceful shutdown can complete. Entries remove
+// themselves from the map via the handler's deferred remove; closeAll only triggers the cancel.
+func (r *registry) closeAll() {
+	r.mu.Lock()
+	conns := make([]*conn, 0, len(r.conns))
+	for _, c := range r.conns {
+		conns = append(conns, c)
+	}
+	r.mu.Unlock()
+	for _, c := range conns {
+		c.close()
+	}
+}

--- a/server/response/internal/tests/integration_test.go
+++ b/server/response/internal/tests/integration_test.go
@@ -447,7 +447,7 @@ func TestBuildControlGateway(t *testing.T) {
 	t.Parallel()
 	r := newResponse(t, nil)
 
-	gw := r.BuildControlGateway(stubVerifier{}, nil, nil)
+	gw := r.BuildControlGateway(stubVerifier{}, nil)
 	require.NotNil(t, gw)
 	require.NotNil(t, gw.GRPCServer())
 


### PR DESCRIPTION
<!-- Keep this short. Delete sections that do not apply. -->

## What & why



## Checklist

- [ ] **OpenSpec updated for behavior changes.** If this PR changes observable behavior (a detection rule, the event
      wire schema, persistence semantics, an API/wire shape, or an emitted event), `openspec/specs/**` is updated (and
      an `openspec/changes/` proposal added), with a `spec:<id>` test marker for any new/renamed scenario. Only if this
      PR changes NO observable behavior (a comment / refactor / gofmt / dep bump that happens to touch a scoped path)
      may you assert `no-behavior-change` (label or `[no-behavior-change]` in the title) to clear the OpenSpec-sync gate.
      That is an assertion a reviewer will check, not a way to skip the spec for a real behavior change.
- [ ] Tests added/updated for the change (unit / integration / efficacy / UI as applicable).
- [ ] Agent/extension change touching ESF, XPC, or the event wire format: exercised on a live macOS VM before RC
      (flagged below).
- [ ] **Docs updated for user-facing changes.** If this PR changes a user-facing surface (the React UI, an HTTP
      handler, or a detection rule), `docs/` or `CHANGELOG.md` is updated in the same PR. Only if nothing a user sees
      changed (an internal refactor, a non-visible UI tweak) may you assert `no-docs-change` (label or
      `[no-docs-change]` in the title) to clear the Docs-sync gate. The model is in `docs/doc-versioning.md`.

## VM / RC notes (if applicable)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The app now uses a single shared port for the server UI/API and the agent control channel.
  * The agent automatically derives its control endpoint from the main server URL, using secure or insecure transport based on the URL scheme.

* **Bug Fixes**
  * Improved control-channel shutdown so active streams close cleanly during server stop.
  * Updated proxy and HTTP/2 handling so long-lived control connections work reliably through the shared listener.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->