### PR TITLE
feat(detection): reconcile exclusion match types with rules + signature exclusions for suspicious_exec (#520)

### DIFF
--- a/docs/recommended-exclusions.md
+++ b/docs/recommended-exclusions.md
@@ -9,21 +9,26 @@ Add these on the detection-config exclusions surface in the console (sign in as 
 An exclusion is `(rule_id, match_type, value)`. The value is matched per the rule's match type:
 
 - `parent_path_glob`: matches a chain's non-shell parent path. `*` matches any run of characters including `/`. A pattern with no `*` is an exact match.
-- `team_id`: matches an Apple Developer team ID exactly.
+- `team_id`: matches an Apple Developer team ID exactly (the `TeamIdentifier` field of the code signature).
+- `signing_id`: matches a code-signing identifier exactly (the `Identifier` field, for example `com.anthropic.claude-code`).
+- `cdhash`: matches a binary's code-directory hash exactly (40 lowercase hex characters), pinning one exact build.
 - `path_glob`: matches an absolute filesystem path with the same glob semantics as `parent_path_glob`.
 
-Which rule consumes which match type is fixed by the rule:
+Which rule consumes which match type is fixed by the rule, and the console offers only the match types the selected rule actually consults. Creating an exclusion for a `(rule_id, match_type)` pair the rule does not consult, or for a rule that does not exist, is rejected by the API, so a stored exclusion can no longer silently do nothing:
 
-| Rule                            | Match type used    |
-| ------------------------------- | ------------------ |
-| `suspicious_exec`               | `parent_path_glob` |
-| `privilege_launchd_plist_write` | `team_id`          |
-| `persistence_launchagent`       | `path_glob`        |
-| `sudoers_tamper`                | `path_glob`        |
+| Rule                            | Match types used                                      |
+| ------------------------------- | ----------------------------------------------------- |
+| `suspicious_exec`               | `parent_path_glob`, `team_id`, `signing_id`, `cdhash` |
+| `privilege_launchd_plist_write` | `team_id`                                             |
+| `persistence_launchagent`       | `path_glob`                                           |
+| `sudoers_tamper`                | `path_glob`                                           |
+
+`suspicious_exec` matches its signature match types (`team_id`, `signing_id`, `cdhash`) against the chain's non-shell parent. A code-signed parent can therefore be excluded by its non-spoofable signing identity instead of a path glob, which is the preferred form for any signed tool (see the caveats below).
 
 ## Caveats before you add an exclusion
 
-- A `suspicious_exec` `parent_path_glob` exclusion silences BOTH arms of the rule for that parent (the temp-path exec arm and the outbound-network arm). You are trusting everything that parent does, not just the one connection you saw.
+- Prefer a signature exclusion over a path glob whenever the parent is code-signed. A `team_id` (or `signing_id` / `cdhash`) exclusion on `suspicious_exec` matches the parent's signing identity, which survives version churn and cannot be spoofed by planting a binary at a lookalike path, unlike a `parent_path_glob`. Reach for a path glob only when the tool is unsigned.
+- A `suspicious_exec` exclusion silences BOTH arms of the rule for that parent (the temp-path exec arm and the outbound-network arm), whichever match type you use. You are trusting everything that parent does, not just the one connection you saw.
 - Never start a path glob with `*`, and minimize interior wildcards. Because `*` matches any run of characters including `/`, a leading-wildcard pattern like `*/claude/versions/*` matches that fragment anywhere on disk, so an attacker who can write to `/tmp` creates `/tmp/claude/versions/payload` and runs it to land inside the exclusion. Anchor to the full absolute install path instead; the longer the literal prefix, the less an attacker can spoof.
 - A path exclusion is only as trustworthy as the write permissions on the directory it points at. Anchor to a root-owned install root (`/usr/bin`, `/usr/local/bin`, `/opt/homebrew/...`) that an unprivileged attacker cannot write to. A path under a user home or any world-writable location can be recreated by the attacker, so it carries real residual risk even when anchored. This is sharper on multi-user hosts: a home-anchored glob with a wildcarded user segment (`/Users/*/...`) matches every user's home, so any local user, not just the intended one, can plant a binary at the excluded path and evade the rule.
 - For `team_id`, notarization is deliberately not a trust signal (Apple has notarized malware, and it is not checkable network-free on the event thread). The team-ID allowlist is the operator's explicit trust decision. Confirm the exact team before allowlisting it: `codesign -dv <binary>` prints `TeamIdentifier`.
@@ -43,9 +48,9 @@ The `FDG8Q7N4CC` entry is the only one keyed on a team ID because `privilege_lau
 
 ## Environment-specific exclusions
 
-The table above is deliberately minimal because it is the only set that applies to every deployment. Most of the benign `suspicious_exec` noise you actually see comes from tooling specific to your fleet, so those exclusions are yours to add, not blanket recommendations: add one only for a tool actually present in your environment. Common offenders shell out and then reach the network, which is exactly the rule's shape: infrastructure-as-code tools, AI coding assistants, CI runners, and package managers. Exclude each with a `parent_path_glob` anchored to the tool's full absolute install path, never a leading-wildcard fragment (see the caveats above for why `*/tool/...` is attacker-spoofable). For example, only if your fleet runs them:
+The table above is deliberately minimal because it is the only set that applies to every deployment. Most of the benign `suspicious_exec` noise you actually see comes from tooling specific to your fleet, so those exclusions are yours to add, not blanket recommendations: add one only for a tool actually present in your environment. Common offenders shell out and then reach the network, which is exactly the rule's shape: infrastructure-as-code tools, AI coding assistants, CI runners, and package managers. For a code-signed tool, exclude it by its `team_id` (or `signing_id`), which is update-stable and cannot be spoofed by a binary planted at a lookalike path. Fall back to a `parent_path_glob` anchored to the tool's full absolute install path only for an unsigned tool, and never a leading-wildcard fragment (see the caveats above for why `*/tool/...` is attacker-spoofable). For example, only if your fleet runs them:
 
-- Terraform installed via Homebrew on Apple Silicon: `/opt/homebrew/Cellar/terraform/*/bin/terraform`. Anchored under the root-owned Homebrew prefix; the single `*` spans only the version directory.
-- Claude Code: `/Users/*/.local/share/claude/versions/*`. This one lives under a user home, which an attacker can also write to, so it carries more residual risk than a root-owned path even when anchored. Add it only on workstations where the noise is real, and never on servers.
+- Claude Code (signed by Anthropic): `team_id` `Q6L2SF6YDW`, or the more specific `signing_id` `com.anthropic.claude-code`. The signature holds across version updates and cannot be spoofed, so this is preferred over the path glob that earlier releases documented (`/Users/*/.local/share/claude/versions/*`, which lives under a user home an attacker can write to). Confirm the team on your own host with `codesign -dv $(which claude)` before allowlisting it.
+- Terraform installed via Homebrew on Apple Silicon (unsigned): `parent_path_glob` `/opt/homebrew/Cellar/terraform/*/bin/terraform`. Anchored under the root-owned Homebrew prefix; the single `*` spans only the version directory.
 
-Confirm the real install path on one of your own hosts (`which <tool>`, then resolve symlinks) before adding the glob, and anchor to that exact location.
+Confirm the signing identity (`codesign -dv <binary>`) or the real install path (`which <tool>`, then resolve symlinks) on one of your own hosts before adding an exclusion, and anchor to that exact value.

--- a/openspec/changes/reconcile-exclusion-match-types/proposal.md
+++ b/openspec/changes/reconcile-exclusion-match-types/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+The detection-config exclusion editor (UI + API) offers every exclusion match type for every rule, but each rule only consults a fixed subset at evaluation time (issue #520). Of the 8 defined `ExclusionMatchType` values only 3 are consulted by any rule, and only 4 of the 10 catalog rules consult exclusions at all, yet the UI lists all 8 for every rule and the API validates only that the match type is a valid enum value and that `rule_id` is non-empty (it does not even check `rule_id` names a real rule). An operator can therefore create an exclusion whose `(rule_id, match_type)` pair no rule reads; it is accepted, stored, and shown as active while silently doing nothing.
+
+This is also the blocker for the motivating use case: excluding a code-signed developer tool (for example Claude Code, `TeamIdentifier=Q6L2SF6YDW`) by its signing identity. `suspicious_exec` today consults only `parent_path_glob`, and because a path glob's `*` matches `/`, a leading-wildcard exclusion like `*/claude/versions/*` also matches `/tmp/claude/versions/payload`, so an attacker who can write to `/tmp` lands inside the exclusion. The non-spoofable, update-stable exclusion is `team_id=Q6L2SF6YDW`, but the rule cannot consult it. The parent's signing identity is already persisted on the process record (`Process.CodeSigning`, `Process.CDHash`); the rule just does not read it.
+
+Industry practice (CrowdStrike Falcon, Microsoft Defender ASR, SentinelOne) surfaces only the exclusion dimensions a rule actually consumes, validates them server-side, and prefers signer/hash exclusions over path globs for signed tooling. This change reconciles the UI, API, and rules onto one model.
+
+## What changes
+
+- Each rule declares the exclusion match types it consults as a single source of truth (`SupportedExclusionMatchTypes() []ExclusionMatchType` on the rule interface), surfaced on `GET /api/rules`.
+- The create-exclusion API validates `match_type` against the target rule's supported set and rejects an unsupported pair, and rejects a `rule_id` that does not name a registered rule, with a clear message.
+- The admin UI's exclusion editor offers only the match types the selected rule supports, sourced from `GET /api/rules`, and resets the selection when the rule changes so a stale unsupported match type cannot be submitted.
+- `suspicious_exec` gains signature-based parent exclusions (`team_id`, `signing_id`, `cdhash`) matched against the non-shell parent's already-persisted code-signing identity, in addition to `parent_path_glob`. No agent or event-wire change: the data is already stored.
+- Rules that consult no exclusions offer none. No new exclusion capabilities are added to other rules in this change (candidates such as `domain` for `dns_c2_beacon` or `command_substring` for argv rules are out of scope).
+
+Existing stored exclusions whose `(rule_id, match_type)` pair is unsupported under the new validation are already inert (they match nothing); they are left in place. Validation applies to new creates only; no migration touches stored rows.
+
+## Capabilities
+
+### Modified capabilities
+
+- `server-detection-rules-engine`: the durable detection-configuration surface validates the `(rule_id, match_type)` pair on create and exposes each rule's supported exclusion match types; `suspicious_exec` suppresses by the non-shell parent's code-signing identity in addition to its path glob.
+- `web-ui`: the detection-configuration exclusion editor offers only the selected rule's supported match types.
+
+## Impact
+
+- Code: `SupportedExclusionMatchTypes()` on `api.Rule` (`server/rules/api/types.go`) implemented by all 10 catalog rules; `api.RuleMetadata` + the `GET /api/rules` response gain the field; `suspicious_exec.parentExcluded` reads the parent's signing (`server/rules/internal/catalog/suspicious_exec.go`); the detection-config service validates against a per-rule capability map injected by bootstrap (`server/rules/internal/detectionconfig/service.go`, `server/rules/bootstrap/bootstrap.go`); the admin UI filters the match-type picker (`ui/src/api.ts`, `ui/src/components/DetectionConfig/DetectionConfig.tsx`).
+- Data: none. No migration. No wire or event-schema change. No agent change.
+- Behavior: creating an exclusion for an unsupported pair or an unknown rule now returns HTTP 400 where it previously succeeded; this is the intended fix. Existing inert rows are unaffected.
+- Rollback is a code revert; no data to unwind.

--- a/openspec/changes/reconcile-exclusion-match-types/specs/server-detection-rules-engine/spec.md
+++ b/openspec/changes/reconcile-exclusion-match-types/specs/server-detection-rules-engine/spec.md
@@ -1,0 +1,60 @@
+## MODIFIED Requirements
+
+### Requirement: Durable detection configuration surface
+
+The system SHALL persist detection-rule configuration (per-rule mode, optional severity override, per-rule settings, and false-positive exclusions) as durable state in MySQL, edited through the authenticated admin API and UI. Detection configuration MUST NOT be sourced from boot-time environment variables. Every mutation MUST pass through the RBAC authorization chokepoint and record an audit entry naming the actor. Each configuration record MAY carry a host-group scope (or be global); records also support an optional expiration after which they no longer apply. A configuration change MUST become effective for subsequent evaluations without a server restart.
+
+Each registered rule SHALL declare the set of exclusion match types it consults at evaluation time, and the rule catalog surface (`GET /api/rules`) SHALL expose that set for every rule so operator tooling can offer only the match types a rule actually reads. Creating an exclusion SHALL be rejected when its `rule_id` does not name a registered rule, and when its `match_type` is not one the named rule consults; the rejection is a client error that names the supported match types. This prevents an operator from storing an exclusion whose `(rule_id, match_type)` pair no rule reads, which would otherwise be accepted and displayed as active while suppressing nothing.
+
+#### Scenario: An operator adds a false-positive exclusion without restarting
+
+- **GIVEN** a rule that is currently producing a benign finding for a known-good process
+- **WHEN** an operator adds an exclusion for that rule (by a typed match such as a parent-path glob or a signing team ID) through the detection-configuration API
+- **THEN** the exclusion is persisted in MySQL with the actor recorded in the audit log
+- **AND** subsequent batches no longer produce that finding, without a server restart
+
+#### Scenario: An expired exclusion stops applying
+
+- **GIVEN** an exclusion whose expiration timestamp is in the past
+- **WHEN** the engine evaluates a batch that the exclusion would otherwise suppress
+- **THEN** the exclusion does not apply and the finding is produced
+
+#### Scenario: The rule catalog exposes per-rule supported exclusion match types
+
+- **GIVEN** the registered rule catalog
+- **WHEN** a client reads `GET /api/rules`
+- **THEN** each rule carries the set of exclusion match types it consults, as an array (empty for a rule that consults no exclusions)
+
+#### Scenario: Creating an exclusion for a match type the rule does not consult is rejected
+
+- **GIVEN** a rule that consults a fixed set of exclusion match types
+- **WHEN** an operator attempts to create an exclusion for that rule with a match type outside the rule's supported set
+- **THEN** the request is rejected as a client error whose message names the rule's supported match types
+- **AND** no exclusion is persisted
+
+#### Scenario: Creating an exclusion for an unknown rule is rejected
+
+- **GIVEN** a `rule_id` that names no registered rule (including the empty string)
+- **WHEN** an operator attempts to create an exclusion for it
+- **THEN** the request is rejected as a client error and no exclusion is persisted
+
+## ADDED Requirements
+
+### Requirement: Signature-based parent exclusions
+
+The `suspicious_exec` rule SHALL suppress a finding when the chain's non-shell parent process matches an operator exclusion by its code-signing identity, in addition to the existing parent-path-glob match. The consulted signature dimensions are the parent's Apple Developer team ID (`team_id`), its code-signing identifier (`signing_id`), and its code-directory hash (`cdhash`), read from the parent process's already-persisted code-signing record; no agent or event-wire change is required. A finding with no resolved non-shell parent, or a parent that carries no signing identity, MUST NOT be suppressed by a signature exclusion, so an unsigned binary at a benign-looking path is not silently allowed. This lets an operator exclude a code-signed developer tool by its non-spoofable signing identity instead of a path glob that an attacker who can write to a world-writable directory could land inside.
+
+#### Scenario: A signed parent is suppressed by its team ID
+
+- **GIVEN** a `suspicious_exec` chain whose non-shell parent is a code-signed binary with team ID `Q6L2SF6YDW`
+- **AND** an exclusion of match type `team_id` with value `Q6L2SF6YDW` for `suspicious_exec`
+- **WHEN** the engine evaluates the rule against the batch
+- **THEN** the engine produces no `suspicious_exec` finding, because the parent's signing team ID matches the exclusion
+- **AND** the same holds for a `signing_id` exclusion matching the parent's signing identifier and a `cdhash` exclusion matching the parent's code-directory hash
+
+#### Scenario: An unsigned lookalike parent is not suppressed
+
+- **GIVEN** an exclusion of match type `team_id` with value `Q6L2SF6YDW` for `suspicious_exec`
+- **AND** a `suspicious_exec` chain whose non-shell parent is an unsigned binary at a path resembling the benign tool (for example `/tmp/claude/versions/1.0/claude`)
+- **WHEN** the engine evaluates the rule against the batch
+- **THEN** the finding is produced, because the unsigned parent carries no team ID for the signature exclusion to match

--- a/openspec/changes/reconcile-exclusion-match-types/specs/web-ui/spec.md
+++ b/openspec/changes/reconcile-exclusion-match-types/specs/web-ui/spec.md
@@ -1,0 +1,47 @@
+## MODIFIED Requirements
+
+### Requirement: Detection configuration admin views
+
+The web UI SHALL provide an authenticated admin surface to view and edit detection configuration: per-rule mode (alert / disabled), an optional severity override, and false-positive exclusions. Monitor is NOT an operator-selectable mode; the detection engine still honors a legacy `monitor` value persisted on a rule setting, so the UI MUST display such a row (and let the operator migrate it to alert or disabled) but MUST NOT offer monitor as a new choice. The per-rule mode and severity controls MUST render uniformly for every registered rule (driven from the rule catalog), so a newly added rule appears without bespoke UI, and the table MUST show each rule's declared (default) severity alongside the optional override. The exclusion editor MUST let an operator create and delete global-scope exclusions with a typed match type, a value, a reason, and an optional expiration, and MUST surface the existing entries with their creation time and their author resolved to a display email when the author is a known user, falling back to the raw principal identifier when the user cannot be resolved. The match-type picker MUST offer only the match types the selected rule consults (sourced from the rule catalog's per-rule supported set), and MUST reset its selection when the rule changes, so an operator cannot submit an exclusion whose match type the rule would silently ignore. When an operator disables a rule, the UI MUST capture an operator-supplied reason before the change is submitted, because that reason is recorded in the audit trail; restoring a rule to alert and severity-only edits MAY use a system-generated reason. Mutations MUST go through the authenticated admin API and are subject to the same RBAC the API enforces. Per-rule schema-driven settings beyond mode + severity, exclusion editing, and host-group-scoped configuration are deferred to a later change (they land with the editable host groups and per-rule config-schema work).
+
+#### Scenario: An operator adds an exclusion from the UI
+
+- **GIVEN** an authenticated operator with detection-config write access
+- **WHEN** they add an exclusion with a match type, value, and reason
+- **THEN** the exclusion is created through the admin API
+- **AND** it appears in the exclusion list with its creation time and its author shown as a resolved email when the author is a known user
+
+#### Scenario: Per-rule mode and severity controls render for every rule
+
+- **GIVEN** the rule catalog registers a set of rules
+- **WHEN** an operator opens the detection-configuration admin view
+- **THEN** every registered rule shows mode and severity-override controls without UI changes specific to that rule
+- **AND** each rule's declared default severity is shown alongside its optional override
+
+#### Scenario: Disabling a rule requires an operator reason
+
+- **GIVEN** an authenticated operator with detection-config write access
+- **WHEN** they set a rule's mode to disabled
+- **THEN** the UI captures an operator-supplied reason before submitting the change
+- **AND** restoring the rule to alert or editing only its severity override does not require an operator-supplied reason (a system-generated reason is recorded instead)
+
+#### Scenario: Monitor is not an operator-selectable mode
+
+- **GIVEN** an authenticated operator viewing the rule-modes table
+- **WHEN** they open a rule's mode control
+- **THEN** a rule with no persisted monitor setting offers only alert and disabled
+- **AND** a rule with a legacy persisted monitor value still displays monitor so the operator can migrate it to alert or disabled
+
+#### Scenario: Exclusion author is shown as a resolved email
+
+- **GIVEN** an exclusion whose author is a known user
+- **WHEN** the operator views the exclusions list
+- **THEN** the Created by column shows that user's email
+- **AND** an exclusion whose author cannot be resolved falls back to the raw principal identifier
+
+#### Scenario: Exclusion match-type picker offers only the supported types for a rule
+
+- **GIVEN** the rule catalog reports each rule's supported exclusion match types
+- **WHEN** an operator selects a rule in the exclusion editor
+- **THEN** the match-type picker offers only that rule's supported match types
+- **AND** selecting a different rule resets the match-type selection to that rule's supported set

--- a/openspec/changes/reconcile-exclusion-match-types/tasks.md
+++ b/openspec/changes/reconcile-exclusion-match-types/tasks.md
@@ -1,0 +1,35 @@
+## 1. Single source of truth for supported match types
+
+- [x] 1.1 Add `SupportedExclusionMatchTypes() []ExclusionMatchType` to the `api.Rule` interface.
+- [x] 1.2 Implement it on all 10 catalog rules (the 4 consuming rules return their consulted set; the other 6 return nil).
+- [x] 1.3 Add `SupportedExclusionMatchTypes` to `api.RuleMetadata` and populate it in `service.List()` and `bootstrap.catalogList.List()`.
+- [x] 1.4 Surface `supported_exclusion_match_types` on `GET /api/rules` (always an array, never null).
+
+## 2. Signature-based parent exclusions for suspicious_exec
+
+- [x] 2.1 Extend the shared `codeSigningJSON` struct with `signing_id`.
+- [x] 2.2 Extend `suspicious_exec.parentExcluded` to match the parent's `team_id` / `signing_id` (from `Process.CodeSigning`) and `cdhash` (from `Process.CDHash`), after the existing `parent_path_glob` check.
+
+## 3. Create-exclusion validation
+
+- [x] 3.1 Add a per-rule capability map + `SetRuleExclusionSupport` setter to the detection-config `Service`.
+- [x] 3.2 Validate `(rule_id, match_type)` in `Service.CreateExclusion`: reject an unknown rule id, a rule that accepts no exclusions, and an unsupported match type, as `ErrInvalidRequest` (HTTP 400) with a clear message.
+- [x] 3.3 Wire the capability map from bootstrap, built from the live rule set.
+
+## 4. UI
+
+- [x] 4.1 Add `supported_exclusion_match_types` to the `RuleDocEntry` type.
+- [x] 4.2 Filter the exclusion editor's match-type picker to the selected rule's supported set, in display order; disable it until a rule is selected; reset the selection when the rule changes.
+
+## 5. Tests
+
+- [x] 5.1 Anti-drift guard: pin each rule's declared set, and a recording resolver proving `suspicious_exec` queries exactly its declared set.
+- [x] 5.2 `suspicious_exec` signature-exclusion suppression (team_id / signing_id / cdhash) and non-suppression of an unsigned lookalike.
+- [x] 5.3 Service validation cases (unsupported pair, unknown rule, no-exclusion rule, unset map skips).
+- [x] 5.4 Handler: `GET /api/rules` includes the field; create rejection message reaches the 400 body.
+- [x] 5.5 UI: picker offers only the supported set and resets on rule change.
+
+## 6. Spec + verification
+
+- [x] 6.1 OpenSpec delta (this change).
+- [x] 6.2 `go build ./...`, `go vet -tags integration ./...`, `go test ./server/rules/... ./server/detection/...`, `cd ui && npm test`, `task lint:go`, `task lint:dashes`, `task lint:md:prose`, `openspec validate --all --strict`, `spectrace check --strict`.

--- a/server/detection/internal/engine/engine_test.go
+++ b/server/detection/internal/engine/engine_test.go
@@ -33,6 +33,7 @@ func (r *stubRule) Doc() rulesapi.Documentation {
 func (r *stubRule) Evaluate(_ context.Context, _ []api.Event, _ rulesapi.GraphReader) ([]api.Finding, error) {
 	return nil, nil
 }
+func (r *stubRule) SupportedExclusionMatchTypes() []rulesapi.ExclusionMatchType { return nil }
 
 func TestEngine_RegisterAccumulates(t *testing.T) {
 	t.Parallel()

--- a/server/detection/internal/tests/integration_test.go
+++ b/server/detection/internal/tests/integration_test.go
@@ -91,6 +91,8 @@ func (r *stubRule) Evaluate(_ context.Context, events []api.Event, _ rulesapi.Gr
 	return out, nil
 }
 
+func (r *stubRule) SupportedExclusionMatchTypes() []rulesapi.ExclusionMatchType { return nil }
+
 // stubProvider satisfies the rules.api.RuleProvider shape Engine.LoadActive
 // consumes (inline interface).
 type stubProvider struct{ rules []rulesapi.Rule }
@@ -139,6 +141,8 @@ func (r *multiPIDStub) Evaluate(_ context.Context, events []api.Event, _ rulesap
 	return out, nil
 }
 
+func (r *multiPIDStub) SupportedExclusionMatchTypes() []rulesapi.ExclusionMatchType { return nil }
+
 // fixedPIDStub emits one finding per "trigger" event with a configured ProcessID. Used by
 // TestEngine_PersistenceFailureSurfacesError to force the FK violation deterministically: a ProcessID that's nowhere
 // near the AUTO_INCREMENT counter triggers fk_alerts_process every time InsertAlert runs, surfacing the persistence-
@@ -181,6 +185,8 @@ func (r *fixedPIDStub) Evaluate(_ context.Context, events []api.Event, _ rulesap
 	return out, nil
 }
 
+func (r *fixedPIDStub) SupportedExclusionMatchTypes() []rulesapi.ExclusionMatchType { return nil }
+
 // errorStub returns an error from Evaluate. Used by TestEngine_OneRuleErrorsRestContinue to prove the engine's
 // per-rule loop isolates failures: the error is logged and the loop continues to the next rule.
 type errorStub struct{ id string }
@@ -195,6 +201,8 @@ func (r *errorStub) Doc() rulesapi.Documentation {
 func (r *errorStub) Evaluate(_ context.Context, _ []api.Event, _ rulesapi.GraphReader) ([]api.Finding, error) {
 	return nil, fmt.Errorf("errorStub %s: deliberate evaluation failure", r.id)
 }
+
+func (r *errorStub) SupportedExclusionMatchTypes() []rulesapi.ExclusionMatchType { return nil }
 
 // execFiringStub fires one finding per "exec" event the rule sees. Used by TestEngine_SnapshotExecExcludedFromEvaluation
 // to prove the engine filters snapshot exec events BEFORE rule evaluation: if the rule never sees the snapshot=true
@@ -238,6 +246,8 @@ func (r *execFiringStub) Evaluate(_ context.Context, events []api.Event, _ rules
 	}
 	return out, nil
 }
+
+func (r *execFiringStub) SupportedExclusionMatchTypes() []rulesapi.ExclusionMatchType { return nil }
 
 // recordingMetrics captures every hook invocation so tests can assert
 // observability survived the phase-5 wiring rewrite.

--- a/server/rules/api/types.go
+++ b/server/rules/api/types.go
@@ -81,10 +81,10 @@ type Rule interface {
 	// mutate state. Returning an error skips the rule for this batch (logged at WARN); returning nil findings is the common case.
 	Evaluate(ctx context.Context, events []Event, gr GraphReader) ([]Finding, error)
 	// SupportedExclusionMatchTypes returns the exclusion match types this rule consults at evaluation time, i.e. the match types it
-	// passes to the ExclusionResolver. It returns an empty slice for a rule that consults no exclusions. This is the single source of
-	// truth (issue #520) the create-exclusion API validates against and the admin UI's match-type picker derives from, so a rule can
-	// never offer an exclusion dimension it silently ignores. The catalog guard test asserts a rule never queries a match type outside
-	// this set.
+	// passes to the ExclusionResolver. It returns no match types (nil or an empty slice, treated alike) for a rule that consults no
+	// exclusions. This is the single source of truth (issue #520) the create-exclusion API validates against and the admin UI's
+	// match-type picker derives from, so a rule can never offer an exclusion dimension it silently ignores. The catalog guard test
+	// asserts a rule never queries a match type outside this set.
 	SupportedExclusionMatchTypes() []ExclusionMatchType
 }
 

--- a/server/rules/api/types.go
+++ b/server/rules/api/types.go
@@ -80,6 +80,12 @@ type Rule interface {
 	// Evaluate runs the rule against a batch of events. Implementations may use gr to walk the historical process graph but must not
 	// mutate state. Returning an error skips the rule for this batch (logged at WARN); returning nil findings is the common case.
 	Evaluate(ctx context.Context, events []Event, gr GraphReader) ([]Finding, error)
+	// SupportedExclusionMatchTypes returns the exclusion match types this rule consults at evaluation time, i.e. the match types it
+	// passes to the ExclusionResolver. It returns an empty slice for a rule that consults no exclusions. This is the single source of
+	// truth (issue #520) the create-exclusion API validates against and the admin UI's match-type picker derives from, so a rule can
+	// never offer an exclusion dimension it silently ignores. The catalog guard test asserts a rule never queries a match type outside
+	// this set.
+	SupportedExclusionMatchTypes() []ExclusionMatchType
 }
 
 // RuleMetadata is the per-rule descriptor the operator endpoints render. Used in two surfaces: GET /api/rules (the operator handler
@@ -90,6 +96,9 @@ type RuleMetadata struct {
 	ID         string
 	Techniques []string
 	Doc        Documentation
+	// SupportedExclusionMatchTypes mirrors the rule's SupportedExclusionMatchTypes() (issue #520). Surfaced on GET /api/rules so the
+	// admin UI offers only the match types the rule consults, and validated against by the create-exclusion API.
+	SupportedExclusionMatchTypes []ExclusionMatchType
 }
 
 // Documentation is the structured per-rule descriptor consumed by the

--- a/server/rules/bootstrap/bootstrap.go
+++ b/server/rules/bootstrap/bootstrap.go
@@ -89,6 +89,15 @@ func New(deps Deps) (*Rules, error) {
 	rules := catalog.New(detectionConfigSvc)
 	svc := service.New(rules, logger)
 
+	// Inject the per-rule exclusion-support map (issue #520) built from the live rule set so the create-exclusion API rejects a
+	// (rule_id, match_type) pair no rule consults, and a rule_id that names no registered rule. Single source of truth: each rule's
+	// SupportedExclusionMatchTypes(), the same set GET /api/rules surfaces to the admin UI.
+	exclusionSupport := make(map[string][]api.ExclusionMatchType, len(rules))
+	for _, r := range rules {
+		exclusionSupport[r.ID()] = r.SupportedExclusionMatchTypes()
+	}
+	detectionConfigSvc.SetRuleExclusionSupport(exclusionSupport)
+
 	opH := operator.New(svc, deps.AuthZ, logger)
 	opH.SetAudit(deps.Audit)
 
@@ -219,9 +228,10 @@ func (c catalogList) List() []api.RuleMetadata {
 	out := make([]api.RuleMetadata, 0, len(c))
 	for _, r := range c {
 		out = append(out, api.RuleMetadata{
-			ID:         r.ID(),
-			Techniques: r.Techniques(),
-			Doc:        r.Doc(),
+			ID:                           r.ID(),
+			Techniques:                   r.Techniques(),
+			Doc:                          r.Doc(),
+			SupportedExclusionMatchTypes: r.SupportedExclusionMatchTypes(),
 		})
 	}
 	return out

--- a/server/rules/internal/catalog/application_control_block.go
+++ b/server/rules/internal/catalog/application_control_block.go
@@ -31,6 +31,9 @@ const applicationControlBlockEventType = "application_control_block"
 
 func (r *ApplicationControlBlock) ID() string { return "application_control_block" }
 
+// SupportedExclusionMatchTypes returns nil: this rule consults no exclusions, so the admin UI offers none for it (issue #520).
+func (r *ApplicationControlBlock) SupportedExclusionMatchTypes() []api.ExclusionMatchType { return nil }
+
 // DisplayName is the canonical name for the rule's catalog entry (Doc().Title). Unlike the other rules, the alert this rule raises
 // does NOT carry DisplayName as its title: each block event maps to a finding whose RuleID is the matched app-control rule
 // (`app_control:<n>`, not this catalog ID) and whose title is computed per block (`Application blocked: <binary>`), so the operator

--- a/server/rules/internal/catalog/credential_keychain_dump.go
+++ b/server/rules/internal/catalog/credential_keychain_dump.go
@@ -30,6 +30,9 @@ type CredentialKeychainDump struct{}
 
 func (r *CredentialKeychainDump) ID() string { return "credential_keychain_dump" }
 
+// SupportedExclusionMatchTypes returns nil: this rule consults no exclusions, so the admin UI offers none for it (issue #520).
+func (r *CredentialKeychainDump) SupportedExclusionMatchTypes() []api.ExclusionMatchType { return nil }
+
 // DisplayName is the canonical human-readable name reused by Doc().Title and the finding (issue #519).
 func (r *CredentialKeychainDump) DisplayName() string { return "Keychain credential dump" }
 

--- a/server/rules/internal/catalog/dns_c2_beacon.go
+++ b/server/rules/internal/catalog/dns_c2_beacon.go
@@ -34,6 +34,9 @@ type DNSC2Beacon struct{}
 
 func (r *DNSC2Beacon) ID() string { return "dns_c2_beacon" }
 
+// SupportedExclusionMatchTypes returns nil: this rule consults no exclusions, so the admin UI offers none for it (issue #520).
+func (r *DNSC2Beacon) SupportedExclusionMatchTypes() []api.ExclusionMatchType { return nil }
+
 // DisplayName is the canonical human-readable name reused by Doc().Title and the finding (issue #519).
 func (r *DNSC2Beacon) DisplayName() string { return "DNS C2 beacon" }
 

--- a/server/rules/internal/catalog/dyld_insert.go
+++ b/server/rules/internal/catalog/dyld_insert.go
@@ -24,6 +24,9 @@ type DyldInsert struct{}
 
 func (r *DyldInsert) ID() string { return "dyld_insert" }
 
+// SupportedExclusionMatchTypes returns nil: this rule consults no exclusions, so the admin UI offers none for it (issue #520).
+func (r *DyldInsert) SupportedExclusionMatchTypes() []api.ExclusionMatchType { return nil }
+
 // DisplayName is the canonical human-readable name reused by Doc().Title and the finding (issue #519).
 func (r *DyldInsert) DisplayName() string { return "DYLD injection on exec" }
 

--- a/server/rules/internal/catalog/exclusion_reconciliation_test.go
+++ b/server/rules/internal/catalog/exclusion_reconciliation_test.go
@@ -1,0 +1,123 @@
+package catalog
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fleetdm/edr/server/rules/api"
+)
+
+// TestExclusionMatchTypes_Reconciled is the anti-drift guard for issue #520. It pins, for every registered rule, the exact set of
+// exclusion match types the rule declares via SupportedExclusionMatchTypes(). That declared set is the single source of truth the
+// create-exclusion API validates against and the admin UI's match-type picker derives from, so this pin makes any change to a rule's
+// exclusion surface a visible, reviewed diff rather than silent drift where the UI offers a match type no rule consults.
+//
+// The companion recording guard (TestExclusionMatchTypes_NoUndeclaredConsultation) proves a rule never QUERIES a match type outside
+// its declared set; each rule's own suppression tests prove it actually consults the types it declares.
+func TestExclusionMatchTypes_Reconciled(t *testing.T) {
+	t.Parallel()
+
+	// expected is the authoritative (rule id -> supported match types) table. A new rule, or a change to a rule's exclusion surface,
+	// MUST update this table, which is exactly the reviewable signal we want.
+	expected := map[string][]api.ExclusionMatchType{
+		"suspicious_exec": {
+			api.ExclusionMatchParentPathGlob, api.ExclusionMatchTeamID, api.ExclusionMatchSigningID, api.ExclusionMatchCDHash,
+		},
+		"persistence_launchagent":       {api.ExclusionMatchPathGlob},
+		"sudoers_tamper":                {api.ExclusionMatchPathGlob},
+		"privilege_launchd_plist_write": {api.ExclusionMatchTeamID},
+		"dyld_insert":                   {},
+		"shell_from_office":             {},
+		"osascript_network_exec":        {},
+		"credential_keychain_dump":      {},
+		"application_control_block":     {},
+		"dns_c2_beacon":                 {},
+	}
+
+	rules := New(nil)
+	require.Len(t, rules, len(expected), "expected table must list every registered rule; update it when adding a rule")
+
+	for _, r := range rules {
+		t.Run(r.ID(), func(t *testing.T) {
+			t.Parallel()
+			want, ok := expected[r.ID()]
+			require.Truef(t, ok, "rule %q is not in the expected match-type table; add it", r.ID())
+			got := r.SupportedExclusionMatchTypes()
+			// A rule that consults nothing may return nil or an empty slice; treat them alike. Otherwise order matters: it is the
+			// display order the UI offers and the order the API rejection message lists.
+			if len(want) == 0 {
+				assert.Emptyf(t, got, "rule %q must offer no exclusion match types", r.ID())
+			} else {
+				assert.Equalf(t, want, got, "rule %q supported match types drifted from the pin", r.ID())
+			}
+			for _, mt := range got {
+				assert.Truef(t, api.IsValidExclusionMatchType(mt), "rule %q declares invalid match type %q", r.ID(), mt)
+			}
+		})
+	}
+}
+
+// recordingResolver is an api.ExclusionResolver that records every (ruleID, matchType) pair a rule queries and never excludes, so the
+// rule under test fully evaluates and reaches all of its exclusion checks.
+type recordingResolver struct {
+	queried map[string]map[api.ExclusionMatchType]bool
+}
+
+func newRecordingResolver() *recordingResolver {
+	return &recordingResolver{queried: map[string]map[api.ExclusionMatchType]bool{}}
+}
+
+func (r *recordingResolver) Excluded(ruleID string, matchType api.ExclusionMatchType, _, _ string) bool {
+	if r.queried[ruleID] == nil {
+		r.queried[ruleID] = map[api.ExclusionMatchType]bool{}
+	}
+	r.queried[ruleID][matchType] = true
+	return false
+}
+
+// TestExclusionMatchTypes_NoUndeclaredConsultation drives suspicious_exec (the rule with the richest exclusion surface and the one
+// extended in issue #520) through a scenario that reaches every one of its exclusion checks, with a recording resolver, and asserts
+// the set of match types it actually queries equals the set it declares. A signed non-shell parent makes the rule consult the path
+// glob AND all three signature dimensions, so the recording set is exactly the declared set: no undeclared consultation, no declared
+// dead entry.
+func TestExclusionMatchTypes_NoUndeclaredConsultation(t *testing.T) {
+	t.Parallel()
+
+	s := openCatalogStore(t)
+	ctx := t.Context()
+	// Signed claude -> /bin/sh -> /tmp/payload: the parent carries code_signing (team_id + signing_id) and a cdhash, so parentExcluded
+	// queries all four match types the rule declares.
+	events := []api.Event{
+		{EventID: "fork-parent", HostID: "host-a", TimestampNs: 1000, EventType: "fork",
+			Payload: json.RawMessage(`{"child_pid":50,"parent_pid":1}`)},
+		{EventID: "exec-parent", HostID: "host-a", TimestampNs: 1100, EventType: "exec",
+			Payload: json.RawMessage(`{"pid":50,"ppid":1,"path":"/Applications/Claude.app/Contents/MacOS/claude","args":["claude"],` +
+				`"uid":501,"gid":20,"code_signing":{"team_id":"Q6L2SF6YDW","signing_id":"com.anthropic.claude-code","flags":0,` +
+				`"is_platform_binary":false},"cdhash":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}`)},
+		{EventID: "fork-sh", HostID: "host-a", TimestampNs: 2000, EventType: "fork",
+			Payload: json.RawMessage(`{"child_pid":100,"parent_pid":50}`)},
+		{EventID: "exec-sh", HostID: "host-a", TimestampNs: 2100, EventType: "exec",
+			Payload: json.RawMessage(`{"pid":100,"ppid":50,"path":"/bin/sh","args":["sh"],"uid":501,"gid":20}`)},
+		{EventID: "fork-payload", HostID: "host-a", TimestampNs: 3000, EventType: "fork",
+			Payload: json.RawMessage(`{"child_pid":200,"parent_pid":100}`)},
+		{EventID: "exec-payload", HostID: "host-a", TimestampNs: 3100, EventType: "exec",
+			Payload: json.RawMessage(`{"pid":200,"ppid":100,"path":"/tmp/payload","args":["/tmp/payload"],"uid":501,"gid":20}`)},
+	}
+	require.NoError(t, s.InsertEvents(ctx, events))
+	materialize(t, s, events)
+
+	rec := newRecordingResolver()
+	rule := &SuspiciousExec{Exclusions: rec}
+	_, err := rule.Evaluate(ctx, events, s.GraphReader())
+	require.NoError(t, err)
+
+	declared := map[api.ExclusionMatchType]bool{}
+	for _, mt := range rule.SupportedExclusionMatchTypes() {
+		declared[mt] = true
+	}
+	assert.Equal(t, declared, rec.queried["suspicious_exec"],
+		"suspicious_exec must query exactly the match types it declares: no undeclared consultation, no dead declaration")
+}

--- a/server/rules/internal/catalog/osascript_network_exec.go
+++ b/server/rules/internal/catalog/osascript_network_exec.go
@@ -36,6 +36,9 @@ type OsascriptNetworkExec struct{}
 
 func (r *OsascriptNetworkExec) ID() string { return "osascript_network_exec" }
 
+// SupportedExclusionMatchTypes returns nil: this rule consults no exclusions, so the admin UI offers none for it (issue #520).
+func (r *OsascriptNetworkExec) SupportedExclusionMatchTypes() []api.ExclusionMatchType { return nil }
+
 // DisplayName is the canonical human-readable name reused by Doc().Title and the finding (issue #519).
 func (r *OsascriptNetworkExec) DisplayName() string { return "AppleScript dropper" }
 

--- a/server/rules/internal/catalog/persistence_launchagent.go
+++ b/server/rules/internal/catalog/persistence_launchagent.go
@@ -24,6 +24,11 @@ type PersistenceLaunchAgent struct {
 
 func (r *PersistenceLaunchAgent) ID() string { return "persistence_launchagent" }
 
+// SupportedExclusionMatchTypes lists the match types this rule consults: the LaunchAgent plist writer path glob (issue #520).
+func (r *PersistenceLaunchAgent) SupportedExclusionMatchTypes() []api.ExclusionMatchType {
+	return []api.ExclusionMatchType{api.ExclusionMatchPathGlob}
+}
+
 // DisplayName is the canonical human-readable name reused by Doc().Title and the finding (issue #519).
 func (r *PersistenceLaunchAgent) DisplayName() string { return "LaunchAgent persistence" }
 

--- a/server/rules/internal/catalog/privilege_launchd_plist_write.go
+++ b/server/rules/internal/catalog/privilege_launchd_plist_write.go
@@ -44,6 +44,11 @@ type PrivilegeLaunchdPlistWrite struct {
 
 func (r *PrivilegeLaunchdPlistWrite) ID() string { return "privilege_launchd_plist_write" }
 
+// SupportedExclusionMatchTypes lists the match types this rule consults: the registered executable's signing team ID (issue #520).
+func (r *PrivilegeLaunchdPlistWrite) SupportedExclusionMatchTypes() []api.ExclusionMatchType {
+	return []api.ExclusionMatchType{api.ExclusionMatchTeamID}
+}
+
 // DisplayName is the canonical human-readable name reused by Doc().Title and the finding (issue #519). The ID stays the stale-but-stable
 // snake_case identifier (renaming it is a migration-backed change); the prose name reflects what the rule actually detects today.
 func (r *PrivilegeLaunchdPlistWrite) DisplayName() string { return "LaunchDaemon persistence" }
@@ -98,10 +103,13 @@ type btmLaunchItemAddPayload struct {
 	InstigatorCodeSigning *codeSigningJSON `json:"instigator_code_signing"`
 }
 
-// codeSigningJSON mirrors the extension's CodeSigning wire struct. The executable decision consumes team_id and
-// is_platform_binary; the instigator copy carries the same shape but is forensic-only.
+// codeSigningJSON mirrors the extension's CodeSigning wire struct (schema/events.json `code_signing`). The executable decision here
+// consumes team_id and is_platform_binary; suspicious_exec's signature exclusions (issue #520) also read signing_id off the same
+// stored blob, so the field lives here rather than in a second near-identical struct. The instigator copy carries the same shape but
+// is forensic-only.
 type codeSigningJSON struct {
 	TeamID           string `json:"team_id"`
+	SigningID        string `json:"signing_id"`
 	IsPlatformBinary bool   `json:"is_platform_binary"`
 }
 

--- a/server/rules/internal/catalog/shell_from_office.go
+++ b/server/rules/internal/catalog/shell_from_office.go
@@ -19,6 +19,9 @@ type ShellFromOffice struct{}
 
 func (r *ShellFromOffice) ID() string { return "shell_from_office" }
 
+// SupportedExclusionMatchTypes returns nil: this rule consults no exclusions, so the admin UI offers none for it (issue #520).
+func (r *ShellFromOffice) SupportedExclusionMatchTypes() []api.ExclusionMatchType { return nil }
+
 // DisplayName is the canonical human-readable name reused by Doc().Title and the finding (issue #519).
 func (r *ShellFromOffice) DisplayName() string { return "Shell spawned by Microsoft Office" }
 

--- a/server/rules/internal/catalog/sudoers_tamper.go
+++ b/server/rules/internal/catalog/sudoers_tamper.go
@@ -52,6 +52,11 @@ type SudoersTamper struct {
 
 func (r *SudoersTamper) ID() string { return "sudoers_tamper" }
 
+// SupportedExclusionMatchTypes lists the match types this rule consults: the sudoers writer path glob (issue #520).
+func (r *SudoersTamper) SupportedExclusionMatchTypes() []api.ExclusionMatchType {
+	return []api.ExclusionMatchType{api.ExclusionMatchPathGlob}
+}
+
 // DisplayName is the canonical human-readable name reused by Doc().Title and the finding (issue #519).
 func (r *SudoersTamper) DisplayName() string { return "Sudoers tamper" }
 

--- a/server/rules/internal/catalog/suspicious_exec.go
+++ b/server/rules/internal/catalog/suspicious_exec.go
@@ -61,6 +61,18 @@ type SuspiciousExec struct {
 
 func (r *SuspiciousExec) ID() string { return "suspicious_exec" }
 
+// SupportedExclusionMatchTypes lists the match types parentExcluded consults: the non-shell parent's path glob plus its code-signing
+// identity (team_id / signing_id / cdhash), so an operator can exclude a benign signed parent (e.g. a Developer-ID developer tool) by
+// its non-spoofable signature rather than a path glob a writable-directory attacker can land inside (issue #520).
+func (r *SuspiciousExec) SupportedExclusionMatchTypes() []api.ExclusionMatchType {
+	return []api.ExclusionMatchType{
+		api.ExclusionMatchParentPathGlob,
+		api.ExclusionMatchTeamID,
+		api.ExclusionMatchSigningID,
+		api.ExclusionMatchCDHash,
+	}
+}
+
 // DisplayName is the canonical human-readable name reused by Doc().Title and the finding (issue #519). Both trigger arms (the
 // temp-path exec and the outbound network_connect) emit this one title; which arm fired lives in the finding Description, so the
 // alert maps 1:1 to the one rule an operator can look up (SIEM/Sigma catalog convention) rather than forking into two titles.
@@ -510,14 +522,34 @@ func (r *SuspiciousExec) makeExecFinding(
 	}
 }
 
-// parentExcluded reports whether the given non-shell parent process is excluded for hostID (match type parent_path_glob, value = the
-// parent path). A nil parent (shell parented at launchd, or parent not yet materialised) never matches: those are the cases the rule
-// must continue to flag because there's no human-attested entry point. Glob semantics live in the resolver (api.GlobMatch).
+// parentExcluded reports whether the given non-shell parent process is excluded for hostID. It matches four dimensions of the parent
+// (issue #520): the path glob (match type parent_path_glob) and the parent's already-persisted code-signing identity (team_id,
+// signing_id, cdhash). The signature dimensions let an operator exclude a benign signed parent (e.g. a Developer-ID developer tool
+// such as Claude Code) by a non-spoofable identifier rather than a path glob an attacker who can write to /tmp can land inside. A nil
+// parent (shell parented at launchd, or parent not yet materialised) never matches: those are the cases the rule must continue to
+// flag because there's no human-attested entry point. Glob semantics live in the resolver (api.GlobMatch).
 func (r *SuspiciousExec) parentExcluded(parent *api.Process, hostID string) bool {
 	if r.Exclusions == nil || parent == nil {
 		return false
 	}
-	return r.Exclusions.Excluded(r.ID(), api.ExclusionMatchParentPathGlob, parent.Path, hostID)
+	if r.Exclusions.Excluded(r.ID(), api.ExclusionMatchParentPathGlob, parent.Path, hostID) {
+		return true
+	}
+	if len(parent.CodeSigning) > 0 {
+		var cs codeSigningJSON
+		// A malformed blob is unexpected (the agent writes it), so a decode error just means "no signature to match on" rather than a
+		// rule failure: fall through to the cdhash check.
+		if err := json.Unmarshal(parent.CodeSigning, &cs); err == nil {
+			if cs.TeamID != "" && r.Exclusions.Excluded(r.ID(), api.ExclusionMatchTeamID, cs.TeamID, hostID) {
+				return true
+			}
+			if cs.SigningID != "" && r.Exclusions.Excluded(r.ID(), api.ExclusionMatchSigningID, cs.SigningID, hostID) {
+				return true
+			}
+		}
+	}
+	return parent.CDHash != nil && *parent.CDHash != "" &&
+		r.Exclusions.Excluded(r.ID(), api.ExclusionMatchCDHash, *parent.CDHash, hostID)
 }
 
 // dnsPort is the well-known DNS port. An outbound connection to it to a local-resolver-class address is name resolution against the

--- a/server/rules/internal/catalog/suspicious_exec_test.go
+++ b/server/rules/internal/catalog/suspicious_exec_test.go
@@ -477,6 +477,86 @@ func TestSuspiciousExec_ParentAllowlistSuppresses(t *testing.T) {
 	})
 }
 
+// TestSuspiciousExec_ParentSignatureExclusion covers signature-based parent exclusions (issue #520): an operator can suppress a benign
+// signed parent by its non-spoofable code-signing identity (team_id / signing_id / cdhash) read from the parent's already-persisted
+// process record, and an unsigned lookalike at a benign-looking path is NOT suppressed by such an exclusion. This is the concrete win
+// that lets team_id=Q6L2SF6YDW replace a spoofable `*/claude/versions/*` path glob for a Developer-ID tool like Claude Code.
+//
+// spec:server-detection-rules-engine/signature-based-parent-exclusions/a-signed-parent-is-suppressed-by-its-team-id
+// spec:server-detection-rules-engine/signature-based-parent-exclusions/an-unsigned-lookalike-parent-is-not-suppressed
+func TestSuspiciousExec_ParentSignatureExclusion(t *testing.T) {
+	t.Parallel()
+
+	const (
+		teamID    = "Q6L2SF6YDW"
+		signingID = "com.anthropic.claude-code"
+		cdhash    = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	)
+	// signed parent -> /bin/sh -> /tmp/payload. parentExtra embeds a code_signing blob + cdhash on the parent exec so the graph
+	// persists them on the process record parentExcluded reads; passing "" models an attacker's unsigned /tmp lookalike.
+	makeEvents := func(parentPath, parentExtra string) []api.Event {
+		return []api.Event{
+			{EventID: "fork-parent", HostID: "host-a", TimestampNs: 1000, EventType: "fork",
+				Payload: json.RawMessage(`{"child_pid":50,"parent_pid":1}`)},
+			{EventID: "exec-parent", HostID: "host-a", TimestampNs: 1100, EventType: "exec",
+				Payload: json.RawMessage(`{"pid":50,"ppid":1,"path":"` + parentPath + `","args":["claude"],"uid":501,"gid":20` + parentExtra + `}`)},
+			{EventID: "fork-sh", HostID: "host-a", TimestampNs: 2000, EventType: "fork",
+				Payload: json.RawMessage(`{"child_pid":100,"parent_pid":50}`)},
+			{EventID: "exec-sh", HostID: "host-a", TimestampNs: 2100, EventType: "exec",
+				Payload: json.RawMessage(`{"pid":100,"ppid":50,"path":"/bin/sh","args":["sh"],"uid":501,"gid":20}`)},
+			{EventID: "fork-payload", HostID: "host-a", TimestampNs: 3000, EventType: "fork",
+				Payload: json.RawMessage(`{"child_pid":200,"parent_pid":100}`)},
+			{EventID: "exec-payload", HostID: "host-a", TimestampNs: 3100, EventType: "exec",
+				Payload: json.RawMessage(`{"pid":200,"ppid":100,"path":"/tmp/payload","args":["/tmp/payload"],"uid":501,"gid":20}`)},
+		}
+	}
+	signedExtra := `,"code_signing":{"team_id":"` + teamID + `","signing_id":"` + signingID +
+		`","flags":0,"is_platform_binary":false},"cdhash":"` + cdhash + `"`
+	const signedParentPath = "/Applications/Claude.app/Contents/MacOS/claude"
+
+	suppressCases := []struct {
+		name string
+		excl fakeExcl
+	}{
+		{"team_id suppresses", fakeExcl{ruleID: "suspicious_exec", matchType: api.ExclusionMatchTeamID, value: teamID}},
+		{"signing_id suppresses", fakeExcl{ruleID: "suspicious_exec", matchType: api.ExclusionMatchSigningID, value: signingID}},
+		{"cdhash suppresses", fakeExcl{ruleID: "suspicious_exec", matchType: api.ExclusionMatchCDHash, value: cdhash}},
+	}
+	for _, tc := range suppressCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			s := openCatalogStore(t)
+			ctx := t.Context()
+			events := makeEvents(signedParentPath, signedExtra)
+			require.NoError(t, s.InsertEvents(ctx, events))
+			materialize(t, s, events)
+
+			rule := &SuspiciousExec{Exclusions: &fakeExclusions{entries: []fakeExcl{tc.excl}}}
+			findings, err := rule.Evaluate(ctx, events, s.GraphReader())
+			require.NoError(t, err)
+			assert.Empty(t, findings, "signed parent matched by its signing identity must suppress the finding")
+		})
+	}
+
+	t.Run("unsigned lookalike parent is not suppressed by a team_id exclusion", func(t *testing.T) {
+		t.Parallel()
+		s := openCatalogStore(t)
+		ctx := t.Context()
+		// The attacker's lookalike: an unsigned binary at a path that resembles the benign tool. It carries no code_signing, so the
+		// team_id exclusion cannot match even though a `*/claude/versions/*` path glob would have.
+		events := makeEvents("/tmp/claude/versions/1.0/claude", "")
+		require.NoError(t, s.InsertEvents(ctx, events))
+		materialize(t, s, events)
+
+		rule := &SuspiciousExec{Exclusions: &fakeExclusions{entries: []fakeExcl{
+			{ruleID: "suspicious_exec", matchType: api.ExclusionMatchTeamID, value: teamID},
+		}}}
+		findings, err := rule.Evaluate(ctx, events, s.GraphReader())
+		require.NoError(t, err)
+		require.Len(t, findings, 1, "an unsigned parent has no team_id, so the signature exclusion must not suppress it")
+	})
+}
+
 // Cross-batch race: in production the agent flushes events ~once per second while a real chain completes in ~150ms, so when the
 // cadence boundary lands mid-chain the shell exec arrives in batch N and the temp-binary exec in batch N+1. Forward-direction matching
 // missed the chain entirely under those conditions because at batch N's Evaluate the temp-binary descendant hadn't been materialised.

--- a/server/rules/internal/catalog/suspicious_exec_test.go
+++ b/server/rules/internal/catalog/suspicious_exec_test.go
@@ -514,6 +514,22 @@ func TestSuspiciousExec_ParentSignatureExclusion(t *testing.T) {
 		`","flags":0,"is_platform_binary":false},"cdhash":"` + cdhash + `"`
 	const signedParentPath = "/Applications/Claude.app/Contents/MacOS/claude"
 
+	// Baseline: the signed fixture must be detection-positive with NO exclusion. Without this, a regression that stops the fixture
+	// firing for an unrelated reason would let every suppression subtest below pass vacuously (they only assert zero findings).
+	t.Run("signed parent fires without an exclusion", func(t *testing.T) {
+		t.Parallel()
+		s := openCatalogStore(t)
+		ctx := t.Context()
+		events := makeEvents(signedParentPath, signedExtra)
+		require.NoError(t, s.InsertEvents(ctx, events))
+		materialize(t, s, events)
+
+		rule := &SuspiciousExec{}
+		findings, err := rule.Evaluate(ctx, events, s.GraphReader())
+		require.NoError(t, err)
+		require.Len(t, findings, 1, "signed parent fixture must fire before the suppression cases assert it is suppressed")
+	})
+
 	suppressCases := []struct {
 		name string
 		excl fakeExcl

--- a/server/rules/internal/detectionconfig/service.go
+++ b/server/rules/internal/detectionconfig/service.go
@@ -2,8 +2,11 @@ package detectionconfig
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
+	"slices"
 	"strconv"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -22,6 +25,11 @@ type Service struct {
 	audit      identityapi.AuditRecorder
 	logger     *slog.Logger
 	snap       atomic.Pointer[Snapshot]
+	// ruleExclusionSupport maps each registered rule id to the exclusion match types it consults (issue #520), injected by bootstrap
+	// from the live rule set via SetRuleExclusionSupport. CreateExclusion validates the (rule_id, match_type) pair against it. Nil when
+	// unset (non-production constructors / tests), in which case the validation is skipped. Set once during wiring, then read-only, so
+	// it needs no synchronization (same posture as audit / membership).
+	ruleExclusionSupport map[string][]api.ExclusionMatchType
 }
 
 var (
@@ -45,6 +53,45 @@ func NewService(store *Store, membership Membership, audit identityapi.AuditReco
 	return s
 }
 
+// SetRuleExclusionSupport injects the per-rule map of exclusion match types the catalog rules consult (issue #520), built by bootstrap
+// from the live rule set. CreateExclusion validates the (rule_id, match_type) pair against it so an operator cannot store an exclusion
+// a rule would silently ignore, and so a rule_id that names no registered rule is rejected. Set post-construction (mirrors
+// SetPrincipalLabelResolver / SetAudit); when left unset the validation is skipped, keeping non-production constructors and the
+// store-level tests working. Production always wires it.
+func (s *Service) SetRuleExclusionSupport(support map[string][]api.ExclusionMatchType) {
+	s.ruleExclusionSupport = support
+}
+
+// validateExclusionSupport rejects a create-exclusion request whose rule_id names no registered rule, or whose match_type the target
+// rule does not consult (issue #520). A nil support map (never wired) skips the check. Returns ErrInvalidRequest so the handler maps
+// it to HTTP 400.
+func (s *Service) validateExclusionSupport(in CreateExclusionInput) error {
+	if s.ruleExclusionSupport == nil {
+		return nil
+	}
+	supported, ok := s.ruleExclusionSupport[in.RuleID]
+	if !ok {
+		return fmt.Errorf("%w: rule_id %q does not name a registered rule", ErrInvalidRequest, in.RuleID)
+	}
+	if len(supported) == 0 {
+		return fmt.Errorf("%w: rule %q does not accept exclusions", ErrInvalidRequest, in.RuleID)
+	}
+	if slices.Contains(supported, in.MatchType) {
+		return nil
+	}
+	return fmt.Errorf("%w: rule %q does not support match_type %q; supported match types: %s",
+		ErrInvalidRequest, in.RuleID, in.MatchType, joinMatchTypes(supported))
+}
+
+// joinMatchTypes renders a rule's supported match types for the rejection message, in the rule's declared order.
+func joinMatchTypes(mts []api.ExclusionMatchType) string {
+	parts := make([]string, len(mts))
+	for i, mt := range mts {
+		parts[i] = string(mt)
+	}
+	return strings.Join(parts, ", ")
+}
+
 // ListExclusions / ListRuleSettings are read passthroughs to the store for the operator surface.
 func (s *Service) ListExclusions(ctx context.Context) ([]api.DetectionExclusion, error) {
 	return s.store.ListExclusions(ctx)
@@ -60,6 +107,9 @@ func (s *Service) CreateExclusion(
 	ctx context.Context, actor *identityapi.Actor, reason string, in CreateExclusionInput,
 ) (api.DetectionExclusion, error) {
 	in.Actor = actorIdentifier(actor)
+	if err := s.validateExclusionSupport(in); err != nil {
+		return api.DetectionExclusion{}, err
+	}
 	excl, err := s.store.CreateExclusion(ctx, in)
 	if err != nil {
 		return api.DetectionExclusion{}, err

--- a/server/rules/internal/detectionconfig/service_test.go
+++ b/server/rules/internal/detectionconfig/service_test.go
@@ -67,6 +67,86 @@ func TestService_CreateExclusion_PersistsResolvesAndAudits(t *testing.T) {
 	assert.Equal(t, "Claude Code CLI", ev.Payload["reason"])
 }
 
+// TestService_CreateExclusion_ValidatesSupport covers the (rule_id, match_type) validation wired via SetRuleExclusionSupport
+// (issue #520): with the capability map set, an unsupported pair, an unknown rule, and a rule that accepts no exclusions are all
+// rejected as ErrInvalidRequest, while a supported pair persists. When the map is left unset (the default), validation is skipped so
+// the store-level tests keep working.
+//
+// spec:server-detection-rules-engine/durable-detection-configuration-surface/creating-an-exclusion-for-a-match-type-the-rule-does-not-consult-is-rejected
+// spec:server-detection-rules-engine/durable-detection-configuration-surface/creating-an-exclusion-for-an-unknown-rule-is-rejected
+func TestService_CreateExclusion_ValidatesSupport(t *testing.T) {
+	t.Parallel()
+	actor := &identityapi.Actor{Principal: identityapi.UserPrincipal(1, "ops@fleetdm.com")}
+	support := map[string][]api.ExclusionMatchType{
+		"suspicious_exec": {api.ExclusionMatchParentPathGlob, api.ExclusionMatchTeamID},
+		"dns_c2_beacon":   {},
+	}
+
+	t.Run("supported pair persists", func(t *testing.T) {
+		t.Parallel()
+		svc := newService(t, &fakeAudit{})
+		svc.SetRuleExclusionSupport(support)
+		excl, err := svc.CreateExclusion(context.Background(), actor, "benign", detectionconfig.CreateExclusionInput{
+			RuleID: "suspicious_exec", MatchType: api.ExclusionMatchTeamID, Value: "Q6L2SF6YDW",
+		})
+		require.NoError(t, err)
+		assert.NotZero(t, excl.ID)
+	})
+
+	t.Run("unsupported match type for the rule is rejected", func(t *testing.T) {
+		t.Parallel()
+		svc := newService(t, &fakeAudit{})
+		svc.SetRuleExclusionSupport(support)
+		_, err := svc.CreateExclusion(context.Background(), actor, "benign", detectionconfig.CreateExclusionInput{
+			RuleID: "suspicious_exec", MatchType: api.ExclusionMatchDomain, Value: "example.com",
+		})
+		require.ErrorIs(t, err, detectionconfig.ErrInvalidRequest)
+		assert.Contains(t, err.Error(), "does not support match_type")
+	})
+
+	t.Run("unknown rule id is rejected", func(t *testing.T) {
+		t.Parallel()
+		svc := newService(t, &fakeAudit{})
+		svc.SetRuleExclusionSupport(support)
+		_, err := svc.CreateExclusion(context.Background(), actor, "benign", detectionconfig.CreateExclusionInput{
+			RuleID: "no_such_rule", MatchType: api.ExclusionMatchTeamID, Value: "X",
+		})
+		require.ErrorIs(t, err, detectionconfig.ErrInvalidRequest)
+		assert.Contains(t, err.Error(), "does not name a registered rule")
+	})
+
+	t.Run("empty rule id is rejected", func(t *testing.T) {
+		t.Parallel()
+		svc := newService(t, &fakeAudit{})
+		svc.SetRuleExclusionSupport(support)
+		_, err := svc.CreateExclusion(context.Background(), actor, "benign", detectionconfig.CreateExclusionInput{
+			RuleID: "", MatchType: api.ExclusionMatchTeamID, Value: "X",
+		})
+		require.ErrorIs(t, err, detectionconfig.ErrInvalidRequest)
+		assert.Contains(t, err.Error(), "does not name a registered rule")
+	})
+
+	t.Run("rule that accepts no exclusions is rejected", func(t *testing.T) {
+		t.Parallel()
+		svc := newService(t, &fakeAudit{})
+		svc.SetRuleExclusionSupport(support)
+		_, err := svc.CreateExclusion(context.Background(), actor, "benign", detectionconfig.CreateExclusionInput{
+			RuleID: "dns_c2_beacon", MatchType: api.ExclusionMatchDomain, Value: "example.com",
+		})
+		require.ErrorIs(t, err, detectionconfig.ErrInvalidRequest)
+		assert.Contains(t, err.Error(), "does not accept exclusions")
+	})
+
+	t.Run("validation skipped when support map unset", func(t *testing.T) {
+		t.Parallel()
+		svc := newService(t, &fakeAudit{}) // no SetRuleExclusionSupport
+		_, err := svc.CreateExclusion(context.Background(), actor, "benign", detectionconfig.CreateExclusionInput{
+			RuleID: "anything", MatchType: api.ExclusionMatchDomain, Value: "example.com",
+		})
+		require.NoError(t, err, "with no capability map wired the pair check is skipped")
+	})
+}
+
 func TestService_UpsertRuleSetting_ResolvesAndAudits(t *testing.T) {
 	t.Parallel()
 	audit := &fakeAudit{}

--- a/server/rules/internal/operator/detectionconfig_handler_test.go
+++ b/server/rules/internal/operator/detectionconfig_handler_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -225,6 +226,29 @@ func TestDetectionConfigHandler_CreateExclusion(t *testing.T) {
 			resp.Body.Close()
 		})
 	}
+}
+
+// TestDetectionConfigHandler_CreateExclusion_UnsupportedPairMessage pins that the service's (rule_id, match_type) rejection message
+// (issue #520) reaches the client in the 400 body, so an operator sees WHY the pair was rejected and which match types are supported,
+// rather than a bare status code.
+func TestDetectionConfigHandler_CreateExclusion_UnsupportedPairMessage(t *testing.T) {
+	t.Parallel()
+	svc := &fakeDCService{createErr: fmt.Errorf("%w: %s", detectionconfig.ErrInvalidRequest,
+		`rule "suspicious_exec" does not support match_type "domain"; supported match types: parent_path_glob, team_id`)}
+	srv := dcServer(t, svc, true)
+	resp := dcDo(t, srv, http.MethodPost, "/api/v1/detection-config/exclusions",
+		`{"rule_id":"suspicious_exec","match_type":"domain","value":"example.com","reason":"r"}`)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+
+	var body struct {
+		Error   string `json:"error"`
+		Message string `json:"message"`
+	}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	assert.Equal(t, "detection_config.invalid_input", body.Error)
+	assert.Contains(t, body.Message, `does not support match_type "domain"`)
+	assert.Contains(t, body.Message, "supported match types: parent_path_glob, team_id")
 }
 
 func TestDetectionConfigHandler_DeleteExclusion(t *testing.T) {

--- a/server/rules/internal/operator/handler.go
+++ b/server/rules/internal/operator/handler.go
@@ -68,14 +68,23 @@ func (h *Handler) handleListRules(w http.ResponseWriter, r *http.Request) {
 		ID         string            `json:"id"`
 		Techniques []string          `json:"techniques"`
 		Doc        api.Documentation `json:"doc"`
+		// SupportedExclusionMatchTypes lets the admin UI's exclusion editor offer only the match types the rule actually consults
+		// (issue #520). Always a JSON array (never null) so the UI can iterate without a nil guard: a rule that consults no exclusions
+		// serializes []. Additive field; the existing consumers (RuleDetail.tsx, gen-rule-docs) ignore it.
+		SupportedExclusionMatchTypes []api.ExclusionMatchType `json:"supported_exclusion_match_types"`
 	}
 	rules := h.svc.List()
 	out := make([]ruleResponse, 0, len(rules))
 	for _, rm := range rules {
+		matchTypes := rm.SupportedExclusionMatchTypes
+		if matchTypes == nil {
+			matchTypes = []api.ExclusionMatchType{}
+		}
 		out = append(out, ruleResponse{
-			ID:         rm.ID,
-			Techniques: rm.Techniques,
-			Doc:        rm.Doc,
+			ID:                           rm.ID,
+			Techniques:                   rm.Techniques,
+			Doc:                          rm.Doc,
+			SupportedExclusionMatchTypes: matchTypes,
 		})
 	}
 	writeJSON(ctx, h.logger, w, http.StatusOK, map[string]any{"rules": out})

--- a/server/rules/internal/operator/handler_test.go
+++ b/server/rules/internal/operator/handler_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	rulesapi "github.com/fleetdm/edr/server/rules/api"
+	"github.com/fleetdm/edr/server/rules/internal/catalog"
 	"github.com/fleetdm/edr/server/rules/internal/service"
 
 	identityapi "github.com/fleetdm/edr/server/identity/api"
@@ -79,4 +80,44 @@ func TestHandler_ATTACKCoverage_NoRules(t *testing.T) {
 		assert.NotNil(t, layer.Techniques, "techniques field MUST be present (empty array), not omitted")
 		assert.Empty(t, layer.Techniques, "with zero registered rules, the coverage layer MUST carry zero techniques")
 	})
+}
+
+// TestHandler_ListRules_SupportedExclusionMatchTypes pins that GET /api/rules surfaces each rule's supported exclusion match types
+// (issue #520), the field the admin UI's exclusion editor uses to offer only the match types a rule consults. A consuming rule
+// carries its declared list; a rule that consults no exclusions MUST carry an empty array (never null) so the UI can iterate without
+// a nil guard.
+//
+// spec:server-detection-rules-engine/durable-detection-configuration-surface/the-rule-catalog-exposes-per-rule-supported-exclusion-match-types
+func TestHandler_ListRules_SupportedExclusionMatchTypes(t *testing.T) {
+	t.Parallel()
+	svc := service.New(catalog.New(nil), slog.Default())
+	h := New(svc, allowAllAuthZ{}, slog.Default())
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+"/api/rules", nil)
+	require.NoError(t, err)
+	resp, err := srv.Client().Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var body struct {
+		Rules []struct {
+			ID                           string   `json:"id"`
+			SupportedExclusionMatchTypes []string `json:"supported_exclusion_match_types"`
+		} `json:"rules"`
+	}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+
+	byID := map[string][]string{}
+	for _, r := range body.Rules {
+		assert.NotNilf(t, r.SupportedExclusionMatchTypes, "rule %q MUST carry an array, not null", r.ID)
+		byID[r.ID] = r.SupportedExclusionMatchTypes
+	}
+	assert.Equal(t, []string{"parent_path_glob", "team_id", "signing_id", "cdhash"}, byID["suspicious_exec"])
+	assert.Equal(t, []string{"path_glob"}, byID["sudoers_tamper"])
+	assert.Empty(t, byID["dns_c2_beacon"], "a rule that consults no exclusions offers an empty set")
 }

--- a/server/rules/internal/service/service.go
+++ b/server/rules/internal/service/service.go
@@ -36,9 +36,10 @@ func (s *Service) List() []api.RuleMetadata {
 	out := make([]api.RuleMetadata, 0, len(s.rules))
 	for _, r := range s.rules {
 		out = append(out, api.RuleMetadata{
-			ID:         r.ID(),
-			Techniques: r.Techniques(),
-			Doc:        r.Doc(),
+			ID:                           r.ID(),
+			Techniques:                   r.Techniques(),
+			Doc:                          r.Doc(),
+			SupportedExclusionMatchTypes: r.SupportedExclusionMatchTypes(),
 		})
 	}
 	return out

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -417,6 +417,10 @@ export interface RuleDocEntry {
   id: string;
   techniques: string[];
   doc: RuleDoc;
+  // The exclusion match types this rule actually consults (issue #520). The detection-tuning exclusion editor offers only these for
+  // the selected rule, so an operator cannot create an exclusion the rule would silently ignore. Optional so an older server response
+  // that predates the field degrades to "offer nothing".
+  supported_exclusion_match_types?: string[];
 }
 
 // fetchRuleDocs returns every registered detection rule with its operator-

--- a/ui/src/components/DetectionConfig/DetectionConfig.test.tsx
+++ b/ui/src/components/DetectionConfig/DetectionConfig.test.tsx
@@ -33,6 +33,9 @@ const makeRuleEntry = (over: Partial<RuleDocEntry> = {}): RuleDocEntry => ({
   id: "suspicious_exec",
   techniques: ["T1059"],
   doc: makeRuleDoc(),
+  // Mirrors the real suspicious_exec supported set (issue #520): parent path glob plus signature dimensions. Tests that need a
+  // different set (e.g. a path-only rule) override this.
+  supported_exclusion_match_types: ["parent_path_glob", "team_id", "signing_id", "cdhash"],
   ...over,
 });
 
@@ -184,9 +187,10 @@ describe("DetectionConfig", () => {
     fireEvent.click(screen.getByRole("button", { name: /add exclusion/i }));
 
     await waitFor(() => {
+      // Selecting the rule defaulted the match type to its first supported type (parent_path_glob for suspicious_exec).
       expect(create).toHaveBeenCalledWith({
         rule_id: "suspicious_exec",
-        match_type: "path_glob",
+        match_type: "parent_path_glob",
         value: "*/foo/*",
         reason: "benign tool",
       });
@@ -215,6 +219,63 @@ describe("DetectionConfig", () => {
     renderPage();
     await waitFor(() => { expect(screen.getByText(/no exclusions configured/i)).toBeInTheDocument(); });
     expect(screen.getByRole("button", { name: /add exclusion/i })).toBeDisabled();
+  });
+
+  // The match-type picker offers ONLY the match types the selected rule consults (issue #520), in canonical display order, so an
+  // operator cannot create an exclusion the rule would silently ignore.
+  // spec:web-ui/detection-configuration-admin-views/exclusion-match-type-picker-offers-only-the-supported-types-for-a-rule
+  it("offers only the selected rule's supported match types, in display order", async () => {
+    stubReads({
+      rules: [
+        makeRuleEntry({
+          id: "suspicious_exec",
+          doc: makeRuleDoc({ title: "Suspicious execution" }),
+          supported_exclusion_match_types: ["team_id", "cdhash", "parent_path_glob"],
+        }),
+      ],
+    });
+    renderPage();
+    await waitFor(() => { expect(screen.getByText(/no exclusions configured/i)).toBeInTheDocument(); });
+
+    // Before a rule is picked the match-type select is disabled with a prompt option.
+    const matchSelect = screen.getByLabelText("Match type");
+    expect(matchSelect).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText("Rule"), { target: { value: "suspicious_exec" } });
+    // Options are the supported set intersected with the canonical order (parent_path_glob, team_id, cdhash), not the raw eight.
+    const options = within(screen.getByLabelText("Match type")).getAllByRole("option").map((o) => o.textContent);
+    expect(options).toEqual(["parent_path_glob", "team_id", "cdhash"]);
+    expect(screen.getByLabelText("Match type")).not.toBeDisabled();
+  });
+
+  // Switching rules re-scopes the picker to the newly selected rule and resets the selection so a stale unsupported type can't submit.
+  it("resets the match-type selection when the rule changes", async () => {
+    stubReads({
+      rules: [
+        makeRuleEntry({ id: "suspicious_exec", doc: makeRuleDoc({ title: "Suspicious execution" }),
+          supported_exclusion_match_types: ["parent_path_glob", "team_id"] }),
+        makeRuleEntry({ id: "sudoers_tamper", doc: makeRuleDoc({ title: "Sudoers tamper" }),
+          supported_exclusion_match_types: ["path_glob"] }),
+      ],
+    });
+    const create = vi.spyOn(api, "createDetectionExclusion").mockResolvedValue(makeExclusion());
+    renderPage();
+    await waitFor(() => { expect(screen.getByText(/no exclusions configured/i)).toBeInTheDocument(); });
+
+    fireEvent.change(screen.getByLabelText("Rule"), { target: { value: "suspicious_exec" } });
+    expect(screen.getByLabelText("Match type")).toHaveValue("parent_path_glob");
+
+    fireEvent.change(screen.getByLabelText("Rule"), { target: { value: "sudoers_tamper" } });
+    expect(screen.getByLabelText("Match type")).toHaveValue("path_glob");
+    const options = within(screen.getByLabelText("Match type")).getAllByRole("option").map((o) => o.textContent);
+    expect(options).toEqual(["path_glob"]);
+
+    fireEvent.change(screen.getByLabelText("Value"), { target: { value: "/etc/sudoers" } });
+    fireEvent.change(screen.getByLabelText("Reason"), { target: { value: "package manager" } });
+    fireEvent.click(screen.getByRole("button", { name: /add exclusion/i }));
+    await waitFor(() => {
+      expect(create).toHaveBeenCalledWith(expect.objectContaining({ rule_id: "sudoers_tamper", match_type: "path_glob" }));
+    });
   });
 
   it("deletes an exclusion with an audit reason", async () => {

--- a/ui/src/components/DetectionConfig/DetectionConfig.tsx
+++ b/ui/src/components/DetectionConfig/DetectionConfig.tsx
@@ -108,13 +108,17 @@ export function DetectionConfig() {
     () => [...rules].sort((a, b) => a.doc.title.localeCompare(b.doc.title)),
     [rules],
   );
-  // supportedMatchTypesFor returns, in canonical display order, the match types the given rule consults (issue #520). The exclusion
+  // supportedMatchTypesFor returns the match types the given rule consults (issue #520), in canonical display order. The exclusion
   // editor offers only these, so an operator cannot store a (rule, match type) pair the rule ignores. A rule with no supported types
-  // (or an unknown id) yields an empty list, which disables the match-type picker.
+  // (or an unknown id) yields an empty list, which disables the match-type picker. The server is the source of truth: any supported
+  // value not in the UI's canonical MATCH_TYPES order (e.g. a match type a newer server added while this bundle is version-skewed) is
+  // still offered, appended after the known ones, so the editor stays functional across a rolling deploy rather than silently hiding it.
   const supportedMatchTypesFor = useCallback(
     (ruleID: string): string[] => {
       const supported = rules.find((r) => r.id === ruleID)?.supported_exclusion_match_types ?? [];
-      return MATCH_TYPES.filter((m) => supported.includes(m));
+      const known = MATCH_TYPES.filter((m) => supported.includes(m));
+      const unknown = supported.filter((m) => !(MATCH_TYPES as readonly string[]).includes(m));
+      return [...known, ...unknown];
     },
     [rules],
   );

--- a/ui/src/components/DetectionConfig/DetectionConfig.tsx
+++ b/ui/src/components/DetectionConfig/DetectionConfig.tsx
@@ -19,7 +19,9 @@ import { Input, Select } from "../ui/Input";
 import { ReasonModal } from "./ReasonModal";
 import "./DetectionConfig.scss";
 
-// The match types the exclusion editor offers, mirroring api.ExclusionMatchType server-side.
+// The canonical display order for exclusion match types, mirroring api.ExclusionMatchType server-side. The editor never offers all of
+// these at once: it filters this list down to the match types the selected rule actually consults (issue #520), sourced from that
+// rule's supported_exclusion_match_types on GET /api/rules.
 const MATCH_TYPES = [
   "path_glob",
   "parent_path_glob",
@@ -89,7 +91,8 @@ export function DetectionConfig() {
 
   // Add-exclusion form state. formExpires is an optional YYYY-MM-DD from a date input; converted to an RFC3339 end-of-day instant.
   const [formRuleID, setFormRuleID] = useState("");
-  const [formMatchType, setFormMatchType] = useState<string>(MATCH_TYPES[0]);
+  // Empty until a rule is selected: the match-type picker is populated from the chosen rule's supported set (issue #520).
+  const [formMatchType, setFormMatchType] = useState<string>("");
   const [formValue, setFormValue] = useState("");
   const [formReason, setFormReason] = useState("");
   const [formExpires, setFormExpires] = useState("");
@@ -105,6 +108,18 @@ export function DetectionConfig() {
     () => [...rules].sort((a, b) => a.doc.title.localeCompare(b.doc.title)),
     [rules],
   );
+  // supportedMatchTypesFor returns, in canonical display order, the match types the given rule consults (issue #520). The exclusion
+  // editor offers only these, so an operator cannot store a (rule, match type) pair the rule ignores. A rule with no supported types
+  // (or an unknown id) yields an empty list, which disables the match-type picker.
+  const supportedMatchTypesFor = useCallback(
+    (ruleID: string): string[] => {
+      const supported = rules.find((r) => r.id === ruleID)?.supported_exclusion_match_types ?? [];
+      return MATCH_TYPES.filter((m) => supported.includes(m));
+    },
+    [rules],
+  );
+  const supportedMatchTypes = useMemo(() => supportedMatchTypesFor(formRuleID), [supportedMatchTypesFor, formRuleID]);
+
   // The rule-modes table orders by declared severity (critical first), where muting a rule is most consequential, then
   // alphabetically by title within a severity band.
   const rulesBySeverity = useMemo(
@@ -226,7 +241,7 @@ export function DetectionConfig() {
     setModalError(null);
   }, []);
 
-  const addDisabled = !formRuleID || !formValue.trim() || !formReason.trim();
+  const addDisabled = !formRuleID || !formMatchType || !formValue.trim() || !formReason.trim();
 
   return (
     <>
@@ -245,13 +260,22 @@ export function DetectionConfig() {
             {canWrite && (
               <div className="detection-config__form">
                 <Select label="Rule" id="dc-rule" inline={false} value={formRuleID}
-                  onChange={(e) => { setFormRuleID(e.target.value); }}>
+                  onChange={(e) => {
+                    // Selecting a rule narrows the match-type picker to that rule's supported set and resets the selection to the
+                    // first supported type, so a stale unsupported match type from a previous rule can never be submitted.
+                    const ruleID = e.target.value;
+                    setFormRuleID(ruleID);
+                    setFormMatchType(supportedMatchTypesFor(ruleID)[0] ?? "");
+                  }}>
                   <option value="">Select a rule...</option>
                   {rulesByName.map((r) => <option key={r.id} value={r.id}>{r.doc.title}</option>)}
                 </Select>
                 <Select label="Match type" id="dc-match" inline={false} value={formMatchType}
+                  disabled={supportedMatchTypes.length === 0}
                   onChange={(e) => { setFormMatchType(e.target.value); }}>
-                  {MATCH_TYPES.map((m) => <option key={m} value={m}>{m}</option>)}
+                  {supportedMatchTypes.length === 0
+                    ? <option value="">Select a rule first...</option>
+                    : supportedMatchTypes.map((m) => <option key={m} value={m}>{m}</option>)}
                 </Select>
                 <div className="detection-config__form-field--full">
                   <Input label="Value" id="dc-value" value={formValue} onChange={(e) => { setFormValue(e.target.value); }}


### PR DESCRIPTION
## Summary

Fixes #520. Reconciles the detection-config exclusion editor (UI + API) with what each rule actually consults, and adds non-spoofable signature-based exclusions to `suspicious_exec`.

Before this change the editor offered all 8 `ExclusionMatchType` values for every one of the 10 rules, but only 4 rules consult exclusions and only 3 match types are ever read. An operator could store a `(rule_id, match_type)` pair no rule reads: accepted, persisted, shown active, suppressing nothing. `suspicious_exec` could also only exclude by parent path, which is spoofable (`*/claude/versions/*` also matches `/tmp/claude/versions/payload`), blocking the motivating use case of excluding a signed developer tool like Claude Code by `team_id=Q6L2SF6YDW`.

## What changed

- **Single source of truth**: `SupportedExclusionMatchTypes()` on the `api.Rule` interface (compile-error gate on all 10 rules), surfaced on `GET /api/rules`.
- **API validation**: creating an exclusion now rejects an unknown `rule_id` and a `match_type` the rule does not consult, returning HTTP 400 with a message naming the supported set.
- **UI**: the exclusion editor offers only the selected rule's supported match types and resets the selection when the rule changes.
- **`suspicious_exec` signature exclusions**: suppresses by the non-shell parent's already-persisted code-signing identity (`team_id` / `signing_id` / `cdhash`) in addition to `parent_path_glob`. No agent or event-wire change. An unsigned lookalike is not suppressed.
- No new exclusion capabilities added to other rules; rules that consult nothing offer nothing.

Existing stored exclusions whose pair is now unsupported are already inert and are left in place; validation applies to new creates only (no migration).

## Behavior change

Creating an exclusion for an unsupported `(rule_id, match_type)` pair or an unknown rule now returns HTTP 400 where it previously returned success. This is the intended fix and is captured in the OpenSpec delta.

## Tests

- Anti-drift guard pinning each rule's declared set + a recording resolver proving `suspicious_exec` queries exactly what it declares.
- `suspicious_exec` signature-suppression (team_id / signing_id / cdhash) and unsigned-lookalike-not-suppressed.
- Service validation (unsupported pair, unknown rule, no-exclusion rule, unset-map skip).
- Handler: `/api/rules` includes the field; the 400 rejection message reaches the body.
- UI: picker offers only the supported set and resets on rule change.
- Ships `openspec/changes/reconcile-exclusion-match-types` (proposal, tasks, spec delta); spectrace markers reference the new scenarios.

Verified: `go build`, `go vet -tags integration`, `go test ./server/rules/... ./server/detection/...`, full UI suite (435 pass), `task lint:go` / `lint:dashes` / `lint:md:prose`, `openspec validate --all --strict`, `spectrace check --strict`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Exclusion options now adapt to the selected rule, showing only supported match types.
  * `suspicious_exec` now supports additional signature-based parent exclusion matching.

* **Bug Fixes**
  * Prevented saving exclusions with unsupported rule/match-type combinations.
  * Reset match type selection when changing rules to avoid stale values.

* **Chores**
  * Rule listings now include supported exclusion match types for a more accurate admin experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->