### PR TITLE
chore(rules): retire per-rule config-knob surface (openspec: remove-per-rule-config-knobs)

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1214,30 +1214,6 @@ components:
           items:
             type: string
           description: Coverage gaps the rule does NOT catch.
-        config:
-          type: array
-          items:
-            $ref: "#/components/schemas/RuleConfig"
-          description: Operator tuning knobs (env vars). Empty for non-configurable rules.
-
-    RuleConfig:
-      type: object
-      required: [env_var, type, default, description]
-      properties:
-        env_var:
-          type: string
-          example: EDR_LAUNCHAGENT_ALLOWLIST
-        type:
-          type: string
-          description: Value-shape hint (e.g. `csv-paths`, `csv-team-ids`, `duration`).
-          example: csv-paths
-        default:
-          type: string
-          description: Literal default value when the env var is unset. Empty string means "feature off until configured".
-          example: ""
-        description:
-          type: string
-          example: "Comma-separated absolute plist paths the rule should silently accept."
 
     DetectionExclusion:
       type: object

--- a/openspec/changes/remove-per-rule-config-knobs/proposal.md
+++ b/openspec/changes/remove-per-rule-config-knobs/proposal.md
@@ -11,7 +11,7 @@ This change retires the per-rule config-knob capability. It is a documented SHAL
 - **BREAKING (API surface, in practice inert):** `GET /api/rules` no longer includes `doc.config`, and the OpenAPI `RuleConfig` schema is removed. Because no rule has populated `config` since #459, the field was already never present on the wire, so no client observes a change.
 - Remove the `config` clause from the per-rule documentation requirement, keeping `false_positives` and `limitations`.
 - Remove the "Rule with config knobs" scenario (`server-admin-surface`) and the config-knob rendering from the web-ui rule-detail requirement.
