### PR TITLE
feat(webhook): console Webhooks settings page + #567 review follow-ups (#496)

### DIFF
--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -1,6 +1,6 @@
 # Outbound alert webhooks
 
-Fleet EDR can POST every alert to an HTTP endpoint you control, so alerts reach your team (Slack, PagerDuty, a SIEM, a SOAR runbook, or your own glue) in seconds instead of waiting for someone to open the console. This page covers configuring destinations, the payload shape, and how a receiver verifies a delivery. It describes the backend (API) surface; the console settings page is a separate follow-up.
+Fleet EDR can POST every alert to an HTTP endpoint you control, so alerts reach your team (Slack, PagerDuty, a SIEM, a SOAR runbook, or your own glue) in seconds instead of waiting for someone to open the console. This page covers configuring destinations, the payload shape, and how a receiver verifies a delivery. Operators manage destinations under Admin, Settings, Webhooks in the console, backed by the API described here.
 
 Related: deferred hardening and vendor-specific formatters are tracked in [issue #565](https://github.com/getvictor/fleet-edr/issues/565). Feature proposal: [issue #496](https://github.com/getvictor/fleet-edr/issues/496).
 
@@ -10,7 +10,7 @@ A delivery fires when an alert is created, and (for destinations subscribed to i
 
 ## Configuring destinations
 
-Destination management requires the `webhook.manage` permission (granted to the admin role). It is exposed as an operator API under the session cookie plus CSRF boundary. A destination has:
+Destination management requires the `webhook.manage` permission (granted to the admin role). The console page and the operator API both sit under the session cookie plus CSRF boundary. A destination has:
 
 | Field          | Meaning                                                                                    |
 | -------------- | ------------------------------------------------------------------------------------------ |

--- a/server/detection/internal/mysql/webhook_delivery.go
+++ b/server/detection/internal/mysql/webhook_delivery.go
@@ -38,7 +38,7 @@ func (s *Store) ClaimDueWebhookDeliveries(ctx context.Context, limit int, lease 
 		SELECT d.id, d.public_id, d.attempt, d.payload, wd.url, wd.secret_sealed
 		FROM webhook_delivery d
 		JOIN webhook_destination wd ON wd.id = d.destination_id
-		WHERE d.status = 'pending' AND d.next_attempt_at <= NOW(6)
+		WHERE d.status = 'pending' AND d.next_attempt_at <= NOW(6) AND wd.enabled = 1
 		ORDER BY d.next_attempt_at
 		LIMIT ?
 		FOR UPDATE OF d SKIP LOCKED`, limit); err != nil {

--- a/server/detection/internal/pipeline/webhookdelivery.go
+++ b/server/detection/internal/pipeline/webhookdelivery.go
@@ -144,6 +144,8 @@ func (r *WebhookDeliveryRunner) deliver(ctx context.Context, c detapi.WebhookDel
 		r.fail(ctx, c.ID, 0, "unseal destination secret: "+err.Error())
 		return
 	}
+	// Zero the plaintext signing secret once we're done with it so it does not linger in memory beyond this delivery.
+	defer clear(secret)
 	// Overlay the current attempt number onto the stored point-in-time envelope, then sign the exact bytes we send.
 	var env webhook.Envelope
 	if err := json.Unmarshal(c.Payload, &env); err != nil {

--- a/server/detection/internal/tests/webhook_store_test.go
+++ b/server/detection/internal/tests/webhook_store_test.go
@@ -11,6 +11,7 @@ import (
 	"crypto/rand"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/jmoiron/sqlx"
 	"github.com/stretchr/testify/assert"
@@ -165,6 +166,26 @@ func TestWebhookDestinationStore_DeliveriesReadout(t *testing.T) {
 	require.NotNil(t, got[0].LastStatusCode)
 	assert.Equal(t, 503, *got[0].LastStatusCode)
 	assert.Equal(t, "receiver unavailable", got[0].LastError)
+}
+
+// TestWebhookDelivery_disabledDestinationNotClaimed pins that disabling a destination stops delivery of its already-queued rows: the
+// claim query filters on wd.enabled, so a delivery enqueued while the destination was enabled is no longer claimed once it is disabled.
+func TestWebhookDelivery_disabledDestinationNotClaimed(t *testing.T) {
+	t.Parallel()
+	store, _, _ := newWebhookStore(t)
+	ctx := context.Background()
+	destID := makeDest(t, store, "sink", detapi.SeverityLow, true, detapi.WebhookEventAlertCreated)
+	_, _, err := store.InsertAlert(ctx, highAlert("test:1"), nil)
+	require.NoError(t, err)
+
+	require.NoError(t, store.UpdateWebhookDestination(ctx, destID, detapi.WebhookDestinationInput{
+		Name: "sink", URL: "https://hooks.example.com/sink",
+		EventTypes: []string{detapi.WebhookEventAlertCreated}, MinSeverity: detapi.SeverityLow, Enabled: false,
+	}))
+
+	claims, err := store.ClaimDueWebhookDeliveries(ctx, 10, time.Minute)
+	require.NoError(t, err)
+	assert.Empty(t, claims, "a disabled destination's queued deliveries must not be claimed")
 }
 
 func TestWebhookDestinationStore_SealerUnset(t *testing.T) {

--- a/server/detection/internal/webhook/client_test.go
+++ b/server/detection/internal/webhook/client_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"syscall"
 	"testing"
 	"time"
@@ -25,8 +26,12 @@ func testClient() *Client { return newClient(5*time.Second, 64*1024, allowLoopba
 func TestClient_DeliverSignsAndPosts(t *testing.T) {
 	t.Parallel()
 	secret := []byte("shared-secret")
+	// The handler runs on the server goroutine; guard the captured request fields so the test's reads don't race the writes.
+	var mu sync.Mutex
 	var gotID, gotTS, gotSig, gotBody string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
 		gotID = r.Header.Get(HeaderID)
 		gotTS = r.Header.Get(HeaderTimestamp)
 		gotSig = r.Header.Get(HeaderSignature)
@@ -41,6 +46,8 @@ func TestClient_DeliverSignsAndPosts(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, code)
 
+	mu.Lock()
+	defer mu.Unlock()
 	assert.Equal(t, "whd_1", gotID)
 	assert.Equal(t, "1767225600", gotTS)
 	assert.Equal(t, string(body), gotBody)

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -8,6 +8,7 @@ import { ApplicationControlRoutes } from "./components/ApplicationControl/Applic
 import { DetectionConfig } from "./components/DetectionConfig/DetectionConfig";
 import { RuleDetail } from "./components/RuleDetail";
 import { SSOSettings } from "./components/SSOSettings/SSOSettings";
+import { Webhooks } from "./components/Webhooks/Webhooks";
 import { ServiceAccounts } from "./components/ServiceAccounts/ServiceAccounts";
 import { Users } from "./components/Users/Users";
 import { SettingsLayout } from "./components/Settings/SettingsLayout";
@@ -174,6 +175,14 @@ export function AuthedApp() {
             element={(
               <RequirePermission action={PermissionAction.SSOManage} surface="Single sign-on settings">
                 <SettingsLayout><SSOSettings /></SettingsLayout>
+              </RequirePermission>
+            )}
+          />
+          <Route
+            path="/admin/settings/webhooks"
+            element={(
+              <RequirePermission action={PermissionAction.WebhookManage} surface="Webhooks">
+                <SettingsLayout><Webhooks /></SettingsLayout>
               </RequirePermission>
             )}
           />

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -717,6 +717,67 @@ export async function testSSOConnection(issuer: string): Promise<{ ok: boolean; 
   });
 }
 
+// --- Outbound alert webhooks (issue #496) ---------------------------------------
+
+// WebhookDestination is the read shape from GET /api/settings/webhooks. The signing secret is NEVER returned: secret_set only reports
+// whether one is stored. event_types is the subscribed set ("alert.created" and/or "alert.status_changed").
+export interface WebhookDestination {
+  id: number;
+  name: string;
+  url: string;
+  event_types: string[];
+  min_severity: string;
+  enabled: boolean;
+  secret_set: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+// WebhookDestinationInput is the create/update body. secret is write-only: required on create, omitted or empty on update to keep the
+// stored one.
+export interface WebhookDestinationInput {
+  name: string;
+  url: string;
+  event_types: string[];
+  min_severity: string;
+  enabled: boolean;
+  secret?: string;
+}
+
+// WebhookDelivery is one row of the per-destination delivery-status readout. It carries no payload or secret.
+export interface WebhookDelivery {
+  id: number;
+  destination_id: number;
+  event_type: string;
+  status: string;
+  attempt: number;
+  last_status_code?: number;
+  last_error?: string;
+  created_at: string;
+  updated_at: string;
+  next_attempt_at: string;
+}
+
+export async function listWebhooks(): Promise<WebhookDestination[]> {
+  return fetchJSON<WebhookDestination[]>("/settings/webhooks");
+}
+
+export async function createWebhook(req: WebhookDestinationInput): Promise<WebhookDestination> {
+  return fetchJSON<WebhookDestination>("/settings/webhooks", { method: "POST", body: JSON.stringify(req) });
+}
+
+export async function updateWebhook(id: number, req: WebhookDestinationInput): Promise<WebhookDestination> {
+  return fetchJSON<WebhookDestination>(`/settings/webhooks/${String(id)}`, { method: "PUT", body: JSON.stringify(req) });
+}
+
+export async function deleteWebhook(id: number): Promise<void> {
+  await fetchJSON<unknown>(`/settings/webhooks/${String(id)}`, { method: "DELETE" });
+}
+
+export async function listWebhookDeliveries(id: number): Promise<WebhookDelivery[]> {
+  return fetchJSON<WebhookDelivery[]>(`/settings/webhooks/${String(id)}/deliveries`);
+}
+
 // --- Service accounts (issue #376) ----------------------------------------------
 
 // ServiceAccount is the read shape from GET /api/settings/service-accounts. The secret is

--- a/ui/src/components/Settings/SettingsLayout.tsx
+++ b/ui/src/components/Settings/SettingsLayout.tsx
@@ -10,6 +10,7 @@ import "./SettingsLayout.scss";
 // omitted; the server chokepoint remains the authority (ADR-0012).
 const SECTIONS = [
   { to: "/admin/settings/sso", label: "Single sign-on", action: PermissionAction.SSOManage },
+  { to: "/admin/settings/webhooks", label: "Webhooks", action: PermissionAction.WebhookManage },
   { to: "/admin/settings/users", label: "Users", action: PermissionAction.UserRead },
   { to: "/admin/settings/service-accounts", label: "Service accounts", action: PermissionAction.ServiceAccountRead },
 ] as const;

--- a/ui/src/components/Webhooks/Webhooks.scss
+++ b/ui/src/components/Webhooks/Webhooks.scss
@@ -1,0 +1,63 @@
+.webhooks {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+
+  h3 {
+    margin-top: 0;
+  }
+
+  &__error,
+  &__save-error {
+    color: var(--color-danger, #b00020);
+  }
+
+  &__saved {
+    color: var(--color-success, #1b7f4b);
+  }
+
+  &__events {
+    display: flex;
+    gap: 1.5rem;
+    border: none;
+    padding: 0;
+    margin: 0.75rem 0;
+
+    legend {
+      padding: 0;
+      font-weight: 600;
+    }
+
+    label {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.35rem;
+    }
+  }
+
+  &__enabled {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    margin: 0.5rem 0;
+  }
+
+  &__actions {
+    display: flex;
+    gap: 0.75rem;
+    margin-top: 0.75rem;
+  }
+
+  &__table {
+    width: 100%;
+    border-collapse: collapse;
+
+    th,
+    td {
+      text-align: left;
+      padding: 0.5rem 0.75rem;
+      border-bottom: 1px solid var(--color-border, #e2e2e2);
+      vertical-align: top;
+    }
+  }
+}

--- a/ui/src/components/Webhooks/Webhooks.test.tsx
+++ b/ui/src/components/Webhooks/Webhooks.test.tsx
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import * as api from "../../api";
+import { Webhooks } from "./Webhooks";
+
+const dest: api.WebhookDestination = {
+  id: 1,
+  name: "pd",
+  url: "https://hooks.example.com/edr",
+  event_types: ["alert.created"],
+  min_severity: "high",
+  enabled: true,
+  secret_set: true,
+  created_at: "",
+  updated_at: "",
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("Webhooks", () => {
+  it("lists destinations and keeps the secret field write-only", async () => {
+    vi.spyOn(api, "listWebhooks").mockResolvedValue([dest]);
+    render(<Webhooks />);
+    expect(await screen.findByText("pd")).toBeInTheDocument();
+    expect(screen.getByText("https://hooks.example.com/edr")).toBeInTheDocument();
+    // The signing secret is never rendered: the field is empty even though a secret is set.
+    expect(screen.getByLabelText("Signing secret")).toHaveValue("");
+  });
+
+  it("creates a destination and refreshes the list", async () => {
+    vi.spyOn(api, "listWebhooks").mockResolvedValueOnce([]).mockResolvedValueOnce([dest]);
+    const create = vi.spyOn(api, "createWebhook").mockResolvedValue(dest);
+    render(<Webhooks />);
+    await screen.findByText("No destinations configured.");
+
+    fireEvent.change(screen.getByLabelText("Name"), { target: { value: "pd" } });
+    fireEvent.change(screen.getByLabelText("URL"), { target: { value: "https://hooks.example.com/edr" } });
+    fireEvent.change(screen.getByLabelText("Signing secret"), { target: { value: "sekret" } });
+    fireEvent.click(screen.getByRole("button", { name: "Add destination" }));
+
+    await waitFor(() => {
+      expect(create).toHaveBeenCalledTimes(1);
+    });
+    expect(create.mock.calls[0][0]).toMatchObject({
+      name: "pd",
+      url: "https://hooks.example.com/edr",
+      secret: "sekret",
+      event_types: ["alert.created"],
+    });
+    expect(await screen.findByText("pd")).toBeInTheDocument();
+  });
+
+  it("rejects a non-https URL before calling the API", async () => {
+    vi.spyOn(api, "listWebhooks").mockResolvedValue([]);
+    const create = vi.spyOn(api, "createWebhook");
+    render(<Webhooks />);
+    await screen.findByText("No destinations configured.");
+
+    fireEvent.change(screen.getByLabelText("Name"), { target: { value: "x" } });
+    fireEvent.change(screen.getByLabelText("URL"), { target: { value: "http://insecure.example.com" } });
+    fireEvent.change(screen.getByLabelText("Signing secret"), { target: { value: "s" } });
+    fireEvent.click(screen.getByRole("button", { name: "Add destination" }));
+
+    expect(await screen.findByText("URL must be a valid https URL.")).toBeInTheDocument();
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it("shows the per-destination delivery-status readout", async () => {
+    vi.spyOn(api, "listWebhooks").mockResolvedValue([dest]);
+    vi.spyOn(api, "listWebhookDeliveries").mockResolvedValue([
+      {
+        id: 9,
+        destination_id: 1,
+        event_type: "alert.created",
+        status: "failed",
+        attempt: 3,
+        last_status_code: 503,
+        last_error: "receiver unavailable",
+        created_at: "",
+        updated_at: "",
+        next_attempt_at: "",
+      },
+    ]);
+    render(<Webhooks />);
+    await screen.findByText("pd");
+
+    fireEvent.click(screen.getByRole("button", { name: "Deliveries" }));
+    expect(await screen.findByText("receiver unavailable")).toBeInTheDocument();
+    expect(screen.getByText("failed")).toBeInTheDocument();
+  });
+});

--- a/ui/src/components/Webhooks/Webhooks.test.tsx
+++ b/ui/src/components/Webhooks/Webhooks.test.tsx
@@ -25,8 +25,19 @@ describe("Webhooks", () => {
     render(<Webhooks />);
     expect(await screen.findByText("pd")).toBeInTheDocument();
     expect(screen.getByText("https://hooks.example.com/edr")).toBeInTheDocument();
-    // The signing secret is never rendered: the field is empty even though a secret is set.
     expect(screen.getByLabelText("Signing secret")).toHaveValue("");
+  });
+
+  it("renders a load error", async () => {
+    vi.spyOn(api, "listWebhooks").mockRejectedValue(new Error("nope"));
+    render(<Webhooks />);
+    expect(await screen.findByRole("alert")).toHaveTextContent("nope");
+  });
+
+  it("shows a disabled destination with a disabled badge", async () => {
+    vi.spyOn(api, "listWebhooks").mockResolvedValue([{ ...dest, enabled: false }]);
+    render(<Webhooks />);
+    expect(await screen.findByText("Disabled")).toBeInTheDocument();
   });
 
   it("creates a destination and refreshes the list", async () => {
@@ -43,13 +54,20 @@ describe("Webhooks", () => {
     await waitFor(() => {
       expect(create).toHaveBeenCalledTimes(1);
     });
-    expect(create.mock.calls[0][0]).toMatchObject({
-      name: "pd",
-      url: "https://hooks.example.com/edr",
-      secret: "sekret",
-      event_types: ["alert.created"],
-    });
-    expect(await screen.findByText("pd")).toBeInTheDocument();
+    expect(create.mock.calls[0][0]).toMatchObject({ name: "pd", secret: "sekret", event_types: ["alert.created"] });
+    expect(await screen.findByText("Saved.")).toBeInTheDocument();
+  });
+
+  it("surfaces a save error", async () => {
+    vi.spyOn(api, "listWebhooks").mockResolvedValue([]);
+    vi.spyOn(api, "createWebhook").mockRejectedValue(new Error("boom"));
+    render(<Webhooks />);
+    await screen.findByText("No destinations configured.");
+    fireEvent.change(screen.getByLabelText("Name"), { target: { value: "x" } });
+    fireEvent.change(screen.getByLabelText("URL"), { target: { value: "https://ok.example.com" } });
+    fireEvent.change(screen.getByLabelText("Signing secret"), { target: { value: "s" } });
+    fireEvent.click(screen.getByRole("button", { name: "Add destination" }));
+    expect(await screen.findByText("boom")).toBeInTheDocument();
   });
 
   it("rejects a non-https URL before calling the API", async () => {
@@ -57,14 +75,85 @@ describe("Webhooks", () => {
     const create = vi.spyOn(api, "createWebhook");
     render(<Webhooks />);
     await screen.findByText("No destinations configured.");
-
     fireEvent.change(screen.getByLabelText("Name"), { target: { value: "x" } });
     fireEvent.change(screen.getByLabelText("URL"), { target: { value: "http://insecure.example.com" } });
     fireEvent.change(screen.getByLabelText("Signing secret"), { target: { value: "s" } });
     fireEvent.click(screen.getByRole("button", { name: "Add destination" }));
-
     expect(await screen.findByText("URL must be a valid https URL.")).toBeInTheDocument();
     expect(create).not.toHaveBeenCalled();
+  });
+
+  it("requires a name and at least one event type", async () => {
+    vi.spyOn(api, "listWebhooks").mockResolvedValue([]);
+    render(<Webhooks />);
+    await screen.findByText("No destinations configured.");
+
+    // No name.
+    fireEvent.click(screen.getByRole("button", { name: "Add destination" }));
+    expect(await screen.findByText("Name is required.")).toBeInTheDocument();
+
+    // Name + url + secret but no event type selected.
+    fireEvent.change(screen.getByLabelText("Name"), { target: { value: "x" } });
+    fireEvent.change(screen.getByLabelText("URL"), { target: { value: "https://ok.example.com" } });
+    fireEvent.change(screen.getByLabelText("Signing secret"), { target: { value: "s" } });
+    fireEvent.click(screen.getByLabelText("Alert created")); // uncheck the default
+    fireEvent.click(screen.getByRole("button", { name: "Add destination" }));
+    expect(await screen.findByText("Select at least one event type.")).toBeInTheDocument();
+
+    // Create with the secret cleared.
+    fireEvent.click(screen.getByLabelText("Alert created")); // re-check
+    fireEvent.change(screen.getByLabelText("Signing secret"), { target: { value: "" } });
+    fireEvent.click(screen.getByRole("button", { name: "Add destination" }));
+    expect(await screen.findByText("A signing secret is required.")).toBeInTheDocument();
+  });
+
+  it("edits a destination, keeping the secret when left blank", async () => {
+    vi.spyOn(api, "listWebhooks").mockResolvedValue([dest]);
+    const update = vi.spyOn(api, "updateWebhook").mockResolvedValue({ ...dest, name: "pd-renamed" });
+    render(<Webhooks />);
+    await screen.findByText("pd");
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+    // The form is populated from the destination; the secret stays write-only (blank).
+    expect(screen.getByLabelText("Name")).toHaveValue("pd");
+    expect(screen.getByLabelText("Signing secret")).toHaveValue("");
+    fireEvent.change(screen.getByLabelText("Name"), { target: { value: "pd-renamed" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+
+    await waitFor(() => {
+      expect(update).toHaveBeenCalledTimes(1);
+    });
+    expect(update.mock.calls[0][0]).toBe(1);
+    expect(update.mock.calls[0][1]).not.toHaveProperty("secret");
+  });
+
+  it("cancels an edit and resets the form", async () => {
+    vi.spyOn(api, "listWebhooks").mockResolvedValue([dest]);
+    render(<Webhooks />);
+    await screen.findByText("pd");
+    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+    expect(screen.getByLabelText("Name")).toHaveValue("pd");
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(screen.getByLabelText("Name")).toHaveValue("");
+    expect(screen.getByRole("button", { name: "Add destination" })).toBeInTheDocument();
+  });
+
+  it("deletes only after confirmation", async () => {
+    vi.spyOn(api, "listWebhooks").mockResolvedValueOnce([dest]).mockResolvedValueOnce([]);
+    const del = vi.spyOn(api, "deleteWebhook").mockResolvedValue();
+    const confirm = vi.spyOn(globalThis, "confirm").mockReturnValueOnce(false).mockReturnValueOnce(true);
+    render(<Webhooks />);
+    await screen.findByText("pd");
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+    expect(confirm).toHaveBeenCalledTimes(1);
+    expect(del).not.toHaveBeenCalled(); // declined
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+    await waitFor(() => {
+      expect(del).toHaveBeenCalledWith(1);
+    });
+    expect(await screen.findByText("No destinations configured.")).toBeInTheDocument();
   });
 
   it("shows the per-destination delivery-status readout", async () => {
@@ -82,12 +171,32 @@ describe("Webhooks", () => {
         updated_at: "",
         next_attempt_at: "",
       },
+      {
+        id: 10,
+        destination_id: 1,
+        event_type: "alert.created",
+        status: "pending",
+        attempt: 0,
+        created_at: "",
+        updated_at: "",
+        next_attempt_at: "",
+      },
     ]);
     render(<Webhooks />);
     await screen.findByText("pd");
-
     fireEvent.click(screen.getByRole("button", { name: "Deliveries" }));
     expect(await screen.findByText("receiver unavailable")).toBeInTheDocument();
     expect(screen.getByText("failed")).toBeInTheDocument();
+    // The pending row has no status code, rendering the "-" fallback.
+    expect(screen.getByText("-")).toBeInTheDocument();
+  });
+
+  it("surfaces a deliveries load error", async () => {
+    vi.spyOn(api, "listWebhooks").mockResolvedValue([dest]);
+    vi.spyOn(api, "listWebhookDeliveries").mockRejectedValue(new Error("delivery boom"));
+    render(<Webhooks />);
+    await screen.findByText("pd");
+    fireEvent.click(screen.getByRole("button", { name: "Deliveries" }));
+    expect(await screen.findByText("delivery boom")).toBeInTheDocument();
   });
 });

--- a/ui/src/components/Webhooks/Webhooks.tsx
+++ b/ui/src/components/Webhooks/Webhooks.tsx
@@ -71,8 +71,14 @@ export function Webhooks() {
 
   const [deliveries, setDeliveries] = useState<{ id: number; rows: WebhookDelivery[] } | null>(null);
 
+  // refresh reloads the list and handles its own error, so a reload failure after a successful create/update/delete surfaces as a
+  // load error rather than being caught by the caller's try/catch and misreported as a save/delete failure (Copilot, Qodo).
   async function refresh() {
-    setDestinations(await listWebhooks());
+    try {
+      setDestinations(await listWebhooks());
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : "Failed to reload webhooks");
+    }
   }
 
   useEffect(() => {
@@ -140,6 +146,7 @@ export function Webhooks() {
   }
 
   async function handleDelete(id: number) {
+    if (!globalThis.confirm("Delete this webhook destination? Queued deliveries to it are discarded.")) return;
     try {
       await deleteWebhook(id);
       if (deliveries?.id === id) setDeliveries(null);

--- a/ui/src/components/Webhooks/Webhooks.tsx
+++ b/ui/src/components/Webhooks/Webhooks.tsx
@@ -1,0 +1,316 @@
+import { useEffect, useState } from "react";
+import {
+  listWebhooks,
+  createWebhook,
+  updateWebhook,
+  deleteWebhook,
+  listWebhookDeliveries,
+  type WebhookDestination,
+  type WebhookDestinationInput,
+  type WebhookDelivery,
+} from "../../api";
+import { PageHeader } from "../ui/PageHeader";
+import { Card } from "../ui/Card";
+import { Button } from "../ui/Button";
+import { Input, Select } from "../ui/Input";
+import { Badge } from "../ui/Badge";
+import "./Webhooks.scss";
+
+const EVENT_CREATED = "alert.created";
+const EVENT_STATUS_CHANGED = "alert.status_changed";
+const SEVERITIES = ["low", "medium", "high", "critical"];
+
+// FormState mirrors the operator-editable fields. The signing secret is write-only: empty unless the operator is setting or rotating
+// it. editingId is null for the add form and the destination id when editing an existing one.
+interface FormState {
+  editingId: number | null;
+  name: string;
+  url: string;
+  onCreated: boolean;
+  onStatusChanged: boolean;
+  minSeverity: string;
+  enabled: boolean;
+  secret: string;
+}
+
+function emptyForm(): FormState {
+  return { editingId: null, name: "", url: "", onCreated: true, onStatusChanged: false, minSeverity: "low", enabled: true, secret: "" };
+}
+
+function toForm(d: WebhookDestination): FormState {
+  return {
+    editingId: d.id,
+    name: d.name,
+    url: d.url,
+    onCreated: d.event_types.includes(EVENT_CREATED),
+    onStatusChanged: d.event_types.includes(EVENT_STATUS_CHANGED),
+    minSeverity: d.min_severity,
+    enabled: d.enabled,
+    secret: "",
+  };
+}
+
+function isHTTPSURL(raw: string): boolean {
+  try {
+    const u = new URL(raw.trim());
+    return u.protocol === "https:" && u.host !== "";
+  } catch {
+    return false;
+  }
+}
+
+export function Webhooks() {
+  const [destinations, setDestinations] = useState<WebhookDestination[] | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [form, setForm] = useState<FormState>(emptyForm());
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [saved, setSaved] = useState(false);
+
+  const [deliveries, setDeliveries] = useState<{ id: number; rows: WebhookDelivery[] } | null>(null);
+
+  async function refresh() {
+    setDestinations(await listWebhooks());
+  }
+
+  useEffect(() => {
+    let cancelled = false;
+    listWebhooks()
+      .then((d) => {
+        if (!cancelled) setDestinations(d);
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : "Failed to load webhooks");
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  function update<K extends keyof FormState>(key: K, value: FormState[K]) {
+    setForm((prev) => ({ ...prev, [key]: value }));
+    setSaved(false);
+  }
+
+  function validate(f: FormState): string | null {
+    if (f.name.trim() === "") return "Name is required.";
+    if (!isHTTPSURL(f.url)) return "URL must be a valid https URL.";
+    if (!f.onCreated && !f.onStatusChanged) return "Select at least one event type.";
+    if (f.editingId === null && f.secret.trim() === "") return "A signing secret is required.";
+    return null;
+  }
+
+  async function handleSave() {
+    const invalid = validate(form);
+    if (invalid !== null) {
+      setSaveError(invalid);
+      return;
+    }
+    setSaving(true);
+    setSaveError(null);
+    setSaved(false);
+    const eventTypes: string[] = [];
+    if (form.onCreated) eventTypes.push(EVENT_CREATED);
+    if (form.onStatusChanged) eventTypes.push(EVENT_STATUS_CHANGED);
+    const secret = form.secret.trim();
+    const body: WebhookDestinationInput = {
+      name: form.name.trim(),
+      url: form.url.trim(),
+      event_types: eventTypes,
+      min_severity: form.minSeverity,
+      enabled: form.enabled,
+      ...(secret === "" ? {} : { secret }),
+    };
+    try {
+      if (form.editingId === null) await createWebhook(body);
+      else await updateWebhook(form.editingId, body);
+      setForm(emptyForm());
+      setSaved(true);
+      await refresh();
+    } catch (err: unknown) {
+      setSaveError(err instanceof Error ? err.message : "Failed to save webhook.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleDelete(id: number) {
+    try {
+      await deleteWebhook(id);
+      if (deliveries?.id === id) setDeliveries(null);
+      if (form.editingId === id) setForm(emptyForm());
+      await refresh();
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : "Failed to delete webhook.");
+    }
+  }
+
+  async function viewDeliveries(id: number) {
+    try {
+      setDeliveries({ id, rows: await listWebhookDeliveries(id) });
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : "Failed to load deliveries.");
+    }
+  }
+
+  if (loading) return <div className="webhooks">Loading</div>;
+
+  return (
+    <div className="webhooks">
+      <PageHeader title="Webhooks" subtitle="Deliver alerts to an external endpoint over a signed HTTPS POST." />
+      {error !== null && (
+        <div className="webhooks__error" role="alert">
+          {error}
+        </div>
+      )}
+
+      <Card padding="large">
+        <h3>{form.editingId === null ? "Add destination" : "Edit destination"}</h3>
+        <Input id="wh-name" label="Name" value={form.name} onChange={(e) => { update("name", e.target.value); }} />
+        <Input
+          id="wh-url"
+          label="URL"
+          type="text"
+          placeholder="https://hooks.example.com/edr"
+          value={form.url}
+          onChange={(e) => { update("url", e.target.value); }}
+        />
+        <fieldset className="webhooks__events">
+          <legend>Events</legend>
+          <label>
+            <input type="checkbox" checked={form.onCreated} onChange={(e) => { update("onCreated", e.target.checked); }} /> Alert created
+          </label>
+          <label>
+            <input type="checkbox" checked={form.onStatusChanged} onChange={(e) => { update("onStatusChanged", e.target.checked); }} /> Status changed
+          </label>
+        </fieldset>
+        <Select id="wh-severity" label="Minimum severity" value={form.minSeverity} onChange={(e) => { update("minSeverity", e.target.value); }} inline>
+          {SEVERITIES.map((s) => (
+            <option key={s} value={s}>
+              {s}
+            </option>
+          ))}
+        </Select>
+        <label className="webhooks__enabled">
+          <input type="checkbox" checked={form.enabled} onChange={(e) => { update("enabled", e.target.checked); }} /> Enabled
+        </label>
+        <Input
+          id="wh-secret"
+          label="Signing secret"
+          type="password"
+          autoComplete="off"
+          data-1p-ignore=""
+          data-lpignore="true"
+          data-form-type="other"
+          placeholder={form.editingId !== null ? "•••••• enter a new value to rotate" : "enter the signing secret"}
+          value={form.secret}
+          onChange={(e) => { update("secret", e.target.value); }}
+        />
+        <div className="webhooks__actions">
+          <Button type="button" variant="primary" isLoading={saving} onClick={() => void handleSave()}>
+            {form.editingId === null ? "Add destination" : "Save changes"}
+          </Button>
+          {form.editingId !== null && (
+            <Button
+              type="button"
+              variant="inverse"
+              onClick={() => {
+                setForm(emptyForm());
+                setSaved(false);
+              }}
+            >
+              Cancel
+            </Button>
+          )}
+        </div>
+        {saveError !== null && (
+          <div className="webhooks__save-error" role="alert">
+            {saveError}
+          </div>
+        )}
+        {saved && (
+          <output className="webhooks__saved" aria-live="polite">
+            Saved.
+          </output>
+        )}
+      </Card>
+
+      <Card padding="large">
+        <h3>Destinations</h3>
+        {destinations !== null && destinations.length === 0 && <p>No destinations configured.</p>}
+        {destinations !== null && destinations.length > 0 && (
+          <table className="webhooks__table">
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>URL</th>
+                <th>Events</th>
+                <th>Min severity</th>
+                <th>Status</th>
+                <th aria-label="Actions" />
+              </tr>
+            </thead>
+            <tbody>
+              {destinations.map((d) => (
+                <tr key={d.id}>
+                  <td>{d.name}</td>
+                  <td>{d.url}</td>
+                  <td>{d.event_types.join(", ")}</td>
+                  <td>{d.min_severity}</td>
+                  <td>{d.enabled ? <Badge variant="success">Enabled</Badge> : <Badge variant="neutral">Disabled</Badge>}</td>
+                  <td>
+                    <Button type="button" variant="text-link" size="small" onClick={() => { setForm(toForm(d)); }}>
+                      Edit
+                    </Button>
+                    <Button type="button" variant="text-link" size="small" onClick={() => void viewDeliveries(d.id)}>
+                      Deliveries
+                    </Button>
+                    <Button type="button" variant="text-link" size="small" onClick={() => void handleDelete(d.id)}>
+                      Delete
+                    </Button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </Card>
+
+      {deliveries !== null && (
+        <Card padding="large">
+          <h3>Recent deliveries</h3>
+          {deliveries.rows.length === 0 && <p>No deliveries yet.</p>}
+          {deliveries.rows.length > 0 && (
+            <table className="webhooks__table">
+              <thead>
+                <tr>
+                  <th>Event</th>
+                  <th>Status</th>
+                  <th>Attempt</th>
+                  <th>HTTP</th>
+                  <th>Last error</th>
+                </tr>
+              </thead>
+              <tbody>
+                {deliveries.rows.map((r) => (
+                  <tr key={r.id}>
+                    <td>{r.event_type}</td>
+                    <td>{r.status}</td>
+                    <td>{r.attempt}</td>
+                    <td>{r.last_status_code ?? "-"}</td>
+                    <td>{r.last_error ?? ""}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/ui/src/permissions-core.ts
+++ b/ui/src/permissions-core.ts
@@ -27,6 +27,7 @@ export const PermissionAction = {
   DetectionConfigRead: "detection_config.read",
   DetectionConfigWrite: "detection_config.write",
   SSOManage: "sso.manage",
+  WebhookManage: "webhook.manage",
   ServiceAccountRead: "service_account.read",
   UserRead: "user.read",
   UserManage: "user.manage",


### PR DESCRIPTION
## What

The console UI for the outbound alert webhook (#496), stacked on the merged backend (#567). Operators can now manage webhook destinations from Admin, Settings, Webhooks instead of the API alone. Also folds in the post-merge review follow-ups from #567.

## UI

- New **Webhooks** settings page (`ui/src/components/Webhooks/`) modeled on the SSO settings page: add/edit form with a write-only signing secret, event-type (created / status-changed) and minimum-severity filters and an enable toggle, a destinations list with edit/delete, and a per-destination **delivery-status readout** (status, attempt, HTTP code, last error).
- `permissions-core` `WebhookManage` action; `api.ts` client (`/settings/webhooks` CRUD + `/deliveries`; secret write-only); nav section + route, both gated on `webhook.manage`.
- vitest: list + write-only secret, create-and-refresh, non-https rejected before the API call, delivery-status readout.

## Backend follow-ups (from #567 review)

- **Disabled destinations are no longer claimable**: the delivery worker's claim query filters `wd.enabled = 1`, so disabling a destination stops delivery of its already-queued rows (matches the spec's "disabling stops future deliveries"). Integration test added.
- **Zero the unsealed signing secret** after each delivery (defense in depth).
- **Synchronize the client test's handler-captured state** so reads don't race the server goroutine under `-race`.

Skipped (with reasoning in the commit): fold-not-found-into-`UPDATE` (`RowsAffected` can't distinguish not-found from a no-op update without `CLIENT_FOUND_ROWS`), compare-and-swap finalization (heavy; at-least-once tolerates a rare double-send), and "don't wire the admin surface without a root secret" (wiring it always so list/delete work while writes return 503 is the intended design).

## Tests / gates

- `cd ui`: vitest 412 pass, eslint + tsc clean.
- `go build`, `-race` webhook + pipeline tests, full detection integration suite, standard + strict new-code lint (0 issues), spectrace, dashes, markdownlint all pass.

## Deferred (separate follow-ups)

Test-send endpoint + button, OTel delivery metrics, env config knobs. Vendor formatters + further hardening remain in #565.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BxbWcMpjYFGpHZDU2d2mfm


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Webhooks settings page in the admin console for managing webhook destinations.
  * Users can now create, edit, delete, and review recent delivery attempts for each destination.
  * Webhook settings are now available directly from the admin navigation.

* **Bug Fixes**
  * Disabled webhook destinations are no longer claimed for delivery.
  * Signing secrets are cleared from memory after use.
  * Improved test coverage for webhook delivery behavior and UI validation.

* **Documentation**
  * Updated webhook docs to reflect the console-based management flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->