### PR TITLE
chore(lint): resolve SonarCloud findings (fix 15, waive 5) [no-behavior-change] [no-docs-change]

### DIFF
--- a/agent/cmd/fleet-edr-agent/main.go
+++ b/agent/cmd/fleet-edr-agent/main.go
@@ -248,8 +248,15 @@ func run() error {
 	// streamConnected is the shared flag the control channel raises while its stream is up so the commander suspends polling. Per-replica
 	// ephemeral state, lost on restart; the commander reads it, the control client sets it.
 	var streamConnected atomic.Bool
-	startCommander(ctx, hostID, cfg.ServerURL, tokenProvider, esfDispatcher, agentTransport, &streamConnected, commandLedger, logger)
-	if err := startControlClient(ctx, cfg, hostID, tokenProvider, esfDispatcher, &streamConnected, commandLedger, logger); err != nil {
+	cmdDeps := commandDeps{
+		tokenProvider:    tokenProvider,
+		appControlSender: esfDispatcher,
+		streamConnected:  &streamConnected,
+		ledger:           commandLedger,
+		logger:           logger,
+	}
+	startCommander(ctx, hostID, cfg.ServerURL, agentTransport, cmdDeps)
+	if err := startControlClient(ctx, cfg, hostID, cmdDeps); err != nil {
 		// Cancel first so the goroutines started above (receiver loops, uploader, commander, coalescer) wind down before the
 		// deferred queue close runs; otherwise the LIFO defers would close the queue while those goroutines still write to it.
 		cancel()
@@ -376,40 +383,42 @@ func safePrefix(s string) string {
 	return s[:8]
 }
 
+// commandDeps bundles the plumbing both command transports share: the enrollment token source, the app-control sender the executor
+// drives, the stream-connected flag the poll path consults, the durable command ledger, and the logger. Grouped so the two start
+// functions stay under the positional-argument limit (SonarCloud go:S107).
+type commandDeps struct {
+	tokenProvider    enrollment.TokenProvider
+	appControlSender commander.ApplicationControlSender
+	streamConnected  *atomic.Bool
+	ledger           commander.Ledger
+	logger           *slog.Logger
+}
+
 // startCommander spins up the command-poll loop when we have a host_id. With no host_id the agent keeps running (events still upload)
 // but cannot receive commands, so commander launch is skipped and logged.
-func startCommander(
-	ctx context.Context,
-	hostID, serverURL string,
-	tokenProvider enrollment.TokenProvider,
-	appControlSender commander.ApplicationControlSender,
-	transport http.RoundTripper,
-	streamConnected *atomic.Bool,
-	ledger commander.Ledger,
-	logger *slog.Logger,
-) {
+func startCommander(ctx context.Context, hostID, serverURL string, transport http.RoundTripper, deps commandDeps) {
 	if hostID == "" {
-		logger.WarnContext(ctx, "no host_id available; commander disabled")
+		deps.logger.WarnContext(ctx, "no host_id available; commander disabled")
 		return
 	}
 	cmdr := commander.New(commander.Config{
 		ServerURL:                serverURL,
-		TokenFn:                  tokenProvider.Token,
-		OnAuthFail:               tokenProvider.OnUnauthorized,
+		TokenFn:                  deps.tokenProvider.Token,
+		OnAuthFail:               deps.tokenProvider.OnUnauthorized,
 		HostID:                   hostID,
 		Interval:                 commanderPollInterval,
-		ApplicationControlSender: appControlSender,
+		ApplicationControlSender: deps.appControlSender,
 		// Defer to the control channel while it is connected (the gateway pushes commands in real time); the poll is the fallback floor.
-		StreamConnected: streamConnected.Load,
+		StreamConnected: deps.streamConnected.Load,
 		// Shared durable dedup so the poll path does not re-execute a command the control client already ran (issue #558).
-		Ledger: ledger,
-	}, &http.Client{Transport: transport, Timeout: 10 * time.Second}, logger)
+		Ledger: deps.ledger,
+	}, &http.Client{Transport: transport, Timeout: 10 * time.Second}, deps.logger)
 	go func() {
 		if err := cmdr.Run(ctx); err != nil && ctx.Err() == nil {
-			logger.ErrorContext(ctx, "commander", "err", err)
+			deps.logger.ErrorContext(ctx, "commander", "err", err)
 		}
 	}()
-	logger.InfoContext(ctx, "commander polling", "host_id_prefix", safePrefix(hostID))
+	deps.logger.InfoContext(ctx, "commander polling", "host_id_prefix", safePrefix(hostID))
 }
 
 // startControlClient opens the persistent control-channel stream to the server. The endpoint is derived from EDR_SERVER_URL (issue
@@ -417,16 +426,8 @@ func startCommander(
 // over the same pinned TLS the agent uses for HTTP, presents the host token at connect, and signals streamConnected so the commander
 // suspends polling while the stream is up. If the stream can't connect or won't stay up, the commander's GET /api/commands short-poll
 // remains the floor; the control channel is an always-on enhancement, not a separately-enabled feature.
-func startControlClient(
-	ctx context.Context,
-	cfg *config.Config,
-	hostID string,
-	tokenProvider enrollment.TokenProvider,
-	appControlSender commander.ApplicationControlSender,
-	streamConnected *atomic.Bool,
-	ledger commander.Ledger,
-	logger *slog.Logger,
-) error {
+func startControlClient(ctx context.Context, cfg *config.Config, hostID string, deps commandDeps) error {
+	logger := deps.logger
 	if hostID == "" {
 		logger.WarnContext(ctx, "no host_id available; control channel disabled")
 		return nil
@@ -453,11 +454,11 @@ func startControlClient(
 	client := controlclient.New(controlclient.Config{
 		Client:                   control.NewControlChannelClient(conn),
 		HostID:                   hostID,
-		TokenFn:                  tokenProvider.Token,
-		OnAuthFail:               tokenProvider.OnUnauthorized,
-		ApplicationControlSender: appControlSender,
-		Ledger:                   ledger,
-		OnConnectedChange:        streamConnected.Store,
+		TokenFn:                  deps.tokenProvider.Token,
+		OnAuthFail:               deps.tokenProvider.OnUnauthorized,
+		ApplicationControlSender: deps.appControlSender,
+		Ledger:                   deps.ledger,
+		OnConnectedChange:        deps.streamConnected.Store,
 		Logger:                   logger,
 	})
 	go func() {

--- a/agent/controlclient/controlclient.go
+++ b/agent/controlclient/controlclient.go
@@ -120,38 +120,53 @@ func (c *Client) Run(ctx context.Context) error {
 // runStream opens one stream and pumps it until it ends. The bool reports whether the stream actually connected (so Run can reset the
 // backoff); the error is the disconnect cause.
 func (c *Client) runStream(ctx context.Context) (bool, error) {
-	sctx := ctx
-	if c.cfg.TokenFn != nil {
-		if token := c.cfg.TokenFn(); token != "" {
-			sctx = metadata.AppendToOutgoingContext(ctx, "authorization", "Bearer "+token)
-		}
-	}
-	stream, err := c.cfg.Client.Connect(sctx)
+	stream, err := c.cfg.Client.Connect(c.streamContext(ctx))
 	if err != nil {
-		// The server's auth interceptor can reject the stream during setup, not only on the first Recv; treat an
-		// Unauthenticated rejection here the same way so a revoked/expired token still drives re-enrollment.
-		if status.Code(err) == codes.Unauthenticated && c.cfg.OnAuthFail != nil {
-			c.cfg.OnAuthFail(ctx)
-		}
+		c.notifyAuthFailure(ctx, err)
 		return false, err
 	}
 	c.setConnected(true)
 	defer c.setConnected(false)
 	c.logger.InfoContext(ctx, "control channel connected", "host_id_present", c.cfg.HostID != "")
+	return true, c.pumpStream(ctx, stream)
+}
 
+// streamContext attaches the current host token as a bearer credential to ctx for the stream, or returns ctx unchanged when no token
+// source is configured or it yields an empty token.
+func (c *Client) streamContext(ctx context.Context) context.Context {
+	if c.cfg.TokenFn == nil {
+		return ctx
+	}
+	token := c.cfg.TokenFn()
+	if token == "" {
+		return ctx
+	}
+	return metadata.AppendToOutgoingContext(ctx, "authorization", "Bearer "+token)
+}
+
+// notifyAuthFailure invokes the auth-failure callback when err is a gRPC Unauthenticated rejection. The server's auth interceptor can
+// reject the stream during setup, not only on the first Recv, so both the Connect error and a later Recv error route through here to
+// keep a revoked or expired token driving re-enrollment.
+func (c *Client) notifyAuthFailure(ctx context.Context, err error) {
+	if status.Code(err) == codes.Unauthenticated && c.cfg.OnAuthFail != nil {
+		c.cfg.OnAuthFail(ctx)
+	}
+}
+
+// pumpStream reads frames until the stream ends, dispatching each pushed command. It returns the disconnect cause; by the time it runs
+// the stream has already connected, so the caller reports connected=true regardless of how it ends.
+func (c *Client) pumpStream(ctx context.Context, stream control.ControlChannel_ConnectClient) error {
 	for {
 		frame, err := stream.Recv()
 		if err != nil {
-			if status.Code(err) == codes.Unauthenticated && c.cfg.OnAuthFail != nil {
-				c.cfg.OnAuthFail(ctx)
-			}
-			return true, err
+			c.notifyAuthFailure(ctx, err)
+			return err
 		}
 		if cmd := frame.GetCommand(); cmd != nil {
 			if err := c.handleCommand(ctx, stream, cmd); err != nil {
 				// A send failure means the stream is one-way broken (we can still Recv but can no longer report outcomes). Tear it
 				// down and reconnect rather than sit "connected" while silently dropping every outcome.
-				return true, err
+				return err
 			}
 		}
 	}

--- a/server/detection/bootstrap/bootstrap.go
+++ b/server/detection/bootstrap/bootstrap.go
@@ -163,73 +163,9 @@ func New(deps Deps) (*Detection, error) {
 	}
 
 	if deps.Mode == ModeFull {
-		det.engine = engine.New(store, logger)
-		if deps.Metrics != nil {
-			det.engine.SetMetrics(deps.Metrics)
+		if err := det.wireFullMode(deps, store, intakeH, logger); err != nil {
+			return nil, err
 		}
-		query := graph.NewQuery(store)
-		det.svc = service.New(store, query, intakeH, deps.EventLog, deps.UserExists, logger)
-		if deps.AuthZ == nil {
-			return nil, errors.New("detection bootstrap: AuthZ is required in ModeFull")
-		}
-		det.operatorH = operator.New(det.svc, deps.AuthZ, logger)
-		det.operatorH.SetAudit(deps.Audit)
-		// The webhook admin surface reads/writes destinations through the store. Wiring it always (independent of the sealer) keeps
-		// list/get/delete working; a create/update that needs to seal a secret returns a configured-error when no root secret is set.
-		det.operatorH.SetWebhookAdmin(store)
-		// The per-host agent-health detail (GET /api/hosts/{host_id}/health) reads the endpoint context's host_health table through the
-		// same store; wire it alongside the webhook admin surface (issue #359).
-		det.operatorH.SetHostHealth(store)
-		det.operatorH.SetHostDetail(store)
-		det.operatorH.SetActivityHistogram(store)
-		det.operatorH.SetProcessSearch(store)
-		det.operatorH.SetEventSearch(store)
-		det.operatorH.SetHostTimeline(store)
-
-		processor := pipeline.NewProcessor(
-			deps.EventLog,
-			graph.NewBuilder(store, logger),
-			det.engine,
-			logger,
-			deps.ProcessInterval,
-			deps.ProcessBatch,
-			deps.ProcessConcurrency,
-		)
-		processTTL := pipeline.NewProcessTTL(store, pipeline.ProcessTTLOptions{
-			MaxAge:   deps.StaleProcessTTL,
-			Interval: deps.StaleProcessInterval,
-			Logger:   logger,
-		})
-		retention := pipeline.NewRetention(deps.DB, pipeline.RetentionOptions{
-			RetentionDays: deps.RetentionDays,
-			Interval:      deps.RetentionInterval,
-			Logger:        logger,
-		})
-		queuePrune := pipeline.NewQueuePrune(deps.EventLog, pipeline.QueuePruneOptions{
-			Interval: deps.QueuePruneInterval,
-			Logger:   logger,
-		})
-
-		// Outbound webhook (issue #496): wire the sealer into the store and build the delivery worker (both only when a root secret
-		// is configured; see configureWebhookDelivery).
-		webhookDelivery, webhookTester, webhookErr := configureWebhookDelivery(store, deps, logger)
-		if webhookErr != nil {
-			return nil, webhookErr
-		}
-		// Guard the typed-nil: only install the tester when one was built, so the handler's nil check stays honest.
-		if webhookTester != nil {
-			det.operatorH.SetWebhookTester(webhookTester)
-		}
-
-		det.pipe = pipeline.NewRunner(pipeline.RunnerOptions{
-			Processor:       processor,
-			ProcessTTL:      processTTL,
-			Retention:       retention,
-			QueuePrune:      queuePrune,
-			WebhookDelivery: webhookDelivery,
-			DB:              deps.DB,
-			Coordinator:     deps.Coordinator,
-		})
 	} else {
 		// Intake-only: still expose a service with the intake handler
 		// so RegisterIngestRoutes works.
@@ -237,6 +173,80 @@ func New(deps Deps) (*Detection, error) {
 	}
 
 	return det, nil
+}
+
+// wireFullMode wires the ModeFull-only components (correlation engine, operator API surface, and background pipeline runner) onto the
+// Detection handle. Factored out of New to keep New's cognitive complexity in bounds (SonarCloud go:S3776), mirroring
+// configureWebhookDelivery.
+func (d *Detection) wireFullMode(deps Deps, store *mysql.Store, intakeH *intake.Handler, logger *slog.Logger) error {
+	d.engine = engine.New(store, logger)
+	if deps.Metrics != nil {
+		d.engine.SetMetrics(deps.Metrics)
+	}
+	query := graph.NewQuery(store)
+	d.svc = service.New(store, query, intakeH, deps.EventLog, deps.UserExists, logger)
+	if deps.AuthZ == nil {
+		return errors.New("detection bootstrap: AuthZ is required in ModeFull")
+	}
+	d.operatorH = operator.New(d.svc, deps.AuthZ, logger)
+	d.operatorH.SetAudit(deps.Audit)
+	// The webhook admin surface reads/writes destinations through the store. Wiring it always (independent of the sealer) keeps
+	// list/get/delete working; a create/update that needs to seal a secret returns a configured-error when no root secret is set.
+	d.operatorH.SetWebhookAdmin(store)
+	// The per-host agent-health detail (GET /api/hosts/{host_id}/health) reads the endpoint context's host_health table through the
+	// same store; wire it alongside the webhook admin surface (issue #359).
+	d.operatorH.SetHostHealth(store)
+	d.operatorH.SetHostDetail(store)
+	d.operatorH.SetActivityHistogram(store)
+	d.operatorH.SetProcessSearch(store)
+	d.operatorH.SetEventSearch(store)
+	d.operatorH.SetHostTimeline(store)
+
+	processor := pipeline.NewProcessor(
+		deps.EventLog,
+		graph.NewBuilder(store, logger),
+		d.engine,
+		logger,
+		deps.ProcessInterval,
+		deps.ProcessBatch,
+		deps.ProcessConcurrency,
+	)
+	processTTL := pipeline.NewProcessTTL(store, pipeline.ProcessTTLOptions{
+		MaxAge:   deps.StaleProcessTTL,
+		Interval: deps.StaleProcessInterval,
+		Logger:   logger,
+	})
+	retention := pipeline.NewRetention(deps.DB, pipeline.RetentionOptions{
+		RetentionDays: deps.RetentionDays,
+		Interval:      deps.RetentionInterval,
+		Logger:        logger,
+	})
+	queuePrune := pipeline.NewQueuePrune(deps.EventLog, pipeline.QueuePruneOptions{
+		Interval: deps.QueuePruneInterval,
+		Logger:   logger,
+	})
+
+	// Outbound webhook (issue #496): wire the sealer into the store and build the delivery worker (both only when a root secret
+	// is configured; see configureWebhookDelivery).
+	webhookDelivery, webhookTester, webhookErr := configureWebhookDelivery(store, deps, logger)
+	if webhookErr != nil {
+		return webhookErr
+	}
+	// Guard the typed-nil: only install the tester when one was built, so the handler's nil check stays honest.
+	if webhookTester != nil {
+		d.operatorH.SetWebhookTester(webhookTester)
+	}
+
+	d.pipe = pipeline.NewRunner(pipeline.RunnerOptions{
+		Processor:       processor,
+		ProcessTTL:      processTTL,
+		Retention:       retention,
+		QueuePrune:      queuePrune,
+		WebhookDelivery: webhookDelivery,
+		DB:              deps.DB,
+		Coordinator:     deps.Coordinator,
+	})
+	return nil
 }
 
 // ApplySchema runs the CREATE TABLE statements detection owns. Idempotent.

--- a/server/detection/internal/graph/batch.go
+++ b/server/detection/internal/graph/batch.go
@@ -19,7 +19,7 @@ type processStore interface {
 	EventAlreadyApplied(ctx context.Context, hostID string, pid int, eventID string) (bool, error)
 	InsertProcess(ctx context.Context, p api.Process) (int64, error)
 	UpdateProcessExec(ctx context.Context, u mysql.ProcessExecUpdate) error
-	UpdateProcessExit(ctx context.Context, hostID string, pid int, exitTimeNs, exitIngestedAtNs int64, exitCode int, reason, exitEventID string) (int64, error)
+	UpdateProcessExit(ctx context.Context, u mysql.ProcessExitUpdate) (int64, error)
 	CloseStaleProcess(ctx context.Context, hostID string, pid int, closedAtNs int64) error
 	ReExec(ctx context.Context, priorID int64, exitTimeNs, exitIngestedAtNs int64, newRow api.Process) (newID int64, reLinked bool, err error)
 	UpdateLastSeenForSnapshot(ctx context.Context, hostID string, pid int, lastSeenNs int64) error
@@ -219,25 +219,24 @@ func (s *batchSession) UpdateProcessExec(_ context.Context, u mysql.ProcessExecU
 	return nil
 }
 
-func (s *batchSession) UpdateProcessExit(_ context.Context, hostID string, pid int,
-	exitTimeNs, exitIngestedAtNs int64, exitCode int, reason, exitEventID string,
-) (int64, error) {
+func (s *batchSession) UpdateProcessExit(_ context.Context, u mysql.ProcessExitUpdate) (int64, error) {
+	reason := u.Reason
 	if reason == "" {
 		reason = api.ExitReasonEvent // mirrors the store's normalisation
 	}
-	r := s.mostRecentLiveForkedAtOrBefore(hostID, pid, exitTimeNs)
+	r := s.mostRecentLiveForkedAtOrBefore(u.HostID, u.PID, u.ExitTimeNs)
 	if r == nil {
 		return 0, nil
 	}
-	et := exitTimeNs
+	et := u.ExitTimeNs
 	r.proc.ExitTimeNs = &et
-	ei := exitIngestedAtNs
+	ei := u.ExitIngestedAtNs
 	r.proc.ExitIngestedAtNs = &ei
 	rs := reason
 	r.proc.ExitReason = &rs
-	ec := exitCode
+	ec := u.ExitCode
 	r.proc.ExitCode = &ec
-	eid := exitEventID
+	eid := u.ExitEventID
 	r.proc.ExitEventID = &eid
 	markDirty(r)
 	return 1, nil

--- a/server/detection/internal/graph/builder.go
+++ b/server/detection/internal/graph/builder.go
@@ -487,7 +487,15 @@ func (b *Builder) handleExit(ctx context.Context, w processStore, evt api.Event)
 		reason = api.ExitReasonHostReconciled
 	}
 
-	affected, err := w.UpdateProcessExit(ctx, evt.HostID, p.PID, evt.TimestampNs, evt.IngestedAtNs, p.ExitCode, reason, evt.EventID)
+	affected, err := w.UpdateProcessExit(ctx, mysql.ProcessExitUpdate{
+		HostID:           evt.HostID,
+		PID:              p.PID,
+		ExitTimeNs:       evt.TimestampNs,
+		ExitIngestedAtNs: evt.IngestedAtNs,
+		ExitCode:         p.ExitCode,
+		Reason:           reason,
+		ExitEventID:      evt.EventID,
+	})
 	if err != nil {
 		return err
 	}

--- a/server/detection/internal/mysql/idempotency_columns_test.go
+++ b/server/detection/internal/mysql/idempotency_columns_test.go
@@ -27,7 +27,9 @@ func TestStore_EventAlreadyApplied(t *testing.T) {
 		SourceEventID: new("fork-1"), ExecEventID: new("exec-1"),
 	})
 	require.NoError(t, err)
-	affected, err := s.UpdateProcessExit(ctx, "h", 10, 200, 201, 0, api.ExitReasonEvent, "exit-1")
+	affected, err := s.UpdateProcessExit(ctx, mysql.ProcessExitUpdate{
+		HostID: "h", PID: 10, ExitTimeNs: 200, ExitIngestedAtNs: 201, ExitCode: 0, Reason: api.ExitReasonEvent, ExitEventID: "exit-1",
+	})
 	require.NoError(t, err)
 	require.Equal(t, int64(1), affected)
 
@@ -57,12 +59,16 @@ func TestStore_UpdateProcessExit_ForkTimeBound(t *testing.T) {
 	_, err := s.InsertProcess(ctx, api.Process{HostID: "h", PID: 20, ForkTimeNs: 200})
 	require.NoError(t, err)
 
-	affected, err := s.UpdateProcessExit(ctx, "h", 20, 100, 101, 0, api.ExitReasonEvent, "exit-stale")
+	affected, err := s.UpdateProcessExit(ctx, mysql.ProcessExitUpdate{
+		HostID: "h", PID: 20, ExitTimeNs: 100, ExitIngestedAtNs: 101, ExitCode: 0, Reason: api.ExitReasonEvent, ExitEventID: "exit-stale",
+	})
 	require.NoError(t, err)
 	assert.Equal(t, int64(0), affected, "an exit before the row's fork must not close it")
 
 	// An exit after the fork closes it and stamps exit_event_id.
-	affected, err = s.UpdateProcessExit(ctx, "h", 20, 300, 301, 7, api.ExitReasonEvent, "exit-real")
+	affected, err = s.UpdateProcessExit(ctx, mysql.ProcessExitUpdate{
+		HostID: "h", PID: 20, ExitTimeNs: 300, ExitIngestedAtNs: 301, ExitCode: 7, Reason: api.ExitReasonEvent, ExitEventID: "exit-real",
+	})
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), affected)
 

--- a/server/detection/internal/mysql/processes.go
+++ b/server/detection/internal/mysql/processes.go
@@ -177,14 +177,25 @@ func (s *Store) UpdateProcessExec(ctx context.Context, u ProcessExecUpdate) erro
 	return err
 }
 
-// UpdateProcessExit sets the exit timestamp, code, and reason for a running process. exitIngestedAtNs is the server-stamped ingest
+// ProcessExitUpdate carries the exit metadata stamped onto a running process row. Grouped as a struct so callers don't pass an
+// 8-parameter positional list (SonarCloud go:S107).
+type ProcessExitUpdate struct {
+	HostID           string
+	PID              int
+	ExitTimeNs       int64
+	ExitIngestedAtNs int64
+	ExitCode         int
+	Reason           string
+	ExitEventID      string
+}
+
+// UpdateProcessExit sets the exit timestamp, code, and reason for a running process. ExitIngestedAtNs is the server-stamped ingest
 // time of the originating exit event and anchors the upper bound of correlation queries against a server-controlled clock (issue #7).
-// reason distinguishes kernel-observed exits (ExitReasonEvent: the default) from agent-side reconciled ones (ExitReasonHostReconciled:
+// Reason distinguishes kernel-observed exits (ExitReasonEvent: the default) from agent-side reconciled ones (ExitReasonHostReconciled:
 // issue #6 client half) so the UI can render the latter with a "reconciled" badge instead of pretending it was a clean observed exit.
 // An empty reason normalises to ExitReasonEvent.
-func (s *Store) UpdateProcessExit(ctx context.Context, hostID string, pid int,
-	exitTimeNs, exitIngestedAtNs int64, exitCode int, reason, exitEventID string,
-) (int64, error) {
+func (s *Store) UpdateProcessExit(ctx context.Context, u ProcessExitUpdate) (int64, error) {
+	reason := u.Reason
 	if reason == "" {
 		reason = api.ExitReasonEvent
 	}
@@ -196,7 +207,7 @@ func (s *Store) UpdateProcessExit(ctx context.Context, hostID string, pid int,
 		                    exit_reason = ?, exit_code = ?, exit_event_id = ?
 		WHERE host_id = ? AND pid = ? AND exit_time_ns IS NULL AND fork_time_ns <= ?
 		ORDER BY fork_time_ns DESC, id DESC LIMIT 1`,
-		exitTimeNs, exitIngestedAtNs, reason, exitCode, exitEventID, hostID, pid, exitTimeNs,
+		u.ExitTimeNs, u.ExitIngestedAtNs, reason, u.ExitCode, u.ExitEventID, u.HostID, u.PID, u.ExitTimeNs,
 	)
 	if err != nil {
 		return 0, err

--- a/server/detection/internal/mysql/search.go
+++ b/server/detection/internal/mysql/search.go
@@ -136,21 +136,25 @@ var (
 // developer-id, then the platform flag, then a signing-id-only residual is signed. The classes are mutually exclusive by
 // construction, so the server filter partitions rows the same way the UI labels a node. The unsigned class additionally requires an
 // exec, since a fork-only row has no signature to judge (matching the UI's fork-only suppression).
+// csHasBlock is the shared prefix of every signer-class predicate that requires a present code-signing block; extracted so the literal
+// is defined once (SonarCloud go:S1192).
+const csHasBlock = "(code_signing IS NOT NULL AND "
+
 func signingClassSQL(class string) (string, bool) {
 	switch class {
 	case "unsigned":
 		return "(exec_time_ns IS NOT NULL AND (code_signing IS NULL OR (" +
 			csValidNoTeam + " AND NOT (" + csPlatform + ") AND " + csSID + " = '')))", true
 	case "invalid":
-		return "(code_signing IS NOT NULL AND NOT " + csValid + ")", true
+		return csHasBlock + "NOT " + csValid + ")", true
 	case "ad-hoc":
-		return "(code_signing IS NOT NULL AND " + csValid + " AND " + csAdhoc + ")", true
+		return csHasBlock + csValid + " AND " + csAdhoc + ")", true
 	case "developer-id":
-		return "(code_signing IS NOT NULL AND " + csValid + " AND NOT " + csAdhoc + " AND " + csTeam + " <> '')", true
+		return csHasBlock + csValid + " AND NOT " + csAdhoc + " AND " + csTeam + " <> '')", true
 	case "platform":
-		return "(code_signing IS NOT NULL AND " + csValidNoTeam + " AND (" + csPlatform + "))", true
+		return csHasBlock + csValidNoTeam + " AND (" + csPlatform + "))", true
 	case "signed":
-		return "(code_signing IS NOT NULL AND " + csValidNoTeam + " AND NOT (" + csPlatform + ") AND " + csSID + " <> '')", true
+		return csHasBlock + csValidNoTeam + " AND NOT (" + csPlatform + ") AND " + csSID + " <> '')", true
 	default:
 		return "", false
 	}

--- a/server/visibility/internal/tests/eventlog_integration_test.go
+++ b/server/visibility/internal/tests/eventlog_integration_test.go
@@ -312,45 +312,56 @@ func TestEventLog_ConcurrentClaimersNoDeadlock(t *testing.T) {
 	require.NoError(t, log.Append(ctx, seed))
 
 	const workers = 8
-	const batch = 50
-	var (
-		mu        sync.Mutex
-		claimed   = make(map[string]int) // event_id -> times claimed; must end at exactly 1 each
-		claimErrs atomic.Int64
-		ackErrs   atomic.Int64
-	)
-	var wg sync.WaitGroup
-	wg.Add(workers)
+	run := &claimRun{log: log, batch: 50, claimed: make(map[string]int)}
+	run.wg.Add(workers)
 	for range workers {
-		go func() {
-			defer wg.Done()
-			for {
-				batchEvents, err := log.Claim(ctx, batch)
-				if err != nil {
-					claimErrs.Add(1)
-					return
-				}
-				if len(batchEvents) == 0 {
-					return // no claimable rows left: every event has already been claimed by some worker
-				}
-				mu.Lock()
-				for _, e := range batchEvents {
-					claimed[e.EventID]++
-				}
-				mu.Unlock()
-				if err := log.Ack(ctx, ids(batchEvents)); err != nil {
-					ackErrs.Add(1)
-				}
-			}
-		}()
+		go run.drain(ctx)
 	}
-	wg.Wait()
+	run.wg.Wait()
 
-	require.Zero(t, claimErrs.Load(), "concurrent claimers must not surface a deadlock error (#544)")
-	require.Zero(t, ackErrs.Load(), "acks must not error under concurrency")
-	require.Len(t, claimed, totalEvents, "every seeded event is claimed exactly once")
-	for id, n := range claimed {
+	require.Zero(t, run.claimErrs.Load(), "concurrent claimers must not surface a deadlock error (#544)")
+	require.Zero(t, run.ackErrs.Load(), "acks must not error under concurrency")
+	require.Len(t, run.claimed, totalEvents, "every seeded event is claimed exactly once")
+	for id, n := range run.claimed {
 		assert.Equalf(t, 1, n, "event %s must be claimed by exactly one worker (no double-claim)", id)
+	}
+}
+
+// claimRun holds the state the concurrent claimers share: claimed counts how many times each event_id was handed out (must end at
+// exactly 1), and the atomics tally any claim/ack error. Bundling it lets drain be a low-complexity method rather than a deeply nested
+// inline goroutine closure (SonarCloud go:S3776).
+type claimRun struct {
+	log       visibilityapi.EventLog
+	batch     int
+	wg        sync.WaitGroup
+	mu        sync.Mutex
+	claimed   map[string]int
+	claimErrs atomic.Int64
+	ackErrs   atomic.Int64
+}
+
+// drain claims and acks batches until an empty claim shows the queue is drained, recording every claimed event and any error. One
+// worker observes an empty claim only once no claimable (processed = 0 or lease-expired) rows remain, so returning on empty drains
+// the whole queue without a spin.
+func (r *claimRun) drain(ctx context.Context) {
+	defer r.wg.Done()
+	for {
+		batchEvents, err := r.log.Claim(ctx, r.batch)
+		if err != nil {
+			r.claimErrs.Add(1)
+			return
+		}
+		if len(batchEvents) == 0 {
+			return // no claimable rows left: every event has already been claimed by some worker
+		}
+		r.mu.Lock()
+		for _, e := range batchEvents {
+			r.claimed[e.EventID]++
+		}
+		r.mu.Unlock()
+		if err := r.log.Ack(ctx, ids(batchEvents)); err != nil {
+			r.ackErrs.Add(1)
+		}
 	}
 }
 

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -372,7 +372,8 @@ export async function searchProcesses(filter: ProcessSearchFilter, cursor?: stri
   set("to", filter.to);
   set("cursor", cursor);
   const qs = query.toString();
-  const res = await fetchJSON<ProcessSearchResult>(`/search/processes${qs ? `?${qs}` : ""}`);
+  const suffix = qs ? `?${qs}` : "";
+  const res = await fetchJSON<ProcessSearchResult>(`/search/processes${suffix}`);
   // A zero-match page marshals a nil Go slice as JSON null; normalize to [] so list consumers never read .length of null. The
   // disable is required because the response type models rows as non-null, which the wire does not guarantee for an empty page.
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Go marshals a nil slice as JSON null (a non-nil empty slice would be [])

--- a/ui/src/cmdline.ts
+++ b/ui/src/cmdline.ts
@@ -8,6 +8,6 @@ export function formatCommandLine(args: string[] | undefined, path: string): str
 
 function quoteArg(arg: string): string {
   if (arg === "") return '""';
-  if (/[\s"]/.test(arg)) return `"${arg.split('"').join('\\"')}"`;
+  if (/[\s"]/.test(arg)) return `"${arg.split('"').join(String.raw`\"`)}"`;
   return arg;
 }

--- a/ui/src/components/ProcessTree.test.tsx
+++ b/ui/src/components/ProcessTree.test.tsx
@@ -287,7 +287,7 @@ describe("ProcessTreeView conviction evidence", () => {
   it("applies the evidence class to unsigned and ad-hoc nodes only", async () => {
     const { container } = renderTree("");
     await waitFor(() => {
-      expect(container.querySelectorAll("g.node").length).toBe(3);
+      expect(container.querySelectorAll("g.node")).toHaveLength(3);
     });
     const marked = [...container.querySelectorAll("g.node--evidence")].map(
       (g) => g.querySelector(".node__label")?.textContent ?? "",
@@ -301,7 +301,7 @@ describe("ProcessTreeView conviction evidence", () => {
   it("shows the evidence tooltip on hover and clears it on leave", async () => {
     const { container } = renderTree("");
     await waitFor(() => {
-      expect(container.querySelectorAll("g.node--evidence").length).toBe(2);
+      expect(container.querySelectorAll("g.node--evidence")).toHaveLength(2);
     });
     const unsignedNode = [...container.querySelectorAll("g.node--evidence")].find((g) =>
       (g.querySelector(".node__label")?.textContent ?? "").includes("dropper"),

--- a/ui/src/components/Search/SearchPage.tsx
+++ b/ui/src/components/Search/SearchPage.tsx
@@ -32,7 +32,8 @@ export function SearchPage() {
     if (key !== "process") next.set("mode", key);
     if (hostId) next.set("host_id", hostId);
     const qs = next.toString();
-    return `/search${qs ? `?${qs}` : ""}`;
+    const suffix = qs ? `?${qs}` : "";
+    return `/search${suffix}`;
   };
 
   return (

--- a/ui/src/components/Webhooks/Webhooks.tsx
+++ b/ui/src/components/Webhooks/Webhooks.tsx
@@ -227,7 +227,7 @@ export function Webhooks() {
           data-1p-ignore=""
           data-lpignore="true"
           data-form-type="other"
-          placeholder={form.editingId !== null ? "•••••• enter a new value to rotate" : "enter the signing secret"}
+          placeholder={form.editingId === null ? "enter the signing secret" : "•••••• enter a new value to rotate"}
           value={form.secret}
           onChange={(e) => { update("secret", e.target.value); }}
         />
@@ -297,9 +297,9 @@ export function Webhooks() {
                       Delete
                     </Button>
                     {testResult !== null && testResult.id === d.id && (
-                      <span className={testResult.ok ? "webhooks__test-ok" : "webhooks__test-err"} role="status">
+                      <output className={testResult.ok ? "webhooks__test-ok" : "webhooks__test-err"}>
                         {testResult.message}
-                      </span>
+                      </output>
                     )}
                   </td>
                 </tr>


### PR DESCRIPTION
Resolves the 20 open SonarCloud issues on `main`: 15 fixed in code here, 5 waived directly on SonarCloud with justification.

All changes are behavior-preserving refactors / lint fixes, so this carries `[no-behavior-change]`. None of the paths touch the OpenSpec-gated `server/rules/internal/catalog/`, `schema/events.json`, or `server/detection/migrations/`.

## Fixed in code (15)
- **go:S107 ×4** — `UpdateProcessExit` folds its 8 positional args into a `mysql.ProcessExitUpdate` struct (interface + both impls + caller + tests, mirroring the existing `ProcessExecUpdate`); agent `startCommander` / `startControlClient` bundle shared plumbing into a `commandDeps` struct.
- **go:S3776 ×3** — `bootstrap.New` extracts the `ModeFull` wiring into `wireFullMode` (mirrors the existing `configureWebhookDelivery` extraction); `controlclient.runStream` extracts `streamContext` / `notifyAuthFailure` / `pumpStream`; the eventlog concurrency test moves its worker into a `claimRun.drain` method.
- **go:S1192** — extract the shared `"(code_signing IS NOT NULL AND "` prefix into `csHasBlock` in `search.go`.
- **typescript ×7** — hoist the query-suffix out of the nested template literal (`api.ts`, `SearchPage.tsx`); `String.raw` for the escaped quote (`cmdline.ts`); `toHaveLength` instead of `.length` + `toBe` (`ProcessTree.test.tsx` ×2); `<output>` instead of `role="status"` and an un-negated placeholder ternary (`Webhooks.tsx`).

## Waived on SonarCloud (justification)
- **go:S1313** `ssrf.go` — the `100.64.0.0/10` CIDR is a deliberate SSRF guard (RFC 6598). Accepted.
- **godre:S8242** `gateway.go` — `wrappedStream` is the canonical `grpc.ServerStream` wrapper; `Context()` is interface-mandated and cannot be a parameter. Accepted.
- **css:S7924** `SSOSettings.scss`, `AccountMenu.scss` — false positive: Sonar reads the `rgba(…,0.15/0.2)` background as opaque. Composited over the white card the real contrast is ~5.4:1 / ~5.5:1, both clearing WCAG AA.
- **typescript:S7763** `timewindow.ts` — `DEFAULT_LIVE_WINDOW_MS` is a semantic default that happens to equal one hour, not a pure re-export. Accepted.

## Verification
- `go build ./...`, `go vet -tags integration`, `gofmt`, custom `golangci-lint` → clean.
- Go tests pass: `mysql`, `graph`, `bootstrap`, `controlclient`, and the `eventlog` integration test.
- UI: `tsc --noEmit`, `eslint`, 117 vitest tests → pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)