-- Remove the backing code: `rules/api` `RuleType.Config` field and the `ConfigKnob` type; the `gen-rule-docs` Configuration renderer; the UI `RuleConfig` type, `RuleDoc.config`, and the rule-detail Configuration table. Scrub the `RuleConfig` schema from BOTH OpenAPI copies (`docs/api/openapi.yaml` and the `go:embed`ed `server/apidocs/embed/openapi.yaml` served at `/api/docs`).
+- Remove the backing code: `rules/api` `Documentation.Config` field and the `ConfigKnob` type; the `gen-rule-docs` Configuration renderer; the UI `RuleConfig` type, `RuleDoc.config`, and the rule-detail Configuration table. Scrub the `RuleConfig` schema from BOTH OpenAPI copies (`docs/api/openapi.yaml` and the `go:embed`ed `server/apidocs/embed/openapi.yaml` served at `/api/docs`).
 
 Out of scope: the DB-backed detection-config surface (#459) that replaced this is unchanged; rule false-positive/limitation documentation is unchanged.
 

--- a/openspec/changes/remove-per-rule-config-knobs/proposal.md
+++ b/openspec/changes/remove-per-rule-config-knobs/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+The per-rule documentation surface (`GET /api/rules` -> the admin rule-detail page) advertises optional operator-tunable env-var knobs: each rule could declare a `config` array of `ConfigKnob`s (`env_var`, `type`, `default`, `description`), which the API exposed as `doc.config`, the OpenAPI documented as `RuleConfig`, `gen-rule-docs` rendered as a "Configuration" table in `detection-rules.md`, and the UI rendered as a "Configuration" table on the rule-detail page.
+
+That model predates #459, which moved all rule tuning off per-rule boot-time env vars and onto the DB-backed detection-config surface (`server/rules/internal/detectionconfig/`: exclusions + rule-mode), managed at runtime through the admin UI. Since #459, no catalog rule declares a config knob, so `doc.config` is always absent: the API field never serializes (`omitempty`), the OpenAPI schema documents a shape the server never emits, the generator's Configuration section never renders, and the UI table never appears. The capability is vestigial dead surface that misleads API consumers (the OpenAPI advertises operator env-var tuning that no longer exists) and future contributors.
+
+This change retires the per-rule config-knob capability. It is a documented SHALL scenario (`server-admin-surface` "Rule with config knobs"; `web-ui` config-knob rendering), so the removal is expressed as an OpenSpec delta rather than a silent code deletion. False-positive sources and limitations (still populated by rules) are unaffected.
+
+## What Changes
+
+- **BREAKING (API surface, in practice inert):** `GET /api/rules` no longer includes `doc.config`, and the OpenAPI `RuleConfig` schema is removed. Because no rule has populated `config` since #459, the field was already never present on the wire, so no client observes a change.
+- Remove the `config` clause from the per-rule documentation requirement, keeping `false_positives` and `limitations`.
+- Remove the "Rule with config knobs" scenario (`server-admin-surface`) and the config-knob rendering from the web-ui rule-detail requirement.
+- Remove the backing code: `rules/api` `RuleType.Config` field and the `ConfigKnob` type; the `gen-rule-docs` Configuration renderer; the UI `RuleConfig` type, `RuleDoc.config`, and the rule-detail Configuration table. Scrub the `RuleConfig` schema from BOTH OpenAPI copies (`docs/api/openapi.yaml` and the `go:embed`ed `server/apidocs/embed/openapi.yaml` served at `/api/docs`).
+
+Out of scope: the DB-backed detection-config surface (#459) that replaced this is unchanged; rule false-positive/limitation documentation is unchanged.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `server-admin-surface`: the per-rule documentation endpoint no longer exposes `doc.config`; the "Rule with config knobs" scenario is removed. The catalog-read and false-positive/limitation exposure are unchanged.
+- `web-ui`: the rule-detail page no longer renders a configuration-knobs section; title/summary/severity/techniques/event-types/description and the false-positive/limitation sections are unchanged.
+
+## Impact
+
+- Wire: `doc.config` and the OpenAPI `RuleConfig` schema removed. No observable change (field was never populated post-#459).
+- Code: `server/rules/api`, `tools/gen-rule-docs`, `ui/src` (api types + RuleDetail), both OpenAPI copies, and the `rule-with-config-knobs` test + spectrace marker.

--- a/openspec/changes/remove-per-rule-config-knobs/specs/server-admin-surface/spec.md
+++ b/openspec/changes/remove-per-rule-config-knobs/specs/server-admin-surface/spec.md
@@ -1,0 +1,16 @@
+# server-admin-surface (delta: retire per-rule config knobs)
+
+## MODIFIED Requirements
+
+### Requirement: Per-rule documentation endpoint
+
+The system SHALL expose `GET /api/rules` returning the per-rule documentation surface the admin UI's rule-detail page relies on. The response MUST include, for every registered rule, the rule's `id`, the list of ATT&CK `techniques` it covers, and a `doc` object carrying at least `title`, `summary`, `description`, `severity`, and `event_types`. When a rule declares false-positive sources or limitations, those MUST be exposed under `false_positives` and `limitations` respectively.
+
+The "Rule with config knobs" scenario is dropped: per-rule config knobs (`doc.config`) are retired (rule tuning moved to the DB-backed detection-config surface in #459), so the endpoint no longer exposes a `config` array.
+
+#### Scenario: Operator reads the rule catalog
+
+- **GIVEN** a server with one or more rules registered
+- **WHEN** the operator requests `GET /api/rules`
+- **THEN** the server returns `200 OK` with a `rules` array
+- **AND** each entry carries `id`, `techniques`, and a non-empty `doc` block with `title`, `summary`, `description`, `severity`, and `event_types`

--- a/openspec/changes/remove-per-rule-config-knobs/specs/web-ui/spec.md
+++ b/openspec/changes/remove-per-rule-config-knobs/specs/web-ui/spec.md
@@ -1,0 +1,20 @@
+# web-ui (delta: retire per-rule config knobs)
+
+## MODIFIED Requirements
+
+### Requirement: Per-rule documentation page
+
+The UI SHALL provide a rule documentation page reachable by rule id from the coverage page and from the alert breadcrumb. The page MUST render the rule's title, summary, severity, ATT&CK technique mapping, event types, description, false-positive sources when present, and limitations when present. An unknown rule id MUST land on an empty state pointing back to the coverage page rather than producing a hard error.
+
+#### Scenario: Rule detail renders documented fields
+
+- **GIVEN** a registered rule with documentation
+- **WHEN** the operator navigates to that rule's detail page
+- **THEN** the UI renders the rule's title, summary, severity, ATT&CK techniques, event types, and description
+- **AND** when the rule declares false positives or limitations, those sections render
+
+#### Scenario: Unknown rule id renders a navigable empty state
+
+- **GIVEN** a rule id that the server does not know about
+- **WHEN** the operator navigates to that rule's detail page
+- **THEN** the UI renders an empty state that links back to the ATT&CK coverage page

--- a/openspec/changes/remove-per-rule-config-knobs/tasks.md
+++ b/openspec/changes/remove-per-rule-config-knobs/tasks.md
@@ -1,0 +1,24 @@
+## 1. Server API + generator
+
+- [ ] 1.1 `server/rules/api/types.go`: remove `RuleType.Config` field and the `ConfigKnob` type.
+- [ ] 1.2 `tools/gen-rule-docs/main.go`: remove the `writeRuleConfig` call and function.
+- [ ] 1.3 `tools/gen-rule-docs/main_test.go`: remove `TestRenderConfigKnobsListed`.
+- [ ] 1.4 `server/rules/internal/catalog/registry_test.go`: remove the config-knob assertion loop and the `spec:server-admin-surface/per-rule-documentation-endpoint/rule-with-config-knobs` marker (the scenario is removed by this change's delta).
+
+## 2. OpenAPI (both copies)
+
+- [ ] 2.1 `docs/api/openapi.yaml`: remove the `config` property from the rule `doc` schema and the `RuleConfig` schema.
+- [ ] 2.2 `server/apidocs/embed/openapi.yaml`: same removal (this is the `go:embed`ed spec served at `/api/docs`).
+
+## 3. UI
+
+- [ ] 3.1 `ui/src/api.ts`: remove the `RuleConfig` interface and `RuleDoc.config`.
+- [ ] 3.2 `ui/src/components/RuleDetail.tsx`: remove the Configuration table.
+- [ ] 3.3 `ui/src/components/RuleDetail.test.tsx`: remove the config-knob fixture and the "renders the config table" test.
+
+## 4. Verify
+
+- [ ] 4.1 `go build ./...`, `go vet`; `go test` for `server/rules/...`, `tools/gen-rule-docs/...`, `server/metrics/...`.
+- [ ] 4.2 UI: `eslint`, `tsc --noEmit`, `vitest run src/components/RuleDetail.test.tsx`.
+- [ ] 4.3 `openspec validate --all --strict` passes; spectrace passes (the removed scenario is exempt via this delta).
+- [ ] 4.4 Regenerate `docs/detection-rules.md` if needed (no change expected: no rule declared a knob).

--- a/openspec/changes/remove-per-rule-config-knobs/tasks.md
+++ b/openspec/changes/remove-per-rule-config-knobs/tasks.md
@@ -1,24 +1,24 @@
 ## 1. Server API + generator
 
-- [ ] 1.1 `server/rules/api/types.go`: remove `RuleType.Config` field and the `ConfigKnob` type.
-- [ ] 1.2 `tools/gen-rule-docs/main.go`: remove the `writeRuleConfig` call and function.
-- [ ] 1.3 `tools/gen-rule-docs/main_test.go`: remove `TestRenderConfigKnobsListed`.
-- [ ] 1.4 `server/rules/internal/catalog/registry_test.go`: remove the config-knob assertion loop and the `spec:server-admin-surface/per-rule-documentation-endpoint/rule-with-config-knobs` marker (the scenario is removed by this change's delta).
+- [x] 1.1 `server/rules/api/types.go`: remove the `Documentation.Config` field and the `ConfigKnob` type.
+- [x] 1.2 `tools/gen-rule-docs/main.go`: remove the `writeRuleConfig` call and function.
+- [x] 1.3 `tools/gen-rule-docs/main_test.go`: remove `TestRenderConfigKnobsListed`.
+- [x] 1.4 `server/rules/internal/catalog/registry_test.go`: remove the config-knob assertion loop. Retain the `spec:server-admin-surface/per-rule-documentation-endpoint/rule-with-config-knobs` marker transitionally (with an explanatory note), because a MODIFIED delta does not exempt a dropped scenario pre-archive; delete the marker at release archive when the canonical scenario is removed.
 
 ## 2. OpenAPI (both copies)
 
-- [ ] 2.1 `docs/api/openapi.yaml`: remove the `config` property from the rule `doc` schema and the `RuleConfig` schema.
-- [ ] 2.2 `server/apidocs/embed/openapi.yaml`: same removal (this is the `go:embed`ed spec served at `/api/docs`).
+- [x] 2.1 `docs/api/openapi.yaml`: remove the `config` property from the rule `doc` schema and the `RuleConfig` schema.
+- [x] 2.2 `server/apidocs/embed/openapi.yaml`: same removal (this is the `go:embed`ed spec served at `/api/docs`).
 
 ## 3. UI
 
-- [ ] 3.1 `ui/src/api.ts`: remove the `RuleConfig` interface and `RuleDoc.config`.
-- [ ] 3.2 `ui/src/components/RuleDetail.tsx`: remove the Configuration table.
-- [ ] 3.3 `ui/src/components/RuleDetail.test.tsx`: remove the config-knob fixture and the "renders the config table" test.
+- [x] 3.1 `ui/src/api.ts`: remove the `RuleConfig` interface and `RuleDoc.config`.
+- [x] 3.2 `ui/src/components/RuleDetail.tsx`: remove the Configuration table (and scrub the header comment).
+- [x] 3.3 `ui/src/components/RuleDetail.test.tsx`: remove the config-knob fixture and the "renders the config table" test.
 
 ## 4. Verify
 
-- [ ] 4.1 `go build ./...`, `go vet`; `go test` for `server/rules/...`, `tools/gen-rule-docs/...`, `server/metrics/...`.
-- [ ] 4.2 UI: `eslint`, `tsc --noEmit`, `vitest run src/components/RuleDetail.test.tsx`.
-- [ ] 4.3 `openspec validate --all --strict` passes; spectrace passes (the removed scenario is exempt via this delta).
-- [ ] 4.4 Regenerate `docs/detection-rules.md` if needed (no change expected: no rule declared a knob).
+- [x] 4.1 `go build ./...`, `go vet`; `go test` for `server/rules/...`, `tools/gen-rule-docs/...`, `server/metrics/...`.
+- [x] 4.2 UI: `eslint`, `tsc --noEmit`, `vitest run src/components/RuleDetail.test.tsx`.
+- [x] 4.3 `openspec validate --all --strict` passes; `spectrace --strict` passes (the dropped scenario's marker is retained transitionally rather than exempt, since exemption applies only to whole `## REMOVED` requirements).
+- [x] 4.4 Regenerate `docs/detection-rules.md` if needed (no change: no rule declared a knob, so the generator never emitted a Configuration section).

--- a/server/apidocs/embed/openapi.yaml
+++ b/server/apidocs/embed/openapi.yaml
@@ -1178,30 +1178,6 @@ components:
           items:
             type: string
           description: Coverage gaps the rule does NOT catch.
-        config:
-          type: array
-          items:
-            $ref: "#/components/schemas/RuleConfig"
-          description: Operator tuning knobs (env vars). Empty for non-configurable rules.
-
-    RuleConfig:
-      type: object
-      required: [env_var, type, default, description]
-      properties:
-        env_var:
-          type: string
-          example: EDR_LAUNCHAGENT_ALLOWLIST
-        type:
-          type: string
-          description: Value-shape hint (e.g. `csv-paths`, `csv-team-ids`, `duration`).
-          example: csv-paths
-        default:
-          type: string
-          description: Literal default value when the env var is unset. Empty string means "feature off until configured".
-          example: ""
-        description:
-          type: string
-          example: "Comma-separated absolute plist paths the rule should silently accept."
 
     DetectionExclusion:
       type: object

--- a/server/rules/api/types.go
+++ b/server/rules/api/types.go
@@ -146,24 +146,6 @@ type Documentation struct {
 	// Limitations names known coverage gaps so an operator knows what the rule does NOT catch (atomic renames, env-inherited DYLD vars,
 	// etc.).
 	Limitations []string `json:"limitations,omitempty"`
-	// Config enumerates the env var knobs the rule honours. Empty for
-	// rules without configuration (e.g. credential_keychain_dump).
-	Config []ConfigKnob `json:"config,omitempty"`
-}
-
-// ConfigKnob describes one operator-facing tuning env var.
-type ConfigKnob struct {
-	// EnvVar is the canonical name (e.g. EDR_LAUNCHAGENT_ALLOWLIST).
-	EnvVar string `json:"env_var"`
-	// Type tells the operator what value-shape the env var expects: "csv-paths" for absolute filesystem paths, "csv-team-ids" for Apple
-	// team-ID strings, "duration" for time.ParseDuration values, etc.
-	Type string `json:"type"`
-	// Default is the literal value the rule uses when the env var is
-	// unset. Empty string means "feature off until configured".
-	Default string `json:"default"`
-	// Description is one-sentence guidance for what the operator is
-	// buying by setting this knob.
-	Description string `json:"description"`
 }
 
 // --- Application Control types -----------------------------------------------

--- a/server/rules/internal/catalog/registry_test.go
+++ b/server/rules/internal/catalog/registry_test.go
@@ -58,12 +58,11 @@ func TestAll_DeclareValidPlatforms(t *testing.T) {
 
 // spec:server-admin-surface/per-rule-documentation-endpoint/rule-with-config-knobs
 //
-// For every shipped rule that declares operator-tunable config knobs, the doc.Config entries MUST each
-// carry env_var, type, default, and description. ConfigKnob.Default (server/rules/api/types.go) can
-// legitimately be the empty string for "feature off until configured", so the loop below asserts only
-// that env_var, type, and description are non-empty plus that the Default field is reachable. A regression
-// that removed the Default field from the JSON shape would break compilation here rather than landing as
-// silent contract drift in the operator UI.
+// TRANSITIONAL marker. The "Rule with config knobs" scenario is retired by the in-flight change
+// `remove-per-rule-config-knobs` (a MODIFIED delta that drops it). spectrace exempts only whole `## REMOVED`
+// requirements, not a scenario dropped from a kept requirement, so this marker is retained until the release
+// archive removes the canonical scenario, at which point this comment is deleted. No config-knob assertion
+// remains because the `Documentation.Config` surface was removed by the same change.
 //
 // TestAll_DocStructIsPopulated walks every shipped rule's Doc() and locks in the operator-facing invariants. Drives coverage of each
 // rule's Doc() body from the rules package itself so SonarCloud's Go coverage profile attributes the lines correctly (cross-package
@@ -88,15 +87,6 @@ func TestAll_DocStructIsPopulated(t *testing.T) {
 				"%s declares severity %q; expected one of the SeverityLow|Medium|High|Critical constants",
 				r.ID(), d.Severity)
 			assert.NotEmpty(t, d.EventTypes, "EventTypes must list at least one type for %s", r.ID())
-			for _, c := range d.Config {
-				assert.NotEmpty(t, c.EnvVar, "%s config knob missing EnvVar", r.ID())
-				assert.NotEmpty(t, c.Type, "%s config knob %s missing Type", r.ID(), c.EnvVar)
-				assert.NotEmpty(t, c.Description, "%s config knob %s missing Description", r.ID(), c.EnvVar)
-				// Default is allowed to be the empty string (feature off until configured); the field
-				// must exist on the struct so the JSON shape advertises the knob's default to operators.
-				// _ = is a compile-time reference, not a runtime assertion.
-				_ = c.Default
-			}
 		})
 	}
 }

--- a/tools/gen-rule-docs/main.go
+++ b/tools/gen-rule-docs/main.go
@@ -93,7 +93,6 @@ func writeRule(b *strings.Builder, r rulesapi.RuleMetadata) {
 	writeRuleHeading(b, r.ID, r.Doc)
 	writeRuleMeta(b, r.ID, r.Doc, r.Techniques)
 	writeRuleDescription(b, r.Doc)
-	writeRuleConfig(b, r.Doc.Config)
 	writeRuleBulletSection(b, "Known false-positive sources", r.Doc.FalsePositives)
 	writeRuleBulletSection(b, "Limitations", r.Doc.Limitations)
 }
@@ -126,23 +125,6 @@ func writeRuleDescription(b *strings.Builder, d rulesapi.Documentation) {
 	b.WriteString("### Description\n\n")
 	b.WriteString(d.Description)
 	b.WriteString("\n\n")
-}
-
-func writeRuleConfig(b *strings.Builder, knobs []rulesapi.ConfigKnob) {
-	if len(knobs) == 0 {
-		return
-	}
-	b.WriteString("### Configuration\n\n")
-	b.WriteString("| Env var | Type | Default | Description |\n")
-	b.WriteString("| --- | --- | --- | --- |\n")
-	for _, c := range knobs {
-		def := "_(unset)_"
-		if c.Default != "" {
-			def = "`" + c.Default + "`"
-		}
-		fmt.Fprintf(b, "| `%s` | `%s` | %s | %s |\n", c.EnvVar, c.Type, def, mdCell(c.Description))
-	}
-	b.WriteString("\n")
 }
 
 func writeRuleBulletSection(b *strings.Builder, heading string, items []string) {

--- a/tools/gen-rule-docs/main_test.go
+++ b/tools/gen-rule-docs/main_test.go
@@ -69,36 +69,3 @@ func TestRenderTechniqueLinks(t *testing.T) {
 	// Top-level technique: no slash translation needed.
 	assert.Contains(t, out, "https://attack.mitre.org/techniques/T1059/")
 }
-
-// TestRenderConfigKnobsListed confirms that a rule with config knobs surfaces their env var, type, and description in the per-rule
-// Configuration table. The shipped catalog currently declares no env-var knobs (per-host tuning moved to the durable detection-config
-// exclusion surface, issue #459), so this drives the renderer with a synthetic rule that does, pinning writeRuleConfig's output shape
-// independent of whether any live rule happens to carry a knob.
-func TestRenderConfigKnobsListed(t *testing.T) {
-	t.Parallel()
-	synthetic := []rulesapi.RuleMetadata{{
-		ID:         "synthetic_configurable_rule",
-		Techniques: []string{"T1059"},
-		Doc: rulesapi.Documentation{
-			Title:       "Synthetic configurable rule",
-			Summary:     "fixture",
-			Description: "fixture",
-			Severity:    rulesapi.SeverityHigh,
-			EventTypes:  []string{"exec"},
-			Config: []rulesapi.ConfigKnob{{
-				EnvVar:      "EDR_SYNTHETIC_ALLOWLIST",
-				Type:        "csv-paths",
-				Default:     "",
-				Description: "Absolute paths exempt from the synthetic rule.",
-			}},
-		},
-	}}
-	var buf bytes.Buffer
-	require.NoError(t, render(&buf, synthetic))
-	out := buf.String()
-
-	assert.Contains(t, out, "### Configuration", "a rule with config knobs must render a Configuration section")
-	assert.Contains(t, out, "`EDR_SYNTHETIC_ALLOWLIST`", "config knob env var must appear in the table")
-	assert.Contains(t, out, "`csv-paths`", "config knob type must appear in the table")
-	assert.Contains(t, out, "Absolute paths exempt from the synthetic rule.", "config knob description must appear in the table")
-}

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -505,15 +505,6 @@ export async function fetchAttackNavigatorLayer(): Promise<AttackNavigatorLayer>
   return fetchJSON<AttackNavigatorLayer>("/attack-coverage");
 }
 
-// RuleConfig describes one operator-tuning env var. Wire shape matches
-// admin.RuleConfig in the server.
-export interface RuleConfig {
-  env_var: string;
-  type: string;
-  default: string;
-  description: string;
-}
-
 // RuleDoc is the structured per-rule documentation surfaced by GET
 // /api/rules. Mirrors detection.Documentation on the server, with
 // the JSON tag spellings the wire format uses.
@@ -525,7 +516,6 @@ export interface RuleDoc {
   event_types: string[];
   false_positives?: string[];
   limitations?: string[];
-  config?: RuleConfig[];
 }
 
 export interface RuleDocEntry {

--- a/ui/src/components/RuleDetail.test.tsx
+++ b/ui/src/components/RuleDetail.test.tsx
@@ -23,10 +23,6 @@ function makeEntry(over: Partial<RuleDocEntry> = {}): RuleDocEntry {
       event_types: ["exec"],
       false_positives: ["build scripts"],
       limitations: ["macOS only"],
-      config: [
-        { env_var: "EDR_FOO", type: "bool", default: "", description: "toggle foo" },
-        { env_var: "EDR_BAR", type: "int", default: "5", description: "bar threshold" },
-      ],
     },
     ...over,
   };
@@ -92,15 +88,6 @@ describe("RuleDetail body", () => {
     expect(screen.getByText("Second paragraph.")).toBeInTheDocument();
     const link = screen.getByRole("link", { name: "T1059.004" });
     expect(link).toHaveAttribute("href", "https://attack.mitre.org/techniques/T1059/004/");
-  });
-
-  it("renders the config table, marking an empty default as (unset)", async () => {
-    mockDocs([makeEntry()]);
-    renderAt("suspicious_exec");
-    await waitFor(() => expect(screen.getByText("Configuration")).toBeInTheDocument());
-    expect(screen.getByText("EDR_FOO")).toBeInTheDocument();
-    expect(screen.getByText("(unset)")).toBeInTheDocument();
-    expect(screen.getByText("5")).toBeInTheDocument();
   });
 
   it("renders the false-positive and limitations lists", async () => {

--- a/ui/src/components/RuleDetail.tsx
+++ b/ui/src/components/RuleDetail.tsx
@@ -6,7 +6,7 @@ import { Table, EmptyState } from "./ui/Table";
 import "./RuleDetail.scss";
 
 // RuleDetail renders a single detection rule's documentation: behaviour,
-// severity, ATT&CK mapping, configuration knobs, false-positive sources, and
+// severity, ATT&CK mapping, false-positive sources, and
 // limitations. This page loads rule docs from /api/rules; the
 // markdown reference at docs/detection-rules.md is generated directly from
 // the same Go-side `detection.Rule.Doc()` definitions, so the two surfaces

--- a/ui/src/components/RuleDetail.tsx
+++ b/ui/src/components/RuleDetail.tsx
@@ -117,32 +117,6 @@ function RuleBody({ entry }: Readonly<{ entry: RuleDocEntry }>) {
         <p key={`${entry.id}-p${String(i)}`} className="rule-detail__para">{para}</p>
       ))}
 
-      {doc.config && doc.config.length > 0 && (
-        <>
-          <h2>Configuration</h2>
-          <Table className="rule-detail__config">
-            <thead>
-              <tr>
-                <th>Env var</th>
-                <th>Type</th>
-                <th>Default</th>
-                <th>Description</th>
-              </tr>
-            </thead>
-            <tbody>
-              {doc.config.map((c) => (
-                <tr key={c.env_var}>
-                  <td><code>{c.env_var}</code></td>
-                  <td><code>{c.type}</code></td>
-                  <td>{c.default === "" ? <span className="rule-detail__muted">(unset)</span> : <code>{c.default}</code>}</td>
-                  <td>{c.description}</td>
-                </tr>
-              ))}
-            </tbody>
-          </Table>
-        </>
-      )}
-
       {doc.false_positives && doc.false_positives.length > 0 && (
         <>
           <h2>Known false-positive sources</h2>


### PR DESCRIPTION
## What & why

Retires the vestigial per-rule env-var config-knob surface (`doc.config` / `ConfigKnob`). It has been dead since #459 moved rule tuning off per-rule boot-time env vars onto the DB-backed detection-config surface (`server/rules/internal/detectionconfig/`, UI-managed). No catalog rule declares a knob, so `doc.config` was never populated: never on the wire (`omitempty`), never rendered in the UI, never generated into `detection-rules.md`. The OpenAPI advertised a `RuleConfig` shape the server never emits.

This was first attempted inside the maintenance code sweep (#616) as a `[no-behavior-change]` deletion and reverted there: Copilot + Qodo correctly flagged that it removes a documented SHALL scenario and that a second embedded OpenAPI copy was missed. This PR does it the spec-governed way.

## What changes

- **OpenSpec change `remove-per-rule-config-knobs`** (this PR carries the delta):
  - `server-admin-surface`: MODIFIED "Per-rule documentation endpoint" — drops the `config` clause and the "Rule with config knobs" scenario; keeps the catalog-read scenario and the false-positive / limitation exposure.
  - `web-ui`: MODIFIED "Per-rule documentation page" — drops config-knob rendering.
- Code: removed `RuleType.Config` + `ConfigKnob` (`server/rules/api`); the `config` property + `RuleConfig` schema from **both** OpenAPI copies (`docs/api/openapi.yaml` and the `go:embed`ed `server/apidocs/embed/openapi.yaml` served at `/api/docs`); the UI `RuleConfig` type + `RuleDoc.config` + the RuleDetail Configuration table + test; the `gen-rule-docs` Configuration renderer + test; the `registry_test` config-knob assertion.
- The `rule-with-config-knobs` spectrace marker is retained **transitionally** with an explanatory comment: a MODIFIED delta cannot exempt a dropped scenario pre-archive (spectrace exempts only whole `## REMOVED` requirements, and OpenSpec forbids REMOVE+ADD of the same requirement name), so the marker is deleted at release archive when the canonical scenario is removed.

**BREAKING (inert):** `doc.config` and the OpenAPI `RuleConfig` schema are removed. No client observes a change (the field was never populated post-#459).

## Checklist

- [x] **OpenSpec updated for behavior changes.** This PR ships `openspec/changes/remove-per-rule-config-knobs/` with MODIFIED deltas for `server-admin-surface` + `web-ui`. `openspec validate --all --strict` passes (63/0); `spectrace --strict` passes (543/543).
- [x] Tests: removed the config-knob tests (gen-rule-docs, RuleDetail, registry); surviving doc/false-positive/limitation coverage unchanged. `go build`/`vet` + rules/catalog/gen-rule-docs tests + UI eslint/tsc/RuleDetail vitest all green.
- [x] Agent/extension ESF/XPC/wire: N/A. Not touched.
- [x] **Docs**: both OpenAPI copies updated. The removed UI config table was never rendered (server never populated `config`), so no user-visible surface changed.

## VM / RC notes

None. No agent/extension/ESF/XPC/wire changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ER9GMfKy1x7fhAGBMWsE2P
