### PR TITLE
fix(detection): wire SetMetrics before Run in tests to close the data race (#561)

### DIFF
--- a/server/detection/bootstrap/bootstrap.go
+++ b/server/detection/bootstrap/bootstrap.go
@@ -251,8 +251,11 @@ func (d *Detection) SetMetrics(m api.MetricsRecorder) {
 }
 
 // SetModeResolver wires the per-host rule-mode resolver into the engine AFTER construction (issue #459). cmd/main passes the rules
-// context's detection-config service. No-op in ModeIntake (no engine). Like SetMetrics, it is set-once construction-phase config and
-// MUST be called before Run, not concurrently with the running loops.
+// context's detection-config service. No-op in ModeIntake (no engine). It is set-once construction-phase config, but unlike the metrics
+// recorder (read by the pipeline runners on their immediate first sweep at Run start) the engine reads the mode resolver only while
+// evaluating a claimed event batch. So it need only be wired before events are evaluated, not necessarily before Run: calling it after
+// newDetection but before any events flow is safe (as the integration tests do); what is unsafe is calling it concurrently with the
+// engine's evaluation of a batch.
 func (d *Detection) SetModeResolver(m rulesapi.RuleModeResolver) {
 	if d.engine != nil {
 		d.engine.SetModeResolver(m)
@@ -264,8 +267,11 @@ func (d *Detection) SetModeResolver(m rulesapi.RuleModeResolver) {
 func (d *Detection) Store() *mysql.Store { return d.store }
 
 // LoadActive registers the active rule set with the engine. cmd/main
-// calls this after rulesCtx is built. Skipped in ModeIntake (no engine). Like SetMetrics, it is set-once construction-phase config and
-// MUST be called before Run, not concurrently with the running loops.
+// calls this after rulesCtx is built. Skipped in ModeIntake (no engine). Like SetModeResolver it is set-once config the engine reads
+// only while evaluating a claimed event batch, so wire it before events are evaluated, not necessarily before Run: after newDetection
+// but before any events flow is fine (the engine has not read the rules yet); concurrent with the engine's evaluation of a batch is not.
+// Tests that can fix the rule set at construction should pass it through the helper's opts (wired before Run); those whose rules depend
+// on post-newDetection state (for example a just-inserted process id) call it after newDetection, before inserting the triggering events.
 func (d *Detection) LoadActive(rp interface{ ActiveRules() []rulesapi.Rule }) {
 	if d.engine == nil {
 		return

--- a/server/detection/bootstrap/bootstrap.go
+++ b/server/detection/bootstrap/bootstrap.go
@@ -233,6 +233,10 @@ func (d *Detection) Service() api.Service { return d.svc }
 // SetMetrics wires the metrics recorder into the engine + intake + pipeline (processttl + retention) AFTER construction. Used by
 // cmd/main to break the circular dependency between detectionCtx and metrics.New (the OfflineHosts gauge source needs detectionCtx;
 // detectionCtx's engine + intake + pipeline need the recorder).
+//
+// It MUST be called before Run. The recorder is set-once construction-phase config that the running loops read (the pipeline runners
+// read it on their immediate first sweep), so calling it concurrently with the loops is a data race (issue #561). cmd/main wires it
+// before `go runDetection`; tests wire it through the helper before the loops launch.
 func (d *Detection) SetMetrics(m api.MetricsRecorder) {
 	d.metrics = m
 	if d.engine != nil {
@@ -247,7 +251,8 @@ func (d *Detection) SetMetrics(m api.MetricsRecorder) {
 }
 
 // SetModeResolver wires the per-host rule-mode resolver into the engine AFTER construction (issue #459). cmd/main passes the rules
-// context's detection-config service. No-op in ModeIntake (no engine).
+// context's detection-config service. No-op in ModeIntake (no engine). Like SetMetrics, it is set-once construction-phase config and
+// MUST be called before Run, not concurrently with the running loops.
 func (d *Detection) SetModeResolver(m rulesapi.RuleModeResolver) {
 	if d.engine != nil {
 		d.engine.SetModeResolver(m)
@@ -259,7 +264,8 @@ func (d *Detection) SetModeResolver(m rulesapi.RuleModeResolver) {
 func (d *Detection) Store() *mysql.Store { return d.store }
 
 // LoadActive registers the active rule set with the engine. cmd/main
-// calls this after rulesCtx is built. Skipped in ModeIntake (no engine).
+// calls this after rulesCtx is built. Skipped in ModeIntake (no engine). Like SetMetrics, it is set-once construction-phase config and
+// MUST be called before Run, not concurrently with the running loops.
 func (d *Detection) LoadActive(rp interface{ ActiveRules() []rulesapi.Rule }) {
 	if d.engine == nil {
 		return

--- a/server/detection/internal/tests/integration_test.go
+++ b/server/detection/internal/tests/integration_test.go
@@ -307,10 +307,11 @@ type detectionOpts struct {
 	userExists    bootstrap.UserExists
 	processTTL    time.Duration
 	retentionDays int
-	// metrics and ruleProvider, when set, are wired (SetMetrics / LoadActive) BEFORE the Run loops are launched, matching the
-	// production order (cmd/main wires these before `go runDetection`). These setters are construction-phase config published before
-	// the loops start; wiring them after newDetection has already launched Run would race the loops (issue #561). A ModeFull test that
-	// needs metrics or rules in effect must pass them here rather than calling the setters after newDetection.
+	// metrics and ruleProvider, when set, are wired (SetMetrics / LoadActive) BEFORE the Run loops are launched. metrics MUST be wired
+	// before launch: the pipeline runners read the recorder on their immediate first sweep at Run start, so setting it after newDetection
+	// has launched Run races them (issue #561). ruleProvider is wired before launch only as a convenience; LoadActive is also safe to
+	// call after newDetection as long as it precedes any events (the engine reads rules only while evaluating a batch), which is what
+	// most ModeFull tests do.
 	metrics      api.MetricsRecorder
 	ruleProvider interface{ ActiveRules() []rulesapi.Rule }
 }
@@ -354,9 +355,9 @@ func newDetectionWithArchive(t *testing.T, opts detectionOpts) (*bootstrap.Detec
 	require.NoError(t, err)
 	require.NoError(t, d.ApplySchema(t.Context()))
 
-	// Wire construction-phase config BEFORE launching the Run loops, the same order cmd/main uses (SetMetrics / LoadActive happen-before
-	// `go runDetection`). Doing it after the loops start would race them (issue #561): the pipeline runners read the metrics recorder on
-	// their immediate first sweep.
+	// Wire construction-phase config BEFORE launching the Run loops. This is REQUIRED for metrics (the pipeline runners read the recorder
+	// on their immediate first sweep at Run start, so a later SetMetrics races them: issue #561) and a convenience for rules (LoadActive
+	// is also safe after newDetection as long as it precedes any events). cmd/main wires both before `go runDetection`.
 	if opts.metrics != nil {
 		d.SetMetrics(opts.metrics)
 	}

--- a/server/detection/internal/tests/integration_test.go
+++ b/server/detection/internal/tests/integration_test.go
@@ -307,6 +307,12 @@ type detectionOpts struct {
 	userExists    bootstrap.UserExists
 	processTTL    time.Duration
 	retentionDays int
+	// metrics and ruleProvider, when set, are wired (SetMetrics / LoadActive) BEFORE the Run loops are launched, matching the
+	// production order (cmd/main wires these before `go runDetection`). These setters are construction-phase config published before
+	// the loops start; wiring them after newDetection has already launched Run would race the loops (issue #561). A ModeFull test that
+	// needs metrics or rules in effect must pass them here rather than calling the setters after newDetection.
+	metrics      api.MetricsRecorder
+	ruleProvider interface{ ActiveRules() []rulesapi.Rule }
 }
 
 // newDetection builds a fresh Detection bootstrap against an isolated
@@ -347,6 +353,16 @@ func newDetectionWithArchive(t *testing.T, opts detectionOpts) (*bootstrap.Detec
 	d, err := bootstrap.New(deps)
 	require.NoError(t, err)
 	require.NoError(t, d.ApplySchema(t.Context()))
+
+	// Wire construction-phase config BEFORE launching the Run loops, the same order cmd/main uses (SetMetrics / LoadActive happen-before
+	// `go runDetection`). Doing it after the loops start would race them (issue #561): the pipeline runners read the metrics recorder on
+	// their immediate first sweep.
+	if opts.metrics != nil {
+		d.SetMetrics(opts.metrics)
+	}
+	if opts.ruleProvider != nil {
+		d.LoadActive(opts.ruleProvider)
+	}
 
 	if opts.mode == bootstrap.ModeFull {
 		runCtx, cancel := context.WithCancel(context.Background())
@@ -1722,12 +1738,15 @@ func TestBootstrap_SchemaIdempotent(t *testing.T) {
 
 func TestSetMetrics_PropagatesToEngineAndIntake(t *testing.T) {
 	t.Parallel()
-	d := newDetection(t, detectionOpts{mode: bootstrap.ModeFull})
-	ctx := t.Context()
-
+	// Wire the recorder + rules via opts so the helper installs them BEFORE launching Run, matching production order. Calling
+	// d.SetMetrics after newDetection (which has already started the loops) would race the pipeline runners' first sweep (issue #561).
 	rec := &recordingMetrics{}
-	d.SetMetrics(rec)
-	d.LoadActive(stubProvider{rules: []rulesapi.Rule{&stubRule{id: "metrics"}}})
+	d := newDetection(t, detectionOpts{
+		mode:         bootstrap.ModeFull,
+		metrics:      rec,
+		ruleProvider: stubProvider{rules: []rulesapi.Rule{&stubRule{id: "metrics"}}},
+	})
+	ctx := t.Context()
 
 	mustInsertProcess(t, ctx, d, "host-a", 100)
 	insertEventsViaIngest(ctx, t, d, "host-a", []api.Event{


### PR DESCRIPTION
Closes #561.

## What it was

An intermittent `-race` failure in CI. The detection setters (`SetMetrics`, `LoadActive`, `SetModeResolver`) are set-once construction-phase config the running loops read. Production is safe: cmd/main wires them before `go runDetection`, so the loops observe them via the goroutine-launch happens-before. The race was test-induced: the `newDetection(ModeFull)` helper launches `d.Run` during construction, and `TestSetMetrics_PropagatesToEngineAndIntake` then called `d.SetMetrics` afterward, racing the pipeline runners' immediate first sweep (which reads the metrics recorder).

## The fix

Make the test honor the same wire-before-`Run` order production uses: `detectionOpts` gains `metrics` and `ruleProvider`, which the helper installs before launching the loops; the test passes them via opts instead of calling the setters after `newDetection`. The contract ("call before Run, not concurrently with the loops") is now documented on all three setters.

No production logic changed. Locks were deliberately not added to the metrics/rules fields: they are set-once-before-launch config published via the `go` happens-before edge, so synchronizing would put a mutex on hot-path reads for data that never changes after startup and mis-model a one-shot construction setter.

## Verification

- The two flagged tests at `-race -count=20`, and the full detection integration package at `-race -count=2`.
- build + `go vet -tags integration`, golangci `0 issues`, new-code gate `0 issues`, dashes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BxbWcMpjYFGpHZDU2d2mfm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup reliability for detection by ensuring configuration is applied before processing begins, reducing the risk of early-run race conditions.
  * Fixed test coverage to reflect the safer initialization flow and validate metrics behavior during startup.

* **Documentation**
  * Clarified setup guidance for detection initialization, including when configuration must be applied relative to runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->