### PR TITLE
test(webhook-ui): cover the test-send fallback + thrown-error branches (#496) [no-behavior-change]

### DIFF
--- a/ui/src/components/Webhooks/Webhooks.test.tsx
+++ b/ui/src/components/Webhooks/Webhooks.test.tsx
@@ -225,6 +225,26 @@ describe("Webhooks", () => {
     expect(await screen.findByText("Failed (500)")).toBeInTheDocument();
   });
 
+  it("falls back to a generic message when a failed test has neither error nor status code", async () => {
+    vi.spyOn(api, "listWebhooks").mockResolvedValue([dest]);
+    // The ultimate fallback arm: not ok, and the response carries no diagnostic detail at all.
+    vi.spyOn(api, "testWebhook").mockResolvedValue({ ok: false });
+    render(<Webhooks />);
+    await screen.findByText("pd");
+    fireEvent.click(screen.getByRole("button", { name: "Send test" }));
+    expect(await screen.findByText("Test delivery failed")).toBeInTheDocument();
+  });
+
+  it("surfaces a thrown error from the test-send request", async () => {
+    vi.spyOn(api, "listWebhooks").mockResolvedValue([dest]);
+    // A rejected request (e.g. a network failure before any response) is caught and shown to the operator.
+    vi.spyOn(api, "testWebhook").mockRejectedValue(new Error("network down"));
+    render(<Webhooks />);
+    await screen.findByText("pd");
+    fireEvent.click(screen.getByRole("button", { name: "Send test" }));
+    expect(await screen.findByText("network down")).toBeInTheDocument();
+  });
+
   it("surfaces a deliveries load error", async () => {
     vi.spyOn(api, "listWebhooks").mockResolvedValue([dest]);
     vi.spyOn(api, "listWebhookDeliveries").mockRejectedValue(new Error("delivery boom"));


### PR DESCRIPTION
## What

Test-only follow-up to #496: covers the two `sendTest` UI branches PR #569 left uncovered (the reason `codecov/patch/ui` was red).

- **Generic fallback** — a failed test carrying neither `error` nor `status_code` renders "Test delivery failed".
- **Thrown request** — a rejected `testWebhook` is caught and its message surfaced.

## Why

PR #569's SSRF-error sanitization added the fallback arm and left the `catch` path unexercised, holding codecov's ui-flag patch under its 70% target. This finishes the coverage. The two remaining branch sub-arms (`status_code ?? ""` on a 2xx with no code, and a non-`Error` throw) are idiomatic defensive arms below the target and are intentionally not chased (repo no-speculative-edge-cases rule).

## Tests / gates

No source or behavior change (tagged `[no-behavior-change]`). Full UI vitest (433) + eslint + tsc pass locally; `sendTest`'s outcome lines are now executed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BxbWcMpjYFGpHZDU2d2mfm
