### PR TITLE
test(e2e): demo smoke enters /ui/hosts after alert-first nav (#578)

### DIFF
--- a/test/e2e/tests/demo/demo-smoke.spec.ts
+++ b/test/e2e/tests/demo/demo-smoke.spec.ts
@@ -48,7 +48,9 @@ async function signInViaDex(page: Page): Promise<void> {
   await page.locator('input[name="password"]').fill(DEMO_PASSWORD);
   await page.getByRole("button", { name: /login/i }).click();
 
-  // The EDR exchanges the code, mints a session, and redirects to /ui/.
+  // The EDR exchanges the code, mints a session, and redirects into the app
+  // (post-#578 the landing route is /ui/alerts, not the host list); this only
+  // asserts we've left the login / break-glass pages.
   await page.waitForURL(
     (url) => url.host === "localhost:8088" && !url.pathname.includes("login") && !url.pathname.includes("break-glass"),
     { timeout: 30_000 },
@@ -78,6 +80,11 @@ test.describe("demo stack smoke", () => {
     if (STRICT_BUILD) {
       expect(supportsHostnameField, "the source build must expose hostnames on /api/hosts").toBe(true);
     }
+
+    // Alert-first navigation (#578) redirects "/" to /alerts and moved the host list
+    // to /hosts, so enter it explicitly before asserting the rows render (the qa
+    // host-list e2e does the same). The API checks above already ran on the session.
+    await page.goto("/ui/hosts");
 
     if (supportsHostnameField) {
       // API + UI: the hostnames are populated, match the seeded set, and render in


### PR DESCRIPTION
## What

The `source` leg of **Demo nightly** failed on 2026-07-03 ([run 28656577845](https://github.com/getvictor/fleet-edr/actions/runs/28656577845)). The seeder and API/UI probes passed; the Playwright smoke test timed out at `demo-smoke.spec.ts` waiting for `getByText('alex-mbp.local', { exact: true })`.

## Root cause

PR #578 (`5182a192`, alert-first navigation) changed `ui/src/App.tsx` so `/` redirects to the first permitted nav route (`/alerts` for anyone with `alert.read`) and moved the host list to `/hosts`. The demo smoke test signs in and asserts the seeded hostnames on whatever the post-login landing page renders, without navigating anywhere. It now lands on **Alerts**, which doesn't render the hostnames, so the assertion times out.

`/api/hosts` still returns the correct hostnames (the `toEqual` on line 87 passed), so this is purely a test-vs-routing mismatch, not a data or API regression. The `released` leg passed because `latest` (v0.3.0) predates the routing change, but it would break too once a release ships alert-first nav. #578 updated the qa host-list e2e to enter at `/ui/hosts` but missed this duplicated assertion in the demo smoke test.

## Fix

Navigate to `/ui/hosts` before the host-row assertions, mirroring the qa host-list e2e. Also refreshes the now-stale "redirects to /ui/" comment. The `/api/hosts` and `/api/alerts` checks are unchanged.

## Testing

- `tsc --noEmit` clean; Playwright discovers the test.
- Full `task test:e2e:demo` against the compose stack is exercised by the Demo nightly workflow itself (both legs).

No openspec delta: this realigns a test with behavior that already shipped in #578 and touches no sync-gated path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)