### PR TITLE
refactor: consolidation-pass cognitive-complexity paydown + deferred fixes [no-behavior-change] [no-docs-change]

### DIFF
--- a/server/cmd/fleet-edr-demo-seed/refresh_branches_test.go
+++ b/server/cmd/fleet-edr-demo-seed/refresh_branches_test.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fleetdm/edr/server/testdb/full"
+)
+
+// TestMaybeRefreshExisting covers the idempotent re-run dispatcher's branches: the --force short-circuit, the not-yet-seeded
+// "proceed with a fresh replay" report, the already-seeded refresh-in-place report, and the wrapped already-seeded-check error.
+func TestMaybeRefreshExisting(t *testing.T) {
+	t.Parallel()
+
+	t.Run("force short-circuits to a full re-seed", func(t *testing.T) {
+		t.Parallel()
+		db := full.Open(t)
+		s := newSeeder(config{force: true}, db, testHTTPClient(), discardLogger())
+		handled, err := s.maybeRefreshExisting(t.Context())
+		require.NoError(t, err)
+		assert.False(t, handled, "force=true means run() proceeds to a full replay, not a refresh")
+	})
+
+	t.Run("not-yet-seeded reports handled=false", func(t *testing.T) {
+		t.Parallel()
+		db := full.Open(t)
+		s := newSeeder(config{}, db, testHTTPClient(), discardLogger())
+		handled, err := s.maybeRefreshExisting(t.Context())
+		require.NoError(t, err)
+		assert.False(t, handled, "an empty DB is not seeded, so a fresh replay must proceed")
+	})
+
+	t.Run("already-seeded refreshes in place and reports handled=true", func(t *testing.T) {
+		t.Parallel()
+		db := full.Open(t)
+		// The keychain marker on a demo host makes alreadySeeded true; with no replayed process rows the refresh is a no-op, but
+		// maybeRefreshExisting must still report handled=true so run() skips the replay.
+		insertAlert(t, db, firstDemoHostID(t), keychainRuleID, "detection", "high")
+		s := newSeeder(config{}, db, testHTTPClient(), discardLogger())
+		handled, err := s.maybeRefreshExisting(t.Context())
+		require.NoError(t, err)
+		assert.True(t, handled)
+	})
+
+	t.Run("already-seeded check error is wrapped", func(t *testing.T) {
+		t.Parallel()
+		db := full.Open(t)
+		require.NoError(t, db.Close()) // a closed handle makes every query fail, exercising the error branch
+		s := newSeeder(config{}, db, testHTTPClient(), discardLogger())
+		_, err := s.maybeRefreshExisting(t.Context())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "check already-seeded")
+	})
+}
+
+// TestRefreshTimestampsAlreadyRecent covers the deltaSec <= 0 skip: when the newest replayed row is already at (or newer than) the
+// target recent window, refreshTimestamps must NOT slide anything backward.
+func TestRefreshTimestampsAlreadyRecent(t *testing.T) {
+	t.Parallel()
+	db := full.Open(t)
+	ctx := t.Context()
+	s := newSeeder(config{}, db, testHTTPClient(), discardLogger())
+	hostID := firstDemoHostID(t)
+
+	nowNs := time.Now().UnixNano()
+	_, err := db.ExecContext(ctx,
+		`INSERT INTO processes (host_id, pid, ppid, path, fork_time_ns, last_seen_ns) VALUES (?, ?, 1, '/bin/recent', ?, ?)`,
+		hostID, 700, nowNs, nowNs)
+	require.NoError(t, err)
+
+	require.NoError(t, s.refreshTimestamps(ctx))
+
+	var fork int64
+	require.NoError(t, db.QueryRowContext(ctx,
+		`SELECT fork_time_ns FROM processes WHERE host_id = ? AND pid = 700`, hostID).Scan(&fork))
+	assert.Equal(t, nowNs, fork, "an already-recent demo must not be slid backward (deltaSec <= 0 is a no-op)")
+}
+
+// TestRefreshTimestampsDBErrors covers the DB-error branches of the refresh path via a closed handle (a legitimate fault injector
+// that touches no production code): the newest-timestamp read error propagates from refreshTimestamps, and applyTimestampSlide's
+// begin-transaction failure is wrapped.
+func TestRefreshTimestampsDBErrors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("newest-timestamp read error propagates", func(t *testing.T) {
+		t.Parallel()
+		db := full.Open(t)
+		require.NoError(t, db.Close())
+		s := newSeeder(config{}, db, testHTTPClient(), discardLogger())
+		err := s.refreshTimestamps(t.Context())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "read newest demo timestamp")
+	})
+
+	t.Run("applyTimestampSlide begin-tx error is wrapped", func(t *testing.T) {
+		t.Parallel()
+		db := full.Open(t)
+		require.NoError(t, db.Close())
+		s := newSeeder(config{}, db, testHTTPClient(), discardLogger())
+		inClause, hostArgs, err := demoHostScope()
+		require.NoError(t, err)
+		err = s.applyTimestampSlide(t.Context(), inClause, hostArgs, 1000, 1)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "begin refresh tx")
+	})
+}

--- a/server/cmd/fleet-edr-demo-seed/seed.go
+++ b/server/cmd/fleet-edr-demo-seed/seed.go
@@ -87,21 +87,9 @@ func (s *seeder) run(ctx context.Context) error {
 		return fmt.Errorf("server did not become ready: %w", err)
 	}
 
