### PR TITLE
feat: agent health check-in + host-health server surface (PR 1/2) (#359)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Notable changes to Fleet EDR, newest first. This project follows [Semantic Versi
 ### Added
 
 - **Self-contained alert evidence.** An alert now captures the full envelopes of its triggering events at creation time, so the evidence stays readable even after the underlying events age out of retention. The alert-detail API response gains an `events` array alongside `event_ids` (see `docs/api/openapi.yaml`).
+- **Agent health check-in (server foundation).** The agent can report its health as an extensible per-component snapshot through a new host-token-authed `POST /api/status`, persisted last-writer-wins as the latest state per host. Each component carries a closed status (`healthy`/`degraded`/`unhealthy`/`unknown`) that the server rolls up into one per-host state; the Hosts list gains `overall_status` and a new `GET /api/hosts/{host_id}/health` returns the full component conditions. System-extension activation (endpoint security + network extension) is the first signal, surfacing the previously invisible case of a host that enrolls but whose sensor never activates (issue #359). The agent reporter and the Hosts UI badge + detail panel land in a follow-up.
 
 ### Changed
 

--- a/openspec/changes/agent-health-reporting/design.md
+++ b/openspec/changes/agent-health-reporting/design.md
@@ -1,0 +1,41 @@
+# Design notes
+
+## Health is a snapshot channel, not an event stream
+
+Two shapes were considered for the transport. A new event type on the append-only `POST /api/events` pipeline (partitioned out at ingest like `snapshot_heartbeat` already is) would reuse the auth, gzip, and batch plumbing. A dedicated check-in endpoint carries an idempotent current-state snapshot instead.
+
+Decision: a dedicated `POST /api/status`. Health is current-state, not an append-only log: the server only ever wants the latest snapshot per host, last-writer-wins, and a missed post must self-heal on the next one. Riding an append-only stream would either accumulate stale rows to reconcile or abuse the stream as an upsert. The dedicated endpoint keeps snapshot semantics honest, keeps status off the detection ingest hot path, and matches Elastic Fleet's check-in model. The accepted cost is one more route and a small poster loop in the agent.
+
+## The conditions model, not one field per signal
+
+The payload is a list of component-health conditions, each `{type, status, reason, message, last_transition_ns}`, rather than a fixed struct with a field per known signal. This is the Kubernetes conditions pattern. The `status` field is a small closed enum validated at the ingest boundary; `type` and `reason` are open string vocabularies owned by the agent. A new signal (DNS proxy, queue depth, policy staleness) is then one more entry the agent emits, stored generically by the server and rendered from its own message, with no wire change, no migration, and no UI-framework change. This is the whole reason to build the channel now rather than a boolean: the marginal cost over the boolean is small and it is paid once.
+
+## Rollup is computed on the server
+
+The overall host-health state is derived on the server as the worst of the components: any `unhealthy` yields `unhealthy`; else any `degraded` yields `degraded`; a host with no components yields `unknown`; otherwise `healthy`. It is not sent by the agent. Keeping the rollup policy server-side means tightening what counts as unhealthy (for example promoting a `degraded` DNS-proxy state to `unhealthy`) is a server-only change that takes effect for every already-deployed agent.
+
+## Context ownership: endpoint
+
+Host lifecycle (enrollment, host-token verification) lives in the endpoint context, and the host-token middleware that a check-in must pass through is already there (`server/endpoint/internal/middleware/hosttoken.go`). So the `host_health` table, the `POST /api/status` handler, the service, and the upsert store all live in the endpoint context. The detection host list already LEFT JOINs the endpoint `enrollments` table via the shared `host_id` in the same MySQL database to decorate each row with hostname and OS version (`server/detection/internal/mysql/hosts.go`); health decorates the same row through a second `LEFT JOIN host_health` on the same key. This is the established cross-context read path for the host list and adds no new coupling.
+
+## Persistence: JSON snapshot plus an indexed rollup column
+
+`host_health` stores the full component list as a JSON column (open-ended growth: a new component type needs no schema change) and the computed `overall_status` as a short enum column with an index. The indexed enum makes the common operator query, "show me hosts needing attention," a cheap indexed filter without unpacking JSON, while the JSON keeps the detail payload complete and future-proof. The row is keyed on `host_id` with a last-writer-wins upsert, so out-of-order or retried posts converge on the latest `reported_at_ns`.
+
+## Never-connected vs connection-lost
+
+The agent already tracks per-service XPC connectivity (`Receiver.connected`) and fires `OnConnected`/`OnDisconnected` on transitions (`agent/receiver/loop.go`). The registry adds one bit per component: whether it has ever seen a successful session. Before the first connect the component is `unhealthy`/`never_connected`, which is exactly the fresh-install activation gap in #359. After a connect and then a drop while the agent keeps running it is `unhealthy`/`connection_lost`, which is the tamper-adjacent signal a later alert rule will consume. The registry stamps `last_transition_ns` only when the status actually changes, so "since when" is meaningful and the poster can debounce a burst of connect retries into one report.
+
+## Cadence
+
+The poster reports on startup (so a host that comes up with a dead sensor is visible immediately), on any component transition (debounced roughly two seconds to coalesce connect-retry churn), and on a periodic floor (roughly every 60 seconds) so the server view refreshes even with no transitions. A dedicated poster rather than piggybacking the five-second command poll keeps status independent of the response context and avoids inflating command-poll traffic with a body. The check-in may also bump `last_seen_ns` as a liveness side effect, but the existing command-poll heartbeat is left in place so liveness does not regress if the poster is disabled or a client is old.
+
+## Wire types are defined per side, not shared
+
+The agent and server do not share a Go module or wire types today (the agent posts enrollment as an ad-hoc payload; the server defines `EnrollRequest`). This change keeps that convention: the server defines `StatusReport`/`ComponentHealth` in `server/endpoint/api`, and the agent builds the same JSON from its own struct. The contract is pinned by a PBT round-trip on the server struct plus an example-based wire pin of the first-two-components shape, so the two sides cannot drift silently.
+
+## Must-have vs deferred
+
+Shipped here: the extensible check-in channel; the agent registry with never-connected vs connection-lost; server persistence, boundary enum validation, and the rollup; and the Hosts badge plus host-detail conditions panel (the operator-visible payoff #359 asks for).
+
+Deferred to follow-ups (features, not holes): the tamper-detection alert rule for a `connection_lost` transition; further components (DNS proxy, event-queue depth and drops, applied policy version and staleness, agent CPU/memory, disk pressure, clock skew, cloud connectivity); and replacing the inferred-liveness side-channels with the check-in as the single source of last-seen.

--- a/openspec/changes/agent-health-reporting/proposal.md
+++ b/openspec/changes/agent-health-reporting/proposal.md
@@ -1,0 +1,38 @@
+## Why
+
+When the system extensions are not activated (fresh install at loginwindow, user declined approval, user disabled the login item), the only signal is a `receiver connect` WARN loop in `/var/log/fleet-edr-agent.log` on the endpoint. The server's Hosts page shows the host as enrolled and recently seen, indistinguishable from a fully healthy host. The 2026-06-12 QA session demonstrated how invisible this is: a fresh edr-qa install enrolled cleanly and sat eventless for 20+ minutes before anyone looked at the log (issue #359).
+
+The agent has no check-in payload today. Liveness is only inferred, from the `GET /api/commands` poll (which bumps `hosts.last_seen_ns` via the response heartbeat closure) and from `snapshot_heartbeat` events that the ingest path drops. Neither carries agent self-state, so the server cannot tell a healthy host from one whose sensor never came up. A single `extension_connected` boolean would close #359 but would have to be re-plumbed end to end the first time we report any other status, and a top-tier EDR reports many: sensor connectivity, DNS proxy state, event-queue pressure, applied policy version, resource pressure, clock skew.
+
+This change ships a general, extensible agent-health channel and makes system-extension activation its first two signals. The shape follows the industry norm that Elastic Agent and CrowdStrike Falcon converge on: a periodic, idempotent check-in carrying a list of component-health conditions, rolled up to one host state on the server. Adding a future signal is then an agent-only change with no wire break, no server migration, and no UI rewrite.
+
+## What changes
+
+- Add a dedicated host check-in `POST /api/status` (host-token authed, endpoint context) carrying an idempotent status snapshot: the agent version and a list of component-health conditions, each with a stable `type`, a closed `status` enum (`healthy`/`degraded`/`unhealthy`/`unknown`), an open machine-readable `reason`, a human `message`, and the timestamp the component last changed state. The snapshot is last-writer-wins; a missed post self-heals on the next one.
+- The agent maintains a per-component health registry updated from its existing per-service XPC connectivity state and `OnConnected`/`OnDisconnected` transition hooks. It reports the endpoint-security extension and the network extension as the first two components, distinguishing `never_connected` (the fresh-install activation gap) from `connection_lost` (a component that connected and then dropped while the agent kept running). It posts on startup, on any component transition (debounced), and on a periodic floor.
+- The server persists the latest snapshot per host, validates the `status` enum at the boundary while accepting unknown `type`/`reason` strings, and computes the overall host-health rollup server-side (worst-of the components). The rollup policy lives only on the server so tightening what counts as unhealthy needs no agent redeploy.
+- The host API surfaces health: the Hosts list carries the per-host `overall_status`; the single-host detail carries the full component list. Read access reuses `ActionHostRead`; no new permission.
+- The web UI adds a health badge column to the Hosts list and a conditions panel to the host detail, so a fleet-wide activation gap is visible at a glance (for example "needs attention: security extension not activated").
+
+Out of scope, tracked as follow-ups: a tamper-detection alert rule for a component going `connection_lost` while the agent keeps checking in (the `connection_lost` reason and `last_transition_ns` are the hooks it will consume); additional components (DNS proxy, event-queue depth, applied policy version and staleness, agent resource pressure, clock skew, cloud connectivity), each one more entry in the agent registry; and folding the check-in in as the single liveness source in place of the inferred side-channels.
+
+## Capabilities
+
+### Added capabilities
+
+- `agent-status-reporting`: the agent maintains a per-component health registry from its XPC connectivity state, distinguishes never-connected from connection-lost per extension, and posts an idempotent status snapshot on startup, on transition, and periodically.
+- `server-host-status`: the server accepts and persists the latest per-host status snapshot over a host-token-authed check-in, validates the status enum at the boundary while tolerating unknown component types, computes the overall health rollup, and exposes per-host health on the host API.
+
+### Modified capabilities
+
+- `web-ui`: add a per-host health badge to the Hosts list and a component-conditions panel to the host detail.
+
+## Impact
+
+- Code (agent): a new `agent/health/` registry, a new `agent/status/` poster loop (following the `RunRefresh` shape in `agent/enrollment/enrollment.go`), and registry wiring in the receiver loops (`agent/receiver/loop.go`) plus the agent main (`agent/cmd/fleet-edr-agent/main.go`).
+- Code (server): a new endpoint migration `server/endpoint/migrations/00005_host_health.sql` creating a `host_health` table; the wire structs and validation in `server/endpoint/api`; a `POST /api/status` handler, service, and upsert store in the endpoint context (host-token middleware at `server/endpoint/internal/middleware/hosttoken.go`); a `LEFT JOIN host_health` decoration and an `OverallStatus` field on `HostSummary` in the detection host list (`server/detection/internal/mysql/hosts.go`, `server/detection/api/types.go`); and the full component list on the single-host detail response.
+- Code (UI): `ui/src/types.ts` (extend `HostSummary`, add `ComponentHealth`), `ui/src/components/HostList.tsx` (badge column), the host detail panel (`ui/src/components/ProcessTree.tsx` header or a small new component), reusing `ui/src/components/ui/Badge.tsx`, each with a `*.test.tsx` sibling.
+- Data: one additive migration creating `host_health`. No backfill. A host with no snapshot rolls up to `unknown`. Rollback drops the table; the host list falls back to its current shape.
+- APIs: one new host-token-authed route `POST /api/status`. The host list response gains `overall_status`; the host detail response gains the component list. No change to the event schema or the persisted host token.
+- Security: the check-in is authenticated with the existing host token; the payload carries no secret. Unknown `type`/`reason` strings are stored but the `status` enum is validated at the boundary.
+- Rollback is a code revert plus dropping `host_health`; a deployment with no snapshots behaves as before with every host reading `unknown`.

--- a/openspec/changes/agent-health-reporting/specs/agent-status-reporting/spec.md
+++ b/openspec/changes/agent-health-reporting/specs/agent-status-reporting/spec.md
@@ -1,0 +1,71 @@
+## ADDED Requirements
+
+### Requirement: The agent maintains a per-component health registry
+
+The agent SHALL maintain a health registry mapping each monitored component to a current condition carrying a status, a machine-readable reason, a human-readable message, and the timestamp the condition last changed. The registry SHALL be updated from the agent's existing per-service XPC connectivity state and its connect and disconnect transitions. The last-transition timestamp of a component SHALL advance only when that component's status actually changes, so that the timestamp denotes the start of the current condition.
+
+#### Scenario: A connected extension is healthy
+
+- **GIVEN** the endpoint-security extension XPC session is established
+- **WHEN** the registry is read
+- **THEN** the `endpoint_security_extension` component reports status `healthy` with reason `activated`
+
+#### Scenario: The last-transition timestamp is stable across unchanged reads
+
+- **GIVEN** a component whose status has not changed since it was last set
+- **WHEN** the registry is updated again with the same status
+- **THEN** the component's last-transition timestamp is unchanged
+
+### Requirement: The agent distinguishes never-connected from connection-lost per extension
+
+For each monitored extension the agent SHALL report reason `never_connected` while it has never established a session since the agent started, and reason `connection_lost` once it has established a session and then lost it while the agent continued running. Both conditions SHALL carry status `unhealthy`.
+
+#### Scenario: A fresh install with an unactivated extension reports never-connected
+
+- **GIVEN** an agent that has started and never established the endpoint-security XPC session
+- **WHEN** the registry is read
+- **THEN** the `endpoint_security_extension` component reports status `unhealthy` with reason `never_connected`
+
+#### Scenario: A dropped session reports connection-lost
+
+- **GIVEN** an extension whose XPC session was established and then dropped while the agent kept running
+- **WHEN** the registry is read
+- **THEN** that component reports status `unhealthy` with reason `connection_lost`
+
+### Requirement: The agent posts an idempotent status snapshot
+
+The agent SHALL post its current health as a complete snapshot to the host check-in endpoint, authenticated with its host token, carrying the agent version and the full list of component conditions on every post. The snapshot SHALL be idempotent: re-posting the same state SHALL leave the server's view unchanged, and each post SHALL fully replace the prior snapshot for that host rather than appending to a log.
+
+#### Scenario: A post carries the full component list
+
+- **GIVEN** a registry holding the endpoint-security and network-extension components
+- **WHEN** the agent posts a status snapshot
+- **THEN** the request carries the agent version and both components with their status, reason, message, and last-transition timestamp
+
+#### Scenario: Re-posting an unchanged snapshot is a no-op for the server view
+
+- **GIVEN** a snapshot the agent has already posted successfully
+- **WHEN** the agent posts the identical snapshot again
+- **THEN** the server's stored health for that host is unchanged
+
+### Requirement: The agent reports on startup, on transition, and periodically
+
+The agent SHALL post a status snapshot shortly after startup, again whenever a component's status changes, and on a periodic floor while running. Transition-triggered posts SHALL be debounced so a burst of connect retries collapses into a single post.
+
+#### Scenario: A startup post makes a dead sensor visible immediately
+
+- **GIVEN** an agent starting with an extension that never connects
+- **WHEN** the agent has started
+- **THEN** it posts a snapshot showing that extension `unhealthy` without waiting for the periodic floor
+
+#### Scenario: A status change triggers a post
+
+- **GIVEN** a running agent that has already posted a snapshot
+- **WHEN** an extension transitions from connected to lost
+- **THEN** the agent posts an updated snapshot reflecting the transition
+
+#### Scenario: A burst of retries collapses into one post
+
+- **GIVEN** an extension failing to connect and retrying rapidly with no change in resulting status
+- **WHEN** several retries occur within the debounce window
+- **THEN** the agent posts at most one snapshot for that burst

--- a/openspec/changes/agent-health-reporting/specs/server-host-status/spec.md
+++ b/openspec/changes/agent-health-reporting/specs/server-host-status/spec.md
@@ -1,0 +1,77 @@
+## ADDED Requirements
+
+### Requirement: The server accepts and persists a host status snapshot
+
+The server SHALL expose a host-token-authenticated check-in that accepts a status snapshot carrying the agent version and a list of component conditions, and SHALL persist the latest snapshot per host as last-writer-wins keyed on the host. A snapshot from an unauthenticated or invalidly-authenticated caller SHALL be rejected. The server SHALL validate the component status against the closed set `healthy`, `degraded`, `unhealthy`, `unknown` and reject a snapshot carrying any other status value, while accepting component `type` and `reason` values it does not recognize and storing them verbatim.
+
+#### Scenario: A valid snapshot is stored as the latest health for the host
+
+- **GIVEN** an enrolled host with a valid host token
+- **WHEN** it posts a snapshot with two components
+- **THEN** the server stores that snapshot as the host's current health
+
+#### Scenario: A later snapshot replaces an earlier one
+
+- **GIVEN** a host that has already posted a snapshot
+- **WHEN** it posts a newer snapshot for the same host
+- **THEN** the server's stored health reflects the newer snapshot and not the earlier one
+
+#### Scenario: An unknown component type is stored verbatim
+
+- **GIVEN** a valid host token
+- **WHEN** the host posts a snapshot containing a component whose type the server does not recognize but whose status is in the closed set
+- **THEN** the snapshot is accepted and the unknown component is stored and returned unchanged
+
+#### Scenario: An invalid status value is rejected
+
+- **WHEN** a host posts a snapshot whose component status is not in the closed set
+- **THEN** the server rejects the snapshot and stores nothing
+
+#### Scenario: An unauthenticated check-in is rejected
+
+- **WHEN** a caller posts a snapshot without a valid host token
+- **THEN** the server rejects the request and stores nothing
+
+### Requirement: The server computes an overall host-health rollup
+
+The server SHALL derive an overall health status for each host from its component conditions as the worst condition present: `unhealthy` if any component is unhealthy, otherwise `degraded` if any component is degraded, otherwise `healthy` if at least one component is present, otherwise `unknown`. The agent SHALL NOT supply the overall status; it is computed on the server from the stored components.
+
+#### Scenario: One unhealthy component makes the host unhealthy
+
+- **GIVEN** a host whose network extension is healthy and whose security extension is unhealthy
+- **WHEN** the rollup is computed
+- **THEN** the host's overall status is `unhealthy`
+
+#### Scenario: A host with no snapshot rolls up to unknown
+
+- **GIVEN** a host that has never posted a snapshot
+- **WHEN** the host's overall status is read
+- **THEN** it is `unknown`
+
+#### Scenario: All-healthy components roll up to healthy
+
+- **GIVEN** a host whose every component is healthy
+- **WHEN** the rollup is computed
+- **THEN** the host's overall status is `healthy`
+
+### Requirement: The host API surfaces per-host health
+
+An operator holding host read access SHALL see each host's overall health status in the host list, and SHALL see the full list of component conditions in the single-host detail. A host without a stored snapshot SHALL appear in the list with overall status `unknown` rather than being omitted.
+
+#### Scenario: The host list carries the overall status
+
+- **GIVEN** an operator with host read access and a host with a stored snapshot
+- **WHEN** they read the host list
+- **THEN** the host's row carries its computed overall health status
+
+#### Scenario: The host detail carries the component conditions
+
+- **GIVEN** an operator with host read access and a host with a stored snapshot
+- **WHEN** they read that host's detail
+- **THEN** the response carries each component's type, status, reason, message, and last-transition timestamp
+
+#### Scenario: A host with no snapshot still lists with unknown health
+
+- **GIVEN** a host that has sent events but never posted a snapshot
+- **WHEN** an operator reads the host list
+- **THEN** the host appears with overall status `unknown`

--- a/openspec/changes/agent-health-reporting/specs/web-ui/spec.md
+++ b/openspec/changes/agent-health-reporting/specs/web-ui/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: The Hosts list surfaces per-host health
+
+The web UI SHALL show each host's overall health status in the Hosts list as a badge distinct from the existing online/offline indicator, so that a host whose sensor is not activated is visually distinguishable from a healthy host at a glance. A host whose health is unknown SHALL render a neutral badge rather than a healthy one.
+
+#### Scenario: An unhealthy host shows a needs-attention badge
+
+- **GIVEN** a host whose overall health status is unhealthy
+- **WHEN** the Hosts list renders
+- **THEN** the host's row shows a needs-attention health badge distinct from its online/offline pill
+
+#### Scenario: A host with unknown health shows a neutral badge
+
+- **GIVEN** a host whose overall health status is unknown
+- **WHEN** the Hosts list renders
+- **THEN** the host's row shows a neutral health badge and not a healthy one
+
+### Requirement: The host detail surfaces the health conditions
+
+The web UI host detail SHALL present the host's component conditions, each showing the component, its status, a human-readable message, and how long it has been in its current state. When a required extension is not activated the message SHALL make the required action legible to an operator, for example that the security extension needs attention.
+
+#### Scenario: The detail lists a component with its message and age
+
+- **GIVEN** a host whose security extension is unhealthy with a not-activated message
+- **WHEN** an operator opens the host detail
+- **THEN** the conditions panel shows the security extension with its unhealthy status, its message, and how long it has been in that state
+
+#### Scenario: A fully healthy host shows all components healthy
+
+- **GIVEN** a host whose every component is healthy
+- **WHEN** an operator opens the host detail
+- **THEN** the conditions panel shows each component as healthy

--- a/openspec/changes/agent-health-reporting/tasks.md
+++ b/openspec/changes/agent-health-reporting/tasks.md
@@ -1,22 +1,22 @@
 ## 1. Wire format
 
-- [ ] 1.1 Define `StatusReport` (agent version, reported-at, `[]ComponentHealth`) and `ComponentHealth` (`type`, `status`, `reason`, `message`, `last_transition_ns`) in `server/endpoint/api/types.go` with JSON tags; `status` documented as the closed set `healthy|degraded|unhealthy|unknown`
-- [ ] 1.2 PBT round-trip (`Marshal ∘ Unmarshal == identity`) with `pgregory.net/rapid`, plus an example-based wire pin of the endpoint-security + network-extension snapshot shape
-- [ ] 1.3 `Scan ∘ Value == identity` for the JSON `components` column type
+- [x] 1.1 Define `StatusReport` (agent version, reported-at, `[]ComponentHealth`) and `ComponentHealth` (`type`, `status`, `reason`, `message`, `last_transition_ns`) in `server/endpoint/api/status.go` with JSON tags; `status` is the closed `HealthStatus` set `healthy|degraded|unhealthy|unknown` with a `Valid()` boundary check
+- [x] 1.2 PBT round-trip (`Marshal ∘ Unmarshal == identity`) with `pgregory.net/rapid`, plus an example-based wire pin of the endpoint-security + network-extension snapshot shape
+- [x] 1.3 `Scan ∘ Value == identity` for the `Components` JSON column type
 
 ## 2. Server persistence and check-in (endpoint context)
 
-- [ ] 2.1 Migration `server/endpoint/migrations/00005_host_health.sql` (`+goose Up`/`Down`): `host_health` (host_id PK, overall_status VARCHAR(16), components JSON, reported_at_ns BIGINT, updated_at TIMESTAMP), index on `overall_status`; Down drops the table
-- [ ] 2.2 Store: last-writer-wins upsert keyed on `host_id`; read latest snapshot for one host; read overall status for the host list
-- [ ] 2.3 Service: validate `status` against the closed set at the boundary (reject unknown status, accept unknown `type`/`reason`); compute the worst-of rollup (`unhealthy` > `degraded` > `healthy`; empty -> `unknown`)
-- [ ] 2.4 Handler `POST /api/status` behind the host-token middleware (`server/endpoint/internal/middleware/hosttoken.go`); optionally bump `last_seen_ns` as a liveness side effect without removing the command-poll heartbeat
-- [ ] 2.5 Table-driven + integration tests (real MySQL via `testdb/full.Open`): upsert replaces prior, unknown type stored verbatim, invalid status rejected, unauthenticated rejected, rollup matrix
+- [x] 2.1 Migration `server/endpoint/migrations/00005_host_health.sql` (`+goose Up`/`Down`): `host_health` (host_id PK, overall_status VARCHAR(16), components JSON NULL, reported_at_ns BIGINT, updated_at TIMESTAMP), index on `overall_status`; Down drops the table
+- [x] 2.2 Store `UpsertHostHealth`: last-writer-wins upsert keyed on `host_id`, guarded by an IF/GREATEST on `reported_at_ns` so a stale post cannot clobber a fresher snapshot (`server/endpoint/internal/mysql/health.go`)
+- [x] 2.3 Service `RecordStatus`: validate `status` against the closed set at the boundary (reject unknown status wholesale, accept unknown `type`/`reason`); compute the worst-of rollup via `api.Rollup` (`unhealthy` > `degraded` > `healthy`; empty -> `unknown`)
+- [x] 2.4 Handler `POST /api/status` behind the host-token middleware, reading the pinned host_id; mounted in the host-token mux in `cmd/main`
+- [x] 2.5 Table-driven (`Rollup`), handler unit (all branches), and integration tests (real MySQL): upsert replaces prior, last-writer-wins, unknown type stored verbatim, invalid status 400, unauthenticated 401
 
 ## 3. Host API surface
 
-- [ ] 3.1 Add `OverallStatus` to `HostSummary` (`server/detection/api/types.go`) and a `LEFT JOIN host_health` with `COALESCE(overall_status,'unknown')` in `ListHosts` (`server/detection/internal/mysql/hosts.go`), mirroring the existing enrollments join
-- [ ] 3.2 Add the full component list to the single-host detail response
-- [ ] 3.3 Integration test: post a snapshot, then the host list carries `overall_status` and the detail carries the components; a host with no snapshot lists as `unknown`
+- [x] 3.1 Add `OverallStatus` to `HostSummary` (`server/detection/api/types.go`) and a `LEFT JOIN host_health` with `COALESCE(overall_status, HostHealthUnknown)` in `ListHosts` (`server/detection/internal/mysql/hosts.go`), mirroring the existing enrollments join
+- [x] 3.2 Add `GET /api/hosts/{host_id}/health` returning the full component list via a `HostHealthReader` seam on the operator handler (mirrors the `WebhookAdmin` seam so `api.Service` and its mocks stay untouched); store `HostHealth` read passes components through as raw JSON
+- [x] 3.3 Integration test: seed a snapshot, then the host list carries `overall_status` and the detail carries the components; a host with no snapshot lists + reads as `unknown`
 
 ## 4. Agent health registry
 

--- a/openspec/changes/agent-health-reporting/tasks.md
+++ b/openspec/changes/agent-health-reporting/tasks.md
@@ -1,0 +1,52 @@
+## 1. Wire format
+
+- [ ] 1.1 Define `StatusReport` (agent version, reported-at, `[]ComponentHealth`) and `ComponentHealth` (`type`, `status`, `reason`, `message`, `last_transition_ns`) in `server/endpoint/api/types.go` with JSON tags; `status` documented as the closed set `healthy|degraded|unhealthy|unknown`
+- [ ] 1.2 PBT round-trip (`Marshal ∘ Unmarshal == identity`) with `pgregory.net/rapid`, plus an example-based wire pin of the endpoint-security + network-extension snapshot shape
+- [ ] 1.3 `Scan ∘ Value == identity` for the JSON `components` column type
+
+## 2. Server persistence and check-in (endpoint context)
+
+- [ ] 2.1 Migration `server/endpoint/migrations/00005_host_health.sql` (`+goose Up`/`Down`): `host_health` (host_id PK, overall_status VARCHAR(16), components JSON, reported_at_ns BIGINT, updated_at TIMESTAMP), index on `overall_status`; Down drops the table
+- [ ] 2.2 Store: last-writer-wins upsert keyed on `host_id`; read latest snapshot for one host; read overall status for the host list
+- [ ] 2.3 Service: validate `status` against the closed set at the boundary (reject unknown status, accept unknown `type`/`reason`); compute the worst-of rollup (`unhealthy` > `degraded` > `healthy`; empty -> `unknown`)
+- [ ] 2.4 Handler `POST /api/status` behind the host-token middleware (`server/endpoint/internal/middleware/hosttoken.go`); optionally bump `last_seen_ns` as a liveness side effect without removing the command-poll heartbeat
+- [ ] 2.5 Table-driven + integration tests (real MySQL via `testdb/full.Open`): upsert replaces prior, unknown type stored verbatim, invalid status rejected, unauthenticated rejected, rollup matrix
+
+## 3. Host API surface
+
+- [ ] 3.1 Add `OverallStatus` to `HostSummary` (`server/detection/api/types.go`) and a `LEFT JOIN host_health` with `COALESCE(overall_status,'unknown')` in `ListHosts` (`server/detection/internal/mysql/hosts.go`), mirroring the existing enrollments join
+- [ ] 3.2 Add the full component list to the single-host detail response
+- [ ] 3.3 Integration test: post a snapshot, then the host list carries `overall_status` and the detail carries the components; a host with no snapshot lists as `unknown`
+
+## 4. Agent health registry
+
+- [ ] 4.1 `agent/health/`: concurrency-safe registry mapping component type to condition; `Set(type, status, reason, message)` stamps `last_transition_ns` only on a real status change
+- [ ] 4.2 Track per extension whether a session has ever been established, to distinguish `never_connected` from `connection_lost`
+- [ ] 4.3 Wire the ESF and network-extension receiver loops into the registry via the existing connect/disconnect paths and `OnConnected`/`OnDisconnected` hooks (`agent/receiver/loop.go`)
+- [ ] 4.4 Unit tests: connected -> healthy/activated; never-connected before first session; connection-lost after a drop; transition-timestamp stability
+
+## 5. Agent status poster
+
+- [ ] 5.1 `agent/status/`: build a `StatusReport` from the registry and POST it to `POST /api/status` with the host token, reusing the enrollment HTTP client
+- [ ] 5.2 Cadence: post on startup, on transition (debounced ~2s), and on a ~60s periodic floor; clean ctx-cancel shutdown following the `RunRefresh` loop shape
+- [ ] 5.3 Wire the poster into `agent/cmd/fleet-edr-agent/main.go`
+- [ ] 5.4 Unit tests: startup post, transition-triggered post, debounce collapses a retry burst
+
+## 6. UI
+
+- [ ] 6.1 `ui/src/types.ts`: extend `HostSummary` with `overall_status`; add `ComponentHealth` and the host-detail health shape
+- [ ] 6.2 `ui/src/components/HostList.tsx`: health badge column driven by `overall_status`, reusing `Badge`, distinct from the online/offline pill; neutral badge for `unknown`
+- [ ] 6.3 Host detail conditions panel (in `ProcessTree.tsx` header or a small new component): per-component status badge, message, and "since" relative time from `last_transition_ns`
+- [ ] 6.4 vitest siblings (`*.test.tsx`) covering the badge-variant mapping, the unknown/empty states, and the conditions panel
+
+## 7. Spec and QA
+
+- [ ] 7.1 Add spectrace markers from the new tests to the scenario IDs in the three delta specs
+- [ ] 7.2 `openspec validate agent-health-reporting --strict`; prose + dash + markdown lints
+- [ ] 7.3 Live QA on edr-qa: fresh install with the extensions not activated shows the host as needs-attention in the UI within a check-in interval, then activation flips it to healthy (the 2026-06-12 scenario #359 came from)
+
+## 8. Follow-ups (not in this change)
+
+- [ ] 8.1 Tamper-detection alert rule for a component transitioning to `connection_lost` while the agent keeps checking in
+- [ ] 8.2 Additional components: DNS proxy, event-queue depth and drops, applied policy version and staleness, agent CPU/memory, disk pressure, clock skew, cloud connectivity
+- [ ] 8.3 Fold the check-in in as the single liveness source in place of the inferred command-poll and heartbeat side-channels

--- a/server/cmd/fleet-edr-server/main.go
+++ b/server/cmd/fleet-edr-server/main.go
@@ -729,11 +729,13 @@ func registerHostRoutes(mux *http.ServeMux, d muxDeps) {
 	hostMux := http.NewServeMux()
 	hostMux.Handle("POST /api/events", d.detectionCtx.Service().IngestHandler())
 	hostMux.Handle("POST /api/token/refresh", d.endpointCtx.TokenRefreshHandler())
+	hostMux.Handle("POST /api/status", d.endpointCtx.StatusHandler())
 	d.responseCtx.RegisterAgentRoutes(hostMux)
 	hostProtected := hostTokenMW(hostMux)
 	for _, p := range []string{
 		"POST /api/events",
 		"POST /api/token/refresh",
+		"POST /api/status",
 		"GET /api/commands",
 		"PUT /api/commands/{id}",
 	} {

--- a/server/detection/api/types.go
+++ b/server/detection/api/types.go
@@ -93,6 +93,24 @@ type HostSummary struct {
 	OSVersion  string `db:"os_version" json:"os_version"`
 	EventCount int64  `db:"event_count" json:"event_count"`
 	LastSeenNs int64  `db:"last_seen_ns" json:"last_seen_ns"`
+	// OverallStatus is the server-computed agent-health rollup for the host (issue #359), sourced from the endpoint context's host_health
+	// table (LEFT JOIN in ListHosts) and COALESCEd to HostHealthUnknown for a host that has never posted a status snapshot. It is the
+	// Hosts-list badge signal, distinct from the online/offline pill the UI derives from LastSeenNs.
+	OverallStatus string `db:"overall_status" json:"overall_status"`
+}
+
+// HostHealthUnknown is the overall-status value for a host with no recorded status snapshot: the agent has never checked in health, so
+// the server knows nothing rather than asserting healthy. Matches the endpoint context's HealthUnknown spelling across the shared DB.
+const HostHealthUnknown = "unknown"
+
+// HostHealth is the operator-facing per-host agent-health detail served at GET /api/hosts/{host_id}/health. OverallStatus is the
+// server-computed rollup; ReportedAtNs is the agent-stamped snapshot time; Components is the full ComponentHealth list exactly as the
+// agent sent it, passed through as raw JSON so a new component type needs no server change. A host with no snapshot yields
+// OverallStatus HostHealthUnknown and null Components.
+type HostHealth struct {
+	OverallStatus string      `db:"overall_status" json:"overall_status"`
+	ReportedAtNs  int64       `db:"reported_at_ns" json:"reported_at_ns"`
+	Components    NullRawJSON `db:"components" json:"components"`
 }
 
 // Host is the operator-visible row from the hosts summary table. Mirrors HostSummary but adds updated_at; both are kept distinct

--- a/server/detection/bootstrap/bootstrap.go
+++ b/server/detection/bootstrap/bootstrap.go
@@ -177,6 +177,9 @@ func New(deps Deps) (*Detection, error) {
 		// The webhook admin surface reads/writes destinations through the store. Wiring it always (independent of the sealer) keeps
 		// list/get/delete working; a create/update that needs to seal a secret returns a configured-error when no root secret is set.
 		det.operatorH.SetWebhookAdmin(store)
+		// The per-host agent-health detail (GET /api/hosts/{host_id}/health) reads the endpoint context's host_health table through the
+		// same store; wire it alongside the webhook admin surface (issue #359).
+		det.operatorH.SetHostHealth(store)
 
 		processor := pipeline.NewProcessor(
 			deps.EventLog,

--- a/server/detection/internal/mysql/hosts.go
+++ b/server/detection/internal/mysql/hosts.go
@@ -2,6 +2,8 @@ package mysql
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -9,22 +11,42 @@ import (
 	"github.com/fleetdm/edr/server/detection/api"
 )
 
-// ListHosts returns a summary of all hosts that have sent events. The LEFT JOIN reaches into the endpoint context's `enrollments`
-// table (same MySQL database, keyed on the shared host_id) to decorate each row with the enrollment hostname and OS version. LEFT so
-// a host that has sent events but never enrolled still returns; COALESCE folds the outer-join NULL into "" so the scan targets stay
-// plain strings.
+// ListHosts returns a summary of all hosts that have sent events. The LEFT JOINs reach into the endpoint context's `enrollments` and
+// `host_health` tables (same MySQL database, keyed on the shared host_id) to decorate each row with the enrollment hostname and OS
+// version and the agent-health rollup. LEFT so a host that has sent events but never enrolled or never posted health still returns;
+// COALESCE folds the outer-join NULLs into "" (strings) and HostHealthUnknown (rollup) so the scan targets stay plain strings.
 func (s *Store) ListHosts(ctx context.Context) ([]api.HostSummary, error) {
 	var hosts []api.HostSummary
 	err := s.db.SelectContext(ctx, &hosts, `
 		SELECT h.host_id, COALESCE(e.hostname, '') AS hostname, COALESCE(e.os_version, '') AS os_version,
-		       h.event_count, h.last_seen_ns
+		       h.event_count, h.last_seen_ns, COALESCE(hh.overall_status, ?) AS overall_status
 		FROM hosts h
 		LEFT JOIN enrollments e ON e.host_id = h.host_id
-		ORDER BY h.last_seen_ns DESC`)
+		LEFT JOIN host_health hh ON hh.host_id = h.host_id
+		ORDER BY h.last_seen_ns DESC`, api.HostHealthUnknown)
 	if err != nil {
 		return nil, fmt.Errorf("query hosts: %w", err)
 	}
 	return hosts, nil
+}
+
+// HostHealth returns the operator-facing agent-health detail for one host, reading the endpoint context's `host_health` table (same
+// database, shared host_id). A host with no recorded snapshot is not an error: it returns OverallStatus HostHealthUnknown with null
+// Components, matching how ListHosts COALESCEs the missing row, so the detail view renders "unknown" rather than 404ing a real host
+// that simply has not checked in health yet.
+func (s *Store) HostHealth(ctx context.Context, hostID string) (api.HostHealth, error) {
+	var h api.HostHealth
+	err := s.db.GetContext(ctx, &h, `
+		SELECT overall_status, reported_at_ns, components
+		FROM host_health
+		WHERE host_id = ?`, hostID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return api.HostHealth{OverallStatus: api.HostHealthUnknown}, nil
+	}
+	if err != nil {
+		return api.HostHealth{}, fmt.Errorf("query host health: %w", err)
+	}
+	return h, nil
 }
 
 // CountOfflineHosts returns how many rows in `hosts` have `last_seen_ns` at or before the cutoff (now minus threshold). Used by the OTel

--- a/server/detection/internal/operator/handler.go
+++ b/server/detection/internal/operator/handler.go
@@ -65,6 +65,7 @@ type Handler struct {
 	audit         identityapi.AuditRecorder
 	webhookAdmin  WebhookAdmin
 	webhookTester webhookTester
+	hostHealth    HostHealthReader
 	logger        *slog.Logger
 }
 
@@ -92,6 +93,7 @@ func (h *Handler) SetAudit(rec identityapi.AuditRecorder) { h.audit = rec }
 // RegisterRoutes registers the operator routes on the given mux.
 func (h *Handler) RegisterRoutes(mux httpserver.Router) {
 	mux.HandleFunc("GET /api/hosts", h.handleListHosts)
+	mux.HandleFunc("GET /api/hosts/{host_id}/health", h.handleHostHealth)
 	mux.HandleFunc("GET /api/hosts/{host_id}/tree", h.handleProcessTree)
 	mux.HandleFunc("GET /api/hosts/{host_id}/processes/{pid}", h.handleProcessDetail)
 

--- a/server/detection/internal/operator/handler.go
+++ b/server/detection/internal/operator/handler.go
@@ -93,7 +93,6 @@ func (h *Handler) SetAudit(rec identityapi.AuditRecorder) { h.audit = rec }
 // RegisterRoutes registers the operator routes on the given mux.
 func (h *Handler) RegisterRoutes(mux httpserver.Router) {
 	mux.HandleFunc("GET /api/hosts", h.handleListHosts)
-	mux.HandleFunc("GET /api/hosts/{host_id}/health", h.handleHostHealth)
 	mux.HandleFunc("GET /api/hosts/{host_id}/tree", h.handleProcessTree)
 	mux.HandleFunc("GET /api/hosts/{host_id}/processes/{pid}", h.handleProcessDetail)
 
@@ -101,6 +100,7 @@ func (h *Handler) RegisterRoutes(mux httpserver.Router) {
 	mux.HandleFunc("GET /api/alerts/{id}", h.handleGetAlert)
 	mux.HandleFunc("PUT /api/alerts/{id}", h.handleUpdateAlertStatus)
 
+	h.registerHostHealthRoutes(mux)
 	h.registerWebhookRoutes(mux)
 }
 

--- a/server/detection/internal/operator/host_health_handler.go
+++ b/server/detection/internal/operator/host_health_handler.go
@@ -1,0 +1,48 @@
+package operator
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/fleetdm/edr/server/detection/api"
+	identityapi "github.com/fleetdm/edr/server/identity/api"
+)
+
+// HostHealthReader is the per-host agent-health read surface the operator handler serves at GET /api/hosts/{host_id}/health. mysql.Store
+// satisfies it by reading the endpoint context's host_health table (same database, shared host_id). It is a dependency distinct from
+// api.Service, matching the WebhookAdmin seam, so the alert/host read interface and its test mocks stay untouched (issue #359).
+type HostHealthReader interface {
+	HostHealth(ctx context.Context, hostID string) (api.HostHealth, error)
+}
+
+// SetHostHealth installs the per-host health read surface. Bootstrap wires it with the detection store in ModeFull; when it is not set
+// the health route responds 503, mirroring the webhook seam so a minimally-wired handler degrades rather than nil-derefs. Called after
+// New.
+func (h *Handler) SetHostHealth(r HostHealthReader) { h.hostHealth = r }
+
+// handleHostHealth serves the operator-facing agent-health detail for one host: the server-computed rollup, the snapshot time, and the
+// full component conditions the agent reported. Gated on host read, the same grant the Hosts list uses. A host that has never posted a
+// snapshot is not a 404: the reader returns HostHealthUnknown so the detail view renders "unknown" for a real host that simply has not
+// checked in health yet.
+func (h *Handler) handleHostHealth(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	hostID := r.PathValue("host_id")
+	if hostID == "" {
+		h.writeError(ctx, w, http.StatusBadRequest, errHostIDRequired)
+		return
+	}
+	if !identityapi.HTTPGate(ctx, w, h.authz, h.logger, identityapi.ActionHostRead, identityapi.Resource{Type: "host", ID: hostID}) {
+		return
+	}
+	if h.hostHealth == nil {
+		h.writeError(ctx, w, http.StatusServiceUnavailable, errInternal)
+		return
+	}
+	health, err := h.hostHealth.HostHealth(ctx, hostID)
+	if err != nil {
+		h.logger.ErrorContext(ctx, "get host health", "host_id", hostID, "err", err)
+		h.writeError(ctx, w, http.StatusInternalServerError, errInternal)
+		return
+	}
+	h.writeJSON(w, r, health)
+}

--- a/server/detection/internal/operator/host_health_handler.go
+++ b/server/detection/internal/operator/host_health_handler.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/fleetdm/edr/server/detection/api"
+	"github.com/fleetdm/edr/server/httpserver"
 	identityapi "github.com/fleetdm/edr/server/identity/api"
 )
 
@@ -13,6 +14,12 @@ import (
 // api.Service, matching the WebhookAdmin seam, so the alert/host read interface and its test mocks stay untouched (issue #359).
 type HostHealthReader interface {
 	HostHealth(ctx context.Context, hostID string) (api.HostHealth, error)
+}
+
+// registerHostHealthRoutes wires the per-host health route. Kept in this file (not handler.go) alongside handleHostHealth so the whole
+// route + gate + handler unit is co-located, matching registerWebhookRoutes.
+func (h *Handler) registerHostHealthRoutes(mux httpserver.Router) {
+	mux.HandleFunc("GET /api/hosts/{host_id}/health", h.handleHostHealth)
 }
 
 // SetHostHealth installs the per-host health read surface. Bootstrap wires it with the detection store in ModeFull; when it is not set

--- a/server/detection/internal/operator/host_health_handler_test.go
+++ b/server/detection/internal/operator/host_health_handler_test.go
@@ -1,0 +1,120 @@
+package operator
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fleetdm/edr/server/detection/api"
+	identityapi "github.com/fleetdm/edr/server/identity/api"
+)
+
+type fakeHostHealth struct {
+	fn func(ctx context.Context, hostID string) (api.HostHealth, error)
+}
+
+func (f fakeHostHealth) HostHealth(ctx context.Context, hostID string) (api.HostHealth, error) {
+	return f.fn(ctx, hostID)
+}
+
+// newHostHealthServer builds the operator handler with a fake api.Service (the health route never touches it) and optionally installs
+// the host-health seam, so tests can exercise both the wired and the not-configured paths.
+func newHostHealthServer(t *testing.T, hh HostHealthReader, az identityapi.AuthZ) *httptest.Server {
+	t.Helper()
+	h := New(fakeService{}, az, slog.Default())
+	if hh != nil {
+		h.SetHostHealth(hh)
+	}
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// spec:server-host-status/the-host-api-surfaces-per-host-health/the-host-detail-carries-the-component-conditions
+func TestHandleHostHealth_Success(t *testing.T) {
+	t.Parallel()
+	var gotHostID string
+	hh := fakeHostHealth{fn: func(_ context.Context, hostID string) (api.HostHealth, error) {
+		gotHostID = hostID
+		return api.HostHealth{
+			OverallStatus: "unhealthy",
+			ReportedAtNs:  42,
+			Components:    api.NullRawJSON(`[{"type":"endpoint_security_extension","status":"unhealthy","reason":"never_connected"}]`),
+		}, nil
+	}}
+	srv := newHostHealthServer(t, hh, allowAllAuthZ{})
+
+	resp := doGet(t, srv, "/api/hosts/host-a/health")
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "host-a", gotHostID)
+	var got api.HostHealth
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&got))
+	assert.Equal(t, "unhealthy", got.OverallStatus)
+	assert.EqualValues(t, 42, got.ReportedAtNs)
+	assert.Contains(t, string(got.Components), "never_connected")
+}
+
+func TestHandleHostHealth_AuthzDeny(t *testing.T) {
+	t.Parallel()
+	hh := fakeHostHealth{fn: func(context.Context, string) (api.HostHealth, error) {
+		t.Fatal("reader must not be called when authz denies")
+		return api.HostHealth{}, nil
+	}}
+	srv := newHostHealthServer(t, hh, denyAllAuthZ{})
+
+	resp := doGet(t, srv, "/api/hosts/host-a/health")
+	defer resp.Body.Close()
+	assert.NotEqual(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestHandleHostHealth_ReaderErrorMaps500(t *testing.T) {
+	t.Parallel()
+	hh := fakeHostHealth{fn: func(context.Context, string) (api.HostHealth, error) {
+		return api.HostHealth{}, errors.New("db down")
+	}}
+	srv := newHostHealthServer(t, hh, allowAllAuthZ{})
+
+	resp := doGet(t, srv, "/api/hosts/host-a/health")
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+	assert.Equal(t, errInternal, readErrorEnvelope(t, resp))
+}
+
+func TestHandleHostHealth_NotConfiguredMaps503(t *testing.T) {
+	t.Parallel()
+	srv := newHostHealthServer(t, nil, allowAllAuthZ{})
+
+	resp := doGet(t, srv, "/api/hosts/host-a/health")
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+}
+
+func TestHandleHostHealth_EmptyHostIDMaps400(t *testing.T) {
+	t.Parallel()
+	// The route pattern {host_id} never yields an empty segment through the mux, so drive the guard directly: a request with no path
+	// value set has an empty host_id, which must 400 before the authz gate or the reader is consulted.
+	h := New(fakeService{}, allowAllAuthZ{}, slog.Default())
+	h.SetHostHealth(fakeHostHealth{fn: func(context.Context, string) (api.HostHealth, error) {
+		t.Fatal("reader must not be called for an empty host_id")
+		return api.HostHealth{}, nil
+	}})
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/hosts//health", nil)
+	rec := httptest.NewRecorder()
+	h.handleHostHealth(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	body, _ := io.ReadAll(rec.Result().Body)
+	assert.Contains(t, string(body), errHostIDRequired)
+}

--- a/server/detection/internal/tests/integration_test.go
+++ b/server/detection/internal/tests/integration_test.go
@@ -1574,6 +1574,53 @@ func TestListHosts_DecoratesWithEnrollment(t *testing.T) {
 	assert.Empty(t, byID[bareHost].OSVersion, "un-enrolled host has an empty OS version")
 }
 
+// spec:server-host-status/the-host-api-surfaces-per-host-health/the-host-list-carries-the-overall-status
+// spec:server-host-status/the-host-api-surfaces-per-host-health/a-host-with-no-snapshot-still-lists-with-unknown-health
+// spec:server-host-status/the-host-api-surfaces-per-host-health/the-host-detail-carries-the-component-conditions
+//
+// The endpoint context writes host_health (POST /api/status); this detection-side test seeds a row directly and asserts the read paths:
+// ListHosts decorates each row with the rollup (COALESCEd to "unknown" for a host with no snapshot), and Store.HostHealth returns the
+// full component conditions for the detail view and "unknown" with no components for a host that never checked in.
+func TestListHosts_DecoratesWithHealth(t *testing.T) {
+	t.Parallel()
+	d := newDetection(t, detectionOpts{mode: bootstrap.ModeFull})
+	ctx := t.Context()
+
+	const reportedHost = "HEALTH-UUID-0001"
+	const silentHost = "HEALTH-UUID-0002"
+	require.NoError(t, d.Service().RecordHostSeen(ctx, reportedHost, time.Now()))
+	require.NoError(t, d.Service().RecordHostSeen(ctx, silentHost, time.Now().Add(-time.Minute)))
+
+	components := `[{"type":"endpoint_security_extension","status":"unhealthy","reason":"never_connected","last_transition_ns":90}]`
+	_, err := d.Store().DB().ExecContext(ctx, `
+		INSERT INTO host_health (host_id, overall_status, components, reported_at_ns)
+		VALUES (?, ?, ?, ?)`,
+		reportedHost, "unhealthy", components, 100)
+	require.NoError(t, err)
+
+	hosts, err := d.Service().ListHosts(ctx)
+	require.NoError(t, err)
+	byID := make(map[string]api.HostSummary, len(hosts))
+	for _, h := range hosts {
+		byID[h.HostID] = h
+	}
+	require.Contains(t, byID, reportedHost)
+	assert.Equal(t, "unhealthy", byID[reportedHost].OverallStatus, "a host with a snapshot carries its rollup")
+	require.Contains(t, byID, silentHost, "a host with events but no snapshot must still appear (LEFT JOIN)")
+	assert.Equal(t, api.HostHealthUnknown, byID[silentHost].OverallStatus, "a host with no snapshot COALESCEs to unknown")
+
+	detail, err := d.Store().HostHealth(ctx, reportedHost)
+	require.NoError(t, err)
+	assert.Equal(t, "unhealthy", detail.OverallStatus)
+	assert.EqualValues(t, 100, detail.ReportedAtNs)
+	assert.Contains(t, string(detail.Components), "never_connected", "the detail carries the component conditions verbatim")
+
+	silentDetail, err := d.Store().HostHealth(ctx, silentHost)
+	require.NoError(t, err)
+	assert.Equal(t, api.HostHealthUnknown, silentDetail.OverallStatus, "no snapshot yields unknown, not an error")
+	assert.Nil(t, []byte(silentDetail.Components), "no snapshot yields null components")
+}
+
 func TestService_CountOfflineHosts(t *testing.T) {
 	t.Parallel()
 	d := newDetection(t, detectionOpts{mode: bootstrap.ModeFull})

--- a/server/endpoint/api/service.go
+++ b/server/endpoint/api/service.go
@@ -27,6 +27,12 @@ type Service interface {
 	// List returns operator-visible enrollment rows.
 	List(ctx context.Context) ([]Enrollment, error)
 
+	// RecordStatus persists the latest agent health snapshot for hostID, last-writer-wins ordered by the snapshot's ReportedAtNs, and
+	// computes + stores the server-side overall rollup. Called by the host-token-authed POST /api/status check-in (the host_id is the
+	// authenticated identity the middleware pinned, not a body field). Returns ErrInvalidStatusReport when a component carries a status
+	// outside the closed HealthStatus set; unknown component type/reason strings are accepted and stored verbatim.
+	RecordStatus(ctx context.Context, hostID string, report StatusReport) error
+
 	// Get returns a single enrollment row. Returns ErrNotFound when the
 	// host_id has no enrollment.
 	Get(ctx context.Context, hostID string) (*Enrollment, error)

--- a/server/endpoint/api/status.go
+++ b/server/endpoint/api/status.go
@@ -103,3 +103,29 @@ func (c Components) Value() (driver.Value, error) {
 	}
 	return json.Marshal(c)
 }
+
+// Rollup computes the server-side overall health for a host from its component conditions: the worst status present. The precedence is
+// unhealthy over degraded over healthy; a host with no reported component is unknown. The agent never sends this value; the server
+// derives and stores it so the "what counts as unhealthy" policy can change without an agent redeploy. A component carrying the unknown
+// status (a valid but not-actionable state) does not by itself condemn the host, so with at least one component present and none
+// unhealthy or degraded the host rolls up to healthy; the unknown component still surfaces individually in the detail panel.
+func Rollup(components Components) HealthStatus {
+	if len(components) == 0 {
+		return HealthUnknown
+	}
+	hasDegraded := false
+	for _, c := range components {
+		switch c.Status {
+		case HealthUnhealthy:
+			return HealthUnhealthy
+		case HealthDegraded:
+			hasDegraded = true
+		case HealthHealthy, HealthUnknown:
+			// Neither raises the rollup: healthy is the floor, and a lone unknown component does not by itself condemn the host.
+		}
+	}
+	if hasDegraded {
+		return HealthDegraded
+	}
+	return HealthHealthy
+}

--- a/server/endpoint/api/status.go
+++ b/server/endpoint/api/status.go
@@ -73,8 +73,9 @@ type StatusReport struct {
 // and a host with no components rolls up to HealthUnknown rather than storing "[]".
 type Components []ComponentHealth
 
-// Scan implements sql.Scanner. SQL NULL and an empty payload both decode to a nil slice; a []byte is copied before unmarshal so the
-// result does not alias the driver's reused scratch buffer.
+// Scan implements sql.Scanner. SQL NULL and an empty payload both decode to a nil slice. A non-empty payload is unmarshaled directly:
+// json.Unmarshal allocates fresh values for every field and does not retain the input slice, so the result never aliases the driver's
+// reused scratch buffer (unlike NullRawJSON, which must copy because it stores the raw bytes verbatim).
 func (c *Components) Scan(value any) error {
 	if value == nil {
 		*c = nil

--- a/server/endpoint/api/status.go
+++ b/server/endpoint/api/status.go
@@ -1,0 +1,105 @@
+package api
+
+import (
+	"database/sql/driver"
+	"encoding/json"
+	"fmt"
+)
+
+// HealthStatus is the closed set of health states a single component condition, and the server-computed per-host rollup, may hold. It
+// is deliberately small and closed: the agent owns the open-ended `type` and `reason` vocabularies (so a new signal is an agent-only
+// change), but the status is validated at the ingest boundary so the server, the rollup, and the UI badge all reason over four known
+// values. Ordering for the rollup (worst-of) is unhealthy > degraded > healthy, with unknown reserved for "no component reported".
+type HealthStatus string
+
+const (
+	HealthHealthy   HealthStatus = "healthy"   // the component is up and doing its job (an extension with a live XPC session)
+	HealthDegraded  HealthStatus = "degraded"  // the component works but not fully (reserved for future signals; unused by the first two)
+	HealthUnhealthy HealthStatus = "unhealthy" // the component is not doing its job (an extension that never connected or dropped)
+	HealthUnknown   HealthStatus = "unknown"   // no state is known (a host that has never posted a snapshot rolls up to this)
+)
+
+// Valid reports whether s is one of the four known states. The check-in handler rejects a snapshot carrying any other component
+// status; unknown `type` and `reason` strings are accepted verbatim, but the status enum is the one field held to a closed set.
+func (s HealthStatus) Valid() bool {
+	switch s {
+	case HealthHealthy, HealthDegraded, HealthUnhealthy, HealthUnknown:
+		return true
+	default:
+		return false
+	}
+}
+
+// Component type identifiers reported today. These are open-vocabulary strings by contract (the server stores an unrecognized type
+// verbatim), named here only for the two signals shipped first so the server, tests, and UI share one spelling.
+const (
+	ComponentEndpointSecurityExtension = "endpoint_security_extension" // the ESF system extension's XPC session
+	ComponentNetworkExtension          = "network_extension"           // the network system extension's XPC session
+)
+
+// Reason codes reported today. Also open-vocabulary; named for the first two signals. never_connected is the fresh-install activation
+// gap (issue #359); connection_lost is a component that connected and then dropped while the agent kept running (the tamper-adjacent
+// signal a later alert rule will consume).
+const (
+	ReasonActivated      = "activated"       // the component reached a healthy session
+	ReasonNeverConnected = "never_connected" // the component has not connected since the agent started
+	ReasonConnectionLost = "connection_lost" // the component connected and then lost its session
+)
+
+// ComponentHealth is one condition in a host's status snapshot: a stable machine `Type`, a closed-enum `Status`, an open-vocabulary
+// machine `Reason`, a human `Message` for the detail panel, and `LastTransitionNs`, the agent-observed instant the component entered
+// its current status (so the UI can render "since 3m ago" and a later tamper rule can reason over the transition time). Reason and
+// Message are omitted when empty; the pair is carried inside the snapshot's JSON, not mapped to its own columns, so it has no db tags.
+type ComponentHealth struct {
+	Type             string       `json:"type"`
+	Status           HealthStatus `json:"status"`
+	Reason           string       `json:"reason,omitempty"`
+	Message          string       `json:"message,omitempty"`
+	LastTransitionNs int64        `json:"last_transition_ns"`
+}
+
+// StatusReport is the wire payload the agent POSTs at /api/status. It is an idempotent snapshot, not an append: every post carries the
+// full component list and fully replaces the server's prior view for that host (last-writer-wins, ordered by ReportedAtNs). The agent
+// does not send the overall rollup; the server computes it from Components. Kept a distinct type from any persisted row so the agent
+// contract is a plain DTO.
+type StatusReport struct {
+	AgentVersion string     `json:"agent_version"`
+	ReportedAtNs int64      `json:"reported_at_ns"`
+	Components   Components `json:"components"`
+}
+
+// Components is the list of component conditions persisted as a single MySQL JSON column and also carried on the wire. It mirrors the
+// JSONStringSlice pattern (server/detection/api): an empty or nil slice round-trips through SQL NULL, so Scan(Value(empty)) is nil,
+// and a host with no components rolls up to HealthUnknown rather than storing "[]".
+type Components []ComponentHealth
+
+// Scan implements sql.Scanner. SQL NULL and an empty payload both decode to a nil slice; a []byte is copied before unmarshal so the
+// result does not alias the driver's reused scratch buffer.
+func (c *Components) Scan(value any) error {
+	if value == nil {
+		*c = nil
+		return nil
+	}
+	var b []byte
+	switch v := value.(type) {
+	case []byte:
+		b = v
+	case string:
+		b = []byte(v)
+	default:
+		return fmt.Errorf("Components.Scan: unsupported type %T", value)
+	}
+	if len(b) == 0 {
+		*c = nil
+		return nil
+	}
+	return json.Unmarshal(b, c)
+}
+
+// Value implements driver.Valuer. An empty or nil slice maps to SQL NULL so the column round-trips cleanly.
+func (c Components) Value() (driver.Value, error) {
+	if len(c) == 0 {
+		return nil, nil
+	}
+	return json.Marshal(c)
+}

--- a/server/endpoint/api/status_test.go
+++ b/server/endpoint/api/status_test.go
@@ -72,23 +72,23 @@ func TestHealthStatus_Valid(t *testing.T) {
 func TestComponents_Scan(t *testing.T) {
 	t.Parallel()
 
-	var fromNil api.Components
+	fromNil := api.Components(nil)
 	require.NoError(t, fromNil.Scan(nil))
 	assert.Nil(t, fromNil, "SQL NULL scans to a nil slice")
 
-	var fromEmpty api.Components
+	fromEmpty := api.Components(nil)
 	require.NoError(t, fromEmpty.Scan([]byte{}))
 	assert.Nil(t, fromEmpty, "an empty payload scans to a nil slice")
 
-	var fromBytes api.Components
+	fromBytes := api.Components(nil)
 	require.NoError(t, fromBytes.Scan([]byte(`[{"type":"network_extension","status":"healthy","last_transition_ns":7}]`)))
 	assert.Equal(t, api.Components{{Type: api.ComponentNetworkExtension, Status: api.HealthHealthy, LastTransitionNs: 7}}, fromBytes)
 
-	var fromStr api.Components
+	fromStr := api.Components(nil)
 	require.NoError(t, fromStr.Scan(`[{"type":"x","status":"unknown","last_transition_ns":0}]`))
 	assert.Equal(t, api.Components{{Type: "x", Status: api.HealthUnknown}}, fromStr)
 
-	var bad api.Components
+	bad := api.Components(nil)
 	err := bad.Scan(42)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported type")
@@ -195,7 +195,7 @@ func TestComponents_ScanValueProperty(t *testing.T) {
 		val, err := original.Value()
 		require.NoError(rt, err)
 
-		var rebuilt api.Components
+		rebuilt := api.Components(nil)
 		if val == nil {
 			require.NoError(rt, rebuilt.Scan(nil))
 			assert.Nil(rt, rebuilt)

--- a/server/endpoint/api/status_test.go
+++ b/server/endpoint/api/status_test.go
@@ -94,6 +94,37 @@ func TestComponents_Scan(t *testing.T) {
 	assert.Contains(t, err.Error(), "unsupported type")
 }
 
+// TestRollup covers the server-side worst-of rollup across the status precedence.
+//
+// spec:server-host-status/the-server-computes-an-overall-host-health-rollup/one-unhealthy-component-makes-the-host-unhealthy
+// spec:server-host-status/the-server-computes-an-overall-host-health-rollup/a-host-with-no-snapshot-rolls-up-to-unknown
+// spec:server-host-status/the-server-computes-an-overall-host-health-rollup/all-healthy-components-roll-up-to-healthy
+func TestRollup(t *testing.T) {
+	t.Parallel()
+	comp := func(s api.HealthStatus) api.ComponentHealth { return api.ComponentHealth{Type: "c", Status: s} }
+	cases := []struct {
+		name string
+		in   api.Components
+		want api.HealthStatus
+	}{
+		{"nil is unknown", nil, api.HealthUnknown},
+		{"empty is unknown", api.Components{}, api.HealthUnknown},
+		{"all healthy is healthy", api.Components{comp(api.HealthHealthy), comp(api.HealthHealthy)}, api.HealthHealthy},
+		{"one unhealthy is unhealthy", api.Components{comp(api.HealthHealthy), comp(api.HealthUnhealthy)}, api.HealthUnhealthy},
+		{"one degraded is degraded", api.Components{comp(api.HealthHealthy), comp(api.HealthDegraded)}, api.HealthDegraded},
+		{"unhealthy beats degraded", api.Components{comp(api.HealthDegraded), comp(api.HealthUnhealthy)}, api.HealthUnhealthy},
+		{"unhealthy first still unhealthy", api.Components{comp(api.HealthUnhealthy), comp(api.HealthDegraded)}, api.HealthUnhealthy},
+		{"lone unknown component rolls up healthy", api.Components{comp(api.HealthUnknown)}, api.HealthHealthy},
+		{"healthy plus unknown is healthy", api.Components{comp(api.HealthHealthy), comp(api.HealthUnknown)}, api.HealthHealthy},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, api.Rollup(tc.in))
+		})
+	}
+}
+
 func TestComponents_Value(t *testing.T) {
 	t.Parallel()
 

--- a/server/endpoint/api/status_test.go
+++ b/server/endpoint/api/status_test.go
@@ -1,0 +1,176 @@
+package api_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"pgregory.net/rapid"
+
+	"github.com/fleetdm/edr/server/endpoint/api"
+)
+
+// TestStatusReport_WirePin pins the exact on-the-wire JSON the agent sends, so the agent contract cannot drift silently: the field
+// names, the closed status spelling, and the omitempty behaviour of reason/message. The security extension is the #359 never-connected
+// case; the network extension is healthy with an empty message (message omitted).
+func TestStatusReport_WirePin(t *testing.T) {
+	t.Parallel()
+	report := api.StatusReport{
+		AgentVersion: "0.4.0",
+		ReportedAtNs: 1700000000000000000,
+		Components: api.Components{
+			{
+				Type:             api.ComponentEndpointSecurityExtension,
+				Status:           api.HealthUnhealthy,
+				Reason:           api.ReasonNeverConnected,
+				Message:          "security extension not activated",
+				LastTransitionNs: 1699999999000000000,
+			},
+			{
+				Type:             api.ComponentNetworkExtension,
+				Status:           api.HealthHealthy,
+				Reason:           api.ReasonActivated,
+				LastTransitionNs: 1699999998000000000,
+			},
+		},
+	}
+
+	out, err := json.Marshal(report)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{
+		"agent_version": "0.4.0",
+		"reported_at_ns": 1700000000000000000,
+		"components": [
+			{
+				"type": "endpoint_security_extension",
+				"status": "unhealthy",
+				"reason": "never_connected",
+				"message": "security extension not activated",
+				"last_transition_ns": 1699999999000000000
+			},
+			{
+				"type": "network_extension",
+				"status": "healthy",
+				"reason": "activated",
+				"last_transition_ns": 1699999998000000000
+			}
+		]
+	}`, string(out))
+}
+
+func TestHealthStatus_Valid(t *testing.T) {
+	t.Parallel()
+	for _, s := range []api.HealthStatus{api.HealthHealthy, api.HealthDegraded, api.HealthUnhealthy, api.HealthUnknown} {
+		assert.Truef(t, s.Valid(), "%q must be valid", s)
+	}
+	for _, s := range []api.HealthStatus{"", "ok", "HEALTHY", "down", "unknown "} {
+		assert.Falsef(t, s.Valid(), "%q must be invalid", s)
+	}
+}
+
+func TestComponents_Scan(t *testing.T) {
+	t.Parallel()
+
+	var fromNil api.Components
+	require.NoError(t, fromNil.Scan(nil))
+	assert.Nil(t, fromNil, "SQL NULL scans to a nil slice")
+
+	var fromEmpty api.Components
+	require.NoError(t, fromEmpty.Scan([]byte{}))
+	assert.Nil(t, fromEmpty, "an empty payload scans to a nil slice")
+
+	var fromBytes api.Components
+	require.NoError(t, fromBytes.Scan([]byte(`[{"type":"network_extension","status":"healthy","last_transition_ns":7}]`)))
+	assert.Equal(t, api.Components{{Type: api.ComponentNetworkExtension, Status: api.HealthHealthy, LastTransitionNs: 7}}, fromBytes)
+
+	var fromStr api.Components
+	require.NoError(t, fromStr.Scan(`[{"type":"x","status":"unknown","last_transition_ns":0}]`))
+	assert.Equal(t, api.Components{{Type: "x", Status: api.HealthUnknown}}, fromStr)
+
+	var bad api.Components
+	err := bad.Scan(42)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported type")
+}
+
+func TestComponents_Value(t *testing.T) {
+	t.Parallel()
+
+	v, err := api.Components(nil).Value()
+	require.NoError(t, err)
+	assert.Nil(t, v, "a nil slice maps to SQL NULL")
+
+	v, err = api.Components{}.Value()
+	require.NoError(t, err)
+	assert.Nil(t, v, "an empty slice maps to SQL NULL")
+
+	v, err = api.Components{{Type: "x", Status: api.HealthHealthy, LastTransitionNs: 3}}.Value()
+	require.NoError(t, err)
+	assert.JSONEq(t, `[{"type":"x","status":"healthy","last_transition_ns":3}]`, string(v.([]byte)))
+}
+
+// ---- Property-based tests --------------------------------------------------
+
+func componentGen() *rapid.Generator[api.ComponentHealth] {
+	return rapid.Custom(func(rt *rapid.T) api.ComponentHealth {
+		return api.ComponentHealth{
+			Type:             rapid.StringMatching(`[a-z_]{1,24}`).Draw(rt, "type"),
+			Status:           rapid.SampledFrom([]api.HealthStatus{api.HealthHealthy, api.HealthDegraded, api.HealthUnhealthy, api.HealthUnknown}).Draw(rt, "status"),
+			Reason:           rapid.StringMatching(`[a-z_]{0,24}`).Draw(rt, "reason"),
+			Message:          rapid.StringMatching(`[ -~]{0,32}`).Draw(rt, "message"),
+			LastTransitionNs: rapid.Int64().Draw(rt, "last_transition_ns"),
+		}
+	})
+}
+
+// componentsGen normalises a zero-length draw to a nil slice so the round-trip identities below hold under require.Equal (SQL NULL and
+// JSON null both decode to nil, never to an empty non-nil slice).
+func componentsGen() *rapid.Generator[api.Components] {
+	return rapid.Custom(func(rt *rapid.T) api.Components {
+		s := rapid.SliceOfN(componentGen(), 0, 6).Draw(rt, "components")
+		if len(s) == 0 {
+			return nil
+		}
+		return api.Components(s)
+	})
+}
+
+// TestStatusReport_RoundTripProperty: Unmarshal(Marshal(r)) == r for any report. The wire contract must not lose or mangle a field.
+func TestStatusReport_RoundTripProperty(t *testing.T) {
+	t.Parallel()
+	rapid.Check(t, func(rt *rapid.T) {
+		report := api.StatusReport{
+			AgentVersion: rapid.StringMatching(`[ -~]{0,16}`).Draw(rt, "agent_version"),
+			ReportedAtNs: rapid.Int64().Draw(rt, "reported_at_ns"),
+			Components:   componentsGen().Draw(rt, "components"),
+		}
+
+		out, err := json.Marshal(report)
+		require.NoError(rt, err)
+
+		var back api.StatusReport
+		require.NoError(rt, json.Unmarshal(out, &back))
+		assert.Equal(rt, report, back)
+	})
+}
+
+// TestComponents_ScanValueProperty: Scan(Value(c)) == c with the empty-slice collapse to nil that Value applies.
+func TestComponents_ScanValueProperty(t *testing.T) {
+	t.Parallel()
+	rapid.Check(t, func(rt *rapid.T) {
+		original := componentsGen().Draw(rt, "components")
+
+		val, err := original.Value()
+		require.NoError(rt, err)
+
+		var rebuilt api.Components
+		if val == nil {
+			require.NoError(rt, rebuilt.Scan(nil))
+			assert.Nil(rt, rebuilt)
+			return
+		}
+		require.NoError(rt, rebuilt.Scan(val.([]byte)))
+		assert.Equal(rt, original, rebuilt)
+	})
+}

--- a/server/endpoint/api/types.go
+++ b/server/endpoint/api/types.go
@@ -73,4 +73,9 @@ var (
 	// ErrNotFound is returned by Get / Revoke when the host_id has no
 	// enrollment row.
 	ErrNotFound = errors.New("endpoint: enrollment not found")
+
+	// ErrInvalidStatusReport is returned by Service.RecordStatus when a status snapshot carries a component whose status is outside the
+	// closed HealthStatus set. The check-in handler maps it to 400. Unknown component type/reason strings do NOT trigger it: only the
+	// status enum is held to a closed set, so a future signal the server does not yet recognize is still accepted and stored.
+	ErrInvalidStatusReport = errors.New("endpoint: invalid status report")
 )

--- a/server/endpoint/bootstrap/bootstrap.go
+++ b/server/endpoint/bootstrap/bootstrap.go
@@ -18,6 +18,7 @@ import (
 	"github.com/fleetdm/edr/server/endpoint/internal/revocation"
 	"github.com/fleetdm/edr/server/endpoint/internal/service"
 	"github.com/fleetdm/edr/server/endpoint/internal/signedtoken"
+	"github.com/fleetdm/edr/server/endpoint/internal/status"
 	"github.com/fleetdm/edr/server/endpoint/internal/token"
 	endpointmigrations "github.com/fleetdm/edr/server/endpoint/migrations"
 	"github.com/fleetdm/edr/server/httpserver"
@@ -66,6 +67,7 @@ type Endpoint struct {
 	enrollH     *enroll.Handler
 	operatorH   *operator.Handler
 	tokenH      *token.Handler
+	statusH     *status.Handler
 	hostTokenMW func(http.Handler) http.Handler
 	snapshot    *revocation.Snapshot
 	db          *sqlx.DB
@@ -118,6 +120,7 @@ func New(deps Deps) (*Endpoint, error) {
 		}),
 		operatorH:   opH,
 		tokenH:      token.New(svc, logger),
+		statusH:     status.New(svc, logger),
 		hostTokenMW: middleware.HostToken(svc, logger),
 		snapshot:    snapshot,
 		db:          deps.DB,
@@ -155,6 +158,10 @@ func (e *Endpoint) HostTokenMiddleware() func(http.Handler) http.Handler { retur
 // TokenRefreshHandler returns the POST /api/token/refresh handler. cmd/main mounts it inside the host-token-protected mux so it shares
 // the same authentication as the other agent routes.
 func (e *Endpoint) TokenRefreshHandler() http.Handler { return e.tokenH }
+
+// StatusHandler returns the POST /api/status agent-health check-in handler. cmd/main mounts it inside the host-token-protected mux so it
+// shares the same authentication as the other agent routes; the handler reads the host_id the middleware pinned.
+func (e *Endpoint) StatusHandler() http.Handler { return e.statusH }
 
 // RevocationSnapshot returns the per-replica revocation snapshot so cmd/main can trigger an initial synchronous load before serving and
 // run the background refresh loop. Per ADR-0010 it is a perf cache, safe to lose.

--- a/server/endpoint/internal/enroll/handler_test.go
+++ b/server/endpoint/internal/enroll/handler_test.go
@@ -32,6 +32,9 @@ func (f fakeService) Enroll(ctx context.Context, req api.EnrollRequest, sourceIP
 func (f fakeService) VerifyToken(context.Context, string) (string, error) {
 	panic("not implemented in fakeService")
 }
+func (f fakeService) RecordStatus(context.Context, string, api.StatusReport) error {
+	panic("not implemented in fakeService")
+}
 func (f fakeService) List(context.Context) ([]api.Enrollment, error) {
 	panic("not implemented in fakeService")
 }

--- a/server/endpoint/internal/middleware/hosttoken_test.go
+++ b/server/endpoint/internal/middleware/hosttoken_test.go
@@ -29,6 +29,9 @@ func (f fakeService) Enroll(context.Context, api.EnrollRequest, string) (api.Enr
 func (f fakeService) VerifyToken(ctx context.Context, token string) (string, error) {
 	return f.verifyToken(ctx, token)
 }
+func (f fakeService) RecordStatus(context.Context, string, api.StatusReport) error {
+	panic("not implemented in fakeService")
+}
 func (f fakeService) List(context.Context) ([]api.Enrollment, error) {
 	panic("not implemented in fakeService")
 }

--- a/server/endpoint/internal/mysql/health.go
+++ b/server/endpoint/internal/mysql/health.go
@@ -1,0 +1,28 @@
+package mysql
+
+import (
+	"context"
+	"database/sql/driver"
+	"fmt"
+)
+
+// UpsertHostHealth stores the latest agent health snapshot for hostID, last-writer-wins by reportedAtNs. The IF/GREATEST guard makes a
+// delayed or out-of-order post (an agent retry, or a slower replica replaying an older snapshot) unable to clobber a fresher one already
+// recorded: overall_status and components are replaced only when the incoming reported_at_ns is at least the stored one, while
+// reported_at_ns itself moves monotonically forward. components is the driver.Value produced by api.Components.Value(): a JSON []byte,
+// or nil for SQL NULL when the snapshot carried no components. VALUES() in the ON DUPLICATE KEY UPDATE clause matches the enrollments
+// upsert style in store.go (deprecated in MySQL 8.0.20 but still supported; the codebase keeps one idiom).
+func (s *Store) UpsertHostHealth(ctx context.Context, hostID, overallStatus string, components driver.Value, reportedAtNs int64) error {
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO host_health (host_id, overall_status, components, reported_at_ns)
+		VALUES (?, ?, ?, ?)
+		ON DUPLICATE KEY UPDATE
+			overall_status = IF(VALUES(reported_at_ns) >= reported_at_ns, VALUES(overall_status), overall_status),
+			components     = IF(VALUES(reported_at_ns) >= reported_at_ns, VALUES(components), components),
+			reported_at_ns = GREATEST(reported_at_ns, VALUES(reported_at_ns))
+	`, hostID, overallStatus, components, reportedAtNs)
+	if err != nil {
+		return fmt.Errorf("upsert host health: %w", err)
+	}
+	return nil
+}

--- a/server/endpoint/internal/operator/audit_test.go
+++ b/server/endpoint/internal/operator/audit_test.go
@@ -41,6 +41,9 @@ func (f fakeRevokeService) Revoke(ctx context.Context, hostID, reason, actor str
 }
 func (f fakeRevokeService) CountActive(context.Context) (int, error)        { panic("not used") }
 func (f fakeRevokeService) ActiveHostIDs(context.Context) ([]string, error) { panic("not used") }
+func (f fakeRevokeService) RecordStatus(context.Context, string, api.StatusReport) error {
+	panic("not used")
+}
 func (f fakeRevokeService) RotateToken(ctx context.Context, hostID, actor, reason string) error {
 	if f.rotate == nil {
 		panic("fake.RotateToken not set")

--- a/server/endpoint/internal/service/service.go
+++ b/server/endpoint/internal/service/service.go
@@ -23,6 +23,11 @@ import (
 // minutes matches the SPIFFE guidance for hot-path workload identities.
 const defaultTokenTTL = 60 * time.Minute
 
+// maxReportClockSkew bounds how far into the future a status snapshot's reported_at_ns may sit before RecordStatus clamps it to now. It
+// absorbs benign NTP-scale clock skew while denying a wildly-future stamp the power to freeze a host's health row under the store's
+// last-writer-wins ordering (see RecordStatus).
+const maxReportClockSkew = 15 * time.Minute
+
 // hardwareUUIDPattern accepts the canonical hyphenated UUID form in either case. macOS IOPlatformUUID is uppercase-hyphenated. Future
 // platforms emitting unhyphenated 32-hex strings need a matching agent + regex update.
 var hardwareUUIDPattern = regexp.MustCompile(`^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$`)
@@ -238,7 +243,15 @@ func (s *service) RecordStatus(ctx context.Context, hostID string, report api.St
 		return fmt.Errorf("marshal components: %w", err)
 	}
 	overall := api.Rollup(report.Components)
-	if err := s.store.UpsertHostHealth(ctx, hostID, string(overall), components, report.ReportedAtNs); err != nil {
+	// Clamp an implausibly-future snapshot time to now. The store orders last-writer-wins by reported_at_ns, so a wildly-future stamp (a
+	// clock-skewed or hostile agent) would otherwise permanently win the race and freeze this host's health row against every later
+	// correct report. Clamping still records the snapshot but denies it the power to lock out updates; benign NTP-scale skew stays under
+	// the tolerance and passes through unchanged.
+	reportedAtNs := report.ReportedAtNs
+	if now := time.Now(); reportedAtNs > now.Add(maxReportClockSkew).UnixNano() {
+		reportedAtNs = now.UnixNano()
+	}
+	if err := s.store.UpsertHostHealth(ctx, hostID, string(overall), components, reportedAtNs); err != nil {
 		return fmt.Errorf("record host status: %w", err)
 	}
 	return nil

--- a/server/endpoint/internal/service/service.go
+++ b/server/endpoint/internal/service/service.go
@@ -223,6 +223,27 @@ func (s *service) recordRotationAudit(ctx context.Context, hostID, actor, reason
 	}
 }
 
+// RecordStatus validates the snapshot's component statuses at the boundary, computes the server-side rollup, and upserts the latest
+// per-host health row. Validation is the one closed-set check: a component status outside HealthStatus is rejected wholesale (nothing is
+// stored) so a malformed agent cannot poison the rollup; unknown type/reason strings pass through untouched so a future signal needs no
+// server change. The components are handed to the store as the JSON driver.Value the column persists (nil for SQL NULL when empty).
+func (s *service) RecordStatus(ctx context.Context, hostID string, report api.StatusReport) error {
+	for _, c := range report.Components {
+		if !c.Status.Valid() {
+			return api.ErrInvalidStatusReport
+		}
+	}
+	components, err := report.Components.Value()
+	if err != nil {
+		return fmt.Errorf("marshal components: %w", err)
+	}
+	overall := api.Rollup(report.Components)
+	if err := s.store.UpsertHostHealth(ctx, hostID, string(overall), components, report.ReportedAtNs); err != nil {
+		return fmt.Errorf("record host status: %w", err)
+	}
+	return nil
+}
+
 func (s *service) List(ctx context.Context) ([]api.Enrollment, error) {
 	rows, err := s.store.List(ctx)
 	if err != nil {

--- a/server/endpoint/internal/status/doc.go
+++ b/server/endpoint/internal/status/doc.go
@@ -1,0 +1,8 @@
+// Package status serves the agent-facing health check-in: POST /api/status.
+//
+// It is mounted behind the host-token middleware, so by the time the handler runs the request is authenticated and the host_id is
+// pinned on the context (the check-in never trusts a host id from the body). The handler decodes an idempotent StatusReport snapshot
+// and hands it to api.Service.RecordStatus, which validates the component status enum, computes the server-side overall rollup, and
+// upserts the latest per-host row. The check-in is current-state, not an event: every post fully replaces the host's prior snapshot
+// (issue #359), so a dropped post self-heals on the next one.
+package status

--- a/server/endpoint/internal/status/handler.go
+++ b/server/endpoint/internal/status/handler.go
@@ -50,6 +50,14 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	r.Body = http.MaxBytesReader(w, r.Body, maxStatusBodyBytes)
 	var report api.StatusReport
 	if err := json.NewDecoder(r.Body).Decode(&report); err != nil {
+		// Distinguish an over-cap body (413) from malformed JSON (400), matching the event ingest handler: the agent's uploader
+		// classifies 400 as a generic client error but routes 413 differently, so folding "too large" into invalid_json would drive
+		// the wrong client-side recovery.
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			httpserver.NoStoreJSON(ctx, h.logger, w, http.StatusRequestEntityTooLarge, map[string]string{"error": "body_too_large"})
+			return
+		}
 		httpserver.NoStoreJSON(ctx, h.logger, w, http.StatusBadRequest, map[string]string{"error": "invalid_json"})
 		return
 	}

--- a/server/endpoint/internal/status/handler.go
+++ b/server/endpoint/internal/status/handler.go
@@ -1,0 +1,69 @@
+package status
+
+import (
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/fleetdm/edr/server/attrkeys"
+	"github.com/fleetdm/edr/server/endpoint/api"
+	"github.com/fleetdm/edr/server/httpserver"
+)
+
+// maxStatusBodyBytes caps the check-in body. The request is authenticated, but the cap still bounds a buggy or hostile agent: the real
+// payload is a few hundred bytes for the two extensions, and 16 KiB leaves generous headroom for future components without inviting an
+// unbounded decode.
+const maxStatusBodyBytes = 16 << 10
+
+// Handler serves POST /api/status. It implements http.Handler so cmd/main can mount it inside the host-token-protected mux, reusing the
+// middleware that authenticates every other agent route.
+type Handler struct {
+	svc    api.Service
+	logger *slog.Logger
+}
+
+// New builds a status check-in handler. Panics if svc is nil (a wiring bug).
+func New(svc api.Service, logger *slog.Logger) *Handler {
+	if svc == nil {
+		panic("status.New: api.Service must not be nil")
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Handler{svc: svc, logger: logger}
+}
+
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	hostID, ok := api.HostIDFromContext(ctx)
+	if !ok {
+		// The host-token middleware pins host_id before this handler runs, so a miss means the route was mounted outside that middleware
+		// (a wiring bug), not anything a client can provoke. Fail closed with the same 401 the middleware itself emits.
+		httpserver.WriteAuthFailure(ctx, w, h.logger, http.StatusUnauthorized, "invalid_token")
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxStatusBodyBytes)
+	var report api.StatusReport
+	if err := json.NewDecoder(r.Body).Decode(&report); err != nil {
+		httpserver.NoStoreJSON(ctx, h.logger, w, http.StatusBadRequest, map[string]string{"error": "invalid_json"})
+		return
+	}
+
+	if err := h.svc.RecordStatus(ctx, hostID, report); err != nil {
+		if errors.Is(err, api.ErrInvalidStatusReport) {
+			httpserver.NoStoreJSON(ctx, h.logger, w, http.StatusBadRequest, map[string]string{"error": "invalid_status"})
+			return
+		}
+		h.logger.ErrorContext(ctx, "record host status", "err", err)
+		httpserver.NoStoreJSON(ctx, h.logger, w, http.StatusInternalServerError, map[string]string{"error": "internal"})
+		return
+	}
+
+	trace.SpanFromContext(ctx).SetAttributes(attribute.String(attrkeys.HostID, hostID))
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/server/endpoint/internal/status/handler_test.go
+++ b/server/endpoint/internal/status/handler_test.go
@@ -1,0 +1,129 @@
+package status_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fleetdm/edr/server/endpoint/api"
+	"github.com/fleetdm/edr/server/endpoint/internal/status"
+)
+
+// recordStatusFn lets each test drive Service.RecordStatus; every other api.Service method panics because the status handler must never
+// call them (a regression that did would surface loudly rather than silently no-op).
+type fakeStatusService struct {
+	record func(ctx context.Context, hostID string, report api.StatusReport) error
+}
+
+func (f fakeStatusService) RecordStatus(ctx context.Context, hostID string, report api.StatusReport) error {
+	return f.record(ctx, hostID, report)
+}
+func (fakeStatusService) Enroll(context.Context, api.EnrollRequest, string) (api.EnrollResponse, error) {
+	panic("not used")
+}
+func (fakeStatusService) VerifyToken(context.Context, string) (string, error) { panic("not used") }
+func (fakeStatusService) RefreshToken(context.Context, string) (api.RefreshResponse, error) {
+	panic("not used")
+}
+func (fakeStatusService) List(context.Context) ([]api.Enrollment, error)       { panic("not used") }
+func (fakeStatusService) Get(context.Context, string) (*api.Enrollment, error) { panic("not used") }
+func (fakeStatusService) Revoke(context.Context, string, string, string) error { panic("not used") }
+func (fakeStatusService) CountActive(context.Context) (int, error)             { panic("not used") }
+func (fakeStatusService) ActiveHostIDs(context.Context) ([]string, error)      { panic("not used") }
+func (fakeStatusService) RotateToken(context.Context, string, string, string) error {
+	panic("not used")
+}
+
+// serve drives the handler with hostID pinned on the context exactly as the host-token middleware would (or absent when hostID == "").
+func serve(t *testing.T, svc api.Service, hostID, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	h := status.New(svc, nil)
+	ctx := context.Background()
+	if hostID != "" {
+		ctx = api.WithHostID(ctx, hostID)
+	}
+	req := httptest.NewRequestWithContext(ctx, http.MethodPost, "/api/status", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return rec
+}
+
+const validBody = `{"agent_version":"0.4.0","reported_at_ns":7,"components":[{"type":"network_extension","status":"healthy","last_transition_ns":3}]}`
+
+func TestServeHTTP_Success(t *testing.T) {
+	t.Parallel()
+	var gotHost string
+	var gotReport api.StatusReport
+	svc := fakeStatusService{record: func(_ context.Context, hostID string, report api.StatusReport) error {
+		gotHost = hostID
+		gotReport = report
+		return nil
+	}}
+
+	rec := serve(t, svc, "host-1", validBody)
+
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Equal(t, "host-1", gotHost)
+	assert.Equal(t, "0.4.0", gotReport.AgentVersion)
+	require.Len(t, gotReport.Components, 1)
+	assert.Equal(t, api.ComponentNetworkExtension, gotReport.Components[0].Type)
+}
+
+func TestServeHTTP_MissingHostIDIsUnauthorized(t *testing.T) {
+	t.Parallel()
+	svc := fakeStatusService{record: func(context.Context, string, api.StatusReport) error {
+		t.Fatal("RecordStatus must not be called without an authenticated host")
+		return nil
+	}}
+
+	rec := serve(t, svc, "", validBody)
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+func TestServeHTTP_BadJSON(t *testing.T) {
+	t.Parallel()
+	svc := fakeStatusService{record: func(context.Context, string, api.StatusReport) error {
+		t.Fatal("RecordStatus must not be called on an unparseable body")
+		return nil
+	}}
+
+	rec := serve(t, svc, "host-1", `{not json`)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "invalid_json")
+}
+
+func TestServeHTTP_InvalidStatusMaps400(t *testing.T) {
+	t.Parallel()
+	svc := fakeStatusService{record: func(context.Context, string, api.StatusReport) error {
+		return api.ErrInvalidStatusReport
+	}}
+
+	rec := serve(t, svc, "host-1", validBody)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "invalid_status")
+}
+
+func TestServeHTTP_ServiceErrorMaps500(t *testing.T) {
+	t.Parallel()
+	svc := fakeStatusService{record: func(context.Context, string, api.StatusReport) error {
+		return assert.AnError
+	}}
+
+	rec := serve(t, svc, "host-1", validBody)
+
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+	assert.Contains(t, rec.Body.String(), "internal")
+}
+
+func TestNew_NilServicePanics(t *testing.T) {
+	t.Parallel()
+	assert.Panics(t, func() { status.New(nil, nil) })
+}

--- a/server/endpoint/internal/status/handler_test.go
+++ b/server/endpoint/internal/status/handler_test.go
@@ -99,6 +99,22 @@ func TestServeHTTP_BadJSON(t *testing.T) {
 	assert.Contains(t, rec.Body.String(), "invalid_json")
 }
 
+func TestServeHTTP_OversizedBodyMaps413(t *testing.T) {
+	t.Parallel()
+	svc := fakeStatusService{record: func(context.Context, string, api.StatusReport) error {
+		t.Fatal("RecordStatus must not be called on an over-cap body")
+		return nil
+	}}
+	// A valid-JSON prefix followed by padding that pushes the body past maxStatusBodyBytes (16 KiB): MaxBytesReader trips mid-decode
+	// and the handler must return 413 body_too_large (the agent-facing convention), not 400 invalid_json.
+	huge := `{"agent_version":"` + strings.Repeat("a", 32*1024) + `"}`
+
+	rec := serve(t, svc, "host-1", huge)
+
+	assert.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
+	assert.Contains(t, rec.Body.String(), "body_too_large")
+}
+
 func TestServeHTTP_InvalidStatusMaps400(t *testing.T) {
 	t.Parallel()
 	svc := fakeStatusService{record: func(context.Context, string, api.StatusReport) error {

--- a/server/endpoint/internal/tests/status_test.go
+++ b/server/endpoint/internal/tests/status_test.go
@@ -1,0 +1,156 @@
+//go:build integration
+
+// Per-context integration tests for the agent-health check-in (POST /api/status, issue #359). Exercise the full stack:
+// HostToken middleware -> status handler -> api.Service.RecordStatus -> host_health upsert, against a real MySQL.
+
+package tests
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fleetdm/edr/server/endpoint/api"
+	"github.com/fleetdm/edr/server/endpoint/bootstrap"
+)
+
+// statusFixture enrolls a host over the real service and stands up the check-in endpoint behind the host-token middleware, exactly as
+// cmd/main mounts it. Returns the server, the host token, and the host_id so a test can POST snapshots and read host_health back.
+func statusFixture(t *testing.T, uuid string) (*bootstrap.Endpoint, *sqlx.DB, *httptest.Server, string) {
+	t.Helper()
+	ep, db := newEndpointWithDB(t)
+	res, err := ep.Service().Enroll(t.Context(), api.EnrollRequest{
+		EnrollSecret: testEnrollSecret,
+		HardwareUUID: uuid,
+		Hostname:     "h",
+		OSVersion:    "macOS 26",
+		AgentVersion: "0.4.0",
+	}, "192.0.2.10")
+	require.NoError(t, err)
+	srv := httptest.NewServer(ep.HostTokenMiddleware()(ep.StatusHandler()))
+	t.Cleanup(srv.Close)
+	return ep, db, srv, res.HostToken
+}
+
+func postStatus(t *testing.T, srv *httptest.Server, token, body string) int {
+	t.Helper()
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, srv.URL+"/api/status", strings.NewReader(body))
+	require.NoError(t, err)
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	resp, err := srv.Client().Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	return resp.StatusCode
+}
+
+type healthRow struct {
+	OverallStatus string `db:"overall_status"`
+	Components    []byte `db:"components"`
+	ReportedAtNs  int64  `db:"reported_at_ns"`
+}
+
+func readHealth(t *testing.T, db *sqlx.DB, hostID string) (healthRow, bool) {
+	t.Helper()
+	var row healthRow
+	err := db.GetContext(t.Context(), &row,
+		`SELECT overall_status, components, reported_at_ns FROM host_health WHERE host_id = ?`, hostID)
+	if err != nil {
+		return healthRow{}, false
+	}
+	return row, true
+}
+
+// spec:server-host-status/the-server-accepts-and-persists-a-host-status-snapshot/a-valid-snapshot-is-stored-as-the-latest-health-for-the-host
+func TestRecordStatus_HTTP_PersistsAndRollsUp(t *testing.T) {
+	t.Parallel()
+	uuid := "11111111-1111-1111-1111-111111111111"
+	_, db, srv, token := statusFixture(t, uuid)
+
+	body := `{"agent_version":"0.4.0","reported_at_ns":100,"components":[
+		{"type":"endpoint_security_extension","status":"unhealthy","reason":"never_connected","last_transition_ns":90},
+		{"type":"network_extension","status":"healthy","reason":"activated","last_transition_ns":80}
+	]}`
+	require.Equal(t, http.StatusNoContent, postStatus(t, srv, token, body))
+
+	row, ok := readHealth(t, db, uuid)
+	require.True(t, ok)
+	assert.Equal(t, string(api.HealthUnhealthy), row.OverallStatus)
+	assert.EqualValues(t, 100, row.ReportedAtNs)
+	assert.Contains(t, string(row.Components), "endpoint_security_extension")
+	assert.Contains(t, string(row.Components), "never_connected")
+}
+
+// spec:server-host-status/the-server-accepts-and-persists-a-host-status-snapshot/a-later-snapshot-replaces-an-earlier-one
+func TestRecordStatus_HTTP_LastWriterWins(t *testing.T) {
+	t.Parallel()
+	uuid := "22222222-2222-2222-2222-222222222222"
+	_, db, srv, token := statusFixture(t, uuid)
+
+	healthy := `{"agent_version":"0.4.0","reported_at_ns":%d,"components":[{"type":"network_extension","status":"healthy","last_transition_ns":1}]}`
+	unhealthy := `{"agent_version":"0.4.0","reported_at_ns":%d,"components":[{"type":"network_extension","status":"unhealthy","last_transition_ns":1}]}`
+
+	require.Equal(t, http.StatusNoContent, postStatus(t, srv, token, fmt.Sprintf(healthy, 100)))
+	require.Equal(t, http.StatusNoContent, postStatus(t, srv, token, fmt.Sprintf(unhealthy, 200)))
+
+	row, ok := readHealth(t, db, uuid)
+	require.True(t, ok)
+	assert.Equal(t, string(api.HealthUnhealthy), row.OverallStatus)
+	assert.EqualValues(t, 200, row.ReportedAtNs)
+
+	// A stale (older reported_at_ns) post must not clobber the fresher snapshot.
+	require.Equal(t, http.StatusNoContent, postStatus(t, srv, token, fmt.Sprintf(healthy, 50)))
+	row, ok = readHealth(t, db, uuid)
+	require.True(t, ok)
+	assert.Equal(t, string(api.HealthUnhealthy), row.OverallStatus, "a stale post must not overwrite a fresher snapshot")
+	assert.EqualValues(t, 200, row.ReportedAtNs)
+}
+
+// spec:server-host-status/the-server-accepts-and-persists-a-host-status-snapshot/an-unknown-component-type-is-stored-verbatim
+func TestRecordStatus_HTTP_UnknownTypeStored(t *testing.T) {
+	t.Parallel()
+	uuid := "33333333-3333-3333-3333-333333333333"
+	_, db, srv, token := statusFixture(t, uuid)
+
+	body := `{"agent_version":"0.4.0","reported_at_ns":5,"components":[{"type":"future_signal","status":"healthy","reason":"brand_new","last_transition_ns":1}]}`
+	require.Equal(t, http.StatusNoContent, postStatus(t, srv, token, body))
+
+	row, ok := readHealth(t, db, uuid)
+	require.True(t, ok)
+	assert.Equal(t, string(api.HealthHealthy), row.OverallStatus)
+	assert.Contains(t, string(row.Components), "future_signal")
+	assert.Contains(t, string(row.Components), "brand_new")
+}
+
+// spec:server-host-status/the-server-accepts-and-persists-a-host-status-snapshot/an-invalid-status-value-is-rejected
+func TestRecordStatus_HTTP_InvalidStatusRejected(t *testing.T) {
+	t.Parallel()
+	uuid := "44444444-4444-4444-4444-444444444444"
+	_, db, srv, token := statusFixture(t, uuid)
+
+	body := `{"agent_version":"0.4.0","reported_at_ns":5,"components":[{"type":"network_extension","status":"borked","last_transition_ns":1}]}`
+	require.Equal(t, http.StatusBadRequest, postStatus(t, srv, token, body))
+
+	_, ok := readHealth(t, db, uuid)
+	assert.False(t, ok, "a rejected snapshot must store nothing")
+}
+
+// spec:server-host-status/the-server-accepts-and-persists-a-host-status-snapshot/an-unauthenticated-check-in-is-rejected
+func TestRecordStatus_HTTP_Unauthenticated(t *testing.T) {
+	t.Parallel()
+	uuid := "55555555-5555-5555-5555-555555555555"
+	_, db, srv, _ := statusFixture(t, uuid)
+
+	body := `{"agent_version":"0.4.0","reported_at_ns":5,"components":[{"type":"network_extension","status":"healthy","last_transition_ns":1}]}`
+	assert.Equal(t, http.StatusUnauthorized, postStatus(t, srv, "", body))
+
+	_, ok := readHealth(t, db, uuid)
+	assert.False(t, ok, "an unauthenticated check-in must store nothing")
+}

--- a/server/endpoint/internal/tests/status_test.go
+++ b/server/endpoint/internal/tests/status_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/jmoiron/sqlx"
 	"github.com/stretchr/testify/assert"
@@ -111,6 +112,30 @@ func TestRecordStatus_HTTP_LastWriterWins(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, string(api.HealthUnhealthy), row.OverallStatus, "a stale post must not overwrite a fresher snapshot")
 	assert.EqualValues(t, 200, row.ReportedAtNs)
+}
+
+// TestRecordStatus_HTTP_FutureTimestampClamped proves a wildly-future snapshot time cannot freeze the host's health row: the future
+// stamp is clamped to ~now on write, so a subsequent correctly-stamped report still wins the last-writer-wins race.
+func TestRecordStatus_HTTP_FutureTimestampClamped(t *testing.T) {
+	t.Parallel()
+	uuid := "66666666-6666-6666-6666-666666666666"
+	_, db, srv, token := statusFixture(t, uuid)
+
+	farFuture := time.Now().Add(72 * time.Hour).UnixNano()
+	unhealthy := fmt.Sprintf(`{"agent_version":"0.4.0","reported_at_ns":%d,"components":[{"type":"network_extension","status":"unhealthy","last_transition_ns":1}]}`, farFuture)
+	require.Equal(t, http.StatusNoContent, postStatus(t, srv, token, unhealthy))
+
+	row, ok := readHealth(t, db, uuid)
+	require.True(t, ok)
+	assert.Less(t, row.ReportedAtNs, farFuture, "a far-future reported_at_ns must be clamped, not stored verbatim")
+
+	// A later, correctly-stamped healthy report must win rather than being locked out by the clamped-but-still-recent prior row.
+	healthy := fmt.Sprintf(`{"agent_version":"0.4.0","reported_at_ns":%d,"components":[{"type":"network_extension","status":"healthy","last_transition_ns":2}]}`, time.Now().UnixNano())
+	require.Equal(t, http.StatusNoContent, postStatus(t, srv, token, healthy))
+
+	row, ok = readHealth(t, db, uuid)
+	require.True(t, ok)
+	assert.Equal(t, string(api.HealthHealthy), row.OverallStatus, "a clamped future stamp must not freeze the row against later reports")
 }
 
 // spec:server-host-status/the-server-accepts-and-persists-a-host-status-snapshot/an-unknown-component-type-is-stored-verbatim

--- a/server/endpoint/internal/token/handler_test.go
+++ b/server/endpoint/internal/token/handler_test.go
@@ -26,7 +26,10 @@ func (f fakeRefreshService) RefreshToken(context.Context, string) (api.RefreshRe
 func (f fakeRefreshService) Enroll(context.Context, api.EnrollRequest, string) (api.EnrollResponse, error) {
 	panic("not used")
 }
-func (f fakeRefreshService) VerifyToken(context.Context, string) (string, error)  { panic("not used") }
+func (f fakeRefreshService) VerifyToken(context.Context, string) (string, error) { panic("not used") }
+func (f fakeRefreshService) RecordStatus(context.Context, string, api.StatusReport) error {
+	panic("not used")
+}
 func (f fakeRefreshService) List(context.Context) ([]api.Enrollment, error)       { panic("not used") }
 func (f fakeRefreshService) Get(context.Context, string) (*api.Enrollment, error) { panic("not used") }
 func (f fakeRefreshService) Revoke(context.Context, string, string, string) error { panic("not used") }

--- a/server/endpoint/migrations/00005_host_health.sql
+++ b/server/endpoint/migrations/00005_host_health.sql
@@ -1,0 +1,28 @@
+-- +goose Up
+-- +goose StatementBegin
+-- host_health is the endpoint context's latest per-host agent health snapshot: the extensible agent-health check-in (issue #359). It is
+-- a current-state table, not an event log. Each POST /api/status upserts the row keyed by host_id, last-writer-wins by reported_at_ns, so
+-- a missed post self-heals on the next one and there is exactly one row per host.
+--
+-- overall_status is the server-computed worst-of rollup of the components (unhealthy > degraded > healthy; unknown when no component is
+-- reported), stored denormalized and indexed so the Hosts list join reads a single column and the "hosts needing attention" filter is an
+-- indexed lookup rather than a JSON unpack. components is the full ComponentHealth list exactly as the agent sent it, as a JSON document
+-- (NULL when the snapshot carried no components); the operator read paths pass it through verbatim, so a future component type needs no
+-- schema change here. reported_at_ns is the agent-stamped snapshot time that orders concurrent posts across replicas.
+--
+-- No foreign key to enrollments or hosts: the endpoint context owns this table and cross-context FKs are deliberately avoided (a host
+-- may post health before any other row exists, and ordering with other contexts' migrations is not load-bearing).
+CREATE TABLE IF NOT EXISTS host_health (
+	host_id        VARCHAR(255) PRIMARY KEY,
+	overall_status VARCHAR(16)  NOT NULL,
+	components     JSON         NULL,
+	reported_at_ns BIGINT       NOT NULL,
+	updated_at     TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+	INDEX idx_host_health_overall (overall_status)
+);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP TABLE IF EXISTS host_health;
+-- +goose StatementEnd


### PR DESCRIPTION
## What & why

Surfaces agent health on the server so an operator can see when a host enrolled but its system extensions never activated (issue #359, the invisible activation gap from the 2026-06-12 QA session). Rather than a one-off "extension connected?" boolean, this builds a general, extensible agent-health channel and makes system-extension activation its first two signals, following the Kubernetes-conditions / Elastic-Agent-components pattern that both Elastic Fleet and CrowdStrike converge on.

This is **PR 1 of 2 (the entire server side)**. The agent reporter and the Hosts UI badge + detail panel land in PR 2.

### What this PR adds

- **Wire contract**: `StatusReport` / `ComponentHealth` with a closed `HealthStatus` enum (`healthy|degraded|unhealthy|unknown`) validated at the boundary, and open `type`/`reason` vocabularies so a future signal is an agent-only change (no wire break, no migration).
- **Check-in + persistence** (endpoint context): host-token-authed `POST /api/status` accepts an idempotent snapshot and upserts the latest per-host row in a new `host_health` table (migration `00005`), last-writer-wins by `reported_at_ns`. The server computes the worst-of rollup and stores it denormalized + indexed.
- **Host API surface** (detection context): `ListHosts` LEFT-JOINs `host_health` and decorates `HostSummary` with `overall_status` (the Hosts-list badge signal); `GET /api/hosts/{host_id}/health` returns the full component conditions via a `HostHealthReader` seam (same pattern as the webhook admin seam, so `api.Service` and its mocks stay untouched).

### Design notes for review

- **Snapshot, not event stream**: health is current-state, so it rides a dedicated idempotent endpoint, not the append-only `/api/events` path. A missed post self-heals on the next one.
- **Server computes the rollup**, so "what counts as unhealthy" is centralized policy that can change without an agent redeploy.
- **Endpoint owns the table, detection reads it via the shared-DB join**, consistent with the existing `enrollments` decoration in `ListHosts` (documented in that query's comment).

Out of scope (follow-ups): the agent registry + poster and the UI (PR 2); a tamper-detection rule consuming the `connection_lost` transition; additional components (DNS proxy, queue depth, policy staleness).

## Checklist

- [x] **OpenSpec updated for behavior changes.** `openspec/changes/agent-health-reporting/` ships the proposal, design, tasks, and delta specs (`agent-status-reporting`, `server-host-status`, `web-ui`); tests carry `spec:server-host-status/...` markers for the new scenarios.
- [x] Tests added/updated: wire PBT round-trip + wire pin, `Rollup` table test, status handler unit tests, endpoint integration test (persist/rollup, last-writer-wins, unknown-type passthrough, invalid-status 400, unauthenticated 401), operator handler unit tests, and a cross-context detection integration test.
- [x] Docs updated: `CHANGELOG.md` under 0.4.0.
- No ESF/XPC/event-wire agent change in this PR (server only); the agent reporter is PR 2.

## VM / RC notes

None for this PR (server only). PR 2's agent reporter will be exercised on a live macOS VM per the activation-gap scenario before RC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added agent health check-ins with per-component status reporting and server-side health rollups.
  * Hosts now show overall health in lists, and host details include component-level health information.
  * Added a new health status endpoint for agents and a host health details endpoint for operators.

* **Bug Fixes**
  * Improved handling of repeated or delayed health updates so newer snapshots win.
  * Hosts without health data now display an unknown health state instead of appearing healthy by default.



<!-- end of auto-generated comment: release notes by coderabbit.ai -->