### PR TITLE
fix(demo-seed): raise verify timeout to 120s to de-flake dns_c2_beacon

### DIFF
--- a/server/cmd/fleet-edr-demo-seed/config.go
+++ b/server/cmd/fleet-edr-demo-seed/config.go
@@ -11,12 +11,16 @@ import (
 	"github.com/fleetdm/edr/internal/keyring"
 )
 
-// Default timing knobs. The ready window covers MySQL warmup + migrations on first boot; the verify window covers the processor
-// interval plus enroll/ingest round-trips. defaultHeadroom is the extra budget the overall run context allows beyond
-// ready+verify for the enroll/ingest round-trips themselves.
+// Default timing knobs. The ready window covers MySQL warmup + migrations on first boot. The verify window must cover the SLOWEST
+// rule's async materialisation: dns_c2_beacon is a cross-stream correlation (it joins a network_connect to a preceding dns_query and
+// resolves the process on a skew-tolerant retry), so it fires a processor cycle or two after ingest and under CI load occasionally
+// exceeded a 60s window (the 2026-07-04 demo-nightly flake: 5 detection alerts had fired but dns_c2_beacon had not). verify returns as
+// soon as the predicate holds, so the happy path is unaffected; the larger ceiling is only spent when a rule is genuinely slow or
+// never fires. defaultHeadroom is the extra budget the overall run context (ready+verify+headroom) allows for the enroll/ingest
+// round-trips themselves.
 const (
 	defaultReadyTimeout  = 90 * time.Second
-	defaultVerifyTimeout = 60 * time.Second
+	defaultVerifyTimeout = 120 * time.Second
 	defaultPollInterval  = 500 * time.Millisecond
 	defaultHeadroom      = 30 * time.Second
 )


### PR DESCRIPTION
## What

The `Demo nightly` **source** leg intermittently fails at the seeder's verify step:

```
verify demo data: condition not met within 1m0s
(processes=401 detection_alerts=5 app_control_alerts=1 missing_rules=[dns_c2_beacon])
```

The other four detection alerts and the app-control alert materialised, but the `dns_c2_beacon` alert had not fired inside the 60s window.

## Why it's a flake, not a regression

- `dns_c2_beacon` is a cross-stream correlation: it joins a `network_connect` to a preceding `dns_query` within a 30s window, with skew-tolerant process resolution that retries forward. So it surfaces a processor cycle or two after ingest and is the slowest rule to materialise.
- The rule file and the seeder's verify logic are **unchanged** in the range since the last green nightly; the only in-range detection commits are additive search endpoints (plus an index migration that plausibly adds a little ingest overhead on the source server, which is why only the source leg flaked).
- A **re-dispatch of the same commit passed cleanly** (seeder exited 0, e2e `1 passed`), confirming a timing flake.

## Fix

Double `defaultVerifyTimeout` (`server/cmd/fleet-edr-demo-seed/config.go`) from 60s to **120s** so the verify window comfortably covers the slowest rule. `verify` returns as soon as the predicate holds, so the happy path is unchanged; the extra ceiling is only spent when a rule is genuinely slow or never fires. The overall run context is `ready+verify+headroom`, so it scales with this bump. Worst-case seeder wall-clock is ~4 min, well under the 30-min job timeout.

Intentionally minimal: not bumping the released leg's timeout (it hasn't flaked, and 60s is baked into the v0.3.0 image; it inherits this default once `latest` advances), per the "no speculative edge cases" rule.

## Testing

- `go build ./server/cmd/fleet-edr-demo-seed/` + `go test ./server/cmd/fleet-edr-demo-seed/` green.
- Validated end-to-end by dispatching `demo-nightly` against this branch (see checks).

No openspec delta: demo/CI tooling timing knob, no observable product behavior change, outside the sync-gated paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)