### PR TITLE
test(ui): de-flake formatRelativeNs test (freeze clock + mid-bucket offsets)

### DIFF
--- a/ui/src/time.test.ts
+++ b/ui/src/time.test.ts
@@ -1,27 +1,52 @@
-import { describe, it, expect } from "vitest";
+import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
 import { formatRelativeNs } from "./time";
-import { NANOSECONDS_PER_MILLISECOND } from "./constants";
+import {
+  MILLISECONDS_PER_DAY,
+  MILLISECONDS_PER_HOUR,
+  MILLISECONDS_PER_MINUTE,
+  MILLISECONDS_PER_SECOND,
+  NANOSECONDS_PER_MILLISECOND,
+} from "./constants";
 
-const msAgoNs = (ms: number) => (Date.now() - ms) * NANOSECONDS_PER_MILLISECOND;
+// Freeze the clock so formatRelativeNs (which reads Date.now internally) and the test's own "now" can never drift apart, and so a
+// result never depends on the wall clock. The instant is arbitrary but fixed.
+const FROZEN_NOW = new Date("2026-06-15T12:00:00Z").getTime();
+
+// msAgoNs builds a nanosecond epoch timestamp `ms` milliseconds before the frozen now.
+//
+// Every offset below sits comfortably INSIDE its bucket (5m30s, not exactly 5m) on purpose. An epoch-ns value is ~1.75e18, well past
+// Number.MAX_SAFE_INTEGER, so the *1e6 then /1e6 round-trip inside formatRelativeNs carries sub-nanosecond error. An offset landing
+// exactly on a bucket boundary (300000 ms is exactly 5.0 minutes) can be nudged a hair under it and floor to 4, which was a real
+// ~1-in-8 CI flake ("expected '4m ago' to be '5m ago'"). Mid-bucket offsets are immune, and real last-seen timestamps are never
+// boundary-exact to the nanosecond, so the hazard only ever existed for a boundary-exact synthetic input.
+const msAgoNs = (ms: number): number => (Date.now() - ms) * NANOSECONDS_PER_MILLISECOND;
 
 describe("formatRelativeNs", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FROZEN_NOW);
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("returns 'never' for a zero timestamp", () => {
     expect(formatRelativeNs(0)).toBe("never");
   });
 
   it("returns 'just now' for a sub-minute age", () => {
-    expect(formatRelativeNs(msAgoNs(5_000))).toBe("just now");
+    expect(formatRelativeNs(msAgoNs(5 * MILLISECONDS_PER_SECOND))).toBe("just now");
   });
 
   it("formats minutes", () => {
-    expect(formatRelativeNs(msAgoNs(5 * 60 * 1000))).toBe("5m ago");
+    expect(formatRelativeNs(msAgoNs(5 * MILLISECONDS_PER_MINUTE + 30 * MILLISECONDS_PER_SECOND))).toBe("5m ago");
   });
 
   it("formats hours", () => {
-    expect(formatRelativeNs(msAgoNs(3 * 60 * 60 * 1000))).toBe("3h ago");
+    expect(formatRelativeNs(msAgoNs(3 * MILLISECONDS_PER_HOUR + 30 * MILLISECONDS_PER_MINUTE))).toBe("3h ago");
   });
 
   it("formats days", () => {
-    expect(formatRelativeNs(msAgoNs(2 * 24 * 60 * 60 * 1000))).toBe("2d ago");
+    expect(formatRelativeNs(msAgoNs(2 * MILLISECONDS_PER_DAY + 12 * MILLISECONDS_PER_HOUR))).toBe("2d ago");
   });
 });


### PR DESCRIPTION
## Summary

Fixes the intermittent `UI tests` failure in `ui/src/time.test.ts` ("formats minutes": `expected '4m ago' to be '5m ago'`) that has been bouncing CI on unrelated PRs (it flaked twice on #574).

## Root cause

The "formats minutes" case fed an offset sitting *exactly* on a bucket boundary (`5 * 60 * 1000` ms = 5.0 minutes). An epoch-ns timestamp is ~1.75e18, past `Number.MAX_SAFE_INTEGER`, so the `*1e6` then `/1e6` round-trip inside `formatRelativeNs` carries sub-nanosecond error that occasionally nudged the value a hair under the boundary, flooring `4.9999 → 4`. Measured at ~1-in-8 across epochs, which is why it failed CI intermittently while passing locally.

## Fix (test-only)

- Freeze the clock with `vi.useFakeTimers` + `setSystemTime` so the function's internal `Date.now()` and the test's `now` can't drift apart and the result never depends on the wall clock.
- Move every offset comfortably inside its bucket (5m30s, 3h30m, 2d12h) so round-trip precision can never flip the floor.
- Documented the boundary/precision pitfall in a comment so it isn't reintroduced.

`formatRelativeNs` itself is unchanged; real last-seen timestamps are never boundary-exact to the nanosecond, so the hazard only ever existed for the synthetic boundary-exact test input. Verified deterministic across repeated runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)