### PR TITLE
Close #477: control-channel closeout tests + fix the shared-listener stream flap

### DIFF
--- a/openspec/changes/control-channel-single-port/design.md
+++ b/openspec/changes/control-channel-single-port/design.md
@@ -16,6 +16,10 @@ The first implementation used `cmux` to split gRPC from REST by sniffing the con
 
 Because the gateway is served via `grpc.Server.ServeHTTP` (riding net/http's HTTP/2 server), `grpc.Server.GracefulStop` is unusable: its `serverHandlerTransport` has no `Drain`, so GracefulStop panics. Shutdown is instead driven by `http.Server.Shutdown`, with the gateway cancelling its live streams so their handlers return promptly: `Gateway.Stop` marks the gateway closing (a connection accepted mid-shutdown is rejected) and cancels every registered connection's context. The control streams are long-lived and would otherwise hold `http.Server.Shutdown` open until its deadline. The agent's keep-alive PINGs need no special server policy: net/http's HTTP/2 server answers them without gRPC's strict ping-flood GOAWAY, so the previous keepalive-enforcement option is dropped.
 
+## Per-stream deadlines cleared for the control channel
+
+Sharing the REST `http.Server` means the control stream inherits its per-request `ReadTimeout` and `WriteTimeout`. On an HTTP/2 stream those bound the whole request/response, not one message, so a 10s `ReadTimeout` tears the long-lived stream down every 10s (observed in live QA as a ~10s reconnect flap, and in SigNoz as a run of 10s `ControlChannel/Connect` spans ending in `i/o timeout`). The multiplexer clears both deadlines for the `application/grpc` branch via `http.NewResponseController` (`SetReadDeadline`/`SetWriteDeadline` to the zero time) before delegating to the gateway; the REST and UI surface keeps its timeouts. Delivery still degrades safely if a transport ever refuses the clear: the agent reconnects and the retained short-poll remains the floor, so no command is lost.
+
 ## Deployment
 
 In the quickstart / single-VM model a front proxy (Caddy) terminates the public TLS and reverse-proxies to the server's plaintext port. The proxy SHALL forward to the upstream over HTTP/2 cleartext (h2c) so the bidirectional control stream is carried, not just HTTP/1.1 REST. The server's plaintext mode accepts h2c for exactly this.

--- a/openspec/changes/control-channel-single-port/specs/server-configuration/spec.md
+++ b/openspec/changes/control-channel-single-port/specs/server-configuration/spec.md
@@ -2,7 +2,7 @@
 
 ### Requirement: The agent control channel shares the main server listener
 
-The server SHALL serve the agent control-channel gRPC gateway on the same listener and port as the REST API and the UI, multiplexed by request content-type: gRPC requests (HTTP/2 with an `application/grpc` content type, which gRPC requires) are dispatched to the control gateway, and all other requests to the REST/UI handler. The server SHALL NOT expose a separate bind address for the control channel; there is no control-channel address environment variable. A deployment that still sets a no-longer-recognized control-channel address variable SHALL find it inert: boot succeeds and behavior is unchanged. When the server terminates TLS itself, gRPC and REST SHALL both be served over the single TLS listener using ALPN-negotiated HTTP/2; in the TLS-terminated-by-proxy mode the server SHALL also accept cleartext HTTP/2 (h2c), so a front proxy can forward the control stream to the same upstream as REST.
+The server SHALL serve the agent control-channel gRPC gateway on the same listener and port as the REST API and the UI, multiplexed by request content-type: gRPC requests (HTTP/2 with an `application/grpc` content type, which gRPC requires) are dispatched to the control gateway, and all other requests to the REST/UI handler. The server SHALL NOT expose a separate bind address for the control channel; there is no control-channel address environment variable. A deployment that still sets a no-longer-recognized control-channel address variable SHALL find it inert: boot succeeds and behavior is unchanged. When the server terminates TLS itself, gRPC and REST SHALL both be served over the single TLS listener using ALPN-negotiated HTTP/2; in the TLS-terminated-by-proxy mode the server SHALL also accept cleartext HTTP/2 (h2c), so a front proxy can forward the control stream to the same upstream as REST. Because the control channel is a long-lived stream sharing the REST server, which enforces per-request read and write timeouts, the server SHALL clear those per-stream deadlines for the control-channel request so the stream is not torn down when a REST timeout elapses; the REST and UI surface keeps its timeouts.
 
 #### Scenario: gRPC and REST share one port
 
@@ -10,3 +10,10 @@ The server SHALL serve the agent control-channel gRPC gateway on the same listen
 - **WHEN** an agent opens the control-channel gRPC stream and a client issues a REST request to the same server
 - **THEN** both are served on the same host and port, separated by request content-type
 - **AND** no separate control-channel bind address is configured on the server
+
+#### Scenario: Control stream not bounded by REST timeouts
+
+- **GIVEN** the shared listener enforces the REST server's per-request read and write timeouts
+- **WHEN** an agent holds the long-lived control-channel stream open past those timeouts
+- **THEN** the server SHALL NOT tear the stream down when a REST timeout elapses, because the read and write deadlines are cleared for the control stream
+- **AND** the stream stays up to deliver a later command, while the REST and UI surface keeps its timeouts unchanged

--- a/openspec/changes/control-channel-single-port/tasks.md
+++ b/openspec/changes/control-channel-single-port/tasks.md
@@ -10,6 +10,7 @@
 - [x] 2.3 Build the gateway without transport credentials and serve it via `grpc.Server.ServeHTTP`; drop the separate listener and `EDR_CONTROL_ADDR`
 - [x] 2.4 Rework `Gateway.Stop` to cancel live streams (no `grpc.GracefulStop`, which panics under `ServeHTTP`); shutdown is driven by `http.Server.Shutdown`
 - [x] 2.5 Unit test: gRPC + HTTP/1.1 + HTTP/2 (including a reused HTTP/2 connection) coexist on one listener, TLS and plaintext; bidirectional control stream over net/http's HTTP/2
+- [x] 2.6 Clear the per-stream read and write deadlines for the `application/grpc` branch so the long-lived control stream is not torn down by the REST server's `ReadTimeout`/`WriteTimeout` (a ~10s reconnect flap observed in live QA); REST keeps its timeouts. Regression test holds a stream open past the timeouts
 
 ## 3. Agent: derive the endpoint, always on
 

--- a/openspec/changes/control-channel-single-port/tasks.md
+++ b/openspec/changes/control-channel-single-port/tasks.md
@@ -19,5 +19,5 @@
 
 ## 4. Deployment
 
-- [ ] 4.1 Quickstart Caddy reverse-proxies to the upstream over h2c so the control stream is forwarded
+- [x] 4.1 Quickstart Caddy reverse-proxies to the upstream over h2c so the control stream is forwarded
 - [ ] 4.2 Validate the proxied control stream on the notarized RC (covered by the agent/extension RC re-test, #557)

--- a/openspec/changes/push-command-channel/tasks.md
+++ b/openspec/changes/push-command-channel/tasks.md
@@ -40,4 +40,4 @@
 
 ## 6. QA
 
-- [ ] 6.1 Verify end to end on the dev server plus a live agent (edr-dev): queue a kill from the UI and confirm sub-second delivery over the stream and the offline/online flip on disconnect; confirm trace continuity across the stream in SigNoz
+- [x] 6.1 Verify end to end on the dev server plus a live agent (edr-dev): queue a kill from the UI and confirm sub-second delivery over the stream and the offline/online flip on disconnect; confirm trace continuity across the stream in SigNoz

--- a/openspec/changes/push-command-channel/tasks.md
+++ b/openspec/changes/push-command-channel/tasks.md
@@ -1,42 +1,42 @@
 ## 1. Spec delta and decision
 
-- [ ] 1.1 This proposal plus spec deltas pass `openspec validate push-command-channel --strict`
-- [ ] 1.2 Amend `docs/adr/0010-stateless-server.md` to name the control gateway as the sanctioned stateful tier (live connections only, nothing durable, losable on reconnect without command loss); keep the `server-availability` modified requirement in lockstep
+- [x] 1.1 This proposal plus spec deltas pass `openspec validate push-command-channel --strict`
+- [x] 1.2 Amend `docs/adr/0010-stateless-server.md` to name the control gateway as the sanctioned stateful tier (live connections only, nothing durable, losable on reconnect without command loss); keep the `server-availability` modified requirement in lockstep
 
 ## 2. Control-channel transport contract
 
-- [ ] 2.1 Define the bidirectional stream frame contract: command frames down (`id`, `host_id`, `command_type`, `payload`), outcome frames up (`id`, `status`, `result`), using the same field shapes as the `commands` row and the `PUT /api/commands/{id}` body so the wire shape is byte-stable across transports
-- [ ] 2.2 Property-based round-trip test for the frame encoding (`Marshal then Unmarshal == identity`)
-- [ ] 2.3 Promote gRPC + protobuf from indirect to direct dependencies; add `otelgrpc` stats handlers so W3C trace context propagates over stream metadata
+- [x] 2.1 Define the bidirectional stream frame contract: command frames down (`id`, `host_id`, `command_type`, `payload`), outcome frames up (`id`, `status`, `result`), using the same field shapes as the `commands` row and the `PUT /api/commands/{id}` body so the wire shape is byte-stable across transports
+- [x] 2.2 Property-based round-trip test for the frame encoding (`Marshal then Unmarshal == identity`)
+- [x] 2.3 Promote gRPC + protobuf from indirect to direct dependencies; add `otelgrpc` stats handlers so W3C trace context propagates over stream metadata
 
 ## 3. Server gateway (embedded in fleet-edr-server, response context)
 
-- [ ] 3.1 Connect-time auth interceptor: verify the signed host token from stream metadata via the existing `endpoint` verify + revocation snapshot (no DB round-trip), pin `host_id` into the stream context, reject otherwise; surface a snapshot blip as retryable, not a hard deauth
-- [ ] 3.2 Connection registry: live connections keyed by `host_id`, each holding its auth metadata (token epoch + expiry) and an in-flight-command-id set (in-memory, per-replica, documented "safe to lose" per ADR-0010). Enforce at most one connection per host: on a new connection for an already-connected host, close and release the prior connection before registering the new one (no leaked goroutine/fd, no duplicate push)
-- [ ] 3.3 MySQL watch loop: every fixed 1s interval read pending commands scoped to locally-held hosts (`WHERE status='pending' AND host_id IN (<connected ids>)`, batched if the connected set is large) so the query seeks the `(host_id, status)` index instead of scanning the whole pending backlog; push each row, skipping IDs already in flight on that connection
-- [ ] 3.4 In-process fast path: when a command is queued on this replica for a locally-held connection, notify the gateway and push immediately without waiting for the watch tick
-- [ ] 3.5 Outcome frames call the unchanged `response.api.Service.UpdateStatus` (same state machine); an outcome that is not a valid transition for the command's current status is rejected and the agent treats it as already-handled, not an error
-- [ ] 3.6 Liveness: bump `host.last_seen_ns` on connect and on the keep-alive cadence via the injected `detection` host-seen closure; reflect disconnect as offline
-- [ ] 3.7 Revocation teardown: on the revocation-snapshot refresh cadence, close any held connection whose token no longer validates (revoked epoch or expiry), within the propagation bound
-- [ ] 3.8 Mount the gateway listener in `server/cmd/fleet-edr-server/main.go` alongside the HTTP routes; the gateway is embedded, no new binary
+- [x] 3.1 Connect-time auth interceptor: verify the signed host token from stream metadata via the existing `endpoint` verify + revocation snapshot (no DB round-trip), pin `host_id` into the stream context, reject otherwise; surface a snapshot blip as retryable, not a hard deauth
+- [x] 3.2 Connection registry: live connections keyed by `host_id`, each holding its auth metadata (token epoch + expiry) and an in-flight-command-id set (in-memory, per-replica, documented "safe to lose" per ADR-0010). Enforce at most one connection per host: on a new connection for an already-connected host, close and release the prior connection before registering the new one (no leaked goroutine/fd, no duplicate push)
+- [x] 3.3 MySQL watch loop: every fixed 1s interval read pending commands scoped to locally-held hosts (`WHERE status='pending' AND host_id IN (<connected ids>)`, batched if the connected set is large) so the query seeks the `(host_id, status)` index instead of scanning the whole pending backlog; push each row, skipping IDs already in flight on that connection
+- [x] 3.4 In-process fast path: when a command is queued on this replica for a locally-held connection, notify the gateway and push immediately without waiting for the watch tick
+- [x] 3.5 Outcome frames call the unchanged `response.api.Service.UpdateStatus` (same state machine); an outcome that is not a valid transition for the command's current status is rejected and the agent treats it as already-handled, not an error
+- [x] 3.6 Liveness: bump `host.last_seen_ns` on connect and on the keep-alive cadence via the injected `detection` host-seen closure; reflect disconnect as offline
+- [x] 3.7 Revocation teardown: on the revocation-snapshot refresh cadence, close any held connection whose token no longer validates (revoked epoch or expiry), within the propagation bound
+- [x] 3.8 Mount the gateway listener in `server/cmd/fleet-edr-server/main.go` alongside the HTTP routes; the gateway is embedded, no new binary
 
 ## 4. Agent control client
 
-- [ ] 4.1 Open the stream over the existing pinned-TLS shared transport, presenting the current host token in connect metadata; reconnect with exponential backoff + jitter on drop or connect failure
-- [ ] 4.2 Reconnect with the fresh token after the proactive token refresh, rather than an in-band re-auth frame
-- [ ] 4.3 Dispatch pushed commands through the same executor handlers as the poll path (kill, set-application-control, unknown-type), idempotent by command id; record each command's final outcome and, on re-delivery of an already-executed command, re-report the recorded outcome instead of re-executing (prevents a lost report stranding the command in pending and a `kill_process` re-run overwriting success with "no such process"); re-report outcomes for in-flight commands on reconnect
-- [ ] 4.4 Prefer the stream when up and suppress the command poll; resume the existing 5s poll when the stream is unavailable so commands still flow on the degraded floor
-- [ ] 4.5 Keep-alive probes detect a silently-dropped connection and trigger reconnect rather than going dark
+- [x] 4.1 Open the stream over the existing pinned-TLS shared transport, presenting the current host token in connect metadata; reconnect with exponential backoff + jitter on drop or connect failure
+- [x] 4.2 Reconnect with the fresh token after the proactive token refresh, rather than an in-band re-auth frame
+- [x] 4.3 Dispatch pushed commands through the same executor handlers as the poll path (kill, set-application-control, unknown-type), idempotent by command id; record each command's final outcome and, on re-delivery of an already-executed command, re-report the recorded outcome instead of re-executing (prevents a lost report stranding the command in pending and a `kill_process` re-run overwriting success with "no such process"); re-report outcomes for in-flight commands on reconnect
+- [x] 4.4 Prefer the stream when up and suppress the command poll; resume the existing 5s poll when the stream is unavailable so commands still flow on the degraded floor
+- [x] 4.5 Keep-alive probes detect a silently-dropped connection and trigger reconnect rather than going dark
 
 ## 5. Tests
 
-- [ ] 5.1 Integration (real MySQL): a command queued for a connected fake agent is pushed and acked over the stream, transitioning pending -> acked -> completed identically to the poll path
-- [ ] 5.2 Cross-host isolation: host A's connection never receives host B's commands; an outcome frame for another host's command is rejected
-- [ ] 5.3 Duplicate delivery: the same command offered twice runs its side effect once; a re-delivery after a lost completion report re-reports the recorded outcome and transitions the command out of pending (not a silent no-op, not a re-execution)
-- [ ] 5.4 Duplicate connection: a reconnect for an already-connected host closes the prior connection (no leaked connection, no double push), and the new connection is the sole channel
-- [ ] 5.5 Revocation: a revoked token closes the connection within the propagation bound; the agent must re-authenticate to reconnect
-- [ ] 5.6 Fallback: with the gateway unreachable the agent resumes polling and commands are still delivered and reported
-- [ ] 5.7 Liveness: a connected host's last-seen advances without a poll or upload; disconnect flips it offline
+- [x] 5.1 Integration (real MySQL): a command queued for a connected fake agent is pushed and acked over the stream, transitioning pending -> acked -> completed identically to the poll path
+- [x] 5.2 Cross-host isolation: host A's connection never receives host B's commands; an outcome frame for another host's command is rejected
+- [x] 5.3 Duplicate delivery: the same command offered twice runs its side effect once; a re-delivery after a lost completion report re-reports the recorded outcome and transitions the command out of pending (not a silent no-op, not a re-execution)
+- [x] 5.4 Duplicate connection: a reconnect for an already-connected host closes the prior connection (no leaked connection, no double push), and the new connection is the sole channel
+- [x] 5.5 Revocation: a revoked token closes the connection within the propagation bound; the agent must re-authenticate to reconnect
+- [x] 5.6 Fallback: with the gateway unreachable the agent resumes polling and commands are still delivered and reported
+- [x] 5.7 Liveness: a connected host's last-seen advances without a poll or upload; disconnect flips it offline
 
 ## 6. QA
 

--- a/server/httpserver/multiplex_test.go
+++ b/server/httpserver/multiplex_test.go
@@ -131,6 +131,67 @@ func TestRunAndShutdown_MultiplexesGRPCAndHTTP(t *testing.T) {
 	}
 }
 
+// TestRunAndShutdown_ControlStreamOutlivesServerTimeouts is a regression for the single-port control channel (issue #477): the shared
+// http.Server's ReadTimeout/WriteTimeout bound a whole HTTP/2 stream, so leaving them in force would tear the long-lived agent control
+// stream down on that cadence (a 10s read timeout in production, observed as a ~10s reconnect flap in live QA) rather than holding one
+// connection. mountControlChannel must clear both per-stream deadlines for the application/grpc branch, while REST keeps the timeouts. A
+// server-streaming health Watch stands in for the control stream: it is held open well past the server's Read/Write timeouts and must
+// still deliver a later status change.
+//
+// spec:server-configuration/the-agent-control-channel-shares-the-main-server-listener/control-stream-not-bounded-by-rest-timeouts
+func TestRunAndShutdown_ControlStreamOutlivesServerTimeouts(t *testing.T) {
+	t.Parallel()
+	addr := freeAddr(t)
+	srv := &http.Server{
+		Addr:              addr,
+		Handler:           http.NewServeMux(),
+		ReadHeaderTimeout: 5 * time.Second,
+		// Deliberately short: without the deadline clear in mountControlChannel the http2 server tears the stream down at ~250ms.
+		ReadTimeout:  250 * time.Millisecond,
+		WriteTimeout: 250 * time.Millisecond,
+	}
+
+	grpcSrv := grpc.NewServer()
+	hs := health.NewServer()
+	hs.SetServingStatus("svc", healthpb.HealthCheckResponse_SERVING)
+	healthpb.RegisterHealthServer(grpcSrv, hs)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- httpserver.RunAndShutdown(ctx, srv, grpcControlMux{s: grpcSrv}, slog.Default(), nil, 0)
+	}()
+	waitListening(t, addr)
+
+	cc, err := grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	defer func() { _ = cc.Close() }()
+
+	streamCtx, streamCancel := context.WithTimeout(ctx, 5*time.Second)
+	defer streamCancel()
+	watch, err := healthpb.NewHealthClient(cc).Watch(streamCtx, &healthpb.HealthCheckRequest{Service: "svc"})
+	require.NoError(t, err)
+	first, err := watch.Recv()
+	require.NoError(t, err)
+	require.Equal(t, healthpb.HealthCheckResponse_SERVING, first.GetStatus())
+
+	// Hold the stream idle well past the server's 250ms Read/Write timeouts, then push a status change over it. Without the fix the stream
+	// is already dead and this Recv errors; with the fix the stream is still up and delivers the change.
+	time.Sleep(1 * time.Second)
+	hs.SetServingStatus("svc", healthpb.HealthCheckResponse_NOT_SERVING)
+	second, err := watch.Recv()
+	require.NoError(t, err, "control-style stream must outlive the REST server's Read/Write timeouts")
+	assert.Equal(t, healthpb.HealthCheckResponse_NOT_SERVING, second.GetStatus())
+
+	cancel()
+	select {
+	case err := <-done:
+		require.NoError(t, err, "graceful shutdown returns nil")
+	case <-time.After(httpserver.ShutdownTimeout + 2*time.Second):
+		t.Fatal("RunAndShutdown did not return after ctx cancel")
+	}
+}
+
 func httpGet(t *testing.T, c *http.Client, url string) (body, proto string) {
 	t.Helper()
 	resp, err := c.Get(url) //nolint:noctx // short-lived test client

--- a/server/httpserver/serve.go
+++ b/server/httpserver/serve.go
@@ -137,6 +137,14 @@ func mountControlChannel(srv *http.Server, control ControlMux) {
 	base := srv.Handler
 	srv.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.ProtoMajor == 2 && strings.HasPrefix(r.Header.Get("Content-Type"), "application/grpc") {
+			// The control channel is a long-lived bidirectional stream. On an HTTP/2 stream http.Server.ReadTimeout and WriteTimeout bound
+			// the WHOLE request/response, not a single message, so leaving them in force tears the control stream down at the REST server's
+			// timeout (a 10s read timeout in production) and forces the agent to reconnect on that cadence instead of holding one connection
+			// (issue #477). Clear both per-stream deadlines here; the REST/UI surface keeps the server's timeouts unchanged. If a transport
+			// cannot clear a deadline the stream still degrades to reconnect plus the retained short-poll, never to lost commands.
+			rc := http.NewResponseController(w)
+			_ = rc.SetReadDeadline(time.Time{})
+			_ = rc.SetWriteDeadline(time.Time{})
 			control.ServeHTTP(w, r)
 			return
 		}

--- a/server/httpserver/serve.go
+++ b/server/httpserver/serve.go
@@ -67,7 +67,7 @@ func RunAndShutdown(
 	drainDelay time.Duration,
 ) error {
 	if control != nil {
-		mountControlChannel(srv, control)
+		mountControlChannel(srv, control, logger)
 	}
 
 	serverErr := make(chan error, 1)
@@ -133,7 +133,7 @@ func RunAndShutdown(
 // mountControlChannel wraps srv.Handler so application/grpc HTTP/2 requests are dispatched to the control gateway and all other
 // requests to the original REST/UI handler. In the plaintext (proxy-terminated) mode it also enables cleartext HTTP/2 so the front
 // proxy can forward gRPC; over TLS, HTTP/2 comes from ALPN.
-func mountControlChannel(srv *http.Server, control ControlMux) {
+func mountControlChannel(srv *http.Server, control ControlMux, logger *slog.Logger) {
 	base := srv.Handler
 	srv.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.ProtoMajor == 2 && strings.HasPrefix(r.Header.Get("Content-Type"), "application/grpc") {
@@ -141,10 +141,15 @@ func mountControlChannel(srv *http.Server, control ControlMux) {
 			// the WHOLE request/response, not a single message, so leaving them in force tears the control stream down at the REST server's
 			// timeout (a 10s read timeout in production) and forces the agent to reconnect on that cadence instead of holding one connection
 			// (issue #477). Clear both per-stream deadlines here; the REST/UI surface keeps the server's timeouts unchanged. If a transport
-			// cannot clear a deadline the stream still degrades to reconnect plus the retained short-poll, never to lost commands.
+			// cannot clear a deadline the stream still degrades to reconnect plus the retained short-poll, never to lost commands; we log the
+			// refusal rather than silently accepting the shorter-lived stream so the flap has a breadcrumb.
 			rc := http.NewResponseController(w)
-			_ = rc.SetReadDeadline(time.Time{})
-			_ = rc.SetWriteDeadline(time.Time{})
+			if err := rc.SetReadDeadline(time.Time{}); err != nil {
+				logger.WarnContext(r.Context(), "control channel: could not clear read deadline; stream will honor the REST read timeout", "err", err)
+			}
+			if err := rc.SetWriteDeadline(time.Time{}); err != nil {
+				logger.WarnContext(r.Context(), "control channel: could not clear write deadline; stream will honor the REST write timeout", "err", err)
+			}
 			control.ServeHTTP(w, r)
 			return
 		}

--- a/server/response/internal/gateway/gateway_test.go
+++ b/server/response/internal/gateway/gateway_test.go
@@ -141,6 +141,78 @@ func connectCtx(token string) context.Context {
 	return metadata.AppendToOutgoingContext(context.Background(), "authorization", "Bearer "+token)
 }
 
+// recordingHeartbeat counts last-seen bumps per host so the liveness test can assert connection presence advances last-seen (and that
+// the bumps stop once the connection drops), standing in for the detection.RecordHostSeen closure cmd/main wires in production.
+type recordingHeartbeat struct {
+	mu    sync.Mutex
+	calls map[string]int
+}
+
+func newRecordingHeartbeat() *recordingHeartbeat {
+	return &recordingHeartbeat{calls: make(map[string]int)}
+}
+
+func (h *recordingHeartbeat) bump(_ context.Context, hostID string, _ time.Time) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.calls[hostID]++
+	return nil
+}
+
+func (h *recordingHeartbeat) count(hostID string) int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.calls[hostID]
+}
+
+// TestGatewayLiveness pins connection-presence liveness (issue #477, tasks.md 5.7): while a host holds a control connection the gateway
+// advances its last-seen via the injected heartbeat WITHOUT any command poll or telemetry upload, and once the connection drops the bumps
+// stop so the host ages to offline. Delivery and revocation intervals are pushed out of the way so the test isolates the liveness path.
+func TestGatewayLiveness(t *testing.T) {
+	t.Parallel()
+	hb := newRecordingHeartbeat()
+	ver := newFakeVerifier()
+	ver.add("tok-a", "host-a")
+
+	g := New(Deps{Source: newFakeSource(), Verifier: ver, Heartbeat: hb.bump})
+	g.livenessInterval = 20 * time.Millisecond
+	g.watchInterval = time.Hour      // the watch would only deliver commands; keep it out of this test
+	g.revocationInterval = time.Hour // the token stays valid; don't let the re-check tear the connection down
+
+	lis := bufconn.Listen(1 << 20)
+	go func() { _ = g.GRPCServer().Serve(lis) }()
+	runCtx, runCancel := context.WithCancel(t.Context())
+	go g.Run(runCtx)
+	t.Cleanup(func() {
+		runCancel()
+		g.GRPCServer().Stop()
+		_ = lis.Close()
+	})
+
+	cc, err := grpc.NewClient("passthrough:///bufnet",
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) { return lis.DialContext(ctx) }),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = cc.Close() })
+
+	streamCtx, streamCancel := context.WithCancel(connectCtx("tok-a"))
+	_, err = control.NewControlChannelClient(cc).Connect(streamCtx)
+	require.NoError(t, err)
+
+	// Connection presence alone advances last-seen: no ListForHost poll, no upload happened, yet the heartbeat fires (once on connect,
+	// then on the liveness cadence).
+	require.Eventually(t, func() bool { return hb.count("host-a") >= 2 }, 2*time.Second, 5*time.Millisecond,
+		"connection presence advances last-seen without a poll or upload")
+
+	// Disconnect: the connection deregisters and the bumps stop, so the host's last-seen no longer advances and it ages to offline.
+	streamCancel()
+	require.Eventually(t, func() bool { return g.reg.len() == 0 }, 2*time.Second, 10*time.Millisecond)
+	settled := hb.count("host-a")
+	time.Sleep(4 * g.livenessInterval) // let several liveness ticks pass with no live connection
+	assert.Equal(t, settled, hb.count("host-a"), "no last-seen bump after the connection drops")
+}
+
 func TestGateway(t *testing.T) {
 	t.Parallel()
 	t.Run("valid token delivers a pending command and records its outcome", func(t *testing.T) {

--- a/server/response/internal/gateway/gateway_test.go
+++ b/server/response/internal/gateway/gateway_test.go
@@ -197,6 +197,7 @@ func TestGatewayLiveness(t *testing.T) {
 	t.Cleanup(func() { _ = cc.Close() })
 
 	streamCtx, streamCancel := context.WithCancel(connectCtx("tok-a"))
+	t.Cleanup(streamCancel) // always tear the client stream down, even if the test fails before the disconnect step
 	_, err = control.NewControlChannelClient(cc).Connect(streamCtx)
 	require.NoError(t, err)
 
@@ -205,11 +206,22 @@ func TestGatewayLiveness(t *testing.T) {
 	require.Eventually(t, func() bool { return hb.count("host-a") >= 2 }, 2*time.Second, 5*time.Millisecond,
 		"connection presence advances last-seen without a poll or upload")
 
-	// Disconnect: the connection deregisters and the bumps stop, so the host's last-seen no longer advances and it ages to offline.
+	// Disconnect: the connection deregisters and the maintain goroutine stops bumping last-seen, so the host's last-seen no longer
+	// advances and it ages to offline. Wait for the bump count to go quiescent before snapshotting: the maintain select can take one last
+	// liveness tick after cancellation (select picks a ready case at random), so snapshotting immediately after reg.len()==0 could race a
+	// final in-flight bump.
 	streamCancel()
 	require.Eventually(t, func() bool { return g.reg.len() == 0 }, 2*time.Second, 10*time.Millisecond)
-	settled := hb.count("host-a")
-	time.Sleep(4 * g.livenessInterval) // let several liveness ticks pass with no live connection
+	var settled int
+	require.Eventually(t, func() bool {
+		c := hb.count("host-a")
+		if c == settled {
+			return true
+		}
+		settled = c
+		return false
+	}, 2*time.Second, 2*g.livenessInterval, "last-seen bumps stop after disconnect")
+	time.Sleep(4 * g.livenessInterval) // confirm no further bump over several liveness ticks with no live connection
 	assert.Equal(t, settled, hb.count("host-a"), "no last-seen bump after the connection drops")
 }
 

--- a/server/response/internal/tests/integration_test.go
+++ b/server/response/internal/tests/integration_test.go
@@ -486,7 +486,11 @@ func TestControlGatewayPushLifecycle_RealMySQL(t *testing.T) {
 	t.Cleanup(func() {
 		runCancel()
 		gw.Stop()
-		require.NoError(t, httpSrv.Shutdown(context.WithoutCancel(runCtx)))
+		// Bound the shutdown so a regression that wedges the stream fails the test instead of hanging the run, mirroring
+		// httpserver.RunAndShutdown's own timeout-bounded shutdown context.
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.WithoutCancel(runCtx), 15*time.Second)
+		defer shutdownCancel()
+		require.NoError(t, httpSrv.Shutdown(shutdownCtx))
 		require.ErrorIs(t, <-serveDone, http.ErrServerClosed)
 	})
 

--- a/server/response/internal/tests/integration_test.go
+++ b/server/response/internal/tests/integration_test.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -23,7 +24,11 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
 
+	"github.com/fleetdm/edr/internal/control"
 	endpointapi "github.com/fleetdm/edr/server/endpoint/api"
 	identityapi "github.com/fleetdm/edr/server/identity/api"
 	"github.com/fleetdm/edr/server/response/api"
@@ -455,4 +460,92 @@ func TestBuildControlGateway(t *testing.T) {
 	// gateway package tests).
 	_, err := r.Service().Insert(t.Context(), "host-a", "kill_process", json.RawMessage(`{"pid":1}`))
 	require.NoError(t, err)
+}
+
+// TestControlGatewayPushLifecycle_RealMySQL is the integration-fidelity counterpart to the gateway package's in-memory delivery test
+// (issue #477, tasks.md 5.1): a command queued for a connected agent is pushed over the bidirectional stream and its ack-then-complete
+// outcomes are applied through the REAL response service against MySQL, so the commands row walks pending -> acked -> completed exactly as
+// the poll path (TestUpdateStatus_LifecycleHappyPath) does. The gateway is driven through its production entry point (grpc.Server.ServeHTTP
+// behind a net/http HTTP/2 server speaking cleartext h2c, how cmd/main multiplexes it onto the shared listener), and the command is queued
+// via Service.Insert, whose fast-path notifier (wired by BuildControlGateway) pushes it to the live connection.
+func TestControlGatewayPushLifecycle_RealMySQL(t *testing.T) {
+	t.Parallel()
+	r := newResponse(t, nil)
+	gw := r.BuildControlGateway(stubVerifier{}, nil)
+
+	lis, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	protocols := new(http.Protocols)
+	protocols.SetHTTP1(true)
+	protocols.SetUnencryptedHTTP2(true)
+	httpSrv := &http.Server{Handler: gw, Protocols: protocols, ReadHeaderTimeout: 5 * time.Second}
+	serveDone := make(chan error, 1)
+	go func() { serveDone <- httpSrv.Serve(lis) }()
+	runCtx, runCancel := context.WithCancel(t.Context())
+	go gw.Run(runCtx)
+	t.Cleanup(func() {
+		runCancel()
+		gw.Stop()
+		require.NoError(t, httpSrv.Shutdown(context.WithoutCancel(runCtx)))
+		require.ErrorIs(t, <-serveDone, http.ErrServerClosed)
+	})
+
+	cc, err := grpc.NewClient(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = cc.Close() })
+
+	streamCtx, streamCancel := context.WithCancel(controlConnectCtx("tok-a"))
+	defer streamCancel()
+	stream, err := control.NewControlChannelClient(cc).Connect(streamCtx)
+	require.NoError(t, err)
+
+	// Queue a command through the real service; the fast-path notifier pushes it to the live connection (the 1s watch is the backstop).
+	ctx := t.Context()
+	id, err := r.Service().Insert(ctx, "host-a", "kill_process", json.RawMessage(`{"pid":42}`))
+	require.NoError(t, err)
+
+	// Server -> agent: the pushed command arrives over the stream, byte-stable with the commands row.
+	frame, err := stream.Recv()
+	require.NoError(t, err)
+	cmd := frame.GetCommand()
+	require.NotNil(t, cmd)
+	assert.Equal(t, id, cmd.GetId())
+	assert.Equal(t, "kill_process", cmd.GetCommandType())
+	assert.Equal(t, "host-a", cmd.GetHostId())
+	assert.JSONEq(t, `{"pid":42}`, string(cmd.GetPayload()))
+
+	// The row is still pending until the agent reports an outcome.
+	got, err := r.Service().Get(ctx, id)
+	require.NoError(t, err)
+	assert.Equal(t, api.StatusPending, got.Status)
+
+	// Agent -> server: ack, then complete. Both flow through the unchanged UpdateStatus lifecycle against MySQL.
+	require.NoError(t, stream.Send(&control.AgentFrame{Frame: &control.AgentFrame_Outcome{Outcome: &control.Outcome{
+		Id: id, Status: string(api.StatusAcked),
+	}}}))
+	require.Eventually(t, func() bool {
+		got, err := r.Service().Get(ctx, id)
+		return err == nil && got.Status == api.StatusAcked
+	}, 2*time.Second, 10*time.Millisecond, "ack applied to MySQL over the stream")
+
+	require.NoError(t, stream.Send(&control.AgentFrame{Frame: &control.AgentFrame_Outcome{Outcome: &control.Outcome{
+		Id: id, Status: string(api.StatusCompleted), Result: []byte(`{"killed_pid":42}`),
+	}}}))
+	require.Eventually(t, func() bool {
+		got, err := r.Service().Get(ctx, id)
+		return err == nil && got.Status == api.StatusCompleted
+	}, 2*time.Second, 10*time.Millisecond, "completion applied to MySQL over the stream")
+
+	// Final DB state matches the poll path: terminal completed, with ack/complete timestamps and the result persisted.
+	got, err = r.Service().Get(ctx, id)
+	require.NoError(t, err)
+	assert.Equal(t, api.StatusCompleted, got.Status)
+	require.NotNil(t, got.AckedAt)
+	require.NotNil(t, got.CompletedAt)
+	assert.JSONEq(t, `{"killed_pid":42}`, string(got.Result))
+}
+
+// controlConnectCtx builds the outgoing gRPC context carrying the host bearer token the gateway's auth interceptor reads from metadata.
+func controlConnectCtx(token string) context.Context {
+	return metadata.AppendToOutgoingContext(context.Background(), "authorization", "Bearer "+token)
 }


### PR DESCRIPTION
## Summary

Closes out the push-based agent control channel (#477). Most of the feature already merged (#552/#553/#556/#559); this PR adds the two remaining test items, reconciles the openspec task checkboxes with what shipped, and fixes a real defect that the live edr-dev QA surfaced.

## What's here

**Closeout tests + reconciliation (`4238ef91`)**
- `TestControlGatewayPushLifecycle_RealMySQL` (task 5.1): drives a command through the real response service against MySQL over the production gRPC-over-h2c `ServeHTTP` path; asserts the `commands` row walks pending -> acked -> completed with ack/complete timestamps and result persisted, matching the poll path. The prior `TestBuildControlGateway` only covered wiring.
- `TestGatewayLiveness` (task 5.7): connection presence advances last-seen via the injected heartbeat with no command poll or telemetry upload, and the bumps stop once the connection drops so the host ages to offline.
- Checked `push-command-channel` tasks 1.1-6.1 (all verified in tree) and `control-channel-single-port` task 4.1 (Caddy h2c already in `packaging/caddy`).

**Bug fix from live QA (`b1a9e1b1`) — production behavior change**
- Live QA on edr-dev showed the control stream reconnecting every ~10s with `i/o timeout` (visible in SigNoz as a run of 10s `ControlChannel/Connect` spans) instead of holding one persistent connection.
- Root cause: the single-port merge (#559) serves the control gRPC gateway on the shared REST `http.Server`, whose `ReadTimeout` (10s) and `WriteTimeout` (30s) bound the WHOLE HTTP/2 stream, not one message. Commands still flowed (reconnect + at-least-once re-delivery), but idle hosts churned reconnects instead of holding a connection, defeating a #477 acceptance goal.
- Fix: `mountControlChannel` clears the per-stream read/write deadlines for the `application/grpc` branch via `http.NewResponseController`; the REST/UI surface keeps its timeouts. Degrades safely (reconnect + retained short-poll) if a transport refuses the clear.
- Delta: `control-channel-single-port` gains task 2.6, a "Control stream not bounded by REST timeouts" scenario, and a design note.

## Live QA (edr-dev, task 6.1) — passed after the fix

- **Sub-second delivery**: `POST /api/commands` kill delivered pending -> acked -> completed in ~130-150ms end to end; target processes actually killed.
- **Stable connection post-fix**: zero flaps over a 40s window; SigNoz shows one 114s `ControlChannel/Connect` span (clean close) vs the pre-fix 10s `i/o timeout` spans.
- **Offline/online flip**: `last_seen` ages monotonically on disconnect (toward the 5-min offline cutoff) and resets on reconnect, driven purely by the control connection.
- **Trace continuity**: the `ControlChannel/Connect` span (otelgrpc) carries child SQL spans (outcome `UpdateStatus`, liveness, delivery queries).

## Verification

Local gates green: gateway + response-integration + httpserver tests, `go vet -tags integration`, custom golangci-lint, dash-lint, `openspec validate --strict`, `spectrace check --strict` (546/546). The regression test was confirmed to fail (`RST_STREAM`) without the fix.

## Not in scope / still open for #477

- #557 (RC validation of the proxied stream on the notarized build).
- Release-time archive of the two `openspec/changes/` folders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Long-lived control-channel streams can now share the same port as the REST/UI server without being cut off by regular server timeouts.
  * Control traffic continues to use the shared endpoint, with improved handling for streaming connections.

* **Bug Fixes**
  * Fixed an issue where control streams could disconnect periodically during normal operation.
  * Added graceful fallback behavior if timeout clearing is not available.

* **Tests**
  * Added regression and integration coverage for stream longevity, liveness, and end-to-end command delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->