### PR TITLE
feat(agent): durable cross-transport command dedup ledger (#558)

### DIFF
--- a/agent/cmd/fleet-edr-agent/main.go
+++ b/agent/cmd/fleet-edr-agent/main.go
@@ -515,8 +515,10 @@ func pruneLoop(ctx context.Context, q *queue.Queue, ledger *commandledger.Store,
 			case pruned > 0:
 				logger.InfoContext(ctx, "pruned old events", "count", pruned)
 			}
-			// Bound the command ledger too: a command-outcome row older than the prune age is far past any plausible re-delivery.
-			if n, err := ledger.Prune(ctx, pruneAge); err != nil {
+			// Bound the command ledger on its own, longer retention: a command stays eligible for re-delivery until it leaves the
+			// server's pending state, so its dedup row must outlive any realistic offline-then-reconnect window (not the 24h event age),
+			// or a re-delivered kill_process could re-execute.
+			if n, err := ledger.Prune(ctx, config.DefaultCommandLedgerRetention); err != nil {
 				logger.WarnContext(ctx, "prune command ledger", "err", err)
 			} else if n > 0 {
 				logger.InfoContext(ctx, "pruned old command outcomes", "count", n)

--- a/agent/cmd/fleet-edr-agent/main.go
+++ b/agent/cmd/fleet-edr-agent/main.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"sync/atomic"
 	"syscall"
 	"time"
@@ -26,6 +27,7 @@ import (
 	"github.com/fleetdm/edr/agent/coalesce"
 	"github.com/fleetdm/edr/agent/codesign"
 	"github.com/fleetdm/edr/agent/commander"
+	"github.com/fleetdm/edr/agent/commandledger"
 	"github.com/fleetdm/edr/agent/config"
 	"github.com/fleetdm/edr/agent/controlclient"
 	"github.com/fleetdm/edr/agent/enrich"
@@ -158,6 +160,16 @@ func run() error {
 		return err
 	}
 	defer func() { _ = q.Close() }()
+
+	// commandLedger is the durable, cross-transport command dedup store (issue #558): both the poll path and the control client consult
+	// it through the shared executor, so a command's side effect runs at most once across transports and across restarts. It lives next
+	// to the event queue in the agent's state directory.
+	commandLedger, err := commandledger.Open(ctx, filepath.Join(filepath.Dir(cfg.QueueDBPath), "commands.db"), commandledger.Options{Logger: logger})
+	if err != nil {
+		logger.ErrorContext(ctx, "open command ledger", "err", err)
+		return err
+	}
+	defer func() { _ = commandLedger.Close() }()
 	// The Recorder is the single OTel write surface; the queue uses it for QueueDropped, the uploader uses it for
 	// EventsDroppedTooLarge, and the queue-depth observable gauge reads q.Depth() on every collection cycle. metrics.New
 	// returns a no-op-safe Recorder when OTEL_EXPORTER_OTLP_ENDPOINT is unset.
@@ -212,14 +224,14 @@ func run() error {
 	// streamConnected is the shared flag the control channel raises while its stream is up so the commander suspends polling. Per-replica
 	// ephemeral state, lost on restart; the commander reads it, the control client sets it.
 	var streamConnected atomic.Bool
-	startCommander(ctx, hostID, cfg.ServerURL, tokenProvider, esfDispatcher, agentTransport, &streamConnected, logger)
-	if err := startControlClient(ctx, cfg, hostID, tokenProvider, esfDispatcher, &streamConnected, logger); err != nil {
+	startCommander(ctx, hostID, cfg.ServerURL, tokenProvider, esfDispatcher, agentTransport, &streamConnected, commandLedger, logger)
+	if err := startControlClient(ctx, cfg, hostID, tokenProvider, esfDispatcher, &streamConnected, commandLedger, logger); err != nil {
 		// Cancel first so the goroutines started above (receiver loops, uploader, commander, coalescer) wind down before the
 		// deferred queue close runs; otherwise the LIFO defers would close the queue while those goroutines still write to it.
 		cancel()
 		return err
 	}
-	go pruneLoop(ctx, q, config.DefaultPruneAge, logger)
+	go pruneLoop(ctx, q, commandLedger, config.DefaultPruneAge, logger)
 	startProcessReconciler(ctx, cfg, pidTable, q, tokenProvider, logger)
 
 	<-ctx.Done()
@@ -349,6 +361,7 @@ func startCommander(
 	appControlSender commander.ApplicationControlSender,
 	transport http.RoundTripper,
 	streamConnected *atomic.Bool,
+	ledger commander.Ledger,
 	logger *slog.Logger,
 ) {
 	if hostID == "" {
@@ -364,6 +377,8 @@ func startCommander(
 		ApplicationControlSender: appControlSender,
 		// Defer to the control channel while it is connected (the gateway pushes commands in real time); the poll is the fallback floor.
 		StreamConnected: streamConnected.Load,
+		// Shared durable dedup so the poll path does not re-execute a command the control client already ran (issue #558).
+		Ledger: ledger,
 	}, &http.Client{Transport: transport, Timeout: 10 * time.Second}, logger)
 	go func() {
 		if err := cmdr.Run(ctx); err != nil && ctx.Err() == nil {
@@ -385,6 +400,7 @@ func startControlClient(
 	tokenProvider enrollment.TokenProvider,
 	appControlSender commander.ApplicationControlSender,
 	streamConnected *atomic.Bool,
+	ledger commander.Ledger,
 	logger *slog.Logger,
 ) error {
 	if hostID == "" {
@@ -416,6 +432,7 @@ func startControlClient(
 		TokenFn:                  tokenProvider.Token,
 		OnAuthFail:               tokenProvider.OnUnauthorized,
 		ApplicationControlSender: appControlSender,
+		Ledger:                   ledger,
 		OnConnectedChange:        streamConnected.Store,
 		Logger:                   logger,
 	})
@@ -483,7 +500,7 @@ func startProcessReconciler(
 
 // pruneLoop periodically prunes uploaded events older than pruneAge from the
 // persistent queue.
-func pruneLoop(ctx context.Context, q *queue.Queue, pruneAge time.Duration, logger *slog.Logger) {
+func pruneLoop(ctx context.Context, q *queue.Queue, ledger *commandledger.Store, pruneAge time.Duration, logger *slog.Logger) {
 	ticker := time.NewTicker(time.Hour)
 	defer ticker.Stop()
 	for {
@@ -497,6 +514,12 @@ func pruneLoop(ctx context.Context, q *queue.Queue, pruneAge time.Duration, logg
 				logger.WarnContext(ctx, "prune", "err", err)
 			case pruned > 0:
 				logger.InfoContext(ctx, "pruned old events", "count", pruned)
+			}
+			// Bound the command ledger too: a command-outcome row older than the prune age is far past any plausible re-delivery.
+			if n, err := ledger.Prune(ctx, pruneAge); err != nil {
+				logger.WarnContext(ctx, "prune command ledger", "err", err)
+			} else if n > 0 {
+				logger.InfoContext(ctx, "pruned old command outcomes", "count", n)
 			}
 		}
 	}

--- a/agent/commander/commander.go
+++ b/agent/commander/commander.go
@@ -40,6 +40,9 @@ type Config struct {
 	// (the gateway pushes commands in real time), and the poll resumes the moment the stream drops. Nil means "always poll" (the control
 	// channel is disabled), which is the degraded floor.
 	StreamConnected func() bool
+	// Ledger is the durable dedup store shared with the control client so a command executed on the push path is not re-executed by the
+	// poll path after a stream drop (issue #558). Nil disables dedup (the poll path then relies only on the server's pending filter).
+	Ledger Ledger
 }
 
 // Commander polls the server for pending commands and dispatches them.
@@ -65,7 +68,7 @@ func New(cfg Config, client *http.Client, logger *slog.Logger) *Commander {
 	return &Commander{
 		cfg:      cfg,
 		client:   client,
-		executor: NewExecutor(cfg.ApplicationControlSender, logger),
+		executor: NewExecutor(cfg.ApplicationControlSender, cfg.Ledger, logger),
 		logger:   logger,
 	}
 }

--- a/agent/commander/executor.go
+++ b/agent/commander/executor.go
@@ -34,10 +34,13 @@ const statusExecuting = "executing"
 // commandledger.Store; both transports share one instance so a command executed on either path, in this process run or a prior one,
 // is not re-executed. A nil Ledger disables dedup (tests, and a degraded path if the ledger cannot be opened).
 type Ledger interface {
-	// Lookup returns the recorded status and result for a command id; seen is false if the id is unknown.
-	Lookup(ctx context.Context, id int64) (status string, result json.RawMessage, seen bool, err error)
+	// Claim atomically records a write-ahead claim (claimStatus) for a command id if no row exists. won=true means this caller recorded
+	// the claim and must run the side effect; won=false returns the existing status/result and the caller must NOT run the side effect.
+	Claim(ctx context.Context, id int64, claimStatus string) (won bool, status string, result json.RawMessage, err error)
 	// Mark upserts the status (and result) for a command id.
 	Mark(ctx context.Context, id int64, status string, result json.RawMessage) error
+	// Delete removes a command's row, used to roll back a write-ahead claim when the side effect was not started.
+	Delete(ctx context.Context, id int64) error
 }
 
 // invalidPayloadPrefix is the reason prefix every handler emits when json.Unmarshal of cmd.Payload fails. Centralised so the wire shape
@@ -72,59 +75,83 @@ func NewExecutor(sender ApplicationControlSender, ledger Ledger, logger *slog.Lo
 // Execute drives one command through the acknowledged-then-completed-or-failed lifecycle, deduplicated by command identity via the
 // shared Ledger so the side effect runs at most once across transports and across restarts (issue #558):
 //
-//   - If the ledger already has a terminal outcome for the command (executed earlier, on either transport or a prior process run), it
-//     re-acks and replays that outcome WITHOUT re-running the side effect, so a command whose outcome report was lost still transitions
-//     out of pending rather than being re-executed (re-killing a possibly-reused PID).
-//   - If the ledger has a write-ahead "executing" claim with no terminal outcome, a prior attempt was interrupted (a crash between the
-//     side effect and recording its result). The side effect is NOT re-run; the command is terminalized as failed so the server stops
-//     re-delivering it and an operator can re-issue against the current process.
-//   - Otherwise it acks (skipping the side effect and leaving the command eligible for re-dispatch if the ack fails), records the
-//     write-ahead claim, runs the side effect, records the terminal outcome, then reports it.
+//   - It atomically claims the command. If the claim is LOST (a row already exists), the command was already handled: a recorded
+//     terminal outcome is re-acked and replayed without re-running the side effect, and a bare write-ahead claim left by an interrupted
+//     prior attempt is terminalized as failed rather than re-run (so a since-reused PID is never re-signalled).
+//   - If the claim is WON, it acks, runs the side effect, records the terminal outcome, then reports it. If the ack fails the side
+//     effect is skipped and the claim is rolled back, leaving the command eligible for a fresh claim on re-dispatch.
+//   - If the claim cannot be recorded (ledger error), the side effect is NOT run, preserving at-most-once: the command is left pending
+//     for re-dispatch once the ledger recovers.
+//
+// A nil Ledger disables dedup (tests / a degraded path): it acks, runs, and reports with no claim.
 func (e *Executor) Execute(ctx context.Context, cmd Command, report ReportFunc) {
-	if e.replayIfSeen(ctx, cmd, report) {
+	if e.ledger != nil {
+		won, status, result, err := e.ledger.Claim(ctx, cmd.ID, statusExecuting)
+		if err != nil {
+			// Without a durable claim we cannot guarantee at-most-once, so do NOT run a non-idempotent side effect. Leave the command
+			// pending (no report) so a later re-dispatch retries the claim once the ledger recovers.
+			e.logger.ErrorContext(ctx, "command ledger claim", "cmd_id", cmd.ID, "err", err)
+			return
+		}
+		if !won {
+			e.replaySeen(ctx, cmd, report, status, result)
+			return
+		}
+	}
+	e.executeNew(ctx, cmd, report)
+}
+
+// replaySeen handles a command the ledger already records: re-ack and replay a recorded terminal outcome, or terminalize a bare
+// write-ahead claim left by an interrupted prior attempt. The side effect is never run here.
+func (e *Executor) replaySeen(ctx context.Context, cmd Command, report ReportFunc, status string, result json.RawMessage) {
+	e.reportOrLog(ctx, cmd.ID, report, StatusAcked, nil) // re-ack drives the server out of pending if the earlier ack was lost.
+	if status == StatusCompleted || status == StatusFailed {
+		e.reportOrLog(ctx, cmd.ID, report, status, result)
 		return
 	}
-	if err := report(ctx, StatusAcked, nil); err != nil {
-		e.logger.ErrorContext(ctx, "commander ack", "cmd_id", cmd.ID, "err", err)
-		return // ack did not reach the server: leave the command eligible for re-dispatch, with no ledger claim recorded.
-	}
-	e.mark(ctx, cmd.ID, statusExecuting, nil) // write-ahead: claim before the side effect so a crash mid-execution is not re-run.
-	status, result := e.run(ctx, cmd)
-	e.mark(ctx, cmd.ID, status, result)
-	if err := report(ctx, status, result); err != nil {
-		e.logger.ErrorContext(ctx, "commander report outcome", "cmd_id", cmd.ID, "status", status, "err", err)
-	}
-}
-
-// replayIfSeen consults the ledger; it returns true when the command was already seen and was handled here (replayed terminal outcome,
-// or terminalized as failed for an interrupted prior attempt) so Execute must not run the side effect.
-func (e *Executor) replayIfSeen(ctx context.Context, cmd Command, report ReportFunc) bool {
-	if e.ledger == nil {
-		return false
-	}
-	status, result, seen, err := e.ledger.Lookup(ctx, cmd.ID)
-	if err != nil {
-		// A ledger read error must not wedge command delivery; log and fall through to execute (dedup degraded for this command).
-		e.logger.ErrorContext(ctx, "command ledger lookup", "cmd_id", cmd.ID, "err", err)
-		return false
-	}
-	if !seen {
-		return false
-	}
-	_ = report(ctx, StatusAcked, nil) // re-ack: drives the server out of pending if the earlier ack was lost; a dup ack is benign.
-	if status == StatusCompleted || status == StatusFailed {
-		_ = report(ctx, status, result) // replay the recorded terminal outcome; no side effect.
-		return true
-	}
-	// "executing" with no terminal outcome: a prior attempt was interrupted. Do not re-run a non-idempotent side effect.
+	// A bare "executing" claim with no terminal outcome means a prior attempt was interrupted (a crash between the side effect and
+	// recording its result). The no-concurrency invariant (the poll is suspended while the control stream is connected, and each
+	// transport processes commands sequentially) rules out a live concurrent claim, so this is always a crashed prior attempt:
+	// terminalize it so the server stops re-delivering, and never re-run the side effect.
 	res := marshalResult("not retried: a prior execution attempt did not complete")
 	e.mark(ctx, cmd.ID, StatusFailed, res)
-	_ = report(ctx, StatusFailed, res)
-	return true
+	e.reportOrLog(ctx, cmd.ID, report, StatusFailed, res)
 }
 
-// mark records a status in the ledger, logging (not propagating) a failure: a ledger write error degrades dedup for one command but
-// must not stop the command from being executed and reported.
+// executeNew runs a freshly-claimed command (or, with no ledger, any command): ack, side effect, record terminal, report. If the ack
+// fails the side effect is skipped and any claim is rolled back so a re-dispatch re-claims and runs it.
+func (e *Executor) executeNew(ctx context.Context, cmd Command, report ReportFunc) {
+	if err := report(ctx, StatusAcked, nil); err != nil {
+		e.logger.ErrorContext(ctx, "commander ack", "cmd_id", cmd.ID, "err", err)
+		e.rollbackClaim(ctx, cmd.ID)
+		return
+	}
+	status, result := e.run(ctx, cmd)
+	e.mark(ctx, cmd.ID, status, result)
+	e.reportOrLog(ctx, cmd.ID, report, status, result)
+}
+
+// rollbackClaim removes a write-ahead claim whose side effect never started (the ack failed), so a re-dispatch re-claims rather than
+// finding a stranded "executing" row and terminalizing a never-run command. No-op without a ledger.
+func (e *Executor) rollbackClaim(ctx context.Context, id int64) {
+	if e.ledger == nil {
+		return
+	}
+	if err := e.ledger.Delete(ctx, id); err != nil {
+		e.logger.ErrorContext(ctx, "command ledger rollback", "cmd_id", id, "err", err)
+	}
+}
+
+// reportOrLog reports a status transition and logs (does not propagate) a report error, so a dropped ack/outcome on the poll path is
+// visible rather than silent. The control client additionally captures the error out-of-band in its send callback to reconnect.
+func (e *Executor) reportOrLog(ctx context.Context, id int64, report ReportFunc, status string, result json.RawMessage) {
+	if err := report(ctx, status, result); err != nil {
+		e.logger.ErrorContext(ctx, "commander report", "cmd_id", id, "status", status, "err", err)
+	}
+}
+
+// mark records a status in the ledger, logging (not propagating) a failure: a ledger write error here degrades dedup for one command
+// but must not stop the outcome from being reported.
 func (e *Executor) mark(ctx context.Context, id int64, status string, result json.RawMessage) {
 	if e.ledger == nil {
 		return

--- a/agent/commander/executor.go
+++ b/agent/commander/executor.go
@@ -18,12 +18,27 @@ type Command struct {
 }
 
 // Status values the executor reports through ReportFunc. They mirror the server-side command lifecycle and are exported so the
-// control-channel client can recognize a terminal outcome (to cache it for idempotent re-report on re-delivery).
+// control-channel client can recognize a terminal outcome.
 const (
 	StatusAcked     = "acked"
 	StatusCompleted = "completed"
 	StatusFailed    = "failed"
 )
+
+// statusExecuting is an agent-local ledger status, never reported to the server. It is the write-ahead claim the executor records
+// before running a side effect: if the agent crashes mid-execution, a re-delivery finds this status and refuses to re-run the side
+// effect (see Execute), which is the safety guard against re-killing a since-reused PID.
+const statusExecuting = "executing"
+
+// Ledger is the durable, cross-transport dedup store the executor keys execution on (issue #558). It is satisfied by
+// commandledger.Store; both transports share one instance so a command executed on either path, in this process run or a prior one,
+// is not re-executed. A nil Ledger disables dedup (tests, and a degraded path if the ledger cannot be opened).
+type Ledger interface {
+	// Lookup returns the recorded status and result for a command id; seen is false if the id is unknown.
+	Lookup(ctx context.Context, id int64) (status string, result json.RawMessage, seen bool, err error)
+	// Mark upserts the status (and result) for a command id.
+	Mark(ctx context.Context, id int64, status string, result json.RawMessage) error
+}
 
 // invalidPayloadPrefix is the reason prefix every handler emits when json.Unmarshal of cmd.Payload fails. Centralised so the wire shape
 // stays stable across handlers.
@@ -36,94 +51,141 @@ type ReportFunc func(ctx context.Context, status string, result json.RawMessage)
 
 // Executor runs a command's local side effect and reports its outcome through a transport-supplied ReportFunc. It holds no transport
 // state, so the poll loop and the control-channel client share one instance's worth of behavior without coupling to how commands are
-// delivered or how outcomes are sent back.
+// delivered or how outcomes are sent back. A shared Ledger gives it durable, cross-transport at-most-once execution.
 type Executor struct {
 	sender ApplicationControlSender
+	ledger Ledger
 	// kill is the process-termination syscall, injectable so tests exercise the kill_process path without signalling a real process.
 	kill   func(pid int, sig syscall.Signal) error
 	logger *slog.Logger
 }
 
-// NewExecutor builds an Executor. sender may be nil (set_application_control then reports failed with a clear reason); logger nil uses
-// the default.
-func NewExecutor(sender ApplicationControlSender, logger *slog.Logger) *Executor {
+// NewExecutor builds an Executor. sender may be nil (set_application_control then reports failed with a clear reason); ledger may be nil
+// (dedup disabled, for tests or a degraded path if the ledger cannot be opened); logger nil uses the default.
+func NewExecutor(sender ApplicationControlSender, ledger Ledger, logger *slog.Logger) *Executor {
 	if logger == nil {
 		logger = slog.Default()
 	}
-	return &Executor{sender: sender, kill: syscall.Kill, logger: logger}
+	return &Executor{sender: sender, ledger: ledger, kill: syscall.Kill, logger: logger}
 }
 
-// Execute drives one command through the acknowledged-then-completed-or-failed lifecycle: it reports acked first (so an operator never
-// sees a stuck pending command after work has begun), runs the type-specific side effect, then reports the terminal outcome. If the
-// acked report fails the side effect is skipped, leaving the command eligible for re-dispatch. Unknown types fail explicitly.
+// Execute drives one command through the acknowledged-then-completed-or-failed lifecycle, deduplicated by command identity via the
+// shared Ledger so the side effect runs at most once across transports and across restarts (issue #558):
+//
+//   - If the ledger already has a terminal outcome for the command (executed earlier, on either transport or a prior process run), it
+//     re-acks and replays that outcome WITHOUT re-running the side effect, so a command whose outcome report was lost still transitions
+//     out of pending rather than being re-executed (re-killing a possibly-reused PID).
+//   - If the ledger has a write-ahead "executing" claim with no terminal outcome, a prior attempt was interrupted (a crash between the
+//     side effect and recording its result). The side effect is NOT re-run; the command is terminalized as failed so the server stops
+//     re-delivering it and an operator can re-issue against the current process.
+//   - Otherwise it acks (skipping the side effect and leaving the command eligible for re-dispatch if the ack fails), records the
+//     write-ahead claim, runs the side effect, records the terminal outcome, then reports it.
 func (e *Executor) Execute(ctx context.Context, cmd Command, report ReportFunc) {
+	if e.replayIfSeen(ctx, cmd, report) {
+		return
+	}
 	if err := report(ctx, StatusAcked, nil); err != nil {
 		e.logger.ErrorContext(ctx, "commander ack", "cmd_id", cmd.ID, "err", err)
-		return
+		return // ack did not reach the server: leave the command eligible for re-dispatch, with no ledger claim recorded.
 	}
-	switch cmd.CommandType {
-	case "kill_process":
-		e.executeKill(ctx, cmd, report)
-	case "set_application_control":
-		e.executeSetApplicationControl(ctx, cmd, report)
-	default:
-		if err := report(ctx, StatusFailed, marshalResult("unknown command type: "+cmd.CommandType)); err != nil {
-			e.logger.ErrorContext(ctx, "commander fail", "cmd_id", cmd.ID, "err", err)
-		}
+	e.mark(ctx, cmd.ID, statusExecuting, nil) // write-ahead: claim before the side effect so a crash mid-execution is not re-run.
+	status, result := e.run(ctx, cmd)
+	e.mark(ctx, cmd.ID, status, result)
+	if err := report(ctx, status, result); err != nil {
+		e.logger.ErrorContext(ctx, "commander report outcome", "cmd_id", cmd.ID, "status", status, "err", err)
 	}
 }
 
-func (e *Executor) executeKill(ctx context.Context, cmd Command, report ReportFunc) {
-	var payload killPayload
-	if err := json.Unmarshal(cmd.Payload, &payload); err != nil {
-		_ = report(ctx, StatusFailed, marshalResult(invalidPayloadPrefix+err.Error()))
+// replayIfSeen consults the ledger; it returns true when the command was already seen and was handled here (replayed terminal outcome,
+// or terminalized as failed for an interrupted prior attempt) so Execute must not run the side effect.
+func (e *Executor) replayIfSeen(ctx context.Context, cmd Command, report ReportFunc) bool {
+	if e.ledger == nil {
+		return false
+	}
+	status, result, seen, err := e.ledger.Lookup(ctx, cmd.ID)
+	if err != nil {
+		// A ledger read error must not wedge command delivery; log and fall through to execute (dedup degraded for this command).
+		e.logger.ErrorContext(ctx, "command ledger lookup", "cmd_id", cmd.ID, "err", err)
+		return false
+	}
+	if !seen {
+		return false
+	}
+	_ = report(ctx, StatusAcked, nil) // re-ack: drives the server out of pending if the earlier ack was lost; a dup ack is benign.
+	if status == StatusCompleted || status == StatusFailed {
+		_ = report(ctx, status, result) // replay the recorded terminal outcome; no side effect.
+		return true
+	}
+	// "executing" with no terminal outcome: a prior attempt was interrupted. Do not re-run a non-idempotent side effect.
+	res := marshalResult("not retried: a prior execution attempt did not complete")
+	e.mark(ctx, cmd.ID, StatusFailed, res)
+	_ = report(ctx, StatusFailed, res)
+	return true
+}
+
+// mark records a status in the ledger, logging (not propagating) a failure: a ledger write error degrades dedup for one command but
+// must not stop the command from being executed and reported.
+func (e *Executor) mark(ctx context.Context, id int64, status string, result json.RawMessage) {
+	if e.ledger == nil {
 		return
 	}
+	if err := e.ledger.Mark(ctx, id, status, result); err != nil {
+		e.logger.ErrorContext(ctx, "command ledger mark", "cmd_id", id, "status", status, "err", err)
+	}
+}
+
+// run executes a command's type-specific side effect and returns its terminal outcome. It performs no reporting and no ledger writes;
+// Execute owns those so dedup and outcome recording are uniform across command types.
+func (e *Executor) run(ctx context.Context, cmd Command) (status string, result json.RawMessage) {
+	switch cmd.CommandType {
+	case "kill_process":
+		return e.runKill(ctx, cmd)
+	case "set_application_control":
+		return e.runSetApplicationControl(ctx, cmd)
+	default:
+		return StatusFailed, marshalResult("unknown command type: " + cmd.CommandType)
+	}
+}
+
+func (e *Executor) runKill(ctx context.Context, cmd Command) (string, json.RawMessage) {
+	var payload killPayload
+	if err := json.Unmarshal(cmd.Payload, &payload); err != nil {
+		return StatusFailed, marshalResult(invalidPayloadPrefix + err.Error())
+	}
 	if payload.PID <= 0 {
-		_ = report(ctx, StatusFailed, marshalResult("invalid pid"))
-		return
+		return StatusFailed, marshalResult("invalid pid")
 	}
 	e.logger.InfoContext(ctx, "commander kill_process", "pid", payload.PID, "cmd_id", cmd.ID)
 	if err := e.kill(payload.PID, syscall.SIGKILL); err != nil {
-		if reportErr := report(ctx, StatusFailed, marshalResult(err.Error())); reportErr != nil {
-			e.logger.ErrorContext(ctx, "commander report kill failure", "cmd_id", cmd.ID, "err", reportErr)
-		}
-		return
+		return StatusFailed, marshalResult(err.Error())
 	}
 	successResult, _ := json.Marshal(map[string]int{"killed_pid": payload.PID})
-	if err := report(ctx, StatusCompleted, successResult); err != nil {
-		e.logger.ErrorContext(ctx, "commander report kill success", "cmd_id", cmd.ID, "err", err)
-	}
+	return StatusCompleted, successResult
 }
 
-// executeSetApplicationControl forwards the raw command payload to the ESF extension over XPC. Result on success is
+// runSetApplicationControl forwards the raw command payload to the ESF extension over XPC. Result on success is
 // {"policy_id": P, "policy_version": V} so operators can confirm per host which snapshot the agent applied. Envelope validation only
 // (policy_id present, version positive, rules is a JSON array); the per-rule shape is the extension's responsibility, and forwarding the
 // raw bytes keeps the wire shape byte-identical across server, agent, and extension.
-func (e *Executor) executeSetApplicationControl(ctx context.Context, cmd Command, report ReportFunc) {
+func (e *Executor) runSetApplicationControl(ctx context.Context, cmd Command) (string, json.RawMessage) {
 	var payload setApplicationControlPayload
 	if err := json.Unmarshal(cmd.Payload, &payload); err != nil {
-		_ = report(ctx, StatusFailed, marshalResult(invalidPayloadPrefix+err.Error()))
-		return
+		return StatusFailed, marshalResult(invalidPayloadPrefix + err.Error())
 	}
 	if payload.PolicyID <= 0 {
-		_ = report(ctx, StatusFailed, marshalResult("payload missing or invalid policy_id"))
-		return
+		return StatusFailed, marshalResult("payload missing or invalid policy_id")
 	}
 	if payload.PolicyVersion <= 0 {
 		// Versioning is the ordering guard for snapshot state on the extension; a zero/negative version would either mask an
 		// out-of-order delivery or reflect a hand-queued test command that shouldn't be acted on. Fail fast so the audit trail
 		// attributes the error to its source rather than to opaque XPC decode errors from the extension.
-		_ = report(ctx, StatusFailed, marshalResult("invalid policy_version"))
-		return
+		return StatusFailed, marshalResult("invalid policy_version")
 	}
 	if !isJSONArray(payload.Rules) {
-		_ = report(ctx, StatusFailed, marshalResult("payload missing or invalid rules array"))
-		return
+		return StatusFailed, marshalResult("payload missing or invalid rules array")
 	}
 	if e.sender == nil {
-		_ = report(ctx, StatusFailed, marshalResult("application control sender not configured"))
-		return
+		return StatusFailed, marshalResult("application control sender not configured")
 	}
 	e.logger.InfoContext(ctx, "commander set_application_control",
 		"cmd_id", cmd.ID,
@@ -133,16 +195,13 @@ func (e *Executor) executeSetApplicationControl(ctx context.Context, cmd Command
 	// Forward the raw JSON bytes so the extension parses the same shape the server wrote. The send is async: completing here does NOT
 	// mean the extension has applied the snapshot; the audit trail of "command completed on agent" is sufficient for now.
 	if err := e.sender.SendApplicationControl([]byte(cmd.Payload)); err != nil {
-		_ = report(ctx, StatusFailed, marshalResult("xpc send: "+err.Error()))
-		return
+		return StatusFailed, marshalResult("xpc send: " + err.Error())
 	}
 	result, _ := json.Marshal(map[string]any{
 		"policy_id":      payload.PolicyID,
 		"policy_version": payload.PolicyVersion,
 	})
-	if err := report(ctx, StatusCompleted, result); err != nil {
-		e.logger.ErrorContext(ctx, "commander report set_application_control success", "cmd_id", cmd.ID, "err", err)
-	}
+	return StatusCompleted, result
 }
 
 type killPayload struct {

--- a/agent/commander/executor_test.go
+++ b/agent/commander/executor_test.go
@@ -3,7 +3,9 @@ package commander
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"testing"
 
@@ -11,10 +13,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// fakeLedger is an in-memory commander.Ledger for executor unit tests: it gives durable-style dedup without SQLite.
+// fakeLedger is an in-memory commander.Ledger for executor unit tests: it gives durable-style dedup (an atomic claim) without SQLite.
 type fakeLedger struct {
-	mu sync.Mutex
-	m  map[int64]ledgerRow
+	mu       sync.Mutex
+	m        map[int64]ledgerRow
+	claimErr error // when set, Claim returns this error (models a ledger write failure)
 }
 
 type ledgerRow struct {
@@ -24,17 +27,30 @@ type ledgerRow struct {
 
 func newFakeLedger() *fakeLedger { return &fakeLedger{m: make(map[int64]ledgerRow)} }
 
-func (f *fakeLedger) Lookup(_ context.Context, id int64) (string, json.RawMessage, bool, error) {
+func (f *fakeLedger) Claim(_ context.Context, id int64, claimStatus string) (bool, string, json.RawMessage, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	r, ok := f.m[id]
-	return r.status, r.result, ok, nil
+	if f.claimErr != nil {
+		return false, "", nil, f.claimErr
+	}
+	if r, ok := f.m[id]; ok {
+		return false, r.status, r.result, nil
+	}
+	f.m[id] = ledgerRow{status: claimStatus}
+	return true, claimStatus, nil, nil
 }
 
 func (f *fakeLedger) Mark(_ context.Context, id int64, status string, result json.RawMessage) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.m[id] = ledgerRow{status: status, result: result}
+	return nil
+}
+
+func (f *fakeLedger) Delete(_ context.Context, id int64) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	delete(f.m, id)
 	return nil
 }
 
@@ -124,5 +140,71 @@ func TestExecutor_NoLedgerStillExecutes(t *testing.T) {
 	var reports []string
 	e.Execute(t.Context(), Command{ID: 1, CommandType: "kill_process", Payload: json.RawMessage(`{"pid":2}`)}, recordReport(&reports))
 	assert.Equal(t, 1, kills)
+	assert.Equal(t, []string{StatusAcked, StatusCompleted}, reports)
+}
+
+// TestExecutor_ConcurrentDeliveryRunsSideEffectOnce forces the race the no-concurrency invariant normally prevents: two executors
+// sharing one ledger run the same command at the same time. The atomic claim must let only one win, so the privileged side effect
+// (kill) runs exactly once even under concurrent delivery (issue #558, CodeRabbit).
+//
+// spec:agent-command-executor/command-execution-is-deduplicated-durably-across-transports-and-restarts/concurrent-delivery-of-the-same-command-runs-the-side-effect-once
+func TestExecutor_ConcurrentDeliveryRunsSideEffectOnce(t *testing.T) {
+	t.Parallel()
+	ledger := newFakeLedger()
+	var kills atomic.Int32
+	cmd := Command{ID: 7, CommandType: "kill_process", Payload: json.RawMessage(`{"pid":1234}`)}
+	mk := func() *Executor {
+		e := NewExecutor(nil, ledger, nil)
+		e.kill = func(int, syscall.Signal) error { kills.Add(1); return nil }
+		return e
+	}
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for range 2 {
+		wg.Go(func() {
+			<-start
+			mk().Execute(t.Context(), cmd, func(context.Context, string, json.RawMessage) error { return nil })
+		})
+	}
+	close(start) // release both goroutines together
+	wg.Wait()
+	assert.Equal(t, int32(1), kills.Load(), "the side effect runs exactly once even under concurrent delivery")
+}
+
+// TestExecutor_ClaimErrorSkipsSideEffect pins that a ledger write failure does NOT fall through to running a non-idempotent side effect
+// (issue #558, Copilot/Qodo): without a durable claim the at-most-once guarantee is gone, so the command is left pending instead.
+func TestExecutor_ClaimErrorSkipsSideEffect(t *testing.T) {
+	t.Parallel()
+	ledger := newFakeLedger()
+	ledger.claimErr = errors.New("disk full")
+	var kills int
+	e := killCountingExecutor(ledger, &kills)
+	var reports []string
+	e.Execute(t.Context(), Command{ID: 5, CommandType: "kill_process", Payload: json.RawMessage(`{"pid":1}`)}, recordReport(&reports))
+	assert.Equal(t, 0, kills, "a claim that cannot be durably recorded must not run the side effect")
+	assert.Empty(t, reports, "the command is left pending for re-dispatch, not reported")
+}
+
+// TestExecutor_AckFailureRollsBackClaim pins that when the ack report fails (side effect not started) the write-ahead claim is rolled
+// back, so a re-dispatch RE-RUNS the command rather than finding a stranded "executing" row and terminalizing a never-run command.
+func TestExecutor_AckFailureRollsBackClaim(t *testing.T) {
+	t.Parallel()
+	ledger := newFakeLedger()
+	var kills int
+	e := killCountingExecutor(ledger, &kills)
+	cmd := Command{ID: 6, CommandType: "kill_process", Payload: json.RawMessage(`{"pid":1}`)}
+
+	ackFails := func(_ context.Context, status string, _ json.RawMessage) error {
+		if status == StatusAcked {
+			return errors.New("ack send failed")
+		}
+		return nil
+	}
+	e.Execute(t.Context(), cmd, ackFails)
+	assert.Equal(t, 0, kills, "the side effect is skipped when the ack fails")
+
+	var reports []string
+	e.Execute(t.Context(), cmd, recordReport(&reports))
+	assert.Equal(t, 1, kills, "after rollback, a re-dispatch runs the side effect")
 	assert.Equal(t, []string{StatusAcked, StatusCompleted}, reports)
 }

--- a/agent/commander/executor_test.go
+++ b/agent/commander/executor_test.go
@@ -1,0 +1,128 @@
+package commander
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeLedger is an in-memory commander.Ledger for executor unit tests: it gives durable-style dedup without SQLite.
+type fakeLedger struct {
+	mu sync.Mutex
+	m  map[int64]ledgerRow
+}
+
+type ledgerRow struct {
+	status string
+	result json.RawMessage
+}
+
+func newFakeLedger() *fakeLedger { return &fakeLedger{m: make(map[int64]ledgerRow)} }
+
+func (f *fakeLedger) Lookup(_ context.Context, id int64) (string, json.RawMessage, bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	r, ok := f.m[id]
+	return r.status, r.result, ok, nil
+}
+
+func (f *fakeLedger) Mark(_ context.Context, id int64, status string, result json.RawMessage) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.m[id] = ledgerRow{status: status, result: result}
+	return nil
+}
+
+// recordReport collects the status transitions an executor reports, so a test can assert the acked-then-terminal sequence.
+func recordReport(out *[]string) ReportFunc {
+	return func(_ context.Context, status string, _ json.RawMessage) error {
+		*out = append(*out, status)
+		return nil
+	}
+}
+
+func killCountingExecutor(ledger Ledger, kills *int) *Executor {
+	e := NewExecutor(nil, ledger, nil)
+	e.kill = func(int, syscall.Signal) error {
+		*kills++
+		return nil
+	}
+	return e
+}
+
+// TestExecutor_DedupAcrossExecutors is the core #558 regression: two executors sharing one ledger model the push path and the poll
+// path. A kill_process executed by the first must NOT have its side effect re-run by the second (the push-execute -> stream-drop ->
+// poll-refetch sequence); the second replays the recorded terminal outcome, so the terminal status stays stable.
+//
+// spec:agent-command-executor/command-execution-is-deduplicated-durably-across-transports-and-restarts/a-command-executed-on-one-transport-is-not-re-executed-by-the-other
+func TestExecutor_DedupAcrossExecutors(t *testing.T) {
+	t.Parallel()
+	ledger := newFakeLedger()
+	var kills int
+	cmd := Command{ID: 7, CommandType: "kill_process", Payload: json.RawMessage(`{"pid":1234}`)}
+
+	var first []string
+	killCountingExecutor(ledger, &kills).Execute(t.Context(), cmd, recordReport(&first))
+	require.Equal(t, 1, kills, "the first executor runs the side effect once")
+	assert.Equal(t, []string{StatusAcked, StatusCompleted}, first)
+
+	var second []string
+	killCountingExecutor(ledger, &kills).Execute(t.Context(), cmd, recordReport(&second))
+	assert.Equal(t, 1, kills, "a second executor sharing the ledger does not re-run the side effect")
+	assert.Equal(t, []string{StatusAcked, StatusCompleted}, second, "the second executor replays the recorded terminal outcome")
+}
+
+// TestExecutor_ReplaysRecordedFailure pins that a recorded terminal failure is replayed verbatim (not retried): a kill that failed
+// (e.g. ESRCH) stays failed on re-delivery rather than being re-attempted.
+func TestExecutor_ReplaysRecordedFailure(t *testing.T) {
+	t.Parallel()
+	ledger := newFakeLedger()
+	var kills int
+	e := NewExecutor(nil, ledger, nil)
+	e.kill = func(int, syscall.Signal) error { kills++; return syscall.ESRCH }
+	cmd := Command{ID: 8, CommandType: "kill_process", Payload: json.RawMessage(`{"pid":4321}`)}
+
+	var first []string
+	e.Execute(t.Context(), cmd, recordReport(&first))
+	require.Equal(t, 1, kills)
+	assert.Equal(t, []string{StatusAcked, StatusFailed}, first)
+
+	var second []string
+	killCountingExecutor(ledger, &kills).Execute(t.Context(), cmd, recordReport(&second))
+	assert.Equal(t, 1, kills, "a recorded failure is replayed, not retried")
+	assert.Equal(t, []string{StatusAcked, StatusFailed}, second)
+}
+
+// TestExecutor_InterruptedClaimNotRetried pins the restart safety: a command claimed (write-ahead "executing") by a prior process that
+// then crashed before recording a terminal outcome is NOT re-run; it is terminalized as failed so the server stops re-delivering it and
+// the agent never re-signals a possibly-reused PID.
+func TestExecutor_InterruptedClaimNotRetried(t *testing.T) {
+	t.Parallel()
+	ledger := newFakeLedger()
+	require.NoError(t, ledger.Mark(t.Context(), 9, statusExecuting, nil)) // a prior, interrupted attempt
+	var kills int
+	e := killCountingExecutor(ledger, &kills)
+	cmd := Command{ID: 9, CommandType: "kill_process", Payload: json.RawMessage(`{"pid":1}`)}
+
+	var reports []string
+	e.Execute(t.Context(), cmd, recordReport(&reports))
+	assert.Equal(t, 0, kills, "an interrupted prior attempt is never re-run")
+	assert.Equal(t, []string{StatusAcked, StatusFailed}, reports)
+}
+
+// TestExecutor_NoLedgerStillExecutes pins that a nil ledger (tests / degraded path) disables dedup but still runs the command, so the
+// executor never hard-depends on the ledger.
+func TestExecutor_NoLedgerStillExecutes(t *testing.T) {
+	t.Parallel()
+	var kills int
+	e := killCountingExecutor(nil, &kills)
+	var reports []string
+	e.Execute(t.Context(), Command{ID: 1, CommandType: "kill_process", Payload: json.RawMessage(`{"pid":2}`)}, recordReport(&reports))
+	assert.Equal(t, 1, kills)
+	assert.Equal(t, []string{StatusAcked, StatusCompleted}, reports)
+}

--- a/agent/commandledger/commandledger.go
+++ b/agent/commandledger/commandledger.go
@@ -76,6 +76,34 @@ func (s *Store) Lookup(ctx context.Context, id int64) (status string, result jso
 	return status, json.RawMessage(res), true, nil
 }
 
+// Claim atomically records a write-ahead claim (claimStatus, e.g. "executing") for a command id if no row exists yet. It returns
+// won=true when THIS call recorded the claim, so the caller owns execution and must run the side effect. If a row already exists it
+// returns won=false with the existing status/result, so the caller must NOT run the side effect: it replays a recorded terminal
+// outcome, or terminalizes a prior interrupted claim. The INSERT...ON CONFLICT DO NOTHING is a single atomic statement, so two
+// concurrent callers can never both win the claim (and therefore never both run a non-idempotent side effect).
+func (s *Store) Claim(ctx context.Context, id int64, claimStatus string) (won bool, status string, result json.RawMessage, err error) {
+	res, err := s.db.ExecContext(ctx,
+		`INSERT INTO command_outcomes (command_id, status, result, updated_at) VALUES (?, ?, NULL, ?) ON CONFLICT(command_id) DO NOTHING`,
+		id, claimStatus, time.Now().Unix())
+	if err != nil {
+		return false, "", nil, fmt.Errorf("command ledger claim: %w", err)
+	}
+	if n, _ := res.RowsAffected(); n == 1 {
+		return true, claimStatus, nil, nil
+	}
+	status, result, _, err = s.Lookup(ctx, id)
+	return false, status, result, err
+}
+
+// Delete removes a command's ledger row. Used to roll back a write-ahead claim when the side effect was not started (the acknowledgement
+// report failed), so the command stays eligible for a fresh claim on re-delivery instead of being stranded as a never-run "executing".
+func (s *Store) Delete(ctx context.Context, id int64) error {
+	if _, err := s.db.ExecContext(ctx, `DELETE FROM command_outcomes WHERE command_id = ?`, id); err != nil {
+		return fmt.Errorf("command ledger delete: %w", err)
+	}
+	return nil
+}
+
 // Mark upserts the status (and result) for a command id, stamping updated_at to now. result may be nil.
 func (s *Store) Mark(ctx context.Context, id int64, status string, result json.RawMessage) error {
 	_, err := s.db.ExecContext(ctx,

--- a/agent/commandledger/commandledger.go
+++ b/agent/commandledger/commandledger.go
@@ -1,0 +1,101 @@
+// Package commandledger is the agent's durable command-execution ledger: a small SQLite table, keyed by the server command id, that
+// records whether a command has been claimed (executing) or has reached a terminal outcome (completed / failed). Both the poll path
+// (commander) and the push path (controlclient) consult it through the shared commander.Executor, so a command's side effect runs at
+// most once across transports AND across agent restarts (issue #558). That closes the kill_process re-execution window: a re-delivered
+// command replays its recorded outcome instead of signalling its PID again, which is the safety guard against killing a reused PID.
+package commandledger
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"time"
+
+	// modernc.org/sqlite is the CGo-free SQLite driver, registered under "sqlite"; same driver the event queue uses.
+	_ "modernc.org/sqlite"
+)
+
+const schema = `
+CREATE TABLE IF NOT EXISTS command_outcomes (
+	command_id INTEGER PRIMARY KEY,
+	status     TEXT NOT NULL,
+	result     BLOB,
+	updated_at INTEGER NOT NULL
+);`
+
+// Store is the durable command ledger. It is safe for concurrent use (a single pooled connection serializes writes).
+type Store struct {
+	db     *sql.DB
+	logger *slog.Logger
+}
+
+// Options configures Open.
+type Options struct {
+	Logger *slog.Logger
+}
+
+// Open opens (creating if needed) the command ledger at dbPath. It mirrors the event queue's SQLite pragmas: a 5s busy timeout, WAL
+// journaling, and a bounded WAL size, applied to every pooled connection via the DSN.
+func Open(ctx context.Context, dbPath string, opts Options) (*Store, error) {
+	dsn := dbPath +
+		"?_pragma=busy_timeout%3d5000" +
+		"&_pragma=journal_mode%3dwal" +
+		"&_pragma=journal_size_limit%3d33554432"
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("open command ledger: %w", err)
+	}
+	// SQLite allows one writer at a time; a single connection avoids SQLITE_BUSY contention between pooled connections.
+	db.SetMaxOpenConns(1)
+	if _, err := db.ExecContext(ctx, schema); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("create command ledger schema: %w", err)
+	}
+	logger := opts.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Store{db: db, logger: logger}, nil
+}
+
+// Close closes the ledger database.
+func (s *Store) Close() error { return s.db.Close() }
+
+// Lookup returns the recorded status and result for a command id. seen is false if the id is unknown.
+func (s *Store) Lookup(ctx context.Context, id int64) (status string, result json.RawMessage, seen bool, err error) {
+	var res []byte
+	row := s.db.QueryRowContext(ctx, `SELECT status, result FROM command_outcomes WHERE command_id = ?`, id)
+	switch scanErr := row.Scan(&status, &res); {
+	case scanErr == sql.ErrNoRows:
+		return "", nil, false, nil
+	case scanErr != nil:
+		return "", nil, false, fmt.Errorf("command ledger lookup: %w", scanErr)
+	}
+	return status, json.RawMessage(res), true, nil
+}
+
+// Mark upserts the status (and result) for a command id, stamping updated_at to now. result may be nil.
+func (s *Store) Mark(ctx context.Context, id int64, status string, result json.RawMessage) error {
+	_, err := s.db.ExecContext(ctx,
+		`INSERT INTO command_outcomes (command_id, status, result, updated_at) VALUES (?, ?, ?, ?)
+		 ON CONFLICT(command_id) DO UPDATE SET status = excluded.status, result = excluded.result, updated_at = excluded.updated_at`,
+		id, status, []byte(result), time.Now().Unix())
+	if err != nil {
+		return fmt.Errorf("command ledger mark: %w", err)
+	}
+	return nil
+}
+
+// Prune deletes ledger rows older than maxAge and returns the number deleted, keeping the ledger bounded. A pruned row only matters if
+// the same command id is re-delivered after maxAge, which the server's command lifetime makes implausible.
+func (s *Store) Prune(ctx context.Context, maxAge time.Duration) (int64, error) {
+	cutoff := time.Now().Add(-maxAge).Unix()
+	res, err := s.db.ExecContext(ctx, `DELETE FROM command_outcomes WHERE updated_at < ?`, cutoff)
+	if err != nil {
+		return 0, fmt.Errorf("command ledger prune: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	return n, nil
+}

--- a/agent/commandledger/commandledger_test.go
+++ b/agent/commandledger/commandledger_test.go
@@ -1,0 +1,95 @@
+package commandledger_test
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fleetdm/edr/agent/commandledger"
+)
+
+func openTestStore(t *testing.T) *commandledger.Store {
+	t.Helper()
+	s, err := commandledger.Open(t.Context(), filepath.Join(t.TempDir(), "commands.db"), commandledger.Options{})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+	return s
+}
+
+func TestStore(t *testing.T) {
+	t.Parallel()
+
+	t.Run("an unknown command id is not seen", func(t *testing.T) {
+		t.Parallel()
+		s := openTestStore(t)
+		_, _, seen, err := s.Lookup(t.Context(), 42)
+		require.NoError(t, err)
+		assert.False(t, seen)
+	})
+
+	t.Run("mark then lookup round-trips status and result", func(t *testing.T) {
+		t.Parallel()
+		s := openTestStore(t)
+		require.NoError(t, s.Mark(t.Context(), 7, "completed", json.RawMessage(`{"killed_pid":99}`)))
+		status, result, seen, err := s.Lookup(t.Context(), 7)
+		require.NoError(t, err)
+		assert.True(t, seen)
+		assert.Equal(t, "completed", status)
+		assert.JSONEq(t, `{"killed_pid":99}`, string(result))
+	})
+
+	t.Run("mark upserts the status for an id", func(t *testing.T) {
+		t.Parallel()
+		s := openTestStore(t)
+		require.NoError(t, s.Mark(t.Context(), 5, "executing", nil)) // write-ahead claim
+		require.NoError(t, s.Mark(t.Context(), 5, "completed", json.RawMessage(`{"ok":true}`)))
+		status, result, seen, err := s.Lookup(t.Context(), 5)
+		require.NoError(t, err)
+		require.True(t, seen)
+		assert.Equal(t, "completed", status)
+		assert.JSONEq(t, `{"ok":true}`, string(result))
+	})
+
+	t.Run("prune deletes only rows older than maxAge", func(t *testing.T) {
+		t.Parallel()
+		s := openTestStore(t)
+		require.NoError(t, s.Mark(t.Context(), 1, "completed", nil))
+		// A fresh row is retained at a 1h horizon.
+		n, err := s.Prune(t.Context(), time.Hour)
+		require.NoError(t, err)
+		assert.Equal(t, int64(0), n)
+		// A negative maxAge puts the cutoff in the future, so the row is now "old" and is deleted.
+		n, err = s.Prune(t.Context(), -time.Hour)
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), n)
+		_, _, seen, err := s.Lookup(t.Context(), 1)
+		require.NoError(t, err)
+		assert.False(t, seen)
+	})
+}
+
+// TestStore_SurvivesReopen pins the durability that makes the dedup restart-safe: a recorded outcome is still present after the store is
+// closed and reopened (the agent-restart case).
+//
+// spec:agent-command-executor/command-execution-is-deduplicated-durably-across-transports-and-restarts/a-recorded-outcome-survives-an-agent-restart
+func TestStore_SurvivesReopen(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "commands.db")
+	s1, err := commandledger.Open(t.Context(), path, commandledger.Options{})
+	require.NoError(t, err)
+	require.NoError(t, s1.Mark(t.Context(), 11, "completed", json.RawMessage(`{"killed_pid":1}`)))
+	require.NoError(t, s1.Close())
+
+	s2, err := commandledger.Open(t.Context(), path, commandledger.Options{}) // simulate an agent restart
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s2.Close() })
+	status, result, seen, err := s2.Lookup(t.Context(), 11)
+	require.NoError(t, err)
+	assert.True(t, seen)
+	assert.Equal(t, "completed", status)
+	assert.JSONEq(t, `{"killed_pid":1}`, string(result))
+}

--- a/agent/commandledger/commandledger_test.go
+++ b/agent/commandledger/commandledger_test.go
@@ -54,6 +54,38 @@ func TestStore(t *testing.T) {
 		assert.JSONEq(t, `{"ok":true}`, string(result))
 	})
 
+	t.Run("claim wins for a fresh id and loses for an existing one", func(t *testing.T) {
+		t.Parallel()
+		s := openTestStore(t)
+		won, status, _, err := s.Claim(t.Context(), 20, "executing")
+		require.NoError(t, err)
+		assert.True(t, won, "the first claim wins")
+		assert.Equal(t, "executing", status)
+		won2, status2, _, err := s.Claim(t.Context(), 20, "executing")
+		require.NoError(t, err)
+		assert.False(t, won2, "a second claim on the same id loses")
+		assert.Equal(t, "executing", status2)
+		// After a terminal mark, a claim still loses and returns the recorded terminal outcome (the replay path).
+		require.NoError(t, s.Mark(t.Context(), 20, "completed", json.RawMessage(`{"killed_pid":7}`)))
+		won3, status3, result3, err := s.Claim(t.Context(), 20, "executing")
+		require.NoError(t, err)
+		assert.False(t, won3)
+		assert.Equal(t, "completed", status3)
+		assert.JSONEq(t, `{"killed_pid":7}`, string(result3))
+	})
+
+	t.Run("delete rolls back a claim so the id can be re-claimed", func(t *testing.T) {
+		t.Parallel()
+		s := openTestStore(t)
+		won, _, _, err := s.Claim(t.Context(), 21, "executing")
+		require.NoError(t, err)
+		require.True(t, won)
+		require.NoError(t, s.Delete(t.Context(), 21))
+		won2, _, _, err := s.Claim(t.Context(), 21, "executing")
+		require.NoError(t, err)
+		assert.True(t, won2, "after delete the id is claimable again")
+	})
+
 	t.Run("prune deletes only rows older than maxAge", func(t *testing.T) {
 		t.Parallel()
 		s := openTestStore(t)

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -30,6 +30,12 @@ const (
 	// an env knob).
 	DefaultPruneAge = 24 * time.Hour
 
+	// DefaultCommandLedgerRetention bounds the durable command-dedup ledger (issue #558). It is much longer than DefaultPruneAge because
+	// a command stays eligible for re-delivery until it leaves the server's pending state: a host offline for days then reconnecting can
+	// be re-offered a command it already ran, and pruning its dedup row too early would let a non-idempotent kill_process re-execute. 30
+	// days comfortably exceeds any realistic offline-then-reconnect window while keeping the (low-volume) command table bounded.
+	DefaultCommandLedgerRetention = 30 * 24 * time.Hour
+
 	// defaultProcessReconcileInterval is the default for EDR_PROCESS_RECONCILE_INTERVAL: how often the agent sweeps its proctable for
 	// missed exit events. 60s tracks the server's freshness reconciler but is closer to ground truth on a single host.
 	defaultProcessReconcileInterval = 60 * time.Second

--- a/agent/controlclient/controlclient.go
+++ b/agent/controlclient/controlclient.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"log/slog"
 	"math/rand/v2"
-	"sync"
 	"time"
 
 	"google.golang.org/grpc/codes"
@@ -23,9 +22,6 @@ import (
 const (
 	defaultInitialBackoff = 1 * time.Second
 	defaultMaxBackoff     = 30 * time.Second
-	// outcomeCacheCapacity bounds the remembered-outcomes map. Commands are infrequent (operator actions), so a small cache covers the
-	// re-delivery window; it is a per-agent ephemeral cache, lost on restart.
-	outcomeCacheCapacity = 256
 )
 
 // Config holds the control client's dependencies.
@@ -41,6 +37,9 @@ type Config struct {
 	// ApplicationControlSender is the XPC bridge handed to the shared executor; nil means set_application_control commands fail with a
 	// clear reason, matching the poll path.
 	ApplicationControlSender commander.ApplicationControlSender
+	// Ledger is the durable dedup store shared with the poll path so a command executed over the stream is not re-executed on a restart
+	// or by the poll path after a stream drop (issue #558). Nil disables dedup (tests).
+	Ledger commander.Ledger
 	// OnConnectedChange reports stream up (true) / down (false) so the commander can suspend / resume polling. Nil is allowed.
 	OnConnectedChange func(bool)
 	Logger            *slog.Logger
@@ -53,7 +52,6 @@ type Config struct {
 type Client struct {
 	cfg            Config
 	executor       *commander.Executor
-	outcomes       *outcomeCache
 	logger         *slog.Logger
 	initialBackoff time.Duration
 	maxBackoff     time.Duration
@@ -84,8 +82,7 @@ func New(cfg Config) *Client {
 	}
 	return &Client{
 		cfg:            cfg,
-		executor:       commander.NewExecutor(cfg.ApplicationControlSender, logger),
-		outcomes:       newOutcomeCache(outcomeCacheCapacity),
+		executor:       commander.NewExecutor(cfg.ApplicationControlSender, cfg.Ledger, logger),
 		logger:         logger,
 		initialBackoff: initial,
 		maxBackoff:     maxB,
@@ -160,9 +157,9 @@ func (c *Client) runStream(ctx context.Context) (bool, error) {
 	}
 }
 
-// handleCommand executes a pushed command and reports its outcome over the stream. Delivery is at-least-once: if the command has
-// already been executed (its outcome is cached), the agent re-reports the recorded outcome instead of running the side effect again, so
-// a re-delivery after a lost report still drives the command to terminal and a non-idempotent command (kill_process) is never re-run.
+// handleCommand executes a pushed command and reports its outcome over the stream. Delivery is at-least-once; the shared executor keys
+// execution on the durable command ledger, so a re-delivery of an already-executed command replays its recorded outcome instead of
+// re-running the side effect (a non-idempotent kill_process is never re-run), across both transports and across restarts (issue #558).
 // A non-nil return is a stream-send failure: the caller must tear the stream down and reconnect, since outcomes can no longer be
 // reported on it. A dropped or misrouted command (host mismatch) is not a send failure and returns nil.
 func (c *Client) handleCommand(ctx context.Context, stream control.ControlChannel_ConnectClient, pushed *control.Command) error {
@@ -182,23 +179,11 @@ func (c *Client) handleCommand(ctx context.Context, stream control.ControlChanne
 		CommandType: pushed.GetCommandType(),
 		Payload:     pushed.GetPayload(),
 	}
-	if prior, ok := c.outcomes.get(cmd.ID); ok {
-		// Re-delivery of an already-executed command: replay ack + the recorded terminal outcome (no side effect). The ack drives the
-		// server out of pending if its earlier ack was lost; an already-acked command makes the server reject the duplicate ack benignly.
-		if err := c.send(stream, cmd.ID, commander.StatusAcked, nil); err != nil {
-			return err
-		}
-		return c.send(stream, cmd.ID, prior.status, prior.result)
-	}
-	// sendErr captures a stream-send failure from inside the executor callback (the executor itself only logs report errors). The
-	// executor stops on the first report error (it skips the side effect if the ack send fails), so sendErr holds that failure;
-	// handleCommand returns it so runStream reconnects. This also surfaces send failures on the terminal "failed" reports, whose
-	// errors the executor's validation paths otherwise discard.
+	// sendErr captures a stream-send failure from inside the executor callback (the executor only logs report errors). The executor
+	// dedupes via the shared ledger, replaying a recorded outcome instead of re-running the side effect; either way each report goes
+	// through this callback. handleCommand returns the last send error so runStream reconnects on a one-way-broken stream.
 	var sendErr error
 	c.executor.Execute(ctx, cmd, func(_ context.Context, statusValue string, result json.RawMessage) error {
-		if statusValue == commander.StatusCompleted || statusValue == commander.StatusFailed {
-			c.outcomes.put(cmd.ID, cachedOutcome{status: statusValue, result: result})
-		}
 		sendErr = c.send(stream, cmd.ID, statusValue, result)
 		return sendErr
 	})
@@ -217,50 +202,6 @@ func (c *Client) setConnected(v bool) {
 	if c.cfg.OnConnectedChange != nil {
 		c.cfg.OnConnectedChange(v)
 	}
-}
-
-// cachedOutcome is a remembered terminal outcome for idempotent re-report.
-type cachedOutcome struct {
-	status string
-	result json.RawMessage
-}
-
-// outcomeCache is a bounded map of command id to terminal outcome with FIFO (insertion-order) eviction: a get does not change an
-// entry's position, so once the cache is full the oldest-inserted id is dropped first. It is a per-agent in-memory cache, lost on
-// restart, so it dedupes re-deliveries only within a single agent process. It does NOT make a restart-safe guarantee: a still-pending
-// command re-delivered after a restart can be executed again. For set_application_control that is a harmless idempotent snapshot
-// re-apply, but kill_process targets a bare PID, and PIDs can be reused, so a re-execution after restart could in principle signal an
-// unrelated process. Restart-safe dedupe for non-idempotent commands is tracked separately (see issue #558).
-type outcomeCache struct {
-	mu    sync.Mutex
-	m     map[int64]cachedOutcome
-	order []int64
-	cap   int
-}
-
-func newOutcomeCache(capacity int) *outcomeCache {
-	return &outcomeCache{m: make(map[int64]cachedOutcome, capacity), cap: capacity}
-}
-
-func (o *outcomeCache) get(id int64) (cachedOutcome, bool) {
-	o.mu.Lock()
-	defer o.mu.Unlock()
-	oc, ok := o.m[id]
-	return oc, ok
-}
-
-func (o *outcomeCache) put(id int64, oc cachedOutcome) {
-	o.mu.Lock()
-	defer o.mu.Unlock()
-	if _, exists := o.m[id]; !exists {
-		if len(o.order) >= o.cap {
-			oldest := o.order[0]
-			o.order = o.order[1:]
-			delete(o.m, oldest)
-		}
-		o.order = append(o.order, id)
-	}
-	o.m[id] = oc
 }
 
 func sleepCtx(ctx context.Context, d time.Duration) bool {

--- a/agent/controlclient/controlclient_test.go
+++ b/agent/controlclient/controlclient_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"net"
+	"path/filepath"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -17,6 +18,7 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/grpc/test/bufconn"
 
+	"github.com/fleetdm/edr/agent/commandledger"
 	"github.com/fleetdm/edr/agent/controlclient"
 	"github.com/fleetdm/edr/internal/control"
 )
@@ -103,6 +105,12 @@ func startClient(t *testing.T, fake *fakeGateway, sender *recordingSender) (isCo
 	)
 	require.NoError(t, err)
 
+	// A real durable ledger so re-delivery dedup (issue #558) is exercised end to end: the executor replays a recorded outcome instead
+	// of re-running the side effect.
+	ledger, err := commandledger.Open(t.Context(), filepath.Join(t.TempDir(), "commands.db"), commandledger.Options{})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ledger.Close() })
+
 	var connected bool
 	var authFailCount int
 	var mu sync.Mutex
@@ -111,6 +119,7 @@ func startClient(t *testing.T, fake *fakeGateway, sender *recordingSender) (isCo
 		HostID:                   "host-a",
 		TokenFn:                  func() string { return "tok" },
 		ApplicationControlSender: sender,
+		Ledger:                   ledger,
 		OnAuthFail: func(context.Context) {
 			mu.Lock()
 			authFailCount++

--- a/openspec/changes/durable-command-dedup/design.md
+++ b/openspec/changes/durable-command-dedup/design.md
@@ -1,0 +1,24 @@
+# Design: durable, cross-transport command dedup
+
+## The ledger
+
+`agent/commandledger` is a single-table SQLite store (`command_outcomes(command_id PRIMARY KEY, status, result, updated_at)`) opened next to the event queue in the agent state directory, with the same pragmas (5s busy timeout, WAL, bounded WAL size) and a single writer connection. It exposes `Lookup`, `Mark` (upsert), and `Prune`. It is a per-agent store, not synced anywhere; command authority remains in MySQL.
+
+## Write-ahead claim state machine
+
+`commander.Executor.Execute` keys on the ledger:
+
+1. `Lookup(id)`. If a terminal status (`completed` / `failed`) is recorded, re-ack and replay it; do not run the side effect. If `executing` is recorded (a prior attempt that claimed the command but never recorded a terminal outcome), do not run the side effect: terminalize as `failed` ("not retried") so the server stops re-delivering and an operator can re-issue against the current process.
+2. Otherwise: ack. If the ack send fails, return without writing to the ledger, leaving the command eligible for re-dispatch.
+3. `Mark(id, "executing")` BEFORE the side effect (write-ahead), so a crash between the side effect and recording its result is not re-run.
+4. Run the side effect, `Mark(id, terminal, result)`, report the outcome.
+
+A `Lookup` error does not wedge delivery: it is logged and execution proceeds (dedup degraded for that one command). A `Mark` error is logged but non-fatal.
+
+### Why write-ahead, and why "executing" means a crashed prior attempt
+
+There is no concurrent execution of the same command id within one process run: the poll is suspended while the control stream is connected, and each transport processes commands sequentially. So a `Lookup` that returns `executing` is always a claim left by a PRIOR process run that crashed between the write-ahead claim and recording the terminal outcome. Refusing to re-run it is the safety guard for `kill_process`: re-running could SIGKILL a process that has since reused the PID. The common restart case (the terminal outcome WAS recorded before the stop) is the replay branch, not this one.
+
+## Sharing
+
+Both `commander.New` (poll) and `controlclient.New` (push) take a `commander.Ledger`; `cmd/fleet-edr-agent` opens one `commandledger.Store` and passes it to both, so the at-most-once guarantee spans transports. The store is pruned on the agent's existing hourly prune loop. A nil ledger (tests) disables dedup; production always supplies one and fails to start if it cannot be opened, matching the event queue.

--- a/openspec/changes/durable-command-dedup/proposal.md
+++ b/openspec/changes/durable-command-dedup/proposal.md
@@ -1,0 +1,20 @@
+# Durable, cross-transport command dedup
+
+## Why
+
+The push control channel and the poll path each construct their own command executor, and the only dedup state was an in-memory cache local to the control client. So the "side effect runs at most once" guarantee (the `agent-control-channel` delivery requirement) held only within the push transport, within a single process run. Two windows escaped it (issue #558):
+
+- **Cross-transport.** A `kill_process` executed over the control connection, whose ack/outcome did not reach the server before the stream dropped, stays pending. The poll path resumes and re-executes it with a fresh executor that has no memory of the push-path cache, flipping a succeeded kill to `failed`.
+- **Restart + PID reuse.** The in-memory cache is lost on restart, so a still-pending command re-delivered after a restart re-executes. Because `kill_process` carries only a bare PID, and PIDs are reused, a post-restart re-execution could signal an unrelated process.
+
+This change makes the at-most-once guarantee actually hold, durably and across both transports.
+
+## What changes
+
+- A small persistent SQLite ledger (`agent/commandledger`), keyed by the server command id, records each command as `executing` (a write-ahead claim taken before the side effect) and then `completed` / `failed` (the terminal outcome).
+- The shared `commander.Executor` consults the ledger: a command with a recorded terminal outcome is replayed (re-acked and re-reported) without re-running the side effect; a command with only a write-ahead claim (a prior attempt that crashed mid-execution) is terminalized as failed rather than re-run, so a re-delivery never re-signals a possibly-reused PID. Both the poll path and the control client share one ledger.
+- The control client's in-memory outcome cache is removed (the ledger subsumes it).
+
+## Affected specs
+
+- `agent-command-executor`: ADDED requirement that command execution is deduplicated durably across transports and restarts, with a write-ahead claim before the side effect. This realizes, end to end, the existing `agent-control-channel` "side effect at most once / record each outcome" requirement, which previously held only in memory within one transport.

--- a/openspec/changes/durable-command-dedup/specs/agent-command-executor/spec.md
+++ b/openspec/changes/durable-command-dedup/specs/agent-command-executor/spec.md
@@ -17,3 +17,10 @@ The agent SHALL key command execution on a durable, per-agent ledger so a comman
 - **WHEN** the agent restarts and the same command id is delivered again
 - **THEN** the recorded outcome is still available from the durable ledger
 - **AND** the agent re-reports it without re-running the side effect
+
+#### Scenario: Concurrent delivery of the same command runs the side effect once
+
+- **GIVEN** the same command delivered on both transports at the same time
+- **WHEN** the agent attempts to execute it from both
+- **THEN** the write-ahead claim is recorded atomically, so exactly one execution wins the claim
+- **AND** the side effect runs at most once; the other execution does not re-run it

--- a/openspec/changes/durable-command-dedup/specs/agent-command-executor/spec.md
+++ b/openspec/changes/durable-command-dedup/specs/agent-command-executor/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: Command execution is deduplicated durably across transports and restarts
+
+The agent SHALL key command execution on a durable, per-agent ledger so a command's side effect runs at most once across BOTH the push (control connection) and poll transports and across agent restarts. Before running a command's side effect the agent SHALL record a write-ahead claim for the command id; after the side effect it SHALL record the terminal outcome. On encountering a command id that the ledger already records, the agent SHALL NOT re-run the side effect: if a terminal outcome is recorded it re-reports that outcome, and if only a write-ahead claim is recorded (a prior attempt that did not complete, for example an interrupted process) it reports the command failed rather than re-running the side effect, so a non-idempotent command such as `kill_process` never signals a since-reused PID on re-delivery.
+
+#### Scenario: A command executed on one transport is not re-executed by the other
+
+- **GIVEN** a command whose side effect the agent has already run and recorded a terminal outcome for (over the control connection)
+- **WHEN** the same command id is delivered again on the poll path after the connection drops
+- **THEN** the agent does not run the side effect again
+- **AND** it re-reports the recorded terminal outcome, so the command's status stays stable rather than flipping
+
+#### Scenario: A recorded outcome survives an agent restart
+
+- **GIVEN** a command whose terminal outcome the agent recorded before it stopped
+- **WHEN** the agent restarts and the same command id is delivered again
+- **THEN** the recorded outcome is still available from the durable ledger
+- **AND** the agent re-reports it without re-running the side effect

--- a/openspec/changes/durable-command-dedup/tasks.md
+++ b/openspec/changes/durable-command-dedup/tasks.md
@@ -1,0 +1,20 @@
+## 1. Spec delta
+
+- [x] 1.1 This proposal plus the spec delta pass `openspec validate durable-command-dedup --strict`
+
+## 2. Durable ledger
+
+- [x] 2.1 `agent/commandledger`: SQLite store with Lookup / Mark / Prune, opened next to the event queue
+- [x] 2.2 Unit tests: round-trip, upsert, prune-by-age, survives reopen (restart)
+
+## 3. Shared executor dedup
+
+- [x] 3.1 `commander.Executor` takes a `Ledger`; Execute replays a recorded terminal outcome, refuses to re-run a write-ahead claim, and records claim-then-outcome around the side effect
+- [x] 3.2 Remove the control client's in-memory outcome cache (subsumed by the ledger)
+- [x] 3.3 Wire one ledger into both `commander` (poll) and `controlclient` (push) in `cmd/fleet-edr-agent`; prune it on the existing loop
+- [x] 3.4 Unit tests: dedup across two executors sharing a ledger, replayed failure, interrupted-claim-not-retried, no-ledger-still-executes
+
+## 4. Manual verification
+
+- [x] 4.1 Dev server (host-native agent enrolled against `task dev:server`): a kill_process executes once (victim killed, ledger row `completed`); a re-armed (re-delivered) command replays the recorded outcome with zero re-executions (status stays `completed`, not flipped to `failed`); and after an agent restart the persisted ledger still replays (zero re-executions)
+- [x] 4.2 VM (edr-dev, agent against the host dev server over the bridge): a real kill_process executes once (VM victim killed, ledger row `completed`); a forced re-delivery replays with zero re-executions


### PR DESCRIPTION
The push and poll paths each built their own command executor, and the only dedup state was an in-memory cache in the control client. So "a command's side effect runs at most once" held only within the push transport, within one process run. Two windows escaped it:

- Cross-transport: a kill_process executed over the control connection whose outcome didn't reach the server before the stream dropped stays pending; the poll path resumes and re-executes it with a fresh executor, flipping a succeeded kill to failed.
- Restart + PID reuse: the in-memory cache is lost on restart, so a re-delivered kill_process re-executes; since it carries only a bare PID and PIDs are reused, it could signal an unrelated process.

Add a small persistent SQLite ledger (agent/commandledger), keyed by command id, that both transports consult through the shared commander.Executor. The executor write-ahead claims a command (status "executing") before its side effect and records the terminal outcome after; on a re-delivery it replays a recorded terminal outcome instead of re-running, and refuses to re-run a command left in "executing" by a crashed prior attempt (so it never re-signals a reused PID). The control client's in-memory cache is removed (subsumed by the ledger). One ledger is opened in cmd/fleet-edr-agent and shared by both paths; it is pruned on the existing hourly loop.

Includes the openspec delta (durable-command-dedup) with a new agent-command-executor requirement + scenarios (cross-transport and restart), each carrying a test marker.

<!-- Keep this short. Delete sections that do not apply. -->

## What & why



## Checklist

- [ ] **OpenSpec updated for behavior changes.** If this PR changes observable behavior (a detection rule, the event
      wire schema, persistence semantics, an API/wire shape, or an emitted event), `openspec/specs/**` is updated (and
      an `openspec/changes/` proposal added), with a `spec:<id>` test marker for any new/renamed scenario. Only if this
      PR changes NO observable behavior (a comment / refactor / gofmt / dep bump that happens to touch a scoped path)
      may you assert `no-behavior-change` (label or `[no-behavior-change]` in the title) to clear the OpenSpec-sync gate.
      That is an assertion a reviewer will check, not a way to skip the spec for a real behavior change.
- [ ] Tests added/updated for the change (unit / integration / efficacy / UI as applicable).
- [ ] Agent/extension change touching ESF, XPC, or the event wire format: exercised on a live macOS VM before RC
      (flagged below).
- [ ] **Docs updated for user-facing changes.** If this PR changes a user-facing surface (the React UI, an HTTP
      handler, or a detection rule), `docs/` or `CHANGELOG.md` is updated in the same PR. Only if nothing a user sees
      changed (an internal refactor, a non-visible UI tweak) may you assert `no-docs-change` (label or
      `[no-docs-change]` in the title) to clear the Docs-sync gate. The model is in `docs/doc-versioning.md`.

## VM / RC notes (if applicable)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Command handling now keeps a durable record of outcomes, helping prevent duplicate command execution across reconnects and restarts.
  * Commands delivered through different paths now share the same deduplication behavior.

* **Bug Fixes**
  * Reduced the chance of non-idempotent commands running more than once after connection drops or agent restarts.
  * Improved reliability when a command was already in progress or had previously completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->