### PR TITLE
refactor(agent): platform-agnostic receiver.Loop logging + reuse drop coalescing

### DIFF
--- a/agent/cmd/fleet-edr-agent/main.go
+++ b/agent/cmd/fleet-edr-agent/main.go
@@ -559,8 +559,10 @@ func pruneLoop(ctx context.Context, q *queue.Queue, ledger *commandledger.Store,
 // receiverLoopParams configures startReceiverLoop. ctx is passed separately so the call sites read like a normal context-first
 // function; everything else is grouped here. dispatcher may be nil for non-ESF services that do not receive outbound pushes.
 type receiverLoopParams struct {
-	logger       *slog.Logger
-	xpcService   string
+	logger *slog.Logger
+	// serviceLabel scopes this loop's log lines (the "service" field) and, for the default macOS factory, is the XPC Mach service
+	// name passed to receiver.New. When connectorFactory is set (the Windows ETW sensor) it is only a log/heartbeat label.
+	serviceLabel string
 	enqueue      func(context.Context, []byte) error
 	pt           *proctable.Table
 	updateTable  bool
@@ -579,7 +581,7 @@ func startReceiverLoop(ctx context.Context, p receiverLoopParams) {
 	factory := p.connectorFactory
 	if factory == nil {
 		factory = func() receiver.Connector {
-			return receiver.New(p.xpcService, receiverEventBuffer)
+			return receiver.New(p.serviceLabel, receiverEventBuffer)
 		}
 	}
 	hooks := receiver.LoopHooks{
@@ -622,7 +624,7 @@ func startReceiverLoop(ctx context.Context, p receiverLoopParams) {
 	// pending-uninstall old version means "reboot required", not "needs approval" (#399).
 	hooks.UpgradeProbe = p.upgradeProbe
 	loop := receiver.NewLoop(factory, receiver.LoopConfig{
-		ServiceName:       p.xpcService,
+		ServiceName:       p.serviceLabel,
 		HeartbeatInterval: xpcHeartbeatInterval,
 		HeartbeatTimeout:  xpcHeartbeatPingTimeout,
 	}, hooks, p.logger)

--- a/agent/cmd/fleet-edr-agent/sensors_notwindows.go
+++ b/agent/cmd/fleet-edr-agent/sensors_notwindows.go
@@ -21,19 +21,19 @@ func startTelemetrySensors(ctx context.Context, d telemetryDeps) {
 	}
 
 	go startReceiverLoop(ctx, receiverLoopParams{
-		logger:      d.logger,
-		xpcService:  d.cfg.XPCService,
-		enqueue:     d.enqueue,
-		pt:          d.pidTable,
-		updateTable: true,
-		dispatcher:  d.esfDispatcher,
-		health:      d.health,
-		component:   health.ComponentEndpointSecurityExtension,
+		logger:       d.logger,
+		serviceLabel: d.cfg.XPCService,
+		enqueue:      d.enqueue,
+		pt:           d.pidTable,
+		updateTable:  true,
+		dispatcher:   d.esfDispatcher,
+		health:       d.health,
+		component:    health.ComponentEndpointSecurityExtension,
 	})
 	if d.cfg.NetXPCService != "" {
 		go startReceiverLoop(ctx, receiverLoopParams{
 			logger:       d.logger,
-			xpcService:   d.cfg.NetXPCService,
+			serviceLabel: d.cfg.NetXPCService,
 			enqueue:      d.enqueue,
 			pt:           d.pidTable,
 			upgradeProbe: func() bool { return receiver.NEUpgradePending(ctx) },

--- a/agent/cmd/fleet-edr-agent/sensors_windows.go
+++ b/agent/cmd/fleet-edr-agent/sensors_windows.go
@@ -21,13 +21,13 @@ const windowsSensorLabel = "windows-etw"
 func startTelemetrySensors(ctx context.Context, d telemetryDeps) {
 	d.health.Register(health.ComponentWindowsETWSensor, "Windows ETW sensor")
 	go startReceiverLoop(ctx, receiverLoopParams{
-		logger:      d.logger,
-		xpcService:  windowsSensorLabel,
-		enqueue:     d.enqueue,
-		pt:          d.pidTable,
-		updateTable: true,
-		health:      d.health,
-		component:   health.ComponentWindowsETWSensor,
+		logger:       d.logger,
+		serviceLabel: windowsSensorLabel,
+		enqueue:      d.enqueue,
+		pt:           d.pidTable,
+		updateTable:  true,
+		health:       d.health,
+		component:    health.ComponentWindowsETWSensor,
 		connectorFactory: func() receiver.Connector {
 			return wintel.New(d.hostID, receiverEventBuffer, d.logger)
 		},

--- a/agent/cmd/fleet-edr-agent/sensors_windows.go
+++ b/agent/cmd/fleet-edr-agent/sensors_windows.go
@@ -10,10 +10,6 @@ import (
 	"github.com/fleetdm/edr/agent/wintel"
 )
 
-// windowsSensorLabel is the receiver.Loop ServiceName for the ETW sensor: a log/heartbeat label, not an XPC service name (the Windows
-// sensor has no Mach service). Kept distinct so operator logs read "windows-etw" rather than an empty service.
-const windowsSensorLabel = "windows-etw"
-
 // startTelemetrySensors starts the Windows telemetry sensor: one ETW Kernel-Process consumer driven through the shared receiver.Loop
 // (reconnect/backoff/heartbeat + health). The loop's connectorFactory builds a fresh wintel.Sensor per connect, mirroring how the macOS
 // loops build a fresh XPC receiver. The health component is registered before the loop starts so the first status check-in already
@@ -21,8 +17,10 @@ const windowsSensorLabel = "windows-etw"
 func startTelemetrySensors(ctx context.Context, d telemetryDeps) {
 	d.health.Register(health.ComponentWindowsETWSensor, "Windows ETW sensor")
 	go startReceiverLoop(ctx, receiverLoopParams{
-		logger:       d.logger,
-		serviceLabel: windowsSensorLabel,
+		logger: d.logger,
+		// serviceLabel is only a log/heartbeat label on Windows (no Mach service); wintel.SensorLabel is the single source of truth so
+		// the loop's "service" matches the sensor's drop-warning "service".
+		serviceLabel: wintel.SensorLabel,
 		enqueue:      d.enqueue,
 		pt:           d.pidTable,
 		updateTable:  true,

--- a/agent/receiver/common.go
+++ b/agent/receiver/common.go
@@ -93,6 +93,11 @@ func (r *DropReporter) record() (int64, bool) {
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	// A zero-value DropReporter (built as &DropReporter{} rather than via NewDropReporter, now reachable since the type is exported)
+	// has a nil clock; default it here so record never nil-panics on the drop path.
+	if r.now == nil {
+		r.now = time.Now
+	}
 	r.pending++
 	now := r.now()
 	if r.lastEmit.IsZero() || now.Sub(r.lastEmit) >= dropWarnInterval {

--- a/agent/receiver/common.go
+++ b/agent/receiver/common.go
@@ -47,7 +47,7 @@ func SetLogger(l *slog.Logger) {
 }
 
 // getLogger returns the package-level logger or slog.Default if none has been installed. Lives in common.go (rather than the
-// darwin/cgo receiver.go) so non-darwin builds can use it AND so tryDeliverEvent below is reachable from tests without CGo.
+// darwin/cgo receiver.go) so non-darwin builds can use it AND so TryDeliverEvent below is reachable from tests without CGo.
 func getLogger() *slog.Logger {
 	if l := logger.Load(); l != nil {
 		return l
@@ -62,26 +62,29 @@ func getLogger() *slog.Logger {
 // warning per interval carrying the dropped-event count.
 const dropWarnInterval = 5 * time.Second
 
-// dropReporter coalesces a single receiver's "channel full" warnings so a burst of drops does not flood the log. Each Receiver
-// owns one reporter (one Mach service per receiver), which is why the state is a single counter rather than a per-service map and
-// why there is no package-level global: keeping it on the Receiver gives clean test isolation and avoids cross-receiver lock
-// contention on the drop path. It tracks the drops accumulated since the last emitted warning and when that warning fired.
-type dropReporter struct {
+// DropReporter coalesces a single event source's "channel full" warnings so a burst of drops does not flood the log. Each source
+// owns one reporter (the macOS receiver owns one per Mach service; the Windows ETW sensor owns one), which is why the state is a
+// single counter rather than a per-service map and why there is no package-level global: keeping it on the owner gives clean test
+// isolation and avoids cross-source lock contention on the drop path. It tracks the drops accumulated since the last emitted warning
+// and when that warning fired. It is exported so non-receiver event sources (e.g. agent/wintel's ETW sensor) reuse the same
+// coalescing rather than reimplementing per-drop logging.
+type DropReporter struct {
 	mu       sync.Mutex
 	pending  int64            // drops accumulated since the last emitted warning, not yet reflected in any log line
 	lastEmit time.Time        // when the last warning fired; zero until the first drop is reported
 	now      func() time.Time // seam for deterministic tests; defaults to time.Now
 }
 
-func newDropReporter() *dropReporter {
-	return &dropReporter{now: time.Now}
+// NewDropReporter returns a DropReporter using the wall clock. Each event source builds one.
+func NewDropReporter() *DropReporter {
+	return &DropReporter{now: time.Now}
 }
 
 // record registers one dropped event. It returns (count, true) when a warning should be emitted now, where count is the number
 // of drops the warning accounts for (this drop plus any suppressed since the last warning), or (0, false) when the drop is
 // suppressed. Suppressed drops stay in pending and are reported by the next warning that crosses the interval, so the only
 // undercount is a trailing partial window after drops stop entirely, at which point the condition has already been logged.
-func (r *dropReporter) record() (int64, bool) {
+func (r *DropReporter) record() (int64, bool) {
 	// Nil-receiver guard: a Receiver always builds its reporter in New, so production never passes nil, but a future refactor or
 	// partial init might. Degrade safely by surfacing every drop (count 1, emit) rather than panicking on the kernel-adjacent
 	// drop path or silently swallowing the loss. Calling a method on a nil pointer is legal in Go as long as we don't deref it.
@@ -101,14 +104,15 @@ func (r *dropReporter) record() (int64, bool) {
 	return 0, false
 }
 
-// tryDeliverEvent does a non-blocking send of evt onto ch. When ch's buffer is full it DROPS the event without blocking the
+// TryDeliverEvent does a non-blocking send of evt onto ch. When ch's buffer is full it DROPS the event without blocking the
 // caller and surfaces the loss via a rate-limited warning naming serviceName and the dropped-event count, throttled by dr. The
-// production CGo onEvent callback uses this so a slow downstream consumer cannot back-pressure into the XPC kernel side; tests
-// exercise it directly to pin the drop-and-warn contract without needing a live Mach service. The dropped-event arm is the
-// agent-xpc-receiver "downstream consumer falls behind" scenario: the receiver MUST keep reading subsequent events from the
-// connector, so the send is non-blocking and the loss is surfaced via a warning rather than a returned error. The warning is
-// coalesced per receiver (see dropReporter) so a sustained overflow does not flood the log.
-func tryDeliverEvent(ch chan<- Event, evt Event, serviceName string, dr *dropReporter) {
+// production CGo onEvent callback uses this so a slow downstream consumer cannot back-pressure into the XPC kernel side, and the
+// Windows ETW sensor (agent/wintel) uses it so its ProcessTrace callback shares the same non-blocking drop-and-coalesce behaviour;
+// tests exercise it directly to pin the drop-and-warn contract without needing a live event source. The dropped-event arm is the
+// agent-xpc-receiver "downstream consumer falls behind" scenario: the source MUST keep reading subsequent events, so the send is
+// non-blocking and the loss is surfaced via a warning rather than a returned error. The warning is coalesced per source (see
+// DropReporter) so a sustained overflow does not flood the log.
+func TryDeliverEvent(ch chan<- Event, evt Event, serviceName string, dr *DropReporter) {
 	select {
 	case ch <- evt:
 	default:

--- a/agent/receiver/common_test.go
+++ b/agent/receiver/common_test.go
@@ -14,7 +14,7 @@ import (
 // spec:agent-xpc-receiver/events-flow-into-the-queue-without-blocking-the-receiver/downstream-consumer-falls-behind
 //
 // Pins the receiver's drop-and-warn contract for a slow downstream consumer: when the events channel is full,
-// tryDeliverEvent MUST NOT block (so the XPC kernel callback returns promptly and the receiver continues reading
+// TryDeliverEvent MUST NOT block (so the XPC kernel callback returns promptly and the receiver continues reading
 // subsequent events), MUST drop the affected event, and MUST emit a warning identifying the affected service so
 // operators see the loss in SigNoz. The production CGo onEvent callback (receiver.go) delegates to this helper so
 // the test exercises exactly the production drop path without standing up a Mach service.
@@ -24,9 +24,9 @@ func TestTryDeliverEvent_DropsAndWarnsOnFullChannel(t *testing.T) { //nolint:par
 	t.Cleanup(func() { logger.Store(prev) })
 
 	// A fresh per-receiver reporter keeps this test isolated without touching any shared global.
-	dr := newDropReporter()
+	dr := NewDropReporter()
 
-	// Capture warn-level output to assert on the log line. A bytes.Buffer + mutex is enough since the test drives tryDeliverEvent
+	// Capture warn-level output to assert on the log line. A bytes.Buffer + mutex is enough since the test drives TryDeliverEvent
 	// synchronously from a single goroutine; the lock is defensive against a future test that runs the helper concurrently.
 	var (
 		mu  sync.Mutex
@@ -35,24 +35,24 @@ func TestTryDeliverEvent_DropsAndWarnsOnFullChannel(t *testing.T) { //nolint:par
 	lockedWriter := &mutexWriter{w: &buf, mu: &mu}
 	SetLogger(slog.New(slog.NewTextHandler(lockedWriter, &slog.HandlerOptions{Level: slog.LevelDebug})))
 
-	// Buffer of 1 so the second send fills the channel and the third tryDeliverEvent call hits the drop branch.
+	// Buffer of 1 so the second send fills the channel and the third TryDeliverEvent call hits the drop branch.
 	ch := make(chan Event, 1)
 	first := Event{Data: []byte("first")}
 	dropped := Event{Data: []byte("dropped")}
 
-	tryDeliverEvent(ch, first, "svc-xpc", dr)
+	TryDeliverEvent(ch, first, "svc-xpc", dr)
 	// Channel now full. The next call MUST drop without blocking. If the implementation regressed to a blocking send, the test
 	// would otherwise deadlock until go test's package-level timeout (default 10m). Use a tight time.After timeout so a regression
 	// fails the test in a second instead of hanging the suite.
 	done := make(chan struct{})
 	go func() {
-		tryDeliverEvent(ch, dropped, "svc-xpc", dr)
+		TryDeliverEvent(ch, dropped, "svc-xpc", dr)
 		close(done)
 	}()
 	select {
 	case <-done:
 	case <-time.After(time.Second):
-		t.Fatal("tryDeliverEvent did not return within 1s on a full channel; non-blocking contract regressed")
+		t.Fatal("TryDeliverEvent did not return within 1s on a full channel; non-blocking contract regressed")
 	}
 
 	// Surviving event in the channel is the first one; the dropped one was discarded.
@@ -71,12 +71,12 @@ func TestTryDeliverEvent_DropsAndWarnsOnFullChannel(t *testing.T) { //nolint:par
 
 	// The receiver continues reading: a fresh send (after the test drained `first`) succeeds.
 	next := Event{Data: []byte("next")}
-	tryDeliverEvent(ch, next, "svc-xpc", dr)
+	TryDeliverEvent(ch, next, "svc-xpc", dr)
 	got = <-ch
 	assert.Equal(t, "next", string(got.Data), "after a drop, the receiver MUST keep accepting subsequent events")
 }
 
-// Happy-path companion: when the channel has space, tryDeliverEvent delivers the event and emits no warning. Pins the "no spurious
+// Happy-path companion: when the channel has space, TryDeliverEvent delivers the event and emits no warning. Pins the "no spurious
 // log lines under steady-state load" half of the contract; a regression that logged on every successful delivery would surface here.
 func TestTryDeliverEvent_DeliversWhenChannelHasSpace(t *testing.T) { //nolint:paralleltest // swaps package-global logger; serial
 	prev := logger.Load()
@@ -88,10 +88,10 @@ func TestTryDeliverEvent_DeliversWhenChannelHasSpace(t *testing.T) { //nolint:pa
 	)
 	SetLogger(slog.New(slog.NewTextHandler(&mutexWriter{w: &buf, mu: &mu}, &slog.HandlerOptions{Level: slog.LevelDebug})))
 
-	dr := newDropReporter()
+	dr := NewDropReporter()
 	ch := make(chan Event, 4)
 	for _, b := range [][]byte{[]byte("a"), []byte("b"), []byte("c")} {
-		tryDeliverEvent(ch, Event{Data: b}, "svc-xpc", dr)
+		TryDeliverEvent(ch, Event{Data: b}, "svc-xpc", dr)
 	}
 	require.Len(t, ch, 3, "three sends MUST land when the channel has room")
 
@@ -106,11 +106,11 @@ func TestTryDeliverEvent_DeliversWhenChannelHasSpace(t *testing.T) { //nolint:pa
 // Pins the rate-limiting half of the drop-and-warn contract: a sustained overflow MUST NOT emit one warning per dropped event
 // (which floods the agent log when a slow consumer falls behind). The first drop after a quiet period warns immediately so the
 // onset is visible; further drops within dropWarnInterval are counted and folded into the next summary, which carries the
-// accumulated dropped-event count. Driven through dropReporter with a fake clock so the window boundary is deterministic.
+// accumulated dropped-event count. Driven through DropReporter with a fake clock so the window boundary is deterministic.
 func TestDropReporter_CoalescesSustainedDrops(t *testing.T) {
 	t.Parallel()
 	now := time.Unix(0, 0)
-	r := newDropReporter()
+	r := NewDropReporter()
 	r.now = func() time.Time { return now }
 
 	// First drop: emits immediately, accounting for exactly one event.
@@ -133,7 +133,7 @@ func TestDropReporter_CoalescesSustainedDrops(t *testing.T) {
 
 	// Each receiver owns its own reporter, so a second reporter's window is independent: its first drop warns even while r is
 	// mid-throttle. This is what gives the two receiver loops (system + network extension) independent drop accounting.
-	other := newDropReporter()
+	other := NewDropReporter()
 	other.now = func() time.Time { return now }
 	count, emit = other.record()
 	require.True(t, emit, "a separate reporter MUST warn on its own first drop, not share another receiver's throttle")
@@ -144,7 +144,7 @@ func TestDropReporter_CoalescesSustainedDrops(t *testing.T) {
 // refactor passing nil: record degrades to "surface every drop" (count 1, emit) rather than crashing the receiver callback.
 func TestDropReporter_NilReporterDoesNotPanic(t *testing.T) {
 	t.Parallel()
-	var r *dropReporter
+	var r *DropReporter
 	count, emit := r.record()
 	require.True(t, emit, "a nil reporter MUST surface the drop rather than swallow it")
 	assert.Equal(t, int64(1), count, "a nil reporter accounts for the single drop")

--- a/agent/receiver/common_test.go
+++ b/agent/receiver/common_test.go
@@ -35,7 +35,7 @@ func TestTryDeliverEvent_DropsAndWarnsOnFullChannel(t *testing.T) { //nolint:par
 	lockedWriter := &mutexWriter{w: &buf, mu: &mu}
 	SetLogger(slog.New(slog.NewTextHandler(lockedWriter, &slog.HandlerOptions{Level: slog.LevelDebug})))
 
-	// Buffer of 1 so the second send fills the channel and the third TryDeliverEvent call hits the drop branch.
+	// Buffer of 1 so the first send fills the channel and the second TryDeliverEvent call hits the drop branch.
 	ch := make(chan Event, 1)
 	first := Event{Data: []byte("first")}
 	dropped := Event{Data: []byte("dropped")}

--- a/agent/receiver/loop.go
+++ b/agent/receiver/loop.go
@@ -1,14 +1,16 @@
 // Package receiver: Loop owns the reconnect/backoff/heartbeat machinery that
-// drives a single XPC service's connection lifecycle. It depends on the
-// Connector interface (production: *Receiver, tests: a stub) so the loop
-// semantics (exponential backoff, post-success reset, heartbeat-driven
-// reconnect, clean shutdown) can be exercised without standing up a real
-// Mach service. The agent main wires one Loop per service (ESF + network
-// extension) plus a Dispatcher so outbound application_control pushes can
-// route to whichever connector is currently active.
+// drives a single connector's connection lifecycle. It depends on the
+// Connector interface (production on macOS: *Receiver over XPC; on Windows:
+// the agent/wintel ETW sensor; tests: a stub) so the loop semantics
+// (exponential backoff, post-success reset, heartbeat-driven reconnect, clean
+// shutdown) can be exercised without standing up a real event source. The
+// agent main wires one Loop per source (macOS ESF + network extension, or the
+// Windows ETW sensor) plus a Dispatcher so outbound application_control pushes
+// can route to whichever connector is currently active.
 //
-// This file is build-tag-free: the Loop talks to Connector, never to CGo,
-// so the same loop code runs on linux against the non-darwin stub.
+// This file is build-tag-free: the Loop talks to Connector, never to CGo, so
+// the same loop code runs on every platform (darwin XPC, the linux stub, and
+// the Windows ETW sensor).
 package receiver
 
 import (
@@ -37,9 +39,10 @@ const (
 	staleProbeAfterFailures = 3
 )
 
-// Connector represents a single XPC connection's lifecycle. Production code satisfies it with *Receiver; tests pass a deterministic
-// stub. The Loop constructs one fresh Connector per reconnect cycle via a ConnectorFactory, so a Connector's Connect / Disconnect
-// contract only needs to support one connect followed by one disconnect: re-use across cycles is not required.
+// Connector represents a single event source's connection lifecycle. Production code satisfies it with *Receiver (macOS XPC) or the
+// agent/wintel ETW sensor (Windows); tests pass a deterministic stub. The Loop constructs one fresh Connector per reconnect cycle via
+// a ConnectorFactory, so a Connector's Connect / Disconnect contract only needs to support one connect followed by one disconnect:
+// re-use across cycles is not required.
 type Connector interface {
 	Connect() error
 	Disconnect()
@@ -96,7 +99,7 @@ type LoopHooks struct {
 	UpgradeProbe func() bool
 }
 
-// Loop runs a single XPC service's connect/reconnect/event-pump cycle. Build one with NewLoop and call Run(ctx) in its own goroutine.
+// Loop runs a single connector's connect/reconnect/event-pump cycle. Build one with NewLoop and call Run(ctx) in its own goroutine.
 // Run blocks until ctx is cancelled.
 type Loop struct {
 	factory ConnectorFactory
@@ -247,11 +250,11 @@ func (l *Loop) pipeEvents(ctx context.Context, conn Connector) bool {
 		case <-heartbeatFailed:
 			// Heartbeat ping did not get a "hello-ack" within the timeout. The XPC channel is one-way dead even though no error
 			// event arrived. Reconnect to bind a fresh Mach port.
-			l.logger.WarnContext(ctx, "xpc heartbeat failed, reconnecting", "service", l.cfg.ServiceName)
+			l.logger.WarnContext(ctx, "connector heartbeat failed, reconnecting", "service", l.cfg.ServiceName)
 			return true
 		case evt, ok := <-eventsCh:
 			if !ok {
-				l.logger.WarnContext(ctx, "xpc events channel closed, reconnecting", "service", l.cfg.ServiceName)
+				l.logger.WarnContext(ctx, "connector events channel closed, reconnecting", "service", l.cfg.ServiceName)
 				return true
 			}
 			if l.hooks.OnEvent != nil {
@@ -259,13 +262,13 @@ func (l *Loop) pipeEvents(ctx context.Context, conn Connector) bool {
 			}
 		case errCode, ok := <-errorsCh:
 			if !ok {
-				l.logger.WarnContext(ctx, "xpc errors channel closed, reconnecting", "service", l.cfg.ServiceName)
+				l.logger.WarnContext(ctx, "connector errors channel closed, reconnecting", "service", l.cfg.ServiceName)
 				return true
 			}
-			// All XPC error codes force a reconnect today; the classification is for log fidelity so SigNoz operators can tell
+			// All connector error codes force a reconnect today; the classification is for log fidelity so SigNoz operators can tell
 			// expected transient codes apart from unexpected ones at a glance. service is included so concurrent ESF +
 			// network-extension loops produce distinguishable log lines.
-			l.logger.WarnContext(ctx, "xpc error",
+			l.logger.WarnContext(ctx, "connector error",
 				"service", l.cfg.ServiceName,
 				"code", errCode,
 				"expected", errCode == ErrorConnectionInvalid ||
@@ -290,7 +293,7 @@ func (l *Loop) runHeartbeat(ctx context.Context, conn Connector, done <-chan str
 			return
 		case <-ticker.C:
 			if err := conn.Ping(l.cfg.HeartbeatTimeout); err != nil {
-				l.logger.WarnContext(ctx, "xpc heartbeat ping failed", "service", l.cfg.ServiceName, "err", err)
+				l.logger.WarnContext(ctx, "connector heartbeat ping failed", "service", l.cfg.ServiceName, "err", err)
 				select {
 				case failed <- struct{}{}:
 				default:

--- a/agent/receiver/loop.go
+++ b/agent/receiver/loop.go
@@ -224,7 +224,7 @@ func (l *Loop) logConnectFailure(ctx context.Context, err error) {
 // pipeEvents reads from the connector's event + error channels and dispatches
 // to OnEvent until ctx is cancelled, the connector errors, or the heartbeat
 // detects a silently-dead channel. Returns true if the caller should
-// reconnect (XPC error or heartbeat failure), false if ctx was cancelled.
+// reconnect (connector error or heartbeat failure), false if ctx was cancelled.
 //
 // The heartbeat goroutine is the agent's positive liveness probe (issue #178)
 // for the case where macOS XPC silently routes an open connection to a stale
@@ -248,8 +248,8 @@ func (l *Loop) pipeEvents(ctx context.Context, conn Connector) bool {
 		case <-ctx.Done():
 			return false
 		case <-heartbeatFailed:
-			// Heartbeat ping did not get a "hello-ack" within the timeout. The XPC channel is one-way dead even though no error
-			// event arrived. Reconnect to bind a fresh Mach port.
+			// Heartbeat ping did not get an ack within the timeout: the connection is one-way dead even though no error event arrived
+			// (on macOS this is XPC silently routed to a stale Mach port). Reconnect to establish a fresh session.
 			l.logger.WarnContext(ctx, "connector heartbeat failed, reconnecting", "service", l.cfg.ServiceName)
 			return true
 		case evt, ok := <-eventsCh:

--- a/agent/receiver/receiver.go
+++ b/agent/receiver/receiver.go
@@ -191,7 +191,7 @@ func (r *Receiver) Disconnect() {
 	receiversMu.Unlock()
 }
 
-// onEvent is called from C (via callbacks.go) when an XPC event message arrives. The drop-on-full + warn behaviour lives in tryDeliverEvent (common.go); see TestTryDeliverEvent_DropsAndWarnsOnFullChannel for the agent-xpc-receiver "downstream consumer falls behind" contract.
+// onEvent is called from C (via callbacks.go) when an XPC event message arrives. The drop-on-full + warn behaviour lives in TryDeliverEvent (common.go); see TestTryDeliverEvent_DropsAndWarnsOnFullChannel for the agent-xpc-receiver "downstream consumer falls behind" contract.
 func onEvent(receiverID int, data unsafe.Pointer, length int) {
 	receiversMu.Lock()
 	recv := receivers[receiverID]

--- a/agent/receiver/receiver.go
+++ b/agent/receiver/receiver.go
@@ -35,7 +35,7 @@ type Receiver struct {
 	connected   bool
 	handle      int           // C bridge connection handle, -1 when not connected
 	receiverID  int           // ID used to route C callbacks to this receiver
-	drops       *dropReporter // coalesces "channel full" drop warnings for this receiver's service
+	drops       *DropReporter // coalesces "channel full" drop warnings for this receiver's service
 }
 
 // Registry of active receivers, keyed by receiverID.
@@ -59,7 +59,7 @@ func New(serviceName string, eventBuf int) *Receiver {
 		errors:      make(chan int, 8),
 		handle:      -1,
 		receiverID:  id,
-		drops:       newDropReporter(),
+		drops:       NewDropReporter(),
 	}
 }
 
@@ -202,7 +202,7 @@ func onEvent(receiverID int, data unsafe.Pointer, length int) {
 	}
 
 	buf := C.GoBytes(data, C.int(length))
-	tryDeliverEvent(recv.events, Event{Data: buf}, recv.serviceName, recv.drops)
+	TryDeliverEvent(recv.events, Event{Data: buf}, recv.serviceName, recv.drops)
 }
 
 // onError is called from C (via callbacks.go) when an XPC connection error occurs.

--- a/agent/wintel/sensor_windows.go
+++ b/agent/wintel/sensor_windows.go
@@ -27,6 +27,11 @@ const (
 	eventProcessStop            = 2
 )
 
+// SensorLabel is the log/heartbeat identity for the Windows ETW sensor. The agent uses it as the receiver.Loop ServiceName AND the
+// sensor stamps it as the drop-warning "service", so every Windows sensor log line (connect/heartbeat/error and dropped-event) shares
+// one value for correlation. It is deliberately distinct from sessionName, which is the OS ETW session object name, not a log label.
+const SensorLabel = "windows-etw"
+
 // ErrUnsupported is returned by SendApplicationControl: application-control enforcement is a privileged-tier (ELAM/PPL) capability the
 // driverless sensor does not provide yet (ADR-0018, Phase 3).
 var ErrUnsupported = errors.New("wintel: application control not supported on the driverless Windows sensor")
@@ -131,7 +136,7 @@ func (s *Sensor) handle(r etw.Record) {
 		s.logger.Warn("etw map event", "event_id", r.EventID(), "err", err)
 		return
 	}
-	receiver.TryDeliverEvent(s.events, receiver.Event{Data: data}, sessionName, s.drops)
+	receiver.TryDeliverEvent(s.events, receiver.Event{Data: data}, SensorLabel, s.drops)
 }
 
 func (s *Sensor) execFromRecord(r etw.Record) ([]byte, error) {

--- a/agent/wintel/sensor_windows.go
+++ b/agent/wintel/sensor_windows.go
@@ -39,6 +39,7 @@ type Sensor struct {
 	logger *slog.Logger
 	events chan receiver.Event
 	errs   chan int
+	drops  *receiver.DropReporter // coalesces "channel full" drop warnings so a burst does not flood the log
 
 	mu        sync.Mutex
 	session   *etw.Session
@@ -59,6 +60,7 @@ func New(hostID string, eventBuf int, logger *slog.Logger) *Sensor {
 		logger: logger,
 		events: make(chan receiver.Event, eventBuf),
 		errs:   make(chan int, 8),
+		drops:  receiver.NewDropReporter(),
 	}
 }
 
@@ -111,7 +113,9 @@ func (s *Sensor) Connect() error {
 }
 
 // handle maps a Kernel-Process event to an envelope and enqueues it. Runs on the ProcessTrace thread; it must not block, so a full
-// Events() buffer drops the event with a warning rather than stalling the trace (which would lose events kernel-side anyway).
+// Events() buffer drops the event rather than stalling the trace (which would lose events kernel-side anyway). The drop is delivered
+// through receiver.TryDeliverEvent so it shares the macOS receiver's non-blocking send + coalesced "channel full" warning instead of
+// logging one line per dropped event.
 func (s *Sensor) handle(r etw.Record) {
 	var data []byte
 	var err error
@@ -127,11 +131,7 @@ func (s *Sensor) handle(r etw.Record) {
 		s.logger.Warn("etw map event", "event_id", r.EventID(), "err", err)
 		return
 	}
-	select {
-	case s.events <- receiver.Event{Data: data}:
-	default:
-		s.logger.Warn("etw event dropped: buffer full")
-	}
+	receiver.TryDeliverEvent(s.events, receiver.Event{Data: data}, sessionName, s.drops)
 }
 
 func (s *Sensor) execFromRecord(r etw.Record) ([]byte, error) {


### PR DESCRIPTION
Follow-up polish on the Windows ETW sensor (#598), addressing two Copilot review notes deferred from that PR. Agent-only; no user-facing surface, no wire/API/persistence change.

## Issue 1: reuse the coalesced drop reporting (Copilot: `sensor_windows.go:134`)

The ETW sensor logged one warning per dropped event when its `Events()` buffer was full, which floods logs under bursty process creation. The macOS receiver already solved this with a per-source coalescer, but it was unexported.

- Export `receiver.DropReporter` / `NewDropReporter` / `TryDeliverEvent` (was the unexported drop-and-coalesce helper used only by the macOS receiver).
- The ETW sensor now delivers through `receiver.TryDeliverEvent`, so a burst collapses to one coalesced "channel full" warning per interval carrying the drop count, matching the macOS behavior and the existing `agent-xpc-receiver` drop-and-warn spec contract (reused, unchanged).

## Issue 2: platform-agnostic `receiver.Loop` logging (Copilot: `sensors_windows.go:30`)

`receiver.Loop` drives any `Connector` (macOS XPC receiver, Windows ETW sensor), but its reconnect/heartbeat/error logs said `"xpc ..."`, which reads as misleading on Windows.

- Reword loop logs `"xpc ..."` -> `"connector ..."` and update the doc comments that described the loop as XPC-only.
- Rename `receiverLoopParams.xpcService` -> `serviceLabel`: on the Windows path it is only a log/heartbeat label, not an XPC service name.

## Verification

- darwin: `go build ./agent/...`, `go test ./agent/...`, `golangci-lint` (0 issues)
- windows: `GOOS=windows` amd64 + arm64 build, `go vet`
- `task lint:dashes` clean

No openspec/CHANGELOG gate applies (agent-only paths; the drop-and-warn spec contract is unchanged; docs-sync only fires on UI/handler/router/catalog).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved service labeling across telemetry and receiver components for more consistent identification.

* **Bug Fixes**
  * Refined event delivery to keep non-blocking behavior while improving drop warnings and summaries.
  * Updated connection and heartbeat messaging to use clearer, platform-neutral wording.
  * Improved handling of dropped events on Windows and non-Windows paths, with better warning context and coalescing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->