-	if !s.cfg.force {
-		seeded, err := s.alreadySeeded(ctx)
-		if err != nil {
-			return fmt.Errorf("check already-seeded: %w", err)
-		}
-		if seeded {
-			// Don't re-replay, but slide the existing rows forward so the graph still reads as recent activity. The persisted
-			// demo volume survives restarts, so without this the timestamps stay frozen at the first seed and age out of the UI's
-			// last-hour process-tree window, leaving the host view empty after a day or a restart.
-			if err := s.refreshTimestamps(ctx); err != nil {
-				return fmt.Errorf("refresh demo timestamps: %w", err)
-			}
-			s.logger.InfoContext(ctx, "demo data already present, refreshed timestamps to recent (pass --force to re-seed)")
-			return s.seedUserIfConfigured(ctx)
-		}
+	// On an idempotent re-run (demo data already present, --force off) slide the existing rows forward instead of re-replaying.
+	if handled, err := s.maybeRefreshExisting(ctx); handled || err != nil {
+		return err
 	}
 
 	// Replay each rich captured host (deep real process tree + correlated network_connect/dns_query) and weave its attacks
@@ -121,6 +109,30 @@ func (s *seeder) run(ctx context.Context) error {
 
 	s.logger.InfoContext(ctx, "demo seed complete")
 	return nil
+}
+
+// maybeRefreshExisting handles the idempotent re-run path. When --force is off and the demo data is already present, it slides the
+// existing rows forward (so the graph still reads as recent) and reprovisions the SSO user instead of re-replaying the corpus, then
+// reports handled=true so run returns without replaying. It reports handled=false when a fresh replay should proceed.
+func (s *seeder) maybeRefreshExisting(ctx context.Context) (bool, error) {
+	if s.cfg.force {
+		return false, nil
+	}
+	seeded, err := s.alreadySeeded(ctx)
+	if err != nil {
+		return false, fmt.Errorf("check already-seeded: %w", err)
+	}
+	if !seeded {
+		return false, nil
+	}
+	// Don't re-replay, but slide the existing rows forward so the graph still reads as recent activity. The persisted
+	// demo volume survives restarts, so without this the timestamps stay frozen at the first seed and age out of the UI's
+	// last-hour process-tree window, leaving the host view empty after a day or a restart.
+	if err := s.refreshTimestamps(ctx); err != nil {
+		return true, fmt.Errorf("refresh demo timestamps: %w", err)
+	}
+	s.logger.InfoContext(ctx, "demo data already present, refreshed timestamps to recent (pass --force to re-seed)")
+	return true, s.seedUserIfConfigured(ctx)
 }
 
 // buildBlockEnvelope constructs the application_control_block wire envelope the ApplicationControlBlock rule consumes. Payload shape
@@ -287,14 +299,46 @@ func (s *seeder) refreshTimestamps(ctx context.Context) error {
 		return err
 	}
 
-	var newestNs sql.NullInt64
-	// Anchor the delta on the device-clock tail only: fork/exec/event timestamps and their ingest stamps. The exit columns are
-	// deliberately excluded because the process-TTL reconciler (pipeline.ProcessTTLRunner) force-exits long-running processes at
-	// fork + maxAge, so a stale demo's synthesized exit_time_ns sits ~maxAge PAST the real tail. Anchoring on it would shrink the
-	// delta by maxAge and leave every fork that-much stale, which is exactly the empty-1h-window symptom this guards against.
-	// Anchor on the process graph's device-clock tail. Events live in the ClickHouse archive now (ADR-0015), not a MySQL table, but
-	// the process rows are materialized from those events: fork_time_ns tracks the event timestamp tail and fork_ingested_at_ns the
-	// server ingest-stamp tail, so the processes columns carry the same anchor the events MAX used to provide.
+	newestNs, ok, err := s.newestReplayedTimestampNs(ctx, inClause, hostArgs)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return nil // no replayed rows yet; nothing to slide
+	}
+	deltaNs := time.Now().Add(-recentTailOffset).UnixNano() - newestNs
+	// alerts carry SQL TIMESTAMP(6) columns; we slide them at whole-second granularity (the alert -> process-tree window the UI
+	// anchors on created_at spans minutes, so sub-second precision is irrelevant). deltaSec <= 0 means the data is already at or
+	// newer than the target (a quick restart after a fresh seed, or clock skew): nothing to slide, and a backward shift would only
+	// un-recent the graph, so skip the redundant writes.
+	deltaSec := deltaNs / int64(time.Second)
+	if deltaSec <= 0 {
+		return nil
+	}
+
+	if err := s.applyTimestampSlide(ctx, inClause, hostArgs, deltaNs, deltaSec); err != nil {
+		return err
+	}
+
+	if err := s.slideArchiveEvents(ctx, inClause, hostArgs, deltaNs); err != nil {
+		return err
+	}
+
+	s.logger.InfoContext(ctx, "refreshed demo timestamps to recent", "delta_ns", deltaNs)
+	return nil
+}
+
+// newestReplayedTimestampNs reads the demo hosts' device-clock tail, the anchor for the refresh delta. ok is false when no replayed
+// process rows exist yet (a fresh volume), so the caller skips the slide entirely.
+//
+// Anchor the delta on the device-clock tail only: fork/exec/event timestamps and their ingest stamps. The exit columns are
+// deliberately excluded because the process-TTL reconciler (pipeline.ProcessTTLRunner) force-exits long-running processes at
+// fork + maxAge, so a stale demo's synthesized exit_time_ns sits ~maxAge PAST the real tail. Anchoring on it would shrink the
+// delta by maxAge and leave every fork that-much stale, which is exactly the empty-1h-window symptom this guards against.
+// Anchor on the process graph's device-clock tail. Events live in the ClickHouse archive now (ADR-0015), not a MySQL table, but
+// the process rows are materialized from those events: fork_time_ns tracks the event timestamp tail and fork_ingested_at_ns the
+// server ingest-stamp tail, so the processes columns carry the same anchor the events MAX used to provide.
+func (s *seeder) newestReplayedTimestampNs(ctx context.Context, inClause string, hostArgs []any) (int64, bool, error) {
 	newestQuery := `
 		SELECT GREATEST(
 			COALESCE((SELECT MAX(fork_time_ns) FROM processes WHERE ` + inClause + `), 0),
@@ -305,22 +349,20 @@ func (s *seeder) refreshTimestamps(ctx context.Context) error {
 	for range 3 {
 		anchorArgs = append(anchorArgs, hostArgs...)
 	}
+	var newestNs sql.NullInt64
 	if err := s.db.QueryRowContext(ctx, newestQuery, anchorArgs...).Scan(&newestNs); err != nil {
-		return fmt.Errorf("read newest demo timestamp: %w", err)
+		return 0, false, fmt.Errorf("read newest demo timestamp: %w", err)
 	}
 	if !newestNs.Valid || newestNs.Int64 == 0 {
-		return nil // no replayed rows yet; nothing to slide
+		return 0, false, nil // no replayed rows yet; nothing to slide
 	}
-	deltaNs := time.Now().Add(-recentTailOffset).UnixNano() - newestNs.Int64
-	// alerts carry SQL TIMESTAMP(6) columns; we slide them at whole-second granularity (the alert -> process-tree window the UI
-	// anchors on created_at spans minutes, so sub-second precision is irrelevant). deltaSec <= 0 means the data is already at or
-	// newer than the target (a quick restart after a fresh seed, or clock skew): nothing to slide, and a backward shift would only
-	// un-recent the graph, so skip the redundant writes.
-	deltaSec := deltaNs / int64(time.Second)
-	if deltaSec <= 0 {
-		return nil
-	}
+	return newestNs.Int64, true, nil
+}
 
+// applyTimestampSlide runs the MySQL half of the refresh in one transaction: shift every replayed process/host/alert timestamp column
+// forward and drop the synthesized TTL force-exits. deltaNs slides the nanosecond columns; deltaSec slides the alerts' TIMESTAMP(6)
+// columns at whole-second granularity. Every statement carries the demo-host scope.
+func (s *seeder) applyTimestampSlide(ctx context.Context, inClause string, hostArgs []any, deltaNs, deltaSec int64) error {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("begin refresh tx: %w", err)
@@ -355,12 +397,6 @@ func (s *seeder) refreshTimestamps(ctx context.Context) error {
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("commit timestamp refresh: %w", err)
 	}
-
-	if err := s.slideArchiveEvents(ctx, inClause, hostArgs, deltaNs); err != nil {
-		return err
-	}
-
-	s.logger.InfoContext(ctx, "refreshed demo timestamps to recent", "delta_ns", deltaNs)
 	return nil
 }
 

--- a/server/cmd/fleet-edr-ingest/main.go
+++ b/server/cmd/fleet-edr-ingest/main.go
@@ -7,7 +7,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -234,10 +233,7 @@ func run() error {
 // accepted event out to the archive plus the MySQL EventLog queue, so EDR_CLICKHOUSE_DSN is required here too: an unset value is a fatal
 // misconfig, not a MySQL fallback. Returns the ClickHouse handle so the caller can defer its Close.
 func openVisibility(ctx context.Context, logger *slog.Logger, cfg *config.Config, db *sqlx.DB) (*sqlx.DB, *visibilitybootstrap.Visibility, error) {
-	if cfg.ClickHouseDSN == "" {
-		logger.ErrorContext(ctx, "EDR_CLICKHOUSE_DSN is required: the event store is ClickHouse (ADR-0015)")
-		return nil, nil, errors.New("EDR_CLICKHOUSE_DSN is required")
-	}
+	// EDR_CLICKHOUSE_DSN is validated as required in config.Load (ADR-0015: no MySQL events fallback), so it is non-empty here.
 	chDB, err := visibilitybootstrap.OpenClickHouse(ctx, cfg.ClickHouseDSN)
 	if err != nil {
 		logger.ErrorContext(ctx, "open clickhouse", "err", err)

--- a/server/cmd/fleet-edr-server/main.go
+++ b/server/cmd/fleet-edr-server/main.go
@@ -119,12 +119,8 @@ func run() error {
 	}
 	defer func() { _ = db.Close() }()
 
-	// ClickHouse is the event store (ADR-0015): the durable archive intake writes to and correlation/evidence reads from. It is
-	// required, not optional: there is no MySQL events fallback after the cutover, so an unset EDR_CLICKHOUSE_DSN is a fatal misconfig.
-	if cfg.ClickHouseDSN == "" {
-		logger.ErrorContext(ctx, "EDR_CLICKHOUSE_DSN is required: the event store is ClickHouse (ADR-0015)")
-		return errors.New("EDR_CLICKHOUSE_DSN is required")
-	}
+	// ClickHouse is the event store (ADR-0015): the durable archive intake writes to and correlation/evidence reads from.
+	// EDR_CLICKHOUSE_DSN is validated as required in config.Load (no MySQL events fallback after the cutover), so it is non-empty here.
 	chDB, err := visibilitybootstrap.OpenClickHouse(ctx, cfg.ClickHouseDSN)
 	if err != nil {
 		logger.ErrorContext(ctx, "open clickhouse", "err", err)

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -225,9 +225,9 @@ func loadCoreEnv(c *Config, getenv func(string) string, errs *[]error) {
 	// is not supported in the raw DSN string and must be avoided.
 	optionalStr(&c.DSN, "EDR_DSN", getenv)
 	// EDR_CLICKHOUSE_DSN points the visibility event archive at ClickHouse (clickhouse-go DSN form). ClickHouse is the event store
-	// (ADR-0015): there is no MySQL events fallback after the cutover, so the combined server and the standalone ingest binary both refuse
-	// to boot when it is unset (enforced in cmd/main, not here). Use EDR_CLICKHOUSE_DSN_FILE for docker-secret mounts.
-	optionalStr(&c.ClickHouseDSN, "EDR_CLICKHOUSE_DSN", getenv)
+	// (ADR-0015): there is no MySQL events fallback after the cutover, so it is required, not optional. Validated here (like every other
+	// required var) so the combined server and the standalone ingest binary share one check. Use EDR_CLICKHOUSE_DSN_FILE for docker-secret mounts.
+	requireStr(&c.ClickHouseDSN, "EDR_CLICKHOUSE_DSN", getenv, errs, true)
 	if c.DSN == "" {
 		*errs = append(*errs, errors.New("EDR_DSN is required (use EDR_DSN_FILE for docker-secret mounts)"))
 	}

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -33,6 +33,11 @@ func envMap(pairs map[string]string) func(string) string {
 		if k == "EDR_SECRET_KEY" {
 			return validTestSecretKey
 		}
+		// EDR_CLICKHOUSE_DSN is required by every boot (ADR-0015: the event store is ClickHouse); default it so positive cases don't
+		// each set it. Presence in the map (even as "") opts out, which is how the missing-DSN negative case is written.
+		if k == "EDR_CLICKHOUSE_DSN" {
+			return "clickhouse://localhost:9000/edr_test"
+		}
 		return ""
 	}
 }
@@ -126,6 +131,19 @@ func TestLoad(t *testing.T) {
 				"EDR_TLS_KEY_FILE":  keyFile,
 			},
 			wantErr: "EDR_DSN",
+		},
+		{
+			// EDR_CLICKHOUSE_DSN is required (ADR-0015: the event store is ClickHouse, no MySQL fallback). Empty string opts out of
+			// the envMap default so this exercises the required-var validation now centralized in config.Load.
+			name: "missing EDR_CLICKHOUSE_DSN",
+			env: map[string]string{
+				"EDR_DSN":            "x",
+				"EDR_ENROLL_SECRET":  "s",
+				"EDR_TLS_CERT_FILE":  certFile,
+				"EDR_TLS_KEY_FILE":   keyFile,
+				"EDR_CLICKHOUSE_DSN": "",
+			},
+			wantErr: "EDR_CLICKHOUSE_DSN",
 		},
 		{
 			name: "missing EDR_ENROLL_SECRET",

--- a/server/identity/bootstrap/bootstrap.go
+++ b/server/identity/bootstrap/bootstrap.go
@@ -284,8 +284,18 @@ func buildSSOAdminHandler(in ssoAdminHandlerDeps) *ssoadmin.Handler {
 		return nil
 	}
 	oidcHTTPClient := in.deps.OIDC.HTTPClient
-	apply := func(ctx context.Context, oidcIn ssoconfig.UpsertInput, appCfg appconfig.AppConfig, expectedAppVersion int64, updatedBy string) error {
-		tx, err := in.deps.DB.BeginTxx(ctx, nil)
+	apply := newSSOApplyFn(in.deps.DB, in.ssoStore, in.appConfig)
+	return ssoadmin.NewHandler(in.ssoStore, in.appConfig, apply, in.authz, in.audit,
+		func(ctx context.Context, issuer string) error { return oidc.Probe(ctx, issuer, oidcHTTPClient) }, in.logger)
+}
+
+// newSSOApplyFn builds the atomic apply callback ssoadmin.NewHandler takes. It writes oidc_config and app_config in ONE transaction so a
+// partial failure can't pair a new issuer with a stale derived redirect; app_config carries the optimistic-concurrency version check.
+func newSSOApplyFn(db *sqlx.DB, ssoStore *ssoconfig.Store, appConfig *appconfig.Store) func(
+	ctx context.Context, oidcIn ssoconfig.UpsertInput, appCfg appconfig.AppConfig, expectedAppVersion int64, updatedBy string,
+) error {
+	return func(ctx context.Context, oidcIn ssoconfig.UpsertInput, appCfg appconfig.AppConfig, expectedAppVersion int64, updatedBy string) error {
+		tx, err := db.BeginTxx(ctx, nil)
 		if err != nil {
 			return fmt.Errorf("identity bootstrap: begin sso update tx: %w", err)
 		}
@@ -295,10 +305,10 @@ func buildSSOAdminHandler(in ssoAdminHandlerDeps) *ssoadmin.Handler {
 				_ = tx.Rollback()
 			}
 		}()
-		if err := in.ssoStore.UpsertTx(ctx, tx, oidcIn); err != nil {
+		if err := ssoStore.UpsertTx(ctx, tx, oidcIn); err != nil {
 			return err
 		}
-		if err := in.appConfig.PutTx(ctx, tx, appCfg, expectedAppVersion, updatedBy); err != nil {
+		if err := appConfig.PutTx(ctx, tx, appCfg, expectedAppVersion, updatedBy); err != nil {
 			return err
 		}
 		if err := tx.Commit(); err != nil {
@@ -307,8 +317,6 @@ func buildSSOAdminHandler(in ssoAdminHandlerDeps) *ssoadmin.Handler {
 		committed = true
 		return nil
 	}
-	return ssoadmin.NewHandler(in.ssoStore, in.appConfig, apply, in.authz, in.audit,
-		func(ctx context.Context, issuer string) error { return oidc.Probe(ctx, issuer, oidcHTTPClient) }, in.logger)
 }
 
 // serviceAccountSurface bundles the optional service-account handlers plus the API-auth middleware. All fields are nil/zero in
@@ -373,33 +381,9 @@ type breakglassDeps struct {
 // origins). Returns an error when the operator partially configured the surface.
 func buildBreakglass(in breakglassDeps) (*breakglass.Service, *breakglass.Handler, error) {
 	bg := in.deps.Breakglass
-	rpID := bg.RPID
-	rpOrigins := bg.RPOrigins
-	if rpID == "" && len(rpOrigins) == 0 {
-		// Nothing configured: default to localhost so first boot has a working recovery surface without a long env var prelude. The
-		// origins are https:// to match the server's mandatory-TLS posture (issue #140); the browser hits https://localhost:8088, so the
-		// WebAuthn origin check would reject http:// here. Production sets EDR_BREAKGLASS_RP_ID + EDR_BREAKGLASS_RP_ORIGINS to the
-		// externally reachable host.
-		rpID = "localhost"
-		rpOrigins = []string{"https://localhost:8088", "https://127.0.0.1:8088"}
-	}
-	// Reject partial config: an operator who set RP_ORIGINS WITHOUT RP_ID intended to configure break-glass; silently defaulting to the
-	// localhost RP id would brick recovery against the wrong relying party.
-	if rpID == "" && len(rpOrigins) > 0 {
-		return nil, nil, errors.New(
-			"identity bootstrap: EDR_BREAKGLASS_RP_ORIGINS set without EDR_BREAKGLASS_RP_ID")
-	}
-	if len(rpOrigins) == 0 {
-		return nil, nil, errors.New(
-			"identity bootstrap: EDR_BREAKGLASS_RP_ID set without EDR_BREAKGLASS_RP_ORIGINS")
-	}
-	if len(in.deps.SessionSigningKey) == 0 {
-		return nil, nil, errors.New(
-			"identity bootstrap: SessionSigningKey is required when break-glass is configured")
-	}
-	displayName := bg.RPDisplayName
-	if displayName == "" {
-		displayName = "EDR Break-glass"
+	rpID, rpOrigins, displayName, err := resolveBreakglassConfig(bg, in.deps.SessionSigningKey)
+	if err != nil {
+		return nil, nil, err
 	}
 	wa, err := breakglass.NewWebAuthn(breakglass.WebAuthnOptions{
 		RPID:          rpID,
@@ -436,6 +420,41 @@ func buildBreakglass(in breakglassDeps) (*breakglass.Service, *breakglass.Handle
 	return svc, h, nil
 }
 
+// resolveBreakglassConfig normalizes the break-glass relying-party knobs and rejects a partial config. When neither RP id nor origins
+// are set it falls through to a localhost default so first boot has a working recovery surface; a partial config (one of RP id / origins
+// without the other, or a missing session signing key) is an operator error and returns one. The display name defaults when unset.
+func resolveBreakglassConfig(bg BreakglassDeps, sessionSigningKey []byte) (rpID string, rpOrigins []string, displayName string, err error) {
+	rpID = bg.RPID
+	rpOrigins = bg.RPOrigins
+	if rpID == "" && len(rpOrigins) == 0 {
+		// Nothing configured: default to localhost so first boot has a working recovery surface without a long env var prelude. The
+		// origins are https:// to match the server's mandatory-TLS posture (issue #140); the browser hits https://localhost:8088, so the
+		// WebAuthn origin check would reject http:// here. Production sets EDR_BREAKGLASS_RP_ID + EDR_BREAKGLASS_RP_ORIGINS to the
+		// externally reachable host.
+		rpID = "localhost"
+		rpOrigins = []string{"https://localhost:8088", "https://127.0.0.1:8088"}
+	}
+	// Reject partial config: an operator who set RP_ORIGINS WITHOUT RP_ID intended to configure break-glass; silently defaulting to the
+	// localhost RP id would brick recovery against the wrong relying party.
+	if rpID == "" && len(rpOrigins) > 0 {
+		return "", nil, "", errors.New(
+			"identity bootstrap: EDR_BREAKGLASS_RP_ORIGINS set without EDR_BREAKGLASS_RP_ID")
+	}
+	if len(rpOrigins) == 0 {
+		return "", nil, "", errors.New(
+			"identity bootstrap: EDR_BREAKGLASS_RP_ID set without EDR_BREAKGLASS_RP_ORIGINS")
+	}
+	if len(sessionSigningKey) == 0 {
+		return "", nil, "", errors.New(
+			"identity bootstrap: SessionSigningKey is required when break-glass is configured")
+	}
+	displayName = bg.RPDisplayName
+	if displayName == "" {
+		displayName = "EDR Break-glass"
+	}
+	return rpID, rpOrigins, displayName, nil
+}
+
 // oidcHandlerDeps bundles the per-call inputs to buildOIDCHandler. Pulled out of the function signature so the call stays under the
 // linter's per-call parameter budget without churning through fields in two places when the wiring expands.
 type oidcHandlerDeps struct {
@@ -466,9 +485,29 @@ func buildOIDCHandler(in oidcHandlerDeps) (*oidc.Handler, *ssoconfig.Store, erro
 	}
 	store := ssoconfig.New(in.deps.DB, sealer)
 
-	// The resolver reads the decrypted connection config per login; ErrNotFound (no config yet) maps to oidc.ErrNotConfigured so the
-	// login route returns a directed "SSO not configured" response instead of a 500.
-	resolver := oidc.NewResolver(func(ctx context.Context) (oidc.ProviderConfig, error) {
+	resolver := oidc.NewResolver(newOIDCProviderConfigFn(store, in.appCfg), in.deps.OIDC.HTTPClient, in.logger)
+
+	prov := oidc.NewProvisioner(in.deps.DB, in.users, in.identities, in.rbac, in.audit, oidc.ProvisionerOptions{
+		Logger:   in.logger,
+		PolicyFn: newOIDCJITPolicyFn(store),
+	})
+
+	return oidc.NewHandler(oidc.HandlerOptions{
+		Resolve:     resolver.Current,
+		Provisioner: prov,
+		Sessions:    in.sessions,
+		SigningKey:  in.deps.SessionSigningKey,
+		StateTTL:    in.deps.OIDC.StateCookieTTL,
+		Audit:       in.audit,
+		Logger:      in.logger,
+	}), store, nil
+}
+
+// newOIDCProviderConfigFn returns the per-login provider-config resolver the OIDC handler reads through. It reads the decrypted
+// connection config per login; ErrNotFound (no config yet) maps to oidc.ErrNotConfigured so the login route returns a directed "SSO not
+// configured" response instead of a 500.
+func newOIDCProviderConfigFn(store *ssoconfig.Store, appConfig *appconfig.Store) oidc.ConfigFunc {
+	return func(ctx context.Context) (oidc.ProviderConfig, error) {
 		c, err := store.GetDecrypted(ctx)
 		if errors.Is(err, ssoconfig.ErrNotFound) {
 			return oidc.ProviderConfig{}, oidc.ErrNotConfigured
@@ -478,7 +517,7 @@ func buildOIDCHandler(in oidcHandlerDeps) (*oidc.Handler, *ssoconfig.Store, erro
 		}
 		// The redirect URI is derived from the deployment external URL, which lives in the appconfig document and changes independently
 		// of oidc_config; fold both versions into the cache stamp so an external-URL edit rebuilds the client too.
-		appCfg, appVersion, err := in.appCfg.Get(ctx)
+		appCfg, appVersion, err := appConfig.Get(ctx)
 		if err != nil {
 			return oidc.ProviderConfig{}, err
 		}
@@ -496,33 +535,22 @@ func buildOIDCHandler(in oidcHandlerDeps) (*oidc.Handler, *ssoconfig.Store, erro
 			Scopes:       c.Scopes,
 			Stamp:        fmt.Sprintf("%d.%d", c.Version, appVersion),
 		}, nil
-	}, in.deps.OIDC.HTTPClient, in.logger)
+	}
+}
 
-	// The provisioner reads the JIT toggle + default role from the same store at provision time, so a UI edit of either applies on the
-	// next sign-in. No stored config means JIT is off (unknown subjects are denied), matching the wave-1 default.
-	prov := oidc.NewProvisioner(in.deps.DB, in.users, in.identities, in.rbac, in.audit, oidc.ProvisionerOptions{
-		Logger: in.logger,
-		PolicyFn: func(ctx context.Context) (allowJIT bool, defaultRole string, err error) {
-			c, err := store.Get(ctx)
-			if errors.Is(err, ssoconfig.ErrNotFound) {
-				return false, "", nil
-			}
-			if err != nil {
-				return false, "", err
-			}
-			return c.JITEnabled, c.DefaultRole, nil
-		},
-	})
-
-	return oidc.NewHandler(oidc.HandlerOptions{
-		Resolve:     resolver.Current,
-		Provisioner: prov,
-		Sessions:    in.sessions,
-		SigningKey:  in.deps.SessionSigningKey,
-		StateTTL:    in.deps.OIDC.StateCookieTTL,
-		Audit:       in.audit,
-		Logger:      in.logger,
-	}), store, nil
+// newOIDCJITPolicyFn returns the JIT policy the OIDC provisioner reads at provision time, so a UI edit of the toggle or default role
+// applies on the next sign-in. No stored config means JIT is off (unknown subjects are denied), matching the wave-1 default.
+func newOIDCJITPolicyFn(store *ssoconfig.Store) func(ctx context.Context) (allowJIT bool, defaultRole string, err error) {
+	return func(ctx context.Context) (allowJIT bool, defaultRole string, err error) {
+		c, err := store.Get(ctx)
+		if errors.Is(err, ssoconfig.ErrNotFound) {
+			return false, "", nil
+		}
+		if err != nil {
+			return false, "", err
+		}
+		return c.JITEnabled, c.DefaultRole, nil
+	}
 }
 
 // ApplySchema applies identity's goose migration corpus and seeds the
@@ -597,20 +625,35 @@ func SeedOIDCConfig(ctx context.Context, db *sqlx.DB, oidcSecretKey []byte, in O
 		return fmt.Errorf("identity SeedOIDCConfig: build secret sealer: %w", err)
 	}
 	store := ssoconfig.New(db, sealer)
-	// Skip only when a USABLE config already exists and we are not forcing. Usable means the row decrypts AND carries a client secret:
-	// gating on mere row presence would silently no-op over a row whose secret cannot be decrypted (e.g. after an EDR_SECRET_KEY
-	// rotation) or that has no secret at all, leaving SSO broken; an undecryptable row surfaces as an error so the caller can rerun with
-	// Force, while a present-but-secretless row falls through and is (re)seeded.
 	if !in.Force {
-		switch cfg, err := store.GetDecrypted(ctx); {
-		case err == nil && cfg.ClientSecret != "":
+		usable, err := storedOIDCConfigUsable(ctx, store)
+		if err != nil {
+			return err
+		}
+		if usable {
 			return nil // a usable stored config governs; leave it untouched
-		case err != nil && !errors.Is(err, ssoconfig.ErrNotFound):
-			return fmt.Errorf("identity SeedOIDCConfig: read OIDC config: %w", err)
 		}
 	}
-	// Write oidc_config and the external URL in ONE transaction (same shape as the admin API's apply), so a partial failure can't leave a
-	// stored OIDC config paired with a missing derived redirect; a rolled-back seed re-runs cleanly.
+	return seedOIDCConfigTx(ctx, db, store, in)
+}
+
+// storedOIDCConfigUsable reports whether a USABLE OIDC config already exists so SeedOIDCConfig can no-op without forcing. Usable means
+// the row decrypts AND carries a client secret: gating on mere row presence would silently no-op over a row whose secret cannot be
+// decrypted (e.g. after an EDR_SECRET_KEY rotation) or that has no secret at all, leaving SSO broken; an undecryptable row surfaces as an
+// error so the caller can rerun with Force, while a present-but-secretless row is reported not-usable and is (re)seeded.
+func storedOIDCConfigUsable(ctx context.Context, store *ssoconfig.Store) (bool, error) {
+	switch cfg, err := store.GetDecrypted(ctx); {
+	case err == nil && cfg.ClientSecret != "":
+		return true, nil
+	case err != nil && !errors.Is(err, ssoconfig.ErrNotFound):
+		return false, fmt.Errorf("identity SeedOIDCConfig: read OIDC config: %w", err)
+	}
+	return false, nil
+}
+
+// seedOIDCConfigTx writes oidc_config and the external URL in ONE transaction (same shape as the admin API's apply), so a partial
+// failure can't leave a stored OIDC config paired with a missing derived redirect; a rolled-back seed re-runs cleanly.
+func seedOIDCConfigTx(ctx context.Context, db *sqlx.DB, store *ssoconfig.Store, in OIDCSeedInput) error {
 	tx, err := db.BeginTxx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("identity SeedOIDCConfig: begin tx: %w", err)

--- a/server/identity/bootstrap/bootstrap_internal_test.go
+++ b/server/identity/bootstrap/bootstrap_internal_test.go
@@ -1,0 +1,363 @@
+package bootstrap
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fleetdm/edr/server/identity/api"
+	"github.com/fleetdm/edr/server/identity/internal/appconfig"
+	"github.com/fleetdm/edr/server/identity/internal/oidc"
+	"github.com/fleetdm/edr/server/identity/internal/ssoconfig"
+	"github.com/fleetdm/edr/server/testdb"
+)
+
+// sealerKeyA and sealerKeyB are two distinct 32-byte AES-256 sealer keys. Built with bytes.Repeat rather than as string literals so
+// gosec's hardcoded-credential rule (G101) doesn't fire on a test fixture.
+var (
+	sealerKeyA = bytes.Repeat([]byte{0xA5}, 32)
+	sealerKeyB = bytes.Repeat([]byte{0x5A}, 32)
+)
+
+// newSSOStore opens an isolated schema-applied DB and returns a ssoconfig.Store sealed with key. Uses the same-package ApplySchema
+// (not the identity testkit, which imports this package) so there is no import cycle.
+func newSSOStore(t *testing.T, key []byte) (*sqlx.DB, *ssoconfig.Store) {
+	t.Helper()
+	db := testdb.Open(t)
+	require.NoError(t, ApplySchema(t.Context(), db))
+	sealer, err := ssoconfig.NewSealer(key)
+	require.NoError(t, err)
+	return db, ssoconfig.New(db, sealer)
+}
+
+// TestResolveBreakglassConfig exercises every branch of the extracted break-glass config resolver: the localhost default, the two
+// partial-config rejections, the signing-key requirement, and the display-name default.
+func TestResolveBreakglassConfig(t *testing.T) {
+	t.Parallel()
+	key := []byte("session-signing-key-0123456789ab")
+
+	t.Run("both unset defaults to localhost", func(t *testing.T) {
+		t.Parallel()
+		rpID, origins, display, err := resolveBreakglassConfig(BreakglassDeps{}, key)
+		require.NoError(t, err)
+		assert.Equal(t, "localhost", rpID)
+		assert.Equal(t, []string{"https://localhost:8088", "https://127.0.0.1:8088"}, origins)
+		assert.Equal(t, "EDR Break-glass", display, "display name defaults when unset")
+	})
+
+	t.Run("localhost default still requires a signing key", func(t *testing.T) {
+		t.Parallel()
+		_, _, _, err := resolveBreakglassConfig(BreakglassDeps{}, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "SessionSigningKey is required")
+	})
+
+	t.Run("origins without RP id is rejected", func(t *testing.T) {
+		t.Parallel()
+		_, _, _, err := resolveBreakglassConfig(BreakglassDeps{RPOrigins: []string{"https://edr.acme.com"}}, key)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "EDR_BREAKGLASS_RP_ORIGINS set without EDR_BREAKGLASS_RP_ID")
+	})
+
+	t.Run("RP id without origins is rejected", func(t *testing.T) {
+		t.Parallel()
+		_, _, _, err := resolveBreakglassConfig(BreakglassDeps{RPID: "edr.acme.com"}, key)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "EDR_BREAKGLASS_RP_ID set without EDR_BREAKGLASS_RP_ORIGINS")
+	})
+
+	t.Run("fully configured with missing signing key is rejected", func(t *testing.T) {
+		t.Parallel()
+		bg := BreakglassDeps{RPID: "edr.acme.com", RPOrigins: []string{"https://edr.acme.com"}}
+		_, _, _, err := resolveBreakglassConfig(bg, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "SessionSigningKey is required")
+	})
+
+	t.Run("fully configured returns the values with a custom display name", func(t *testing.T) {
+		t.Parallel()
+		bg := BreakglassDeps{RPID: "edr.acme.com", RPDisplayName: "Acme Recovery", RPOrigins: []string{"https://edr.acme.com"}}
+		rpID, origins, display, err := resolveBreakglassConfig(bg, key)
+		require.NoError(t, err)
+		assert.Equal(t, "edr.acme.com", rpID)
+		assert.Equal(t, []string{"https://edr.acme.com"}, origins)
+		assert.Equal(t, "Acme Recovery", display)
+	})
+
+	t.Run("fully configured with empty display name defaults it", func(t *testing.T) {
+		t.Parallel()
+		bg := BreakglassDeps{RPID: "edr.acme.com", RPOrigins: []string{"https://edr.acme.com"}}
+		_, _, display, err := resolveBreakglassConfig(bg, key)
+		require.NoError(t, err)
+		assert.Equal(t, "EDR Break-glass", display)
+	})
+}
+
+// TestClampJITRole pins the JIT default-role floor: analyst/auditor (any case, trimmed) pass through, everything else (including the
+// empty default and a privileged "admin") clamps to the lowest-privilege JIT role.
+func TestClampJITRole(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name, in, want string
+	}{
+		{"analyst passes through", "analyst", "analyst"},
+		{"auditor passes through", "auditor", "auditor"},
+		{"uppercase is normalized", "ANALYST", "analyst"},
+		{"whitespace is trimmed", "  auditor  ", "auditor"},
+		{"empty clamps to default", "", oidc.DefaultJITRole},
+		{"admin clamps to default", "admin", oidc.DefaultJITRole},
+		{"unknown clamps to default", "wheel", oidc.DefaultJITRole},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, clampJITRole(tc.in))
+		})
+	}
+}
+
+// TestStoredOIDCConfigUsable covers the usable/skip switch: no row -> not usable; a row with a decryptable secret -> usable; a row
+// with no secret -> not usable; a row whose secret cannot be decrypted (root-key rotation) -> error so the caller can rerun with Force.
+func TestStoredOIDCConfigUsable(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no stored config is not usable", func(t *testing.T) {
+		t.Parallel()
+		_, store := newSSOStore(t, sealerKeyA)
+		usable, err := storedOIDCConfigUsable(t.Context(), store)
+		require.NoError(t, err)
+		assert.False(t, usable)
+	})
+
+	t.Run("row with a decryptable secret is usable", func(t *testing.T) {
+		t.Parallel()
+		_, store := newSSOStore(t, sealerKeyA)
+		secret := "shh"
+		require.NoError(t, store.Upsert(t.Context(), ssoconfig.UpsertInput{
+			Issuer: "https://idp.example.com", ClientID: "cid", NewSecret: &secret,
+		}))
+		usable, err := storedOIDCConfigUsable(t.Context(), store)
+		require.NoError(t, err)
+		assert.True(t, usable)
+	})
+
+	t.Run("row without a secret is not usable", func(t *testing.T) {
+		t.Parallel()
+		_, store := newSSOStore(t, sealerKeyA)
+		require.NoError(t, store.Upsert(t.Context(), ssoconfig.UpsertInput{
+			Issuer: "https://idp.example.com", ClientID: "cid", NewSecret: nil, // NULL secret column
+		}))
+		usable, err := storedOIDCConfigUsable(t.Context(), store)
+		require.NoError(t, err)
+		assert.False(t, usable, "a present-but-secretless row is (re)seedable, not usable")
+	})
+
+	t.Run("an undecryptable secret surfaces as an error", func(t *testing.T) {
+		t.Parallel()
+		db, storeA := newSSOStore(t, sealerKeyA)
+		secret := "shh"
+		require.NoError(t, storeA.Upsert(t.Context(), ssoconfig.UpsertInput{
+			Issuer: "https://idp.example.com", ClientID: "cid", NewSecret: &secret,
+		}))
+		// A second store keyed differently reads the same row: the secret cannot be opened, which must surface as an error (not a
+		// silent no-op) so the operator reruns with Force after a root-key rotation.
+		sealerB, err := ssoconfig.NewSealer(sealerKeyB)
+		require.NoError(t, err)
+		storeB := ssoconfig.New(db, sealerB)
+		usable, err := storedOIDCConfigUsable(t.Context(), storeB)
+		require.Error(t, err)
+		assert.False(t, usable)
+		assert.Contains(t, err.Error(), "read OIDC config")
+	})
+}
+
+// TestSeedOIDCConfig covers the exported non-interactive seed entry and, through it, the seed transaction, the external-URL seed, and
+// the JIT-role clamp. It also pins the validation guards and the idempotent no-op / Force overwrite behaviour.
+func TestSeedOIDCConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil db is rejected", func(t *testing.T) {
+		t.Parallel()
+		err := SeedOIDCConfig(t.Context(), nil, sealerKeyA, OIDCSeedInput{Issuer: "https://idp.example.com"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "db must not be nil")
+	})
+
+	t.Run("empty issuer is rejected", func(t *testing.T) {
+		t.Parallel()
+		db := testdb.Open(t)
+		require.NoError(t, ApplySchema(t.Context(), db))
+		err := SeedOIDCConfig(t.Context(), db, sealerKeyA, OIDCSeedInput{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "issuer is required")
+	})
+
+	t.Run("a bad sealer key is rejected", func(t *testing.T) {
+		t.Parallel()
+		db := testdb.Open(t)
+		require.NoError(t, ApplySchema(t.Context(), db))
+		err := SeedOIDCConfig(t.Context(), db, []byte("too-short"), OIDCSeedInput{Issuer: "https://idp.example.com"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "build secret sealer")
+	})
+
+	t.Run("fresh seed writes config + external URL and clamps the JIT role", func(t *testing.T) {
+		t.Parallel()
+		db, store := newSSOStore(t, sealerKeyA)
+		ctx := t.Context()
+		require.NoError(t, SeedOIDCConfig(ctx, db, sealerKeyA, OIDCSeedInput{
+			Issuer: "https://idp.example.com", ClientID: "cid", ClientSecret: "shh",
+			Scopes: []string{"openid", "email"}, JITEnabled: true, DefaultRole: "admin", // admin must clamp
+			ExternalURL: "https://edr.example.com",
+		}))
+
+		cfg, err := store.GetDecrypted(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, "https://idp.example.com", cfg.Issuer)
+		assert.Equal(t, "cid", cfg.ClientID)
+		assert.Equal(t, "shh", cfg.ClientSecret)
+		assert.True(t, cfg.JITEnabled)
+		assert.Equal(t, oidc.DefaultJITRole, cfg.DefaultRole, "a privileged seeded default role clamps to the JIT floor")
+
+		appCfg, _, err := appconfig.New(db).Get(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, "https://edr.example.com", appCfg.ExternalURL, "external URL seeded into app_config")
+	})
+
+	t.Run("re-seed without force is a no-op over a usable config", func(t *testing.T) {
+		t.Parallel()
+		db, store := newSSOStore(t, sealerKeyA)
+		ctx := t.Context()
+		first := OIDCSeedInput{Issuer: "https://first.example.com", ClientID: "cid", ClientSecret: "shh"}
+		require.NoError(t, SeedOIDCConfig(ctx, db, sealerKeyA, first))
+		// A second call with a different issuer must NOT clobber the usable stored config.
+		require.NoError(t, SeedOIDCConfig(ctx, db, sealerKeyA, OIDCSeedInput{
+			Issuer: "https://second.example.com", ClientID: "cid2", ClientSecret: "other",
+		}))
+		cfg, err := store.GetDecrypted(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, "https://first.example.com", cfg.Issuer, "usable config governs; the second seed is a no-op")
+	})
+
+	t.Run("a preset external URL is never clobbered", func(t *testing.T) {
+		t.Parallel()
+		db, store := newSSOStore(t, sealerKeyA)
+		ctx := t.Context()
+		// An operator already set the external URL; a later seed must leave it alone even while it writes the (absent) OIDC config.
+		require.NoError(t, appconfig.New(db).Put(ctx, appconfig.AppConfig{ExternalURL: "https://preset.example.com"}, 0, api.PrincipalSystemID))
+		require.NoError(t, SeedOIDCConfig(ctx, db, sealerKeyA, OIDCSeedInput{
+			Issuer: "https://idp.example.com", ClientID: "cid", ClientSecret: "shh", ExternalURL: "https://seed.example.com",
+		}))
+		appCfg, _, err := appconfig.New(db).Get(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, "https://preset.example.com", appCfg.ExternalURL, "the operator's external URL is not clobbered by a seed")
+		cfg, err := store.GetDecrypted(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, "https://idp.example.com", cfg.Issuer, "the OIDC config is still seeded")
+	})
+
+	t.Run("undecryptable existing config without force surfaces the read error", func(t *testing.T) {
+		t.Parallel()
+		db, _ := newSSOStore(t, sealerKeyA)
+		ctx := t.Context()
+		require.NoError(t, SeedOIDCConfig(ctx, db, sealerKeyA,
+			OIDCSeedInput{Issuer: "https://idp.example.com", ClientID: "cid", ClientSecret: "shh"}))
+		// A different root key can't open the stored secret; without Force the usable-check must surface that as an error (so the
+		// operator reruns with Force) rather than silently no-oping over a broken row.
+		err := SeedOIDCConfig(ctx, db, sealerKeyB,
+			OIDCSeedInput{Issuer: "https://idp.example.com", ClientID: "cid", ClientSecret: "shh"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "read OIDC config")
+	})
+
+	t.Run("force overwrites an existing config", func(t *testing.T) {
+		t.Parallel()
+		db, store := newSSOStore(t, sealerKeyA)
+		ctx := t.Context()
+		require.NoError(t, SeedOIDCConfig(ctx, db, sealerKeyA,
+			OIDCSeedInput{Issuer: "https://first.example.com", ClientID: "cid", ClientSecret: "shh"}))
+		require.NoError(t, SeedOIDCConfig(ctx, db, sealerKeyA, OIDCSeedInput{
+			Issuer: "https://second.example.com", ClientID: "cid2", ClientSecret: "other", Force: true,
+		}))
+		cfg, err := store.GetDecrypted(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, "https://second.example.com", cfg.Issuer, "Force re-seeds over the existing config")
+	})
+}
+
+// TestNewOIDCProviderConfigFn exercises the per-login provider-config resolver closure: no stored config maps to ErrNotConfigured; a
+// stored config with no derivable redirect (external URL unset) also maps to ErrNotConfigured; a full config yields the derived
+// redirect URL and a version stamp.
+func TestNewOIDCProviderConfigFn(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no stored config maps to ErrNotConfigured", func(t *testing.T) {
+		t.Parallel()
+		db, store := newSSOStore(t, sealerKeyA)
+		fn := newOIDCProviderConfigFn(store, appconfig.New(db))
+		_, err := fn(t.Context())
+		require.ErrorIs(t, err, oidc.ErrNotConfigured)
+	})
+
+	t.Run("stored config without an external URL maps to ErrNotConfigured", func(t *testing.T) {
+		t.Parallel()
+		db, store := newSSOStore(t, sealerKeyA)
+		ctx := t.Context()
+		secret := "shh"
+		require.NoError(t, store.Upsert(ctx, ssoconfig.UpsertInput{Issuer: "https://idp.example.com", ClientID: "cid", NewSecret: &secret}))
+		fn := newOIDCProviderConfigFn(store, appconfig.New(db))
+		_, err := fn(ctx)
+		require.ErrorIs(t, err, oidc.ErrNotConfigured, "an unset external URL cannot derive a redirect, so it reads as not-configured")
+	})
+
+	t.Run("full config yields the derived redirect and stamp", func(t *testing.T) {
+		t.Parallel()
+		db, store := newSSOStore(t, sealerKeyA)
+		ctx := t.Context()
+		require.NoError(t, SeedOIDCConfig(ctx, db, sealerKeyA, OIDCSeedInput{
+			Issuer: "https://idp.example.com", ClientID: "cid", ClientSecret: "shh", ExternalURL: "https://edr.example.com",
+		}))
+		fn := newOIDCProviderConfigFn(store, appconfig.New(db))
+		got, err := fn(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, "https://idp.example.com", got.Issuer)
+		assert.Equal(t, "cid", got.ClientID)
+		assert.Equal(t, "shh", got.ClientSecret)
+		assert.Equal(t, "https://edr.example.com/api/auth/callback", got.RedirectURL)
+		assert.NotEmpty(t, got.Stamp, "the cache stamp folds both config versions")
+	})
+}
+
+// TestNewOIDCJITPolicyFn exercises the JIT-policy closure the provisioner reads: no stored config means JIT off (deny unknown
+// subjects); a stored config surfaces its JIT toggle + default role.
+func TestNewOIDCJITPolicyFn(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no stored config means JIT off", func(t *testing.T) {
+		t.Parallel()
+		_, store := newSSOStore(t, sealerKeyA)
+		fn := newOIDCJITPolicyFn(store)
+		allow, role, err := fn(t.Context())
+		require.NoError(t, err)
+		assert.False(t, allow)
+		assert.Empty(t, role)
+	})
+
+	t.Run("stored config surfaces its JIT toggle and role", func(t *testing.T) {
+		t.Parallel()
+		_, store := newSSOStore(t, sealerKeyA)
+		ctx := t.Context()
+		secret := "shh"
+		require.NoError(t, store.Upsert(ctx, ssoconfig.UpsertInput{
+			Issuer: "https://idp.example.com", ClientID: "cid", NewSecret: &secret, JITEnabled: true, DefaultRole: "auditor",
+		}))
+		fn := newOIDCJITPolicyFn(store)
+		allow, role, err := fn(ctx)
+		require.NoError(t, err)
+		assert.True(t, allow)
+		assert.Equal(t, "auditor", role)
+	})
+}

--- a/server/identity/bootstrap/bootstrap_internal_test.go
+++ b/server/identity/bootstrap/bootstrap_internal_test.go
@@ -329,6 +329,35 @@ func TestNewOIDCProviderConfigFn(t *testing.T) {
 		assert.Equal(t, "https://edr.example.com/api/auth/callback", got.RedirectURL)
 		assert.NotEmpty(t, got.Stamp, "the cache stamp folds both config versions")
 	})
+
+	t.Run("a non-ErrNotFound store read error is surfaced, not masked as not-configured", func(t *testing.T) {
+		t.Parallel()
+		// Closing the handle makes the next read fail with a driver error ("database is closed"), which is NOT ErrNotFound. The
+		// closure must return that error verbatim so a real store fault surfaces as a 500, not the directed "SSO not configured" reply.
+		db, store := newSSOStore(t, sealerKeyA)
+		require.NoError(t, db.Close())
+		fn := newOIDCProviderConfigFn(store, appconfig.New(db))
+		_, err := fn(t.Context())
+		require.Error(t, err)
+		assert.NotErrorIs(t, err, oidc.ErrNotConfigured, "a store read failure must not be flattened into ErrNotConfigured")
+	})
+
+	t.Run("an app-config read error is surfaced after the OIDC config loads", func(t *testing.T) {
+		t.Parallel()
+		db, store := newSSOStore(t, sealerKeyA)
+		ctx := t.Context()
+		secret := "shh"
+		// A usable OIDC config so GetDecrypted returns cleanly: the failure must come from the app_config read that derives the
+		// redirect URL, exercising the second (appConfig.Get) error branch rather than the first (store) one. Dropping only the
+		// app_config table leaves oidc_config intact, so the first read succeeds and the second fails with a real (non-ErrNoRows) error.
+		require.NoError(t, store.Upsert(ctx, ssoconfig.UpsertInput{Issuer: "https://idp.example.com", ClientID: "cid", NewSecret: &secret}))
+		_, err := db.ExecContext(ctx, "DROP TABLE app_config")
+		require.NoError(t, err)
+		fn := newOIDCProviderConfigFn(store, appconfig.New(db))
+		_, err = fn(ctx)
+		require.Error(t, err)
+		assert.NotErrorIs(t, err, oidc.ErrNotConfigured, "an app_config read failure is a real error, not not-configured")
+	})
 }
 
 // TestNewOIDCJITPolicyFn exercises the JIT-policy closure the provisioner reads: no stored config means JIT off (deny unknown
@@ -359,5 +388,16 @@ func TestNewOIDCJITPolicyFn(t *testing.T) {
 		require.NoError(t, err)
 		assert.True(t, allow)
 		assert.Equal(t, "auditor", role)
+	})
+
+	t.Run("a non-ErrNotFound store read error is surfaced, not silently JIT-off", func(t *testing.T) {
+		t.Parallel()
+		// A closed handle makes store.Get fail with a driver error (not ErrNotFound). The closure must return that error so a store
+		// fault propagates to the provisioner rather than being flattened into the "JIT off, deny unknown subject" default.
+		db, store := newSSOStore(t, sealerKeyA)
+		require.NoError(t, db.Close())
+		fn := newOIDCJITPolicyFn(store)
+		_, _, err := fn(t.Context())
+		require.Error(t, err)
 	})
 }

--- a/server/rules/internal/operator/appcontrol_handler.go
+++ b/server/rules/internal/operator/appcontrol_handler.go
@@ -196,26 +196,18 @@ func (h *AppControlHandler) handleCreateRule(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	body, err := io.ReadAll(io.LimitReader(r.Body, applicationControlReadBodyLimit))
-	if err != nil {
-		writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, errCodeReadBody, errMsgReadBody)
+	body, ok := h.readAppControlBody(ctx, w, r, applicationControlReadBodyLimit)
+	if !ok {
 		return
 	}
 	var req createRuleRequest
-	if err := json.Unmarshal(body, &req); err != nil {
-		writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, errCodeInvalidJSON, errMsgInvalidJSON)
+	if !decodeAppControlBody(ctx, h.logger, w, body, &req) {
 		return
 	}
-	actor, ok := identityapi.ActorFromContext(ctx)
+	actor, ok := h.actorOrInternalError(ctx, w)
 	if !ok {
-		// Session middleware guarantees an actor on every request that reaches HTTPGate's allow path; an absent actor here
-		// is a wiring bug, not a user error. Surface a 500 so the regression is loud rather than silently let CreateRule fall
-		// through to a service-layer guard.
-		h.logger.ErrorContext(ctx, noActorOnContextLogMsg)
-		writeAppControlErr(ctx, h.logger, w, http.StatusInternalServerError, internalErrorCode, internalErrorMessage)
 		return
 	}
-
 	rule, err := h.svc.CreateRule(ctx, api.CreateRuleRequest{
 		PolicyID:   policyID,
 		RuleType:   req.RuleType,
@@ -310,20 +302,16 @@ func (h *AppControlHandler) handleUpdateRule(w http.ResponseWriter, r *http.Requ
 		writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, errCodeInvalidRuleID, errMsgInvalidRuleID)
 		return
 	}
-	body, err := io.ReadAll(io.LimitReader(r.Body, applicationControlReadBodyLimit))
-	if err != nil {
-		writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, errCodeReadBody, errMsgReadBody)
+	body, ok := h.readAppControlBody(ctx, w, r, applicationControlReadBodyLimit)
+	if !ok {
 		return
 	}
 	var req updateRuleRequest
-	if err := json.Unmarshal(body, &req); err != nil {
-		writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, errCodeInvalidJSON, errMsgInvalidJSON)
+	if !decodeAppControlBody(ctx, h.logger, w, body, &req) {
 		return
 	}
-	actor, ok := identityapi.ActorFromContext(ctx)
+	actor, ok := h.actorOrInternalError(ctx, w)
 	if !ok {
-		h.logger.ErrorContext(ctx, noActorOnContextLogMsg)
-		writeAppControlErr(ctx, h.logger, w, http.StatusInternalServerError, internalErrorCode, internalErrorMessage)
 		return
 	}
 	rule, err := h.svc.UpdateRule(ctx, api.UpdateRuleRequest{
@@ -362,24 +350,16 @@ func (h *AppControlHandler) handleDeleteRule(w http.ResponseWriter, r *http.Requ
 		writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, errCodeInvalidRuleID, errMsgInvalidRuleID)
 		return
 	}
-	body, err := io.ReadAll(io.LimitReader(r.Body, applicationControlReadBodyLimit))
-	if err != nil {
-		writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, errCodeReadBody, errMsgReadBody)
+	body, ok := h.readAppControlBody(ctx, w, r, applicationControlReadBodyLimit)
+	if !ok {
 		return
 	}
 	var req deleteRuleRequest
-	// Whitespace-only bodies are normalised to empty so an operator sending a body of just spaces does not get a misleading
-	// invalid_json (the typed reason-required validation should fire instead). Copilot flagged this on PR #188.
-	if len(bytes.TrimSpace(body)) > 0 {
-		if err := json.Unmarshal(body, &req); err != nil {
-			writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, errCodeInvalidJSON, errMsgInvalidJSON)
-			return
-		}
+	if !decodeAppControlBodyIfPresent(ctx, h.logger, w, body, &req) {
+		return
 	}
-	actor, ok := identityapi.ActorFromContext(ctx)
+	actor, ok := h.actorOrInternalError(ctx, w)
 	if !ok {
-		h.logger.ErrorContext(ctx, noActorOnContextLogMsg)
-		writeAppControlErr(ctx, h.logger, w, http.StatusInternalServerError, internalErrorCode, internalErrorMessage)
 		return
 	}
 	if err := h.svc.DeleteRule(ctx, api.DeleteRuleRequest{
@@ -407,20 +387,16 @@ func (h *AppControlHandler) handleCreatePolicy(w http.ResponseWriter, r *http.Re
 		identityapi.Resource{Type: "application_control"}) {
 		return
 	}
-	body, err := io.ReadAll(io.LimitReader(r.Body, applicationControlReadBodyLimit))
-	if err != nil {
-		writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, errCodeReadBody, errMsgReadBody)
+	body, ok := h.readAppControlBody(ctx, w, r, applicationControlReadBodyLimit)
+	if !ok {
 		return
 	}
 	var req createPolicyRequest
-	if err := json.Unmarshal(body, &req); err != nil {
-		writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, errCodeInvalidJSON, errMsgInvalidJSON)
+	if !decodeAppControlBody(ctx, h.logger, w, body, &req) {
 		return
 	}
-	actor, ok := identityapi.ActorFromContext(ctx)
+	actor, ok := h.actorOrInternalError(ctx, w)
 	if !ok {
-		h.logger.ErrorContext(ctx, noActorOnContextLogMsg)
-		writeAppControlErr(ctx, h.logger, w, http.StatusInternalServerError, internalErrorCode, internalErrorMessage)
 		return
 	}
 	policy, err := h.svc.CreatePolicy(ctx, api.CreatePolicyRequest{
@@ -455,20 +431,16 @@ func (h *AppControlHandler) handleUpdatePolicy(w http.ResponseWriter, r *http.Re
 		writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, errCodeInvalidPolicyID, errMsgInvalidPolicyID)
 		return
 	}
-	body, err := io.ReadAll(io.LimitReader(r.Body, applicationControlReadBodyLimit))
-	if err != nil {
-		writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, errCodeReadBody, errMsgReadBody)
+	body, ok := h.readAppControlBody(ctx, w, r, applicationControlReadBodyLimit)
+	if !ok {
 		return
 	}
 	var req updatePolicyRequest
-	if err := json.Unmarshal(body, &req); err != nil {
-		writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, errCodeInvalidJSON, errMsgInvalidJSON)
+	if !decodeAppControlBody(ctx, h.logger, w, body, &req) {
 		return
 	}
-	actor, ok := identityapi.ActorFromContext(ctx)
+	actor, ok := h.actorOrInternalError(ctx, w)
 	if !ok {
-		h.logger.ErrorContext(ctx, noActorOnContextLogMsg)
-		writeAppControlErr(ctx, h.logger, w, http.StatusInternalServerError, internalErrorCode, internalErrorMessage)
 		return
 	}
 	policy, err := h.svc.UpdatePolicy(ctx, api.UpdatePolicyRequest{
@@ -502,24 +474,16 @@ func (h *AppControlHandler) handleDeletePolicy(w http.ResponseWriter, r *http.Re
 		writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, errCodeInvalidPolicyID, errMsgInvalidPolicyID)
 		return
 	}
-	body, err := io.ReadAll(io.LimitReader(r.Body, applicationControlReadBodyLimit))
-	if err != nil {
-		writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, errCodeReadBody, errMsgReadBody)
+	body, ok := h.readAppControlBody(ctx, w, r, applicationControlReadBodyLimit)
+	if !ok {
 		return
 	}
 	var req deletePolicyRequest
-	// Whitespace-only bodies are normalised to empty so an operator sending a body of just spaces does not get a misleading
-	// invalid_json (the typed reason-required validation should fire instead). Copilot flagged this on PR #188.
-	if len(bytes.TrimSpace(body)) > 0 {
-		if err := json.Unmarshal(body, &req); err != nil {
-			writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, errCodeInvalidJSON, errMsgInvalidJSON)
-			return
-		}
+	if !decodeAppControlBodyIfPresent(ctx, h.logger, w, body, &req) {
+		return
 	}
-	actor, ok := identityapi.ActorFromContext(ctx)
+	actor, ok := h.actorOrInternalError(ctx, w)
 	if !ok {
-		h.logger.ErrorContext(ctx, noActorOnContextLogMsg)
-		writeAppControlErr(ctx, h.logger, w, http.StatusInternalServerError, internalErrorCode, internalErrorMessage)
 		return
 	}
 	if err := h.svc.DeletePolicy(ctx, api.DeletePolicyRequest{
@@ -591,20 +555,16 @@ func (h *AppControlHandler) handleBulkUpsertRules(w http.ResponseWriter, r *http
 		writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, errCodeInvalidPolicyID, errMsgInvalidPolicyID)
 		return
 	}
-	body, err := io.ReadAll(io.LimitReader(r.Body, bulkUpsertReadBodyLimit))
-	if err != nil {
-		writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, errCodeReadBody, errMsgReadBody)
+	body, ok := h.readAppControlBody(ctx, w, r, bulkUpsertReadBodyLimit)
+	if !ok {
 		return
 	}
 	var req bulkUpsertRulesRequest
-	if err := json.Unmarshal(body, &req); err != nil {
-		writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, errCodeInvalidJSON, errMsgInvalidJSON)
+	if !decodeAppControlBody(ctx, h.logger, w, body, &req) {
 		return
 	}
-	actor, ok := identityapi.ActorFromContext(ctx)
+	actor, ok := h.actorOrInternalError(ctx, w)
 	if !ok {
-		h.logger.ErrorContext(ctx, noActorOnContextLogMsg)
-		writeAppControlErr(ctx, h.logger, w, http.StatusInternalServerError, internalErrorCode, internalErrorMessage)
 		return
 	}
 	items := make([]api.BulkUpsertRuleItem, 0, len(req.Rules))
@@ -660,6 +620,51 @@ func actorIdentifierFromContext(ctx context.Context) string {
 	// authentication for every actor kind, so a service-account mutation is attributed rather than rejected by the store's required-actor
 	// validation (#518). See ADR-0017.
 	return a.Principal.ID
+}
+
+// readAppControlBody reads the request body under a size cap and, on a read error, writes the typed 400 read-body response and
+// returns ok=false. Extracted so each mutation handler shares one copy of the read-and-map-error block instead of inlining it
+// (Sonar S3776 + S4144). limit lets the bulk-upsert route lift the per-rule cap without a second copy of the logic.
+func (h *AppControlHandler) readAppControlBody(ctx context.Context, w http.ResponseWriter, r *http.Request, limit int64) ([]byte, bool) {
+	body, err := io.ReadAll(io.LimitReader(r.Body, limit))
+	if err != nil {
+		writeAppControlErr(ctx, h.logger, w, http.StatusBadRequest, errCodeReadBody, errMsgReadBody)
+		return nil, false
+	}
+	return body, true
+}
+
+// actorOrInternalError pulls the authenticated actor off ctx. Session middleware guarantees an actor on every request that reaches
+// HTTPGate's allow path, so an absent actor is a wiring bug, not a user error: this logs it and writes a 500 (matching the prior
+// inline handling in every mutation handler) and returns ok=false. Extracted so the seven mutation handlers share one copy.
+func (h *AppControlHandler) actorOrInternalError(ctx context.Context, w http.ResponseWriter) (*identityapi.Actor, bool) {
+	actor, ok := identityapi.ActorFromContext(ctx)
+	if !ok {
+		h.logger.ErrorContext(ctx, noActorOnContextLogMsg)
+		writeAppControlErr(ctx, h.logger, w, http.StatusInternalServerError, internalErrorCode, internalErrorMessage)
+		return nil, false
+	}
+	return actor, true
+}
+
+// decodeAppControlBody unmarshals a request body into dst and, on a JSON error, writes the typed 400 invalid-json response and
+// returns false. Extracted from the mutation handlers so the decode-and-map-error block lives in one place.
+func decodeAppControlBody[T any](ctx context.Context, logger *slog.Logger, w http.ResponseWriter, body []byte, dst *T) bool {
+	if err := json.Unmarshal(body, dst); err != nil {
+		writeAppControlErr(ctx, logger, w, http.StatusBadRequest, errCodeInvalidJSON, errMsgInvalidJSON)
+		return false
+	}
+	return true
+}
+
+// decodeAppControlBodyIfPresent is the DELETE-route variant: a whitespace-only body is normalised to empty (dst is left at its
+// zero value so the typed reason-required validation fires instead of a misleading invalid_json; Copilot flagged this on PR #188),
+// otherwise the body is decoded like decodeAppControlBody. Returns false only when a non-empty body fails to unmarshal.
+func decodeAppControlBodyIfPresent[T any](ctx context.Context, logger *slog.Logger, w http.ResponseWriter, body []byte, dst *T) bool {
+	if len(bytes.TrimSpace(body)) == 0 {
+		return true
+	}
+	return decodeAppControlBody(ctx, logger, w, body, dst)
 }
 
 // errCodeInvalidQuery is the typed code the cross-policy list handler uses to flag a malformed query parameter (negative

--- a/server/rules/internal/operator/appcontrol_handler_test.go
+++ b/server/rules/internal/operator/appcontrol_handler_test.go
@@ -1,0 +1,260 @@
+package operator
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	identityapi "github.com/fleetdm/edr/server/identity/api"
+)
+
+// quietLogger discards handler log output so the error-branch tests (which all log) don't spam the test runner.
+func quietLogger() *slog.Logger { return slog.New(slog.NewTextHandler(io.Discard, nil)) }
+
+// errReader is an io.Reader that always fails, so readAppControlBody's io.ReadAll error branch can be exercised: a real HTTP
+// client can't easily produce a server-side body-read failure, so the request body is swapped for this instead.
+type errReader struct{}
+
+func (errReader) Read([]byte) (int, error) { return 0, io.ErrUnexpectedEOF }
+
+// decodeErrResponse pulls the typed {error,message} envelope writeAppControlErr emits so the tests can assert the exact wire code.
+func decodeErrResponse(t *testing.T, body []byte) (code, message string) {
+	t.Helper()
+	var env struct {
+		Error   string `json:"error"`
+		Message string `json:"message"`
+	}
+	require.NoError(t, json.Unmarshal(body, &env))
+	return env.Error, env.Message
+}
+
+// TestReadAppControlBody covers both arms of the extracted readAppControlBody helper: a clean read returns the bytes + ok, and a
+// failing body read maps to the typed 400 read_body response with ok=false.
+func TestReadAppControlBody(t *testing.T) {
+	t.Parallel()
+	h := &AppControlHandler{logger: quietLogger()}
+
+	t.Run("clean read returns the body", func(t *testing.T) {
+		t.Parallel()
+		req := httptest.NewRequest(http.MethodPost, "/x", strings.NewReader(`{"reason":"r"}`))
+		rec := httptest.NewRecorder()
+		body, ok := h.readAppControlBody(req.Context(), rec, req, applicationControlReadBodyLimit)
+		require.True(t, ok)
+		assert.JSONEq(t, `{"reason":"r"}`, string(body))
+		assert.Equal(t, http.StatusOK, rec.Code, "no error response is written on the happy path")
+	})
+
+	t.Run("body read error maps to 400 read_body", func(t *testing.T) {
+		t.Parallel()
+		req := httptest.NewRequest(http.MethodPost, "/x", nil)
+		req.Body = io.NopCloser(errReader{})
+		rec := httptest.NewRecorder()
+		body, ok := h.readAppControlBody(req.Context(), rec, req, applicationControlReadBodyLimit)
+		require.False(t, ok)
+		assert.Nil(t, body)
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+		code, _ := decodeErrResponse(t, rec.Body.Bytes())
+		assert.Equal(t, errCodeReadBody, code)
+	})
+}
+
+// TestActorOrInternalError covers the extracted actorOrInternalError helper: an authenticated actor is returned as-is, while an
+// absent actor (a session-middleware wiring bug, not a user error) logs and maps to a 500.
+func TestActorOrInternalError(t *testing.T) {
+	t.Parallel()
+	h := &AppControlHandler{logger: quietLogger()}
+
+	t.Run("actor on context is returned", func(t *testing.T) {
+		t.Parallel()
+		want := &identityapi.Actor{Principal: identityapi.UserPrincipal(7, "")}
+		ctx := identityapi.WithActor(t.Context(), want)
+		rec := httptest.NewRecorder()
+		got, ok := h.actorOrInternalError(ctx, rec)
+		require.True(t, ok)
+		assert.Same(t, want, got)
+		assert.Equal(t, http.StatusOK, rec.Code, "no error response is written when an actor is present")
+	})
+
+	t.Run("missing actor maps to 500 internal", func(t *testing.T) {
+		t.Parallel()
+		rec := httptest.NewRecorder()
+		got, ok := h.actorOrInternalError(t.Context(), rec)
+		require.False(t, ok)
+		assert.Nil(t, got)
+		assert.Equal(t, http.StatusInternalServerError, rec.Code)
+		code, _ := decodeErrResponse(t, rec.Body.Bytes())
+		assert.Equal(t, internalErrorCode, code)
+	})
+}
+
+// TestDecodeAppControlBody covers the generic decode helper: valid JSON populates dst and returns true; invalid JSON maps to the
+// typed 400 invalid_json response and returns false.
+func TestDecodeAppControlBody(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid json populates dst", func(t *testing.T) {
+		t.Parallel()
+		rec := httptest.NewRecorder()
+		var dst createPolicyRequest
+		ok := decodeAppControlBody(t.Context(), quietLogger(), rec, []byte(`{"name":"P","reason":"r"}`), &dst)
+		require.True(t, ok)
+		assert.Equal(t, "P", dst.Name)
+		assert.Equal(t, "r", dst.Reason)
+		assert.Equal(t, http.StatusOK, rec.Code)
+	})
+
+	t.Run("invalid json maps to 400 invalid_json", func(t *testing.T) {
+		t.Parallel()
+		rec := httptest.NewRecorder()
+		var dst createPolicyRequest
+		ok := decodeAppControlBody(t.Context(), quietLogger(), rec, []byte(`{not json`), &dst)
+		require.False(t, ok)
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+		code, msg := decodeErrResponse(t, rec.Body.Bytes())
+		assert.Equal(t, errCodeInvalidJSON, code)
+		assert.Equal(t, errMsgInvalidJSON, msg)
+	})
+}
+
+// TestDecodeAppControlBodyIfPresent covers the DELETE-route variant. The load-bearing case is the whitespace-only body: it must be
+// normalized to empty (dst left at its zero value, no 400) so the downstream reason-required validation fires instead of a
+// misleading invalid_json. A non-empty malformed body still maps to 400; a valid body decodes like the base helper.
+func TestDecodeAppControlBodyIfPresent(t *testing.T) {
+	t.Parallel()
+
+	t.Run("whitespace-only body is normalized to empty, not rejected", func(t *testing.T) {
+		t.Parallel()
+		rec := httptest.NewRecorder()
+		var dst deleteRuleRequest
+		ok := decodeAppControlBodyIfPresent(t.Context(), quietLogger(), rec, []byte("  \n\t "), &dst)
+		require.True(t, ok, "a whitespace-only body must not be rejected as invalid_json")
+		assert.Equal(t, deleteRuleRequest{}, dst, "dst is left at its zero value so reason-required validation fires downstream")
+		assert.Equal(t, http.StatusOK, rec.Code, "no error response is written for a whitespace body")
+	})
+
+	t.Run("empty body is treated as absent", func(t *testing.T) {
+		t.Parallel()
+		rec := httptest.NewRecorder()
+		var dst deleteRuleRequest
+		ok := decodeAppControlBodyIfPresent(t.Context(), quietLogger(), rec, nil, &dst)
+		require.True(t, ok)
+		assert.Equal(t, deleteRuleRequest{}, dst)
+	})
+
+	t.Run("valid non-empty body decodes", func(t *testing.T) {
+		t.Parallel()
+		rec := httptest.NewRecorder()
+		var dst deleteRuleRequest
+		ok := decodeAppControlBodyIfPresent(t.Context(), quietLogger(), rec, []byte(`{"reason":"cleanup"}`), &dst)
+		require.True(t, ok)
+		assert.Equal(t, "cleanup", dst.Reason)
+	})
+
+	t.Run("non-empty malformed body maps to 400 invalid_json", func(t *testing.T) {
+		t.Parallel()
+		rec := httptest.NewRecorder()
+		var dst deleteRuleRequest
+		ok := decodeAppControlBodyIfPresent(t.Context(), quietLogger(), rec, []byte(`{"reason":`), &dst)
+		require.False(t, ok)
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+		code, _ := decodeErrResponse(t, rec.Body.Bytes())
+		assert.Equal(t, errCodeInvalidJSON, code)
+	})
+}
+
+// TestActorIdentifierFromContext pins the stable created_by / updated_by tag: the acting principal's id when an actor is present,
+// and empty when none is (so the store-level required-actor gate produces a typed 400 rather than the handler short-circuiting).
+func TestActorIdentifierFromContext(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty when no actor on context", func(t *testing.T) {
+		t.Parallel()
+		assert.Empty(t, actorIdentifierFromContext(t.Context()))
+	})
+
+	t.Run("returns the principal id for a user actor", func(t *testing.T) {
+		t.Parallel()
+		ctx := identityapi.WithActor(t.Context(), &identityapi.Actor{Principal: identityapi.UserPrincipal(42, "a@b.co")})
+		assert.Equal(t, "usr_42", actorIdentifierFromContext(ctx))
+	})
+
+	t.Run("returns the principal id for a service-account actor", func(t *testing.T) {
+		t.Parallel()
+		ctx := identityapi.WithActor(t.Context(), &identityapi.Actor{Principal: identityapi.ServiceAccountPrincipal(3, "ci")})
+		assert.Equal(t, "svc_3", actorIdentifierFromContext(ctx))
+	})
+}
+
+// TestMutationHandlerEarlyExits drives the mutation handlers through their extracted-helper failure branches end to end (allow-all
+// authz, no service call reached). Each case pins that the handler surfaces the helper's typed error and returns before touching
+// the service, so svc is left nil deliberately: a regression that reordered a service call ahead of these guards would panic.
+func TestMutationHandlerEarlyExits(t *testing.T) {
+	t.Parallel()
+	h := &AppControlHandler{authz: allowAllAuthZ{}, logger: quietLogger()}
+
+	t.Run("create rule: invalid json is 400 invalid_json", func(t *testing.T) {
+		t.Parallel()
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/app-control/policies/1/rules", strings.NewReader("{bad"))
+		req.SetPathValue("id", "1")
+		rec := httptest.NewRecorder()
+		h.handleCreateRule(rec, req)
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+		code, _ := decodeErrResponse(t, rec.Body.Bytes())
+		assert.Equal(t, errCodeInvalidJSON, code)
+	})
+
+	t.Run("create rule: valid body but no actor is 500", func(t *testing.T) {
+		t.Parallel()
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/app-control/policies/1/rules",
+			strings.NewReader(`{"rule_type":"BINARY","identifier":"/bin/x","reason":"r"}`))
+		req.SetPathValue("id", "1")
+		rec := httptest.NewRecorder()
+		h.handleCreateRule(rec, req)
+		assert.Equal(t, http.StatusInternalServerError, rec.Code)
+		code, _ := decodeErrResponse(t, rec.Body.Bytes())
+		assert.Equal(t, internalErrorCode, code)
+	})
+
+	t.Run("create rule: body read error is 400 read_body", func(t *testing.T) {
+		t.Parallel()
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/app-control/policies/1/rules", nil)
+		req.Body = io.NopCloser(errReader{})
+		req.SetPathValue("id", "1")
+		rec := httptest.NewRecorder()
+		h.handleCreateRule(rec, req)
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+		code, _ := decodeErrResponse(t, rec.Body.Bytes())
+		assert.Equal(t, errCodeReadBody, code)
+	})
+
+	t.Run("create rule: bad policy id is 400 invalid_policy_id", func(t *testing.T) {
+		t.Parallel()
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/app-control/policies/0/rules", strings.NewReader("{}"))
+		req.SetPathValue("id", "0") // non-positive -> parsePolicyID rejects
+		rec := httptest.NewRecorder()
+		h.handleCreateRule(rec, req)
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+		code, _ := decodeErrResponse(t, rec.Body.Bytes())
+		assert.Equal(t, errCodeInvalidPolicyID, code)
+	})
+
+	t.Run("delete rule: whitespace body is normalized then 500 on missing actor", func(t *testing.T) {
+		t.Parallel()
+		req := httptest.NewRequest(http.MethodDelete, "/api/v1/app-control/rules/1", strings.NewReader("  \n  "))
+		req.SetPathValue("id", "1")
+		rec := httptest.NewRecorder()
+		h.handleDeleteRule(rec, req)
+		// A whitespace body must NOT 400 as invalid_json; it normalizes to empty and the flow proceeds to the actor gate, which
+		// (no actor on this synthetic request) returns 500. This pins the decodeAppControlBodyIfPresent normalization branch.
+		assert.Equal(t, http.StatusInternalServerError, rec.Code)
+		code, _ := decodeErrResponse(t, rec.Body.Bytes())
+		assert.Equal(t, internalErrorCode, code)
+	})
+}

--- a/server/rules/internal/operator/appcontrol_handler_test.go
+++ b/server/rules/internal/operator/appcontrol_handler_test.go
@@ -43,7 +43,7 @@ func TestReadAppControlBody(t *testing.T) {
 
 	t.Run("clean read returns the body", func(t *testing.T) {
 		t.Parallel()
-		req := httptest.NewRequest(http.MethodPost, "/x", strings.NewReader(`{"reason":"r"}`))
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/x", strings.NewReader(`{"reason":"r"}`))
 		rec := httptest.NewRecorder()
 		body, ok := h.readAppControlBody(req.Context(), rec, req, applicationControlReadBodyLimit)
 		require.True(t, ok)
@@ -53,7 +53,7 @@ func TestReadAppControlBody(t *testing.T) {
 
 	t.Run("body read error maps to 400 read_body", func(t *testing.T) {
 		t.Parallel()
-		req := httptest.NewRequest(http.MethodPost, "/x", nil)
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/x", nil)
 		req.Body = io.NopCloser(errReader{})
 		rec := httptest.NewRecorder()
 		body, ok := h.readAppControlBody(req.Context(), rec, req, applicationControlReadBodyLimit)
@@ -118,8 +118,10 @@ func TestDecodeAppControlBody(t *testing.T) {
 		require.False(t, ok)
 		assert.Equal(t, http.StatusBadRequest, rec.Code)
 		code, msg := decodeErrResponse(t, rec.Body.Bytes())
-		assert.Equal(t, errCodeInvalidJSON, code)
-		assert.Equal(t, errMsgInvalidJSON, msg)
+		// errCodeInvalidJSON / errMsgInvalidJSON are plain typed strings ("application_control.invalid_json", "invalid json"), not
+		// JSON documents, so testifylint's encoded-compare false-positives on the "JSON" in the constant name; JSONEq would fail.
+		assert.Equal(t, errCodeInvalidJSON, code) //nolint:testifylint // encoded-compare false positive on JSON-named constant
+		assert.Equal(t, errMsgInvalidJSON, msg)   //nolint:testifylint // encoded-compare false positive on JSON-named constant
 	})
 }
 
@@ -165,7 +167,8 @@ func TestDecodeAppControlBodyIfPresent(t *testing.T) {
 		require.False(t, ok)
 		assert.Equal(t, http.StatusBadRequest, rec.Code)
 		code, _ := decodeErrResponse(t, rec.Body.Bytes())
-		assert.Equal(t, errCodeInvalidJSON, code)
+		// errCodeInvalidJSON is a plain typed error code, not a JSON document: encoded-compare false-positives on the constant name.
+		assert.Equal(t, errCodeInvalidJSON, code) //nolint:testifylint // encoded-compare false positive on JSON-named constant
 	})
 }
 
@@ -201,18 +204,19 @@ func TestMutationHandlerEarlyExits(t *testing.T) {
 
 	t.Run("create rule: invalid json is 400 invalid_json", func(t *testing.T) {
 		t.Parallel()
-		req := httptest.NewRequest(http.MethodPost, "/api/v1/app-control/policies/1/rules", strings.NewReader("{bad"))
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/v1/app-control/policies/1/rules", strings.NewReader("{bad"))
 		req.SetPathValue("id", "1")
 		rec := httptest.NewRecorder()
 		h.handleCreateRule(rec, req)
 		assert.Equal(t, http.StatusBadRequest, rec.Code)
 		code, _ := decodeErrResponse(t, rec.Body.Bytes())
-		assert.Equal(t, errCodeInvalidJSON, code)
+		// errCodeInvalidJSON is a plain typed error code, not a JSON document: encoded-compare false-positives on the constant name.
+		assert.Equal(t, errCodeInvalidJSON, code) //nolint:testifylint // encoded-compare false positive on JSON-named constant
 	})
 
 	t.Run("create rule: valid body but no actor is 500", func(t *testing.T) {
 		t.Parallel()
-		req := httptest.NewRequest(http.MethodPost, "/api/v1/app-control/policies/1/rules",
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/v1/app-control/policies/1/rules",
 			strings.NewReader(`{"rule_type":"BINARY","identifier":"/bin/x","reason":"r"}`))
 		req.SetPathValue("id", "1")
 		rec := httptest.NewRecorder()
@@ -224,7 +228,7 @@ func TestMutationHandlerEarlyExits(t *testing.T) {
 
 	t.Run("create rule: body read error is 400 read_body", func(t *testing.T) {
 		t.Parallel()
-		req := httptest.NewRequest(http.MethodPost, "/api/v1/app-control/policies/1/rules", nil)
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/v1/app-control/policies/1/rules", nil)
 		req.Body = io.NopCloser(errReader{})
 		req.SetPathValue("id", "1")
 		rec := httptest.NewRecorder()
@@ -236,7 +240,7 @@ func TestMutationHandlerEarlyExits(t *testing.T) {
 
 	t.Run("create rule: bad policy id is 400 invalid_policy_id", func(t *testing.T) {
 		t.Parallel()
-		req := httptest.NewRequest(http.MethodPost, "/api/v1/app-control/policies/0/rules", strings.NewReader("{}"))
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/v1/app-control/policies/0/rules", strings.NewReader("{}"))
 		req.SetPathValue("id", "0") // non-positive -> parsePolicyID rejects
 		rec := httptest.NewRecorder()
 		h.handleCreateRule(rec, req)
@@ -247,7 +251,7 @@ func TestMutationHandlerEarlyExits(t *testing.T) {
 
 	t.Run("delete rule: whitespace body is normalized then 500 on missing actor", func(t *testing.T) {
 		t.Parallel()
-		req := httptest.NewRequest(http.MethodDelete, "/api/v1/app-control/rules/1", strings.NewReader("  \n  "))
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodDelete, "/api/v1/app-control/rules/1", strings.NewReader("  \n  "))
 		req.SetPathValue("id", "1")
 		rec := httptest.NewRecorder()
 		h.handleDeleteRule(rec, req)

--- a/test/scale/runner.go
+++ b/test/scale/runner.go
@@ -295,31 +295,7 @@ func Run(ctx context.Context, opts Options) (Report, error) {
 		PassP99:   opts.PassP99,
 		PerHost:   make([]HostReport, opts.HostCount),
 	}
-	hosts := make([]*hostState, opts.HostCount)
-	quietCutoff := int(float64(opts.HostCount) * opts.QuietRatio)
-	for i := range hosts {
-		st := &hostState{
-			index:  i,
-			hostID: uuid.NewString(),
-		}
-		if i < quietCutoff {
-			st.scenario = quiet
-			st.scenarioName = opts.QuietScenarioPath
-			st.gap = opts.QuietIterationGap
-			rep.QuietHostCount++
-		} else {
-			st.scenario = active[i%len(active)]
-			st.scenarioName = opts.ActiveScenarioPaths[i%len(active)]
-			st.gap = opts.ActiveIterationGap
-			rep.ActiveHostCount++
-		}
-		// Pre-allocate the latency slice to the expected observation count (Duration / gap, padded by 2 for jitter +
-		// startup variance). Grow-by-double append in the hot loop is otherwise the largest allocator in a long run and
-		// can skew percentile measurements on GC-busy CI runners.
-		expectedObs := int(opts.Duration/st.gap) + 2
-		st.latencies = make([]time.Duration, 0, expectedObs)
-		hosts[i] = st
-	}
+	hosts := makeHostStates(opts, quiet, active, &rep)
 
 	runCtx, cancel := context.WithTimeout(ctx, opts.Duration)
 	defer cancel()
@@ -355,6 +331,38 @@ func Run(ctx context.Context, opts Options) (Report, error) {
 		aggregateServerBacklog(&rep, backlog.snapshot(), opts)
 	}
 	return rep, ctx.Err()
+}
+
+// makeHostStates builds the per-host state slice: it assigns each host the quiet or an active scenario by the quietCutoff split,
+// pre-sizes its latency buffer, and tallies the quiet/active host counts into rep. Extracted from Run so the entry function stays
+// under Sonar S3776's cognitive-complexity budget.
+func makeHostStates(opts Options, quiet *fakeagent.Scenario, active []*fakeagent.Scenario, rep *Report) []*hostState {
+	hosts := make([]*hostState, opts.HostCount)
+	quietCutoff := int(float64(opts.HostCount) * opts.QuietRatio)
+	for i := range hosts {
+		st := &hostState{
+			index:  i,
+			hostID: uuid.NewString(),
+		}
+		if i < quietCutoff {
+			st.scenario = quiet
+			st.scenarioName = opts.QuietScenarioPath
+			st.gap = opts.QuietIterationGap
+			rep.QuietHostCount++
+		} else {
+			st.scenario = active[i%len(active)]
+			st.scenarioName = opts.ActiveScenarioPaths[i%len(active)]
+			st.gap = opts.ActiveIterationGap
+			rep.ActiveHostCount++
+		}
+		// Pre-allocate the latency slice to the expected observation count (Duration / gap, padded by 2 for jitter +
+		// startup variance). Grow-by-double append in the hot loop is otherwise the largest allocator in a long run and
+		// can skew percentile measurements on GC-busy CI runners.
+		expectedObs := int(opts.Duration/st.gap) + 2
+		st.latencies = make([]time.Duration, 0, expectedObs)
+		hosts[i] = st
+	}
+	return hosts
 }
 
 // hostState is the per-goroutine state: scenario + RNG + observation slice. Latencies accumulate locally to avoid lock contention;
@@ -425,15 +433,7 @@ func (h *hostState) run(
 			return
 		}
 
-		h.mu.Lock()
-		if err != nil {
-			h.errorCount++
-			h.lastErr = err.Error()
-		} else {
-			h.latencies = append(h.latencies, latency)
-			h.postedCount++
-		}
-		h.mu.Unlock()
+		h.recordResult(latency, err)
 
 		// Jittered gap: gap * [jitterFloor, jitterFloor+jitterRange]. De-synchronises hosts so the server does not see a
 		// heartbeat-shaped fan-in spike.
@@ -441,6 +441,21 @@ func (h *hostState) run(
 		if err := sleepCtx(ctx, jittered); err != nil {
 			return
 		}
+	}
+}
+
+// recordResult folds one PostDirect outcome into the host's locked counters: a non-nil err bumps errorCount and records lastErr,
+// otherwise the observed latency is appended and postedCount incremented. Extracted from the run loop so the hot-loop body stays
+// under the cognitive-complexity budget.
+func (h *hostState) recordResult(latency time.Duration, err error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if err != nil {
+		h.errorCount++
+		h.lastErr = err.Error()
+	} else {
+		h.latencies = append(h.latencies, latency)
+		h.postedCount++
 	}
 }
 
@@ -454,6 +469,24 @@ func (h *hostState) recordErr(msg string) {
 // aggregate folds per-host latencies into the Report's percentile fields and computes pass/fail. Latencies are concatenated then
 // sorted once; with ~100 hosts and ~hundreds of observations each, an O(n log n) sort over the union is well under a millisecond.
 func aggregate(rep *Report, hosts []*hostState, opts Options) {
+	all := foldHostLatencies(rep, hosts)
+	slices.Sort(all)
+	rep.LatencyP50 = percentileSorted(all, percentileP50)
+	rep.LatencyP95 = percentileSorted(all, percentileP95)
+	rep.LatencyP99 = percentileSorted(all, percentileP99)
+	if len(all) > 0 {
+		rep.LatencyMax = all[len(all)-1]
+	}
+	if rep.Duration > 0 {
+		rep.ObservationsPerSec = float64(rep.ObservationCount) / rep.Duration.Seconds()
+	}
+	evaluatePassGate(rep, opts)
+}
+
+// foldHostLatencies writes each host's HostReport into rep, accumulates the aggregate observation + error counts, and returns the
+// concatenation of every host's per-observation latencies (pre-sized to the exact total). Extracted from aggregate so the caller
+// stays under the cognitive-complexity budget.
+func foldHostLatencies(rep *Report, hosts []*hostState) []time.Duration {
 	// Pre-size the aggregate latency slice to the exact total observation count. The per-host postedCount is already known
 	// here so the previous `len(hosts)*16` guess is replaced with the precise value; in a 100-host x 5-min x 1s lane the
 	// guess was ~20x low and forced grow-by-double reallocations.
@@ -481,16 +514,13 @@ func aggregate(rep *Report, hosts []*hostState, opts Options) {
 		all = append(all, h.latencies...)
 		h.mu.Unlock()
 	}
-	slices.Sort(all)
-	rep.LatencyP50 = percentileSorted(all, percentileP50)
-	rep.LatencyP95 = percentileSorted(all, percentileP95)
-	rep.LatencyP99 = percentileSorted(all, percentileP99)
-	if len(all) > 0 {
-		rep.LatencyMax = all[len(all)-1]
-	}
-	if rep.Duration > 0 {
-		rep.ObservationsPerSec = float64(rep.ObservationCount) / rep.Duration.Seconds()
-	}
+	return all
+}
+
+// evaluatePassGate sets rep.Pass and appends the human-readable fail reasons for the three direct-mode pass criteria: zero errors,
+// p99 within budget, and a non-empty observation set. Extracted from aggregate so the caller stays under the cognitive-complexity
+// budget.
+func evaluatePassGate(rep *Report, opts Options) {
 	rep.Pass = true
 	if rep.ErrorCount > 0 {
 		rep.Pass = false
@@ -674,14 +704,8 @@ func validateOptions(opts Options) (Options, error) {
 	default:
 		return opts, fmt.Errorf("scale: invalid Mode %q (allowed: %q, %q)", opts.Mode, ModeDirect, ModeHeadless)
 	}
-	if opts.QuietRatio < 0 || opts.QuietRatio > 1 {
-		return opts, fmt.Errorf("scale: QuietRatio must be in [0,1], got %v", opts.QuietRatio)
-	}
-	if opts.QuietRatio > 0 && opts.QuietScenarioPath == "" {
-		return opts, errors.New("scale: QuietScenarioPath is required when QuietRatio > 0")
-	}
-	if opts.QuietRatio < 1 && len(opts.ActiveScenarioPaths) == 0 {
-		return opts, errors.New("scale: ActiveScenarioPaths is required when QuietRatio < 1")
+	if err := validateScenarioOptions(opts); err != nil {
+		return opts, err
 	}
 	if opts.Mode == ModeHeadless && opts.QueueDepthPollInterval <= 0 {
 		// defaultOptions resolved zero -> defaultQueueDepthPollInterval, but a negative value passed in by a misconfigured
@@ -689,17 +713,42 @@ func validateOptions(opts Options) (Options, error) {
 		return opts, fmt.Errorf("scale: QueueDepthPollInterval must be > 0 in headless mode, got %s",
 			opts.QueueDepthPollInterval)
 	}
+	if err := validateBacklogOptions(opts); err != nil {
+		return opts, err
+	}
+	return opts, nil
+}
+
+// validateScenarioOptions checks the QuietRatio range and the scenario-path requirements that follow from it. Extracted from
+// validateOptions so the entry validator stays under the cognitive-complexity budget; the checks run in their original order.
+func validateScenarioOptions(opts Options) error {
+	if opts.QuietRatio < 0 || opts.QuietRatio > 1 {
+		return fmt.Errorf("scale: QuietRatio must be in [0,1], got %v", opts.QuietRatio)
+	}
+	if opts.QuietRatio > 0 && opts.QuietScenarioPath == "" {
+		return errors.New("scale: QuietScenarioPath is required when QuietRatio > 0")
+	}
+	if opts.QuietRatio < 1 && len(opts.ActiveScenarioPaths) == 0 {
+		return errors.New("scale: ActiveScenarioPaths is required when QuietRatio < 1")
+	}
+	return nil
+}
+
+// validateBacklogOptions checks the two server-backlog misconfigurations: a ceiling with no DSN to sample, and a DSN in headless
+// mode where the sampler does not run. Extracted from validateOptions so the entry validator stays under the cognitive-complexity
+// budget; the checks run in their original order.
+func validateBacklogOptions(opts Options) error {
 	// A server-backlog ceiling with no DSN to sample is a silent no-op: the sampler never starts, so the gate the operator
 	// asked for is never evaluated and the run reports a false pass. Reject it (Copilot/Gemini/CodeRabbit #536).
 	if opts.PassMaxServerBacklog > 0 && opts.BacklogDSN == "" {
-		return opts, errors.New("scale: PassMaxServerBacklog requires BacklogDSN to be set")
+		return errors.New("scale: PassMaxServerBacklog requires BacklogDSN to be set")
 	}
 	// The server-backlog poll is only wired into the direct-mode Run; runHeadless ignores it. Reject the flags in headless
 	// mode rather than silently skipping the poll, so --backlog-dsn in a headless run fails loudly instead of no-op'ing.
 	if opts.Mode == ModeHeadless && opts.BacklogDSN != "" {
-		return opts, errors.New("scale: BacklogDSN is only supported in direct mode, not headless")
+		return errors.New("scale: BacklogDSN is only supported in direct mode, not headless")
 	}
-	return opts, nil
+	return nil
 }
 
 func defaultOptions(o Options) Options {

--- a/tools/spectrace/report.go
+++ b/tools/spectrace/report.go
@@ -115,40 +115,56 @@ func loadScenariosAndMarkers(specsDir, changesDir, rootDir string) ([]Scenario, 
 // set. A missing or empty changesDir yields an empty set so a repo with no in-flight proposals behaves exactly as before.
 func parseChangeScenarioIDs(changesDir string) (map[string]struct{}, error) {
 	ids := make(map[string]struct{})
-	if changesDir == "" {
-		return ids, nil
-	}
-	// A missing changes tree (no in-flight proposals) or a path that isn't a directory is not an error:
-	// spectrace simply has no WIP IDs to add and behaves exactly as it did before the feature.
-	info, statErr := os.Stat(changesDir)
-	if statErr != nil {
-		if os.IsNotExist(statErr) {
-			return ids, nil
-		}
-		return nil, statErr
-	}
-	if !info.IsDir() {
-		return ids, nil
-	}
-	entries, err := os.ReadDir(changesDir)
-	if err != nil {
-		return nil, err
-	}
 	// Parse each in-flight proposal directory's delta specs. Skip the archive subtree (already applied into the live
 	// specs) and any plain files, so only genuinely in-flight scenario IDs widen the reference-valid set.
-	for _, e := range entries {
-		if !e.IsDir() || e.Name() == archiveDirName {
-			continue
-		}
-		scenarios, err := ParseAllSpecs(filepath.Join(changesDir, e.Name()))
+	err := forEachInFlightChangeDir(changesDir, func(changeDir string) error {
+		scenarios, err := ParseAllSpecs(changeDir)
 		if err != nil {
-			return nil, err
+			return err
 		}
 		for _, s := range scenarios {
 			ids[s.ID] = struct{}{}
 		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
 	return ids, nil
+}
+
+// forEachInFlightChangeDir invokes fn once per in-flight OpenSpec change directory under changesDir (openspec/changes/<change>),
+// passing the change's path. It skips the archive subtree (already merged into the live specs) and any plain files, so only
+// genuinely in-flight change folders reach fn. A missing or empty changesDir, or a path that isn't a directory, is not an error:
+// fn is simply never called and the caller keeps its empty accumulator, exactly as spectrace behaved before the feature. Shared
+// scaffold behind parseChangeScenarioIDs and parseRemovedRequirementKeys, which differ only in what they extract per change.
+func forEachInFlightChangeDir(changesDir string, fn func(changeDir string) error) error {
+	if changesDir == "" {
+		return nil
+	}
+	info, statErr := os.Stat(changesDir)
+	if statErr != nil {
+		if os.IsNotExist(statErr) {
+			return nil
+		}
+		return statErr
+	}
+	if !info.IsDir() {
+		return nil
+	}
+	entries, err := os.ReadDir(changesDir)
+	if err != nil {
+		return err
+	}
+	for _, e := range entries {
+		if !e.IsDir() || e.Name() == archiveDirName {
+			continue
+		}
+		if err := fn(filepath.Join(changesDir, e.Name())); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // parseRemovedRequirementKeys returns the set of "<capability>/<requirement-slug>" keys that in-flight OpenSpec change deltas
@@ -161,30 +177,11 @@ func parseChangeScenarioIDs(changesDir string) (map[string]struct{}, error) {
 // The archive subtree is skipped: archived removals are already applied into openspec/specs, so the scenarios are simply gone.
 func parseRemovedRequirementKeys(changesDir string) (map[string]struct{}, error) {
 	keys := make(map[string]struct{})
-	if changesDir == "" {
-		return keys, nil
-	}
-	info, statErr := os.Stat(changesDir)
-	if statErr != nil {
-		if os.IsNotExist(statErr) {
-			return keys, nil
-		}
-		return nil, statErr
-	}
-	if !info.IsDir() {
-		return keys, nil
-	}
-	entries, err := os.ReadDir(changesDir)
+	err := forEachInFlightChangeDir(changesDir, func(changeDir string) error {
+		return collectRemovedRequirementKeys(changeDir, keys)
+	})
 	if err != nil {
 		return nil, err
-	}
-	for _, e := range entries {
-		if !e.IsDir() || e.Name() == archiveDirName {
-			continue
-		}
-		if err := collectRemovedRequirementKeys(filepath.Join(changesDir, e.Name()), keys); err != nil {
-			return nil, err
-		}
 	}
 	return keys, nil
 }
@@ -214,14 +211,21 @@ func collectRemovedRequirementKeys(changeDir string, keys map[string]struct{}) e
 		if d.IsDir() || filepath.Base(path) != "spec.md" {
 			return nil
 		}
-		f, err := os.Open(path) //nolint:gosec // path comes from filepath.WalkDir under changesDir/<change>/specs
-		if err != nil {
-			return fmt.Errorf("open %s: %w", path, err)
-		}
-		defer f.Close()
-		capability := filepath.Base(filepath.Dir(path))
-		return scanRemovedRequirements(f, capability, keys)
+		return scanRemovedRequirementsFile(path, keys)
 	})
+}
+
+// scanRemovedRequirementsFile opens one delta spec.md and records its `## REMOVED Requirements` keys under the capability derived
+// from the file's parent directory (specs/<capability>/spec.md). Split out of collectRemovedRequirementKeys' WalkDir callback so
+// the callback stays a flat guard chain.
+func scanRemovedRequirementsFile(path string, keys map[string]struct{}) error {
+	f, err := os.Open(path) //nolint:gosec // path comes from filepath.WalkDir under changesDir/<change>/specs
+	if err != nil {
+		return fmt.Errorf("open %s: %w", path, err)
+	}
+	defer f.Close()
+	capability := filepath.Base(filepath.Dir(path))
+	return scanRemovedRequirements(f, capability, keys)
 }
 
 // scanRemovedRequirements is the streaming parser behind collectRemovedRequirementKeys. It tracks the active `## ` section and,

--- a/ui/src/cmdline.ts
+++ b/ui/src/cmdline.ts
@@ -8,6 +8,9 @@ export function formatCommandLine(args: string[] | undefined, path: string): str
 
 function quoteArg(arg: string): string {
   if (arg === "") return '""';
-  if (/[\s"]/.test(arg)) return `"${arg.split('"').join(String.raw`\"`)}"`;
+  if (/[\s"]/.test(arg)) {
+    const escaped = arg.split('"').join(String.raw`\"`);
+    return `"${escaped}"`;
+  }
   return arg;
 }

--- a/ui/src/components/ProcessTree.helpers.test.ts
+++ b/ui/src/components/ProcessTree.helpers.test.ts
@@ -1,0 +1,469 @@
+import { describe, it, expect } from "vitest";
+import { hierarchy } from "d3";
+
+import {
+  isSystemPath,
+  countDescendants,
+  toD3Hierarchy,
+  collectMatches,
+  findAlertChain,
+  selectNodeFromParams,
+  viewHref,
+  buildPreservedIds,
+  buildQueryFilterIds,
+  buildVisibleRoots,
+  type D3Node,
+  type D3PointNode,
+  type VisibilityFilters,
+} from "./ProcessTree.helpers";
+import type { ProcessNode } from "../types";
+import { NANOSECONDS_PER_MILLISECOND } from "../constants";
+
+// node builds a valid ProcessNode from a partial: every required Process field carries a benign default so a test only names the
+// fields it cares about (id/pid/path/children/args/fork+exit windows/aggregated).
+function node(overrides: Partial<ProcessNode>): ProcessNode {
+  return { id: 0, host_id: "h1", pid: 0, ppid: 0, path: "", fork_time_ns: 0, ...overrides };
+}
+
+// layout mirrors ProcessTree.tsx's d3 layout step just enough to feed collectMatches: build the D3 hierarchy, then take the flat
+// descendant list as point nodes. collectMatches only reads .data and .parent, so the missing x/y from a real tree layout is moot.
+function layout(roots: ProcessNode[]): D3PointNode[] {
+  return hierarchy<D3Node>(toD3Hierarchy(roots)).descendants() as D3PointNode[];
+}
+
+describe("isSystemPath", () => {
+  it("flags each system path segment on a substring (not prefix) match", () => {
+    expect(isSystemPath("/System/Library/Frameworks/WebKit.framework/WebKit")).toBe(true);
+    expect(isSystemPath("/usr/libexec/trustd")).toBe(true);
+    expect(isSystemPath("/Library/Apple/System/Library/CoreServices/XProtect")).toBe(true);
+    // Cryptex-mounted framework binary: the segment appears mid-path, so substring matching still catches it.
+    expect(isSystemPath("/System/Volumes/Preboot/Cryptexes/OS/System/Library/Frameworks/WebKit.framework/WebKit")).toBe(true);
+  });
+
+  it("keeps any .app bundle visible even under /System/Library/", () => {
+    expect(isSystemPath("/System/Library/CoreServices/Finder.app/Contents/MacOS/Finder")).toBe(false);
+    expect(isSystemPath("/Applications/Safari.app/Contents/MacOS/Safari")).toBe(false);
+  });
+
+  it("returns false for ordinary user and third-party binaries", () => {
+    expect(isSystemPath("/usr/local/bin/tool")).toBe(false);
+    expect(isSystemPath("/opt/homebrew/bin/curl")).toBe(false);
+    expect(isSystemPath("/bin/bash")).toBe(false);
+  });
+});
+
+describe("countDescendants", () => {
+  it("returns 0 for a leaf with no children", () => {
+    expect(countDescendants(node({ id: 1 }))).toBe(0);
+    expect(countDescendants(node({ id: 1, children: [] }))).toBe(0);
+  });
+
+  it("counts every descendant across the full subtree", () => {
+    const tree = node({
+      id: 1,
+      children: [
+        node({ id: 2, children: [node({ id: 4 }), node({ id: 5 })] }),
+        node({ id: 3, children: [node({ id: 6, children: [node({ id: 7 })] })] }),
+      ],
+    });
+    // 2,3,4,5,6,7 = six descendants.
+    expect(countDescendants(tree)).toBe(6);
+  });
+});
+
+describe("toD3Hierarchy", () => {
+  it("returns the single root directly with basename as name and children present", () => {
+    const d3n = toD3Hierarchy([
+      node({ id: 1, pid: 100, path: "/usr/bin/curl", children: [node({ id: 2, pid: 200, path: "/bin/sh" })] }),
+    ]);
+    expect(d3n.name).toBe("curl");
+    expect(d3n.pid).toBe(100);
+    expect(d3n.path).toBe("/usr/bin/curl");
+    expect(d3n.children).toHaveLength(1);
+    expect(d3n.children?.[0].name).toBe("sh");
+  });
+
+  it("falls back to `PID <n>` when the node has no path, and drops the empty children array", () => {
+    const d3n = toD3Hierarchy([node({ id: 1, pid: 4242, path: "", children: [] })]);
+    expect(d3n.name).toBe("PID 4242");
+    // An empty children array is normalized to undefined (kids.length === 0 branch).
+    expect(d3n.children).toBeUndefined();
+  });
+
+  it("wraps multiple roots under a synthetic root with pid 0", () => {
+    const d3n = toD3Hierarchy([
+      node({ id: 1, pid: 100, path: "/bin/a" }),
+      node({ id: 2, pid: 101, path: "/bin/b" }),
+    ]);
+    expect(d3n.name).toBe("root");
+    expect(d3n.pid).toBe(0);
+    expect(d3n.path).toBe("");
+    expect(d3n.children?.map((c) => c.pid)).toEqual([100, 101]);
+  });
+});
+
+describe("collectMatches", () => {
+  const roots = [
+    node({
+      id: 1,
+      pid: 100,
+      path: "/bin/a",
+      children: [
+        node({
+          id: 2,
+          pid: 200,
+          path: "/bin/bash",
+          args: ["bash", "-c", "evilcmd"],
+          children: [node({ id: 3, pid: 300, path: "/usr/bin/curl" })],
+        }),
+      ],
+    }),
+  ];
+
+  it("returns empty match + path sets for an empty query", () => {
+    const { matches, pathNodes } = collectMatches(layout(roots), "");
+    expect(matches).toHaveLength(0);
+    expect(pathNodes.size).toBe(0);
+  });
+
+  it("matches by name and includes the whole ancestor path", () => {
+    const { matches, pathNodes } = collectMatches(layout(roots), "bash");
+    expect(matches.map((m) => m.data.pid)).toEqual([200]);
+    // The match's ancestors (a -> bash) are collected so the context stays visible.
+    expect([...pathNodes].map((n) => n.data.pid).sort((x, y) => x - y)).toEqual([100, 200]);
+  });
+
+  it("matches by args, by pid substring, and by path", () => {
+    expect(collectMatches(layout(roots), "evilcmd").matches.map((m) => m.data.pid)).toEqual([200]);
+    expect(collectMatches(layout(roots), "300").matches.map((m) => m.data.pid)).toEqual([300]);
+    // A pid deep match pulls its full chain (a -> bash -> curl) into pathNodes.
+    expect([...collectMatches(layout(roots), "300").pathNodes].map((n) => n.data.pid).sort((x, y) => x - y)).toEqual([100, 200, 300]);
+    expect(collectMatches(layout(roots), "curl").matches.map((m) => m.data.pid)).toEqual([300]);
+    // "usr" appears only in curl's path (/usr/bin/curl), not its basename, so this exercises the path branch on its own.
+    expect(collectMatches(layout(roots), "usr").matches.map((m) => m.data.pid)).toEqual([300]);
+  });
+
+  it("returns nothing when no node matches", () => {
+    const { matches, pathNodes } = collectMatches(layout(roots), "no-such-thing");
+    expect(matches).toHaveLength(0);
+    expect(pathNodes.size).toBe(0);
+  });
+
+  it("skips the synthetic pid-0 root that a multi-root forest inserts", () => {
+    const multi = [node({ id: 1, pid: 100, path: "/bin/a" }), node({ id: 2, pid: 101, path: "/bin/b" })];
+    // "root" only matches the synthetic node's name; it must be skipped, leaving no matches.
+    const { matches } = collectMatches(layout(multi), "root");
+    expect(matches).toHaveLength(0);
+  });
+});
+
+describe("findAlertChain", () => {
+  // R(1) -> X(2) -> {X1(4) -> X1a(6), X2(5)}; R(1) -> Y(3) -> Y1(7)
+  const roots = [
+    node({
+      id: 1,
+      children: [
+        node({
+          id: 2,
+          children: [node({ id: 4, children: [node({ id: 6 })] }), node({ id: 5 })],
+        }),
+        node({ id: 3, children: [node({ id: 7 })] }),
+      ],
+    }),
+  ];
+
+  it("returns the target's ancestors plus the target's descendants, excluding unrelated branches", () => {
+    const chain = findAlertChain(roots, 4);
+    // path R(1)->X(2)->X1(4) plus X1's subtree (4,6). X2(5), Y(3), Y1(7) are off-chain.
+    expect([...chain].sort((a, b) => a - b)).toEqual([1, 2, 4, 6]);
+  });
+
+  it("returns every id when the target is the root", () => {
+    const chain = findAlertChain(roots, 1);
+    expect([...chain].sort((a, b) => a - b)).toEqual([1, 2, 3, 4, 5, 6, 7]);
+  });
+
+  it("returns an empty set when the target is not in the tree", () => {
+    expect(findAlertChain(roots, 999).size).toBe(0);
+  });
+});
+
+describe("selectNodeFromParams", () => {
+  const roots = [
+    node({ id: 1, pid: 1, path: "/sbin/launchd", children: [node({ id: 6, pid: 42, path: "/usr/bin/deep" })] }),
+  ];
+
+  it("returns null when there are no roots", () => {
+    expect(selectNodeFromParams([], new URLSearchParams("process=1"))).toBeNull();
+  });
+
+  it("resolves ?process=<dbId> by walking into children", () => {
+    const found = selectNodeFromParams(roots, new URLSearchParams("process=6"));
+    expect(found?.id).toBe(6);
+    expect(found?.pid).toBe(42);
+  });
+
+  it("returns null for a ?process id that is not present", () => {
+    expect(selectNodeFromParams(roots, new URLSearchParams("process=999"))).toBeNull();
+  });
+
+  it("returns null when neither process nor a pid+at pair is supplied", () => {
+    expect(selectNodeFromParams(roots, new URLSearchParams())).toBeNull();
+    // pid without at falls through to the final return.
+    expect(selectNodeFromParams(roots, new URLSearchParams("pid=1"))).toBeNull();
+  });
+
+  describe("?pid=<pid>&at=<ms> lifetime windows", () => {
+    // Two generations reuse pid 500: gen A [1ms..5ms], gen B [10ms..running].
+    const ms = (n: number) => n * NANOSECONDS_PER_MILLISECOND;
+    const reuseRoots = [
+      node({
+        id: 100,
+        pid: 9,
+        path: "/root",
+        children: [
+          node({ id: 10, pid: 500, path: "/gen-a", fork_time_ns: ms(1), exit_time_ns: ms(5) }),
+          node({ id: 11, pid: 500, path: "/gen-b", fork_time_ns: ms(10) }),
+        ],
+      }),
+    ];
+
+    it("picks the generation whose lifetime brackets the event time", () => {
+      // at=3ms is inside gen A only.
+      expect(selectNodeFromParams(reuseRoots, new URLSearchParams("pid=500&at=3"))?.id).toBe(10);
+      // at=12ms is after gen A exited and inside still-running gen B.
+      expect(selectNodeFromParams(reuseRoots, new URLSearchParams("pid=500&at=12"))?.id).toBe(11);
+      // at=10ms: gen A exited at 5ms, gen B forked exactly at 10ms (fork <= atNs boundary is inclusive).
+      expect(selectNodeFromParams(reuseRoots, new URLSearchParams("pid=500&at=10"))?.id).toBe(11);
+    });
+
+    it("prefers the closest fork at/before the anchor when two generations both bracket it", () => {
+      const overlapping = [
+        node({
+          id: 100,
+          pid: 9,
+          path: "/root",
+          children: [
+            // Visit order matters for the tiebreak: id10 seeds best, id12 (later fork) replaces it, id13 (earlier fork than the
+            // current best) must NOT replace it. This exercises all three outcomes of `best === null || fork > best.fork`.
+            node({ id: 10, pid: 500, path: "/older", fork_time_ns: ms(1), exit_time_ns: ms(5) }),
+            node({ id: 12, pid: 500, path: "/newest", fork_time_ns: ms(2.5), exit_time_ns: ms(5) }),
+            node({ id: 13, pid: 500, path: "/middle", fork_time_ns: ms(1.5), exit_time_ns: ms(5) }),
+          ],
+        }),
+      ];
+      // All three bracket at=3ms; the latest fork (id 12) wins regardless of visit order.
+      expect(selectNodeFromParams(overlapping, new URLSearchParams("pid=500&at=3"))?.id).toBe(12);
+    });
+
+    it("treats exit_time_ns 0 as still-running (not exited at time 0)", () => {
+      const running = [node({ id: 20, pid: 600, path: "/running", fork_time_ns: ms(1), exit_time_ns: 0 })];
+      expect(selectNodeFromParams(running, new URLSearchParams("pid=600&at=100"))?.id).toBe(20);
+    });
+
+    it("returns null when no generation of that pid was alive at the event time", () => {
+      // at=0.5ms is before gen A forked (1ms).
+      expect(selectNodeFromParams(reuseRoots, new URLSearchParams("pid=500&at=0.5"))).toBeNull();
+    });
+  });
+});
+
+describe("viewHref", () => {
+  it("drops ?view= when switching to the default graph view, preserving other params", () => {
+    const sp = new URLSearchParams("view=timeline&window=1h");
+    expect(viewHref("host-1", sp, "graph")).toBe("/hosts/host-1?window=1h");
+  });
+
+  it("sets ?view=timeline while preserving the shared time window", () => {
+    const sp = new URLSearchParams("window=1h");
+    expect(viewHref("host-1", sp, "timeline")).toBe("/hosts/host-1?window=1h&view=timeline");
+  });
+
+  it("emits no query suffix when there are no params", () => {
+    expect(viewHref("host-1", new URLSearchParams(), "graph")).toBe("/hosts/host-1");
+  });
+
+  it("percent-encodes the host id", () => {
+    expect(viewHref("a/b c", new URLSearchParams(), "graph")).toBe("/hosts/a%2Fb%20c");
+  });
+
+  it("does not mutate the caller's URLSearchParams", () => {
+    const sp = new URLSearchParams("view=timeline");
+    viewHref("h", sp, "graph");
+    expect(sp.get("view")).toBe("timeline");
+  });
+});
+
+describe("buildPreservedIds", () => {
+  // R(1) -> A(2) -> B(3); R(1) -> C(4)
+  const roots = [
+    node({ id: 1, children: [node({ id: 2, children: [node({ id: 3 })] }), node({ id: 4 })] }),
+  ];
+
+  it("keeps an alerted node and its full ancestor path, but not unrelated branches", () => {
+    const keep = buildPreservedIds(roots, new Set([3]));
+    expect([...keep].sort((a, b) => a - b)).toEqual([1, 2, 3]);
+  });
+
+  it("keeps only the root when the root itself is alerted", () => {
+    expect([...buildPreservedIds(roots, new Set([1]))]).toEqual([1]);
+  });
+
+  it("returns an empty set when nothing is alerted", () => {
+    expect(buildPreservedIds(roots, new Set()).size).toBe(0);
+  });
+});
+
+describe("buildQueryFilterIds", () => {
+  // R(1,/bin/launchd) -> A(2,/usr/bin/curl args) -> B(3,/bin/sh); R(1) -> C(4,/usr/bin/ssh)
+  const roots = [
+    node({
+      id: 1,
+      pid: 1,
+      path: "/bin/launchd",
+      children: [
+        node({
+          id: 2,
+          pid: 2,
+          path: "/usr/bin/curl",
+          args: ["curl", "http://evil.example"],
+          children: [node({ id: 3, pid: 3, path: "/bin/sh" })],
+        }),
+        node({ id: 4, pid: 4, path: "/usr/bin/ssh" }),
+      ],
+    }),
+  ];
+
+  it("returns null when the query is empty or whitespace", () => {
+    expect(buildQueryFilterIds(roots, "")).toBeNull();
+    expect(buildQueryFilterIds(roots, "   ")).toBeNull();
+  });
+
+  it("keeps a matching node plus its ancestors (including a non-matching parent) and drops the rest", () => {
+    const keep = buildQueryFilterIds(roots, "curl");
+    // A(2) matches by name; R(1) is kept as an ancestor even though launchd does not match. B(3), C(4) drop out.
+    expect([...(keep ?? new Set())].sort((a, b) => a - b)).toEqual([1, 2]);
+  });
+
+  it("matches on args and on a pid substring", () => {
+    expect([...(buildQueryFilterIds(roots, "evil") ?? new Set())].sort((a, b) => a - b)).toEqual([1, 2]);
+    // pid 3 matches only B(3); the chain R(1)->A(2)->B(3) survives.
+    expect([...(buildQueryFilterIds(roots, "3") ?? new Set())].sort((a, b) => a - b)).toEqual([1, 2, 3]);
+  });
+
+  it("trims and lowercases the query before matching", () => {
+    expect([...(buildQueryFilterIds(roots, "  CURL  ") ?? new Set())].sort((a, b) => a - b)).toEqual([1, 2]);
+  });
+});
+
+describe("buildVisibleRoots", () => {
+  // R(1,/sbin/launchd) -> APP(2,/Applications/Foo.app/...) -> {SYS(3,/System/Library/...) -> LEAF(4,/usr/bin/curl), USER(5,/usr/local/bin/tool)}
+  const makeTree = (): ProcessNode[] => [
+    node({
+      id: 1,
+      pid: 1,
+      path: "/sbin/launchd",
+      children: [
+        node({
+          id: 2,
+          pid: 2,
+          path: "/Applications/Foo.app/Contents/MacOS/Foo",
+          children: [
+            node({
+              id: 3,
+              pid: 3,
+              path: "/System/Library/Frameworks/WebKit.framework/WebKit",
+              children: [node({ id: 4, pid: 4, path: "/usr/bin/curl" })],
+            }),
+            node({ id: 5, pid: 5, path: "/usr/local/bin/tool" }),
+          ],
+        }),
+      ],
+    }),
+  ];
+
+  const baseFilters = (): VisibilityFilters => ({
+    showSystem: true,
+    collapsedIds: new Set(),
+    expandedAggIds: new Set(),
+    preservedIds: new Set(),
+    applyCollapse: true,
+    alertChainIds: null,
+    queryFilterIds: null,
+  });
+
+  // childIds pulls the immediate children ids under the first (id 2) grandchild-holder so assertions read clearly.
+  const appChildIds = (out: ProcessNode[]): number[] =>
+    (out[0].children?.[0].children ?? []).map((c) => c.id).sort((a, b) => a - b);
+
+  it("hides system-path nodes and their subtrees when showSystem is false", () => {
+    const out = buildVisibleRoots(makeTree(), { ...baseFilters(), showSystem: false });
+    // SYS(3) is a system path so it and its child LEAF(4) drop out; USER(5) survives.
+    expect(appChildIds(out)).toEqual([5]);
+  });
+
+  it("keeps system-path nodes visible when showSystem is true", () => {
+    const out = buildVisibleRoots(makeTree(), baseFilters());
+    expect(appChildIds(out)).toEqual([3, 5]);
+    // SYS(3) still carries its LEAF child.
+    expect(out[0].children?.[0].children?.[0].children?.[0].id).toBe(4);
+  });
+
+  it("keeps a preserved system node visible even when showSystem is false", () => {
+    const out = buildVisibleRoots(makeTree(), { ...baseFilters(), showSystem: false, preservedIds: new Set([3]) });
+    expect(appChildIds(out)).toEqual([3, 5]);
+  });
+
+  it("restricts the tree to the alert chain, dropping off-chain nodes", () => {
+    const out = buildVisibleRoots(makeTree(), { ...baseFilters(), alertChainIds: new Set([1, 2, 5]) });
+    expect(appChildIds(out)).toEqual([5]);
+  });
+
+  it("restricts the tree to the query-filter set", () => {
+    const out = buildVisibleRoots(makeTree(), { ...baseFilters(), queryFilterIds: new Set([1, 2, 5]) });
+    expect(appChildIds(out)).toEqual([5]);
+  });
+
+  it("collapses a node's children into a _collapsedCount when applyCollapse is on", () => {
+    const out = buildVisibleRoots(makeTree(), { ...baseFilters(), collapsedIds: new Set([2]) });
+    const app = out[0].children?.[0];
+    expect(app?.children).toBeUndefined();
+    // Visible descendants under APP: SYS(3), LEAF(4), USER(5) = 3.
+    expect(app?._collapsedCount).toBe(3);
+  });
+
+  it("skips the collapse step when applyCollapse is off (search active)", () => {
+    const out = buildVisibleRoots(makeTree(), { ...baseFilters(), collapsedIds: new Set([2]), applyCollapse: false });
+    const app = out[0].children?.[0];
+    expect(app?._collapsedCount).toBeUndefined();
+    expect(app?.children?.map((c) => c.id).sort((a, b) => a - b)).toEqual([3, 5]);
+  });
+
+  describe("aggregated nodes", () => {
+    const aggRoots = (sample?: ProcessNode[]): ProcessNode[] => [
+      node({
+        id: 6,
+        pid: 6,
+        path: "/usr/bin/agg",
+        aggregated: { count: 10, exited_count: 7, running_count: 3, first_fork_ns: 1, last_fork_ns: 2, sample },
+      }),
+    ];
+
+    it("materializes the capped sample as children when the aggregate is expanded", () => {
+      const sample = [node({ id: 7, pid: 7, path: "/usr/bin/s1" }), node({ id: 8, pid: 8, path: "/usr/bin/s2" })];
+      const out = buildVisibleRoots(aggRoots(sample), { ...baseFilters(), expandedAggIds: new Set([6]) });
+      expect(out[0].children?.map((c) => c.id)).toEqual([7, 8]);
+    });
+
+    it("ships the aggregate childless when it is not expanded", () => {
+      const sample = [node({ id: 7, pid: 7, path: "/usr/bin/s1" })];
+      const out = buildVisibleRoots(aggRoots(sample), baseFilters());
+      expect(out[0].children).toBeUndefined();
+    });
+
+    it("yields an empty child list for an expanded aggregate with no sample", () => {
+      const out = buildVisibleRoots(aggRoots(undefined), { ...baseFilters(), expandedAggIds: new Set([6]) });
+      expect(out[0].children).toEqual([]);
+    });
+  });
+});

--- a/ui/src/components/ProcessTree.helpers.ts
+++ b/ui/src/components/ProcessTree.helpers.ts
@@ -1,0 +1,298 @@
+// Pure helpers for ProcessTree.tsx (issue: consolidation cognitive-complexity paydown). Everything here is a side-effect-free data
+// transform over the ProcessNode forest, the search query, or the d3 hierarchy: no React, no d3 DOM mutation. Extracted so the
+// ProcessTree component and its d3 render effect stay under Sonar's cognitive-complexity cap. Behavior is identical to the inlined
+// originals; these are verbatim moves plus three build* functions lifted out of the component's useMemo bodies unchanged.
+import type { HierarchyPointNode } from "d3";
+import type { ProcessNode } from "../types";
+import { NANOSECONDS_PER_MILLISECOND } from "../constants";
+
+export interface D3Node {
+  name: string;
+  pid: number;
+  path: string;
+  data: ProcessNode;
+  children?: D3Node[];
+}
+
+export type D3PointNode = HierarchyPointNode<D3Node>;
+
+// Path segments we treat as "system noise" for the hide-system toggle. We match on substring
+// rather than prefix so that cryptex-mounted paths also match. On modern macOS a single framework
+// binary can appear at any of, e.g.:
+//   /System/Library/Frameworks/WebKit.framework/...
+//   /System/Volumes/Preboot/Cryptexes/OS/System/Library/Frameworks/WebKit.framework/...
+//   /System/Cryptexes/Incoming/OS/System/Library/Frameworks/WebKit.framework/...
+// We deliberately do NOT filter /System/Applications/ (Safari, Mail, Notes, Messages, Calendar,
+// etc.) because those are user-facing apps and are as valid an attack surface as anything in
+// /Applications/. Anything packaged as a .app bundle is kept regardless of where it lives, so
+// Finder, Dock, loginwindow-hosted apps, and the like also remain in the tree.
+const SYSTEM_PATH_SEGMENTS = ["/System/Library/", "/usr/libexec/", "/Library/Apple/"];
+
+function basename(path: string): string {
+  if (!path) return "";
+  const parts = path.split("/");
+  return parts[parts.length - 1];
+}
+
+export function isSystemPath(path: string): boolean {
+  // Any .app bundle is a user-launchable application, so keep it visible even if it lives
+  // under /System/Library/ (e.g. /System/Library/CoreServices/Finder.app/...).
+  if (path.includes(".app/")) return false;
+  for (const seg of SYSTEM_PATH_SEGMENTS) {
+    if (path.includes(seg)) return true;
+  }
+  return false;
+}
+
+export function countDescendants(node: ProcessNode): number {
+  if (!node.children) return 0;
+  let n = 0;
+  for (const c of node.children) n += 1 + countDescendants(c);
+  return n;
+}
+
+export function toD3Hierarchy(nodes: ProcessNode[]): D3Node {
+  function convert(n: ProcessNode): D3Node {
+    const kids = n.children?.map(convert);
+    return {
+      name: basename(n.path) || `PID ${String(n.pid)}`,
+      pid: n.pid,
+      path: n.path,
+      data: n,
+      children: kids && kids.length > 0 ? kids : undefined,
+    };
+  }
+
+  if (nodes.length === 1) {
+    return convert(nodes[0]);
+  }
+
+  return {
+    name: "root",
+    pid: 0,
+    path: "",
+    data: nodes[0],
+    children: nodes.map(convert),
+  };
+}
+
+// matchFields holds the four node fields the search box compares against.
+// Both the d3-layout-time matcher and the data-side pre-filter funnel into
+// this so the matching rules can't drift between them.
+function matchFields(name: string, path: string, pid: number, args: string[] | undefined, q: string): boolean {
+  if (name.toLowerCase().includes(q)) return true;
+  if (path.toLowerCase().includes(q)) return true;
+  if (String(pid).includes(q)) return true;
+  if (args?.some((a) => a.toLowerCase().includes(q))) return true;
+  return false;
+}
+
+function nodeMatchesQuery(d: D3Node, q: string): boolean {
+  return matchFields(d.name, d.path, d.pid, d.data.args, q);
+}
+
+// matchesQueryRaw is the data-side mirror of nodeMatchesQuery: it operates on
+// raw ProcessNode rows before the d3 layout runs. Used by the visible-tree
+// pre-filter so the canvas only ever lays out the matches-plus-ancestors set.
+function matchesQueryRaw(n: ProcessNode, q: string): boolean {
+  const name = n.path.split("/").pop() ?? "";
+  return matchFields(name, n.path, n.pid, n.args, q);
+}
+
+// collectMatches walks the laid-out nodes and returns every node whose payload matches
+// q (by name/path/pid/args) plus the set of nodes on the ancestor path of any match,
+// used to dim non-matching subtrees while keeping the context to the match visible.
+export function collectMatches(
+  nodes: D3PointNode[],
+  q: string,
+): { matches: D3PointNode[]; pathNodes: Set<D3PointNode> } {
+  const matches: D3PointNode[] = [];
+  const pathNodes = new Set<D3PointNode>();
+  if (!q) return { matches, pathNodes };
+  for (const n of nodes) {
+    if (n.data.pid === 0) continue; // synthetic root when tree has multiple real roots
+    if (!nodeMatchesQuery(n.data, q)) continue;
+    matches.push(n);
+    let cur: D3PointNode | null = n;
+    while (cur) {
+      pathNodes.add(cur);
+      cur = cur.parent;
+    }
+  }
+  return { matches, pathNodes };
+}
+
+// Given a root list and a target process row id, return the set of ids that form the alert
+// chain: the target, every ancestor back to the top root, and every descendant. If the
+// target isn't in the tree, returns an empty set (the focus filter will then drop the whole
+// tree, making it visually obvious that the target is out of range).
+export function findAlertChain(roots: ProcessNode[], targetDbId: number): Set<number> {
+  const related = new Set<number>();
+  let path: ProcessNode[] = [];
+  const findPath = (nodes: ProcessNode[], acc: ProcessNode[]): boolean => {
+    for (const n of nodes) {
+      const next = [...acc, n];
+      if (n.id === targetDbId) { path = next; return true; }
+      if (n.children?.length && findPath(n.children, next)) return true;
+    }
+    return false;
+  };
+  findPath(roots, []);
+  if (path.length === 0) return related;
+  for (const p of path) related.add(p.id);
+  const addDescendants = (n: ProcessNode) => {
+    related.add(n.id);
+    if (n.children) for (const c of n.children) addDescendants(c);
+  };
+  addDescendants(path[path.length - 1]);
+  return related;
+}
+
+function findNodeByDbId(nodes: ProcessNode[], dbId: number): ProcessNode | null {
+  for (const n of nodes) {
+    if (n.id === dbId) return n;
+    if (n.children) {
+      const found = findNodeByDbId(n.children, dbId);
+      if (found) return found;
+    }
+  }
+  return null;
+}
+
+// findNodeByPidAtTime resolves a timeline row's (pid, event time) to its process node: the node with that pid whose lifetime brackets
+// atNs (fork <= atNs, and no exit or exit >= atNs). This disambiguates pid reuse within the window by picking the generation live at
+// the event, the same (host, pid, at) correlation the process-detail network join relies on. Prefers the closest fork at/before the
+// anchor so an exact hit wins over a wider-lived ancestor sharing the pid.
+function findNodeByPidAtTime(nodes: ProcessNode[], pid: number, atNs: number): ProcessNode | null {
+  let best: ProcessNode | null = null;
+  const visit = (n: ProcessNode) => {
+    // !n.exit_time_ns covers a still-running process whether the API sends the field as undefined, null, or 0; a bare === undefined
+    // check would treat a null (common for running processes over the Go/JSON boundary) as "exited at null" and drop the node.
+    if (n.pid === pid && n.fork_time_ns <= atNs && (!n.exit_time_ns || n.exit_time_ns >= atNs)) {
+      if (best === null || n.fork_time_ns > best.fork_time_ns) best = n;
+    }
+    for (const c of n.children ?? []) visit(c);
+  };
+  for (const n of nodes) visit(n);
+  return best;
+}
+
+// selectNodeFromParams resolves the node the URL asks the graph to select: ?process=<dbId> directly, or ?pid=<pid>&at=<ms> (a timeline
+// row) via findNodeByPidAtTime. Kept at module scope so the selection effect in ProcessTreeView stays a single branch.
+export function selectNodeFromParams(roots: ProcessNode[], searchParams: URLSearchParams): ProcessNode | null {
+  if (roots.length === 0) return null;
+  const processIdParam = searchParams.get("process");
+  if (processIdParam) return findNodeByDbId(roots, Number(processIdParam));
+  const pidQuery = searchParams.get("pid");
+  const atQuery = searchParams.get("at");
+  if (pidQuery && atQuery) {
+    return findNodeByPidAtTime(roots, Number(pidQuery), Number(atQuery) * NANOSECONDS_PER_MILLISECOND);
+  }
+  return null;
+}
+
+// viewHref toggles the view param while preserving the rest of the URL (window, alert anchor, selection), so switching views is a link
+// that never changes the shared time window. Graph is the default, so it drops ?view= rather than setting view=graph.
+export function viewHref(hostId: string, searchParams: URLSearchParams, v: "graph" | "timeline"): string {
+  const next = new URLSearchParams(searchParams);
+  if (v === "graph") {
+    next.delete("view");
+  } else {
+    next.set("view", v);
+  }
+  const qs = next.toString();
+  const suffix = qs ? `?${qs}` : "";
+  return `/hosts/${encodeURIComponent(hostId)}${suffix}`;
+}
+
+// buildPreservedIds: never hide processes that have alerts attached, or that sit on the ancestor path of one (even if their binary is
+// in a system path, the analyst context matters). Lifted verbatim from ProcessTreeView's preservedIds useMemo (complexity paydown).
+export function buildPreservedIds(roots: ProcessNode[], alertProcessIds: Set<number>): Set<number> {
+  const keep = new Set<number>();
+  const walk = (node: ProcessNode, ancestors: number[]) => {
+    const nextAncestors = [...ancestors, node.id];
+    if (alertProcessIds.has(node.id)) {
+      for (const id of nextAncestors) keep.add(id);
+    }
+    if (node.children) for (const c of node.children) walk(c, nextAncestors);
+  };
+  for (const r of roots) walk(r, []);
+  return keep;
+}
+
+// buildQueryFilterIds: the set of ids to keep visible while a search query is active (every matching node plus its ancestors), so the
+// canvas only ever lays out the matches-plus-ancestors set instead of dimming a wall of noise. Null when the query is empty. Lifted
+// verbatim from ProcessTreeView's queryFilterIds useMemo.
+export function buildQueryFilterIds(roots: ProcessNode[], query: string): Set<number> | null {
+  const q = query.trim().toLowerCase();
+  if (!q) return null;
+  const keep = new Set<number>();
+  const visit = (nodes: ProcessNode[], ancestors: number[]): boolean => {
+    let anyMatch = false;
+    for (const n of nodes) {
+      const matches = matchesQueryRaw(n, q);
+      const childMatches = n.children ? visit(n.children, [...ancestors, n.id]) : false;
+      if (matches || childMatches) {
+        keep.add(n.id);
+        for (const a of ancestors) keep.add(a);
+        anyMatch = true;
+      }
+    }
+    return anyMatch;
+  };
+  visit(roots, []);
+  return keep;
+}
+
+// VisibilityFilters bundles the derived state buildVisibleRoots reshapes the raw forest against; grouped so the call stays one argument.
+export interface VisibilityFilters {
+  showSystem: boolean;
+  collapsedIds: Set<number>;
+  expandedAggIds: Set<number>;
+  preservedIds: Set<number>;
+  applyCollapse: boolean;
+  alertChainIds: Set<number> | null;
+  queryFilterIds: Set<number> | null;
+}
+
+// buildVisibleRoots re-shapes the raw tree according to the current filters: hide system-path nodes unconditionally (except preserved),
+// optionally restrict to the alert chain, and drop children of collapsed nodes while stashing the hidden-count on the surviving parent
+// so it can render as "+N". While a search query is active the collapse step is skipped (applyCollapse false) so a match hidden inside a
+// collapsed subtree still surfaces, and the tree is pruned to matches + ancestors. Lifted verbatim from ProcessTreeView's visibleRoots
+// useMemo (issue: complexity paydown).
+export function buildVisibleRoots(roots: ProcessNode[], filters: VisibilityFilters): ProcessNode[] {
+  const { showSystem, collapsedIds, expandedAggIds, preservedIds, applyCollapse, alertChainIds, queryFilterIds } = filters;
+  // Predicate for "is this node visible at all": pulled out to keep the
+  // recursive walk below under Sonar's cognitive-complexity cap.
+  const isVisible = (n: ProcessNode): boolean => {
+    if (alertChainIds && !alertChainIds.has(n.id)) return false;
+    if (!showSystem && isSystemPath(n.path) && !preservedIds.has(n.id)) return false;
+    // Search filter: hide everything outside the matches-plus-ancestors set so
+    // a query like "60289" reduces a 200-node tree to the few rows that matter,
+    // instead of dimming 195 nodes the user has to visually skip past.
+    if (queryFilterIds && !queryFilterIds.has(n.id)) return false;
+    return true;
+  };
+  const apply = (nodes: ProcessNode[]): ProcessNode[] => {
+    const out: ProcessNode[] = [];
+    for (const n of nodes) {
+      if (!isVisible(n)) continue;
+      // An aggregated "×N" node ships childless; when the analyst expands it, its capped sample becomes its children in place
+      // (issue #416). Its own subtree is always the sample, so the generic collapse machinery below doesn't apply to it.
+      if (n.aggregated) {
+        const sample = expandedAggIds.has(n.id) ? apply(n.aggregated.sample ?? []) : undefined;
+        out.push({ ...n, children: sample });
+        continue;
+      }
+      const kids = n.children ? apply(n.children) : undefined;
+      if (applyCollapse && collapsedIds.has(n.id) && kids && kids.length > 0) {
+        const collapsedTotal = kids.reduce((acc, c) => acc + 1 + countDescendants(c), 0);
+        out.push({ ...n, children: undefined, _collapsedCount: collapsedTotal });
+      } else {
+        out.push({ ...n, children: kids });
+      }
+    }
+    return out;
+  };
+  return apply(roots);
+}

--- a/ui/src/components/ProcessTree.tsx
+++ b/ui/src/components/ProcessTree.tsx
@@ -17,6 +17,18 @@ import { ActivityHistogram } from "./ActivityHistogram";
 import { DEFAULT_ALERT_WINDOW_MS, DEFAULT_LIVE_WINDOW_MS, windowBounds, type TimeWindow } from "../timewindow";
 import { Badge, type BadgeVariant } from "./ui/Badge";
 import { Button } from "./ui/Button";
+import {
+  buildPreservedIds,
+  buildQueryFilterIds,
+  buildVisibleRoots,
+  collectMatches,
+  findAlertChain,
+  selectNodeFromParams,
+  toD3Hierarchy,
+  viewHref,
+  type D3Node,
+  type D3PointNode,
+} from "./ProcessTree.helpers";
 import "./ProcessTree.scss";
 
 const SEVERITY_VARIANTS: Record<string, BadgeVariant> = {
@@ -49,22 +61,8 @@ const LABEL_BG_PAD_Y = 1;
 const LABEL_BG_EXTRA_WIDTH = LABEL_BG_PAD_X * 2;
 const LABEL_BG_EXTRA_HEIGHT = LABEL_BG_PAD_Y * 2;
 
-// Path segments we treat as "system noise" for the hide-system toggle. We match on substring
-// rather than prefix so that cryptex-mounted paths also match. On modern macOS a single framework
-// binary can appear at any of, e.g.:
-//   /System/Library/Frameworks/WebKit.framework/...
-//   /System/Volumes/Preboot/Cryptexes/OS/System/Library/Frameworks/WebKit.framework/...
-//   /System/Cryptexes/Incoming/OS/System/Library/Frameworks/WebKit.framework/...
-// We deliberately do NOT filter /System/Applications/ (Safari, Mail, Notes, Messages, Calendar,
-// etc.) because those are user-facing apps and are as valid an attack surface as anything in
-// /Applications/. Anything packaged as a .app bundle is kept regardless of where it lives, so
-// Finder, Dock, loginwindow-hosted apps, and the like also remain in the tree.
-const SYSTEM_PATH_SEGMENTS = ["/System/Library/", "/usr/libexec/", "/Library/Apple/"];
-
 const SHOW_SYSTEM_STORAGE_KEY = "edr.processTree.showSystem";
 const FLATTEN_STORAGE_KEY = "edr.processTree.flatten";
-
-type D3PointNode = d3.HierarchyPointNode<D3Node>;
 
 interface RenderResult {
   zoom: d3.ZoomBehavior<SVGSVGElement, unknown>;
@@ -221,81 +219,20 @@ export function ProcessTreeView() {
 
   // Never hide processes that have alerts attached, or that sit on the ancestor path of one -
   // even if their binary is in a system path, the analyst context matters.
-  const preservedIds = useMemo(() => {
-    const keep = new Set<number>();
-    const walk = (node: ProcessNode, ancestors: number[]) => {
-      const nextAncestors = [...ancestors, node.id];
-      if (alertProcessIds.has(node.id)) {
-        for (const id of nextAncestors) keep.add(id);
-      }
-      if (node.children) for (const c of node.children) walk(c, nextAncestors);
-    };
-    for (const r of roots) walk(r, []);
-    return keep;
-  }, [roots, alertProcessIds]);
+  const preservedIds = useMemo(() => buildPreservedIds(roots, alertProcessIds), [roots, alertProcessIds]);
 
-  // Re-shape the raw tree according to the current filters: hide system-path nodes
-  // unconditionally (except preserved), optionally restrict to the alert chain, and drop
-  // children of collapsed nodes while stashing the hidden-count on the surviving parent so
-  // we can render it as "+N". While a search query is active, skip the collapse step so the
-  // user never sees "0 matches" when a match is only hidden inside a collapsed subtree
-  // AND prune to just matches + ancestors so the canvas isn't a wall of dimmed noise.
+  // Re-shape the raw tree according to the current filters (see buildVisibleRoots in ProcessTree.helpers): hide system-path nodes
+  // unconditionally (except preserved), optionally restrict to the alert chain, and drop children of collapsed nodes while stashing the
+  // hidden-count on the surviving parent so we can render it as "+N". While a search query is active, skip the collapse step so the user
+  // never sees "0 matches" when a match is only hidden inside a collapsed subtree AND prune to just matches + ancestors so the canvas
+  // isn't a wall of dimmed noise.
   const applyCollapse = query.trim() === "";
-  const queryFilterIds = useMemo(() => {
-    const q = query.trim().toLowerCase();
-    if (!q) return null;
-    const keep = new Set<number>();
-    const visit = (nodes: ProcessNode[], ancestors: number[]): boolean => {
-      let anyMatch = false;
-      for (const n of nodes) {
-        const matches = matchesQueryRaw(n, q);
-        const childMatches = n.children ? visit(n.children, [...ancestors, n.id]) : false;
-        if (matches || childMatches) {
-          keep.add(n.id);
-          for (const a of ancestors) keep.add(a);
-          anyMatch = true;
-        }
-      }
-      return anyMatch;
-    };
-    visit(roots, []);
-    return keep;
-  }, [roots, query]);
-  const visibleRoots = useMemo(() => {
-    // Predicate for "is this node visible at all": pulled out to keep the
-    // recursive walk below under Sonar's cognitive-complexity cap.
-    const isVisible = (n: ProcessNode): boolean => {
-      if (alertChainIds && !alertChainIds.has(n.id)) return false;
-      if (!showSystem && isSystemPath(n.path) && !preservedIds.has(n.id)) return false;
-      // Search filter: hide everything outside the matches-plus-ancestors set so
-      // a query like "60289" reduces a 200-node tree to the few rows that matter,
-      // instead of dimming 195 nodes the user has to visually skip past.
-      if (queryFilterIds && !queryFilterIds.has(n.id)) return false;
-      return true;
-    };
-    const apply = (nodes: ProcessNode[]): ProcessNode[] => {
-      const out: ProcessNode[] = [];
-      for (const n of nodes) {
-        if (!isVisible(n)) continue;
-        // An aggregated "×N" node ships childless; when the analyst expands it, its capped sample becomes its children in place
-        // (issue #416). Its own subtree is always the sample, so the generic collapse machinery below doesn't apply to it.
-        if (n.aggregated) {
-          const sample = expandedAggIds.has(n.id) ? apply(n.aggregated.sample ?? []) : undefined;
-          out.push({ ...n, children: sample });
-          continue;
-        }
-        const kids = n.children ? apply(n.children) : undefined;
-        if (applyCollapse && collapsedIds.has(n.id) && kids && kids.length > 0) {
-          const collapsedTotal = kids.reduce((acc, c) => acc + 1 + countDescendants(c), 0);
-          out.push({ ...n, children: undefined, _collapsedCount: collapsedTotal });
-        } else {
-          out.push({ ...n, children: kids });
-        }
-      }
-      return out;
-    };
-    return apply(roots);
-  }, [roots, showSystem, collapsedIds, expandedAggIds, preservedIds, applyCollapse, alertChainIds, queryFilterIds]);
+  const queryFilterIds = useMemo(() => buildQueryFilterIds(roots, query), [roots, query]);
+  const visibleRoots = useMemo(
+    () =>
+      buildVisibleRoots(roots, { showSystem, collapsedIds, expandedAggIds, preservedIds, applyCollapse, alertChainIds, queryFilterIds }),
+    [roots, showSystem, collapsedIds, expandedAggIds, preservedIds, applyCollapse, alertChainIds, queryFilterIds],
+  );
 
   const toggleCollapsed = useCallback((nodeId: number) => {
     setCollapsedIds((prev) => {
@@ -747,189 +684,74 @@ function GraphBody({
   );
 }
 
-// collectMatches walks the laid-out nodes and returns every node whose payload matches
-// q (by name/path/pid/args) plus the set of nodes on the ancestor path of any match,
-// used to dim non-matching subtrees while keeping the context to the match visible.
-function collectMatches(
-  nodes: D3PointNode[],
-  q: string,
-): { matches: D3PointNode[]; pathNodes: Set<D3PointNode> } {
-  const matches: D3PointNode[] = [];
-  const pathNodes = new Set<D3PointNode>();
-  if (!q) return { matches, pathNodes };
+// The pure per-node display derivations renderTree's d3 callbacks delegate to, so the render body below stays flat d3 wiring instead of
+// nested branch logic (issue: complexity paydown). Each takes plain values, so it is side-effect-free and independently testable.
+
+// computeLayoutBounds is the bounding box of the laid-out hierarchy, used to size the svg and center the initial zoom transform.
+function computeLayoutBounds(nodes: D3PointNode[]): { minX: number; maxX: number; minY: number; maxY: number } {
+  let minY = Infinity, maxY = -Infinity;
+  let minX = Infinity, maxX = -Infinity;
   for (const n of nodes) {
-    if (n.data.pid === 0) continue; // synthetic root when tree has multiple real roots
-    if (!nodeMatchesQuery(n.data, q)) continue;
-    matches.push(n);
-    let cur: D3PointNode | null = n;
-    while (cur) {
-      pathNodes.add(cur);
-      cur = cur.parent;
-    }
+    if (n.x < minX) minX = n.x;
+    if (n.x > maxX) maxX = n.x;
+    if (n.y < minY) minY = n.y;
+    if (n.y > maxY) maxY = n.y;
   }
-  return { matches, pathNodes };
+  return { minX, maxX, minY, maxY };
 }
 
-// matchFields holds the four node fields the search box compares against.
-// Both the d3-layout-time matcher and the data-side pre-filter funnel into
-// this so the matching rules can't drift between them.
-function matchFields(name: string, path: string, pid: number, args: string[] | undefined, q: string): boolean {
-  if (name.toLowerCase().includes(q)) return true;
-  if (path.toLowerCase().includes(q)) return true;
-  if (String(pid).includes(q)) return true;
-  if (args?.some((a) => a.toLowerCase().includes(q))) return true;
-  return false;
+// node--evidence drives the amber ring via CSS (ProcessTree.scss) rather than presentation attributes, so the search-match ring's class
+// rule cannot silently override it (CSS rules beat SVG presentation attributes).
+function evidenceNodeClass(p: ProcessNode): string {
+  return nodeEvidenceMarked(p) ? "node node--evidence" : "node";
 }
 
-function nodeMatchesQuery(d: D3Node, q: string): boolean {
-  return matchFields(d.name, d.path, d.pid, d.data.args, q);
+// Alerted nodes get a larger red dot. The label sits far enough from the dot (see LABEL_DX) that neither the bigger dot nor the
+// search-match ring get clipped by the label backdrop.
+function nodeDotRadius(alerted: boolean): number {
+  return alerted ? NODE_DOT_RADIUS_ALERTED : NODE_DOT_RADIUS_DEFAULT;
 }
 
-// matchesQueryRaw is the data-side mirror of nodeMatchesQuery: it operates on
-// raw ProcessNode rows before the d3 layout runs. Used by the visible-tree
-// pre-filter so the canvas only ever lays out the matches-plus-ancestors set.
-function matchesQueryRaw(n: ProcessNode, q: string): boolean {
-  const name = n.path.split("/").pop() ?? "";
-  return matchFields(name, n.path, n.pid, n.args, q);
+function nodeDotFill(p: ProcessNode, alerted: boolean): string {
+  if (alerted) return "#ff5c83"; // core-vibrant-red
+  // An aggregated group is "live" (green) when any member is still running; otherwise grey like a single exited process.
+  if (p.aggregated) return p.aggregated.running_count > 0 ? "#009a7d" : "#8b8fa2";
+  if (p.exit_time_ns) return "#8b8fa2";
+  return "#009a7d";
 }
 
-function isSystemPath(path: string): boolean {
-  // Any .app bundle is a user-launchable application, so keep it visible even if it lives
-  // under /System/Library/ (e.g. /System/Library/CoreServices/Finder.app/...).
-  if (path.includes(".app/")) return false;
-  for (const seg of SYSTEM_PATH_SEGMENTS) {
-    if (path.includes(seg)) return true;
-  }
-  return false;
+// A chevron is drawn when a node has children in the underlying data OR has been collapsed (so it can be expanded back). An aggregated
+// node is always expandable to its sample.
+function nodeHasChevron(p: ProcessNode, collapsedIds: Set<number>): boolean {
+  if (p.aggregated) return true; // always expandable to its sample
+  return (p.children !== undefined && p.children.length > 0) || collapsedIds.has(p.id);
 }
 
-function countDescendants(node: ProcessNode): number {
-  if (!node.children) return 0;
-  let n = 0;
-  for (const c of node.children) n += 1 + countDescendants(c);
-  return n;
+function chevronGlyph(p: ProcessNode, expandedAggIds: Set<number>, collapsedIds: Set<number>): string {
+  if (p.aggregated) return expandedAggIds.has(p.id) ? "▼" : "▶";
+  return collapsedIds.has(p.id) ? "▶" : "▼";
 }
 
-// Given a root list and a target process row id, return the set of ids that form the alert
-// chain: the target, every ancestor back to the top root, and every descendant. If the
-// target isn't in the tree, returns an empty set (the focus filter will then drop the whole
-// tree, making it visually obvious that the target is out of range).
-function findAlertChain(roots: ProcessNode[], targetDbId: number): Set<number> {
-  const related = new Set<number>();
-  let path: ProcessNode[] = [];
-  const findPath = (nodes: ProcessNode[], acc: ProcessNode[]): boolean => {
-    for (const n of nodes) {
-      const next = [...acc, n];
-      if (n.id === targetDbId) { path = next; return true; }
-      if (n.children?.length && findPath(n.children, next)) return true;
-    }
-    return false;
-  };
-  findPath(roots, []);
-  if (path.length === 0) return related;
-  for (const p of path) related.add(p.id);
-  const addDescendants = (n: ProcessNode) => {
-    related.add(n.id);
-    if (n.children) for (const c of n.children) addDescendants(c);
-  };
-  addDescendants(path[path.length - 1]);
-  return related;
+function nodeLabelClass(alerted: boolean): string {
+  return `node__label${alerted ? " node__label--alert" : ""}`;
 }
 
-function findNodeByDbId(nodes: ProcessNode[], dbId: number): ProcessNode | null {
-  for (const n of nodes) {
-    if (n.id === dbId) return n;
-    if (n.children) {
-      const found = findNodeByDbId(n.children, dbId);
-      if (found) return found;
-    }
-  }
-  return null;
+function nodeLabelFill(alerted: boolean): string {
+  return alerted ? "#ff5c83" : "#192147";
 }
 
-// findNodeByPidAtTime resolves a timeline row's (pid, event time) to its process node: the node with that pid whose lifetime brackets
-// atNs (fork <= atNs, and no exit or exit >= atNs). This disambiguates pid reuse within the window by picking the generation live at
-// the event, the same (host, pid, at) correlation the process-detail network join relies on. Prefers the closest fork at/before the
-// anchor so an exact hit wins over a wider-lived ancestor sharing the pid.
-function findNodeByPidAtTime(nodes: ProcessNode[], pid: number, atNs: number): ProcessNode | null {
-  let best: ProcessNode | null = null;
-  const visit = (n: ProcessNode) => {
-    // !n.exit_time_ns covers a still-running process whether the API sends the field as undefined, null, or 0; a bare === undefined
-    // check would treat a null (common for running processes over the Go/JSON boundary) as "exited at null" and drop the node.
-    if (n.pid === pid && n.fork_time_ns <= atNs && (!n.exit_time_ns || n.exit_time_ns >= atNs)) {
-      if (best === null || n.fork_time_ns > best.fork_time_ns) best = n;
-    }
-    for (const c of n.children ?? []) visit(c);
-  };
-  for (const n of nodes) visit(n);
-  return best;
+function nodeLabelWeight(alerted: boolean): string {
+  return alerted ? "bold" : "normal";
 }
 
-// selectNodeFromParams resolves the node the URL asks the graph to select: ?process=<dbId> directly, or ?pid=<pid>&at=<ms> (a timeline
-// row) via findNodeByPidAtTime. Kept at module scope so the selection effect in ProcessTreeView stays a single branch.
-function selectNodeFromParams(roots: ProcessNode[], searchParams: URLSearchParams): ProcessNode | null {
-  if (roots.length === 0) return null;
-  const processIdParam = searchParams.get("process");
-  if (processIdParam) return findNodeByDbId(roots, Number(processIdParam));
-  const pidQuery = searchParams.get("pid");
-  const atQuery = searchParams.get("at");
-  if (pidQuery && atQuery) {
-    return findNodeByPidAtTime(roots, Number(pidQuery), Number(atQuery) * NANOSECONDS_PER_MILLISECOND);
-  }
-  return null;
-}
-
-// viewHref toggles the view param while preserving the rest of the URL (window, alert anchor, selection), so switching views is a link
-// that never changes the shared time window. Graph is the default, so it drops ?view= rather than setting view=graph.
-function viewHref(hostId: string, searchParams: URLSearchParams, v: "graph" | "timeline"): string {
-  const next = new URLSearchParams(searchParams);
-  if (v === "graph") {
-    next.delete("view");
-  } else {
-    next.set("view", v);
-  }
-  const qs = next.toString();
-  const suffix = qs ? `?${qs}` : "";
-  return `/hosts/${encodeURIComponent(hostId)}${suffix}`;
-}
-
-interface D3Node {
-  name: string;
-  pid: number;
-  path: string;
-  data: ProcessNode;
-  children?: D3Node[];
-}
-
-function toD3Hierarchy(nodes: ProcessNode[]): D3Node {
-  function convert(n: ProcessNode): D3Node {
-    const kids = n.children?.map(convert);
-    return {
-      name: basename(n.path) || `PID ${String(n.pid)}`,
-      pid: n.pid,
-      path: n.path,
-      data: n,
-      children: kids && kids.length > 0 ? kids : undefined,
-    };
-  }
-
-  if (nodes.length === 1) {
-    return convert(nodes[0]);
-  }
-
-  return {
-    name: "root",
-    pid: 0,
-    path: "",
-    data: nodes[0],
-    children: nodes.map(convert),
-  };
-}
-
-function basename(path: string): string {
-  if (!path) return "";
-  const parts = path.split("/");
-  return parts[parts.length - 1];
+function nodeLabelText(node: D3Node): string {
+  const p = node.data;
+  // Aggregated nodes read as a group header ("grep ×1000"), not a single pid; the sample members carry the individual pids once the
+  // node is expanded.
+  if (p.aggregated) return `${node.name} ×${String(p.aggregated.count)}`;
+  const base = `${node.name} (${String(node.pid)})`;
+  const hidden = p._collapsedCount;
+  return hidden && hidden > 0 ? `${base}  +${String(hidden)}` : base;
 }
 
 function renderTree(
@@ -950,14 +772,7 @@ function renderTree(
   const links = root.links();
 
   // Compute bounding box.
-  let minY = Infinity, maxY = -Infinity;
-  let minX = Infinity, maxX = -Infinity;
-  for (const n of nodes) {
-    if (n.x < minX) minX = n.x;
-    if (n.x > maxX) maxX = n.x;
-    if (n.y < minY) minY = n.y;
-    if (n.y > maxY) maxY = n.y;
-  }
+  const { minX, maxX, minY } = computeLayoutBounds(nodes);
 
   const margin = TREE_MARGIN_PX;
   const svgHeight = maxX - minX + margin * 2;
@@ -1004,9 +819,7 @@ function renderTree(
     .selectAll("g.node")
     .data(nodes.filter((n) => n.data.pid !== 0 || roots.length === 1))
     .join("g")
-    // node--evidence drives the amber ring via CSS (ProcessTree.scss) rather than presentation attributes, so the search-match
-    // ring's class rule cannot silently override it (CSS rules beat SVG presentation attributes).
-    .attr("class", (d) => (nodeEvidenceMarked(d.data.data) ? "node node--evidence" : "node"))
+    .attr("class", (d) => evidenceNodeClass(d.data.data))
     .attr("transform", (d) => `translate(${String(d.y)},${String(d.x)})`)
     .style("cursor", "pointer")
     .on("click", (_, d) => {
@@ -1031,27 +844,13 @@ function renderTree(
   node
     .append("circle")
     .attr("class", "node__dot")
-    // Alerted nodes get a larger red dot. The label sits far enough away from the
-    // dot (see dx on the label text below) that neither the bigger dot nor the
-    // search-match ring get clipped by the label backdrop.
-    .attr("r", (d) => (alertProcessIds.has(d.data.data.id) ? NODE_DOT_RADIUS_ALERTED : NODE_DOT_RADIUS_DEFAULT))
-    .attr("fill", (d) => {
-      const p = d.data.data;
-      if (alertProcessIds.has(p.id)) return "#ff5c83"; // core-vibrant-red
-      // An aggregated group is "live" (green) when any member is still running; otherwise grey like a single exited process.
-      if (p.aggregated) return p.aggregated.running_count > 0 ? "#009a7d" : "#8b8fa2";
-      if (p.exit_time_ns) return "#8b8fa2";
-      return "#009a7d";
-    });
+    .attr("r", (d) => nodeDotRadius(alertProcessIds.has(d.data.data.id)))
+    .attr("fill", (d) => nodeDotFill(d.data.data, alertProcessIds.has(d.data.data.id)));
 
   // Collapse/expand chevron. Sits in front of the dot. Only rendered when a node has
   // children in the underlying data OR has been collapsed (so we can expand it back).
   // Click events on the chevron stop propagation so they don't also fire the node-select handler.
-  const chevronNodes = node.filter((d) => {
-    const p = d.data.data;
-    if (p.aggregated) return true; // always expandable to its sample
-    return (p.children !== undefined && p.children.length > 0) || collapsedIds.has(p.id);
-  });
+  const chevronNodes = node.filter((d) => nodeHasChevron(d.data.data, collapsedIds));
   chevronNodes
     .append("text")
     .attr("class", "node__chevron")
@@ -1061,11 +860,7 @@ function renderTree(
     .attr("font-family", "ui-monospace, SFMono-Regular, Menlo, monospace")
     .attr("fill", "#515774")
     .style("cursor", "pointer")
-    .text((d) => {
-      const p = d.data.data;
-      if (p.aggregated) return expandedAggIds.has(p.id) ? "▼" : "▶";
-      return collapsedIds.has(p.id) ? "▶" : "▼";
-    })
+    .text((d) => chevronGlyph(d.data.data, expandedAggIds, collapsedIds))
     .on("click", (event: MouseEvent, d) => {
       event.stopPropagation();
       const p = d.data.data;
@@ -1078,10 +873,7 @@ function renderTree(
 
   node
     .append("text")
-    .attr("class", (d) => {
-      const isAlerted = alertProcessIds.has(d.data.data.id);
-      return `node__label${isAlerted ? " node__label--alert" : ""}`;
-    })
+    .attr("class", (d) => nodeLabelClass(alertProcessIds.has(d.data.data.id)))
     // dx=16 leaves enough gap that the label backdrop starts clear of an r=8
     // alert dot (extends to x=8) and of the r=7 + 2px stroke search-match ring
     // (extends to x=9), so neither is clipped by the backdrop rect.
@@ -1089,17 +881,9 @@ function renderTree(
     .attr("dy", LABEL_DY)
     .attr("font-size", "12px")
     .attr("font-family", "ui-monospace, SFMono-Regular, Menlo, monospace")
-    .attr("fill", (d) => (alertProcessIds.has(d.data.data.id) ? "#ff5c83" : "#192147"))
-    .attr("font-weight", (d) => (alertProcessIds.has(d.data.data.id) ? "bold" : "normal"))
-    .text((d) => {
-      const p = d.data.data;
-      // Aggregated nodes read as a group header ("grep ×1000"), not a single pid; the sample members carry the individual pids
-      // once the node is expanded.
-      if (p.aggregated) return `${d.data.name} ×${String(p.aggregated.count)}`;
-      const base = `${d.data.name} (${String(d.data.pid)})`;
-      const hidden = p._collapsedCount;
-      return hidden && hidden > 0 ? `${base}  +${String(hidden)}` : base;
-    });
+    .attr("fill", (d) => nodeLabelFill(alertProcessIds.has(d.data.data.id)))
+    .attr("font-weight", (d) => nodeLabelWeight(alertProcessIds.has(d.data.data.id)))
+    .text((d) => nodeLabelText(d.data));
 
   // White backdrop behind each label so sibling tree links passing through the
   // label area don't visually cut through the text. Inserted after the text is


### PR DESCRIPTION
## What & why

`consolidation-pass` maintenance paydown of the grandfathered cognitive-complexity stock (the monthly mandate in `docs/maintenance/tasks/consolidation-pass.md`), plus two small deferred fixes surfaced during the 2026-07-05 maintenance rerun. Everything is behavior-preserving; no observable behavior changes.

| Commit | Change |
|---|---|
| `config` | Centralize the required `EDR_CLICKHOUSE_DSN` check in `config.Load` via `requireStr` (both binaries checked it independently after Load). Observable boot behavior unchanged. |
| `ui/cmdline.ts` | Fix the one open SonarCloud issue (S4624: nested template literal in `quoteArg`) by extracting the inner expression. |
| `demo-seed/seed.go` | Extract `maybeRefreshExisting`, `newestReplayedTimestampNs`, `applyTimestampSlide`. |
| `spectrace/report.go` | Extract `forEachInFlightChangeDir` + `scanRemovedRequirementsFile` (also removes the lexical dup between the two parse functions). |
| `scale/runner.go` | Extract `makeHostStates`, `hostState.recordResult`, `foldHostLatencies`, `evaluatePassGate`, `validate{Scenario,Backlog}Options`. |
| `identity/bootstrap.go` | Extract the OIDC/SSO/break-glass/seed wiring closures; `New`'s wiring order + dependency set unchanged. |
| `appcontrol_handler.go` | Dedup the identical decode->validate->actor prelude across 7 mutation handlers into `readAppControlBody` / `actorOrInternalError` / `decodeAppControlBody{,IfPresent}`. |
| `ProcessTree.tsx` | Move the pure functions + the three `useMemo` bodies + `renderTree`'s branch callbacks into a new pure `ProcessTree.helpers.ts`. No hook order / effect deps / D3 join / state shape changed. |

Every Go refactor is extract-only (verbatim moves / closure-to-parameter): SQL literals, error strings/wrapping, evaluation order, status codes, response bodies, authz gating, and wiring order are all unchanged. The UI refactor is pure-helper extraction with no rendering-logic change.

## Checklist

- [x] **OpenSpec / behavior**: no observable behavior change (pure extract-refactors + the one config-validation-site move that preserves boot behavior), asserted via `[no-behavior-change]`.
- [x] Tests: no new behavior to test; each refactor verified against its existing package tests, including DB-backed integration (`demo-seed`, `identity` bootstrap wiring, `AppControl`, scale `TestM12_Smoke`) and the full UI vitest suite (597) + `tsc` for `ProcessTree`. Whole-repo `go build ./...` + `go vet ./...` (+ integration-tag vet on touched areas) are green across all 8 commits.
- [x] Agent/extension ESF/XPC/wire: N/A. Not touched.
- [x] **Docs**: N/A. No user-facing surface changed (internal refactors; the config change keeps identical boot behavior).

## VM / RC notes

None. No agent/extension/ESF/XPC/wire changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ER9GMfKy1x7fhAGBMWsE2P


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup validation so missing required connection settings are caught earlier and reported more clearly.
  * Made demo data seeding more reliable when rerun, preserving existing data and refreshing timestamps instead of replaying everything.
  * Fixed process tree behavior by separating shared logic, helping selection, filtering, and collapsed-node display stay consistent.

* **New Features**
  * Added a more robust process tree helper layer to support smoother navigation and filtering in the UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->